### PR TITLE
fix(runtime): commit submissions atomically

### DIFF
--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -19,6 +19,8 @@ const PROMPT_TASK_DESCRIPTION: &str = "prompt task";
 
 #[path = "workflow_runtime_submission/cancel.rs"]
 mod cancel;
+#[path = "workflow_runtime_submission/commit.rs"]
+mod commit;
 #[path = "workflow_runtime_submission/dependencies.rs"]
 mod dependencies;
 #[path = "workflow_runtime_submission/prompt_memory.rs"]
@@ -30,12 +32,14 @@ pub(crate) use cancel::{
     cancel_issue_submission_by_task_id, cancel_submission_by_workflow_id,
     RuntimeSubmissionCancelError, RuntimeSubmissionCancelOutcome,
 };
+use commit::{apply_decision, apply_prompt_decision};
 pub(crate) use dependencies::{
     release_ready_issue_dependencies, release_ready_prompt_dependencies,
     resolve_issue_dependency_status, RuntimeDependencyStatus,
 };
 #[cfg(test)]
 pub(crate) use prompt_memory::clear_prompt_submission_prompt_cache_for_test;
+use prompt_memory::prompt_ref_for_submission;
 #[cfg(test)]
 use prompt_memory::{
     cache_prompt_submission_prompt, remove_prompt_submission_prompt,
@@ -44,14 +48,6 @@ use prompt_memory::{
 pub(crate) use prompt_memory::{
     lookup_prompt_submission_prompt, lookup_prompt_submission_prompt_durable,
     remove_terminal_prompt_submission_payload,
-};
-use prompt_memory::{
-    persist_prompt_submission_prompt, prompt_ref_for_submission,
-    remove_prompt_submission_prompt_durable,
-};
-use replay::{
-    decision_for_event, disambiguate_submission_command_dedupe, submission_event_for_replay,
-    SubmissionEventSelection,
 };
 
 pub(crate) struct PromptSubmissionRuntimeContext<'a> {
@@ -214,245 +210,6 @@ fn prompt_submission_dependency_ids(ctx: &PromptSubmissionRuntimeContext<'_>) ->
         }
     }
     depends_on
-}
-
-async fn apply_decision(
-    store: &WorkflowRuntimeStore,
-    mut instance: WorkflowInstance,
-    new_instance: bool,
-    mut decision: WorkflowDecision,
-    ctx: &IssueSubmissionRuntimeContext<'_>,
-    accepted_data: serde_json::Value,
-) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
-    let validation_context = if instance.is_terminal() {
-        ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
-    } else {
-        ValidationContext::new("workflow-policy", chrono::Utc::now())
-    };
-    if new_instance {
-        store.upsert_instance(&instance).await?;
-    }
-    let event = issue_submission_event_id_or_append(store, &instance.id, ctx).await?;
-    if event.disambiguates_command_dedupe() {
-        disambiguate_submission_command_dedupe(&mut decision, &event.event_id);
-    }
-    let record =
-        if let Some(record) = decision_for_event(store, &instance.id, &event.event_id).await? {
-            record
-        } else {
-            let validation = DecisionValidator::github_issue_pr().validate(
-                &instance,
-                &decision,
-                &validation_context,
-            );
-            match validation {
-                Ok(()) => {
-                    WorkflowDecisionRecord::accepted(decision.clone(), Some(event.event_id.clone()))
-                }
-                Err(error) => {
-                    let reason = error.to_string();
-                    let record =
-                        WorkflowDecisionRecord::rejected(decision, Some(event.event_id), &reason);
-                    store.record_decision(&record).await?;
-                    return Ok(WorkflowSubmissionRuntimeRecord {
-                        workflow_id: instance.id,
-                        accepted: false,
-                        decision_id: record.id,
-                        command_ids: Vec::new(),
-                        rejection_reason: Some(reason),
-                    });
-                }
-            }
-        };
-    if !record.accepted {
-        return Ok(WorkflowSubmissionRuntimeRecord {
-            workflow_id: instance.id,
-            accepted: false,
-            decision_id: record.id,
-            command_ids: Vec::new(),
-            rejection_reason: record.rejection_reason,
-        });
-    }
-    store.record_decision(&record).await?;
-    let mut command_ids = Vec::with_capacity(record.decision.commands.len());
-    for command in &record.decision.commands {
-        command_ids.push(
-            store
-                .enqueue_command(&instance.id, Some(&record.id), command)
-                .await?,
-        );
-    }
-    instance.state = record.decision.next_state.clone();
-    instance.version = instance.version.saturating_add(1);
-    instance.data = merge_last_decision(accepted_data, &record.decision.decision);
-    store.upsert_instance(&instance).await?;
-    Ok(WorkflowSubmissionRuntimeRecord {
-        workflow_id: instance.id,
-        accepted: true,
-        decision_id: record.id,
-        command_ids,
-        rejection_reason: None,
-    })
-}
-async fn issue_submission_event_id_or_append(
-    store: &WorkflowRuntimeStore,
-    workflow_id: &str,
-    ctx: &IssueSubmissionRuntimeContext<'_>,
-) -> anyhow::Result<SubmissionEventSelection> {
-    let lookup =
-        submission_event_for_replay(store, workflow_id, "IssueSubmitted", ctx.task_id).await?;
-    if let Some(event_id) = lookup.event_id {
-        return Ok(SubmissionEventSelection {
-            event_id,
-            has_prior_attempt: true,
-            replay_existing: true,
-        });
-    }
-    let event_id = store
-        .append_event(
-            workflow_id,
-            "IssueSubmitted",
-            "workflow_runtime_submission",
-            json!({
-                "task_id": ctx.task_id.as_str(),
-                "repo": ctx.repo,
-                "issue_number": ctx.issue_number,
-                "labels": ctx.labels,
-                "force_execute": ctx.force_execute,
-                "additional_prompt": ctx.additional_prompt,
-                "depends_on": depends_on_strings(ctx.depends_on),
-                "dependencies_blocked": ctx.dependencies_blocked,
-                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
-            }),
-        )
-        .await?
-        .id;
-    Ok(SubmissionEventSelection {
-        event_id,
-        has_prior_attempt: lookup.has_prior_attempt,
-        replay_existing: false,
-    })
-}
-
-async fn prompt_submission_event_id_or_append(
-    store: &WorkflowRuntimeStore,
-    workflow_id: &str,
-    ctx: &PromptSubmissionRuntimeContext<'_>,
-) -> anyhow::Result<SubmissionEventSelection> {
-    let lookup =
-        submission_event_for_replay(store, workflow_id, "PromptSubmitted", ctx.task_id).await?;
-    if let Some(event_id) = lookup.event_id {
-        return Ok(SubmissionEventSelection {
-            event_id,
-            has_prior_attempt: true,
-            replay_existing: true,
-        });
-    }
-    let event_id = store
-        .append_event(
-            workflow_id,
-            "PromptSubmitted",
-            "workflow_runtime_submission",
-            json!({
-                "task_id": ctx.task_id.as_str(),
-                "prompt_chars": ctx.prompt.chars().count(),
-                "depends_on": depends_on_strings(ctx.depends_on),
-                "serialization_depends_on": depends_on_strings(ctx.serialization_depends_on),
-                "dependencies_blocked": ctx.dependencies_blocked,
-                "source": ctx.source,
-                "external_id": ctx.external_id,
-                "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
-            }),
-        )
-        .await?
-        .id;
-    Ok(SubmissionEventSelection {
-        event_id,
-        has_prior_attempt: lookup.has_prior_attempt,
-        replay_existing: false,
-    })
-}
-async fn apply_prompt_decision(
-    store: &WorkflowRuntimeStore,
-    mut instance: WorkflowInstance,
-    new_instance: bool,
-    mut decision: WorkflowDecision,
-    ctx: &PromptSubmissionRuntimeContext<'_>,
-    accepted_data: serde_json::Value,
-) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
-    let validation_context = if instance.is_terminal() {
-        ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
-    } else {
-        ValidationContext::new("workflow-policy", chrono::Utc::now())
-    };
-    if new_instance {
-        store.upsert_instance(&instance).await?;
-    }
-    let event = prompt_submission_event_id_or_append(store, &instance.id, ctx).await?;
-    if event.disambiguates_command_dedupe() {
-        disambiguate_submission_command_dedupe(&mut decision, &event.event_id);
-    }
-    let record = if let Some(record) =
-        decision_for_event(store, &instance.id, &event.event_id).await?
-    {
-        record
-    } else {
-        let validation =
-            DecisionValidator::prompt_task().validate(&instance, &decision, &validation_context);
-        match validation {
-            Ok(()) => {
-                WorkflowDecisionRecord::accepted(decision.clone(), Some(event.event_id.clone()))
-            }
-            Err(error) => {
-                let reason = error.to_string();
-                let record =
-                    WorkflowDecisionRecord::rejected(decision, Some(event.event_id), &reason);
-                store.record_decision(&record).await?;
-                return Ok(WorkflowSubmissionRuntimeRecord {
-                    workflow_id: instance.id,
-                    accepted: false,
-                    decision_id: record.id,
-                    command_ids: Vec::new(),
-                    rejection_reason: Some(reason),
-                });
-            }
-        }
-    };
-    if !record.accepted {
-        return Ok(WorkflowSubmissionRuntimeRecord {
-            workflow_id: instance.id,
-            accepted: false,
-            decision_id: record.id,
-            command_ids: Vec::new(),
-            rejection_reason: record.rejection_reason,
-        });
-    }
-    store.record_decision(&record).await?;
-    let prompt_ref = string_field(&accepted_data, "prompt_ref")?;
-    let previous_prompt_ref = optional_string_field(&instance.data, "prompt_ref");
-    if previous_prompt_ref.as_deref() != Some(prompt_ref.as_str()) {
-        remove_prompt_submission_prompt_durable(store, previous_prompt_ref.as_deref()).await?;
-    }
-    persist_prompt_submission_prompt(store, &prompt_ref, ctx.prompt).await?;
-    let mut command_ids = Vec::with_capacity(record.decision.commands.len());
-    for command in &record.decision.commands {
-        command_ids.push(
-            store
-                .enqueue_command(&instance.id, Some(&record.id), command)
-                .await?,
-        );
-    }
-    instance.state = record.decision.next_state.clone();
-    instance.version = instance.version.saturating_add(1);
-    instance.data = merge_last_decision(accepted_data, &record.decision.decision);
-    store.upsert_instance(&instance).await?;
-    Ok(WorkflowSubmissionRuntimeRecord {
-        workflow_id: instance.id,
-        accepted: true,
-        decision_id: record.id,
-        command_ids,
-        rejection_reason: None,
-    })
 }
 
 async fn commit_runtime_decision(
@@ -780,6 +537,10 @@ fn set_data_string(mut data: serde_json::Value, key: &str, value: &str) -> serde
     }
     data
 }
