### PR TITLE
fix(store): route review findings to shared schema

### DIFF
--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -101,26 +101,40 @@ async fn build_review_store(
         }
     };
 
-    let context =
-        match harness_core::db::PgStoreContext::from_path(&review_db_path, Some(&database_url)) {
-            Ok(context) => context,
-            Err(error) => {
-                setup_pool.close().await;
-                return Ok((
-                    None,
-                    StoreStartupResult::optional("review_store").failed(error.to_string()),
-                ));
-            }
-        };
+    let context = match crate::review_store::ReviewStore::shared_schema_context(Some(&database_url))
+    {
+        Ok(context) => context,
+        Err(error) => {
+            setup_pool.close().await;
+            return Ok((
+                None,
+                StoreStartupResult::optional("review_store").failed(error.to_string()),
+            ));
+        }
+    };
     let review_store =
         crate::review_store::ReviewStore::open_with_context(&context, &setup_pool).await;
     setup_pool.close().await;
 
     match review_store {
-        Ok(store) => Ok((
-            Some(Arc::new(store)),
-            StoreStartupResult::optional("review_store"),
-        )),
+        Ok(store) => {
+            match crate::review_store::migrate_legacy_review_store_if_needed(
+                &review_db_path,
+                Some(&database_url),
+                &store,
+            )
+            .await
+            {
+                Ok(_) => Ok((
+                    Some(Arc::new(store)),
+                    StoreStartupResult::optional("review_store"),
+                )),
+                Err(error) => Ok((
+                    None,
+                    StoreStartupResult::optional("review_store").failed(error.to_string()),
+                )),
+            }
+        }
         Err(error) => Ok((
             None,
             StoreStartupResult::optional("review_store").failed(error.to_string()),

--- a/crates/harness-server/src/review_store/mod.rs
+++ b/crates/harness-server/src/review_store/mod.rs
@@ -566,7 +566,7 @@ pub async fn migrate_legacy_review_store_if_needed(
     }
 
     let legacy_table: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::text")
-        .bind(format!("{legacy_schema}.review_findings"))
+        .bind(format!("\"{legacy_schema}\".review_findings"))
         .fetch_one(&target_store.pool)
         .await?;
     if legacy_table.is_none() {

--- a/crates/harness-server/src/review_store/mod.rs
+++ b/crates/harness-server/src/review_store/mod.rs
@@ -1,4 +1,5 @@
 use harness_core::db::{Migration, PgStoreContext};
+use harness_core::store_backend::{PostgresBackend, StoreLocation};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -17,6 +18,8 @@ type FindingRow = (
     String,
     Option<String>,
 );
+
+pub const REVIEW_STORE_SCHEMA: &str = "review_store";
 
 /// A single finding from a periodic review.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,6 +113,14 @@ impl ReviewStore {
         let context = PgStoreContext::from_path(path, configured_database_url)?;
         let pool = context.open_migrated_pool(REVIEW_MIGRATIONS).await?;
         Ok(Self { pool })
+    }
+
+    pub fn shared_schema_context(
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<PgStoreContext> {
+        PostgresBackend::new(configured_database_url.map(ToOwned::to_owned)).store_context(
+            &StoreLocation::SharedSchema(REVIEW_STORE_SCHEMA.to_string()),
+        )
     }
 
     pub async fn open_with_context(
@@ -543,6 +554,57 @@ impl ReviewStore {
     }
 }
 
+pub async fn migrate_legacy_review_store_if_needed(
+    legacy_path: &Path,
+    configured_database_url: Option<&str>,
+    target_store: &ReviewStore,
+) -> anyhow::Result<u64> {
+    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_schema = legacy_context.schema();
+    if legacy_schema == REVIEW_STORE_SCHEMA {
+        return Ok(0);
+    }
+
+    let legacy_table: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::text")
+        .bind(format!("{legacy_schema}.review_findings"))
+        .fetch_one(&target_store.pool)
+        .await?;
+    if legacy_table.is_none() {
+        return Ok(0);
+    }
+
+    let copy_sql = format!(
+        "INSERT INTO review_findings (
+            id, review_id, rule_id, priority, impact, confidence, effort,
+            file, line, title, description, action, status, created_at,
+            task_id, claimed_at, real_task_id, failure_count, cooldown_until,
+            project_root
+         )
+         SELECT
+            id, review_id, rule_id, priority, impact, confidence, effort,
+            file, line, title, description, action, status, created_at,
+            task_id, claimed_at, real_task_id, failure_count, cooldown_until,
+            project_root
+         FROM \"{legacy_schema}\".review_findings
+         ON CONFLICT DO NOTHING"
+    );
+    let copied = sqlx::query(&copy_sql)
+        .execute(&target_store.pool)
+        .await?
+        .rows_affected();
+
+    if copied > 0 {
+        tracing::info!(
+            copied,
+            legacy_schema,
+            target_schema = REVIEW_STORE_SCHEMA,
+            "review store migration: backfilled legacy review findings into shared schema"
+        );
+    }
+
+    Ok(copied)
+}
+
 /// Parse the agent's JSON output into a ReviewOutput.
 ///
 /// The agent may wrap the JSON in markdown code fences; this function
@@ -625,6 +687,19 @@ mod tests {
     fn parse_invalid_json_returns_error() {
         let raw = "not json at all";
         assert!(parse_review_output(raw).is_err());
+    }
+
+    #[test]
+    fn shared_schema_context_uses_fixed_review_store_schema() -> anyhow::Result<()> {
+        let context = ReviewStore::shared_schema_context(Some(
+            "postgres://user:pass@localhost:5432/harness",
+        ))?;
+        assert_eq!(context.schema(), REVIEW_STORE_SCHEMA);
+        assert!(
+            context.ownership().is_none(),
+            "shared review store schema must not register path-derived ownership"
+        );
+        Ok(())
     }
 }
 

--- a/crates/harness-server/src/review_store/store_tests.rs
+++ b/crates/harness-server/src/review_store/store_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use chrono::Utc;
-use harness_core::db::resolve_database_url;
+use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
 
 async fn open_test_store() -> anyhow::Result<Option<ReviewStore>> {
     if resolve_database_url(None).is_err() {
@@ -9,6 +9,14 @@ async fn open_test_store() -> anyhow::Result<Option<ReviewStore>> {
     let dir = tempfile::tempdir()?;
     let store = ReviewStore::open(&dir.path().join("review.db")).await?;
     Ok(Some(store))
+}
+
+fn unique_test_schema(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_nanos();
+    format!("{prefix}_{nanos}")
 }
 
 fn make_finding(id: &str, rule_id: &str, file: &str, priority: &str) -> ReviewFinding {
@@ -26,6 +34,69 @@ fn make_finding(id: &str, rule_id: &str, file: &str, priority: &str) -> ReviewFi
         action: "fix it".into(),
         task_id: None,
     }
+}
+
+#[tokio::test]
+async fn legacy_review_store_migration_backfills_shared_schema() -> anyhow::Result<()> {
+    let database_url = match resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempfile::tempdir()?;
+    let legacy_path = dir.path().join("reviews.db");
+    let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
+        .schema()
+        .to_owned();
+    let target_schema = unique_test_schema("review_store_test");
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let target_store = ReviewStore::open_with_context(&target_context, &setup_pool).await?;
+    let legacy_store =
+        ReviewStore::open_with_database_url(&legacy_path, Some(&database_url)).await?;
+
+    let result = async {
+        legacy_store
+            .persist_findings(
+                "/tmp/project-a",
+                "rev-legacy",
+                &[make_finding("F1", "RS-03", "src/lib.rs", "P1")],
+            )
+            .await?;
+
+        let copied =
+            migrate_legacy_review_store_if_needed(&legacy_path, Some(&database_url), &target_store)
+                .await?;
+        assert_eq!(copied, 1, "one legacy finding should be copied");
+
+        let copied_again =
+            migrate_legacy_review_store_if_needed(&legacy_path, Some(&database_url), &target_store)
+                .await?;
+        assert_eq!(copied_again, 0, "migration must be idempotent");
+
+        let spawnable = target_store
+            .list_spawnable_findings("rev-legacy", &["P1"])
+            .await?;
+        assert_eq!(spawnable.len(), 1);
+        assert_eq!(spawnable[0].rule_id, "RS-03");
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+
+    legacy_store.pool().close().await;
+    target_store.pool().close().await;
+    sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{legacy_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await?;
+    sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await?;
+    setup_pool.close().await;
+
+    result
 }
 
 async fn get_cooldown(


### PR DESCRIPTION
## Summary
- Route the server review finding store to a fixed shared Postgres schema (`review_store`) instead of deriving a schema from the configured DB path.
- Backfill rows from the legacy path-derived review-store schema during startup before the shared store is used.
- Add regression coverage for shared-schema selection and idempotent legacy backfill.

Refs #1206. This is a narrow slice of the parent storage epic and intentionally does not close it.

## Validation
- cargo fmt --all -- --check
- git diff --check HEAD~1..HEAD
- cargo check -p harness-server --all-targets
- cargo test -p harness-server review_store -- --nocapture
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo check
- env -u GITHUB_TOKEN -u GH_TOKEN cargo test -- --test-threads=1

## Remaining #1206 scope
- Audit and migrate remaining durable stores that still derive Postgres schemas from local paths.
- Continue moving ephemeral file-first state to the local backend seam.
- Remove remaining path-derived schema usage once migrations are complete and add guard/docs coverage for the final storage contract.
