### PR TITLE
fix(runtime): compact runtime tree polling

### DIFF
--- a/crates/harness-cli/src/commands/status.rs
+++ b/crates/harness-cli/src/commands/status.rs
@@ -139,6 +139,7 @@ async fn get_json(
 fn runtime_tree_path(project_id: Option<&str>, limit: i64) -> String {
     let mut query = form_urlencoded::Serializer::new(String::new());
     query.append_pair("limit", &limit.max(1).to_string());
+    query.append_pair("summary_only", "true");
     if let Some(project_id) = project_id.filter(|value| !value.is_empty()) {
         query.append_pair("project_id", project_id);
     }
@@ -340,7 +341,7 @@ mod tests {
     fn runtime_tree_path_encodes_path_like_project_id() {
         assert_eq!(
             runtime_tree_path(Some("/Users/apple/repo name"), 20),
-            "/api/workflows/runtime/tree?limit=20&project_id=%2FUsers%2Fapple%2Frepo+name"
+            "/api/workflows/runtime/tree?limit=20&summary_only=true&project_id=%2FUsers%2Fapple%2Frepo+name"
         );
     }
 
@@ -348,7 +349,7 @@ mod tests {
     fn runtime_tree_path_clamps_limit_and_encodes_project_id() {
         assert_eq!(
             runtime_tree_path(Some("/project-a"), 0),
-            "/api/workflows/runtime/tree?limit=1&project_id=%2Fproject-a"
+            "/api/workflows/runtime/tree?limit=1&summary_only=true&project_id=%2Fproject-a"
         );
     }
 

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -364,7 +364,7 @@ impl WorkflowRuntimeTreePagination {
         let offset = offset.max(0) as usize;
         let total = total.max(0) as usize;
         let next_offset = offset.saturating_add(returned);
-        let has_more = next_offset < total;
+        let has_more = !summary_only && next_offset < total;
         Self {
             limit,
             offset,
@@ -881,25 +881,36 @@ async fn build_compact_workflow_runtime_nodes(
 }
 
 fn compact_workflow_command(command: WorkflowCommand) -> WorkflowCommand {
+    let WorkflowCommand {
+        command_type,
+        dedupe_key,
+        command,
+    } = command;
+    let Value::Object(object) = command else {
+        return WorkflowCommand {
+            command_type,
+            dedupe_key,
+            command,
+        };
+    };
+
     let mut payload = serde_json::Map::new();
-    if let Some(object) = command.command.as_object() {
-        for key in [
-            "activity",
-            "definition_id",
-            "subject_key",
-            "pr_number",
-            "pr_url",
-            "reason",
-            "concern",
-        ] {
-            if let Some(value) = object.get(key) {
-                payload.insert(key.to_string(), value.clone());
-            }
+    for key in [
+        "activity",
+        "definition_id",
+        "subject_key",
+        "pr_number",
+        "pr_url",
+        "reason",
+        "concern",
+    ] {
+        if let Some(value) = object.get(key) {
+            payload.insert(key.to_string(), value.clone());
         }
     }
     WorkflowCommand {
-        command_type: command.command_type,
-        dedupe_key: command.dedupe_key,
+        command_type,
+        dedupe_key,
         command: Value::Object(payload),
     }
 }

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -13,10 +13,11 @@ use std::sync::Arc;
 
 use super::{state::AppState, task_routes};
 use crate::{router, task_runner};
+use harness_workflow::runtime::store::{RuntimeEventSummary, RuntimeJobCompactRecord};
 use harness_workflow::runtime::{
     runtime_job_running_lease_state_at, RuntimeEvent, RuntimeJob, RuntimeJobStatus,
     WorkflowCommand, WorkflowCommandRecord, WorkflowDecisionRecord, WorkflowEvent,
-    WorkflowInstance,
+    WorkflowInstance, WorkflowLease,
 };
 
 const ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE: &str = "activity_result_envelope";
@@ -25,6 +26,10 @@ const WORKFLOW_RUNTIME_TREE_DEFAULT_LIMIT: i64 = 100;
 const WORKFLOW_RUNTIME_TREE_MAX_LIMIT: i64 = 500;
 const WORKFLOW_RUNTIME_TREE_DEFAULT_JOB_LIMIT: i64 = 5;
 const WORKFLOW_RUNTIME_TREE_MAX_JOB_LIMIT: i64 = 50;
+const WORKFLOW_RUNTIME_TREE_DEFAULT_COMMAND_LIMIT: i64 = 5;
+const WORKFLOW_RUNTIME_TREE_MAX_COMMAND_LIMIT: i64 = 50;
+const WORKFLOW_RUNTIME_TREE_DEFAULT_REJECTED_DECISION_LIMIT: i64 = 3;
+const WORKFLOW_RUNTIME_TREE_MAX_REJECTED_DECISION_LIMIT: i64 = 20;
 
 fn startup_error_code(error: Option<&str>) -> Option<&'static str> {
     let error = error?;
@@ -140,6 +145,26 @@ pub(crate) struct WorkflowRuntimeTreeQuery {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
     pub job_limit: Option<i64>,
+    pub command_limit: Option<i64>,
+    pub rejected_decision_limit: Option<i64>,
+    pub summary_only: Option<bool>,
+    pub detail: Option<WorkflowRuntimeTreeDetail>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WorkflowRuntimeTreeDetail {
+    Compact,
+    Full,
+}
+
+impl WorkflowRuntimeTreeDetail {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Compact => "compact",
+            Self::Full => "full",
+        }
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -177,8 +202,24 @@ impl WorkflowRuntimeCommandNode {
 
 #[derive(Debug, Clone, serde::Serialize)]
 struct WorkflowRuntimeJobNode {
-    #[serde(flatten)]
-    pub job: RuntimeJob,
+    pub id: String,
+    pub command_id: String,
+    pub runtime_kind: harness_workflow::runtime::RuntimeKind,
+    pub runtime_profile: String,
+    pub status: RuntimeJobStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lease: Option<WorkflowLease>,
+    pub lease_generation: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub not_before: Option<chrono::DateTime<chrono::Utc>>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
     pub runtime_event_count: usize,
     pub latest_runtime_event_type: Option<String>,
     pub prompt_packet_digest: Option<String>,
@@ -189,7 +230,7 @@ struct WorkflowRuntimeJobNode {
 }
 
 impl WorkflowRuntimeJobNode {
-    fn new(job: RuntimeJob, runtime_events: Vec<RuntimeEvent>) -> Self {
+    fn full(job: RuntimeJob, runtime_events: Vec<RuntimeEvent>) -> Self {
         let latest_runtime_event_type = runtime_events.last().map(|event| event.event_type.clone());
         let prompt_packet_digest = prompt_packet_digest_from_events(&runtime_events);
         let activity_result_envelope = activity_result_envelope_from_job(&job);
@@ -198,11 +239,73 @@ impl WorkflowRuntimeJobNode {
         let in_flight_model_turn = runtime_job_has_in_flight_model_turn(&job, &runtime_events);
         let last_runtime_observation_at = last_runtime_observation_at(&job, &runtime_events);
         Self {
-            job,
+            id: job.id,
+            command_id: job.command_id,
+            runtime_kind: job.runtime_kind,
+            runtime_profile: job.runtime_profile,
+            status: job.status,
+            lease: job.lease,
+            lease_generation: job.lease_generation,
+            input: Some(job.input),
+            output: job.output,
+            error: job.error,
+            not_before: job.not_before,
+            created_at: job.created_at,
+            updated_at: job.updated_at,
             runtime_event_count: runtime_events.len(),
             latest_runtime_event_type,
             prompt_packet_digest,
             activity_result_envelope,
+            lease_state,
+            in_flight_model_turn,
+            last_runtime_observation_at,
+        }
+    }
+
+    fn compact(job: RuntimeJobCompactRecord, runtime_summary: RuntimeEventSummary) -> Self {
+        let now = chrono::Utc::now();
+        let lease_state = if job.status == RuntimeJobStatus::Running {
+            Some(match job.lease.as_ref() {
+                Some(lease) if lease.expires_at > now => "active_leased",
+                Some(_) => "expired_lease",
+                None => "missing_lease",
+            })
+        } else {
+            None
+        };
+        let latest_turn_sequence = runtime_summary.latest_turn_sequence.unwrap_or(0);
+        let latest_activity_result_sequence =
+            runtime_summary.latest_activity_result_sequence.unwrap_or(0);
+        let in_flight_model_turn = job.status == RuntimeJobStatus::Running
+            && latest_turn_sequence > latest_activity_result_sequence;
+        let last_runtime_observation_at = if job.status == RuntimeJobStatus::Running {
+            Some(
+                runtime_summary
+                    .latest_runtime_event_at
+                    .map(|created_at| created_at.max(job.updated_at))
+                    .unwrap_or(job.updated_at),
+            )
+        } else {
+            runtime_summary.latest_runtime_event_at
+        };
+        Self {
+            id: job.id,
+            command_id: job.command_id,
+            runtime_kind: job.runtime_kind,
+            runtime_profile: job.runtime_profile,
+            status: job.status,
+            lease: job.lease,
+            lease_generation: job.lease_generation,
+            input: None,
+            output: None,
+            error: job.error,
+            not_before: job.not_before,
+            created_at: job.created_at,
+            updated_at: job.updated_at,
+            runtime_event_count: runtime_summary.runtime_event_count,
+            latest_runtime_event_type: runtime_summary.latest_runtime_event_type,
+            prompt_packet_digest: runtime_summary.prompt_packet_digest,
+            activity_result_envelope: None,
             lease_state,
             in_flight_model_turn,
             last_runtime_observation_at,
@@ -214,6 +317,10 @@ impl WorkflowRuntimeJobNode {
 struct WorkflowRuntimeTreeNode {
     pub workflow: WorkflowInstance,
     pub runtime_job_count: usize,
+    pub event_count: usize,
+    pub decision_count: usize,
+    pub rejected_decision_count: usize,
+    pub command_count: usize,
     pub events: Vec<WorkflowEvent>,
     pub decisions: Vec<WorkflowDecisionRecord>,
     pub commands: Vec<WorkflowRuntimeCommandNode>,
@@ -237,10 +344,22 @@ struct WorkflowRuntimeTreePagination {
     pub has_more: bool,
     pub next_offset: Option<usize>,
     pub job_limit: usize,
+    pub command_limit: Option<usize>,
+    pub detail: &'static str,
+    pub summary_only: bool,
 }
 
 impl WorkflowRuntimeTreePagination {
-    fn new(limit: i64, offset: i64, returned: usize, total: i64, job_limit: usize) -> Self {
+    fn new(
+        limit: i64,
+        offset: i64,
+        returned: usize,
+        total: i64,
+        job_limit: usize,
+        command_limit: Option<usize>,
+        detail: WorkflowRuntimeTreeDetail,
+        summary_only: bool,
+    ) -> Self {
         let limit = limit.max(1) as usize;
         let offset = offset.max(0) as usize;
         let total = total.max(0) as usize;
@@ -254,6 +373,9 @@ impl WorkflowRuntimeTreePagination {
             has_more,
             next_offset: has_more.then_some(next_offset),
             job_limit,
+            command_limit,
+            detail: detail.as_str(),
+            summary_only,
         }
     }
 }
@@ -267,6 +389,36 @@ struct WorkflowRuntimeTreeSummary {
     pub running_job_lease_statuses: BTreeMap<String, usize>,
     pub activity_outcomes: BTreeMap<String, usize>,
     pub jobs_without_activity_envelope: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum WorkflowRuntimeTreeMode {
+    SummaryOnly,
+    Compact {
+        command_limit: usize,
+        rejected_decision_limit: usize,
+    },
+    Full,
+}
+
+impl WorkflowRuntimeTreeMode {
+    fn detail(self) -> WorkflowRuntimeTreeDetail {
+        match self {
+            Self::Full => WorkflowRuntimeTreeDetail::Full,
+            Self::SummaryOnly | Self::Compact { .. } => WorkflowRuntimeTreeDetail::Compact,
+        }
+    }
+
+    fn summary_only(self) -> bool {
+        matches!(self, Self::SummaryOnly)
+    }
+
+    fn command_limit(self) -> Option<usize> {
+        match self {
+            Self::Compact { command_limit, .. } => Some(command_limit),
+            Self::SummaryOnly | Self::Full => None,
+        }
+    }
 }
 
 pub(crate) async fn get_issue_workflow_by_issue(
@@ -376,6 +528,26 @@ pub(crate) async fn get_workflow_runtime_tree(
         .job_limit
         .unwrap_or(WORKFLOW_RUNTIME_TREE_DEFAULT_JOB_LIMIT)
         .clamp(0, WORKFLOW_RUNTIME_TREE_MAX_JOB_LIMIT);
+    let command_limit = query
+        .command_limit
+        .unwrap_or(WORKFLOW_RUNTIME_TREE_DEFAULT_COMMAND_LIMIT)
+        .clamp(0, WORKFLOW_RUNTIME_TREE_MAX_COMMAND_LIMIT);
+    let rejected_decision_limit = query
+        .rejected_decision_limit
+        .unwrap_or(WORKFLOW_RUNTIME_TREE_DEFAULT_REJECTED_DECISION_LIMIT)
+        .clamp(0, WORKFLOW_RUNTIME_TREE_MAX_REJECTED_DECISION_LIMIT);
+    let detail = query.detail.unwrap_or(WorkflowRuntimeTreeDetail::Compact);
+    let mode = if query.summary_only.unwrap_or(false) {
+        WorkflowRuntimeTreeMode::SummaryOnly
+    } else {
+        match detail {
+            WorkflowRuntimeTreeDetail::Compact => WorkflowRuntimeTreeMode::Compact {
+                command_limit: command_limit as usize,
+                rejected_decision_limit: rejected_decision_limit as usize,
+            },
+            WorkflowRuntimeTreeDetail::Full => WorkflowRuntimeTreeMode::Full,
+        }
+    };
     match store
         .list_instances_page(query.project_id.as_deref(), limit, offset)
         .await
@@ -385,6 +557,7 @@ pub(crate) async fn get_workflow_runtime_tree(
             page,
             query.project_id.as_deref(),
             job_limit as usize,
+            mode,
         )
         .await
         {
@@ -408,97 +581,52 @@ async fn build_workflow_runtime_tree(
     page: harness_workflow::runtime::store::WorkflowInstancePage,
     project_id: Option<&str>,
     job_limit: usize,
+    mode: WorkflowRuntimeTreeMode,
 ) -> anyhow::Result<WorkflowRuntimeTreeResponse> {
     let instances = page.instances;
     let workflow_ids: Vec<String> = instances
         .iter()
         .map(|instance| instance.id.clone())
         .collect();
-    let mut events_by_workflow = store.events_for_workflows(&workflow_ids).await?;
-    let mut decisions_by_workflow = store.decisions_for_workflows(&workflow_ids).await?;
-    let mut commands_by_workflow = store.commands_for_workflows(&workflow_ids).await?;
-    let command_ids: Vec<String> = commands_by_workflow
-        .values()
-        .flat_map(|commands| commands.iter().map(|command| command.id.clone()))
-        .collect();
-    let runtime_job_counts_by_command = store.runtime_job_counts_for_commands(&command_ids).await?;
-    let mut runtime_jobs_by_command = store
-        .runtime_jobs_for_commands_limited(&command_ids, job_limit as i64)
-        .await?;
-    let runtime_job_ids: Vec<String> = runtime_jobs_by_command
-        .values()
-        .flat_map(|jobs| jobs.iter().map(|job| job.id.clone()))
-        .collect();
-    let mut runtime_events_by_job = store.runtime_events_for_jobs(&runtime_job_ids).await?;
-
-    let mut by_id = BTreeMap::new();
-    let mut children_by_parent: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    let aggregate_summary = store
-        .runtime_summary_counts_for_instances(
-            project_id,
-            ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE,
-            ACTIVITY_RESULT_ENVELOPE_SCHEMA,
-        )
-        .await?;
-    let summary = WorkflowRuntimeTreeSummary {
-        total_commands: aggregate_summary.total_commands,
-        total_runtime_jobs: aggregate_summary.total_runtime_jobs,
-        command_statuses: aggregate_summary.command_statuses,
-        runtime_job_statuses: aggregate_summary.runtime_job_statuses,
-        running_job_lease_statuses: aggregate_summary.running_job_lease_statuses,
-        activity_outcomes: aggregate_summary.activity_outcomes,
-        jobs_without_activity_envelope: aggregate_summary.jobs_without_activity_envelope,
-    };
-    for instance in instances {
-        let workflow_id = instance.id.clone();
-        if let Some(parent_id) = instance.parent_workflow_id.as_ref() {
-            children_by_parent
-                .entry(parent_id.clone())
-                .or_default()
-                .push(workflow_id.clone());
-        }
-        let events = events_by_workflow.remove(&workflow_id).unwrap_or_default();
-        let decisions = decisions_by_workflow
-            .remove(&workflow_id)
-            .unwrap_or_default();
-        let commands: Vec<WorkflowRuntimeCommandNode> = commands_by_workflow
-            .remove(&workflow_id)
-            .unwrap_or_default()
-            .into_iter()
-            .map(|command| {
-                let runtime_job_count = runtime_job_counts_by_command
-                    .get(&command.id)
-                    .copied()
-                    .unwrap_or_default();
-                let runtime_jobs = runtime_jobs_by_command
-                    .remove(&command.id)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|job| {
-                        let runtime_events =
-                            runtime_events_by_job.remove(&job.id).unwrap_or_default();
-                        WorkflowRuntimeJobNode::new(job, runtime_events)
-                    })
-                    .collect();
-                WorkflowRuntimeCommandNode::new(command, runtime_job_count, runtime_jobs)
-            })
-            .collect();
-        let mut runtime_job_count = 0;
-        for command in &commands {
-            runtime_job_count += command.runtime_job_count;
-        }
-        by_id.insert(
-            workflow_id,
-            WorkflowRuntimeTreeNode {
-                workflow: instance,
-                runtime_job_count,
-                events,
-                decisions,
-                commands,
-                children: Vec::new(),
-            },
-        );
+    let summary = workflow_runtime_tree_summary(store, project_id).await?;
+    if mode.summary_only() {
+        return Ok(WorkflowRuntimeTreeResponse {
+            total_workflows: page.total.max(0) as usize,
+            pagination: WorkflowRuntimeTreePagination::new(
+                page.limit,
+                page.offset,
+                0,
+                page.total,
+                job_limit,
+                mode.command_limit(),
+                mode.detail(),
+                true,
+            ),
+            summary,
+            workflows: Vec::new(),
+        });
     }
+
+    let (by_id, children_by_parent) = match mode {
+        WorkflowRuntimeTreeMode::Full => {
+            build_full_workflow_runtime_nodes(store, instances, &workflow_ids, job_limit).await?
+        }
+        WorkflowRuntimeTreeMode::Compact {
+            command_limit,
+            rejected_decision_limit,
+        } => {
+            build_compact_workflow_runtime_nodes(
+                store,
+                instances,
+                &workflow_ids,
+                job_limit,
+                command_limit,
+                rejected_decision_limit,
+            )
+            .await?
+        }
+        WorkflowRuntimeTreeMode::SummaryOnly => unreachable!("summary-only returned above"),
+    };
 
     let mut root_ids = Vec::new();
     for (workflow_id, node) in &by_id {
@@ -533,10 +661,247 @@ async fn build_workflow_runtime_tree(
             by_id.len(),
             page.total,
             job_limit,
+            mode.command_limit(),
+            mode.detail(),
+            false,
         ),
         summary,
         workflows,
     })
+}
+
+async fn workflow_runtime_tree_summary(
+    store: &harness_workflow::runtime::WorkflowRuntimeStore,
+    project_id: Option<&str>,
+) -> anyhow::Result<WorkflowRuntimeTreeSummary> {
+    let aggregate_summary = store
+        .runtime_summary_counts_for_instances(
+            project_id,
+            ACTIVITY_RESULT_ENVELOPE_ARTIFACT_TYPE,
+            ACTIVITY_RESULT_ENVELOPE_SCHEMA,
+        )
+        .await?;
+    Ok(WorkflowRuntimeTreeSummary {
+        total_commands: aggregate_summary.total_commands,
+        total_runtime_jobs: aggregate_summary.total_runtime_jobs,
+        command_statuses: aggregate_summary.command_statuses,
+        runtime_job_statuses: aggregate_summary.runtime_job_statuses,
+        running_job_lease_statuses: aggregate_summary.running_job_lease_statuses,
+        activity_outcomes: aggregate_summary.activity_outcomes,
+        jobs_without_activity_envelope: aggregate_summary.jobs_without_activity_envelope,
+    })
+}
+
+async fn build_full_workflow_runtime_nodes(
+    store: &harness_workflow::runtime::WorkflowRuntimeStore,
+    instances: Vec<WorkflowInstance>,
+    workflow_ids: &[String],
+    job_limit: usize,
+) -> anyhow::Result<(
+    BTreeMap<String, WorkflowRuntimeTreeNode>,
+    BTreeMap<String, Vec<String>>,
+)> {
+    let mut events_by_workflow = store.events_for_workflows(workflow_ids).await?;
+    let mut decisions_by_workflow = store.decisions_for_workflows(workflow_ids).await?;
+    let mut commands_by_workflow = store.commands_for_workflows(workflow_ids).await?;
+    let command_ids: Vec<String> = commands_by_workflow
+        .values()
+        .flat_map(|commands| commands.iter().map(|command| command.id.clone()))
+        .collect();
+    let runtime_job_counts_by_command = store.runtime_job_counts_for_commands(&command_ids).await?;
+    let mut runtime_jobs_by_command = store
+        .runtime_jobs_for_commands_limited(&command_ids, job_limit as i64)
+        .await?;
+    let runtime_job_ids: Vec<String> = runtime_jobs_by_command
+        .values()
+        .flat_map(|jobs| jobs.iter().map(|job| job.id.clone()))
+        .collect();
+    let mut runtime_events_by_job = store.runtime_events_for_jobs(&runtime_job_ids).await?;
+
+    let mut by_id = BTreeMap::new();
+    let mut children_by_parent: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for instance in instances {
+        let workflow_id = instance.id.clone();
+        if let Some(parent_id) = instance.parent_workflow_id.as_ref() {
+            children_by_parent
+                .entry(parent_id.clone())
+                .or_default()
+                .push(workflow_id.clone());
+        }
+        let events = events_by_workflow.remove(&workflow_id).unwrap_or_default();
+        let decisions = decisions_by_workflow
+            .remove(&workflow_id)
+            .unwrap_or_default();
+        let rejected_decision_count = decisions
+            .iter()
+            .filter(|decision| !decision.accepted)
+            .count();
+        let command_records = commands_by_workflow
+            .remove(&workflow_id)
+            .unwrap_or_default();
+        let command_count = command_records.len();
+        let commands: Vec<WorkflowRuntimeCommandNode> = command_records
+            .into_iter()
+            .map(|command| {
+                let runtime_job_count = runtime_job_counts_by_command
+                    .get(&command.id)
+                    .copied()
+                    .unwrap_or_default();
+                let runtime_jobs = runtime_jobs_by_command
+                    .remove(&command.id)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|job| {
+                        let runtime_events =
+                            runtime_events_by_job.remove(&job.id).unwrap_or_default();
+                        WorkflowRuntimeJobNode::full(job, runtime_events)
+                    })
+                    .collect();
+                WorkflowRuntimeCommandNode::new(command, runtime_job_count, runtime_jobs)
+            })
+            .collect();
+        let runtime_job_count = commands
+            .iter()
+            .map(|command| command.runtime_job_count)
+            .sum();
+        by_id.insert(
+            workflow_id,
+            WorkflowRuntimeTreeNode {
+                workflow: instance,
+                runtime_job_count,
+                event_count: events.len(),
+                decision_count: decisions.len(),
+                rejected_decision_count,
+                command_count,
+                events,
+                decisions,
+                commands,
+                children: Vec::new(),
+            },
+        );
+    }
+    Ok((by_id, children_by_parent))
+}
+
+async fn build_compact_workflow_runtime_nodes(
+    store: &harness_workflow::runtime::WorkflowRuntimeStore,
+    instances: Vec<WorkflowInstance>,
+    workflow_ids: &[String],
+    job_limit: usize,
+    command_limit: usize,
+    rejected_decision_limit: usize,
+) -> anyhow::Result<(
+    BTreeMap<String, WorkflowRuntimeTreeNode>,
+    BTreeMap<String, Vec<String>>,
+)> {
+    let detail_counts_by_workflow = store.detail_counts_for_workflows(workflow_ids).await?;
+    let mut decisions_by_workflow = store
+        .rejected_decisions_for_workflows_limited(workflow_ids, rejected_decision_limit as i64)
+        .await?;
+    let mut commands_by_workflow = store
+        .commands_for_workflows_limited(workflow_ids, command_limit as i64)
+        .await?;
+    let command_ids: Vec<String> = commands_by_workflow
+        .values()
+        .flat_map(|commands| commands.iter().map(|command| command.id.clone()))
+        .collect();
+    let runtime_job_counts_by_command = store.runtime_job_counts_for_commands(&command_ids).await?;
+    let mut runtime_jobs_by_command = store
+        .compact_runtime_jobs_for_commands_limited(&command_ids, job_limit as i64)
+        .await?;
+    let runtime_job_ids: Vec<String> = runtime_jobs_by_command
+        .values()
+        .flat_map(|jobs| jobs.iter().map(|job| job.id.clone()))
+        .collect();
+    let mut runtime_event_summaries_by_job = store
+        .runtime_event_summaries_for_jobs(&runtime_job_ids)
+        .await?;
+
+    let mut by_id = BTreeMap::new();
+    let mut children_by_parent: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for instance in instances {
+        let workflow_id = instance.id.clone();
+        if let Some(parent_id) = instance.parent_workflow_id.as_ref() {
+            children_by_parent
+                .entry(parent_id.clone())
+                .or_default()
+                .push(workflow_id.clone());
+        }
+        let detail_counts = detail_counts_by_workflow
+            .get(&workflow_id)
+            .cloned()
+            .unwrap_or_default();
+        let decisions = decisions_by_workflow
+            .remove(&workflow_id)
+            .unwrap_or_default();
+        let commands: Vec<WorkflowRuntimeCommandNode> = commands_by_workflow
+            .remove(&workflow_id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|mut command| {
+                command.command = compact_workflow_command(command.command);
+                let runtime_job_count = runtime_job_counts_by_command
+                    .get(&command.id)
+                    .copied()
+                    .unwrap_or_default();
+                let runtime_jobs = runtime_jobs_by_command
+                    .remove(&command.id)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|job| {
+                        let runtime_summary = runtime_event_summaries_by_job
+                            .remove(&job.id)
+                            .unwrap_or_else(|| RuntimeEventSummary {
+                                runtime_job_id: job.id.clone(),
+                                ..Default::default()
+                            });
+                        WorkflowRuntimeJobNode::compact(job, runtime_summary)
+                    })
+                    .collect();
+                WorkflowRuntimeCommandNode::new(command, runtime_job_count, runtime_jobs)
+            })
+            .collect();
+        by_id.insert(
+            workflow_id,
+            WorkflowRuntimeTreeNode {
+                workflow: instance,
+                runtime_job_count: detail_counts.runtime_job_count,
+                event_count: detail_counts.event_count,
+                decision_count: detail_counts.decision_count,
+                rejected_decision_count: detail_counts.rejected_decision_count,
+                command_count: detail_counts.command_count,
+                events: Vec::new(),
+                decisions,
+                commands,
+                children: Vec::new(),
+            },
+        );
+    }
+    Ok((by_id, children_by_parent))
+}
+
+fn compact_workflow_command(command: WorkflowCommand) -> WorkflowCommand {
+    let mut payload = serde_json::Map::new();
+    if let Some(object) = command.command.as_object() {
+        for key in [
+            "activity",
+            "definition_id",
+            "subject_key",
+            "pr_number",
+            "pr_url",
+            "reason",
+            "concern",
+        ] {
+            if let Some(value) = object.get(key) {
+                payload.insert(key.to_string(), value.clone());
+            }
+        }
+    }
+    WorkflowCommand {
+        command_type: command.command_type,
+        dedupe_key: command.dedupe_key,
+        command: Value::Object(payload),
+    }
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/http/tests/runtime_tree_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_tree_tests.rs
@@ -315,12 +315,20 @@ async fn workflow_runtime_tree_endpoint_defaults_to_compact_polling_shape() -> a
             )
             .await?;
     }
+    let primitive_command = harness_workflow::runtime::WorkflowCommand::new(
+        harness_workflow::runtime::WorkflowCommandType::Wait,
+        "issue-1165-wait",
+        serde_json::json!("wait for review"),
+    );
+    store
+        .enqueue_command(&workflow.id, None, &primitive_command)
+        .await?;
 
     let response = workflow_runtime_app(state)
         .oneshot(
             Request::builder()
                 .uri(
-                    "/api/workflows/runtime/tree?project_id=%2Fproject-a&command_limit=1&job_limit=1",
+                    "/api/workflows/runtime/tree?project_id=%2Fproject-a&command_limit=3&job_limit=1",
                 )
                 .body(Body::empty())?,
         )
@@ -328,15 +336,15 @@ async fn workflow_runtime_tree_endpoint_defaults_to_compact_polling_shape() -> a
     assert_eq!(response.status(), StatusCode::OK);
     let body = response_json(response).await?;
     assert_eq!(body["pagination"]["detail"], "compact");
-    assert_eq!(body["pagination"]["command_limit"], 1);
-    assert_eq!(body["summary"]["total_commands"], 2);
+    assert_eq!(body["pagination"]["command_limit"], 3);
+    assert_eq!(body["summary"]["total_commands"], 3);
     assert_eq!(body["summary"]["total_runtime_jobs"], 2);
 
     let node = &body["workflows"][0];
     assert_eq!(node["event_count"], 1);
     assert_eq!(node["decision_count"], 2);
     assert_eq!(node["rejected_decision_count"], 1);
-    assert_eq!(node["command_count"], 2);
+    assert_eq!(node["command_count"], 3);
     assert_eq!(node["runtime_job_count"], 2);
     assert_eq!(node["events"].as_array().expect("events array").len(), 0);
     assert_eq!(
@@ -348,13 +356,23 @@ async fn workflow_runtime_tree_endpoint_defaults_to_compact_polling_shape() -> a
         "replan limit exhausted"
     );
     let commands = node["commands"].as_array().expect("commands array");
-    assert_eq!(commands.len(), 1);
+    assert_eq!(commands.len(), 3);
+    let implement_command = commands
+        .iter()
+        .find(|command| {
+            command["command"]["command"]["activity"].as_str() == Some("implement_issue")
+        })
+        .expect("compact response should include an implement command");
+    assert!(implement_command["command"]["command"]["large_payload"].is_null());
+    let primitive_command = commands
+        .iter()
+        .find(|command| command["command"]["dedupe_key"].as_str() == Some("issue-1165-wait"))
+        .expect("compact response should include the primitive command");
     assert_eq!(
-        commands[0]["command"]["command"]["activity"],
-        "implement_issue"
+        primitive_command["command"]["command"],
+        serde_json::json!("wait for review")
     );
-    assert!(commands[0]["command"]["command"]["large_payload"].is_null());
-    let jobs = commands[0]["runtime_jobs"]
+    let jobs = implement_command["runtime_jobs"]
         .as_array()
         .expect("runtime jobs array");
     assert_eq!(jobs.len(), 1);
@@ -423,6 +441,8 @@ async fn workflow_runtime_tree_endpoint_returns_summary_only_shape() -> anyhow::
     let body = response_json(response).await?;
     assert_eq!(body["total_workflows"], 1);
     assert_eq!(body["pagination"]["returned"], 0);
+    assert_eq!(body["pagination"]["has_more"], false);
+    assert_eq!(body["pagination"]["next_offset"], serde_json::Value::Null);
     assert_eq!(body["pagination"]["summary_only"], true);
     assert_eq!(body["pagination"]["detail"], "compact");
     assert_eq!(body["summary"]["total_commands"], 1);

--- a/crates/harness-server/src/http/tests/runtime_tree_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_tree_tests.rs
@@ -162,7 +162,7 @@ async fn workflow_runtime_tree_endpoint_returns_nested_runtime_details() -> anyh
     let response = workflow_runtime_app(state)
         .oneshot(
             Request::builder()
-                .uri("/api/workflows/runtime/tree?project_id=%2Fproject-a")
+                .uri("/api/workflows/runtime/tree?project_id=%2Fproject-a&detail=full")
                 .body(Body::empty())?,
         )
         .await?;
@@ -172,12 +172,17 @@ async fn workflow_runtime_tree_endpoint_returns_nested_runtime_details() -> anyh
     assert_eq!(body["pagination"]["limit"], 100);
     assert_eq!(body["pagination"]["offset"], 0);
     assert_eq!(body["pagination"]["returned"], 2);
+    assert_eq!(body["pagination"]["detail"], "full");
+    assert_eq!(body["pagination"]["summary_only"], false);
     assert_eq!(body["summary"]["total_commands"], 1);
     assert_eq!(body["summary"]["total_runtime_jobs"], 1);
     assert_eq!(body["workflows"][0]["workflow"]["id"], "repo-backlog");
     let child_node = &body["workflows"][0]["children"][0];
     assert_eq!(child_node["workflow"]["id"], "issue-123");
     assert_eq!(child_node["runtime_job_count"], 1);
+    assert_eq!(child_node["event_count"], 1);
+    assert_eq!(child_node["decision_count"], 1);
+    assert_eq!(child_node["command_count"], 1);
     assert_eq!(
         child_node["decisions"][0]["rejection_reason"],
         "replan limit exhausted"
@@ -219,6 +224,215 @@ async fn workflow_runtime_tree_endpoint_returns_nested_runtime_details() -> anyh
         child_node["commands"][0]["runtime_jobs"][0]["activity_result_envelope"]["final_result"]
             ["status"],
         "succeeded"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn workflow_runtime_tree_endpoint_defaults_to_compact_polling_shape() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1165"),
+    )
+    .with_id("issue-1165")
+    .with_data(serde_json::json!({
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 1165,
+    }));
+    store.upsert_instance(&workflow).await?;
+    store
+        .append_event(
+            &workflow.id,
+            "IssueSubmitted",
+            "workflow-runtime-test",
+            serde_json::json!({ "large_payload": "x".repeat(1024) }),
+        )
+        .await?;
+    let accepted = harness_workflow::runtime::WorkflowDecisionRecord::accepted(
+        harness_workflow::runtime::WorkflowDecision::new(
+            workflow.id.clone(),
+            "implementing",
+            "wait",
+            "implementing",
+            "No-op decision used to prove compact counts include accepted decisions.",
+        ),
+        None,
+    );
+    store.record_decision(&accepted).await?;
+    let rejected = harness_workflow::runtime::WorkflowDecisionRecord::rejected(
+        harness_workflow::runtime::WorkflowDecision::new(
+            workflow.id.clone(),
+            "implementing",
+            "run_replan",
+            "replanning",
+            "Rejected decision should remain visible as a compact hint.",
+        ),
+        None,
+        "replan limit exhausted",
+    );
+    store.record_decision(&rejected).await?;
+
+    for index in 0..2 {
+        let command = harness_workflow::runtime::WorkflowCommand::new(
+            harness_workflow::runtime::WorkflowCommandType::EnqueueActivity,
+            format!("issue-1165-implement-{index}"),
+            serde_json::json!({
+                "activity": "implement_issue",
+                "large_payload": "x".repeat(1024),
+            }),
+        );
+        let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+        let runtime_job = store
+            .enqueue_runtime_job(
+                &command_id,
+                harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+                "codex-high",
+                serde_json::json!({ "large_input": "x".repeat(1024) }),
+            )
+            .await?;
+        store
+            .record_runtime_event(
+                &runtime_job.id,
+                "RuntimePromptPrepared",
+                serde_json::json!({
+                    "prompt_packet_digest": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+                    "large_payload": "x".repeat(1024),
+                }),
+            )
+            .await?;
+    }
+
+    let response = workflow_runtime_app(state)
+        .oneshot(
+            Request::builder()
+                .uri(
+                    "/api/workflows/runtime/tree?project_id=%2Fproject-a&command_limit=1&job_limit=1",
+                )
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["pagination"]["detail"], "compact");
+    assert_eq!(body["pagination"]["command_limit"], 1);
+    assert_eq!(body["summary"]["total_commands"], 2);
+    assert_eq!(body["summary"]["total_runtime_jobs"], 2);
+
+    let node = &body["workflows"][0];
+    assert_eq!(node["event_count"], 1);
+    assert_eq!(node["decision_count"], 2);
+    assert_eq!(node["rejected_decision_count"], 1);
+    assert_eq!(node["command_count"], 2);
+    assert_eq!(node["runtime_job_count"], 2);
+    assert_eq!(node["events"].as_array().expect("events array").len(), 0);
+    assert_eq!(
+        node["decisions"].as_array().expect("decisions array").len(),
+        1
+    );
+    assert_eq!(
+        node["decisions"][0]["rejection_reason"],
+        "replan limit exhausted"
+    );
+    let commands = node["commands"].as_array().expect("commands array");
+    assert_eq!(commands.len(), 1);
+    assert_eq!(
+        commands[0]["command"]["command"]["activity"],
+        "implement_issue"
+    );
+    assert!(commands[0]["command"]["command"]["large_payload"].is_null());
+    let jobs = commands[0]["runtime_jobs"]
+        .as_array()
+        .expect("runtime jobs array");
+    assert_eq!(jobs.len(), 1);
+    assert!(jobs[0]["input"].is_null());
+    assert!(jobs[0]["output"].is_null());
+    assert_eq!(jobs[0]["runtime_event_count"], 1);
+    assert_eq!(
+        jobs[0]["latest_runtime_event_type"],
+        "RuntimePromptPrepared"
+    );
+    assert_eq!(
+        jobs[0]["prompt_packet_digest"],
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn workflow_runtime_tree_endpoint_returns_summary_only_shape() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1166"),
+    )
+    .with_id("issue-1166")
+    .with_data(serde_json::json!({
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 1166,
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command = harness_workflow::runtime::WorkflowCommand::enqueue_activity(
+        "implement_issue",
+        "issue-1166-implement",
+    );
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    store
+        .enqueue_runtime_job(
+            &command_id,
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-high",
+            serde_json::json!({ "workflow_id": workflow.id }),
+        )
+        .await?;
+
+    let response = workflow_runtime_app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/workflows/runtime/tree?project_id=%2Fproject-a&summary_only=true")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["total_workflows"], 1);
+    assert_eq!(body["pagination"]["returned"], 0);
+    assert_eq!(body["pagination"]["summary_only"], true);
+    assert_eq!(body["pagination"]["detail"], "compact");
+    assert_eq!(body["summary"]["total_commands"], 1);
+    assert_eq!(body["summary"]["total_runtime_jobs"], 1);
+    assert_eq!(
+        body["workflows"]
+            .as_array()
+            .expect("workflows should be an array")
+            .len(),
+        0
     );
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -2,7 +2,7 @@ use super::errors::RuntimeJobNotFoundError;
 use super::model::{
     ActivityResult, ActivityStatus, RuntimeEvent, RuntimeJob, RuntimeJobStatus, RuntimeKind,
     WorkflowCommand, WorkflowCommandRecord, WorkflowCommandType, WorkflowDecision,
-    WorkflowDecisionRecord, WorkflowDefinition, WorkflowEvent, WorkflowInstance,
+    WorkflowDecisionRecord, WorkflowDefinition, WorkflowEvent, WorkflowInstance, WorkflowLease,
 };
 use super::pr_feedback::PR_FEEDBACK_DEFINITION_ID;
 use super::prompt_task::PROMPT_TASK_DEFINITION_ID;
@@ -15,7 +15,7 @@ use super::validator::{DecisionValidator, ValidationContext};
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 use harness_core::db::PgStoreContext;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
 use sqlx::postgres::PgPool;
 use std::collections::BTreeMap;
@@ -39,6 +39,14 @@ pub struct WorkflowInstancePage {
     pub offset: i64,
 }
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct WorkflowRuntimeDetailCounts {
+    pub event_count: usize,
+    pub decision_count: usize,
+    pub rejected_decision_count: usize,
+    pub command_count: usize,
+    pub runtime_job_count: usize,
+}
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct WorkflowRuntimeSummaryCounts {
     pub total_commands: usize,
     pub total_runtime_jobs: usize,
@@ -47,6 +55,30 @@ pub struct WorkflowRuntimeSummaryCounts {
     pub running_job_lease_statuses: BTreeMap<String, usize>,
     pub activity_outcomes: BTreeMap<String, usize>,
     pub jobs_without_activity_envelope: usize,
+}
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeJobCompactRecord {
+    pub id: String,
+    pub command_id: String,
+    pub runtime_kind: RuntimeKind,
+    pub runtime_profile: String,
+    pub status: RuntimeJobStatus,
+    pub lease: Option<WorkflowLease>,
+    pub lease_generation: u64,
+    pub error: Option<String>,
+    pub not_before: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RuntimeEventSummary {
+    pub runtime_job_id: String,
+    pub runtime_event_count: usize,
+    pub latest_runtime_event_type: Option<String>,
+    pub prompt_packet_digest: Option<String>,
+    pub latest_runtime_event_at: Option<DateTime<Utc>>,
+    pub latest_turn_sequence: Option<u64>,
+    pub latest_activity_result_sequence: Option<u64>,
 }
 pub struct WorkflowDecisionTransition<'a> {
     pub expected_state: &'a str,
@@ -75,6 +107,28 @@ type WorkflowCommandRecordRow = (
     Option<String>,
     Option<DateTime<Utc>>,
     String,
+    DateTime<Utc>,
+    DateTime<Utc>,
+);
+type RuntimeEventSummaryRow = (
+    String,
+    i64,
+    Option<String>,
+    Option<DateTime<Utc>>,
+    Option<String>,
+    Option<i64>,
+    Option<i64>,
+);
+type RuntimeJobCompactRecordRow = (
+    String,
+    String,
+    String,
+    String,
+    String,
+    Option<String>,
+    i64,
+    Option<String>,
+    Option<DateTime<Utc>>,
     DateTime<Utc>,
     DateTime<Utc>,
 );
@@ -819,6 +873,109 @@ impl WorkflowRuntimeStore {
         Ok(by_workflow)
     }
 
+    pub async fn detail_counts_for_workflows(
+        &self,
+        workflow_ids: &[String],
+    ) -> anyhow::Result<BTreeMap<String, WorkflowRuntimeDetailCounts>> {
+        if workflow_ids.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+        let rows: Vec<(String, i64, i64, i64, i64, i64)> = sqlx::query_as(
+            "SELECT selected.workflow_id,
+                    COALESCE(events.event_count, 0),
+                    COALESCE(decisions.decision_count, 0),
+                    COALESCE(decisions.rejected_decision_count, 0),
+                    COALESCE(commands.command_count, 0),
+                    COALESCE(jobs.runtime_job_count, 0)
+             FROM unnest($1::text[]) AS selected(workflow_id)
+             LEFT JOIN LATERAL (
+                 SELECT COUNT(*) AS event_count
+                 FROM workflow_events
+                 WHERE workflow_id = selected.workflow_id
+             ) AS events ON true
+             LEFT JOIN LATERAL (
+                 SELECT COUNT(*) AS decision_count,
+                        COUNT(*) FILTER (WHERE accepted = false) AS rejected_decision_count
+                 FROM workflow_decisions
+                 WHERE workflow_id = selected.workflow_id
+             ) AS decisions ON true
+             LEFT JOIN LATERAL (
+                 SELECT COUNT(*) AS command_count
+                 FROM workflow_commands
+                 WHERE workflow_id = selected.workflow_id
+             ) AS commands ON true
+             LEFT JOIN LATERAL (
+                 SELECT COUNT(runtime_jobs.id) AS runtime_job_count
+                 FROM workflow_commands
+                 JOIN runtime_jobs ON runtime_jobs.command_id = workflow_commands.id
+                 WHERE workflow_commands.workflow_id = selected.workflow_id
+             ) AS jobs ON true",
+        )
+        .bind(workflow_ids)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(
+                |(
+                    workflow_id,
+                    event_count,
+                    decision_count,
+                    rejected_decision_count,
+                    command_count,
+                    runtime_job_count,
+                )| {
+                    (
+                        workflow_id,
+                        WorkflowRuntimeDetailCounts {
+                            event_count: event_count.max(0) as usize,
+                            decision_count: decision_count.max(0) as usize,
+                            rejected_decision_count: rejected_decision_count.max(0) as usize,
+                            command_count: command_count.max(0) as usize,
+                            runtime_job_count: runtime_job_count.max(0) as usize,
+                        },
+                    )
+                },
+            )
+            .collect())
+    }
+
+    pub async fn rejected_decisions_for_workflows_limited(
+        &self,
+        workflow_ids: &[String],
+        per_workflow_limit: i64,
+    ) -> anyhow::Result<BTreeMap<String, Vec<WorkflowDecisionRecord>>> {
+        if workflow_ids.is_empty() || per_workflow_limit <= 0 {
+            return Ok(BTreeMap::new());
+        }
+        let per_workflow_limit = per_workflow_limit.clamp(1, 20);
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT decision.workflow_id, decision.data
+             FROM unnest($1::text[]) AS selected(workflow_id)
+             JOIN LATERAL (
+                 SELECT workflow_id, data::text AS data, created_at
+                 FROM workflow_decisions
+                 WHERE workflow_id = selected.workflow_id
+                   AND accepted = false
+                 ORDER BY created_at DESC
+                 LIMIT $2
+             ) AS decision ON true
+             ORDER BY decision.workflow_id ASC, decision.created_at DESC",
+        )
+        .bind(workflow_ids)
+        .bind(per_workflow_limit)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut by_workflow = BTreeMap::new();
+        for (workflow_id, data) in rows {
+            by_workflow
+                .entry(workflow_id)
+                .or_insert_with(Vec::new)
+                .push(serde_json::from_str(&data)?);
+        }
+        Ok(by_workflow)
+    }
+
     pub async fn enqueue_command(
         &self,
         workflow_id: &str,
@@ -878,6 +1035,45 @@ impl WorkflowRuntimeStore {
              ORDER BY workflow_id ASC, created_at ASC",
         )
         .bind(workflow_ids)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut by_workflow = BTreeMap::new();
+        for row in rows {
+            let record = workflow_command_record_from_row(row)?;
+            by_workflow
+                .entry(record.workflow_id.clone())
+                .or_insert_with(Vec::new)
+                .push(record);
+        }
+        Ok(by_workflow)
+    }
+
+    pub async fn commands_for_workflows_limited(
+        &self,
+        workflow_ids: &[String],
+        per_workflow_limit: i64,
+    ) -> anyhow::Result<BTreeMap<String, Vec<WorkflowCommandRecord>>> {
+        if workflow_ids.is_empty() || per_workflow_limit <= 0 {
+            return Ok(BTreeMap::new());
+        }
+        let per_workflow_limit = per_workflow_limit.clamp(1, 50);
+        let rows: Vec<WorkflowCommandRecordRow> = sqlx::query_as(
+            "SELECT command.id, command.workflow_id, command.decision_id, command.status,
+                    command.dispatch_owner, command.dispatch_lease_expires_at, command.data,
+                    command.created_at, command.updated_at
+             FROM unnest($1::text[]) AS selected(workflow_id)
+             JOIN LATERAL (
+                 SELECT id, workflow_id, decision_id, status, dispatch_owner,
+                        dispatch_lease_expires_at, data::text AS data, created_at, updated_at
+                 FROM workflow_commands
+                 WHERE workflow_id = selected.workflow_id
+                 ORDER BY created_at DESC
+                 LIMIT $2
+             ) AS command ON true
+             ORDER BY command.workflow_id ASC, command.created_at ASC",
+        )
+        .bind(workflow_ids)
+        .bind(per_workflow_limit)
         .fetch_all(&self.pool)
         .await?;
         let mut by_workflow = BTreeMap::new();
@@ -1320,6 +1516,82 @@ impl WorkflowRuntimeStore {
                 .push(serde_json::from_str(&data)?);
         }
         Ok(by_job)
+    }
+
+    pub async fn runtime_event_summaries_for_jobs(
+        &self,
+        runtime_job_ids: &[String],
+    ) -> anyhow::Result<BTreeMap<String, RuntimeEventSummary>> {
+        if runtime_job_ids.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+        let rows: Vec<RuntimeEventSummaryRow> = sqlx::query_as(
+            "SELECT selected.runtime_job_id,
+                    COALESCE(counts.runtime_event_count, 0),
+                    latest.event_type,
+                    latest.created_at,
+                    prompt.prompt_packet_digest,
+                    counts.latest_turn_sequence,
+                    counts.latest_activity_result_sequence
+             FROM unnest($1::text[]) AS selected(runtime_job_id)
+             LEFT JOIN LATERAL (
+                 SELECT COUNT(*) AS runtime_event_count,
+                        MAX(sequence) FILTER (WHERE event_type = 'RuntimeTurnStarted')
+                            AS latest_turn_sequence,
+                        MAX(sequence) FILTER (WHERE event_type = 'ActivityResultReady')
+                            AS latest_activity_result_sequence
+                 FROM runtime_events
+                 WHERE runtime_job_id = selected.runtime_job_id
+             ) AS counts ON true
+             LEFT JOIN LATERAL (
+                 SELECT event_type, created_at
+                 FROM runtime_events
+                 WHERE runtime_job_id = selected.runtime_job_id
+                 ORDER BY sequence DESC
+                 LIMIT 1
+             ) AS latest ON true
+             LEFT JOIN LATERAL (
+                 SELECT data #>> '{event,prompt_packet_digest}' AS prompt_packet_digest
+                 FROM runtime_events
+                 WHERE runtime_job_id = selected.runtime_job_id
+                   AND event_type = 'RuntimePromptPrepared'
+                   AND data #>> '{event,prompt_packet_digest}' IS NOT NULL
+                 ORDER BY sequence DESC
+                 LIMIT 1
+             ) AS prompt ON true",
+        )
+        .bind(runtime_job_ids)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(
+                |(
+                    runtime_job_id,
+                    runtime_event_count,
+                    latest_runtime_event_type,
+                    latest_runtime_event_at,
+                    prompt_packet_digest,
+                    latest_turn_sequence,
+                    latest_activity_result_sequence,
+                )| {
+                    (
+                        runtime_job_id.clone(),
+                        RuntimeEventSummary {
+                            runtime_job_id,
+                            runtime_event_count: runtime_event_count.max(0) as usize,
+                            latest_runtime_event_type,
+                            prompt_packet_digest,
+                            latest_runtime_event_at,
+                            latest_turn_sequence: latest_turn_sequence
+                                .and_then(|sequence| u64::try_from(sequence).ok()),
+                            latest_activity_result_sequence: latest_activity_result_sequence
+                                .and_then(|sequence| u64::try_from(sequence).ok()),
+                        },
+                    )
+                },
+            )
+            .collect())
     }
 
     pub async fn complete_runtime_job_if_owned(
@@ -1844,6 +2116,79 @@ impl WorkflowRuntimeStore {
         Ok(by_command)
     }
 
+    pub async fn compact_runtime_jobs_for_commands_limited(
+        &self,
+        command_ids: &[String],
+        per_command_limit: i64,
+    ) -> anyhow::Result<BTreeMap<String, Vec<RuntimeJobCompactRecord>>> {
+        if command_ids.is_empty() || per_command_limit <= 0 {
+            return Ok(BTreeMap::new());
+        }
+        let per_command_limit = per_command_limit.clamp(1, 50);
+        let rows: Vec<RuntimeJobCompactRecordRow> = sqlx::query_as(
+            "SELECT job.command_id, job.id, job.runtime_kind, job.runtime_profile,
+                    job.status, (job.data->'lease')::text AS lease,
+                    COALESCE((job.data->>'lease_generation')::bigint, 0),
+                    job.data->>'error',
+                    (job.data->>'not_before')::timestamptz,
+                    job.created_at, job.updated_at
+             FROM unnest($1::text[]) AS selected(command_id)
+             JOIN LATERAL (
+                 SELECT command_id, id, runtime_kind, runtime_profile, status, data,
+                        created_at, updated_at,
+                        (data->>'created_at')::timestamptz AS job_created_at
+                 FROM runtime_jobs
+                 WHERE command_id = selected.command_id
+                 ORDER BY created_at DESC, (data->>'created_at')::timestamptz DESC
+                 LIMIT $2
+             ) AS job ON true
+             ORDER BY job.command_id ASC, job.created_at ASC, job.job_created_at ASC",
+        )
+        .bind(command_ids)
+        .bind(per_command_limit)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut by_command = BTreeMap::new();
+        for (
+            command_id,
+            id,
+            runtime_kind,
+            runtime_profile,
+            status,
+            lease_json,
+            lease_generation,
+            error,
+            not_before,
+            created_at,
+            updated_at,
+        ) in rows
+        {
+            let lease = lease_json
+                .as_deref()
+                .filter(|value| *value != "null")
+                .map(serde_json::from_str)
+                .transpose()?;
+            let record = RuntimeJobCompactRecord {
+                id,
+                command_id: command_id.clone(),
+                runtime_kind: enum_from_str(&runtime_kind)?,
+                runtime_profile,
+                status: enum_from_str(&status)?,
+                lease,
+                lease_generation: lease_generation.max(0) as u64,
+                error,
+                not_before,
+                created_at,
+                updated_at,
+            };
+            by_command
+                .entry(command_id)
+                .or_insert_with(Vec::new)
+                .push(record);
+        }
+        Ok(by_command)
+    }
+
     pub async fn runtime_turns_started_for_workflow(
         &self,
         workflow_id: &str,
@@ -1888,6 +2233,13 @@ pub(super) fn enum_str(value: &impl Serialize) -> anyhow::Result<String> {
         .as_str()
         .map(str::to_string)
         .ok_or_else(|| anyhow::anyhow!("serialized enum did not produce a string"))
+}
+
+fn enum_from_str<T>(value: &str) -> anyhow::Result<T>
+where
+    T: DeserializeOwned,
+{
+    Ok(serde_json::from_value(Value::String(value.to_string()))?)
 }
 
 async fn runtime_job_for_command_tx(

--- a/scripts/evaluate_pr_repair.sh
+++ b/scripts/evaluate_pr_repair.sh
@@ -602,6 +602,7 @@ collect_runtime_tree_artifact() {
     --data-urlencode "project_id=$project_root" \
     --data-urlencode "limit=100" \
     --data-urlencode "job_limit=5" \
+    --data-urlencode "detail=full" \
     "$SERVER_URL/api/workflows/runtime/tree" \
     > "$RUNTIME_TREE_FINAL_JSON" 2>"$RUNTIME_TREE_FINAL_ERROR"; then
     python3 "$SCRIPT_DIR/evaluate_pr_repair_artifacts.py" merge-runtime-tree \

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -157,6 +157,9 @@ export function useWorkflowRuntimeTree(projectId?: string | null) {
     queryFn: ({ signal }) => {
       const params = new URLSearchParams();
       params.set("limit", "100");
+      params.set("detail", "compact");
+      params.set("command_limit", "5");
+      params.set("job_limit", "1");
       if (projectId) params.set("project_id", projectId);
       return apiJson<WorkflowRuntimeTreePayload>(`/api/workflows/runtime/tree?${params}`, {
         signal,

--- a/web/src/routes/dashboard/Active.test.tsx
+++ b/web/src/routes/dashboard/Active.test.tsx
@@ -333,6 +333,7 @@ describe("<Active>", () => {
                   created_at: "2026-04-30T00:00:00Z",
                   updated_at: "2026-04-30T00:00:00Z",
                 },
+                rejected_decision_count: 6,
                 events: [
                   {
                     id: "event-1",
@@ -428,6 +429,7 @@ describe("<Active>", () => {
     expect(screen.getByText("2 expired/missing")).toBeInTheDocument();
     expect(screen.getByText("repo_backlog - owner/repo")).toBeInTheDocument();
     expect(screen.getByText("github_issue_pr - issue:123")).toBeInTheDocument();
+    expect(screen.getByText("rejected 6")).toBeInTheDocument();
     expect(screen.getByText("activity: replan_issue")).toBeInTheDocument();
     expect(screen.getByText("7 jobs")).toBeInTheDocument();
     expect(

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -102,7 +102,11 @@ function fallbackTriggerLabel(trigger?: string | null): string | null {
 }
 
 function commandLabel(command: WorkflowRuntimeCommandNode): string {
-  const activity = command.command.command.activity;
+  const payload = command.command.command;
+  const activity =
+    payload && typeof payload === "object" && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>).activity
+      : null;
   if (typeof activity === "string" && activity.trim()) return activity;
   return command.command.command_type.replaceAll("_", " ");
 }
@@ -174,6 +178,10 @@ function rejectedDecisions(decisions: WorkflowRuntimeDecisionRecord[]) {
   return decisions.filter((decision) => !decision.accepted);
 }
 
+function rejectedDecisionCount(node: WorkflowRuntimeTreeNode) {
+  return node.rejected_decision_count ?? rejectedDecisions(node.decisions).length;
+}
+
 function workflowRuntimeCounts(nodes: WorkflowRuntimeTreeNode[]) {
   let workflows = 0;
   let commands = 0;
@@ -183,7 +191,7 @@ function workflowRuntimeCounts(nodes: WorkflowRuntimeTreeNode[]) {
   const visit = (node: WorkflowRuntimeTreeNode) => {
     workflows += 1;
     commands += node.command_count ?? node.commands.length;
-    rejected += node.rejected_decision_count ?? rejectedDecisions(node.decisions).length;
+    rejected += rejectedDecisionCount(node);
     jobs +=
       node.runtime_job_count ??
       node.commands.reduce((total, command) => total + command.runtime_jobs.length, 0);
@@ -226,6 +234,7 @@ function WorkflowRuntimeNode({
   cancellingWorkflowIds?: Set<string>;
 }) {
   const rejected = rejectedDecisions(node.decisions);
+  const rejectedCount = rejectedDecisionCount(node);
   const canCancel = runtimeWorkflowCanCancel(node.workflow);
   const cancelling = cancellingWorkflowIds?.has(node.workflow.id) ?? false;
   return (
@@ -246,9 +255,9 @@ function WorkflowRuntimeNode({
         <span className="border border-line bg-bg px-1.5 py-[1px] font-mono text-[10px] text-ink-2">
           {workflowLabel(node.workflow.state)}
         </span>
-        {rejected.length > 0 ? (
+        {rejectedCount > 0 ? (
           <span className="border border-rust/40 bg-rust/10 px-1.5 py-[1px] font-mono text-[10px] text-rust">
-            rejected {rejected.length}
+            rejected {rejectedCount}
           </span>
         ) : null}
         {canCancel && onCancel ? (

--- a/web/src/routes/dashboard/Active.tsx
+++ b/web/src/routes/dashboard/Active.tsx
@@ -182,9 +182,11 @@ function workflowRuntimeCounts(nodes: WorkflowRuntimeTreeNode[]) {
 
   const visit = (node: WorkflowRuntimeTreeNode) => {
     workflows += 1;
-    commands += node.commands.length;
-    rejected += rejectedDecisions(node.decisions).length;
-    for (const command of node.commands) jobs += command.runtime_jobs.length;
+    commands += node.command_count ?? node.commands.length;
+    rejected += node.rejected_decision_count ?? rejectedDecisions(node.decisions).length;
+    jobs +=
+      node.runtime_job_count ??
+      node.commands.reduce((total, command) => total + command.runtime_jobs.length, 0);
     for (const child of node.children) visit(child);
   };
   for (const node of nodes) visit(node);
@@ -237,7 +239,8 @@ function WorkflowRuntimeNode({
             {node.workflow.definition_id} - {node.workflow.subject.subject_key}
           </div>
           <div className="mt-0.5 truncate font-mono text-[10px] text-ink-3">
-            {node.events.length} events - {node.commands.length} commands
+            {node.event_count ?? node.events.length} events -{" "}
+            {node.command_count ?? node.commands.length} commands
           </div>
         </div>
         <span className="border border-line bg-bg px-1.5 py-[1px] font-mono text-[10px] text-ink-2">

--- a/web/src/types/workflow_runtime.ts
+++ b/web/src/types/workflow_runtime.ts
@@ -85,7 +85,7 @@ export interface WorkflowRuntimeCommandNode {
   command: {
     command_type: string;
     dedupe_key: string;
-    command: Record<string, unknown>;
+    command: unknown;
   };
   runtime_job_count?: number;
   runtime_jobs: WorkflowRuntimeJob[];

--- a/web/src/types/workflow_runtime.ts
+++ b/web/src/types/workflow_runtime.ts
@@ -9,6 +9,9 @@ export interface WorkflowRuntimeTreePayload {
     has_more: boolean;
     next_offset?: number | null;
     job_limit: number;
+    command_limit?: number | null;
+    detail?: "compact" | "full";
+    summary_only?: boolean;
   };
   summary?: {
     total_commands: number;
@@ -16,12 +19,18 @@ export interface WorkflowRuntimeTreePayload {
     command_statuses: Record<string, number>;
     runtime_job_statuses: Record<string, number>;
     running_job_lease_statuses?: Record<string, number>;
+    activity_outcomes?: Record<string, number>;
+    jobs_without_activity_envelope?: number;
   };
 }
 
 export interface WorkflowRuntimeTreeNode {
   workflow: WorkflowRuntimeInstance;
   runtime_job_count?: number;
+  event_count?: number;
+  decision_count?: number;
+  rejected_decision_count?: number;
+  command_count?: number;
   events: WorkflowRuntimeEvent[];
   decisions: WorkflowRuntimeDecisionRecord[];
   commands: WorkflowRuntimeCommandNode[];
@@ -97,7 +106,7 @@ export interface WorkflowRuntimeJob {
   lease_state?: string | null;
   in_flight_model_turn?: boolean;
   last_runtime_observation_at?: string | null;
-  input: Record<string, unknown>;
+  input?: Record<string, unknown>;
   output?: Record<string, unknown> | null;
   error?: string | null;
   not_before?: string | null;


### PR DESCRIPTION
## Summary
- Make `/api/workflows/runtime/tree` default to a compact polling shape with real event/decision/command/job counts, bounded command and job slices, and rejected-decision hints only.
- Preserve the previous full debug payload behind `detail=full` and add `summary_only=true` for status checks.
- Update `harness status` and dashboard polling to use the compact/summary runtime tree contracts.

Closes #1165

## Validation
- `cargo check -p harness-server --all-targets`
- `cargo test -p harness-server runtime_tree -- --nocapture`
- `cargo test -p harness-cli status::tests -- --nocapture`
- `bun run typecheck`
- `bun run test src/routes/dashboard/Active.test.tsx`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`