+
+#[cfg(test)]
+#[path = "workflow_runtime_submission/atomicity_tests.rs"]
+mod atomicity_tests;
 
 #[cfg(test)]
 #[path = "workflow_runtime_submission/identity_tests.rs"]

--- a/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
@@ -140,3 +140,67 @@ async fn accepted_issue_replay_repairs_pending_command_without_advancing_instanc
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn conflicted_prompt_submission_does_not_persist_prompt_payload() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = open_runtime_store(dir.path()).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let project_id = project_root.to_string_lossy().into_owned();
+    let task_id = TaskId::from_str("runtime-prompt-conflict");
+    let prompt = "preserve this prompt only if the submission commits";
+    let prompt_ref = prompt_ref_for_submission(&project_id, None, &task_id, prompt);
+    let workflow_id = prompt_workflow_id(&project_id, None, &task_id);
+    let stale_instance = prompt_instance(
+        workflow_id.clone(),
+        project_id.clone(),
+        task_id.as_str().to_string(),
+    );
+    let mut live_instance = stale_instance.clone();
+    live_instance.version = live_instance.version.saturating_add(1);
+    store.upsert_instance(&live_instance).await?;
+    let ctx = PromptSubmissionRuntimeContext {
+        project_root: &project_root,
+        task_id: &task_id,
+        prompt,
+        depends_on: &[],
+        serialization_depends_on: &[],
+        dependencies_blocked: false,
+        source: None,
+        external_id: None,
+    };
+    let accepted_data =
+        prompt_submission_data(&ctx, &project_id, &stale_instance.data, &prompt_ref, &[]);
+    let output = build_prompt_submission_decision(
+        &stale_instance,
+        PromptSubmissionDecisionInput {
+            task_id: task_id.as_str(),
+            prompt,
+            prompt_ref: &prompt_ref,
+            source: None,
+            external_id: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+        },
+    );
+
+    let result = commit::apply_prompt_decision(
+        &store,
+        stale_instance,
+        false,
+        output.decision,
+        &ctx,
+        accepted_data,
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert!(store.get_prompt_payload(&prompt_ref).await?.is_none());
+    assert!(lookup_prompt_submission_prompt(&prompt_ref).is_none());
+    Ok(())
+}

