### PR TITLE
fix(runtime): centralize workflow projection mapping

### DIFF
--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -8,6 +8,7 @@
 //! returned as `null` so the UI degrades gracefully.
 
 use crate::http::AppState;
+use crate::runtime_projection::{RuntimeActiveBucket, RuntimeWorkflowProjection};
 use crate::task_runner::{SchedulerAuthorityState, TaskSummary};
 use axum::{extract::State, http::StatusCode, Json};
 use chrono::{DateTime, Duration, Timelike, Utc};
@@ -523,60 +524,26 @@ fn add_active_runtime_workflow(
     counts: &mut ActiveTaskOverviewCounts,
     workflow: &harness_workflow::runtime::WorkflowInstance,
 ) -> bool {
-    let Some(bucket) = runtime_workflow_active_bucket(&workflow.state) else {
+    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+    let Some(bucket) = projection.active_bucket() else {
         return false;
     };
-    let project = workflow
-        .data
-        .get("project_id")
-        .and_then(serde_json::Value::as_str);
-    counts.add(project, bucket);
+    let bucket = match bucket {
+        RuntimeActiveBucket::Running => ActiveTaskBucket::Running,
+        RuntimeActiveBucket::Queued => ActiveTaskBucket::Queued,
+    };
+    counts.add(projection.project_id.as_deref(), bucket);
     true
-}
-
-fn runtime_workflow_active_bucket(state: &str) -> Option<ActiveTaskBucket> {
-    match state {
-        "done" | "passed" | "failed" | "cancelled" => None,
-        "planning" | "implementing" | "replanning" | "addressing_feedback" => {
-            Some(ActiveTaskBucket::Running)
-        }
-        _ => Some(ActiveTaskBucket::Queued),
-    }
 }
 
 fn runtime_workflow_matches_active_legacy_task(
     workflow: &harness_workflow::runtime::WorkflowInstance,
     active_legacy_task_ids: &HashSet<String>,
 ) -> bool {
-    runtime_workflow_dedupe_task_handle(workflow)
+    RuntimeWorkflowProjection::from_workflow(workflow)
+        .legacy_dedupe_task_handle
+        .as_ref()
         .is_some_and(|task_id| active_legacy_task_ids.contains(task_id.as_str()))
-}
-
-fn runtime_workflow_dedupe_task_handle(
-    workflow: &harness_workflow::runtime::WorkflowInstance,
-) -> Option<String> {
-    workflow
-        .data
-        .get("task_id")
-        .and_then(serde_json::Value::as_str)
-        .map(str::trim)
-        .filter(|task_id| !task_id.is_empty())
-        .map(ToOwned::to_owned)
-        .or_else(|| {
-            workflow
-                .data
-                .get("task_ids")
-                .and_then(serde_json::Value::as_array)
-                .and_then(|task_ids| {
-                    task_ids.iter().rev().find_map(|task_id| {
-                        task_id
-                            .as_str()
-                            .map(str::trim)
-                            .filter(|task_id| !task_id.is_empty())
-                            .map(ToOwned::to_owned)
-                    })
-                })
-        })
 }
 
 /// Top of the current hour (i.e. `HH:00:00Z`). Falls back to `now` on the

--- a/crates/harness-server/src/handlers/overview_tests.rs
+++ b/crates/harness-server/src/handlers/overview_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runtime_projection::RuntimeWorkflowProjection;
 use crate::test_helpers;
 use axum::{body::to_bytes, routing::get, Router};
 use harness_core::types::SessionId;
@@ -202,7 +203,9 @@ fn runtime_workflow_without_task_handle_still_counts_active_work() {
         "project_id": "/repo",
     }));
 
-    assert!(runtime_workflow_dedupe_task_handle(&runtime).is_none());
+    assert!(RuntimeWorkflowProjection::from_workflow(&runtime)
+        .legacy_dedupe_task_handle
+        .is_none());
     assert!(!runtime_workflow_matches_active_legacy_task(
         &runtime,
         &active_legacy_task_ids,
@@ -241,7 +244,8 @@ fn terminal_legacy_summary_does_not_suppress_active_runtime_workflow() {
         "project_id": "/repo",
         "task_id": "runtime-task-1",
     }));
