### PR TITLE
Stabilize parallel harness-server tests

### DIFF
--- a/crates/harness-server/src/http/startup_tests.rs
+++ b/crates/harness-server/src/http/startup_tests.rs
@@ -64,7 +64,6 @@ fn http_listener_starts_before_background_work() {
 async fn persisted_skills_survive_restart() -> anyhow::Result<()> {
     // Hold the shared HOME_LOCK so no sibling test races on HOME.
     let _lock = HOME_LOCK.lock().await;
-    let _ = crate::test_helpers::test_database_url()?;
 
     let sandbox = tempfile::tempdir()?;
     let project_root = sandbox.path().join("project");

--- a/crates/harness-server/src/http/startup_tests.rs
+++ b/crates/harness-server/src/http/startup_tests.rs
@@ -70,7 +70,7 @@ async fn persisted_skills_survive_restart() -> anyhow::Result<()> {
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;
     let data_dir = sandbox.path().join("data");
-    let database_url = crate::test_helpers::ensure_test_database_url_override()?;
+    let database_url = crate::test_helpers::test_database_url()?;
 
     // Redirect HOME to an empty sandbox directory so that
     // $HOME/.harness/skills/ cannot shadow the persisted skill under

--- a/crates/harness-server/src/http/test_fixtures.rs
+++ b/crates/harness-server/src/http/test_fixtures.rs
@@ -141,7 +141,7 @@ async fn make_read_only_route_test_state_with_project_root(
     agent_registry: AgentRegistry,
 ) -> anyhow::Result<Arc<AppState>> {
     let db_state_guard = crate::test_helpers::acquire_db_state_guard().await;
-    let database_url = crate::test_helpers::ensure_test_database_url_override()?;
+    let database_url = crate::test_helpers::test_database_url()?;
     config.server.database_url = Some(database_url.clone());
     let feishu_intake = config.intake.feishu.as_ref().and_then(|cfg| {
         (cfg.enabled && crate::intake::feishu::has_verification_token(cfg))

--- a/crates/harness-server/src/http/tests/state_support.rs
+++ b/crates/harness-server/src/http/tests/state_support.rs
@@ -255,7 +255,7 @@ pub(super) async fn make_test_state_with_project_root(
 ) -> anyhow::Result<Arc<AppState>> {
     let _ = crate::test_helpers::test_database_url()?;
     let db_state_guard = crate::test_helpers::acquire_db_state_guard().await;
-    let database_url = crate::test_helpers::ensure_test_database_url_override()?;
+    let database_url = crate::test_helpers::test_database_url()?;
     config.server.database_url = Some(database_url.clone());
     let feishu_intake = config.intake.feishu.as_ref().and_then(|cfg| {
         (cfg.enabled && crate::intake::feishu::has_verification_token(cfg))
@@ -324,6 +324,7 @@ pub(super) async fn make_test_state_with_project_root(
         None,
         vec![],
     );
+    drop(db_state_guard);
     Ok(Arc::new(AppState {
         core: crate::http::CoreServices {
             server,
@@ -366,7 +367,7 @@ pub(super) async fn make_test_state_with_project_root(
             workspace_mgr: None,
         },
         #[cfg(test)]
-        _db_state_guard: Some(db_state_guard),
+        _db_state_guard: None,
         runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),

--- a/crates/harness-server/src/http/tests/state_support.rs
+++ b/crates/harness-server/src/http/tests/state_support.rs
@@ -253,7 +253,6 @@ pub(super) async fn make_test_state_with_project_root(
     mut config: harness_core::config::HarnessConfig,
     agent_registry: harness_agents::registry::AgentRegistry,
 ) -> anyhow::Result<Arc<AppState>> {
-    let _ = crate::test_helpers::test_database_url()?;
     let db_state_guard = crate::test_helpers::acquire_db_state_guard().await;
     let database_url = crate::test_helpers::test_database_url()?;
     config.server.database_url = Some(database_url.clone());

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -864,7 +864,7 @@ mod tests {
         }
 
         let _db_state_guard = crate::test_helpers::acquire_db_state_guard().await;
-        let database_url = crate::test_helpers::ensure_test_database_url_override()?;
+        let database_url = crate::test_helpers::test_database_url()?;
         let dir = tempfile::tempdir()?;
         let tasks = crate::task_runner::TaskStore::open_with_database_url(
             &harness_core::config::dirs::default_db_path(dir.path(), "tasks"),

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -83,6 +83,8 @@ impl HarnessServer {
         agent_registry: AgentRegistry,
     ) -> Self {
         config.apply_derived_defaults();
+        #[cfg(test)]
+        crate::test_helpers::configure_test_pg_pool_defaults();
         let retention_days = config.observe.log_retention_days;
         Self {
             config,

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -22,7 +22,7 @@ static TEST_PG_POOL_CONFIGURED: OnceLock<()> = OnceLock::new();
 pub fn configure_test_pg_pool_defaults() {
     TEST_PG_POOL_CONFIGURED.get_or_init(|| {
         let server = harness_core::config::server::ServerConfig {
-            database_pool_max_connections: Some(2),
+            database_pool_max_connections: Some(1),
             database_pool_acquire_timeout_secs: Some(30),
             ..Default::default()
         };

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -22,7 +22,7 @@ static TEST_PG_POOL_CONFIGURED: OnceLock<()> = OnceLock::new();
 pub fn configure_test_pg_pool_defaults() {
     TEST_PG_POOL_CONFIGURED.get_or_init(|| {
         let server = harness_core::config::server::ServerConfig {
-            database_pool_max_connections: Some(1),
+            database_pool_max_connections: Some(2),
             database_pool_acquire_timeout_secs: Some(30),
             ..Default::default()
         };

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicBool, AtomicU64},
-    Arc, Mutex, OnceLock,
+    Arc, OnceLock,
 };
 use std::time::Duration;
 
@@ -15,9 +15,20 @@ use tokio::sync::OnceCell;
 /// spurious "project root must be within HOME" failures.
 pub static HOME_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 static DB_AVAILABLE: OnceCell<bool> = OnceCell::const_new();
-static DATABASE_URL_ENV_LOCK: Mutex<()> = Mutex::new(());
 static DB_STATE_LOCK: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
 static TEST_DATABASE_URL: OnceLock<String> = OnceLock::new();
+static TEST_PG_POOL_CONFIGURED: OnceLock<()> = OnceLock::new();
+
+pub fn configure_test_pg_pool_defaults() {
+    TEST_PG_POOL_CONFIGURED.get_or_init(|| {
+        let server = harness_core::config::server::ServerConfig {
+            database_pool_max_connections: Some(1),
+            database_pool_acquire_timeout_secs: Some(30),
+            ..Default::default()
+        };
+        harness_core::db::configure_pg_pool_from_server(&server);
+    });
+}
 
 fn db_state_lock() -> Arc<tokio::sync::Mutex<()>> {
     DB_STATE_LOCK
@@ -81,6 +92,7 @@ pub fn tempdir_in_home(prefix: &str) -> anyhow::Result<tempfile::TempDir> {
 }
 
 pub async fn db_tests_enabled() -> bool {
+    configure_test_pg_pool_defaults();
     if resolve_database_url(None).is_err() {
         return false;
     }
@@ -102,10 +114,12 @@ pub async fn db_tests_enabled() -> bool {
 }
 
 pub async fn acquire_db_state_guard() -> tokio::sync::OwnedMutexGuard<()> {
+    configure_test_pg_pool_defaults();
     db_state_lock().lock_owned().await
 }
 
 pub fn test_database_url() -> anyhow::Result<String> {
+    configure_test_pg_pool_defaults();
     if let Some(database_url) = TEST_DATABASE_URL.get() {
         return Ok(database_url.clone());
     }
@@ -121,24 +135,6 @@ pub fn test_database_url() -> anyhow::Result<String> {
 
     let url = resolve_database_url(None)?;
     let _ = TEST_DATABASE_URL.set(url.clone());
-    Ok(url)
-}
-
-pub fn ensure_test_database_url_override() -> anyhow::Result<String> {
-    let _guard = DATABASE_URL_ENV_LOCK
-        .lock()
-        .expect("database URL env lock poisoned");
-    if let Ok(url) = std::env::var("HARNESS_DATABASE_URL") {
-        let url = url.trim();
-        if !url.is_empty() {
-            return Ok(url.to_string());
-        }
-    }
-
-    let url = test_database_url()?;
-    unsafe {
-        std::env::set_var("HARNESS_DATABASE_URL", &url);
-    }
     Ok(url)
 }
 
@@ -202,7 +198,7 @@ async fn make_state_inner(
     mut config: HarnessConfig,
 ) -> anyhow::Result<AppState> {
     let db_setup_guard = acquire_db_state_guard().await;
-    let database_url = ensure_test_database_url_override()?;
+    let database_url = test_database_url()?;
     config.server.database_url = Some(database_url.clone());
     let server = Arc::new(HarnessServer::new(
         config,


### PR DESCRIPTION
## Summary
- Remove the harness-server test helper that mutates HARNESS_DATABASE_URL and route remaining fixtures through explicit cached database URLs.
- Install conservative test-only Postgres pool defaults so parallel test stores do not exhaust local Postgres connections.
- Release the shared HTTP test-state DB setup guard before returning AppState.

Closes #1191

## Validation
- cargo fmt --all -- --check
- cargo check -p harness-server --all-targets
- cargo test -p harness-server --lib skill_governance_history
- cargo test -p harness-server --lib runtime_review_concurrency
- cargo test -p harness-server --lib post_tool_use_returns_violations_when_guard_fires
- cargo test -p harness-server --lib empty_data_dir_produces_empty_project_registry
- /usr/bin/time -p cargo test -p harness-server --lib
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- git diff --check