### PR TITLE
Add runtime PR hygiene sweep

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -23,6 +23,12 @@ pr_feedback:
   enabled: true
   sweep_interval_secs: 60
   claim_stale_after_secs: 300
+  hygiene_enabled: true
+  hygiene_interval_secs: 1800
+  dirty_age_to_repair_secs: 172800
+  dirty_age_to_comment_secs: 604800
+  rebase_needed_label: rebase-needed
+  hygiene_batch_limit: 25
 repo_backlog:
   enabled: true
   poll_interval_secs: 60

--- a/config/WORKFLOW.md
+++ b/config/WORKFLOW.md
@@ -30,6 +30,12 @@ pr_feedback:
   enabled: true
   sweep_interval_secs: 60
   claim_stale_after_secs: 300
+  hygiene_enabled: true
+  hygiene_interval_secs: 1800
+  dirty_age_to_repair_secs: 172800
+  dirty_age_to_comment_secs: 604800
+  rebase_needed_label: rebase-needed
+  hygiene_batch_limit: 25
 repo_backlog:
   # Disabled by default: issues/PRs are picked up via webhook events only, so an
   # idle system (no GitHub events) runs zero LLM turns. Set enabled: true in a

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -100,6 +100,18 @@ pub struct PrFeedbackPolicy {
     pub sweep_interval_secs: u64,
     #[serde(default = "default_feedback_claim_stale_after_secs")]
     pub claim_stale_after_secs: u64,
+    #[serde(default = "default_true")]
+    pub hygiene_enabled: bool,
+    #[serde(default = "default_pr_hygiene_interval_secs")]
+    pub hygiene_interval_secs: u64,
+    #[serde(default = "default_pr_hygiene_dirty_age_to_repair_secs")]
+    pub dirty_age_to_repair_secs: u64,
+    #[serde(default = "default_pr_hygiene_dirty_age_to_comment_secs")]
+    pub dirty_age_to_comment_secs: u64,
+    #[serde(default = "default_pr_hygiene_rebase_needed_label")]
+    pub rebase_needed_label: String,
+    #[serde(default = "default_pr_hygiene_batch_limit")]
+    pub hygiene_batch_limit: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -268,6 +280,12 @@ impl Default for PrFeedbackPolicy {
             enabled: default_true(),
             sweep_interval_secs: default_feedback_sweep_interval_secs(),
             claim_stale_after_secs: default_feedback_claim_stale_after_secs(),
+            hygiene_enabled: default_true(),
+            hygiene_interval_secs: default_pr_hygiene_interval_secs(),
+            dirty_age_to_repair_secs: default_pr_hygiene_dirty_age_to_repair_secs(),
+            dirty_age_to_comment_secs: default_pr_hygiene_dirty_age_to_comment_secs(),
+            rebase_needed_label: default_pr_hygiene_rebase_needed_label(),
+            hygiene_batch_limit: default_pr_hygiene_batch_limit(),
         }
     }
 }