-    let task_id = runtime_workflow_dedupe_task_handle(&runtime)
+    let task_id = RuntimeWorkflowProjection::from_workflow(&runtime)
+        .legacy_dedupe_task_handle
         .expect("runtime workflow should expose a task handle");
     if !active_legacy_task_ids.contains(task_id.as_str()) {
         add_active_runtime_workflow(&mut counts, &runtime);
@@ -277,7 +281,8 @@ fn active_legacy_summary_still_suppresses_matching_runtime_workflow() {
         "project_id": "/repo",
         "task_id": "runtime-task-1",
     }));
-    let task_id = runtime_workflow_dedupe_task_handle(&runtime)
+    let task_id = RuntimeWorkflowProjection::from_workflow(&runtime)
+        .legacy_dedupe_task_handle
         .expect("runtime workflow should expose a task handle");
     if !active_legacy_task_ids.contains(task_id.as_str()) {
         add_active_runtime_workflow(&mut counts, &runtime);
@@ -334,9 +339,10 @@ fn active_legacy_summary_suppresses_runtime_workflow_by_current_task_id() {
         "task_id": "current-runtime-task",
         "task_ids": ["historical-runtime-task", "current-runtime-task"],
     }));
-    let task_id = runtime_workflow_dedupe_task_handle(&runtime)
+    let task_id = RuntimeWorkflowProjection::from_workflow(&runtime)
+        .legacy_dedupe_task_handle
         .expect("runtime workflow should expose a task handle");
-    assert_eq!(task_id, "current-runtime-task");
+    assert_eq!(task_id.as_str(), "current-runtime-task");
     if !active_legacy_task_ids.contains(task_id.as_str()) {
         add_active_runtime_workflow(&mut counts, &runtime);
     }

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -12,9 +12,10 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use super::state::AppState;
+use crate::runtime_projection::{runtime_string_field, RuntimeWorkflowProjection};
 use crate::task_runner::{
-    SchedulerAuthorityState, TaskFailureKind, TaskKind, TaskPhase, TaskSchedulerState, TaskState,
-    TaskStatus, TaskSummary, TaskSummaryFilter, TaskSummaryPageCursor, TaskWorkflowSummary,
+    SchedulerAuthorityState, TaskId, TaskKind, TaskState, TaskStatus, TaskSummary,
+    TaskSummaryFilter, TaskSummaryPageCursor, TaskWorkflowSummary,
 };
 use harness_core::proof_of_work::{CiStatus, ProofOfWork, QualitySignal, ReviewOutcome};
 