--- a/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
@@ -1,0 +1,142 @@
+use super::*;
+use harness_core::db::resolve_database_url;
+use serde_json::json;
+
+async fn open_runtime_store(dir: &Path) -> anyhow::Result<WorkflowRuntimeStore> {
+    let database_url = resolve_database_url(None)?;
+    WorkflowRuntimeStore::open_with_database_url(dir, Some(&database_url)).await
+}
+
+#[tokio::test]
+async fn rejected_new_issue_submission_does_not_persist_live_instance_or_commands(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = open_runtime_store(dir.path()).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let project_id = project_root.to_string_lossy().into_owned();
+    let workflow_id =
+        harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 409);
+    let instance = issue_instance(
+        workflow_id.clone(),
+        project_id,
+        Some("owner/repo".to_string()),
+        409,
+    );
+    let task_id = TaskId::from_str("runtime-rejected-new-issue");
+    let ctx = IssueSubmissionRuntimeContext {
+        project_root: &project_root,
+        repo: Some("owner/repo"),
+        issue_number: 409,
+        task_id: &task_id,
+        labels: &[],
+        force_execute: false,
+        additional_prompt: None,
+        depends_on: &[],
+        dependencies_blocked: false,
+        source: Some("github"),
+        external_id: Some("issue:409"),
+    };
+    let decision = WorkflowDecision::new(
+        &workflow_id,
+        "discovered",
+        "submit_issue",
+        "done",
+        "invalid issue submission transition",
+    );
+
+    let result = commit::apply_decision(&store, instance, true, decision, &ctx, json!({})).await?;
+
+    assert!(!result.accepted);
+    assert!(result.rejection_reason.is_some());
+    assert!(store.get_instance(&workflow_id).await?.is_none());
+    assert!(store.commands_for(&workflow_id).await?.is_empty());
+    let decisions = store.decisions_for(&workflow_id).await?;
+    assert_eq!(decisions.len(), 1);
+    assert!(!decisions[0].accepted);
+    let events = store.events_for(&workflow_id).await?;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_type, "IssueSubmitted");
+    Ok(())
+}
+
+#[tokio::test]
+async fn accepted_issue_replay_repairs_pending_command_without_advancing_instance(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = open_runtime_store(dir.path()).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("runtime-accepted-replay");
+    let labels = vec!["bug".to_string()];
+
+    let first = record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 410,
+            task_id: &task_id,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("github"),
+            external_id: Some("issue:410"),
+        },
+    )
+    .await?;
+    let first_instance = store
+        .get_instance(&first.workflow_id)
+        .await?
+        .expect("accepted issue submission should persist an instance");
+
+    let second = record_issue_submission(
+        &store,
+        IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 410,
+            task_id: &task_id,
+            labels: &labels,
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("github"),
+            external_id: Some("issue:410"),
+        },
+    )
+    .await?;
+
+    assert!(second.accepted);
+    assert_eq!(second.decision_id, first.decision_id);
+    assert_eq!(second.command_ids, first.command_ids);
+    let replayed_instance = store
+        .get_instance(&first.workflow_id)
+        .await?
+        .expect("workflow should remain persisted");
+    assert_eq!(replayed_instance.state, first_instance.state);
+    assert_eq!(replayed_instance.version, first_instance.version);
+    assert_eq!(replayed_instance.data, first_instance.data);
+    assert_eq!(store.decisions_for(&first.workflow_id).await?.len(), 1);
+    assert_eq!(store.commands_for(&first.workflow_id).await?.len(), 1);
+    let events = store.events_for(&first.workflow_id).await?;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.event_type == "IssueSubmitted")
+            .count(),
+        1
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
@@ -204,3 +204,78 @@ async fn conflicted_prompt_submission_does_not_persist_prompt_payload() -> anyho
     assert!(lookup_prompt_submission_prompt(&prompt_ref).is_none());
     Ok(())
 }
+
+#[tokio::test]
+async fn accepted_prompt_replay_with_new_prompt_keeps_referenced_payload() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = open_runtime_store(dir.path()).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("runtime-prompt-replay");
+    let first_prompt = "original prompt";
+    let replay_prompt = "changed prompt on replay";
+    let first = record_prompt_submission(
+        &store,
+        PromptSubmissionRuntimeContext {
+            project_root: &project_root,
+            task_id: &task_id,
+            prompt: first_prompt,
+            depends_on: &[],
+            serialization_depends_on: &[],
+            dependencies_blocked: false,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+    let workflow = store
+        .get_instance(&first.workflow_id)
+        .await?
+        .expect("accepted prompt submission should persist a workflow");
+    let first_prompt_ref = workflow.data["prompt_ref"]
+        .as_str()
+        .expect("workflow should reference the first prompt")
+        .to_string();
+    let replay_prompt_ref = prompt_ref_for_submission(
+        project_root.to_string_lossy().as_ref(),
+        None,
+        &task_id,
+        replay_prompt,
+    );
+
+    let replay = record_prompt_submission(
+        &store,
+        PromptSubmissionRuntimeContext {
+            project_root: &project_root,
+            task_id: &task_id,
+            prompt: replay_prompt,
+            depends_on: &[],
+            serialization_depends_on: &[],
+            dependencies_blocked: false,
+            source: None,
+            external_id: None,
+        },
+    )
+    .await?;
+
+    assert!(replay.accepted);
+    assert_eq!(replay.decision_id, first.decision_id);
+    let workflow = store
+        .get_instance(&first.workflow_id)
+        .await?
+        .expect("workflow should remain persisted");
+    assert_eq!(workflow.data["prompt_ref"], first_prompt_ref);
+    assert_eq!(
+        store.get_prompt_payload(&first_prompt_ref).await?,
+        Some(first_prompt.to_string())
+    );
+    assert!(store
+        .get_prompt_payload(&replay_prompt_ref)
+        .await?
+        .is_none());
+    Ok(())
+}

--- a/crates/harness-server/src/workflow_runtime_submission/commit.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/commit.rs
@@ -224,8 +224,11 @@ pub(super) async fn apply_prompt_decision(
         })
         .await?
         .ok_or_else(|| submission_commit_conflict(&instance.id))?;