@@ -445,6 +463,26 @@ fn default_feedback_sweep_interval_secs() -> u64 {
 
 fn default_feedback_claim_stale_after_secs() -> u64 {
     300
+}
+
+fn default_pr_hygiene_interval_secs() -> u64 {
+    30 * 60
+}
+
+fn default_pr_hygiene_dirty_age_to_repair_secs() -> u64 {
+    48 * 60 * 60
+}
+
+fn default_pr_hygiene_dirty_age_to_comment_secs() -> u64 {
+    7 * 24 * 60 * 60
+}
+
+fn default_pr_hygiene_rebase_needed_label() -> String {
+    "rebase-needed".to_string()
+}
+
+fn default_pr_hygiene_batch_limit() -> u32 {
+    25
 }
 
 fn default_repo_backlog_poll_interval_secs() -> u64 {

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -27,6 +27,12 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert!(cfg.pr_feedback.enabled);
     assert_eq!(cfg.pr_feedback.sweep_interval_secs, 60);
     assert_eq!(cfg.pr_feedback.claim_stale_after_secs, 300);
+    assert!(cfg.pr_feedback.hygiene_enabled);
+    assert_eq!(cfg.pr_feedback.hygiene_interval_secs, 1800);
+    assert_eq!(cfg.pr_feedback.dirty_age_to_repair_secs, 172800);
+    assert_eq!(cfg.pr_feedback.dirty_age_to_comment_secs, 604800);
+    assert_eq!(cfg.pr_feedback.rebase_needed_label, "rebase-needed");
+    assert_eq!(cfg.pr_feedback.hygiene_batch_limit, 25);
     assert!(cfg.repo_backlog.enabled);
     assert_eq!(cfg.repo_backlog.poll_interval_secs, 60);
     assert_eq!(cfg.repo_backlog.batch_limit, 128);
@@ -142,6 +148,12 @@ pr_feedback:
   enabled: false
   sweep_interval_secs: 15
   claim_stale_after_secs: 45
+  hygiene_enabled: false
+  hygiene_interval_secs: 1801
+  dirty_age_to_repair_secs: 1802
+  dirty_age_to_comment_secs: 1803
+  rebase_needed_label: needs-rebase
+  hygiene_batch_limit: 6
 repo_backlog:
   enabled: false
   poll_interval_secs: 20
@@ -241,6 +253,12 @@ Body
     assert!(!cfg.pr_feedback.enabled);
     assert_eq!(cfg.pr_feedback.sweep_interval_secs, 15);
     assert_eq!(cfg.pr_feedback.claim_stale_after_secs, 45);
+    assert!(!cfg.pr_feedback.hygiene_enabled);
+    assert_eq!(cfg.pr_feedback.hygiene_interval_secs, 1801);
+    assert_eq!(cfg.pr_feedback.dirty_age_to_repair_secs, 1802);
+    assert_eq!(cfg.pr_feedback.dirty_age_to_comment_secs, 1803);
+    assert_eq!(cfg.pr_feedback.rebase_needed_label, "needs-rebase");
+    assert_eq!(cfg.pr_feedback.hygiene_batch_limit, 6);
     assert!(!cfg.repo_backlog.enabled);
     assert_eq!(cfg.repo_backlog.poll_interval_secs, 20);
     assert_eq!(cfg.repo_backlog.batch_limit, 9);

--- a/crates/harness-server/src/github_pr_hygiene.rs
+++ b/crates/harness-server/src/github_pr_hygiene.rs
@@ -1,0 +1,310 @@
+use anyhow::Context;
+use chrono::{DateTime, SecondsFormat, Utc};
+use reqwest::header::{ACCEPT, USER_AGENT};
+use serde_json::{json, Value};
+use std::time::Duration;
+
+use crate::github_pr_snapshot::{errors_is_empty, value_string, value_u64};
+
+const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubOpenPrHygiene {
+    pub repo_slug: String,
+    pub pr_number: u64,
+    pub pr_url: String,
+    pub title: Option<String>,
+    pub merge_state_status: Option<String>,
+    pub head_oid: Option<String>,
+    pub updated_at: DateTime<Utc>,
+    pub labels: Vec<String>,
+}
+
+impl GitHubOpenPrHygiene {
+    pub(crate) fn dirty_age_secs(&self, now: DateTime<Utc>) -> u64 {
+        now.signed_duration_since(self.updated_at)
+            .to_std()
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn requires_mergeability_repair(&self) -> bool {
+        self.merge_state_status
+            .as_deref()
+            .is_some_and(merge_state_requires_repair)
+    }
+
+    pub(crate) fn updated_at_rfc3339(&self) -> String {
+        self.updated_at.to_rfc3339_opts(SecondsFormat::Secs, true)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitHubOpenPrHygienePage {
+    prs: Vec<GitHubOpenPrHygiene>,
+    has_next_page: bool,
+    end_cursor: Option<String>,
+}
+
+pub(crate) async fn fetch_open_pr_hygiene(
+    repo_slug: &str,
+    github_token: Option<&str>,
+    limit: usize,
+) -> anyhow::Result<Vec<GitHubOpenPrHygiene>> {
+    validate_repo_slug(repo_slug)?;
+    let client = reqwest::Client::new();
+    fetch_open_pr_hygiene_with_client(&client, repo_slug, github_token, limit).await
+}
+
+async fn fetch_open_pr_hygiene_with_client(
+    client: &reqwest::Client,
+    repo_slug: &str,
+    github_token: Option<&str>,
+    limit: usize,
+) -> anyhow::Result<Vec<GitHubOpenPrHygiene>> {
+    let mut prs = Vec::new();
+    let mut after = None;
+    let limit = limit.max(1);
+    while prs.len() < limit {
+        let first = (limit - prs.len()).min(100);
+        let page =
+            fetch_open_pr_hygiene_page(client, repo_slug, github_token, first, after.as_deref())
+                .await?;
+        prs.extend(page.prs);
+        if !page.has_next_page || prs.len() >= limit {
+            break;
+        }
+        after = page.end_cursor;
+        if after.is_none() {
+            break;
+        }
+    }
+    Ok(prs)
+}
+
+async fn fetch_open_pr_hygiene_page(
+    client: &reqwest::Client,
+    repo_slug: &str,
+    github_token: Option<&str>,
+    first: usize,
+    after: Option<&str>,
+) -> anyhow::Result<GitHubOpenPrHygienePage> {
+    let (owner, repo) = repo_slug
+        .split_once('/')
+        .context("validated repo slug should contain owner and repo")?;
+    let query = r#"
+        query HarnessOpenPrHygiene($owner: String!, $repo: String!, $first: Int!, $after: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequests(
+              states: OPEN
+              first: $first
+              after: $after
+              orderBy: {field: UPDATED_AT, direction: DESC}
+            ) {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              nodes {
+                number
+                url
+                title
+                mergeStateStatus
+                headRefOid
+                updatedAt
+                labels(first: 50) {
+                  nodes {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    "#;
+
+    let mut request = client
+        .post(GITHUB_GRAPHQL_URL)
+        .header(ACCEPT, "application/vnd.github+json")
+        .header(USER_AGENT, "harness-server")
+        .json(&json!({
+            "query": query,
+            "variables": {
+                "owner": owner,
+                "repo": repo,
+                "first": i64::try_from(first).unwrap_or(100),
+                "after": after,
+            }
+        }));
+    if let Some(token) = crate::github_auth::resolve_github_token(github_token) {
+        request = request.bearer_auth(token);
+    }
+
+    let response = tokio::time::timeout(Duration::from_secs(15), request.send()).await??;
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        anyhow::bail!("GitHub PR hygiene query failed with status {status}: {body}");
+    }
+    let parsed: Value =
+        serde_json::from_str(&body).context("GitHub PR hygiene response was invalid JSON")?;
+    if let Some(errors) = parsed
+        .get("errors")
+        .filter(|errors| !errors_is_empty(errors))
+    {
+        anyhow::bail!("GitHub PR hygiene query returned errors: {errors}");
+    }
+    let connection = parsed
+        .get("data")
+        .and_then(|data| data.get("repository").cloned())
+        .and_then(|repository| repository.get("pullRequests").cloned())
+        .filter(|pull_requests| !pull_requests.is_null())
+        .ok_or_else(|| anyhow::anyhow!("GitHub PR hygiene query returned no PR connection"))?;
+    parse_open_pr_hygiene_page(repo_slug, &connection)
+}
+
+fn parse_open_pr_hygiene_page(
+    repo_slug: &str,
+    connection: &Value,
+) -> anyhow::Result<GitHubOpenPrHygienePage> {
+    validate_repo_slug(repo_slug)?;
+    let prs = connection
+        .get("nodes")
+        .and_then(Value::as_array)
+        .context("GitHub PR hygiene connection missing nodes")?
+        .iter()
+        .map(|node| parse_open_pr_hygiene_node(repo_slug, node))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let page_info = connection
+        .get("pageInfo")
+        .context("GitHub PR hygiene connection missing pageInfo")?;
+    Ok(GitHubOpenPrHygienePage {
+        prs,
+        has_next_page: page_info
+            .get("hasNextPage")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        end_cursor: value_string(page_info.get("endCursor")),
+    })
+}
+
+fn parse_open_pr_hygiene_node(
+    repo_slug: &str,
+    node: &Value,
+) -> anyhow::Result<GitHubOpenPrHygiene> {
+    let pr_number = value_u64(node.get("number")).context("GitHub PR hygiene missing number")?;
+    let pr_url = value_string(node.get("url")).context("GitHub PR hygiene missing url")?;
+    let updated_at = value_string(node.get("updatedAt"))
+        .context("GitHub PR hygiene missing updatedAt")
+        .and_then(|value| {
+            DateTime::parse_from_rfc3339(&value)
+                .map(|datetime| datetime.with_timezone(&Utc))
+                .map_err(|error| anyhow::anyhow!("invalid GitHub PR updatedAt `{value}`: {error}"))
+        })?;
+    Ok(GitHubOpenPrHygiene {
+        repo_slug: repo_slug.to_string(),
+        pr_number,
+        pr_url,
+        title: value_string(node.get("title")),
+        merge_state_status: value_string(node.get("mergeStateStatus")),
+        head_oid: value_string(node.get("headRefOid")),
+        updated_at,
+        labels: label_names(node),
+    })
+}
+
+fn validate_repo_slug(repo_slug: &str) -> anyhow::Result<()> {
+    let Some((owner, repo)) = repo_slug.split_once('/') else {
+        anyhow::bail!("invalid GitHub repo slug `{repo_slug}`");
+    };
+    if owner.trim().is_empty() || repo.trim().is_empty() {
+        anyhow::bail!("invalid GitHub repo slug `{repo_slug}`");
+    }
+    Ok(())
+}
+
+fn label_names(node: &Value) -> Vec<String> {
+    node.pointer("/labels/nodes")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|label| value_string(label.get("name")))
+        .collect()
+}
+
+fn merge_state_requires_repair(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_uppercase().as_str(),
+        "DIRTY" | "BEHIND"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_pr_hygiene_parses_open_pr_page() -> anyhow::Result<()> {
+        let connection = json!({
+            "pageInfo": {"hasNextPage": true, "endCursor": "cursor-1"},
+            "nodes": [
+                {
+                    "number": 77,
+                    "url": "https://github.com/owner/repo/pull/77",
+                    "title": "Refresh branch",
+                    "mergeStateStatus": "DIRTY",
+                    "headRefOid": "abc123",
+                    "updatedAt": "2026-06-10T00:00:00Z",
+                    "labels": {"nodes": [{"name": "ready"}, {"name": "rebase-needed"}]}
+                }
+            ]
+        });
+
+        let page = parse_open_pr_hygiene_page("owner/repo", &connection)?;
+
+        assert!(page.has_next_page);
+        assert_eq!(page.end_cursor.as_deref(), Some("cursor-1"));
+        assert_eq!(page.prs.len(), 1);
+        let pr = &page.prs[0];
+        assert_eq!(pr.repo_slug, "owner/repo");
+        assert_eq!(pr.pr_number, 77);
+        assert_eq!(pr.merge_state_status.as_deref(), Some("DIRTY"));
+        assert_eq!(pr.head_oid.as_deref(), Some("abc123"));
+        assert!(pr.requires_mergeability_repair());
+        assert_eq!(pr.labels, vec!["ready", "rebase-needed"]);
+        Ok(())
+    }
+
+    #[test]
+    fn github_pr_hygiene_uses_updated_at_for_dirty_age() -> anyhow::Result<()> {
+        let node = json!({
+            "number": 78,
+            "url": "https://github.com/owner/repo/pull/78",
+            "mergeStateStatus": "BEHIND",
+            "headRefOid": "def456",
+            "updatedAt": "2026-06-10T00:00:00Z",
+            "labels": {"nodes": []}
+        });
+        let pr = parse_open_pr_hygiene_node("owner/repo", &node)?;
+        let now = DateTime::parse_from_rfc3339("2026-06-12T00:00:00Z")?.with_timezone(&Utc);
+
+        assert_eq!(pr.dirty_age_secs(now), 172800);
+        assert!(pr.requires_mergeability_repair());
+        assert_eq!(pr.updated_at_rfc3339(), "2026-06-10T00:00:00Z");
+        Ok(())
+    }
+
+    #[test]
+    fn github_pr_hygiene_clean_pr_does_not_require_repair() -> anyhow::Result<()> {
+        let node = json!({
+            "number": 79,
+            "url": "https://github.com/owner/repo/pull/79",
+            "mergeStateStatus": "CLEAN",
+            "updatedAt": "2026-06-10T00:00:00Z"
+        });
+        let pr = parse_open_pr_hygiene_node("owner/repo", &node)?;
+
+        assert!(!pr.requires_mergeability_repair());
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/github_pr_hygiene.rs
+++ b/crates/harness-server/src/github_pr_hygiene.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use crate::github_pr_snapshot::{errors_is_empty, value_string, value_u64};
 
 const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
+const OPEN_PR_HYGIENE_PAGE_SIZE: usize = 100;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GitHubOpenPrHygiene {
@@ -66,11 +67,11 @@ async fn fetch_open_pr_hygiene_with_client(
     let mut after = None;
     let limit = limit.max(1);
     while prs.len() < limit {
-        let first = (limit - prs.len()).min(100);
+        let first = OPEN_PR_HYGIENE_PAGE_SIZE;
         let page =
             fetch_open_pr_hygiene_page(client, repo_slug, github_token, first, after.as_deref())
                 .await?;
-        prs.extend(page.prs);
+        append_mergeability_repair_candidates(&mut prs, page.prs, limit);
         if !page.has_next_page || prs.len() >= limit {
             break;
         }
@@ -99,7 +100,7 @@ async fn fetch_open_pr_hygiene_page(
               states: OPEN
               first: $first
               after: $after
-              orderBy: {field: UPDATED_AT, direction: DESC}
+              orderBy: {field: UPDATED_AT, direction: ASC}
             ) {
               pageInfo {
                 hasNextPage
@@ -161,6 +162,20 @@ async fn fetch_open_pr_hygiene_page(
         .filter(|pull_requests| !pull_requests.is_null())
         .ok_or_else(|| anyhow::anyhow!("GitHub PR hygiene query returned no PR connection"))?;
     parse_open_pr_hygiene_page(repo_slug, &connection)
+}
+
+fn append_mergeability_repair_candidates(
+    prs: &mut Vec<GitHubOpenPrHygiene>,
+    page_prs: Vec<GitHubOpenPrHygiene>,
+    limit: usize,
+) {
+    let remaining = limit.saturating_sub(prs.len());
+    prs.extend(
+        page_prs
+            .into_iter()
+            .filter(GitHubOpenPrHygiene::requires_mergeability_repair)
+            .take(remaining),
+    );
 }
 
 fn parse_open_pr_hygiene_page(
@@ -305,6 +320,44 @@ mod tests {
         let pr = parse_open_pr_hygiene_node("owner/repo", &node)?;
 
         assert!(!pr.requires_mergeability_repair());
+        Ok(())
+    }
+
+    #[test]
+    fn github_pr_hygiene_collects_repair_candidates_past_clean_prs() -> anyhow::Result<()> {
+        let connection = json!({
+            "pageInfo": {"hasNextPage": false, "endCursor": null},
+            "nodes": [
+                {
+                    "number": 80,
+                    "url": "https://github.com/owner/repo/pull/80",
+                    "mergeStateStatus": "CLEAN",
+                    "updatedAt": "2026-06-10T00:00:00Z",
+                    "labels": {"nodes": []}
+                },
+                {
+                    "number": 81,
+                    "url": "https://github.com/owner/repo/pull/81",
+                    "mergeStateStatus": "DIRTY",
+                    "updatedAt": "2026-06-10T01:00:00Z",
+                    "labels": {"nodes": []}
+                },
+                {
+                    "number": 82,
+                    "url": "https://github.com/owner/repo/pull/82",
+                    "mergeStateStatus": "BEHIND",
+                    "updatedAt": "2026-06-10T02:00:00Z",
+                    "labels": {"nodes": []}
+                }
+            ]
+        });
+        let page = parse_open_pr_hygiene_page("owner/repo", &connection)?;
+        let mut prs = Vec::new();
+
+        append_mergeability_repair_candidates(&mut prs, page.prs, 1);
+
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].pr_number, 81);
         Ok(())
     }
 }

--- a/crates/harness-server/src/github_pr_snapshot.rs
+++ b/crates/harness-server/src/github_pr_snapshot.rs
@@ -190,7 +190,7 @@ struct GitHubPrSnapshotGraphQlResponse {
     errors: Option<Value>,
 }
 
-fn errors_is_empty(errors: &Value) -> bool {
+pub(crate) fn errors_is_empty(errors: &Value) -> bool {
     errors.as_array().is_some_and(Vec::is_empty)
 }
 
@@ -431,7 +431,7 @@ fn pr_feedback_summary(signal_type: &str, snapshot: &Value) -> String {
     }
 }
 
-fn value_string(value: Option<&Value>) -> Option<String> {
+pub(crate) fn value_string(value: Option<&Value>) -> Option<String> {
     value
         .and_then(Value::as_str)
         .map(str::trim)
@@ -439,7 +439,7 @@ fn value_string(value: Option<&Value>) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-fn value_u64(value: Option<&Value>) -> Option<u64> {
+pub(crate) fn value_u64(value: Option<&Value>) -> Option<u64> {
     value.and_then(|value| {
         value
             .as_u64()

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -751,7 +751,7 @@ fn workflow_project_root(instance: &WorkflowInstance) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
-fn load_runtime_workflow_config(
+pub(super) fn load_runtime_workflow_config(
     project_root: &Path,
     subsystem: &str,
 ) -> anyhow::Result<harness_core::config::workflow::WorkflowConfig> {
@@ -864,7 +864,7 @@ pub(super) async fn run_runtime_repo_backlog_poll_tick(
     Ok(tick)
 }
 
-async fn repo_backlog_project_root(
+pub(super) async fn repo_backlog_project_root(
     repo_config: &harness_core::config::intake::GitHubRepoConfig,
     fallback: &Path,
 ) -> PathBuf {

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod http_router;
 pub(crate) mod init;
 pub(crate) mod misc_routes;
 mod orphan_reaper;
+pub(crate) mod pr_hygiene_background;
 pub(crate) mod rate_limit;
 pub(crate) mod sse_routes;
 pub(crate) mod state;
@@ -239,6 +240,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     // Periodically sweep runtime issue workflows with attached PRs and emit
     // workflow command outbox rows.
     background::spawn_runtime_pr_feedback_sweeper(&state);
+
+    // Periodically inspect managed open PRs for stale DIRTY/BEHIND mergeability
+    // and route repair through workflow-owned PR feedback activities.
+    pr_hygiene_background::spawn_runtime_pr_hygiene_sweeper(&state);
 
     // Periodically ask repo backlog workflows to scan GitHub through runtime
     // jobs so GitHub intake becomes workflow-owned when the runtime is enabled.

--- a/crates/harness-server/src/http/pr_hygiene_background.rs
+++ b/crates/harness-server/src/http/pr_hygiene_background.rs
@@ -1,0 +1,407 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use harness_core::types::{Decision, Event, SessionId};
+
+use super::{background, state::AppState};
+
+const RUNTIME_WORKFLOW_CONFIG_RETRY_SECS: u64 = 30;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RuntimePrHygieneSweepTick {
+    pub inspected: usize,
+    pub repair_requested: usize,
+    pub active_command_exists: usize,
+    pub not_needed: usize,
+    pub skipped: usize,
+    pub rejected: usize,
+}
+
+impl RuntimePrHygieneSweepTick {
+    fn has_visible_activity(self) -> bool {
+        self.inspected > 0
+            || self.repair_requested > 0
+            || self.active_command_exists > 0
+            || self.not_needed > 0
+            || self.skipped > 0
+            || self.rejected > 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct RuntimePrHygieneRepo {
+    repo: String,
+    project_root: PathBuf,
+}
+
+pub(super) async fn run_runtime_pr_hygiene_sweep_tick(
+    state: &Arc<AppState>,
+    limit: usize,
+) -> anyhow::Result<RuntimePrHygieneSweepTick> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(RuntimePrHygieneSweepTick::default());
+    };
+    let repos = runtime_pr_hygiene_repos(state).await;
+    let mut tick = RuntimePrHygieneSweepTick::default();
+    let mut remaining = limit.max(1);
+    for repo in repos {
+        if remaining == 0 {
+            break;
+        }
+        if !repo.project_root.exists() {
+            tracing::warn!(
+                repo = %repo.repo,
+                project_root = %repo.project_root.display(),
+                "workflow runtime PR hygiene skipped unresolvable project path"
+            );
+            tick.skipped += 1;
+            continue;
+        }
+        let workflow_cfg = match background::load_runtime_workflow_config(
+            &repo.project_root,
+            "workflow runtime PR hygiene",
+        ) {
+            Ok(config) => config,
+            Err(_) => {
+                tick.skipped += 1;
+                continue;
+            }
+        };
+        if !workflow_cfg.pr_feedback.enabled
+            || !workflow_cfg.pr_feedback.hygiene_enabled
+            || !workflow_cfg.runtime_dispatch.enabled
+            || !workflow_cfg.runtime_worker.enabled
+        {
+            tick.skipped += 1;
+            continue;
+        }
+        let repo_slug = workflow_source_repo(&workflow_cfg)
+            .unwrap_or(repo.repo.as_str())
+            .to_string();
+        let fetch_limit =
+            remaining.min(workflow_cfg.pr_feedback.hygiene_batch_limit.max(1) as usize);
+        let open_prs = crate::github_pr_hygiene::fetch_open_pr_hygiene(
+            &repo_slug,
+            state.core.server.config.server.github_token.as_deref(),
+            fetch_limit,
+        )
+        .await?;
+        let now = chrono::Utc::now();
+        for pr in open_prs {
+            if remaining == 0 {
+                break;
+            }
+            remaining -= 1;
+            tick.inspected += 1;
+            let dirty_age_secs = pr.dirty_age_secs(now);
+            let result = if pr.requires_mergeability_repair() {
+                let task_id = crate::workflow_runtime_pr_feedback::synthesized_pr_feedback_task_id(
+                    &repo.project_root.to_string_lossy(),
+                    Some(pr.repo_slug.as_str()),
+                    pr.pr_number,
+                );
+                let observed_at = now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+                let updated_at = pr.updated_at_rfc3339();
+                let outcome = crate::workflow_runtime_pr_feedback::request_pr_hygiene_repair(
+                    store,
+                    crate::workflow_runtime_pr_feedback::PrHygieneRepairRuntimeContext {
+                        project_root: &repo.project_root,
+                        repo: Some(pr.repo_slug.as_str()),
+                        task_id: &task_id,
+                        pr_number: pr.pr_number,
+                        pr_url: Some(pr.pr_url.as_str()),
+                        title: pr.title.as_deref(),
+                        merge_state_status: pr.merge_state_status.as_deref(),
+                        head_oid: pr.head_oid.as_deref(),
+                        updated_at: Some(updated_at.as_str()),
+                        observed_at: observed_at.as_str(),
+                        dirty_age_secs,
+                        dirty_age_to_repair_secs: workflow_cfg.pr_feedback.dirty_age_to_repair_secs,
+                        dirty_age_to_comment_secs: workflow_cfg
+                            .pr_feedback
+                            .dirty_age_to_comment_secs,
+                        rebase_needed_label: workflow_cfg.pr_feedback.rebase_needed_label.as_str(),
+                    },
+                )
+                .await?;
+                map_repair_outcome(
+                    &mut tick,
+                    outcome,
+                    dirty_age_secs,
+                    &workflow_cfg.pr_feedback,
+                )
+            } else {
+                tick.not_needed += 1;
+                "ok"
+            };
+            record_pr_hygiene_telemetry(
+                state,
+                &pr,
+                dirty_age_secs,
+                result,
+                &workflow_cfg.pr_feedback,
+            )
+            .await;
+        }
+    }
+    Ok(tick)
+}
+
+fn map_repair_outcome(
+    tick: &mut RuntimePrHygieneSweepTick,
+    outcome: crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome,
+    dirty_age_secs: u64,
+    policy: &harness_core::config::workflow::PrFeedbackPolicy,
+) -> &'static str {
+    match outcome {
+        crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::Requested { .. } => {
+            tick.repair_requested += 1;
+            if dirty_age_secs >= policy.dirty_age_to_comment_secs {
+                "comment_only"
+            } else {
+                "skill_dispatched"
+            }
+        }
+        crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::ActiveCommandExists {
+            ..
+        } => {
+            tick.active_command_exists += 1;
+            "active_command_exists"
+        }
+        crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::NotCandidate {
+            ..
+        } => {
+            tick.skipped += 1;
+            "not_candidate"
+        }
+        crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::Rejected { .. } => {
+            tick.rejected += 1;
+            "rejected"
+        }
+    }
+}
+
+async fn runtime_pr_hygiene_repos(state: &Arc<AppState>) -> Vec<RuntimePrHygieneRepo> {
+    let mut repos = Vec::new();
+    let mut seen = BTreeSet::new();
+    if let Some(github_config) = state
+        .core
+        .server
+        .config
+        .intake
+        .github
+        .as_ref()
+        .filter(|config| config.enabled)
+    {
+        for repo_config in github_config.effective_repos() {
+            let project_root =
+                background::repo_backlog_project_root(&repo_config, &state.core.project_root).await;
+            push_pr_hygiene_repo(&mut repos, &mut seen, repo_config.repo, project_root);
+        }
+    }
+
+    if let Ok(workflow_cfg) = background::load_runtime_workflow_config(
+        &state.core.project_root,
+        "workflow runtime PR hygiene",
+    ) {
+        if let Some(repo) = workflow_source_repo(&workflow_cfg) {
+            push_pr_hygiene_repo(
+                &mut repos,
+                &mut seen,
+                repo.to_string(),
+                state.core.project_root.clone(),
+            );
+        }
+    }
+    repos
+}
+
+fn push_pr_hygiene_repo(
+    repos: &mut Vec<RuntimePrHygieneRepo>,
+    seen: &mut BTreeSet<(String, PathBuf)>,
+    repo: String,
+    project_root: PathBuf,
+) {
+    if repo.trim().is_empty() {
+        return;
+    }
+    let key = (repo.clone(), project_root.clone());
+    if seen.insert(key) {
+        repos.push(RuntimePrHygieneRepo { repo, project_root });
+    }
+}
+
+fn workflow_source_repo(
+    workflow_cfg: &harness_core::config::workflow::WorkflowConfig,
+) -> Option<&str> {
+    workflow_cfg
+        .source
+        .kind
+        .as_deref()
+        .map(|kind| kind.eq_ignore_ascii_case("github"))
+        .unwrap_or(true)
+        .then_some(workflow_cfg.source.repo.as_deref())
+        .flatten()
+        .map(str::trim)
+        .filter(|repo| !repo.is_empty())
+}
+
+async fn record_pr_hygiene_telemetry(
+    state: &Arc<AppState>,
+    pr: &crate::github_pr_hygiene::GitHubOpenPrHygiene,
+    dirty_age_secs: u64,
+    result: &str,
+    policy: &harness_core::config::workflow::PrFeedbackPolicy,
+) {
+    let decision = match result {
+        "rejected" | "not_candidate" | "active_command_exists" => Decision::Warn,
+        _ => Decision::Pass,
+    };
+    let mut event = Event::new(
+        SessionId::new(),
+        "pr_rebase_attempted",
+        "workflow_runtime_pr_hygiene",
+        decision,
+    );
+    event.reason = Some(result.to_string());
+    event.detail = Some(format!(
+        "repo={} pr_number={} merge_state_status={} dirty_age_secs={} result={}",
+        pr.repo_slug,
+        pr.pr_number,
+        pr.merge_state_status.as_deref().unwrap_or("<unknown>"),
+        dirty_age_secs,
+        result
+    ));
+    event.content = Some(
+        serde_json::json!({
+            "repo": pr.repo_slug,
+            "pr_number": pr.pr_number,
+            "pr_url": pr.pr_url,
+            "merge_state_status": pr.merge_state_status,
+            "head_oid": pr.head_oid,
+            "updated_at": pr.updated_at_rfc3339(),
+            "dirty_age_secs": dirty_age_secs,
+            "age_source": "updated_at",
+            "result": result,
+            "dirty_age_to_repair_secs": policy.dirty_age_to_repair_secs,
+            "dirty_age_to_comment_secs": policy.dirty_age_to_comment_secs,
+            "rebase_needed_label": policy.rebase_needed_label,
+        })
+        .to_string(),
+    );
+    if let Err(error) = state.observability.events.log(&event).await {
+        tracing::warn!(
+            repo = %pr.repo_slug,
+            pr_number = pr.pr_number,
+            "workflow runtime PR hygiene failed to log pr_rebase_attempted: {error}"
+        );
+    }
+    tracing::info!(
+        repo = %pr.repo_slug,
+        pr_number = pr.pr_number,
+        merge_state_status = ?pr.merge_state_status,
+        dirty_age_secs,
+        result,
+        "pr_rebase_attempted"
+    );
+}
+
+pub(super) fn spawn_runtime_pr_hygiene_sweeper(state: &Arc<AppState>) {
+    if state.core.workflow_runtime_store.is_none() {
+        tracing::debug!("workflow runtime PR hygiene sweeper disabled: store unavailable");
+        return;
+    }
+
+    let weak_state = Arc::downgrade(state);
+    tokio::spawn(async move {
+        loop {
+            let state = match weak_state.upgrade() {
+                Some(state) => state,
+                None => break,
+            };
+            let workflow_cfg = match background::load_runtime_workflow_config(
+                &state.core.project_root,
+                "workflow runtime PR hygiene sweeper",
+            ) {
+                Ok(config) => config,
+                Err(_) => {
+                    tokio::time::sleep(std::time::Duration::from_secs(
+                        RUNTIME_WORKFLOW_CONFIG_RETRY_SECS,
+                    ))
+                    .await;
+                    continue;
+                }
+            };
+            let interval = std::time::Duration::from_secs(
+                workflow_cfg.pr_feedback.hygiene_interval_secs.max(1),
+            );
+            let batch_limit = workflow_cfg.pr_feedback.hygiene_batch_limit.max(1) as usize;
+            if workflow_cfg.pr_feedback.enabled && workflow_cfg.pr_feedback.hygiene_enabled {
+                match run_runtime_pr_hygiene_sweep_tick(&state, batch_limit).await {
+                    Ok(tick) if tick.has_visible_activity() => {
+                        tracing::info!(
+                            inspected = tick.inspected,
+                            repair_requested = tick.repair_requested,
+                            active_command_exists = tick.active_command_exists,
+                            not_needed = tick.not_needed,
+                            skipped = tick.skipped,
+                            rejected = tick.rejected,
+                            "workflow runtime PR hygiene sweeper tick complete"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        tracing::warn!("workflow runtime PR hygiene sweeper tick failed: {error}");
+                    }
+                }
+            }
+            tokio::time::sleep(interval).await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workflow_source_repo_accepts_github_source_repo() {
+        let mut cfg = harness_core::config::workflow::WorkflowConfig::default();
+        cfg.source.kind = Some("github".to_string());
+        cfg.source.repo = Some("owner/repo".to_string());
+
+        assert_eq!(workflow_source_repo(&cfg), Some("owner/repo"));
+    }
+
+    #[test]
+    fn workflow_source_repo_ignores_non_github_source_repo() {
+        let mut cfg = harness_core::config::workflow::WorkflowConfig::default();
+        cfg.source.kind = Some("feishu".to_string());
+        cfg.source.repo = Some("owner/repo".to_string());
+
+        assert_eq!(workflow_source_repo(&cfg), None);
+    }
+
+    #[test]
+    fn map_repair_outcome_marks_comment_threshold() {
+        let mut tick = RuntimePrHygieneSweepTick::default();
+        let policy = harness_core::config::workflow::PrFeedbackPolicy {
+            dirty_age_to_comment_secs: 100,
+            ..Default::default()
+        };
+
+        let result = map_repair_outcome(
+            &mut tick,
+            crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::Requested {
+                workflow_id: "wf".to_string(),
+                task_id: "task".to_string(),
+            },
+            100,
+            &policy,
+        );
+
+        assert_eq!(result, "comment_only");
+        assert_eq!(tick.repair_requested, 1);
+    }
+}

--- a/crates/harness-server/src/http/pr_hygiene_background.rs
+++ b/crates/harness-server/src/http/pr_hygiene_background.rs
@@ -95,7 +95,9 @@ pub(super) async fn run_runtime_pr_hygiene_sweep_tick(
             remaining -= 1;
             tick.inspected += 1;
             let dirty_age_secs = pr.dirty_age_secs(now);
-            let result = if pr.requires_mergeability_repair() {
+            let result = if pr.requires_mergeability_repair()
+                && should_request_pr_hygiene_repair(dirty_age_secs, &workflow_cfg.pr_feedback)
+            {
                 let task_id = crate::workflow_runtime_pr_feedback::synthesized_pr_feedback_task_id(
                     &repo.project_root.to_string_lossy(),
                     Some(pr.repo_slug.as_str()),
@@ -131,6 +133,9 @@ pub(super) async fn run_runtime_pr_hygiene_sweep_tick(
                     dirty_age_secs,
                     &workflow_cfg.pr_feedback,
                 )
+            } else if pr.requires_mergeability_repair() {
+                tick.not_needed += 1;
+                "not_stale_enough"
             } else {
                 tick.not_needed += 1;
                 "ok"
@@ -146,6 +151,13 @@ pub(super) async fn run_runtime_pr_hygiene_sweep_tick(
         }
     }
     Ok(tick)
+}
+
+fn should_request_pr_hygiene_repair(
+    dirty_age_secs: u64,
+    policy: &harness_core::config::workflow::PrFeedbackPolicy,
+) -> bool {
+    dirty_age_secs >= policy.dirty_age_to_repair_secs
 }
 
 fn map_repair_outcome(
@@ -403,5 +415,16 @@ mod tests {
 
         assert_eq!(result, "comment_only");
         assert_eq!(tick.repair_requested, 1);
+    }
+
+    #[test]
+    fn should_request_pr_hygiene_repair_honors_repair_threshold() {
+        let policy = harness_core::config::workflow::PrFeedbackPolicy {
+            dirty_age_to_repair_secs: 100,
+            ..Default::default()
+        };
+
+        assert!(!should_request_pr_hygiene_repair(99, &policy));
+        assert!(should_request_pr_hygiene_repair(100, &policy));
     }
 }

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -21,6 +21,7 @@ pub mod db;
 pub mod eval_store;
 pub mod event_replay;
 pub(crate) mod github_auth;
+pub(crate) mod github_pr_hygiene;
 pub(crate) mod github_pr_snapshot;
 pub mod handlers;
 pub mod hook_enforcer;

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -2,13 +2,14 @@ use crate::task_runner::TaskId;
 use harness_workflow::runtime::{
     build_local_review_completed_decision, build_local_review_request_decision,
     build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_sweep_decision,
-    DecisionValidator, LocalReviewCompletedInput, LocalReviewDecisionInput, LocalReviewOutcome,
-    PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
-    PrFeedbackSweepDecisionInput, ValidationContext, WorkflowCommand, WorkflowCommandStatus,
-    WorkflowCommandType, WorkflowDecision, WorkflowDecisionTransition, WorkflowDefinition,
-    WorkflowEvidence, WorkflowInstance, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
-    WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY,
-    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
+    build_pr_hygiene_repair_decision, DecisionValidator, LocalReviewCompletedInput,
+    LocalReviewDecisionInput, LocalReviewOutcome, PrDetectedDecisionInput, PrFeedbackDecisionInput,
+    PrFeedbackOutcome, PrFeedbackSweepDecisionInput, PrHygieneRepairDecisionInput,
+    ValidationContext, WorkflowCommand, WorkflowCommandStatus, WorkflowCommandType,
+    WorkflowDecision, WorkflowDecisionTransition, WorkflowDefinition, WorkflowEvidence,
+    WorkflowInstance, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore, WorkflowSubject,
+    GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
+    PR_FEEDBACK_INSPECT_ACTIVITY,
 };
 use serde_json::json;
 use std::path::Path;
@@ -70,6 +71,23 @@ pub(crate) struct PrFeedbackSweepRuntimeContext<'a> {
     pub task_id: &'a TaskId,
     pub pr_number: u64,
     pub pr_url: Option<&'a str>,
+}
+
+pub(crate) struct PrHygieneRepairRuntimeContext<'a> {
+    pub project_root: &'a Path,
+    pub repo: Option<&'a str>,
+    pub task_id: &'a TaskId,
+    pub pr_number: u64,
+    pub pr_url: Option<&'a str>,
+    pub title: Option<&'a str>,
+    pub merge_state_status: Option<&'a str>,
+    pub head_oid: Option<&'a str>,
+    pub updated_at: Option<&'a str>,
+    pub observed_at: &'a str,
+    pub dirty_age_secs: u64,
+    pub dirty_age_to_repair_secs: u64,
+    pub dirty_age_to_comment_secs: u64,
+    pub rebase_needed_label: &'a str,
 }
 
 struct PrRuntimeTarget {
@@ -310,6 +328,53 @@ pub(crate) async fn request_pr_feedback_sweep_for_pr(
     upsert_github_issue_pr_definition(store).await?;
     store.upsert_instance(&instance).await?;
     request_local_review(store, &instance.id).await
+}
+
+pub(crate) async fn request_pr_hygiene_repair(
+    store: &WorkflowRuntimeStore,
+    ctx: PrHygieneRepairRuntimeContext<'_>,
+) -> anyhow::Result<PrFeedbackSweepRequestOutcome> {
+    let PrRuntimeTarget {
+        instance,
+        new_instance,
+        issue_number,
+    } = load_or_pr_runtime_target(
+        store,
+        ctx.project_root,
+        ctx.repo,
+        None,
+        ctx.pr_number,
+        ctx.task_id,
+        ctx.pr_url,
+        "awaiting_feedback",
+    )
+    .await?;
+
+    match instance.state.as_str() {
+        "awaiting_feedback" | "addressing_feedback" => {}
+        "pr_open" => return request_local_review(store, &instance.id).await,
+        "local_review_gate" => {
+            return Ok(PrFeedbackSweepRequestOutcome::ActiveCommandExists {
+                workflow_id: instance.id.clone(),
+                task_id: runtime_task_id_from_instance(&instance),
+            });
+        }
+        _ => {
+            return Ok(PrFeedbackSweepRequestOutcome::NotCandidate {
+                workflow_id: instance.id,
+                state: instance.state,
+            });
+        }
+    }
+
+    if has_active_pr_feedback_command_with_activity(store, &instance.id, 0, None).await? {
+        return Ok(PrFeedbackSweepRequestOutcome::ActiveCommandExists {
+            workflow_id: instance.id.clone(),
+            task_id: runtime_task_id_from_instance(&instance),
+        });
+    }
+
+    persist_pr_hygiene_repair_request(store, instance, new_instance, issue_number, ctx).await
 }
 
 pub(crate) async fn request_local_review(
@@ -584,6 +649,121 @@ async fn persist_pr_feedback_sweep_request(
         output.decision,
         "PrFeedbackSweepRequested",
         "workflow_runtime_pr_feedback",
+        event_payload,
+        accepted_data,
+    )
+    .await?
+    {
+        RuntimeDecisionCommitOutcome::Accepted => Ok(PrFeedbackSweepRequestOutcome::Requested {
+            workflow_id,
+            task_id,
+        }),
+        RuntimeDecisionCommitOutcome::Rejected { reason } => {
+            Ok(PrFeedbackSweepRequestOutcome::Rejected {
+                workflow_id,
+                reason,
+            })
+        }
+        RuntimeDecisionCommitOutcome::Stale => {
+            let state = store
+                .get_instance(&workflow_id)
+                .await?
+                .map(|instance| instance.state)
+                .unwrap_or_else(|| "missing".to_string());
+            Ok(PrFeedbackSweepRequestOutcome::NotCandidate { workflow_id, state })
+        }
+    }
+}
+
+async fn persist_pr_hygiene_repair_request(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    new_instance: bool,
+    issue_number: Option<u64>,
+    ctx: PrHygieneRepairRuntimeContext<'_>,
+) -> anyhow::Result<PrFeedbackSweepRequestOutcome> {
+    let workflow_id = instance.id.clone();
+    let task_id = runtime_task_id_from_instance(&instance);
+    let project_id = ctx.project_root.to_string_lossy().into_owned();
+    let pr_url = optional_string_field(&instance.data, "pr_url").or_else(|| {
+        ctx.pr_url
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    });
+    let repo = optional_string_field(&instance.data, "repo").or_else(|| {
+        ctx.repo
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    });
+    let summary = format!(
+        "Runtime PR hygiene found mergeability repair is needed for PR #{}.",
+        ctx.pr_number
+    );
+    let hygiene_context = json!({
+        "source": "pr_hygiene",
+        "repo": repo.as_deref(),
+        "pr_number": ctx.pr_number,
+        "pr_url": pr_url.as_deref(),
+        "title": ctx.title,
+        "merge_state_status": ctx.merge_state_status,
+        "head_oid": ctx.head_oid,
+        "updated_at": ctx.updated_at,
+        "observed_at": ctx.observed_at,
+        "dirty_age_secs": ctx.dirty_age_secs,
+        "age_source": "updated_at",
+        "dirty_age_to_repair_secs": ctx.dirty_age_to_repair_secs,
+        "dirty_age_to_comment_secs": ctx.dirty_age_to_comment_secs,
+        "rebase_needed_label": ctx.rebase_needed_label,
+        "instructions": [
+            "Try a GitHub-side update or rebase for this PR before making unrelated code changes.",
+            "If GitHub-side update or rebase fails, apply the configured rebase-needed label.",
+            "Escalate when dirty_age_secs is at least dirty_age_to_repair_secs.",
+            "Comment asking whether the PR should be closed when dirty_age_secs is at least dirty_age_to_comment_secs and no recent activity explains the stale state."
+        ],
+    });
+    let mut accepted_data = pr_runtime_data(
+        ctx.project_root,
+        project_id,
+        repo.as_deref(),
+        issue_number,
+        ctx.task_id,
+        ctx.pr_number,
+        pr_url.as_deref(),
+        Some(&summary),
+    );
+    if let Some(object) = accepted_data.as_object_mut() {
+        object.insert("hygiene_context".to_string(), hygiene_context.clone());
+    }
+    let repair_nonce = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
+    let output = build_pr_hygiene_repair_decision(
+        &instance,
+        PrHygieneRepairDecisionInput {
+            dedupe_key: &format!("pr-hygiene:{}:{repair_nonce}", instance.id),
+            pr_number: ctx.pr_number,
+            pr_url: pr_url.as_deref(),
+            issue_number,
+            repo: repo.as_deref(),
+            summary: &summary,
+            hygiene_context: hygiene_context.clone(),
+        },
+    );
+    let event_payload = json!({
+        "issue_number": issue_number,
+        "repo": repo.as_deref(),
+        "pr_number": ctx.pr_number,
+        "pr_url": pr_url.as_deref(),
+        "merge_state_status": ctx.merge_state_status,
+        "dirty_age_secs": ctx.dirty_age_secs,
+    });
+    match commit_runtime_decision(
+        store,
+        instance,
+        new_instance,
+        output.decision,
+        "PrHygieneRepairRequested",
+        "workflow_runtime_pr_hygiene",
         event_payload,
         accepted_data,
     )

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
@@ -356,6 +356,69 @@ async fn pr_feedback_without_issue_requests_local_review_first() -> anyhow::Resu
 }
 
 #[tokio::test]
+async fn pr_hygiene_repair_requests_address_pr_feedback_with_context() -> anyhow::Result<()> {
+    let Ok(database_url) = resolve_database_url(None) else {
+        return Ok(());
+    };
+    let dir = tempfile::tempdir()?;
+    let store =
+        match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url)).await {
+            Ok(store) => store,
+            Err(_) => return Ok(()),
+        };
+    let project_root = dir.path().join("project-hygiene");
+    std::fs::create_dir(&project_root)?;
+    let task_id =
+        synthesized_pr_feedback_task_id(&project_root.to_string_lossy(), Some("owner/repo"), 81);
+
+    let outcome = request_pr_hygiene_repair(
+        &store,
+        PrHygieneRepairRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            task_id: &task_id,
+            pr_number: 81,
+            pr_url: Some("https://github.com/owner/repo/pull/81"),
+            title: Some("Dirty PR"),
+            merge_state_status: Some("DIRTY"),
+            head_oid: Some("abc123"),
+            updated_at: Some("2026-06-10T00:00:00Z"),
+            observed_at: "2026-06-12T00:00:00Z",
+            dirty_age_secs: 172800,
+            dirty_age_to_repair_secs: 172800,
+            dirty_age_to_comment_secs: 604800,
+            rebase_needed_label: "rebase-needed",
+        },
+    )
+    .await?;
+
+    let workflow_id = match outcome {
+        PrFeedbackSweepRequestOutcome::Requested { workflow_id, .. } => workflow_id,
+        other => anyhow::bail!("expected hygiene repair request, got {other:?}"),
+    };
+    let Some(instance) = store.get_instance(&workflow_id).await? else {
+        anyhow::bail!("workflow should exist");
+    };
+    assert_eq!(instance.state, "addressing_feedback");
+    let commands = store.commands_for(&workflow_id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(
+        commands[0].command.activity_name(),
+        Some("address_pr_feedback")
+    );
+    assert_eq!(commands[0].command.command["source"], "pr_hygiene");
+    assert_eq!(
+        commands[0].command.command["hygiene"]["dirty_age_secs"],
+        172800
+    );
+    assert_eq!(
+        commands[0].command.command["hygiene"]["rebase_needed_label"],
+        "rebase-needed"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn pr_feedback_without_issue_uses_bound_workflow_for_local_review() -> anyhow::Result<()> {
     let Ok(database_url) = resolve_database_url(None) else {
         return Ok(());

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -332,7 +332,7 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
             "on_succeeded": {
                 "reducer_next_state": "local_review_gate",
                 "success_requires": "A succeeded address_pr_feedback result MUST include pr_repair_snapshot with final head, observed_at, action proof, and passing validation evidence, unless IssueClosed/IssueAlreadyResolved or issue_state proves the issue or PR is already closed/resolved.",
-                "required_summary": "Describe addressed review feedback, pushed/no-code action, validation evidence, or closed issue evidence. Harness will run local review before remote feedback unless terminal closed evidence finishes the workflow."
+                "required_summary": "Describe addressed review feedback, pushed/no-code action, validation evidence, or closed issue evidence. For command_input.source=pr_hygiene, describe the GitHub-side update/rebase attempt, configured rebase-needed label action on failure, and stale comment/escalation threshold decision. Harness will run local review before remote feedback unless terminal closed evidence finishes the workflow."
             },
             "on_failed": {
                 "reducer_next_state": "failed_or_retry",
@@ -533,7 +533,7 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             "must_not_include": ["direct workflow state changes"],
         }),
         ("github_issue_pr", "address_pr_feedback") => json!({
-            "must_include": ["review feedback addressed or explicit no-code reason", "changed files or explicit no-code-change reason", "validation commands or closed issue evidence", "fresh PR state checked before final response", "final PR head or closed issue evidence"],
+            "must_include": ["review feedback addressed or explicit no-code reason", "changed files or explicit no-code-change reason", "validation commands or closed issue evidence", "fresh PR state checked before final response", "final PR head or closed issue evidence", "pr_hygiene update/rebase, label, escalation, or stale-comment outcome when command_input.source=pr_hygiene"],
             "must_not_include": ["claiming review approval without a fresh review signal", "marking review threads resolved without current GitHub evidence"],
             "artifacts": {
                 "pr_repair_snapshot": {

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -97,6 +97,16 @@ fn activity_result_schema_reminds_pr_feedback_to_recheck_pr_state() {
         .is_some_and(
             |items| items.contains(&json!("fresh PR state checked before final response"))
         ));
+    assert!(schema["agent_summary_contract"]["must_include"]
+        .as_array()
+        .is_some_and(|items| items.iter().any(|item| item
+            .as_str()
+            .is_some_and(|value| value.contains("pr_hygiene update/rebase")))));
+    assert!(
+        schema["transition_contract"]["on_succeeded"]["required_summary"]
+            .as_str()
+            .is_some_and(|value| value.contains("command_input.source=pr_hygiene"))
+    );
     assert_eq!(
         schema["agent_summary_contract"]["artifacts"]["pr_repair_snapshot"]["required_unless"],
         "IssueClosed/IssueAlreadyResolved signal or issue_state artifact proves the issue or PR is already closed/resolved."

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -42,13 +42,13 @@ pub use plan_issue::{
 pub use pr_feedback::{
     build_local_review_completed_decision, build_local_review_request_decision,
     build_pr_detected_decision, build_pr_feedback_decision, build_pr_feedback_inspect_decision,
-    build_pr_feedback_sweep_decision, LocalReviewCompletedInput, LocalReviewDecisionInput,
-    LocalReviewOutcome, PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackDecisionOutput,
-    PrFeedbackInspectDecisionInput, PrFeedbackOutcome, PrFeedbackSweepDecisionInput,
-    PrFeedbackWorkflowAction, LOCAL_REVIEW_ACTIVITY, LOCAL_REVIEW_BLOCKED_SIGNAL,
-    LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL, LOCAL_REVIEW_PASSED_SIGNAL, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY, PR_FEEDBACK_SNAPSHOT_ARTIFACT, PR_REPAIR_SNAPSHOT_ARTIFACT,
-    SERVER_PR_SNAPSHOT_ARTIFACT,
+    build_pr_feedback_sweep_decision, build_pr_hygiene_repair_decision, LocalReviewCompletedInput,
+    LocalReviewDecisionInput, LocalReviewOutcome, PrDetectedDecisionInput, PrFeedbackDecisionInput,
+    PrFeedbackDecisionOutput, PrFeedbackInspectDecisionInput, PrFeedbackOutcome,
+    PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, PrHygieneRepairDecisionInput,
+    LOCAL_REVIEW_ACTIVITY, LOCAL_REVIEW_BLOCKED_SIGNAL, LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+    LOCAL_REVIEW_PASSED_SIGNAL, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
+    PR_FEEDBACK_SNAPSHOT_ARTIFACT, PR_REPAIR_SNAPSHOT_ARTIFACT, SERVER_PR_SNAPSHOT_ARTIFACT,
 };
 pub use prompt_task::{
     build_prompt_submission_decision, PromptSubmissionDecisionInput,

--- a/crates/harness-workflow/src/runtime/pr_feedback.rs
+++ b/crates/harness-workflow/src/runtime/pr_feedback.rs
@@ -2,6 +2,7 @@ use super::model::{
     WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowEvidence, WorkflowInstance,
 };
 use super::quality_gate::{QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID};
+use serde_json::{json, Value};
 
 pub const PR_FEEDBACK_DEFINITION_ID: &str = "pr_feedback";
 pub const PR_FEEDBACK_INSPECT_ACTIVITY: &str = "inspect_pr_feedback";
@@ -23,6 +24,7 @@ pub enum PrFeedbackWorkflowAction {
     SweepFeedback,
     InspectFeedback,
     AddressFeedback,
+    HygieneRepair,
     AwaitFeedback,
     RequestQualityGate,
     ReadyToMerge,
@@ -59,6 +61,17 @@ pub struct PrFeedbackSweepDecisionInput<'a> {
     pub issue_number: Option<u64>,
     pub repo: Option<&'a str>,
     pub summary: &'a str,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrHygieneRepairDecisionInput<'a> {
+    pub dedupe_key: &'a str,
+    pub pr_number: u64,
+    pub pr_url: Option<&'a str>,
+    pub issue_number: Option<u64>,
+    pub repo: Option<&'a str>,
+    pub summary: &'a str,
+    pub hygiene_context: Value,
 }
 
 #[derive(Debug, Clone)]
@@ -342,6 +355,42 @@ pub fn build_pr_feedback_sweep_decision(
     }
 }
 
+pub fn build_pr_hygiene_repair_decision(
+    instance: &WorkflowInstance,
+    input: PrHygieneRepairDecisionInput<'_>,
+) -> PrFeedbackDecisionOutput {
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "address_pr_feedback",
+        "addressing_feedback",
+        input.summary,
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        input.dedupe_key,
+        json!({
+            "activity": "address_pr_feedback",
+            "source": "pr_hygiene",
+            "pr_number": input.pr_number,
+            "pr_url": input.pr_url,
+            "issue_number": input.issue_number,
+            "repo": input.repo,
+            "review_summary": input.summary,
+            "hygiene": input.hygiene_context,
+        }),
+    ))
+    .with_evidence(WorkflowEvidence::new(
+        "pr_hygiene",
+        hygiene_repair_summary(input),
+    ));
+
+    PrFeedbackDecisionOutput {
+        action: PrFeedbackWorkflowAction::HygieneRepair,
+        decision,
+    }
+}
+
 pub fn build_pr_feedback_inspect_decision(
     instance: &WorkflowInstance,
     input: PrFeedbackInspectDecisionInput<'_>,
@@ -436,6 +485,35 @@ fn feedback_sweep_summary(input: PrFeedbackSweepDecisionInput<'_>) -> String {
     }
     if let Some(repo) = input.repo {
         parts.push(format!("repo={repo}"));
+    }
+    parts.push(input.summary.to_string());
+    parts.join(" ")
+}
+
+fn hygiene_repair_summary(input: PrHygieneRepairDecisionInput<'_>) -> String {
+    let mut parts = vec![format!("pr={}", input.pr_number)];
+    if let Some(pr_url) = input.pr_url {
+        parts.push(format!("url={pr_url}"));
+    }
+    if let Some(issue_number) = input.issue_number {
+        parts.push(format!("issue={issue_number}"));
+    }
+    if let Some(repo) = input.repo {
+        parts.push(format!("repo={repo}"));
+    }
+    if let Some(merge_state_status) = input
+        .hygiene_context
+        .get("merge_state_status")
+        .and_then(Value::as_str)
+    {
+        parts.push(format!("merge_state_status={merge_state_status}"));
+    }
+    if let Some(dirty_age_secs) = input
+        .hygiene_context
+        .get("dirty_age_secs")
+        .and_then(Value::as_u64)
+    {
+        parts.push(format!("dirty_age_secs={dirty_age_secs}"));
     }
     parts.push(input.summary.to_string());
     parts.join(" ")

--- a/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
+++ b/crates/harness-workflow/src/runtime/tests/pr_repair_evidence.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::runtime::{PR_REPAIR_SNAPSHOT_ARTIFACT, SERVER_PR_SNAPSHOT_ARTIFACT};
+use crate::runtime::{
+    build_pr_hygiene_repair_decision, PrHygieneRepairDecisionInput, PR_REPAIR_SNAPSHOT_ARTIFACT,
+    SERVER_PR_SNAPSHOT_ARTIFACT,
+};
 
 fn pr_workflow_state(state: &str) -> WorkflowInstance {
     issue_instance(state).with_data(json!({
@@ -21,6 +24,49 @@ fn event_for_result(result: ActivityResult) -> WorkflowEvent {
         "runtime_job_id": "job-1",
         "activity_result": result,
     }))
+}
+
+#[test]
+fn pr_hygiene_repair_decision_preserves_rebase_context() {
+    let instance = issue_instance("awaiting_feedback");
+    let output = build_pr_hygiene_repair_decision(
+        &instance,
+        PrHygieneRepairDecisionInput {
+            dedupe_key: "pr-hygiene:owner/repo:77",
+            pr_number: 77,
+            pr_url: Some("https://github.com/owner/repo/pull/77"),
+            issue_number: Some(123),
+            repo: Some("owner/repo"),
+            summary: "Runtime PR hygiene found mergeability repair is needed.",
+            hygiene_context: json!({
+                "merge_state_status": "DIRTY",
+                "dirty_age_secs": 172800,
+                "dirty_age_to_repair_secs": 172800,
+                "dirty_age_to_comment_secs": 604800,
+                "rebase_needed_label": "rebase-needed",
+            }),
+        },
+    );
+
+    assert_eq!(output.action, PrFeedbackWorkflowAction::HygieneRepair);
+    assert_eq!(output.decision.decision, "address_pr_feedback");
+    assert_eq!(output.decision.next_state, "addressing_feedback");
+    assert_eq!(
+        output.decision.commands[0].activity_name(),
+        Some("address_pr_feedback")
+    );
+    assert_eq!(output.decision.commands[0].command["source"], "pr_hygiene");
+    assert_eq!(
+        output.decision.commands[0].command["hygiene"]["rebase_needed_label"],
+        "rebase-needed"
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &output.decision,
+            &ValidationContext::new("workflow-policy", Utc::now()),
+        )
+        .expect("PR hygiene repair decision should validate");
 }
 
 fn ready_snapshot_artifact() -> ActivityArtifact {


### PR DESCRIPTION
## Summary
- add configurable PR hygiene policy defaults for cadence, dirty-age thresholds, label, and batch limit
- collect open PR mergeability snapshots through GitHub GraphQL and log pr_rebase_attempted telemetry per PR per tick
- run a server-owned hygiene sweeper that routes DIRTY/BEHIND PRs into address_pr_feedback with rebase/update, label, escalation, and stale-comment context

## Validation
- cargo test -p harness-core load_workflow_config
- cargo test -p harness-workflow pr_hygiene_repair_decision_preserves_rebase_context
- cargo test -p harness-server github_pr_hygiene
- cargo test -p harness-server pr_hygiene_repair_requests_address_pr_feedback_with_context
- cargo test -p harness-server pr_hygiene_background
- cargo test -p harness-server runtime_pr_feedback_sweep
- cargo test -p harness-workflow pr_feedback
- cargo test -p harness-server activity_result_schema_reminds_pr_feedback_to_recheck_pr_state
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- rg -n 'Command::new\\(\"(gh|git)\"' crates/harness-core crates/harness-server crates/harness-workflow || true

Closes #987