@@ -617,9 +618,8 @@ async fn append_runtime_definition_summaries(
         .map(|summary| summary.id.as_str().to_string())
         .collect();
     for workflow in workflows {
-        let Some(task_id) =
-            crate::workflow_runtime_submission::runtime_issue_task_handle(&workflow)
-        else {
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+        let Some(task_id) = projection.submission_handle.clone() else {
             continue;
         };
         if !listed_ids.insert(task_id.as_str().to_string()) {
@@ -638,8 +638,8 @@ fn runtime_workflow_task_summary(
     task_id: harness_core::types::TaskId,
     task_kind: TaskKind,
 ) -> TaskSummary {
-    let status = runtime_workflow_state_to_task_status(&workflow.state);
-    let scheduler = runtime_workflow_scheduler_state(&workflow.state, &status);
+    let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+    let status = projection.task_status.clone();
     let issue = workflow
         .data
         .get("issue_number")
@@ -661,7 +661,7 @@ fn runtime_workflow_task_summary(
         id: task_id,
         task_kind,
         status: status.clone(),
-        failure_kind: status.is_failure().then_some(TaskFailureKind::Task),
+        failure_kind: projection.failure_kind,
         turn: 0,
         pr_url: runtime_string_field(&workflow.data, "pr_url"),
         error: runtime_string_field(&workflow.data, "failure_reason"),
@@ -671,89 +671,16 @@ fn runtime_workflow_task_summary(
         repo: runtime_string_field(&workflow.data, "repo"),
         description,
         created_at: Some(workflow.created_at.to_rfc3339()),
-        phase: runtime_workflow_state_to_task_phase(&workflow.state),
+        phase: projection.phase,
         depends_on: runtime_task_id_array(&workflow.data, "depends_on"),
         subtask_ids: Vec::new(),
-        project: runtime_string_field(&workflow.data, "project_id"),
+        project: projection.project_id,
         workspace_path: None,
         workspace_owner: None,
         run_generation: 0,
         workflow: Some(TaskWorkflowSummary::from_runtime_workflow(&workflow)),
-        scheduler,
+        scheduler: projection.scheduler,
     }
-}
-
-pub(super) fn runtime_workflow_state_to_task_status(state: &str) -> TaskStatus {
-    match state {
-        "awaiting_dependencies" => TaskStatus::AwaitingDeps,
-        "scheduled" | "discovered" => TaskStatus::Pending,
-        "planning" => TaskStatus::Planning,
-        "implementing" | "replanning" | "addressing_feedback" => TaskStatus::Implementing,
-        "pr_open"
-        | "local_review_gate"
-        | "awaiting_feedback"
-        | "quality_gate_pending"
-        | "ready_to_merge"
-        | "blocked" => TaskStatus::Waiting,
-        "done" | "passed" => TaskStatus::Done,
-        "failed" => TaskStatus::Failed,
-        "cancelled" => TaskStatus::Cancelled,
-        _ => TaskStatus::Waiting,
-    }
-}
-
-fn runtime_workflow_state_to_task_phase(state: &str) -> TaskPhase {
-    match state {
-        "done" | "passed" | "failed" | "cancelled" => TaskPhase::Terminal,
-        "pr_open"
-        | "local_review_gate"
-        | "awaiting_feedback"
-        | "quality_gate_pending"
-        | "ready_to_merge" => TaskPhase::Review,
-        "planning" | "replanning" | "blocked" => TaskPhase::Plan,
-        _ => TaskPhase::Implement,
-    }
-}
-
-fn runtime_workflow_scheduler_state(state: &str, status: &TaskStatus) -> TaskSchedulerState {
-    match state {
-        "awaiting_dependencies" => TaskSchedulerState::awaiting_dependencies(),
-        "scheduled" | "discovered" => TaskSchedulerState::queued(),
-        "planning" | "implementing" | "replanning" | "addressing_feedback" => TaskSchedulerState {
-            authority_state: SchedulerAuthorityState::Running,
-            owner: None,
-            run_generation: 0,
-            recovery_generation: 0,
-            lease_expires_at: None,
-        },
-        "done" | "passed" | "failed" | "cancelled" => {
-            let mut scheduler = TaskSchedulerState::queued();
-            scheduler.mark_terminal(status);
-            scheduler
-        }
-        "pr_open"
-        | "local_review_gate"
-        | "awaiting_feedback"
-        | "quality_gate_pending"
-        | "ready_to_merge"
-        | "blocked" => TaskSchedulerState::queued(),
-        _ => match status {
-            TaskStatus::AwaitingDeps => TaskSchedulerState::awaiting_dependencies(),
-            TaskStatus::Pending => TaskSchedulerState::queued(),
-            TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled => {
-                let mut scheduler = TaskSchedulerState::queued();
-                scheduler.mark_terminal(status);
-                scheduler
-            }
-            _ => TaskSchedulerState::queued(),
-        },
-    }
-}
-
-pub(super) fn runtime_string_field(data: &serde_json::Value, field: &str) -> Option<String> {
-    data.get(field)
-        .and_then(|value| value.as_str())
-        .map(ToOwned::to_owned)
 }
 
 /// Render the `external_id` shown for a runtime-backed task in dashboard
@@ -772,16 +699,13 @@ pub(super) fn runtime_external_id(
     }
 }
 
-fn runtime_task_id_array(
-    data: &serde_json::Value,
-    field: &str,
-) -> Vec<harness_core::types::TaskId> {
+fn runtime_task_id_array(data: &serde_json::Value, field: &str) -> Vec<TaskId> {
     data.get(field)
         .and_then(|value| value.as_array())
         .into_iter()
         .flatten()
         .filter_map(|value| value.as_str())
-        .map(harness_core::types::TaskId::from_str)
+        .map(TaskId::from_str)
         .collect()
 }
 

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -305,7 +305,8 @@ pub(crate) fn proof_from_runtime_workflow(
     events: &[harness_workflow::runtime::WorkflowEvent],
     decisions: &[harness_workflow::runtime::WorkflowDecisionRecord],
 ) -> ProofOfWork {
-    let status = runtime_workflow_state_to_task_status(&workflow.state);
+    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+    let status = projection.task_status;
     let pr_url = runtime_string_field(&workflow.data, "pr_url")
         .or_else(|| runtime_string_field(&workflow.data, "last_pr_url"));
     let accepted_decisions = decisions
@@ -414,7 +415,7 @@ async fn runtime_proof_by_handle(
     let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
         return Ok(RuntimeProofLookup::Missing);
     };
-    let status = runtime_workflow_state_to_task_status(&workflow.state);
+    let status = RuntimeWorkflowProjection::from_workflow(&workflow).task_status;
     if !status.is_terminal() {
         return Ok(RuntimeProofLookup::InFlight(status.as_ref().to_string()));
     }

--- a/crates/harness-server/src/http/task_query_routes_tests.rs
+++ b/crates/harness-server/src/http/task_query_routes_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
-use crate::task_runner::{RoundResult, TaskState};
+use crate::runtime_projection::RuntimeWorkflowProjection;
+use crate::task_runner::{RoundResult, SchedulerAuthorityState, TaskState, TaskStatus};
 
 fn task_with_id(id: &str) -> TaskState {
     TaskState::new(harness_core::types::TaskId(id.to_string()))
@@ -241,23 +242,32 @@ fn runtime_proof_excludes_merge_events_from_review_rounds() {
 
 #[test]
 fn runtime_workflow_scheduler_state_only_marks_executing_states_running() {
-    let blocked = runtime_workflow_scheduler_state("blocked", &TaskStatus::Waiting);
+    let scheduler_for = |state: &str| {
+        RuntimeWorkflowProjection::from_workflow(&harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            state,
+            harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1"),
+        ))
+        .scheduler
+    };
+
+    let blocked = scheduler_for("blocked");
     assert_eq!(blocked.authority_state, SchedulerAuthorityState::Queued);
 
-    let awaiting_feedback =
-        runtime_workflow_scheduler_state("awaiting_feedback", &TaskStatus::Waiting);
+    let awaiting_feedback = scheduler_for("awaiting_feedback");
     assert_eq!(
         awaiting_feedback.authority_state,
         SchedulerAuthorityState::Queued
     );
 
-    let implementing = runtime_workflow_scheduler_state("implementing", &TaskStatus::Implementing);
+    let implementing = scheduler_for("implementing");
     assert_eq!(
         implementing.authority_state,
         SchedulerAuthorityState::Running
     );
 
-    let planning = runtime_workflow_scheduler_state("planning", &TaskStatus::Planning);
+    let planning = scheduler_for("planning");
     assert_eq!(planning.authority_state, SchedulerAuthorityState::Running);
 }
 

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -47,6 +47,7 @@ pub mod runtime_hosts;
 pub mod runtime_hosts_state;
 pub mod runtime_project_cache;
 pub mod runtime_project_cache_state;
+pub(crate) mod runtime_projection;
 pub mod runtime_state_store;
 pub mod scheduler;
 pub mod self_evolution;

--- a/crates/harness-server/src/runtime_projection.rs
+++ b/crates/harness-server/src/runtime_projection.rs
@@ -125,14 +125,14 @@ fn runtime_submission_handle(data: &serde_json::Value) -> Option<TaskId> {
     trimmed_string_field(data, "submission_id")
         .or_else(|| first_string_array_field(data, "task_ids"))
         .or_else(|| trimmed_string_field(data, "task_id"))
-        .map(|task_id| TaskId::from_str(&task_id))
+        .map(harness_core::types::TaskId)
 }
 
 fn legacy_dedupe_task_handle(data: &serde_json::Value) -> Option<TaskId> {
     trimmed_string_field(data, "task_id")
         .or_else(|| last_string_array_field(data, "task_ids"))
         .or_else(|| trimmed_string_field(data, "submission_id"))
-        .map(|task_id| TaskId::from_str(&task_id))
+        .map(harness_core::types::TaskId)
 }
 
 fn trimmed_string_field(data: &serde_json::Value, field: &str) -> Option<String> {

--- a/crates/harness-server/src/runtime_projection.rs
+++ b/crates/harness-server/src/runtime_projection.rs
@@ -1,0 +1,276 @@
+use crate::task_runner::{
+    SchedulerAuthorityState, TaskFailureKind, TaskId, TaskPhase, TaskSchedulerState, TaskStatus,
+};
+use harness_workflow::runtime::WorkflowInstance;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeActiveBucket {
+    Running,
+    Queued,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RuntimeWorkflowProjection {
+    pub(crate) task_status: TaskStatus,
+    pub(crate) failure_kind: Option<TaskFailureKind>,
+    pub(crate) phase: TaskPhase,
+    pub(crate) scheduler: TaskSchedulerState,
+    pub(crate) project_id: Option<String>,
+    pub(crate) submission_handle: Option<TaskId>,
+    pub(crate) legacy_dedupe_task_handle: Option<TaskId>,
+}
+
+impl RuntimeWorkflowProjection {
+    pub(crate) fn from_workflow(workflow: &WorkflowInstance) -> Self {
+        let task_status = workflow_state_to_task_status(&workflow.state);
+        let scheduler = workflow_scheduler_state(&workflow.state, &task_status);
+        Self {
+            failure_kind: task_status.is_failure().then_some(TaskFailureKind::Task),
+            phase: workflow_state_to_task_phase(&workflow.state),
+            task_status,
+            scheduler,
+            project_id: runtime_string_field(&workflow.data, "project_id"),
+            submission_handle: runtime_submission_handle(&workflow.data),
+            legacy_dedupe_task_handle: legacy_dedupe_task_handle(&workflow.data),
+        }
+    }
+
+    pub(crate) fn active_bucket(&self) -> Option<RuntimeActiveBucket> {
+        if self.task_status.is_terminal() {
+            return None;
+        }
+        match self.scheduler.authority_state {
+            SchedulerAuthorityState::Running
+            | SchedulerAuthorityState::Leased
+            | SchedulerAuthorityState::Recovering => Some(RuntimeActiveBucket::Running),
+            _ => Some(RuntimeActiveBucket::Queued),
+        }
+    }
+}
+
+pub(crate) fn runtime_string_field(data: &serde_json::Value, field: &str) -> Option<String> {
+    data.get(field)
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+}
+
+pub(crate) fn workflow_state_to_task_status(state: &str) -> TaskStatus {
+    match state {
+        "awaiting_dependencies" => TaskStatus::AwaitingDeps,
+        "scheduled" | "discovered" => TaskStatus::Pending,
+        "planning" => TaskStatus::Planning,
+        "implementing" | "replanning" | "addressing_feedback" => TaskStatus::Implementing,
+        "pr_open"
+        | "local_review_gate"
+        | "awaiting_feedback"
+        | "quality_gate_pending"
+        | "ready_to_merge"
+        | "blocked" => TaskStatus::Waiting,
+        "done" | "passed" => TaskStatus::Done,
+        "failed" => TaskStatus::Failed,
+        "cancelled" => TaskStatus::Cancelled,
+        _ => TaskStatus::Waiting,
+    }
+}
+
+fn workflow_state_to_task_phase(state: &str) -> TaskPhase {
+    match state {
+        "done" | "passed" | "failed" | "cancelled" => TaskPhase::Terminal,
+        "pr_open"
+        | "local_review_gate"
+        | "awaiting_feedback"
+        | "quality_gate_pending"
+        | "ready_to_merge" => TaskPhase::Review,
+        "planning" | "replanning" | "blocked" => TaskPhase::Plan,
+        _ => TaskPhase::Implement,
+    }
+}
+
+fn workflow_scheduler_state(state: &str, status: &TaskStatus) -> TaskSchedulerState {
+    match state {
+        "awaiting_dependencies" => TaskSchedulerState::awaiting_dependencies(),
+        "scheduled" | "discovered" => TaskSchedulerState::queued(),
+        "planning" | "implementing" | "replanning" | "addressing_feedback" => TaskSchedulerState {
+            authority_state: SchedulerAuthorityState::Running,
+            owner: None,
+            run_generation: 0,
+            recovery_generation: 0,
+            lease_expires_at: None,
+        },
+        "done" | "passed" | "failed" | "cancelled" => {
+            let mut scheduler = TaskSchedulerState::queued();
+            scheduler.mark_terminal(status);
+            scheduler
+        }
+        "pr_open"
+        | "local_review_gate"
+        | "awaiting_feedback"
+        | "quality_gate_pending"
+        | "ready_to_merge"
+        | "blocked" => TaskSchedulerState::queued(),
+        _ => match status {
+            TaskStatus::AwaitingDeps => TaskSchedulerState::awaiting_dependencies(),
+            TaskStatus::Pending => TaskSchedulerState::queued(),
+            TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled => {
+                let mut scheduler = TaskSchedulerState::queued();
+                scheduler.mark_terminal(status);
+                scheduler
+            }
+            _ => TaskSchedulerState::queued(),
+        },
+    }
+}
+
+fn runtime_submission_handle(data: &serde_json::Value) -> Option<TaskId> {
+    trimmed_string_field(data, "submission_id")
+        .or_else(|| first_string_array_field(data, "task_ids"))
+        .or_else(|| trimmed_string_field(data, "task_id"))
+        .map(|task_id| TaskId::from_str(&task_id))
+}
+
+fn legacy_dedupe_task_handle(data: &serde_json::Value) -> Option<TaskId> {
+    trimmed_string_field(data, "task_id")
+        .or_else(|| last_string_array_field(data, "task_ids"))
+        .or_else(|| trimmed_string_field(data, "submission_id"))
+        .map(|task_id| TaskId::from_str(&task_id))
+}
+
+fn trimmed_string_field(data: &serde_json::Value, field: &str) -> Option<String> {
+    data.get(field).and_then(trimmed_string)
+}
+
+fn first_string_array_field(data: &serde_json::Value, field: &str) -> Option<String> {
+    data.get(field)
+        .and_then(serde_json::Value::as_array)
+        .and_then(|values| values.iter().find_map(trimmed_string))
+}
+
+fn last_string_array_field(data: &serde_json::Value, field: &str) -> Option<String> {
+    data.get(field)
+        .and_then(serde_json::Value::as_array)
+        .and_then(|values| values.iter().rev().find_map(trimmed_string))
+}
+
+fn trimmed_string(value: &serde_json::Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_workflow::runtime::{WorkflowInstance, WorkflowSubject};
+
+    fn workflow(state: &str, data: serde_json::Value) -> WorkflowInstance {
+        WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            state,
+            WorkflowSubject::new("issue", "issue:1"),
+        )
+        .with_data(data)
+    }
+
+    #[test]
+    fn projection_exposes_stable_submission_handle_and_current_legacy_handle() {
+        let workflow = workflow(
+            "implementing",
+            serde_json::json!({
+                "project_id": "/repo",
+                "submission_id": "first-submission",
+                "task_id": "current-task",
+                "task_ids": ["first-submission", "previous-task"],
+            }),
+        );
+
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+        assert_eq!(
+            projection.submission_handle.as_ref().map(TaskId::as_str),
+            Some("first-submission")
+        );
+        assert_eq!(
+            projection
+                .legacy_dedupe_task_handle
+                .as_ref()
+                .map(TaskId::as_str),
+            Some("current-task")
+        );
+    }
+
+    #[test]
+    fn projection_uses_task_history_when_explicit_task_id_is_missing() {
+        let workflow = workflow(
+            "implementing",
+            serde_json::json!({
+                "task_ids": ["first-submission", "current-task"],
+            }),
+        );
+
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+        assert_eq!(
+            projection.submission_handle.as_ref().map(TaskId::as_str),
+            Some("first-submission")
+        );
+        assert_eq!(
+            projection
+                .legacy_dedupe_task_handle
+                .as_ref()
+                .map(TaskId::as_str),
+            Some("current-task")
+        );
+    }
+
+    #[test]
+    fn projection_marks_active_execution_states_as_running() {
+        let workflow = workflow("implementing", serde_json::json!({}));
+
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+        assert_eq!(projection.task_status, TaskStatus::Implementing);
+        assert_eq!(
+            projection.scheduler.authority_state,
+            SchedulerAuthorityState::Running
+        );
+        assert_eq!(
+            projection.active_bucket(),
+            Some(RuntimeActiveBucket::Running)
+        );
+    }
+
+    #[test]
+    fn projection_marks_review_wait_states_as_queued_active_work() {
+        let workflow = workflow("awaiting_feedback", serde_json::json!({}));
+
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+        assert_eq!(projection.task_status, TaskStatus::Waiting);
+        assert_eq!(
+            projection.scheduler.authority_state,
+            SchedulerAuthorityState::Queued
+        );
+        assert_eq!(
+            projection.active_bucket(),
+            Some(RuntimeActiveBucket::Queued)
+        );
+    }
+
+    #[test]
+    fn projection_excludes_terminal_work_from_active_counts() {
+        let workflow = workflow("failed", serde_json::json!({}));
+
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+        assert_eq!(projection.task_status, TaskStatus::Failed);
+        assert_eq!(
+            projection.scheduler.authority_state,
+            SchedulerAuthorityState::Failed
+        );
+        assert_eq!(projection.phase, TaskPhase::Terminal);
+        assert_eq!(projection.active_bucket(), None);
+    }
+}

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -106,7 +106,7 @@ pub(crate) async fn runtime_issue_by_task_id(
 }
 
 pub(crate) fn runtime_issue_task_handle(instance: &WorkflowInstance) -> Option<TaskId> {
-    runtime_submission_id(&instance.data).map(|submission_id| TaskId::from_str(&submission_id))
+    crate::runtime_projection::RuntimeWorkflowProjection::from_workflow(instance).submission_handle
 }
 
 async fn persist_issue_submission(


### PR DESCRIPTION
## Summary
- add a shared server runtime projection contract for workflow lifecycle, task status, phase, scheduler state, project id, stable submission handle, and legacy dedupe handle
- route /api/overview active workflow counts through the shared projection instead of local state mapping
- route runtime task summaries, proof status, and runtime submission handles through the same projection mapping

## Validation
- cargo fmt --all -- --check
- cargo check -p harness-server --all-targets
- cargo test -p harness-server runtime_projection -- --nocapture
- cargo test -p harness-server overview -- --nocapture
- cargo test -p harness-server runtime_workflow_scheduler_state_only_marks_executing_states_running -- --nocapture
- cargo test -p harness-server runtime_issue_task_handle -- --nocapture
- cargo clippy --workspace --all-targets -- -D warnings

Refs #1238

This is a narrow source-of-truth slice for #1238; it does not close the umbrella issue.