-    if previous_prompt_ref.as_deref() != Some(prompt_ref.as_str()) {
-        remove_prompt_submission_prompt_durable(store, previous_prompt_ref.as_deref()).await?;
+    if let Some(previous_prompt_ref) = previous_prompt_ref
+        .as_deref()
+        .filter(|previous_prompt_ref| *previous_prompt_ref != prompt_ref.as_str())
+    {
+        remove_prompt_submission_prompt_durable(store, Some(previous_prompt_ref)).await?;
     }
     Ok(WorkflowSubmissionRuntimeRecord {
         workflow_id: instance.id,

--- a/crates/harness-server/src/workflow_runtime_submission/commit.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/commit.rs
@@ -4,7 +4,7 @@ use super::{
     EXECUTION_PATH_WORKFLOW_RUNTIME,
 };
 use super::{
-    prompt_memory::{persist_prompt_submission_prompt, remove_prompt_submission_prompt_durable},
+    prompt_memory::{cache_prompt_submission_prompt, remove_prompt_submission_prompt},
     replay::{
         decision_for_event, disambiguate_submission_command_dedupe, submission_event_for_replay,
         SubmissionEventSelection,
@@ -13,6 +13,7 @@ use super::{
 use harness_workflow::runtime::{
     DecisionValidator, ValidationContext, WorkflowCommandStatus, WorkflowDecision,
     WorkflowInstance, WorkflowRuntimeStore, WorkflowSubmissionDecisionTransition,
+    WorkflowSubmissionPromptPayload,
 };
 use serde_json::json;
 
@@ -72,6 +73,7 @@ pub(super) async fn apply_decision(
                     rejection_reason: Some(&reason),
                     final_instance: None,
                     command_status: WorkflowCommandStatus::Pending,
+                    prompt_payload: None,
                 })
                 .await?
                 .ok_or_else(|| submission_commit_conflict(&instance.id))?;
@@ -111,6 +113,7 @@ pub(super) async fn apply_decision(
             rejection_reason: None,
             final_instance: Some(&final_instance),
             command_status: WorkflowCommandStatus::Pending,
+            prompt_payload: None,
         })
         .await?
         .ok_or_else(|| submission_commit_conflict(&instance.id))?;
@@ -179,6 +182,7 @@ pub(super) async fn apply_prompt_decision(
                     rejection_reason: Some(&reason),
                     final_instance: None,
                     command_status: WorkflowCommandStatus::Pending,
+                    prompt_payload: None,
                 })
                 .await?
                 .ok_or_else(|| submission_commit_conflict(&instance.id))?;
@@ -194,7 +198,9 @@ pub(super) async fn apply_prompt_decision(
 
     let prompt_ref = string_field(&accepted_data, "prompt_ref")?;
     let previous_prompt_ref = optional_string_field(&instance.data, "prompt_ref");
-    persist_prompt_submission_prompt(store, &prompt_ref, ctx.prompt).await?;
+    let previous_prompt_ref_to_remove = previous_prompt_ref
+        .as_deref()
+        .filter(|previous_prompt_ref| *previous_prompt_ref != prompt_ref.as_str());
     let committed_decision = existing_record
         .as_ref()
         .map(|record| &record.decision)
@@ -221,15 +227,16 @@ pub(super) async fn apply_prompt_decision(
             rejection_reason: None,
             final_instance: Some(&final_instance),
             command_status: WorkflowCommandStatus::Pending,
+            prompt_payload: Some(WorkflowSubmissionPromptPayload {
+                prompt_ref: &prompt_ref,
+                prompt: ctx.prompt,
+                previous_prompt_ref: previous_prompt_ref_to_remove,
+            }),
         })
         .await?
         .ok_or_else(|| submission_commit_conflict(&instance.id))?;
-    if let Some(previous_prompt_ref) = previous_prompt_ref
-        .as_deref()
-        .filter(|previous_prompt_ref| *previous_prompt_ref != prompt_ref.as_str())
-    {
-        remove_prompt_submission_prompt_durable(store, Some(previous_prompt_ref)).await?;
-    }
+    cache_prompt_submission_prompt(&prompt_ref, ctx.prompt);
+    remove_prompt_submission_prompt(previous_prompt_ref_to_remove);
     Ok(WorkflowSubmissionRuntimeRecord {
         workflow_id: instance.id,
         accepted: true,

--- a/crates/harness-server/src/workflow_runtime_submission/commit.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/commit.rs
@@ -197,10 +197,6 @@ pub(super) async fn apply_prompt_decision(
     }
 
     let prompt_ref = string_field(&accepted_data, "prompt_ref")?;
-    let previous_prompt_ref = optional_string_field(&instance.data, "prompt_ref");
-    let previous_prompt_ref_to_remove = previous_prompt_ref
-        .as_deref()
-        .filter(|previous_prompt_ref| *previous_prompt_ref != prompt_ref.as_str());
     let committed_decision = existing_record
         .as_ref()
         .map(|record| &record.decision)
@@ -211,6 +207,13 @@ pub(super) async fn apply_prompt_decision(
         accepted_data,
         preserves_applied_instance(&instance, existing_record.as_ref()),
     );
+    let final_prompt_ref = optional_string_field(&final_instance.data, "prompt_ref");
+    let prompt_payload_commits = final_prompt_ref.as_deref() == Some(prompt_ref.as_str());
+    let previous_prompt_ref = optional_string_field(&instance.data, "prompt_ref");
+    let previous_prompt_ref_to_remove = prompt_payload_commits
+        .then_some(previous_prompt_ref.as_deref())
+        .flatten()
+        .filter(|previous_prompt_ref| *previous_prompt_ref != prompt_ref.as_str());
     let outcome = store
         .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
             workflow_id: &instance.id,
@@ -227,7 +230,7 @@ pub(super) async fn apply_prompt_decision(
             rejection_reason: None,
             final_instance: Some(&final_instance),
             command_status: WorkflowCommandStatus::Pending,
-            prompt_payload: Some(WorkflowSubmissionPromptPayload {
+            prompt_payload: prompt_payload_commits.then_some(WorkflowSubmissionPromptPayload {
                 prompt_ref: &prompt_ref,
                 prompt: ctx.prompt,
                 previous_prompt_ref: previous_prompt_ref_to_remove,
@@ -235,8 +238,10 @@ pub(super) async fn apply_prompt_decision(
         })
         .await?
         .ok_or_else(|| submission_commit_conflict(&instance.id))?;
-    cache_prompt_submission_prompt(&prompt_ref, ctx.prompt);
-    remove_prompt_submission_prompt(previous_prompt_ref_to_remove);
+    if prompt_payload_commits {
+        cache_prompt_submission_prompt(&prompt_ref, ctx.prompt);
+        remove_prompt_submission_prompt(previous_prompt_ref_to_remove);
+    }
     Ok(WorkflowSubmissionRuntimeRecord {
         workflow_id: instance.id,
         accepted: true,

--- a/crates/harness-server/src/workflow_runtime_submission/commit.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/commit.rs
@@ -1,0 +1,324 @@
+use super::{
+    depends_on_strings, merge_last_decision, optional_string_field, string_field,
+    IssueSubmissionRuntimeContext, PromptSubmissionRuntimeContext, WorkflowSubmissionRuntimeRecord,
+    EXECUTION_PATH_WORKFLOW_RUNTIME,
+};
+use super::{
+    prompt_memory::{persist_prompt_submission_prompt, remove_prompt_submission_prompt_durable},
+    replay::{
+        decision_for_event, disambiguate_submission_command_dedupe, submission_event_for_replay,
+        SubmissionEventSelection,
+    },
+};
+use harness_workflow::runtime::{
+    DecisionValidator, ValidationContext, WorkflowCommandStatus, WorkflowDecision,
+    WorkflowInstance, WorkflowRuntimeStore, WorkflowSubmissionDecisionTransition,
+};
+use serde_json::json;
+
+pub(super) async fn apply_decision(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    new_instance: bool,
+    mut decision: WorkflowDecision,
+    ctx: &IssueSubmissionRuntimeContext<'_>,
+    accepted_data: serde_json::Value,
+) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
+    let validation_context = if instance.is_terminal() {
+        ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
+    } else {
+        ValidationContext::new("workflow-policy", chrono::Utc::now())
+    };
+    let event = issue_submission_event_for_commit(store, &instance.id, ctx).await?;
+    let new_event_id = new_submission_event_id(&event);
+    if event.disambiguates_command_dedupe() {
+        let event_id = new_event_id
+            .as_deref()
+            .expect("new replay attempt should reserve an event id");
+        disambiguate_submission_command_dedupe(&mut decision, event_id);
+    }
+    let existing_record = match event.event_id.as_deref() {
+        Some(event_id) => decision_for_event(store, &instance.id, event_id).await?,
+        None => None,
+    };
+    if let Some(record) = existing_record.as_ref().filter(|record| !record.accepted) {
+        return Ok(WorkflowSubmissionRuntimeRecord {
+            workflow_id: instance.id,
+            accepted: false,
+            decision_id: record.id.clone(),
+            command_ids: Vec::new(),
+            rejection_reason: record.rejection_reason.clone(),
+        });
+    }
+
+    if existing_record.is_none() {
+        if let Err(error) =
+            DecisionValidator::github_issue_pr().validate(&instance, &decision, &validation_context)
+        {
+            let reason = error.to_string();
+            let outcome = store
+                .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
+                    workflow_id: &instance.id,
+                    expected_state: &instance.state,
+                    expected_version: instance.version,
+                    create_if_missing: new_instance.then_some(&instance),
+                    event_id: event.event_id.as_deref(),
+                    new_event_id: new_event_id.as_deref(),
+                    event_type: "IssueSubmitted",
+                    source: "workflow_runtime_submission",
+                    payload: issue_submission_event_payload(ctx),
+                    decision: &decision,
+                    existing_record: None,
+                    rejection_reason: Some(&reason),
+                    final_instance: None,
+                    command_status: WorkflowCommandStatus::Pending,
+                })
+                .await?
+                .ok_or_else(|| submission_commit_conflict(&instance.id))?;
+            return Ok(WorkflowSubmissionRuntimeRecord {
+                workflow_id: instance.id,
+                accepted: false,
+                decision_id: outcome.record.id,
+                command_ids: Vec::new(),
+                rejection_reason: Some(reason),
+            });
+        }
+    }
+
+    let committed_decision = existing_record
+        .as_ref()
+        .map(|record| &record.decision)
+        .unwrap_or(&decision);
+    let final_instance = accepted_submission_instance(
+        instance.clone(),
+        committed_decision,
+        accepted_data,
+        preserves_applied_instance(&instance, existing_record.as_ref()),
+    );
+    let outcome = store
+        .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
+            workflow_id: &instance.id,
+            expected_state: &instance.state,
+            expected_version: instance.version,
+            create_if_missing: new_instance.then_some(&instance),
+            event_id: event.event_id.as_deref(),
+            new_event_id: new_event_id.as_deref(),
+            event_type: "IssueSubmitted",
+            source: "workflow_runtime_submission",
+            payload: issue_submission_event_payload(ctx),
+            decision: &decision,
+            existing_record: existing_record.as_ref(),
+            rejection_reason: None,
+            final_instance: Some(&final_instance),
+            command_status: WorkflowCommandStatus::Pending,
+        })
+        .await?
+        .ok_or_else(|| submission_commit_conflict(&instance.id))?;
+    Ok(WorkflowSubmissionRuntimeRecord {
+        workflow_id: instance.id,
+        accepted: true,
+        decision_id: outcome.record.id,
+        command_ids: outcome.command_ids,
+        rejection_reason: None,
+    })
+}
+
+pub(super) async fn apply_prompt_decision(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    new_instance: bool,
+    mut decision: WorkflowDecision,
+    ctx: &PromptSubmissionRuntimeContext<'_>,
+    accepted_data: serde_json::Value,
+) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
+    let validation_context = if instance.is_terminal() {
+        ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
+    } else {
+        ValidationContext::new("workflow-policy", chrono::Utc::now())
+    };
+    let event = prompt_submission_event_for_commit(store, &instance.id, ctx).await?;
+    let new_event_id = new_submission_event_id(&event);
+    if event.disambiguates_command_dedupe() {
+        let event_id = new_event_id
+            .as_deref()
+            .expect("new replay attempt should reserve an event id");
+        disambiguate_submission_command_dedupe(&mut decision, event_id);
+    }
+    let existing_record = match event.event_id.as_deref() {
+        Some(event_id) => decision_for_event(store, &instance.id, event_id).await?,
+        None => None,
+    };
+    if let Some(record) = existing_record.as_ref().filter(|record| !record.accepted) {
+        return Ok(WorkflowSubmissionRuntimeRecord {
+            workflow_id: instance.id,
+            accepted: false,
+            decision_id: record.id.clone(),
+            command_ids: Vec::new(),
+            rejection_reason: record.rejection_reason.clone(),
+        });
+    }
+
+    if existing_record.is_none() {
+        if let Err(error) =
+            DecisionValidator::prompt_task().validate(&instance, &decision, &validation_context)
+        {
+            let reason = error.to_string();
+            let outcome = store
+                .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
+                    workflow_id: &instance.id,
+                    expected_state: &instance.state,
+                    expected_version: instance.version,
+                    create_if_missing: new_instance.then_some(&instance),
+                    event_id: event.event_id.as_deref(),
+                    new_event_id: new_event_id.as_deref(),
+                    event_type: "PromptSubmitted",
+                    source: "workflow_runtime_submission",
+                    payload: prompt_submission_event_payload(ctx),
+                    decision: &decision,
+                    existing_record: None,
+                    rejection_reason: Some(&reason),
+                    final_instance: None,
+                    command_status: WorkflowCommandStatus::Pending,
+                })
+                .await?
+                .ok_or_else(|| submission_commit_conflict(&instance.id))?;
+            return Ok(WorkflowSubmissionRuntimeRecord {
+                workflow_id: instance.id,
+                accepted: false,
+                decision_id: outcome.record.id,
+                command_ids: Vec::new(),
+                rejection_reason: Some(reason),
+            });
+        }
+    }
+
+    let prompt_ref = string_field(&accepted_data, "prompt_ref")?;
+    let previous_prompt_ref = optional_string_field(&instance.data, "prompt_ref");
+    persist_prompt_submission_prompt(store, &prompt_ref, ctx.prompt).await?;
+    let committed_decision = existing_record
+        .as_ref()
+        .map(|record| &record.decision)
+        .unwrap_or(&decision);
+    let final_instance = accepted_submission_instance(
+        instance.clone(),
+        committed_decision,
+        accepted_data,
+        preserves_applied_instance(&instance, existing_record.as_ref()),
+    );
+    let outcome = store
+        .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
+            workflow_id: &instance.id,
+            expected_state: &instance.state,
+            expected_version: instance.version,
+            create_if_missing: new_instance.then_some(&instance),
+            event_id: event.event_id.as_deref(),
+            new_event_id: new_event_id.as_deref(),
+            event_type: "PromptSubmitted",
+            source: "workflow_runtime_submission",
+            payload: prompt_submission_event_payload(ctx),
+            decision: &decision,
+            existing_record: existing_record.as_ref(),
+            rejection_reason: None,
+            final_instance: Some(&final_instance),
+            command_status: WorkflowCommandStatus::Pending,
+        })
+        .await?
+        .ok_or_else(|| submission_commit_conflict(&instance.id))?;
+    if previous_prompt_ref.as_deref() != Some(prompt_ref.as_str()) {
+        remove_prompt_submission_prompt_durable(store, previous_prompt_ref.as_deref()).await?;
+    }
+    Ok(WorkflowSubmissionRuntimeRecord {
+        workflow_id: instance.id,
+        accepted: true,
+        decision_id: outcome.record.id,
+        command_ids: outcome.command_ids,
+        rejection_reason: None,
+    })
+}
+
+async fn issue_submission_event_for_commit(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    ctx: &IssueSubmissionRuntimeContext<'_>,
+) -> anyhow::Result<SubmissionEventSelection> {
+    let lookup =
+        submission_event_for_replay(store, workflow_id, "IssueSubmitted", ctx.task_id).await?;
+    Ok(SubmissionEventSelection {
+        event_id: lookup.event_id,
+        has_prior_attempt: lookup.has_prior_attempt,
+    })
+}
+
+async fn prompt_submission_event_for_commit(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    ctx: &PromptSubmissionRuntimeContext<'_>,
+) -> anyhow::Result<SubmissionEventSelection> {
+    let lookup =
+        submission_event_for_replay(store, workflow_id, "PromptSubmitted", ctx.task_id).await?;
+    Ok(SubmissionEventSelection {
+        event_id: lookup.event_id,
+        has_prior_attempt: lookup.has_prior_attempt,
+    })
+}
+
+fn new_submission_event_id(event: &SubmissionEventSelection) -> Option<String> {
+    event
+        .disambiguates_command_dedupe()
+        .then(|| uuid::Uuid::new_v4().to_string())
+}
+
+fn issue_submission_event_payload(ctx: &IssueSubmissionRuntimeContext<'_>) -> serde_json::Value {
+    json!({
+        "task_id": ctx.task_id.as_str(),
+        "repo": ctx.repo,
+        "issue_number": ctx.issue_number,
+        "labels": ctx.labels,
+        "force_execute": ctx.force_execute,
+        "additional_prompt": ctx.additional_prompt,
+        "depends_on": depends_on_strings(ctx.depends_on),
+        "dependencies_blocked": ctx.dependencies_blocked,
+        "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
+    })
+}
+
+fn prompt_submission_event_payload(ctx: &PromptSubmissionRuntimeContext<'_>) -> serde_json::Value {
+    json!({
+        "task_id": ctx.task_id.as_str(),
+        "prompt_chars": ctx.prompt.chars().count(),
+        "depends_on": depends_on_strings(ctx.depends_on),
+        "serialization_depends_on": depends_on_strings(ctx.serialization_depends_on),
+        "dependencies_blocked": ctx.dependencies_blocked,
+        "source": ctx.source,
+        "external_id": ctx.external_id,
+        "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
+    })
+}
+
+fn accepted_submission_instance(
+    mut instance: WorkflowInstance,
+    decision: &WorkflowDecision,
+    accepted_data: serde_json::Value,
+    preserve_current: bool,
+) -> WorkflowInstance {
+    if preserve_current {
+        return instance;
+    }
+    instance.state = decision.next_state.clone();
+    instance.version = instance.version.saturating_add(1);
+    instance.data = merge_last_decision(accepted_data, &decision.decision);
+    instance
+}
+
+fn preserves_applied_instance(
+    instance: &WorkflowInstance,
+    record: Option<&harness_workflow::runtime::WorkflowDecisionRecord>,
+) -> bool {
+    record.is_some_and(|record| record.accepted && instance.state == record.decision.next_state)
+}
+
+fn submission_commit_conflict(workflow_id: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "workflow submission `{workflow_id}` changed state or version before decision commit"
+    )
+}

