### PR TITLE
fix(runtime): block unknown successful completions

### DIFF
--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -375,19 +375,29 @@ fn stale_success_completion(instance: &WorkflowInstance, result: &ActivityResult
         return true;
     }
 
-    instance.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID
-        && matches!(
+    if instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID {
+        return false;
+    }
+
+    match result.activity.as_str() {
+        "sweep_pr_feedback" | super::pr_feedback::PR_FEEDBACK_INSPECT_ACTIVITY => matches!(
             instance.state.as_str(),
             "addressing_feedback"
                 | "local_review_gate"
                 | "quality_gate_pending"
                 | "ready_to_merge"
                 | "blocked"
-        )
-        && matches!(
-            result.activity.as_str(),
-            "sweep_pr_feedback" | super::pr_feedback::PR_FEEDBACK_INSPECT_ACTIVITY
-        )
+        ),
+        super::pr_feedback::LOCAL_REVIEW_ACTIVITY => matches!(
+            instance.state.as_str(),
+            "awaiting_feedback"
+                | "addressing_feedback"
+                | "quality_gate_pending"
+                | "ready_to_merge"
+                | "blocked"
+        ),
+        _ => false,
+    }
 }
 
 fn workflow_decision_from_activity_result(

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -240,6 +240,10 @@ fn reduce_success(
         return Some(decision);
     }
 
+    if known_success_without_decision(instance, result) {
+        return None;
+    }
+
     let (next_state, decision, reason) = match (
         instance.definition_id.as_str(),
         instance.state.as_str(),
@@ -294,7 +298,15 @@ fn reduce_success(
             "finish_prompt_task",
             "prompt implementation activity completed successfully",
         ),
-        _ => return None,
+        _ => {
+            let reason = format!(
+                "runtime activity `{}` succeeded for workflow `{}` in state `{}`, but no reducer fallback was available",
+                result.activity, instance.definition_id, instance.state
+            );
+            return Some(invalid_agent_output_blocked_decision(
+                instance, event, result, &reason,
+            ));
+        }
     };
 
     let mut workflow_decision =
@@ -331,6 +343,18 @@ fn reduce_success(
     }
 
     Some(workflow_decision.high_confidence())
+}
+
+fn known_success_without_decision(instance: &WorkflowInstance, result: &ActivityResult) -> bool {
+    (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) == (
+        PR_FEEDBACK_DEFINITION_ID,
+        "inspecting",
+        super::pr_feedback::PR_FEEDBACK_INSPECT_ACTIVITY,
+    )
 }
 
 fn workflow_decision_from_activity_result(

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -240,10 +240,6 @@ fn reduce_success(
         return Some(decision);
     }
 
-    if known_success_without_decision(instance, result) {
-        return None;
-    }
-
     let (next_state, decision, reason) = match (
         instance.definition_id.as_str(),
         instance.state.as_str(),
@@ -298,6 +294,7 @@ fn reduce_success(
             "finish_prompt_task",
             "prompt implementation activity completed successfully",
         ),
+        _ if known_success_without_decision(instance, event, result) => return None,
         _ => {
             let reason = format!(
                 "runtime activity `{}` succeeded for workflow `{}` in state `{}`, but no reducer fallback was available",
@@ -345,7 +342,19 @@ fn reduce_success(
     Some(workflow_decision.high_confidence())
 }
 
-fn known_success_without_decision(instance: &WorkflowInstance, result: &ActivityResult) -> bool {
+fn known_success_without_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> bool {
+    if instance.is_terminal() {
+        return true;
+    }
+
+    if event_command_type(event) == Some(WorkflowCommandType::StartChildWorkflow.as_str()) {
+        return true;
+    }
+
     (
         instance.definition_id.as_str(),
         instance.state.as_str(),

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -222,6 +222,10 @@ fn reduce_success(
         return None;
     }
 
+    if stale_success_completion(instance, result) {
+        return None;
+    }
+
     if let Some(decision) = structured_decision.as_ref() {
         let reason = format!(
             "runtime activity `{}` emitted workflow_decision `{}` for workflow `{}` in state `{}`, but the decision to `{}` did not validate and no domain fallback was available",
@@ -347,11 +351,11 @@ fn known_success_without_decision(
     event: &WorkflowEvent,
     result: &ActivityResult,
 ) -> bool {
-    if instance.is_terminal() {
+    if event_command_type(event) == Some(WorkflowCommandType::StartChildWorkflow.as_str()) {
         return true;
     }
 
-    if event_command_type(event) == Some(WorkflowCommandType::StartChildWorkflow.as_str()) {
+    if stale_success_completion(instance, result) {
         return true;
     }
 
@@ -364,6 +368,26 @@ fn known_success_without_decision(
         "inspecting",
         super::pr_feedback::PR_FEEDBACK_INSPECT_ACTIVITY,
     )
+}
+
+fn stale_success_completion(instance: &WorkflowInstance, result: &ActivityResult) -> bool {
+    if instance.is_terminal() {
+        return true;
+    }
+
+    instance.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID
+        && matches!(
+            instance.state.as_str(),
+            "addressing_feedback"
+                | "local_review_gate"
+                | "quality_gate_pending"
+                | "ready_to_merge"
+                | "blocked"
+        )
+        && matches!(
+            result.activity.as_str(),
+            "sweep_pr_feedback" | super::pr_feedback::PR_FEEDBACK_INSPECT_ACTIVITY
+        )
 }
 
 fn workflow_decision_from_activity_result(

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -1700,6 +1700,65 @@ fn runtime_completion_reducer_blocks_unknown_success_without_structured_decision
 }
 
 #[test]
+fn runtime_completion_reducer_ignores_stale_pr_feedback_sweep_after_parent_advances() {
+    let instance = issue_instance("ready_to_merge").with_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+    }));
+    let result = ActivityResult::succeeded(
+        "sweep_pr_feedback",
+        "Late feedback sweep found actionable feedback after the parent advanced.",
+    )
+    .with_signal(ActivitySignal::new(
+        "FeedbackFound",
+        json!({ "count": 1, "pr_number": 77 }),
+    ));
+    let event = runtime_completion_event(&instance, "sweep_pr_feedback", result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event).expect("event should parse");
+
+    assert!(
+        decision.is_none(),
+        "late feedback sweep completion should be treated as obsolete"
+    );
+}
+
+#[test]
+fn runtime_completion_reducer_ignores_stale_pr_feedback_child_after_parent_advances() {
+    let instance = issue_instance("ready_to_merge").with_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+    }));
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Late feedback child reported no actionable feedback after the parent advanced.",
+    )
+    .with_signal(ActivitySignal::new(
+        "NoFeedbackFound",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "child-command-1",
+        "runtime_job_id": "child-job-1",
+        "child_workflow_id": "pr-feedback-child-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event).expect("event should parse");
+
+    assert!(
+        decision.is_none(),
+        "late feedback child completion should be treated as obsolete"
+    );
+}
+
+#[test]
 fn runtime_completion_reducer_ignores_child_workflow_start_ack_without_parent_decision() {
     let instance = issue_instance("quality_gate_pending");
     let command = WorkflowCommand::start_child_workflow(

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -1759,6 +1759,54 @@ fn runtime_completion_reducer_ignores_stale_pr_feedback_child_after_parent_advan
 }
 
 #[test]
+fn runtime_completion_reducer_ignores_stale_local_review_after_pass_advances_parent() {
+    let instance = issue_instance("awaiting_feedback").with_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+    }));
+    let result = ActivityResult::succeeded(
+        LOCAL_REVIEW_ACTIVITY,
+        "Late local review passed after the parent advanced.",
+    )
+    .with_signal(ActivitySignal::new(
+        "LocalReviewPassed",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = runtime_completion_event(&instance, LOCAL_REVIEW_ACTIVITY, result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event).expect("event should parse");
+
+    assert!(
+        decision.is_none(),
+        "late local review pass should be treated as obsolete"
+    );
+}
+
+#[test]
+fn runtime_completion_reducer_ignores_stale_local_review_after_changes_advance_parent() {
+    let instance = issue_instance("addressing_feedback").with_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+    }));
+    let result = ActivityResult::succeeded(
+        LOCAL_REVIEW_ACTIVITY,
+        "Late local review requested changes after the parent advanced.",
+    )
+    .with_signal(ActivitySignal::new(
+        "LocalReviewChangesRequested",
+        json!({ "pr_number": 77 }),
+    ));
+    let event = runtime_completion_event(&instance, LOCAL_REVIEW_ACTIVITY, result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event).expect("event should parse");
+
+    assert!(
+        decision.is_none(),
+        "late local review change request should be treated as obsolete"
+    );
+}
+
+#[test]
 fn runtime_completion_reducer_ignores_child_workflow_start_ack_without_parent_decision() {
     let instance = issue_instance("quality_gate_pending");
     let command = WorkflowCommand::start_child_workflow(

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -1665,6 +1665,41 @@ fn runtime_completion_reducer_blocks_invalid_structured_workflow_decision() {
 }
 
 #[test]
+fn runtime_completion_reducer_blocks_unknown_success_without_structured_decision() {
+    let instance = issue_instance("awaiting_feedback");
+    let result = ActivityResult::succeeded(
+        "unexpected_activity",
+        "Unexpected activity completed without a workflow decision.",
+    );
+    let event = runtime_completion_event(&instance, "unexpected_activity", result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("unknown success should block instead of silently producing no decision");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision
+        .reason
+        .contains("no reducer fallback was available"));
+    assert!(decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::MarkBlocked));
+    assert!(decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::RequestOperatorAttention));
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("unknown successful activity should reduce to a valid blocked decision");
+}
+
+#[test]
 fn repo_backlog_open_issue_without_workflow_starts_child_workflow() {
     let instance = repo_backlog_instance("idle");
     let output = build_open_issue_without_workflow_decision(

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -1700,6 +1700,56 @@ fn runtime_completion_reducer_blocks_unknown_success_without_structured_decision
 }
 
 #[test]
+fn runtime_completion_reducer_ignores_child_workflow_start_ack_without_parent_decision() {
+    let instance = issue_instance("quality_gate_pending");
+    let command = WorkflowCommand::start_child_workflow(
+        QUALITY_GATE_DEFINITION_ID,
+        "pr:77",
+        "quality-gate:issue-123:77",
+    );
+    let result = ActivityResult::succeeded(
+        WorkflowCommandType::StartChildWorkflow.as_str(),
+        "Quality gate child workflow started.",
+    );
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-1",
+        "command": command,
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event).expect("event should parse");
+
+    assert!(
+        decision.is_none(),
+        "child workflow start acknowledgement should wait for child completion"
+    );
+}
+
+#[test]
+fn runtime_completion_reducer_ignores_success_for_already_terminal_workflow() {
+    let instance = issue_instance("done");
+    let result = ActivityResult::succeeded(
+        "implement_issue",
+        "Workflow was already terminal before runtime execution.",
+    );
+    let event = runtime_completion_event(&instance, "implement_issue", result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event).expect("event should parse");
+
+    assert!(
+        decision.is_none(),
+        "stale terminal workflow completion should not produce a new decision"
+    );
+}
+
+#[test]
 fn repo_backlog_open_issue_without_workflow_starts_child_workflow() {
     let instance = repo_backlog_instance("idle");
     let output = build_open_issue_without_workflow_decision(


### PR DESCRIPTION
## Summary
- Block successful runtime completions that have no structured workflow decision and no known reducer fallback.
- Preserve the explicit pr_feedback inspection no-op path while converting unknown successes into block_invalid_agent_output plus operator attention.
- Ignore stale PR-feedback sweep/child completions and stale local-review completions after the parent issue workflow has already advanced past the relevant state.
- Add focused regression tests for unexpected successful activities and stale PR-feedback/local-review completions.

## Validation
- cargo fmt --all -- --check
- cargo test -p harness-workflow runtime_completion_reducer_ignores_stale -- --nocapture
- cargo test -p harness-workflow runtime_completion_reducer -- --nocapture
- cargo test -p harness-workflow
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets

Refs #1226

## Remaining issue scope
This PR is a narrow high-value slice of #1226. The issue still covers broader runtime state-boundary hardening, including per-definition terminal and state registries, DB graph invariants, atomic parent propagation for PR feedback, eventful recovery paths, and a shared runtime projection contract.