--- a/crates/harness-server/src/workflow_runtime_submission/prompt_memory.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/prompt_memory.rs
@@ -33,16 +33,6 @@ pub(crate) async fn lookup_prompt_submission_prompt_durable(
     Ok(Some(prompt))
 }
 
-pub(super) async fn persist_prompt_submission_prompt(
-    store: &WorkflowRuntimeStore,
-    prompt_ref: &str,
-    prompt: &str,
-) -> anyhow::Result<()> {
-    store.upsert_prompt_payload(prompt_ref, prompt).await?;
-    cache_prompt_submission_prompt(prompt_ref, prompt);
-    Ok(())
-}
-
 pub(super) fn cache_prompt_submission_prompt(prompt_ref: &str, prompt: &str) {
     if let Ok(mut prompts) = prompt_submission_prompts().lock() {
         prompts.insert(prompt_ref.to_string(), prompt.to_string());

--- a/crates/harness-server/src/workflow_runtime_submission/replay.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/replay.rs
@@ -4,14 +4,13 @@ use harness_workflow::runtime::{
 };
 
 pub(super) struct SubmissionEventSelection {
-    pub(super) event_id: String,
+    pub(super) event_id: Option<String>,
     pub(super) has_prior_attempt: bool,
-    pub(super) replay_existing: bool,
 }
 
 impl SubmissionEventSelection {
     pub(super) fn disambiguates_command_dedupe(&self) -> bool {
-        self.has_prior_attempt && !self.replay_existing
+        self.has_prior_attempt && self.event_id.is_none()
     }
 }
 

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -81,6 +81,7 @@ pub use repo_backlog::{
 pub use status::WorkflowCommandStatus;
 pub use store::{
     WorkflowDecisionTransition, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
+    WorkflowSubmissionDecisionCommit, WorkflowSubmissionDecisionTransition,
 };
 pub use submission::{
     build_issue_submission_decision, IssueSubmissionDecisionInput, IssueSubmissionDecisionOutput,

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -82,6 +82,7 @@ pub use status::WorkflowCommandStatus;
 pub use store::{
     WorkflowDecisionTransition, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
     WorkflowSubmissionDecisionCommit, WorkflowSubmissionDecisionTransition,
+    WorkflowSubmissionPromptPayload,
 };
 pub use submission::{
     build_issue_submission_decision, IssueSubmissionDecisionInput, IssueSubmissionDecisionOutput,

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -27,6 +27,7 @@ mod command_store;
 mod submission_commit;
 pub use submission_commit::{
     WorkflowSubmissionDecisionCommit, WorkflowSubmissionDecisionTransition,
+    WorkflowSubmissionPromptPayload,
 };
 pub struct WorkflowRuntimeStore {
     pub(super) pool: PgPool,

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -23,6 +23,11 @@ use std::path::Path;
 
 #[path = "store/commands.rs"]
 mod command_store;
+#[path = "store/submission_commit.rs"]
+mod submission_commit;
+pub use submission_commit::{
+    WorkflowSubmissionDecisionCommit, WorkflowSubmissionDecisionTransition,
+};
 pub struct WorkflowRuntimeStore {
     pub(super) pool: PgPool,
 }
@@ -1979,6 +1984,17 @@ async fn insert_event_tx(
     source: &str,
     payload: Value,
 ) -> anyhow::Result<WorkflowEvent> {
+    insert_event_tx_with_id(tx, workflow_id, event_type, source, payload, None).await
+}
+
+async fn insert_event_tx_with_id(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workflow_id: &str,
+    event_type: &str,
+    source: &str,
+    payload: Value,
+    event_id: Option<&str>,
+) -> anyhow::Result<WorkflowEvent> {
     sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
         .bind(format!("workflow_events:{workflow_id}"))
         .execute(&mut **tx)
@@ -1989,8 +2005,11 @@ async fn insert_event_tx(
     .bind(workflow_id)
     .fetch_one(&mut **tx)
     .await?;
-    let event = WorkflowEvent::new(workflow_id, next_sequence as u64, event_type, source)
+    let mut event = WorkflowEvent::new(workflow_id, next_sequence as u64, event_type, source)
         .with_payload(payload);
+    if let Some(event_id) = event_id {
+        event.id = event_id.to_string();
+    }
     let event_data = to_jsonb_string(&event)?;
     sqlx::query(
         "INSERT INTO workflow_events

--- a/crates/harness-workflow/src/runtime/store/submission_commit.rs
+++ b/crates/harness-workflow/src/runtime/store/submission_commit.rs
@@ -23,6 +23,13 @@ pub struct WorkflowSubmissionDecisionTransition<'a> {
     pub rejection_reason: Option<&'a str>,
     pub final_instance: Option<&'a WorkflowInstance>,
     pub command_status: WorkflowCommandStatus,
+    pub prompt_payload: Option<WorkflowSubmissionPromptPayload<'a>>,
+}
+
+pub struct WorkflowSubmissionPromptPayload<'a> {
+    pub prompt_ref: &'a str,
+    pub prompt: &'a str,
+    pub previous_prompt_ref: Option<&'a str>,
 }
 
 pub struct WorkflowSubmissionDecisionCommit {
@@ -127,6 +134,13 @@ impl WorkflowRuntimeStore {
             let final_instance = transition.final_instance.ok_or_else(|| {
                 anyhow::anyhow!("accepted workflow submission requires a final instance")
             })?;
+            if let Some(prompt_payload) = transition.prompt_payload {
+                upsert_prompt_payload_tx(&mut tx, prompt_payload.prompt_ref, prompt_payload.prompt)
+                    .await?;
+                if let Some(previous_prompt_ref) = prompt_payload.previous_prompt_ref {
+                    delete_prompt_payload_tx(&mut tx, previous_prompt_ref).await?;
+                }
+            }
             for command in &record.decision.commands {
                 command_ids.push(
                     command_store::insert_tx(
@@ -192,6 +206,42 @@ async fn load_submission_instance_tx(
         return Ok(Some(initial.clone()));
     }
     select_instance_for_update_tx(tx, transition.workflow_id).await
+}
+
+async fn upsert_prompt_payload_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    prompt_ref: &str,
+    prompt: &str,
+) -> anyhow::Result<()> {
+    if prompt_ref.trim().is_empty() {
+        anyhow::bail!("workflow prompt payload prompt_ref must not be empty");
+    }
+    sqlx::query(
+        "INSERT INTO workflow_prompt_payloads (prompt_ref, prompt)
+         VALUES ($1, $2)
+         ON CONFLICT (prompt_ref) DO UPDATE SET
+            prompt = EXCLUDED.prompt,
+            updated_at = CURRENT_TIMESTAMP",
+    )
+    .bind(prompt_ref)
+    .bind(prompt)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn delete_prompt_payload_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    prompt_ref: &str,
+) -> anyhow::Result<()> {
+    if prompt_ref.trim().is_empty() {
+        return Ok(());
+    }
+    sqlx::query("DELETE FROM workflow_prompt_payloads WHERE prompt_ref = $1")
+        .bind(prompt_ref)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -261,6 +311,7 @@ mod tests {
                 rejection_reason: None,
                 final_instance: Some(&final_instance),
                 command_status: WorkflowCommandStatus::Pending,
+                prompt_payload: None,
             })
             .await?
             .expect("initial submission commit should be accepted");
@@ -292,6 +343,7 @@ mod tests {
                 rejection_reason: None,
                 final_instance: Some(&final_instance),
                 command_status: WorkflowCommandStatus::Pending,
+                prompt_payload: None,
             })
             .await?
             .expect("submission replay should reuse the accepted decision");

--- a/crates/harness-workflow/src/runtime/store/submission_commit.rs
+++ b/crates/harness-workflow/src/runtime/store/submission_commit.rs
@@ -193,3 +193,134 @@ async fn load_submission_instance_tx(
     }
     select_instance_for_update_tx(tx, transition.workflow_id).await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{WorkflowCommand, WorkflowCommandRecord, WorkflowSubject};
+    use harness_core::db::resolve_database_url;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn submission_replay_keeps_completed_commands_when_repairing_pending_commands(
+    ) -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+        let initial = WorkflowInstance::new(
+            "github_issue_pr",
+            1,
+            "addressing_feedback",
+            WorkflowSubject::new("pr", "77"),
+        )
+        .with_id("submission-replay-keeps-completed-commands")
+        .with_data(json!({
+            "project_id": "/project-a",
+            "pr_number": 77,
+        }));
+        let decision = WorkflowDecision::new(
+            &initial.id,
+            "addressing_feedback",
+            "address_feedback",
+            "awaiting_feedback",
+            "review feedback was addressed",
+        )
+        .with_command(WorkflowCommand::enqueue_activity(
+            "run_local_review",
+            "submission-local-review",
+        ))
+        .with_command(WorkflowCommand::enqueue_activity(
+            "inspect_pr_feedback",
+            "submission-remote-feedback",
+        ));
+        let mut final_instance = initial.clone();
+        final_instance.state = "awaiting_feedback".to_string();
+        final_instance.version = final_instance.version.saturating_add(1);
+        final_instance.data = json!({
+            "project_id": "/project-a",
+            "pr_number": 77,
+            "last_decision": "address_feedback",
+        });
+
+        let first_commit = store
+            .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
+                workflow_id: &initial.id,
+                expected_state: &initial.state,
+                expected_version: initial.version,
+                create_if_missing: Some(&initial),
+                event_id: None,
+                new_event_id: Some("submission-replay-event-1"),
+                event_type: "IssueSubmitted",
+                source: "workflow-runtime-test",
+                payload: json!({"task_id": "feedback-submission"}),
+                decision: &decision,
+                existing_record: None,
+                rejection_reason: None,
+                final_instance: Some(&final_instance),
+                command_status: WorkflowCommandStatus::Pending,
+            })
+            .await?
+            .expect("initial submission commit should be accepted");
+        let commands = store.commands_for(&initial.id).await?;
+        assert_eq!(commands.len(), 2);
+        let completed_command_id = command_by_dedupe(&commands, "submission-local-review")
+            .id
+            .clone();
+        let pending_command_id = command_by_dedupe(&commands, "submission-remote-feedback")
+            .id
+            .clone();
+        store
+            .mark_command_status(&completed_command_id, WorkflowCommandStatus::Completed)
+            .await?;
+
+        let replay_commit = store
+            .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
+                workflow_id: &initial.id,
+                expected_state: &final_instance.state,
+                expected_version: final_instance.version,
+                create_if_missing: Some(&initial),
+                event_id: first_commit.record.event_id.as_deref(),
+                new_event_id: None,
+                event_type: "IssueSubmitted",
+                source: "workflow-runtime-test",
+                payload: json!({"task_id": "feedback-submission"}),
+                decision: &decision,
+                existing_record: Some(&first_commit.record),
+                rejection_reason: None,
+                final_instance: Some(&final_instance),
+                command_status: WorkflowCommandStatus::Pending,
+            })
+            .await?
+            .expect("submission replay should reuse the accepted decision");
+
+        assert_eq!(replay_commit.command_ids, first_commit.command_ids);
+        let commands = store.commands_for(&initial.id).await?;
+        assert_eq!(commands.len(), 2);
+        assert_eq!(
+            command_by_dedupe(&commands, "submission-local-review").status,
+            WorkflowCommandStatus::Completed
+        );
+        assert_eq!(
+            store
+                .get_command(&pending_command_id)
+                .await?
+                .expect("pending command should remain present")
+                .status,
+            WorkflowCommandStatus::Pending
+        );
+        Ok(())
+    }
+
+    fn command_by_dedupe<'a>(
+        commands: &'a [WorkflowCommandRecord],
+        dedupe_key: &str,
+    ) -> &'a WorkflowCommandRecord {
+        commands
+            .iter()
+            .find(|command| command.command.dedupe_key == dedupe_key)
+            .expect("command should be present")
+    }
+}

--- a/crates/harness-workflow/src/runtime/store/submission_commit.rs
+++ b/crates/harness-workflow/src/runtime/store/submission_commit.rs
@@ -1,0 +1,195 @@
+use super::{
+    command_store, insert_decision_record_tx, insert_event_tx_with_id,
+    insert_instance_if_absent_tx, select_instance_for_update_tx, upsert_instance_tx,
+    WorkflowRuntimeStore,
+};
+use crate::runtime::{
+    WorkflowCommandStatus, WorkflowDecision, WorkflowDecisionRecord, WorkflowInstance,
+};
+use serde_json::Value;
+
+pub struct WorkflowSubmissionDecisionTransition<'a> {
+    pub workflow_id: &'a str,
+    pub expected_state: &'a str,
+    pub expected_version: u64,
+    pub create_if_missing: Option<&'a WorkflowInstance>,
+    pub event_id: Option<&'a str>,
+    pub new_event_id: Option<&'a str>,
+    pub event_type: &'a str,
+    pub source: &'a str,
+    pub payload: Value,
+    pub decision: &'a WorkflowDecision,
+    pub existing_record: Option<&'a WorkflowDecisionRecord>,
+    pub rejection_reason: Option<&'a str>,
+    pub final_instance: Option<&'a WorkflowInstance>,
+    pub command_status: WorkflowCommandStatus,
+}
+
+pub struct WorkflowSubmissionDecisionCommit {
+    pub record: WorkflowDecisionRecord,
+    pub command_ids: Vec<String>,
+}
+
+impl WorkflowRuntimeStore {
+    pub async fn commit_submission_decision_transition(
+        &self,
+        transition: WorkflowSubmissionDecisionTransition<'_>,
+    ) -> anyhow::Result<Option<WorkflowSubmissionDecisionCommit>> {
+        let decision = transition
+            .existing_record
+            .map(|record| &record.decision)
+            .unwrap_or(transition.decision);
+        if decision.workflow_id != transition.workflow_id {
+            anyhow::bail!(
+                "workflow submission decision `{}` targets `{}` but transition targets `{}`",
+                decision.decision,
+                decision.workflow_id,
+                transition.workflow_id
+            );
+        }
+        if let Some(record) = transition.existing_record {
+            if record.workflow_id != transition.workflow_id {
+                anyhow::bail!(
+                    "workflow submission record `{}` targets `{}` but transition targets `{}`",
+                    record.id,
+                    record.workflow_id,
+                    transition.workflow_id
+                );
+            }
+        }
+        if let Some(final_instance) = transition.final_instance {
+            if final_instance.id != transition.workflow_id {
+                anyhow::bail!(
+                    "workflow submission final instance `{}` does not match transition `{}`",
+                    final_instance.id,
+                    transition.workflow_id
+                );
+            }
+        }
+
+        let mut tx = self.pool.begin().await?;
+        lock_submission_tx(&mut tx, transition.workflow_id).await?;
+        let accepted = transition
+            .existing_record
+            .map(|record| record.accepted)
+            .unwrap_or_else(|| transition.rejection_reason.is_none());
+        let Some(current) = load_submission_instance_tx(&mut tx, &transition, accepted).await?
+        else {
+            return Ok(None);
+        };
+        if current.state != transition.expected_state
+            || current.version != transition.expected_version
+        {
+            return Ok(None);
+        }
+
+        let event_id = if let Some(event_id) = transition.event_id {
+            event_id.to_string()
+        } else {
+            insert_event_tx_with_id(
+                &mut tx,
+                transition.workflow_id,
+                transition.event_type,
+                transition.source,
+                transition.payload,
+                transition.new_event_id,
+            )
+            .await?
+            .id
+        };
+        let record = match transition.existing_record {
+            Some(record) => {
+                if record.event_id.as_deref() != Some(event_id.as_str()) {
+                    anyhow::bail!(
+                        "workflow submission record `{}` is linked to event `{:?}` but transition uses `{}`",
+                        record.id,
+                        record.event_id,
+                        event_id
+                    );
+                }
+                record.clone()
+            }
+            None => match transition.rejection_reason {
+                Some(reason) => WorkflowDecisionRecord::rejected(
+                    transition.decision.clone(),
+                    Some(event_id),
+                    reason,
+                ),
+                None => {
+                    WorkflowDecisionRecord::accepted(transition.decision.clone(), Some(event_id))
+                }
+            },
+        };
+        insert_decision_record_tx(&mut tx, &record).await?;
+
+        let mut command_ids = Vec::new();
+        if record.accepted {
+            let final_instance = transition.final_instance.ok_or_else(|| {
+                anyhow::anyhow!("accepted workflow submission requires a final instance")
+            })?;
+            for command in &record.decision.commands {
+                command_ids.push(
+                    command_store::insert_tx(
+                        &mut tx,
+                        transition.workflow_id,
+                        Some(&record.id),
+                        command,
+                        transition.command_status,
+                    )
+                    .await?,
+                );
+            }
+            upsert_instance_tx(&mut tx, final_instance).await?;
+        }
+
+        tx.commit().await?;
+        Ok(Some(WorkflowSubmissionDecisionCommit {
+            record,
+            command_ids,
+        }))
+    }
+}
+
+async fn lock_submission_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workflow_id: &str,
+) -> anyhow::Result<()> {
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(format!("workflow_submission:{workflow_id}"))
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+async fn load_submission_instance_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    transition: &WorkflowSubmissionDecisionTransition<'_>,
+    accepted: bool,
+) -> anyhow::Result<Option<WorkflowInstance>> {
+    if let Some(current) = select_instance_for_update_tx(tx, transition.workflow_id).await? {
+        return Ok(Some(current));
+    }
+
+    let Some(initial) = transition.create_if_missing else {
+        return Ok(None);
+    };
+    if initial.id != transition.workflow_id {
+        anyhow::bail!(
+            "initial workflow instance `{}` does not match workflow `{}`",
+            initial.id,
+            transition.workflow_id
+        );
+    }
+    if initial.state != transition.expected_state || initial.version != transition.expected_version
+    {
+        return Ok(None);
+    }
+    if !accepted {
+        return Ok(Some(initial.clone()));
+    }
+
+    if insert_instance_if_absent_tx(tx, initial).await? {
+        return Ok(Some(initial.clone()));
+    }
+    select_instance_for_update_tx(tx, transition.workflow_id).await
+}


### PR DESCRIPTION
## Summary
- commit issue/prompt submission event, decision, commands, and final instance updates through one store transaction
- avoid persisting live workflow instances for rejected new submissions
- preserve already-applied accepted instances during pending-command replay while repairing commands idempotently

## Validation
- cargo test -p harness-server atomicity_tests -- --nocapture
- cargo test -p harness-server workflow_runtime_submission -- --nocapture
- cargo fmt --all -- --check
- cargo check -p harness-workflow --all-targets
- cargo check -p harness-server --all-targets
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- env -u GITHUB_TOKEN -u GH_TOKEN -u HARNESS_GITHUB_TOKEN cargo test (1430 passed; 6 unrelated local Postgres pool-contention failures; failed filters passed serially)

Closes #1291