### PR TITLE
feat(web): add operator monitor cockpit

### DIFF
--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod gc;
 pub mod health;
 pub mod learn;
 pub mod observe;
+pub mod operator_monitor;
 pub mod operator_snapshot;
 pub mod overview;
 pub mod preflight;

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -23,6 +23,13 @@ const MAX_OPERATOR_ACTIONS: usize = 40;
 const MAX_FAILURE_GROUPS: usize = 20;
 const MAX_RECENT_FAILURES: i64 = 100;
 const STALLED_AFTER_MINS: u64 = 30;
+const WORKFLOW_DEFINITION_IDS: &[&str] = &[
+    harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+    harness_workflow::runtime::PR_FEEDBACK_DEFINITION_ID,
+    harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
+    harness_workflow::runtime::REPO_BACKLOG_DEFINITION_ID,
+    harness_workflow::runtime::QUALITY_GATE_DEFINITION_ID,
+];
 
 #[derive(Debug, Clone, Serialize)]
 struct OperatorMonitorPayload {
@@ -238,7 +245,21 @@ async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<Workflow
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(Vec::new());
     };
-    store.list_instances(None, WORKFLOW_SAMPLE_LIMIT).await
+    let mut workflows = Vec::new();
+    for definition_id in WORKFLOW_DEFINITION_IDS {
+        workflows.extend(
+            store
+                .list_nonterminal_instances_by_definition(
+                    definition_id,
+                    None,
+                    Some(WORKFLOW_SAMPLE_LIMIT),
+                )
+                .await?,
+        );
+    }
+    workflows.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    workflows.truncate(WORKFLOW_SAMPLE_LIMIT as usize);
+    Ok(workflows)
 }
 
 fn runtime_workflow_counts(workflows: &[WorkflowInstance]) -> RuntimeWorkflowCounts {
@@ -375,7 +396,7 @@ fn add_workflow_source_activity(
         });
     match workflow_bucket(workflow) {
         WorkflowBucket::Running => entry.running += 1,
-        WorkflowBucket::Blocked => entry.blocked += 1,
+        WorkflowBucket::AwaitingDependencies | WorkflowBucket::Blocked => entry.blocked += 1,
         WorkflowBucket::Failed => entry.failed += 1,
         WorkflowBucket::ReadyToMerge => entry.ready_to_merge += 1,
         _ => {}

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -1,0 +1,791 @@
+//! GET /api/operator-monitor — reconciled operator monitoring cockpit data.
+//!
+//! This endpoint is intentionally separate from `/api/overview`: overview keeps
+//! the broad dashboard payload, while this payload answers current operator
+//! questions across workflow runtime state, legacy task rows, failures, and
+//! worktrees.
+
+use crate::http::AppState;
+use crate::runtime_projection::{RuntimeActiveBucket, RuntimeWorkflowProjection};
+use crate::task_runner::{RecentFailureTask, SchedulerAuthorityState, TaskSummary};
+use crate::workspace::WorkspaceManager;
+use axum::{extract::State, http::StatusCode, Json};
+use chrono::{DateTime, Utc};
+use harness_workflow::runtime::WorkflowInstance;
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+const WORKFLOW_SAMPLE_LIMIT: i64 = 500;
+const MAX_OPERATOR_ACTIONS: usize = 40;
+const MAX_FAILURE_GROUPS: usize = 20;
+const MAX_RECENT_FAILURES: i64 = 100;
+const STALLED_AFTER_MINS: u64 = 30;
+
+#[derive(Debug, Clone, Serialize)]
+struct OperatorMonitorPayload {
+    generated_at: String,
+    sample_limit: i64,
+    health: OperatorHealth,
+    activity: OperatorActivity,
+    operator_actions: Vec<OperatorAction>,
+    failures: Vec<FailureGroup>,
+    worktrees: WorktreeSummary,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OperatorHealth {
+    status: &'static str,
+    degraded_subsystems: Vec<&'static str>,
+    runtime_log_state: &'static str,
+    runtime_log_path: Option<String>,
+    uptime_secs: u64,
+    runtime_hosts_online: u64,
+    runtime_hosts_total: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OperatorActivity {
+    runtime_workflows: RuntimeWorkflowCounts,
+    legacy_queue: LegacyQueueCounts,
+    by_source: Vec<SourceActivity>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+struct RuntimeWorkflowCounts {
+    pending: u64,
+    running: u64,
+    review: u64,
+    awaiting_dependencies: u64,
+    ready_to_merge: u64,
+    blocked: u64,
+    failed: u64,
+    done: u64,
+    other: u64,
+}
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+struct LegacyQueueCounts {
+    queued: u64,
+    running: u64,
+    stalled: u64,
+    failed: u64,
+    done: u64,
+}
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+struct SourceActivity {
+    source: String,
+    running: u64,
+    blocked: u64,
+    failed: u64,
+    ready_to_merge: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OperatorAction {
+    kind: &'static str,
+    repo: Option<String>,
+    issue: Option<u64>,
+    pr: Option<u64>,
+    task_id: Option<String>,
+    workflow_id: String,
+    state: String,
+    age_secs: u64,
+    url: Option<String>,
+    evidence_url: Option<String>,
+    next_action: &'static str,
+    source: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct FailureGroup {
+    family: &'static str,
+    severity: &'static str,
+    message: String,
+    first_seen: Option<String>,
+    last_seen: Option<String>,
+    count: u64,
+    repo: Option<String>,
+    task_id: Option<String>,
+    retryable: bool,
+    next_action: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct WorktreeSummary {
+    used: u64,
+    capacity: u64,
+    stale: Option<u64>,
+    metrics_state: &'static str,
+    cards: Vec<crate::handlers::worktrees::WorktreeResponse>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FailureGroupKey {
+    family: &'static str,
+    message: String,
+    repo: Option<String>,
+}
+
+pub async fn operator_monitor(State(state): State<Arc<AppState>>) -> (StatusCode, Json<Value>) {
+    match build_operator_monitor(&state).await {
+        Ok(payload) => (
+            StatusCode::OK,
+            Json(serde_json::to_value(payload).unwrap_or_else(|error| {
+                json!({ "error": format!("failed to serialize operator monitor: {error}") })
+            })),
+        ),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": error.to_string() })),
+        ),
+    }
+}
+
+async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMonitorPayload> {
+    let generated_at = Utc::now();
+    let workflows = list_runtime_workflows(state).await?;
+    let active_tasks = state.core.tasks.list_active_summaries().await?;
+    let stalled_tasks = state
+        .core
+        .tasks
+        .list_stalled_tasks(Duration::from_secs(STALLED_AFTER_MINS * 60), None)
+        .await?;
+    let recent_failures = state
+        .core
+        .tasks
+        .list_recent_failed(MAX_RECENT_FAILURES)
+        .await?;
+    let worktree_cards = crate::handlers::worktrees::list_worktrees(state).await?;
+
+    let dashboard_counts = state.task_svc.count_for_dashboard().await;
+    let runtime_hosts = state.runtime_hosts.list_hosts();
+    let runtime_log_state = state.core.server.runtime_logs.state.as_str();
+    let degraded_subsystems = state.degraded_subsystems.clone();
+    let health_status = if degraded_subsystems.is_empty() && runtime_log_state != "degraded" {
+        "ok"
+    } else {
+        "degraded"
+    };
+
+    let runtime_workflows = runtime_workflow_counts(&workflows);
+    let legacy_queue = legacy_queue_counts(
+        &active_tasks,
+        stalled_tasks.len() as u64,
+        dashboard_counts.global_failed,
+        dashboard_counts.global_done,
+    );
+    let by_source = source_activity(&workflows, &active_tasks);
+    let operator_actions = operator_actions(&workflows, generated_at);
+    let failures = grouped_failures(&recent_failures);
+    let capacity = state.concurrency.task_queue.global_limit() as u64;
+
+    Ok(OperatorMonitorPayload {
+        generated_at: generated_at.to_rfc3339(),
+        sample_limit: WORKFLOW_SAMPLE_LIMIT,
+        health: OperatorHealth {
+            status: health_status,
+            degraded_subsystems,
+            runtime_log_state,
+            runtime_log_path: state
+                .core
+                .server
+                .runtime_logs
+                .active_path
+                .as_ref()
+                .map(|path| path.to_string_lossy().into_owned()),
+            uptime_secs: crate::handlers::dashboard::SERVER_START
+                .get()
+                .map(|start| start.elapsed().as_secs())
+                .unwrap_or(0),
+            runtime_hosts_online: runtime_hosts.iter().filter(|host| host.online).count() as u64,
+            runtime_hosts_total: runtime_hosts.len() as u64,
+        },
+        activity: OperatorActivity {
+            runtime_workflows,
+            legacy_queue,
+            by_source,
+        },
+        operator_actions,
+        failures,
+        worktrees: WorktreeSummary {
+            used: worktree_cards.len() as u64,
+            capacity,
+            stale: stale_worktree_count(
+                state.concurrency.workspace_mgr.as_deref(),
+                &worktree_cards,
+            ),
+            metrics_state: "unavailable",
+            cards: worktree_cards,
+        },
+    })
+}
+
+async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<WorkflowInstance>> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(Vec::new());
+    };
+    store.list_instances(None, WORKFLOW_SAMPLE_LIMIT).await
+}
+
+fn runtime_workflow_counts(workflows: &[WorkflowInstance]) -> RuntimeWorkflowCounts {
+    let mut counts = RuntimeWorkflowCounts::default();
+    for workflow in workflows {
+        match workflow_bucket(workflow) {
+            WorkflowBucket::Pending => counts.pending += 1,
+            WorkflowBucket::Running => counts.running += 1,
+            WorkflowBucket::Review => counts.review += 1,
+            WorkflowBucket::AwaitingDependencies => counts.awaiting_dependencies += 1,
+            WorkflowBucket::ReadyToMerge => counts.ready_to_merge += 1,
+            WorkflowBucket::Blocked => counts.blocked += 1,
+            WorkflowBucket::Failed => counts.failed += 1,
+            WorkflowBucket::Done => counts.done += 1,
+            WorkflowBucket::Other => counts.other += 1,
+        }
+    }
+    counts
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkflowBucket {
+    Pending,
+    Running,
+    Review,
+    AwaitingDependencies,
+    ReadyToMerge,
+    Blocked,
+    Failed,
+    Done,
+    Other,
+}
+
+fn workflow_bucket(workflow: &WorkflowInstance) -> WorkflowBucket {
+    match workflow.state.as_str() {
+        "scheduled" | "discovered" => WorkflowBucket::Pending,
+        "awaiting_dependencies" => WorkflowBucket::AwaitingDependencies,
+        "ready_to_merge" => WorkflowBucket::ReadyToMerge,
+        "blocked" => WorkflowBucket::Blocked,
+        "failed" => WorkflowBucket::Failed,
+        "done" | "passed" => WorkflowBucket::Done,
+        "pr_open" | "local_review_gate" | "awaiting_feedback" | "quality_gate_pending" => {
+            WorkflowBucket::Review
+        }
+        _ => {
+            let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+            match projection.active_bucket() {
+                Some(RuntimeActiveBucket::Running) => WorkflowBucket::Running,
+                Some(RuntimeActiveBucket::Queued) => WorkflowBucket::Pending,
+                None => WorkflowBucket::Other,
+            }
+        }
+    }
+}
+
+fn legacy_queue_counts(
+    active_tasks: &[TaskSummary],
+    stalled: u64,
+    failed: u64,
+    done: u64,
+) -> LegacyQueueCounts {
+    let mut counts = LegacyQueueCounts {
+        stalled,
+        failed,
+        done,
+        ..Default::default()
+    };
+    for task in active_tasks {
+        match task.scheduler.authority_state {
+            SchedulerAuthorityState::Running
+            | SchedulerAuthorityState::Leased
+            | SchedulerAuthorityState::Recovering => counts.running += 1,
+            _ => counts.queued += 1,
+        }
+    }
+    counts
+}
+
+fn source_activity(
+    workflows: &[WorkflowInstance],
+    active_tasks: &[TaskSummary],
+) -> Vec<SourceActivity> {
+    let mut by_source: HashMap<String, SourceActivity> = HashMap::new();
+    for workflow in workflows {
+        add_workflow_source_activity(&mut by_source, workflow);
+    }
+    for task in active_tasks {
+        if task.workflow.is_some() {
+            continue;
+        }
+        add_legacy_source_activity(&mut by_source, task);
+    }
+    let mut rows: Vec<SourceActivity> = by_source.into_values().collect();
+    rows.sort_by(|a, b| {
+        source_total(b)
+            .cmp(&source_total(a))
+            .then_with(|| a.source.cmp(&b.source))
+    });
+    rows
+}
+
+fn add_workflow_source_activity(
+    by_source: &mut HashMap<String, SourceActivity>,
+    workflow: &WorkflowInstance,
+) {
+    let source = workflow_source(workflow);
+    let entry = by_source
+        .entry(source.clone())
+        .or_insert_with(|| SourceActivity {
+            source,
+            ..Default::default()
+        });
+    match workflow_bucket(workflow) {
+        WorkflowBucket::Running => entry.running += 1,
+        WorkflowBucket::Blocked => entry.blocked += 1,
+        WorkflowBucket::Failed => entry.failed += 1,
+        WorkflowBucket::ReadyToMerge => entry.ready_to_merge += 1,
+        _ => {}
+    }
+}
+
+fn add_legacy_source_activity(by_source: &mut HashMap<String, SourceActivity>, task: &TaskSummary) {
+    let source = task
+        .source
+        .as_deref()
+        .filter(|source| !source.trim().is_empty())
+        .unwrap_or("manual")
+        .to_string();
+    let entry = by_source
+        .entry(source.clone())
+        .or_insert_with(|| SourceActivity {
+            source,
+            ..Default::default()
+        });
+    if task.status.is_failure() {
+        entry.failed += 1;
+    } else if task.status.as_ref() == "waiting" {
+        entry.blocked += 1;
+    } else {
+        entry.running += 1;
+    }
+}
+
+fn source_total(source: &SourceActivity) -> u64 {
+    source.running + source.blocked + source.failed + source.ready_to_merge
+}
+
+fn operator_actions(
+    workflows: &[WorkflowInstance],
+    generated_at: DateTime<Utc>,
+) -> Vec<OperatorAction> {
+    let mut actions = Vec::new();
+    for workflow in workflows {
+        let Some((kind, next_action)) = workflow_action_kind(workflow.state.as_str()) else {
+            continue;
+        };
+        let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+        let task_id = projection
+            .submission_handle
+            .as_ref()
+            .map(|task_id| task_id.as_str().to_string());
+        let repo = string_field(&workflow.data, "repo");
+        let issue = u64_field(&workflow.data, "issue_number");
+        let pr = u64_field(&workflow.data, "pr_number");
+        let pr_url = string_field(&workflow.data, "pr_url");
+        let issue_url = repo
+            .as_ref()
+            .zip(issue)
+            .map(|(repo, issue)| format!("https://github.com/{repo}/issues/{issue}"));
+        actions.push(OperatorAction {
+            kind,
+            repo,
+            issue,
+            pr,
+            evidence_url: task_id.as_ref().map(|id| format!("/tasks/{id}")),
+            task_id,
+            workflow_id: workflow.id.clone(),
+            state: workflow.state.clone(),
+            age_secs: generated_at
+                .signed_duration_since(workflow.updated_at)
+                .num_seconds()
+                .max(0) as u64,
+            url: pr_url.or(issue_url),
+            next_action,
+            source: workflow_source(workflow),
+        });
+    }
+    actions.sort_by(|a, b| {
+        action_priority(a.kind)
+            .cmp(&action_priority(b.kind))
+            .then_with(|| b.age_secs.cmp(&a.age_secs))
+    });
+    actions.truncate(MAX_OPERATOR_ACTIONS);
+    actions
+}
+
+fn workflow_action_kind(state: &str) -> Option<(&'static str, &'static str)> {
+    match state {
+        "ready_to_merge" => Some(("ready_to_merge", "Review and merge")),
+        "awaiting_feedback" => Some(("awaiting_feedback", "Inspect review feedback")),
+        "blocked" => Some(("blocked", "Resolve blocker")),
+        _ => None,
+    }
+}
+
+fn action_priority(kind: &str) -> u8 {
+    match kind {
+        "ready_to_merge" => 0,
+        "blocked" => 1,
+        "awaiting_feedback" => 2,
+        _ => 3,
+    }
+}
+
+fn grouped_failures(failures: &[RecentFailureTask]) -> Vec<FailureGroup> {
+    let mut groups: HashMap<FailureGroupKey, FailureGroup> = HashMap::new();
+    for failure in failures {
+        let raw_message = failure.error.as_deref().unwrap_or("unknown failure");
+        let family = classify_failure_family(raw_message);
+        let key = FailureGroupKey {
+            family,
+            message: normalize_failure_message(raw_message),
+            repo: failure.project.as_deref().map(project_label),
+        };
+        let failed_at = failure.failed_at.clone();
+        let task_id = failure.id.as_str().to_string();
+        let group = groups.entry(key.clone()).or_insert_with(|| FailureGroup {
+            family,
+            severity: failure_severity(family),
+            message: key.message.clone(),
+            first_seen: failed_at.clone(),
+            last_seen: failed_at.clone(),
+            count: 0,
+            repo: key.repo.clone(),
+            task_id: Some(task_id.clone()),
+            retryable: failure_retryable(family),
+            next_action: failure_next_action(family),
+        });
+        group.count += 1;
+        group.first_seen = earlier_timestamp(group.first_seen.as_deref(), failed_at.as_deref());
+        group.last_seen = later_timestamp(group.last_seen.as_deref(), failed_at.as_deref());
+        if group.task_id.is_none() {
+            group.task_id = Some(task_id);
+        }
+    }
+    let mut rows: Vec<FailureGroup> = groups.into_values().collect();
+    rows.sort_by(|a, b| {
+        parsed_timestamp(b.last_seen.as_deref())
+            .cmp(&parsed_timestamp(a.last_seen.as_deref()))
+            .then_with(|| b.count.cmp(&a.count))
+            .then_with(|| a.family.cmp(b.family))
+    });
+    rows.truncate(MAX_FAILURE_GROUPS);
+    rows
+}
+
+fn classify_failure_family(message: &str) -> &'static str {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("ssl_error_syscall")
+        || lower.contains("failed to fetch")
+        || lower.contains("git fetch")
+        || lower.contains("github.com")
+    {
+        "github_fetch"
+    } else if lower.contains("timed out") || lower.contains("timeout") {
+        "timeout"
+    } else if lower.contains("rate limit") || lower.contains("secondary rate limit") {
+        "rate_limit"
+    } else if lower.contains("missing structured output")
+        || lower.contains("activity_result")
+        || lower.contains("structured activity")
+    {
+        "missing_structured_output"
+    } else if lower.contains("worktree") || lower.contains("workspace") {
+        "worktree_collision"
+    } else if lower.contains("agent turn") || lower.contains("agent failed") {
+        "agent_turn_failed"
+    } else {
+        "internal"
+    }
+}
+
+fn failure_severity(family: &str) -> &'static str {
+    match family {
+        "github_fetch" | "timeout" | "rate_limit" => "warn",
+        "missing_structured_output" | "worktree_collision" | "agent_turn_failed" => "error",
+        _ => "error",
+    }
+}
+
+fn failure_retryable(family: &str) -> bool {
+    matches!(family, "github_fetch" | "timeout" | "rate_limit")
+}
+
+fn failure_next_action(family: &str) -> &'static str {
+    match family {
+        "github_fetch" => "Retry after GitHub connectivity recovers",
+        "timeout" => "Retry or inspect the long-running turn",
+        "rate_limit" => "Wait for the rate limit window",
+        "missing_structured_output" => "Inspect agent output and prompt contract",
+        "worktree_collision" => "Inspect workspace ownership",
+        "agent_turn_failed" => "Inspect agent logs",
+        _ => "Inspect task logs",
+    }
+}
+
+fn normalize_failure_message(message: &str) -> String {
+    let first_line = message.lines().next().unwrap_or(message).trim();
+    let collapsed = first_line.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() > 180 {
+        collapsed.chars().take(177).collect::<String>() + "..."
+    } else if collapsed.is_empty() {
+        "unknown failure".to_string()
+    } else {
+        collapsed
+    }
+}
+
+fn earlier_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<String> {
+    match (current, candidate) {
+        (Some(current), Some(candidate)) => {
+            if parsed_timestamp(Some(candidate)) < parsed_timestamp(Some(current)) {
+                Some(candidate.to_string())
+            } else {
+                Some(current.to_string())
+            }
+        }
+        (Some(current), None) => Some(current.to_string()),
+        (None, Some(candidate)) => Some(candidate.to_string()),
+        (None, None) => None,
+    }
+}
+
+fn later_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<String> {
+    match (current, candidate) {
+        (Some(current), Some(candidate)) => {
+            if parsed_timestamp(Some(candidate)) > parsed_timestamp(Some(current)) {
+                Some(candidate.to_string())
+            } else {
+                Some(current.to_string())
+            }
+        }
+        (Some(current), None) => Some(current.to_string()),
+        (None, Some(candidate)) => Some(candidate.to_string()),
+        (None, None) => None,
+    }
+}
+
+fn parsed_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
+    value.and_then(|value| {
+        DateTime::parse_from_rfc3339(value)
+            .ok()
+            .map(|parsed| parsed.with_timezone(&Utc))
+    })
+}
+
+fn stale_worktree_count(
+    manager: Option<&WorkspaceManager>,
+    cards: &[crate::handlers::worktrees::WorktreeResponse],
+) -> Option<u64> {
+    manager.map(|manager| manager.live_count().saturating_sub(cards.len() as u64))
+}
+
+fn workflow_source(workflow: &WorkflowInstance) -> String {
+    string_field(&workflow.data, "source")
+        .filter(|source| !source.trim().is_empty())
+        .unwrap_or_else(|| match workflow.definition_id.as_str() {
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID => "github".to_string(),
+            harness_workflow::runtime::PR_FEEDBACK_DEFINITION_ID => {
+                "operator_pr_feedback".to_string()
+            }
+            harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID => "manual".to_string(),
+            harness_workflow::runtime::REPO_BACKLOG_DEFINITION_ID => "repo_backlog".to_string(),
+            harness_workflow::runtime::QUALITY_GATE_DEFINITION_ID => "quality_gate".to_string(),
+            _ => "workflow_runtime".to_string(),
+        })
+}
+
+fn string_field(data: &Value, field: &str) -> Option<String> {
+    data.get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn u64_field(data: &Value, field: &str) -> Option<u64> {
+    data.get(field)
+        .and_then(|value| value.as_u64().or_else(|| value.as_str()?.parse().ok()))
+}
+
+fn project_label(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::task_runner::TaskWorkflowSummary;
+    use crate::test_helpers;
+    use axum::{body::to_bytes, routing::get, Router};
+    use harness_core::types::TaskId;
+    use harness_workflow::runtime::{WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID};
+
+    fn workflow(state: &str, data: Value) -> WorkflowInstance {
+        WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            state,
+            WorkflowSubject::new("issue", "issue:1"),
+        )
+        .with_data(data)
+    }
+
+    fn github_fetch_failure(id: &str, issue: u64, failed_at: &str) -> RecentFailureTask {
+        RecentFailureTask {
+            id: TaskId(id.to_string()),
+            failure_kind: None,
+            external_id: Some(format!("issue:{issue}")),
+            project: Some("/tmp/harness".to_string()),
+            workspace_path: None,
+            workspace_owner: None,
+            run_generation: 0,
+            error: Some(
+                "git fetch origin main failed: LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443"
+                    .to_string(),
+            ),
+            failed_at: Some(failed_at.to_string()),
+        }
+    }
+
+    #[test]
+    fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
+        let workflows = vec![
+            workflow("implementing", json!({})),
+            workflow("awaiting_feedback", json!({})),
+            workflow("ready_to_merge", json!({})),
+            workflow("awaiting_dependencies", json!({})),
+            workflow("failed", json!({})),
+            workflow("done", json!({})),
+        ];
+
+        let counts = runtime_workflow_counts(&workflows);
+
+        assert_eq!(counts.running, 1);
+        assert_eq!(counts.review, 1);
+        assert_eq!(counts.ready_to_merge, 1);
+        assert_eq!(counts.awaiting_dependencies, 1);
+        assert_eq!(counts.failed, 1);
+        assert_eq!(counts.done, 1);
+    }
+
+    #[test]
+    fn grouped_failures_classifies_and_counts_github_fetch_failures() {
+        let failures = vec![
+            github_fetch_failure("task-1", 1, "2026-06-12T00:00:00Z"),
+            github_fetch_failure("task-2", 2, "2026-06-12T00:05:00Z"),
+        ];
+
+        let groups = grouped_failures(&failures);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].family, "github_fetch");
+        assert_eq!(groups[0].severity, "warn");
+        assert_eq!(groups[0].count, 2);
+        assert_eq!(groups[0].repo.as_deref(), Some("harness"));
+        assert!(groups[0].retryable);
+        assert_eq!(groups[0].last_seen.as_deref(), Some("2026-06-12T00:05:00Z"));
+    }
+
+    #[tokio::test]
+    async fn endpoint_returns_monitor_payload_on_fresh_state() -> anyhow::Result<()> {
+        let _lock = test_helpers::HOME_LOCK.lock().await;
+        let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-")?;
+        let state = Arc::new(test_helpers::make_test_state(dir.path()).await?);
+
+        let app = Router::new()
+            .route("/api/operator-monitor", get(operator_monitor))
+            .with_state(state);
+
+        let req = axum::http::Request::builder()
+            .uri("/api/operator-monitor")
+            .body(axum::body::Body::empty())?;
+        let resp = tower::ServiceExt::oneshot(app, req).await?;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+        let body: Value = serde_json::from_slice(&bytes)?;
+
+        for key in [
+            "generated_at",
+            "health",
+            "activity",
+            "operator_actions",
+            "failures",
+            "worktrees",
+        ] {
+            assert!(body.get(key).is_some(), "missing top-level key: {key}");
+        }
+        assert_eq!(body["worktrees"]["metrics_state"], "unavailable");
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_workflow_summaries_are_not_double_counted_by_source() {
+        let mut by_source = source_activity(
+            &[workflow(
+                "ready_to_merge",
+                json!({
+                    "source": "github",
+                    "pr_number": 7,
+                    "pr_url": "https://github.com/owner/repo/pull/7",
+                }),
+            )],
+            &[TaskSummary {
+                id: TaskId("legacy-row".to_string()),
+                task_kind: crate::task_runner::TaskKind::Issue,
+                status: crate::task_runner::TaskStatus::Waiting,
+                failure_kind: None,
+                turn: 0,
+                pr_url: None,
+                error: None,
+                source: Some("github".to_string()),
+                parent_id: None,
+                external_id: Some("issue:1".to_string()),
+                repo: Some("owner/repo".to_string()),
+                description: None,
+                created_at: None,
+                phase: crate::task_runner::TaskPhase::Review,
+                depends_on: vec![],
+                subtask_ids: vec![],
+                project: None,
+                workspace_path: None,
+                workspace_owner: None,
+                run_generation: 0,
+                workflow: Some(TaskWorkflowSummary {
+                    id: "workflow-1".to_string(),
+                    definition_id: Some(GITHUB_ISSUE_PR_DEFINITION_ID.to_string()),
+                    state: "ready_to_merge".to_string(),
+                    project_id: None,
+                    issue_number: Some(1),
+                    pr_number: Some(7),
+                    force_execute: None,
+                    plan_concern: None,
+                    review_fallback: None,
+                }),
+                scheduler: crate::task_runner::TaskSchedulerState::queued(),
+            }],
+        );
+
+        assert_eq!(by_source.len(), 1);
+        let source = by_source.pop().expect("source row");
+        assert_eq!(source.source, "github");
+        assert_eq!(source.ready_to_merge, 1);
+        assert_eq!(source.blocked, 0);
+    }
+}

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -393,9 +393,8 @@ enum WorkflowBucket {
 fn workflow_bucket(workflow: &WorkflowInstance) -> WorkflowBucket {
     match workflow.state.as_str() {
         "scheduled" | "discovered" => WorkflowBucket::Pending,
-        "checking" | "dispatching" | "planning_batch" | "reconciling" | "scanning" => {
-            WorkflowBucket::Running
-        }
+        "checking" | "dispatching" | "inspecting" | "planning_batch" | "reconciling"
+        | "scanning" => WorkflowBucket::Running,
         "awaiting_dependencies" => WorkflowBucket::AwaitingDependencies,
         "ready_to_merge" => WorkflowBucket::ReadyToMerge,
         "blocked" => WorkflowBucket::Blocked,

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -163,6 +163,10 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
 
     let dashboard_counts = state.task_svc.count_for_dashboard().await;
     let runtime_hosts = state.runtime_hosts.list_hosts();
+    let runtime_host_leases: u64 = runtime_hosts
+        .iter()
+        .map(|host| state.core.tasks.active_runtime_host_lease_count(&host.id) as u64)
+        .sum();
     let runtime_log_state = state.core.server.runtime_logs.state.as_str();
     let degraded_subsystems = state.degraded_subsystems.clone();
     let health_status = if degraded_subsystems.is_empty() && runtime_log_state != "degraded" {
@@ -212,7 +216,7 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
         operator_actions,
         failures,
         worktrees: WorktreeSummary {
-            used: worktree_cards.len() as u64,
+            used: (worktree_cards.len() as u64).saturating_add(runtime_host_leases),
             capacity,
             stale: stale_worktree_count(
                 state.concurrency.workspace_mgr.as_deref(),
@@ -563,27 +567,19 @@ fn normalize_failure_message(message: &str) -> String {
 }
 
 fn earlier_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<String> {
-    Some(
-        match (current, candidate) {
-            (Some(current), Some(candidate)) => current.min(candidate),
-            (Some(current), None) => current,
-            (None, Some(candidate)) => candidate,
-            (None, None) => return None,
-        }
-        .to_string(),
-    )
+    current
+        .into_iter()
+        .chain(candidate)
+        .min()
+        .map(str::to_string)
 }
 
 fn later_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<String> {
-    Some(
-        match (current, candidate) {
-            (Some(current), Some(candidate)) => current.max(candidate),
-            (Some(current), None) => current,
-            (None, Some(candidate)) => candidate,
-            (None, None) => return None,
-        }
-        .to_string(),
-    )
+    current
+        .into_iter()
+        .chain(candidate)
+        .max()
+        .map(str::to_string)
 }
 
 fn stale_worktree_count(

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -296,6 +296,9 @@ enum WorkflowBucket {
 fn workflow_bucket(workflow: &WorkflowInstance) -> WorkflowBucket {
     match workflow.state.as_str() {
         "scheduled" | "discovered" => WorkflowBucket::Pending,
+        "checking" | "dispatching" | "planning_batch" | "reconciling" | "scanning" => {
+            WorkflowBucket::Running
+        }
         "awaiting_dependencies" => WorkflowBucket::AwaitingDependencies,
         "ready_to_merge" => WorkflowBucket::ReadyToMerge,
         "blocked" => WorkflowBucket::Blocked,

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, Utc};
 use harness_workflow::runtime::WorkflowInstance;
 use serde::Serialize;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -176,9 +176,15 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
     };
 
     let runtime_workflows = runtime_workflow_counts(&workflows);
+    let workflow_legacy_task_ids = workflow_legacy_task_ids(&workflows);
+    let stalled_task_count = stalled_tasks
+        .iter()
+        .filter(|task| !workflow_legacy_task_ids.contains(task.id.as_str()))
+        .count() as u64;
+    let active_tasks = filter_workflow_backed_tasks(active_tasks, &workflow_legacy_task_ids);
     let legacy_queue = legacy_queue_counts(
         &active_tasks,
-        stalled_tasks.len() as u64,
+        stalled_task_count,
         dashboard_counts.global_failed,
         dashboard_counts.global_done,
     );
@@ -311,16 +317,38 @@ fn legacy_queue_counts(
     counts
 }
 
+fn workflow_legacy_task_ids(workflows: &[WorkflowInstance]) -> HashSet<String> {
+    workflows
+        .iter()
+        .filter_map(|workflow| {
+            RuntimeWorkflowProjection::from_workflow(workflow)
+                .legacy_dedupe_task_handle
+                .map(|task_id| task_id.0)
+        })
+        .collect()
+}
+
+fn filter_workflow_backed_tasks(
+    tasks: Vec<TaskSummary>,
+    workflow_task_ids: &HashSet<String>,
+) -> Vec<TaskSummary> {
+    tasks
+        .into_iter()
+        .filter(|task| !workflow_task_ids.contains(task.id.as_str()))
+        .collect()
+}
+
 fn source_activity(
     workflows: &[WorkflowInstance],
     active_tasks: &[TaskSummary],
 ) -> Vec<SourceActivity> {
     let mut by_source: HashMap<String, SourceActivity> = HashMap::new();
+    let workflow_task_ids = workflow_legacy_task_ids(workflows);
     for workflow in workflows {
         add_workflow_source_activity(&mut by_source, workflow);
     }
     for task in active_tasks {
-        if task.workflow.is_some() {
+        if task.workflow.is_some() || workflow_task_ids.contains(task.id.as_str()) {
             continue;
         }
         add_legacy_source_activity(&mut by_source, task);
@@ -625,171 +653,4 @@ fn project_label(path: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::task_runner::TaskWorkflowSummary;
-    use crate::test_helpers;
-    use axum::{body::to_bytes, routing::get, Router};
-    use harness_core::types::TaskId;
-    use harness_workflow::runtime::{WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID};
-
-    fn workflow(state: &str, data: Value) -> WorkflowInstance {
-        WorkflowInstance::new(
-            GITHUB_ISSUE_PR_DEFINITION_ID,
-            1,
-            state,
-            WorkflowSubject::new("issue", "issue:1"),
-        )
-        .with_data(data)
-    }
-
-    fn github_fetch_failure(id: &str, issue: u64, failed_at: &str) -> RecentFailureTask {
-        RecentFailureTask {
-            id: TaskId(id.to_string()),
-            failure_kind: None,
-            external_id: Some(format!("issue:{issue}")),
-            project: Some("/tmp/harness".to_string()),
-            workspace_path: None,
-            workspace_owner: None,
-            run_generation: 0,
-            error: Some(
-                "git fetch origin main failed: LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443"
-                    .to_string(),
-            ),
-            failed_at: Some(failed_at.to_string()),
-        }
-    }
-
-    #[test]
-    fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
-        let workflows = vec![
-            workflow("implementing", json!({})),
-            workflow("awaiting_feedback", json!({})),
-            workflow("ready_to_merge", json!({})),
-            workflow("awaiting_dependencies", json!({})),
-            workflow("failed", json!({})),
-            workflow("done", json!({})),
-        ];
-
-        let counts = runtime_workflow_counts(&workflows);
-
-        assert_eq!(counts.running, 1);
-        assert_eq!(counts.review, 1);
-        assert_eq!(counts.ready_to_merge, 1);
-        assert_eq!(counts.awaiting_dependencies, 1);
-        assert_eq!(counts.failed, 1);
-        assert_eq!(counts.done, 1);
-    }
-
-    #[test]
-    fn grouped_failures_classifies_and_counts_github_fetch_failures() {
-        let failures = vec![
-            github_fetch_failure("task-1", 1, "2026-06-12T00:00:00Z"),
-            github_fetch_failure("task-2", 2, "2026-06-12T00:05:00Z"),
-        ];
-
-        let groups = grouped_failures(&failures);
-
-        assert_eq!(groups.len(), 1);
-        assert_eq!(groups[0].family, "github_fetch");
-        assert_eq!(groups[0].severity, "warn");
-        assert_eq!(groups[0].count, 2);
-        assert_eq!(groups[0].repo.as_deref(), Some("harness"));
-        assert!(groups[0].retryable);
-        assert_eq!(groups[0].last_seen.as_deref(), Some("2026-06-12T00:05:00Z"));
-    }
-
-    #[tokio::test]
-    async fn endpoint_returns_monitor_payload_on_fresh_state() -> anyhow::Result<()> {
-        let _lock = test_helpers::HOME_LOCK.lock().await;
-        let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-")?;
-        let state = Arc::new(test_helpers::make_test_state(dir.path()).await?);
-
-        let app = Router::new()
-            .route("/api/operator-monitor", get(operator_monitor))
-            .with_state(state);
-
-        let req = axum::http::Request::builder()
-            .uri("/api/operator-monitor")
-            .body(axum::body::Body::empty())?;
-        let resp = tower::ServiceExt::oneshot(app, req).await?;
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
-        let body: Value = serde_json::from_slice(&bytes)?;
-
-        for key in [
-            "generated_at",
-            "health",
-            "activity",
-            "operator_actions",
-            "failures",
-            "worktrees",
-        ] {
-            assert!(body.get(key).is_some(), "missing top-level key: {key}");
-        }
-        assert_eq!(body["worktrees"]["metrics_state"], "unavailable");
-        Ok(())
-    }
-
-    #[test]
-    fn legacy_workflow_and_queued_tasks_are_not_counted_by_source() {
-        let legacy_row = TaskSummary {
-            id: TaskId("legacy-row".to_string()),
-            task_kind: crate::task_runner::TaskKind::Issue,
-            status: crate::task_runner::TaskStatus::Waiting,
-            failure_kind: None,
-            turn: 0,
-            pr_url: None,
-            error: None,
-            source: Some("github".to_string()),
-            parent_id: None,
-            external_id: Some("issue:1".to_string()),
-            repo: Some("owner/repo".to_string()),
-            description: None,
-            created_at: None,
-            phase: crate::task_runner::TaskPhase::Review,
-            depends_on: vec![],
-            subtask_ids: vec![],
-            project: None,
-            workspace_path: None,
-            workspace_owner: None,
-            run_generation: 0,
-            workflow: Some(TaskWorkflowSummary {
-                id: "workflow-1".to_string(),
-                definition_id: Some(GITHUB_ISSUE_PR_DEFINITION_ID.to_string()),
-                state: "ready_to_merge".to_string(),
-                project_id: None,
-                issue_number: Some(1),
-                pr_number: Some(7),
-                force_execute: None,
-                plan_concern: None,
-                review_fallback: None,
-            }),
-            scheduler: crate::task_runner::TaskSchedulerState::queued(),
-        };
-        let mut queued_row = legacy_row.clone();
-        queued_row.id = TaskId("queued-row".to_string());
-        queued_row.workflow = None;
-        queued_row.status = crate::task_runner::TaskStatus::Pending;
-
-        let mut by_source = source_activity(
-            &[workflow(
-                "ready_to_merge",
-                json!({
-                    "source": "github",
-                    "pr_number": 7,
-                    "pr_url": "https://github.com/owner/repo/pull/7",
-                }),
-            )],
-            &[legacy_row, queued_row],
-        );
-
-        assert_eq!(by_source.len(), 1);
-        let source = by_source.pop().expect("source row");
-        assert_eq!(source.source, "github");
-        assert_eq!(source.ready_to_merge, 1);
-        assert_eq!(source.running, 0);
-        assert_eq!(source.blocked, 0);
-    }
-}
+mod tests;

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -20,10 +20,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 const WORKFLOW_SAMPLE_LIMIT: i64 = 500;
+const FAILED_WORKFLOW_SAMPLE_RESERVE: usize = 100;
 const MAX_OPERATOR_ACTIONS: usize = 40;
 const MAX_FAILURE_GROUPS: usize = 20;
 const MAX_RECENT_FAILURES: i64 = 100;
 const STALLED_AFTER_MINS: u64 = 30;
+const OPERATOR_ACTION_STATES: &[&str] = &["ready_to_merge", "awaiting_feedback", "blocked"];
 const WORKFLOW_DEFINITION_IDS: &[&str] = &[
     harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
     harness_workflow::runtime::PR_FEEDBACK_DEFINITION_ID,
@@ -247,7 +249,14 @@ async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<Workflow
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(Vec::new());
     };
-    let mut workflows = Vec::new();
+    list_runtime_workflows_from_store(store).await
+}
+
+async fn list_runtime_workflows_from_store(
+    store: &WorkflowRuntimeStore,
+) -> anyhow::Result<Vec<WorkflowInstance>> {
+    let mut workflows = list_operator_action_workflows(store).await?;
+    workflows.extend(list_recent_failed_workflows(store, FAILED_WORKFLOW_SAMPLE_RESERVE).await?);
     let sample_limit = WORKFLOW_SAMPLE_LIMIT as usize;
     for definition_id in WORKFLOW_DEFINITION_IDS {
         workflows.extend(
@@ -260,32 +269,66 @@ async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<Workflow
                 .await?,
         );
     }
+    dedupe_workflows(&mut workflows);
     truncate_workflow_sample(&mut workflows, sample_limit);
-    let failed_capacity = sample_limit.saturating_sub(workflows.len());
-    if failed_capacity > 0 {
-        let failed_workflows = list_recent_failed_workflows(store, failed_capacity).await?;
-        workflows.extend(failed_workflows);
-        workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
-    }
     Ok(workflows)
 }
 
 fn truncate_workflow_sample(workflows: &mut Vec<WorkflowInstance>, limit: usize) {
-    workflows.sort_by(|a, b| {
-        workflow_sample_priority(a)
-            .cmp(&workflow_sample_priority(b))
-            .then_with(|| b.updated_at.cmp(&a.updated_at))
-    });
-    workflows.truncate(limit);
-    workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
+    let mut operator_actions = Vec::new();
+    let mut failed = Vec::new();
+    let mut other = Vec::new();
+    for workflow in workflows.drain(..) {
+        if workflow_action_kind(workflow.state.as_str()).is_some() {
+            operator_actions.push(workflow);
+        } else if workflow.state == "failed" {
+            failed.push(workflow);
+        } else {
+            other.push(workflow);
+        }
+    }
+    for group in [&mut operator_actions, &mut failed, &mut other] {
+        group.sort_by_key(|workflow| Reverse(workflow.updated_at));
+    }
+
+    let mut selected = Vec::with_capacity(limit);
+    let failed_reserve = failed.len().min(FAILED_WORKFLOW_SAMPLE_RESERVE).min(limit);
+    selected.extend(failed.drain(..failed_reserve));
+
+    let action_count = operator_actions
+        .len()
+        .min(limit.saturating_sub(selected.len()));
+    selected.extend(operator_actions.drain(..action_count));
+
+    let failed_count = failed.len().min(limit.saturating_sub(selected.len()));
+    selected.extend(failed.drain(..failed_count));
+
+    let other_count = other.len().min(limit.saturating_sub(selected.len()));
+    selected.extend(other.drain(..other_count));
+
+    selected.sort_by_key(|workflow| Reverse(workflow.updated_at));
+    *workflows = selected;
 }
 
-fn workflow_sample_priority(workflow: &WorkflowInstance) -> u8 {
-    if workflow_action_kind(workflow.state.as_str()).is_some() {
-        0
-    } else {
-        1
+async fn list_operator_action_workflows(
+    store: &WorkflowRuntimeStore,
+) -> anyhow::Result<Vec<WorkflowInstance>> {
+    let mut workflows = Vec::new();
+    for definition_id in WORKFLOW_DEFINITION_IDS {
+        for state in OPERATOR_ACTION_STATES {
+            workflows.extend(
+                store
+                    .list_recent_instances_by_state(definition_id, state, WORKFLOW_SAMPLE_LIMIT)
+                    .await?,
+            );
+        }
     }
+    Ok(workflows)
+}
+
+fn dedupe_workflows(workflows: &mut Vec<WorkflowInstance>) {
+    let mut seen = HashSet::new();
+    workflows.retain(|workflow| seen.insert(workflow.id.clone()));
 }
 
 async fn list_recent_failed_workflows(

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -11,7 +11,7 @@ use crate::task_runner::{RecentFailureTask, SchedulerAuthorityState, TaskSummary
 use crate::workspace::WorkspaceManager;
 use axum::{extract::State, http::StatusCode, Json};
 use chrono::{DateTime, Utc};
-use harness_workflow::runtime::WorkflowInstance;
+use harness_workflow::runtime::{WorkflowInstance, WorkflowRuntimeStore};
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::cmp::Reverse;
@@ -87,6 +87,7 @@ struct LegacyQueueCounts {
 struct SourceActivity {
     source: String,
     running: u64,
+    review: u64,
     blocked: u64,
     failed: u64,
     ready_to_merge: u64,
@@ -263,19 +264,31 @@ async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<Workflow
     workflows.truncate(sample_limit);
     let failed_capacity = sample_limit.saturating_sub(workflows.len());
     if failed_capacity > 0 {
-        let mut failed_workflows = Vec::new();
-        for definition_id in WORKFLOW_DEFINITION_IDS {
-            failed_workflows.extend(
-                store
-                    .list_instances_by_state(definition_id, "failed", WORKFLOW_SAMPLE_LIMIT)
-                    .await?,
-            );
-        }
-        failed_workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
-        failed_workflows.truncate(failed_capacity);
+        let failed_workflows = list_recent_failed_workflows(store, failed_capacity).await?;
         workflows.extend(failed_workflows);
         workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
     }
+    Ok(workflows)
+}
+
+async fn list_recent_failed_workflows(
+    store: &WorkflowRuntimeStore,
+    capacity: usize,
+) -> anyhow::Result<Vec<WorkflowInstance>> {
+    if capacity == 0 {
+        return Ok(Vec::new());
+    }
+    let per_definition_limit = capacity.min(WORKFLOW_SAMPLE_LIMIT as usize) as i64;
+    let mut workflows = Vec::new();
+    for definition_id in WORKFLOW_DEFINITION_IDS {
+        workflows.extend(
+            store
+                .list_recent_instances_by_state(definition_id, "failed", per_definition_limit)
+                .await?,
+        );
+    }
+    workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
+    workflows.truncate(capacity);
     Ok(workflows)
 }
 
@@ -416,6 +429,7 @@ fn add_workflow_source_activity(
         });
     match workflow_bucket(workflow) {
         WorkflowBucket::Running => entry.running += 1,
+        WorkflowBucket::Review => entry.review += 1,
         WorkflowBucket::AwaitingDependencies | WorkflowBucket::Blocked => entry.blocked += 1,
         WorkflowBucket::Failed => entry.failed += 1,
         WorkflowBucket::ReadyToMerge => entry.ready_to_merge += 1,
@@ -460,7 +474,7 @@ fn add_legacy_source_activity(by_source: &mut HashMap<String, SourceActivity>, t
 }
 
 fn source_total(source: &SourceActivity) -> u64 {
-    source.running + source.blocked + source.failed + source.ready_to_merge
+    source.running + source.review + source.blocked + source.failed + source.ready_to_merge
 }
 
 fn operator_actions(

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -400,6 +400,7 @@ fn workflow_bucket(workflow: &WorkflowInstance) -> WorkflowBucket {
         "blocked" => WorkflowBucket::Blocked,
         "failed" => WorkflowBucket::Failed,
         "done" | "passed" => WorkflowBucket::Done,
+        "idle" => WorkflowBucket::Other,
         "pr_open" | "local_review_gate" | "awaiting_feedback" | "quality_gate_pending" => {
             WorkflowBucket::Review
         }
@@ -486,6 +487,10 @@ fn add_workflow_source_activity(
     by_source: &mut HashMap<String, SourceActivity>,
     workflow: &WorkflowInstance,
 ) {
+    let bucket = workflow_bucket(workflow);
+    if matches!(bucket, WorkflowBucket::Done | WorkflowBucket::Other) {
+        return;
+    }
     let source = workflow_source(workflow);
     let entry = by_source
         .entry(source.clone())
@@ -493,7 +498,7 @@ fn add_workflow_source_activity(
             source,
             ..Default::default()
         });
-    match workflow_bucket(workflow) {
+    match bucket {
         WorkflowBucket::Pending => entry.pending += 1,
         WorkflowBucket::Running => entry.running += 1,
         WorkflowBucket::Review => entry.review += 1,

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -14,6 +14,7 @@ use chrono::{DateTime, Utc};
 use harness_workflow::runtime::WorkflowInstance;
 use serde::Serialize;
 use serde_json::{json, Value};
+use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -257,7 +258,7 @@ async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<Workflow
                 .await?,
         );
     }
-    workflows.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
     workflows.truncate(WORKFLOW_SAMPLE_LIMIT as usize);
     Ok(workflows)
 }

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -8,7 +8,6 @@
 use crate::http::AppState;
 use crate::runtime_projection::{RuntimeActiveBucket, RuntimeWorkflowProjection};
 use crate::task_runner::{RecentFailureTask, SchedulerAuthorityState, TaskSummary};
-use crate::workspace::WorkspaceManager;
 use axum::{extract::State, http::StatusCode, Json};
 use chrono::{DateTime, Utc};
 use harness_workflow::runtime::{WorkflowInstance, WorkflowRuntimeStore};
@@ -201,8 +200,13 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
     );
     let by_source = source_activity(&workflows, &active_tasks);
     let operator_actions = operator_actions(&workflows, generated_at);
-    let failures = grouped_failures(&recent_failures);
+    let failures = grouped_failures(&recent_failures, &workflows);
     let capacity = state.concurrency.task_queue.global_limit() as u64;
+    let local_live_worktrees = state
+        .concurrency
+        .workspace_mgr
+        .as_deref()
+        .map(|manager| manager.live_count());
 
     Ok(OperatorMonitorPayload {
         generated_at: generated_at.to_rfc3339(),
@@ -233,12 +237,10 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
         operator_actions,
         failures,
         worktrees: WorktreeSummary {
-            used: (worktree_cards.len() as u64).saturating_add(runtime_host_leases),
+            used: worktree_used_count(local_live_worktrees, worktree_cards.len())
+                .saturating_add(runtime_host_leases),
             capacity,
-            stale: stale_worktree_count(
-                state.concurrency.workspace_mgr.as_deref(),
-                &worktree_cards,
-            ),
+            stale: stale_worktree_count(local_live_worktrees, worktree_cards.len()),
             metrics_state: "unavailable",
             cards: worktree_cards,
         },
@@ -604,36 +606,32 @@ fn action_priority(kind: &str) -> u8 {
     }
 }
 
-fn grouped_failures(failures: &[RecentFailureTask]) -> Vec<FailureGroup> {
+fn grouped_failures(
+    failures: &[RecentFailureTask],
+    workflows: &[WorkflowInstance],
+) -> Vec<FailureGroup> {
     let mut groups: HashMap<FailureGroupKey, FailureGroup> = HashMap::new();
     for failure in failures {
         let raw_message = failure.error.as_deref().unwrap_or("unknown failure");
-        let family = classify_failure_family(raw_message);
-        let key = FailureGroupKey {
-            family,
-            message: normalize_failure_message(raw_message),
-            repo: failure.project.as_deref().map(project_label),
-        };
-        let failed_at = failure.failed_at.clone();
-        let task_id = failure.id.as_str().to_string();
-        let group = groups.entry(key.clone()).or_insert_with(|| FailureGroup {
-            family,
-            severity: failure_severity(family),
-            message: key.message.clone(),
-            first_seen: failed_at.clone(),
-            last_seen: failed_at.clone(),
-            count: 0,
-            repo: key.repo.clone(),
-            task_id: Some(task_id.clone()),
-            retryable: failure_retryable(family),
-            next_action: failure_next_action(family),
-        });
-        group.count += 1;
-        group.first_seen = earlier_timestamp(group.first_seen.as_deref(), failed_at.as_deref());
-        group.last_seen = later_timestamp(group.last_seen.as_deref(), failed_at.as_deref());
-        if group.task_id.is_none() {
-            group.task_id = Some(task_id);
-        }
+        add_failure_group(
+            &mut groups,
+            raw_message,
+            failure.failed_at.clone(),
+            failure.project.as_deref().map(project_label),
+            Some(failure.id.as_str().to_string()),
+        );
+    }
+    for workflow in workflows
+        .iter()
+        .filter(|workflow| workflow.state == "failed")
+    {
+        add_failure_group(
+            &mut groups,
+            &workflow_failure_message(workflow),
+            Some(workflow.updated_at.to_rfc3339()),
+            string_field(&workflow.data, "repo"),
+            Some(workflow_failure_id(workflow)),
+        );
     }
     let mut rows: Vec<FailureGroup> = groups.into_values().collect();
     rows.sort_by(|a, b| {
@@ -645,6 +643,61 @@ fn grouped_failures(failures: &[RecentFailureTask]) -> Vec<FailureGroup> {
     });
     rows.truncate(MAX_FAILURE_GROUPS);
     rows
+}
+
+fn add_failure_group(
+    groups: &mut HashMap<FailureGroupKey, FailureGroup>,
+    raw_message: &str,
+    failed_at: Option<String>,
+    repo: Option<String>,
+    task_id: Option<String>,
+) {
+    let family = classify_failure_family(raw_message);
+    let key = FailureGroupKey {
+        family,
+        message: normalize_failure_message(raw_message),
+        repo,
+    };
+    let group = groups.entry(key.clone()).or_insert_with(|| FailureGroup {
+        family,
+        severity: failure_severity(family),
+        message: key.message.clone(),
+        first_seen: failed_at.clone(),
+        last_seen: failed_at.clone(),
+        count: 0,
+        repo: key.repo.clone(),
+        task_id: task_id.clone(),
+        retryable: failure_retryable(family),
+        next_action: failure_next_action(family),
+    });
+    group.count += 1;
+    group.first_seen = earlier_timestamp(group.first_seen.as_deref(), failed_at.as_deref());
+    group.last_seen = later_timestamp(group.last_seen.as_deref(), failed_at.as_deref());
+    if group.task_id.is_none() {
+        if let Some(task_id) = task_id {
+            group.task_id = Some(task_id);
+        }
+    }
+}
+
+fn workflow_failure_message(workflow: &WorkflowInstance) -> String {
+    ["failure_reason", "previous_error", "last_error", "error"]
+        .into_iter()
+        .find_map(|field| string_field(&workflow.data, field))
+        .unwrap_or_else(|| format!("{} workflow failed", workflow.definition_id))
+}
+
+fn workflow_failure_id(workflow: &WorkflowInstance) -> String {
+    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+    projection
+        .submission_handle
+        .map(|task_id| task_id.as_str().to_string())
+        .or_else(|| {
+            projection
+                .legacy_dedupe_task_handle
+                .map(|task_id| task_id.0)
+        })
+        .unwrap_or_else(|| workflow.id.clone())
 }
 
 fn classify_failure_family(message: &str) -> &'static str {
@@ -725,11 +778,12 @@ fn later_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<Str
         .map(str::to_string)
 }
 
-fn stale_worktree_count(
-    manager: Option<&WorkspaceManager>,
-    cards: &[crate::handlers::worktrees::WorktreeResponse],
-) -> Option<u64> {
-    manager.map(|manager| manager.live_count().saturating_sub(cards.len() as u64))
+fn worktree_used_count(local_live_count: Option<u64>, card_count: usize) -> u64 {
+    local_live_count.unwrap_or(card_count as u64)
+}
+
+fn stale_worktree_count(local_live_count: Option<u64>, card_count: usize) -> Option<u64> {
+    local_live_count.map(|count| count.saturating_sub(card_count as u64))
 }
 
 fn workflow_source(workflow: &WorkflowInstance) -> String {

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -87,6 +87,7 @@ struct LegacyQueueCounts {
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
 struct SourceActivity {
     source: String,
+    pending: u64,
     running: u64,
     review: u64,
     blocked: u64,
@@ -490,6 +491,7 @@ fn add_workflow_source_activity(
             ..Default::default()
         });
     match workflow_bucket(workflow) {
+        WorkflowBucket::Pending => entry.pending += 1,
         WorkflowBucket::Running => entry.running += 1,
         WorkflowBucket::Review => entry.review += 1,
         WorkflowBucket::AwaitingDependencies | WorkflowBucket::Blocked => entry.blocked += 1,
@@ -536,7 +538,12 @@ fn add_legacy_source_activity(by_source: &mut HashMap<String, SourceActivity>, t
 }
 
 fn source_total(source: &SourceActivity) -> u64 {
-    source.running + source.review + source.blocked + source.failed + source.ready_to_merge
+    source.pending
+        + source.running
+        + source.review
+        + source.blocked
+        + source.failed
+        + source.ready_to_merge
 }
 
 fn operator_actions(

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -618,7 +618,9 @@ fn grouped_failures(
     workflows: &[WorkflowInstance],
 ) -> Vec<FailureGroup> {
     let mut groups: HashMap<FailureGroupKey, FailureGroup> = HashMap::new();
+    let mut represented_task_ids = HashSet::new();
     for failure in failures {
+        represented_task_ids.insert(failure.id.as_str().to_string());
         let raw_message = failure.error.as_deref().unwrap_or("unknown failure");
         add_failure_group(
             &mut groups,
@@ -632,6 +634,13 @@ fn grouped_failures(
         .iter()
         .filter(|workflow| workflow.state == "failed")
     {
+        let workflow_task_ids = workflow_failure_task_ids(workflow);
+        if workflow_task_ids
+            .iter()
+            .any(|task_id| represented_task_ids.contains(task_id))
+        {
+            continue;
+        }
         add_failure_group(
             &mut groups,
             &workflow_failure_message(workflow),
@@ -705,6 +714,18 @@ fn workflow_failure_id(workflow: &WorkflowInstance) -> String {
                 .map(|task_id| task_id.0)
         })
         .unwrap_or_else(|| workflow.id.clone())
+}
+
+fn workflow_failure_task_ids(workflow: &WorkflowInstance) -> HashSet<String> {
+    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+    let mut ids = HashSet::new();
+    if let Some(task_id) = projection.submission_handle {
+        ids.insert(task_id.as_str().to_string());
+    }
+    if let Some(task_id) = projection.legacy_dedupe_task_handle {
+        ids.insert(task_id.0);
+    }
+    ids
 }
 
 fn classify_failure_family(message: &str) -> &'static str {

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -351,6 +351,26 @@ fn add_workflow_source_activity(
 }
 
 fn add_legacy_source_activity(by_source: &mut HashMap<String, SourceActivity>, task: &TaskSummary) {
+    let update: fn(&mut SourceActivity) = if task.status.is_failure()
+        || task.scheduler.authority_state == SchedulerAuthorityState::Failed
+    {
+        |entry| entry.failed += 1
+    } else if matches!(
+        task.scheduler.authority_state,
+        SchedulerAuthorityState::Running
+            | SchedulerAuthorityState::Leased
+            | SchedulerAuthorityState::Recovering
+    ) {
+        |entry| entry.running += 1
+    } else if matches!(
+        task.scheduler.authority_state,
+        SchedulerAuthorityState::AwaitingDependencies | SchedulerAuthorityState::RetryBackoff
+    ) || matches!(task.status.as_ref(), "awaiting_deps" | "waiting")
+    {
+        |entry| entry.blocked += 1
+    } else {
+        return;
+    };
     let source = task
         .source
         .as_deref()
@@ -363,13 +383,7 @@ fn add_legacy_source_activity(by_source: &mut HashMap<String, SourceActivity>, t
             source,
             ..Default::default()
         });
-    if task.status.is_failure() {
-        entry.failed += 1;
-    } else if task.status.as_ref() == "waiting" {
-        entry.blocked += 1;
-    } else {
-        entry.running += 1;
-    }
+    update(entry);
 }
 
 fn source_total(source: &SourceActivity) -> u64 {
@@ -476,8 +490,9 @@ fn grouped_failures(failures: &[RecentFailureTask]) -> Vec<FailureGroup> {
     }
     let mut rows: Vec<FailureGroup> = groups.into_values().collect();
     rows.sort_by(|a, b| {
-        parsed_timestamp(b.last_seen.as_deref())
-            .cmp(&parsed_timestamp(a.last_seen.as_deref()))
+        b.last_seen
+            .as_deref()
+            .cmp(&a.last_seen.as_deref())
             .then_with(|| b.count.cmp(&a.count))
             .then_with(|| a.family.cmp(b.family))
     });
@@ -548,41 +563,27 @@ fn normalize_failure_message(message: &str) -> String {
 }
 
 fn earlier_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<String> {
-    match (current, candidate) {
-        (Some(current), Some(candidate)) => {
-            if parsed_timestamp(Some(candidate)) < parsed_timestamp(Some(current)) {
-                Some(candidate.to_string())
-            } else {
-                Some(current.to_string())
-            }
+    Some(
+        match (current, candidate) {
+            (Some(current), Some(candidate)) => current.min(candidate),
+            (Some(current), None) => current,
+            (None, Some(candidate)) => candidate,
+            (None, None) => return None,
         }
-        (Some(current), None) => Some(current.to_string()),
-        (None, Some(candidate)) => Some(candidate.to_string()),
-        (None, None) => None,
-    }
+        .to_string(),
+    )
 }
 
 fn later_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<String> {
-    match (current, candidate) {
-        (Some(current), Some(candidate)) => {
-            if parsed_timestamp(Some(candidate)) > parsed_timestamp(Some(current)) {
-                Some(candidate.to_string())
-            } else {
-                Some(current.to_string())
-            }
+    Some(
+        match (current, candidate) {
+            (Some(current), Some(candidate)) => current.max(candidate),
+            (Some(current), None) => current,
+            (None, Some(candidate)) => candidate,
+            (None, None) => return None,
         }
-        (Some(current), None) => Some(current.to_string()),
-        (None, Some(candidate)) => Some(candidate.to_string()),
-        (None, None) => None,
-    }
-}
-
-fn parsed_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
-    value.and_then(|value| {
-        DateTime::parse_from_rfc3339(value)
-            .ok()
-            .map(|parsed| parsed.with_timezone(&Utc))
-    })
+        .to_string(),
+    )
 }
 
 fn stale_worktree_count(
@@ -736,7 +737,46 @@ mod tests {
     }
 
     #[test]
-    fn legacy_workflow_summaries_are_not_double_counted_by_source() {
+    fn legacy_workflow_and_queued_tasks_are_not_counted_by_source() {
+        let legacy_row = TaskSummary {
+            id: TaskId("legacy-row".to_string()),
+            task_kind: crate::task_runner::TaskKind::Issue,
+            status: crate::task_runner::TaskStatus::Waiting,
+            failure_kind: None,
+            turn: 0,
+            pr_url: None,
+            error: None,
+            source: Some("github".to_string()),
+            parent_id: None,
+            external_id: Some("issue:1".to_string()),
+            repo: Some("owner/repo".to_string()),
+            description: None,
+            created_at: None,
+            phase: crate::task_runner::TaskPhase::Review,
+            depends_on: vec![],
+            subtask_ids: vec![],
+            project: None,
+            workspace_path: None,
+            workspace_owner: None,
+            run_generation: 0,
+            workflow: Some(TaskWorkflowSummary {
+                id: "workflow-1".to_string(),
+                definition_id: Some(GITHUB_ISSUE_PR_DEFINITION_ID.to_string()),
+                state: "ready_to_merge".to_string(),
+                project_id: None,
+                issue_number: Some(1),
+                pr_number: Some(7),
+                force_execute: None,
+                plan_concern: None,
+                review_fallback: None,
+            }),
+            scheduler: crate::task_runner::TaskSchedulerState::queued(),
+        };
+        let mut queued_row = legacy_row.clone();
+        queued_row.id = TaskId("queued-row".to_string());
+        queued_row.workflow = None;
+        queued_row.status = crate::task_runner::TaskStatus::Pending;
+
         let mut by_source = source_activity(
             &[workflow(
                 "ready_to_merge",
@@ -746,46 +786,14 @@ mod tests {
                     "pr_url": "https://github.com/owner/repo/pull/7",
                 }),
             )],
-            &[TaskSummary {
-                id: TaskId("legacy-row".to_string()),
-                task_kind: crate::task_runner::TaskKind::Issue,
-                status: crate::task_runner::TaskStatus::Waiting,
-                failure_kind: None,
-                turn: 0,
-                pr_url: None,
-                error: None,
-                source: Some("github".to_string()),
-                parent_id: None,
-                external_id: Some("issue:1".to_string()),
-                repo: Some("owner/repo".to_string()),
-                description: None,
-                created_at: None,
-                phase: crate::task_runner::TaskPhase::Review,
-                depends_on: vec![],
-                subtask_ids: vec![],
-                project: None,
-                workspace_path: None,
-                workspace_owner: None,
-                run_generation: 0,
-                workflow: Some(TaskWorkflowSummary {
-                    id: "workflow-1".to_string(),
-                    definition_id: Some(GITHUB_ISSUE_PR_DEFINITION_ID.to_string()),
-                    state: "ready_to_merge".to_string(),
-                    project_id: None,
-                    issue_number: Some(1),
-                    pr_number: Some(7),
-                    force_execute: None,
-                    plan_concern: None,
-                    review_fallback: None,
-                }),
-                scheduler: crate::task_runner::TaskSchedulerState::queued(),
-            }],
+            &[legacy_row, queued_row],
         );
 
         assert_eq!(by_source.len(), 1);
         let source = by_source.pop().expect("source row");
         assert_eq!(source.source, "github");
         assert_eq!(source.ready_to_merge, 1);
+        assert_eq!(source.running, 0);
         assert_eq!(source.blocked, 0);
     }
 }

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -180,7 +180,11 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
         .sum();
     let runtime_log_state = state.core.server.runtime_logs.state.as_str();
     let degraded_subsystems = state.degraded_subsystems.clone();
-    let health_status = if degraded_subsystems.is_empty() && runtime_log_state != "degraded" {
+    let runtime_state_dirty = state.is_runtime_state_dirty();
+    let health_status = if degraded_subsystems.is_empty()
+        && runtime_log_state != "degraded"
+        && !runtime_state_dirty
+    {
         "ok"
     } else {
         "degraded"
@@ -557,9 +561,15 @@ fn operator_actions(
         };
         let projection = RuntimeWorkflowProjection::from_workflow(workflow);
         let task_id = projection
-            .submission_handle
+            .legacy_dedupe_task_handle
             .as_ref()
-            .map(|task_id| task_id.as_str().to_string());
+            .map(|task_id| task_id.0.clone())
+            .or_else(|| {
+                projection
+                    .submission_handle
+                    .as_ref()
+                    .map(|task_id| task_id.as_str().to_string())
+            });
         let repo = string_field(&workflow.data, "repo");
         let issue = u64_field(&workflow.data, "issue_number");
         let pr = u64_field(&workflow.data, "pr_number");

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -260,8 +260,7 @@ async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<Workflow
                 .await?,
         );
     }
-    workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
-    workflows.truncate(sample_limit);
+    truncate_workflow_sample(&mut workflows, sample_limit);
     let failed_capacity = sample_limit.saturating_sub(workflows.len());
     if failed_capacity > 0 {
         let failed_workflows = list_recent_failed_workflows(store, failed_capacity).await?;
@@ -269,6 +268,24 @@ async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<Workflow
         workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
     }
     Ok(workflows)
+}
+
+fn truncate_workflow_sample(workflows: &mut Vec<WorkflowInstance>, limit: usize) {
+    workflows.sort_by(|a, b| {
+        workflow_sample_priority(a)
+            .cmp(&workflow_sample_priority(b))
+            .then_with(|| b.updated_at.cmp(&a.updated_at))
+    });
+    workflows.truncate(limit);
+    workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
+}
+
+fn workflow_sample_priority(workflow: &WorkflowInstance) -> u8 {
+    if workflow_action_kind(workflow.state.as_str()).is_some() {
+        0
+    } else {
+        1
+    }
 }
 
 async fn list_recent_failed_workflows(

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -247,6 +247,7 @@ async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<Workflow
         return Ok(Vec::new());
     };
     let mut workflows = Vec::new();
+    let sample_limit = WORKFLOW_SAMPLE_LIMIT as usize;
     for definition_id in WORKFLOW_DEFINITION_IDS {
         workflows.extend(
             store
@@ -259,7 +260,22 @@ async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<Workflow
         );
     }
     workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
-    workflows.truncate(WORKFLOW_SAMPLE_LIMIT as usize);
+    workflows.truncate(sample_limit);
+    let failed_capacity = sample_limit.saturating_sub(workflows.len());
+    if failed_capacity > 0 {
+        let mut failed_workflows = Vec::new();
+        for definition_id in WORKFLOW_DEFINITION_IDS {
+            failed_workflows.extend(
+                store
+                    .list_instances_by_state(definition_id, "failed", WORKFLOW_SAMPLE_LIMIT)
+                    .await?,
+            );
+        }
+        failed_workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
+        failed_workflows.truncate(failed_capacity);
+        workflows.extend(failed_workflows);
+        workflows.sort_by_key(|workflow| Reverse(workflow.updated_at));
+    }
     Ok(workflows)
 }
 

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -57,6 +57,37 @@ fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
 }
 
 #[test]
+fn workflow_sample_truncation_preserves_operator_action_states() {
+    let base = Utc::now();
+    let mut workflows = (0..500)
+        .map(|index| {
+            let mut workflow = workflow("checking", json!({ "source": "repo_backlog" }))
+                .with_id(format!("checking-{index}"));
+            workflow.updated_at = base + chrono::Duration::seconds(index);
+            workflow
+        })
+        .collect::<Vec<_>>();
+    let mut ready = workflow(
+        "ready_to_merge",
+        json!({
+            "source": "github",
+            "pr_number": 7,
+            "pr_url": "https://github.com/owner/repo/pull/7",
+        }),
+    )
+    .with_id("older-ready".to_string());
+    ready.updated_at = base - chrono::Duration::hours(1);
+    workflows.push(ready);
+
+    truncate_workflow_sample(&mut workflows, 500);
+
+    assert!(workflows
+        .iter()
+        .any(|workflow| workflow.id == "older-ready"));
+    assert_eq!(workflows.len(), 500);
+}
+
+#[test]
 fn grouped_failures_classifies_and_counts_github_fetch_failures() {
     let failures = vec![
         github_fetch_failure("task-1", 1, "2026-06-12T00:00:00Z"),

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -101,7 +101,7 @@ fn grouped_failures_classifies_and_counts_github_fetch_failures() {
         github_fetch_failure("task-2", 2, "2026-06-12T00:05:00Z"),
     ];
 
-    let groups = grouped_failures(&failures);
+    let groups = grouped_failures(&failures, &[]);
 
     assert_eq!(groups.len(), 1);
     assert_eq!(groups[0].family, "github_fetch");
@@ -110,6 +110,34 @@ fn grouped_failures_classifies_and_counts_github_fetch_failures() {
     assert_eq!(groups[0].repo.as_deref(), Some("harness"));
     assert!(groups[0].retryable);
     assert_eq!(groups[0].last_seen.as_deref(), Some("2026-06-12T00:05:00Z"));
+}
+
+#[test]
+fn grouped_failures_includes_runtime_only_workflow_failures() {
+    let mut failed_workflow = workflow(
+        "failed",
+        json!({
+            "failure_reason": "Quality gate execution failed.",
+            "repo": "owner/repo",
+        }),
+    )
+    .with_id("quality-gate-workflow".to_string());
+    failed_workflow.updated_at = Utc::now();
+
+    let groups = grouped_failures(&[], &[failed_workflow]);
+
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].message, "Quality gate execution failed.");
+    assert_eq!(groups[0].repo.as_deref(), Some("owner/repo"));
+    assert_eq!(groups[0].task_id.as_deref(), Some("quality-gate-workflow"));
+}
+
+#[test]
+fn worktree_used_count_includes_stale_live_worktrees() {
+    assert_eq!(worktree_used_count(Some(5), 3), 5);
+    assert_eq!(stale_worktree_count(Some(5), 3), Some(2));
+    assert_eq!(worktree_used_count(None, 3), 3);
+    assert_eq!(stale_worktree_count(None, 3), None);
 }
 
 #[tokio::test]

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -135,15 +135,18 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
     queued_row.status = crate::task_runner::TaskStatus::Pending;
 
     let mut by_source = source_activity(
-        &[workflow(
-            "ready_to_merge",
-            json!({
-                "source": "github",
-                "task_id": "legacy-row",
-                "pr_number": 7,
-                "pr_url": "https://github.com/owner/repo/pull/7",
-            }),
-        )],
+        &[
+            workflow(
+                "ready_to_merge",
+                json!({
+                    "source": "github",
+                    "task_id": "legacy-row",
+                    "pr_number": 7,
+                    "pr_url": "https://github.com/owner/repo/pull/7",
+                }),
+            ),
+            workflow("awaiting_dependencies", json!({ "source": "github" })),
+        ],
         &[legacy_row, queued_row],
     );
 
@@ -152,5 +155,5 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
     assert_eq!(source.source, "github");
     assert_eq!(source.ready_to_merge, 1);
     assert_eq!(source.running, 0);
-    assert_eq!(source.blocked, 0);
+    assert_eq!(source.blocked, 1);
 }

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -2,7 +2,10 @@ use super::*;
 use crate::test_helpers;
 use axum::{body::to_bytes, routing::get, Router};
 use harness_core::types::TaskId;
-use harness_workflow::runtime::{WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID};
+use harness_workflow::runtime::{
+    WorkflowRuntimeStore, WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID,
+    QUALITY_GATE_DEFINITION_ID,
+};
 
 fn workflow(state: &str, data: Value) -> WorkflowInstance {
     WorkflowInstance::new(
@@ -101,6 +104,60 @@ async fn endpoint_returns_monitor_payload_on_fresh_state() -> anyhow::Result<()>
         assert!(body.get(key).is_some(), "missing top-level key: {key}");
     }
     assert_eq!(body["worktrees"]["metrics_state"], "unavailable");
+    Ok(())
+}
+
+#[tokio::test]
+async fn endpoint_includes_failed_runtime_workflows_without_legacy_tasks() -> anyhow::Result<()> {
+    let _lock = test_helpers::HOME_LOCK.lock().await;
+    let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-failed-runtime-")?;
+    let mut state = test_helpers::make_test_state(dir.path()).await?;
+    let workflow_runtime_store = Arc::new(
+        WorkflowRuntimeStore::open_with_database_url(
+            &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
+            Some(&test_helpers::test_database_url()?),
+        )
+        .await?,
+    );
+    workflow_runtime_store
+        .upsert_instance(
+            &WorkflowInstance::new(
+                QUALITY_GATE_DEFINITION_ID,
+                1,
+                "failed",
+                WorkflowSubject::new("quality_gate", "quality_gate:1"),
+            )
+            .with_id("quality-gate-failed".to_string())
+            .with_data(json!({
+                "source": "quality_gate",
+                "repo": "owner/repo",
+            })),
+        )
+        .await?;
+    state.core.workflow_runtime_store = Some(workflow_runtime_store);
+
+    let app = Router::new()
+        .route("/api/operator-monitor", get(operator_monitor))
+        .with_state(Arc::new(state));
+
+    let req = axum::http::Request::builder()
+        .uri("/api/operator-monitor")
+        .body(axum::body::Body::empty())?;
+    let resp = tower::ServiceExt::oneshot(app, req).await?;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+    let body: Value = serde_json::from_slice(&bytes)?;
+
+    assert_eq!(body["activity"]["runtime_workflows"]["failed"], 1);
+    let sources = body["activity"]["by_source"]
+        .as_array()
+        .expect("source rows");
+    let quality_gate = sources
+        .iter()
+        .find(|source| source["source"] == "quality_gate")
+        .expect("quality gate source row");
+    assert_eq!(quality_gate["failed"], 1);
     Ok(())
 }
 

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -133,6 +133,39 @@ fn grouped_failures_includes_runtime_only_workflow_failures() {
 }
 
 #[test]
+fn grouped_failures_deduplicates_workflow_failures_backed_by_task_rows() {
+    let failures = vec![RecentFailureTask {
+        id: TaskId("legacy-task".to_string()),
+        failure_kind: None,
+        external_id: Some("issue:1".to_string()),
+        project: Some("/tmp/harness".to_string()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        error: Some("Quality gate execution failed.".to_string()),
+        failed_at: Some("2026-06-12T00:00:00Z".to_string()),
+    }];
+    let mut failed_workflow = workflow(
+        "failed",
+        json!({
+            "failure_reason": "Quality gate execution failed.",
+            "repo": "owner/repo",
+            "submission_id": "stable-submission",
+            "task_id": "legacy-task",
+        }),
+    )
+    .with_id("workflow-row".to_string());
+    failed_workflow.updated_at = Utc::now();
+
+    let groups = grouped_failures(&failures, &[failed_workflow]);
+
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].message, "Quality gate execution failed.");
+    assert_eq!(groups[0].count, 1);
+    assert_eq!(groups[0].task_id.as_deref(), Some("legacy-task"));
+}
+
+#[test]
 fn worktree_used_count_includes_stale_live_worktrees() {
     assert_eq!(worktree_used_count(Some(5), 3), 5);
     assert_eq!(stale_worktree_count(Some(5), 3), Some(2));

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -35,6 +35,7 @@ fn github_fetch_failure(id: &str, issue: u64, failed_at: &str) -> RecentFailureT
 fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
     let workflows = vec![
         workflow("implementing", json!({})),
+        workflow("checking", json!({})),
         workflow("awaiting_feedback", json!({})),
         workflow("ready_to_merge", json!({})),
         workflow("awaiting_dependencies", json!({})),
@@ -44,7 +45,7 @@ fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
 
     let counts = runtime_workflow_counts(&workflows);
 
-    assert_eq!(counts.running, 1);
+    assert_eq!(counts.running, 2);
     assert_eq!(counts.review, 1);
     assert_eq!(counts.ready_to_merge, 1);
     assert_eq!(counts.awaiting_dependencies, 1);
@@ -146,6 +147,7 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
                 }),
             ),
             workflow("awaiting_dependencies", json!({ "source": "github" })),
+            workflow("checking", json!({ "source": "github" })),
         ],
         &[legacy_row, queued_row],
     );
@@ -154,6 +156,6 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
     let source = by_source.pop().expect("source row");
     assert_eq!(source.source, "github");
     assert_eq!(source.ready_to_merge, 1);
-    assert_eq!(source.running, 0);
+    assert_eq!(source.running, 1);
     assert_eq!(source.blocked, 1);
 }

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -57,7 +57,7 @@ fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
 }
 
 #[test]
-fn workflow_sample_truncation_preserves_operator_action_states() {
+fn workflow_sample_truncation_preserves_operator_action_and_failed_states() {
     let base = Utc::now();
     let mut workflows = (0..500)
         .map(|index| {
@@ -78,12 +78,19 @@ fn workflow_sample_truncation_preserves_operator_action_states() {
     .with_id("older-ready".to_string());
     ready.updated_at = base - chrono::Duration::hours(1);
     workflows.push(ready);
+    let mut failed =
+        workflow("failed", json!({ "source": "quality_gate" })).with_id("older-failed".to_string());
+    failed.updated_at = base - chrono::Duration::hours(2);
+    workflows.push(failed);
 
     truncate_workflow_sample(&mut workflows, 500);
 
     assert!(workflows
         .iter()
         .any(|workflow| workflow.id == "older-ready"));
+    assert!(workflows
+        .iter()
+        .any(|workflow| workflow.id == "older-failed"));
     assert_eq!(workflows.len(), 500);
 }
 
@@ -238,6 +245,57 @@ async fn recent_failed_workflow_sampling_prefers_newest_rows() -> anyhow::Result
 
     assert_eq!(workflows.len(), 1);
     assert_eq!(workflows[0].id, "recent-failed");
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_workflow_sampling_fetches_action_states_before_definition_cap(
+) -> anyhow::Result<()> {
+    let _lock = test_helpers::HOME_LOCK.lock().await;
+    let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-action-cap-")?;
+    let workflow_runtime_store = WorkflowRuntimeStore::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
+        Some(&test_helpers::test_database_url()?),
+    )
+    .await?;
+    workflow_runtime_store
+        .upsert_instance(
+            &workflow(
+                "ready_to_merge",
+                json!({
+                    "source": "github",
+                    "pr_number": 7,
+                    "pr_url": "https://github.com/owner/repo/pull/7",
+                }),
+            )
+            .with_id("older-ready".to_string()),
+        )
+        .await?;
+    for index in 0..500 {
+        workflow_runtime_store
+            .upsert_instance(
+                &workflow("checking", json!({ "source": "repo_backlog" }))
+                    .with_id(format!("checking-{index}")),
+            )
+            .await?;
+    }
+    sqlx::query(
+        "UPDATE workflow_instances SET updated_at = NOW() - INTERVAL '1 hour' WHERE id = $1",
+    )
+    .bind("older-ready")
+    .execute(workflow_runtime_store.pool())
+    .await?;
+    sqlx::query("UPDATE workflow_instances SET updated_at = NOW() WHERE state = $1")
+        .bind("checking")
+        .execute(workflow_runtime_store.pool())
+        .await?;
+
+    let workflows = list_runtime_workflows_from_store(&workflow_runtime_store).await?;
+
+    assert_eq!(workflows.len(), WORKFLOW_SAMPLE_LIMIT as usize);
+    assert!(workflows
+        .iter()
+        .any(|workflow| workflow.id == "older-ready"));
     Ok(())
 }
 

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -43,6 +43,7 @@ fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
         workflow("awaiting_feedback", json!({})),
         workflow("ready_to_merge", json!({})),
         workflow("awaiting_dependencies", json!({})),
+        workflow("idle", json!({})),
         workflow("failed", json!({})),
         workflow("done", json!({})),
     ];
@@ -55,6 +56,7 @@ fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
     assert_eq!(counts.awaiting_dependencies, 1);
     assert_eq!(counts.failed, 1);
     assert_eq!(counts.done, 1);
+    assert_eq!(counts.other, 1);
 }
 
 #[test]
@@ -258,6 +260,19 @@ fn operator_actions_link_evidence_to_current_legacy_task_id() {
     );
 }
 
+#[test]
+fn idle_workflows_are_inactive_for_source_activity() {
+    let workflows = vec![workflow("idle", json!({ "source": "repo_backlog" }))];
+
+    let counts = runtime_workflow_counts(&workflows);
+    let by_source = source_activity(&workflows, &[]);
+
+    assert_eq!(counts.pending, 0);
+    assert_eq!(counts.running, 0);
+    assert_eq!(counts.other, 1);
+    assert!(by_source.is_empty());
+}
+
 #[tokio::test]
 async fn endpoint_includes_failed_runtime_workflows_without_legacy_tasks() -> anyhow::Result<()> {
     let _lock = test_helpers::HOME_LOCK.lock().await;
@@ -358,6 +373,46 @@ async fn recent_failed_workflow_sampling_prefers_newest_rows() -> anyhow::Result
 
     assert_eq!(workflows.len(), 1);
     assert_eq!(workflows[0].id, "recent-failed");
+    Ok(())
+}
+
+#[tokio::test]
+async fn operator_action_age_uses_store_updated_at() -> anyhow::Result<()> {
+    let _lock = test_helpers::HOME_LOCK.lock().await;
+    let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-action-age-")?;
+    let workflow_runtime_store = WorkflowRuntimeStore::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
+        Some(&test_helpers::test_database_url()?),
+    )
+    .await?;
+    let mut ready = workflow(
+        "ready_to_merge",
+        json!({
+            "source": "github",
+            "pr_number": 7,
+            "pr_url": "https://github.com/owner/repo/pull/7",
+        }),
+    )
+    .with_id("ready-store-age".to_string());
+    ready.updated_at = Utc::now() - chrono::Duration::days(2);
+    workflow_runtime_store.upsert_instance(&ready).await?;
+    sqlx::query("UPDATE workflow_instances SET updated_at = NOW() WHERE id = $1")
+        .bind("ready-store-age")
+        .execute(workflow_runtime_store.pool())
+        .await?;
+
+    let workflows = list_runtime_workflows_from_store(&workflow_runtime_store).await?;
+    let actions = operator_actions(&workflows, Utc::now());
+
+    let action = actions
+        .iter()
+        .find(|action| action.workflow_id == "ready-store-age")
+        .expect("ready action");
+    assert!(
+        action.age_secs < 60,
+        "action age should use the fresh store timestamp, got {}",
+        action.age_secs
+    );
     Ok(())
 }
 

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -39,6 +39,7 @@ fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
     let workflows = vec![
         workflow("implementing", json!({})),
         workflow("checking", json!({})),
+        workflow("inspecting", json!({})),
         workflow("awaiting_feedback", json!({})),
         workflow("ready_to_merge", json!({})),
         workflow("awaiting_dependencies", json!({})),
@@ -48,7 +49,7 @@ fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
 
     let counts = runtime_workflow_counts(&workflows);
 
-    assert_eq!(counts.running, 2);
+    assert_eq!(counts.running, 3);
     assert_eq!(counts.review, 1);
     assert_eq!(counts.ready_to_merge, 1);
     assert_eq!(counts.awaiting_dependencies, 1);
@@ -455,6 +456,7 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
             ),
             workflow("awaiting_dependencies", json!({ "source": "github" })),
             workflow("checking", json!({ "source": "github" })),
+            workflow("inspecting", json!({ "source": "github" })),
             workflow("awaiting_feedback", json!({ "source": "github" })),
             workflow("scheduled", json!({ "source": "github" })),
         ],
@@ -467,6 +469,6 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
     assert_eq!(source.pending, 1);
     assert_eq!(source.ready_to_merge, 1);
     assert_eq!(source.review, 1);
-    assert_eq!(source.running, 1);
+    assert_eq!(source.running, 2);
     assert_eq!(source.blocked, 1);
 }

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -1,0 +1,156 @@
+use super::*;
+use crate::test_helpers;
+use axum::{body::to_bytes, routing::get, Router};
+use harness_core::types::TaskId;
+use harness_workflow::runtime::{WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID};
+
+fn workflow(state: &str, data: Value) -> WorkflowInstance {
+    WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        state,
+        WorkflowSubject::new("issue", "issue:1"),
+    )
+    .with_data(data)
+}
+
+fn github_fetch_failure(id: &str, issue: u64, failed_at: &str) -> RecentFailureTask {
+    RecentFailureTask {
+        id: TaskId(id.to_string()),
+        failure_kind: None,
+        external_id: Some(format!("issue:{issue}")),
+        project: Some("/tmp/harness".to_string()),
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        error: Some(
+            "git fetch origin main failed: LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443"
+                .to_string(),
+        ),
+        failed_at: Some(failed_at.to_string()),
+    }
+}
+
+#[test]
+fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
+    let workflows = vec![
+        workflow("implementing", json!({})),
+        workflow("awaiting_feedback", json!({})),
+        workflow("ready_to_merge", json!({})),
+        workflow("awaiting_dependencies", json!({})),
+        workflow("failed", json!({})),
+        workflow("done", json!({})),
+    ];
+
+    let counts = runtime_workflow_counts(&workflows);
+
+    assert_eq!(counts.running, 1);
+    assert_eq!(counts.review, 1);
+    assert_eq!(counts.ready_to_merge, 1);
+    assert_eq!(counts.awaiting_dependencies, 1);
+    assert_eq!(counts.failed, 1);
+    assert_eq!(counts.done, 1);
+}
+
+#[test]
+fn grouped_failures_classifies_and_counts_github_fetch_failures() {
+    let failures = vec![
+        github_fetch_failure("task-1", 1, "2026-06-12T00:00:00Z"),
+        github_fetch_failure("task-2", 2, "2026-06-12T00:05:00Z"),
+    ];
+
+    let groups = grouped_failures(&failures);
+
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].family, "github_fetch");
+    assert_eq!(groups[0].severity, "warn");
+    assert_eq!(groups[0].count, 2);
+    assert_eq!(groups[0].repo.as_deref(), Some("harness"));
+    assert!(groups[0].retryable);
+    assert_eq!(groups[0].last_seen.as_deref(), Some("2026-06-12T00:05:00Z"));
+}
+
+#[tokio::test]
+async fn endpoint_returns_monitor_payload_on_fresh_state() -> anyhow::Result<()> {
+    let _lock = test_helpers::HOME_LOCK.lock().await;
+    let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-")?;
+    let state = Arc::new(test_helpers::make_test_state(dir.path()).await?);
+
+    let app = Router::new()
+        .route("/api/operator-monitor", get(operator_monitor))
+        .with_state(state);
+
+    let req = axum::http::Request::builder()
+        .uri("/api/operator-monitor")
+        .body(axum::body::Body::empty())?;
+    let resp = tower::ServiceExt::oneshot(app, req).await?;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+    let body: Value = serde_json::from_slice(&bytes)?;
+
+    for key in [
+        "generated_at",
+        "health",
+        "activity",
+        "operator_actions",
+        "failures",
+        "worktrees",
+    ] {
+        assert!(body.get(key).is_some(), "missing top-level key: {key}");
+    }
+    assert_eq!(body["worktrees"]["metrics_state"], "unavailable");
+    Ok(())
+}
+
+#[test]
+fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
+    let legacy_row = TaskSummary {
+        id: TaskId("legacy-row".to_string()),
+        task_kind: crate::task_runner::TaskKind::Issue,
+        status: crate::task_runner::TaskStatus::Waiting,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        error: None,
+        source: Some("github".to_string()),
+        parent_id: None,
+        external_id: Some("issue:1".to_string()),
+        repo: Some("owner/repo".to_string()),
+        description: None,
+        created_at: None,
+        phase: crate::task_runner::TaskPhase::Review,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project: None,
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        workflow: None,
+        scheduler: crate::task_runner::TaskSchedulerState::queued(),
+    };
+    let mut queued_row = legacy_row.clone();
+    queued_row.id = TaskId("queued-row".to_string());
+    queued_row.workflow = None;
+    queued_row.status = crate::task_runner::TaskStatus::Pending;
+
+    let mut by_source = source_activity(
+        &[workflow(
+            "ready_to_merge",
+            json!({
+                "source": "github",
+                "task_id": "legacy-row",
+                "pr_number": 7,
+                "pr_url": "https://github.com/owner/repo/pull/7",
+            }),
+        )],
+        &[legacy_row, queued_row],
+    );
+
+    assert_eq!(by_source.len(), 1);
+    let source = by_source.pop().expect("source row");
+    assert_eq!(source.source, "github");
+    assert_eq!(source.ready_to_merge, 1);
+    assert_eq!(source.running, 0);
+    assert_eq!(source.blocked, 0);
+}

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -161,6 +161,55 @@ async fn endpoint_includes_failed_runtime_workflows_without_legacy_tasks() -> an
     Ok(())
 }
 
+#[tokio::test]
+async fn recent_failed_workflow_sampling_prefers_newest_rows() -> anyhow::Result<()> {
+    let _lock = test_helpers::HOME_LOCK.lock().await;
+    let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-recent-failed-")?;
+    let workflow_runtime_store = WorkflowRuntimeStore::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
+        Some(&test_helpers::test_database_url()?),
+    )
+    .await?;
+    workflow_runtime_store
+        .upsert_instance(
+            &WorkflowInstance::new(
+                QUALITY_GATE_DEFINITION_ID,
+                1,
+                "failed",
+                WorkflowSubject::new("quality_gate", "quality_gate:old"),
+            )
+            .with_id("old-failed".to_string()),
+        )
+        .await?;
+    workflow_runtime_store
+        .upsert_instance(
+            &WorkflowInstance::new(
+                QUALITY_GATE_DEFINITION_ID,
+                1,
+                "failed",
+                WorkflowSubject::new("quality_gate", "quality_gate:recent"),
+            )
+            .with_id("recent-failed".to_string()),
+        )
+        .await?;
+    sqlx::query("UPDATE workflow_instances SET updated_at = $2 WHERE id = $1")
+        .bind("old-failed")
+        .bind(Utc::now() - chrono::Duration::hours(1))
+        .execute(workflow_runtime_store.pool())
+        .await?;
+    sqlx::query("UPDATE workflow_instances SET updated_at = $2 WHERE id = $1")
+        .bind("recent-failed")
+        .bind(Utc::now())
+        .execute(workflow_runtime_store.pool())
+        .await?;
+
+    let workflows = list_recent_failed_workflows(&workflow_runtime_store, 1).await?;
+
+    assert_eq!(workflows.len(), 1);
+    assert_eq!(workflows[0].id, "recent-failed");
+    Ok(())
+}
+
 #[test]
 fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
     let legacy_row = TaskSummary {
@@ -205,6 +254,7 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
             ),
             workflow("awaiting_dependencies", json!({ "source": "github" })),
             workflow("checking", json!({ "source": "github" })),
+            workflow("awaiting_feedback", json!({ "source": "github" })),
         ],
         &[legacy_row, queued_row],
     );
@@ -213,6 +263,7 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
     let source = by_source.pop().expect("source row");
     assert_eq!(source.source, "github");
     assert_eq!(source.ready_to_merge, 1);
+    assert_eq!(source.review, 1);
     assert_eq!(source.running, 1);
     assert_eq!(source.blocked, 1);
 }

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -372,6 +372,7 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
             workflow("awaiting_dependencies", json!({ "source": "github" })),
             workflow("checking", json!({ "source": "github" })),
             workflow("awaiting_feedback", json!({ "source": "github" })),
+            workflow("scheduled", json!({ "source": "github" })),
         ],
         &[legacy_row, queued_row],
     );
@@ -379,6 +380,7 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
     assert_eq!(by_source.len(), 1);
     let source = by_source.pop().expect("source row");
     assert_eq!(source.source, "github");
+    assert_eq!(source.pending, 1);
     assert_eq!(source.ready_to_merge, 1);
     assert_eq!(source.review, 1);
     assert_eq!(source.running, 1);

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -207,6 +207,57 @@ async fn endpoint_returns_monitor_payload_on_fresh_state() -> anyhow::Result<()>
 }
 
 #[tokio::test]
+async fn endpoint_marks_health_degraded_when_runtime_state_is_dirty() -> anyhow::Result<()> {
+    let _lock = test_helpers::HOME_LOCK.lock().await;
+    let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-dirty-state-")?;
+    let state = Arc::new(test_helpers::make_test_state(dir.path()).await?);
+    state
+        .runtime_state_dirty
+        .store(true, std::sync::atomic::Ordering::Release);
+
+    let app = Router::new()
+        .route("/api/operator-monitor", get(operator_monitor))
+        .with_state(state);
+
+    let req = axum::http::Request::builder()
+        .uri("/api/operator-monitor")
+        .body(axum::body::Body::empty())?;
+    let resp = tower::ServiceExt::oneshot(app, req).await?;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+    let body: Value = serde_json::from_slice(&bytes)?;
+
+    assert_eq!(body["health"]["status"], "degraded");
+    Ok(())
+}
+
+#[test]
+fn operator_actions_link_evidence_to_current_legacy_task_id() {
+    let mut ready = workflow(
+        "ready_to_merge",
+        json!({
+            "repo": "owner/repo",
+            "pr_number": 7,
+            "pr_url": "https://github.com/owner/repo/pull/7",
+            "submission_id": "stable-submission",
+            "task_id": "current-task",
+        }),
+    )
+    .with_id("ready-workflow".to_string());
+    ready.updated_at = Utc::now();
+
+    let actions = operator_actions(&[ready], Utc::now());
+
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].task_id.as_deref(), Some("current-task"));
+    assert_eq!(
+        actions[0].evidence_url.as_deref(),
+        Some("/tasks/current-task")
+    );
+}
+
+#[tokio::test]
 async fn endpoint_includes_failed_runtime_workflows_without_legacy_tasks() -> anyhow::Result<()> {
     let _lock = test_helpers::HOME_LOCK.lock().await;
     let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-failed-runtime-")?;

--- a/crates/harness-server/src/handlers/worktrees.rs
+++ b/crates/harness-server/src/handlers/worktrees.rs
@@ -40,7 +40,7 @@ pub async fn worktrees(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
     }
 }
 
-async fn list_worktrees(state: &AppState) -> anyhow::Result<Vec<WorktreeResponse>> {
+pub(crate) async fn list_worktrees(state: &AppState) -> anyhow::Result<Vec<WorktreeResponse>> {
     let Some(manager) = state.concurrency.workspace_mgr.as_ref() else {
         return Ok(Vec::new());
     };

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -51,6 +51,10 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
         .route("/projects/queue-stats", get(project_queue_stats))
         .route("/api/dashboard", get(crate::handlers::dashboard::dashboard))
         .route("/api/overview", get(crate::handlers::overview::overview))
+        .route(
+            "/api/operator-monitor",
+            get(crate::handlers::operator_monitor::operator_monitor),
+        )
         .route("/api/worktrees", get(crate::handlers::worktrees::worktrees))
         .route(
             "/api/operator-snapshot",

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -170,6 +170,16 @@ fn workflow_command_record_from_row(
         updated_at,
     })
 }
+
+fn workflow_instance_from_row(
+    data: String,
+    updated_at: DateTime<Utc>,
+) -> anyhow::Result<WorkflowInstance> {
+    let mut instance: WorkflowInstance = serde_json::from_str(&data)?;
+    instance.updated_at = updated_at;
+    Ok(instance)
+}
+
 impl WorkflowRuntimeStore {
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
         Self::open_with_database_url(path, None).await
@@ -552,8 +562,8 @@ impl WorkflowRuntimeStore {
         limit: i64,
     ) -> anyhow::Result<Vec<WorkflowInstance>> {
         let limit = limit.clamp(1, 500);
-        let rows: Vec<(String,)> = sqlx::query_as(
-            "SELECT data::text FROM workflow_instances
+        let rows: Vec<(String, DateTime<Utc>)> = sqlx::query_as(
+            "SELECT data::text, updated_at FROM workflow_instances
              WHERE definition_id = $1
                AND state = $2
              ORDER BY updated_at DESC
@@ -565,7 +575,7 @@ impl WorkflowRuntimeStore {
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter()
-            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .map(|(data, updated_at)| workflow_instance_from_row(data, updated_at))
             .collect()
     }
 
@@ -718,8 +728,8 @@ impl WorkflowRuntimeStore {
         limit: Option<i64>,
     ) -> anyhow::Result<Vec<WorkflowInstance>> {
         let limit = limit.map(|value| value.clamp(1, 500));
-        let rows: Vec<(String,)> = sqlx::query_as(
-            "SELECT data::text FROM workflow_instances
+        let rows: Vec<(String, DateTime<Utc>)> = sqlx::query_as(
+            "SELECT data::text, updated_at FROM workflow_instances
              WHERE definition_id = $1
                AND state NOT IN ('done', 'passed', 'failed', 'cancelled')
                AND ($2::text IS NULL OR data->'data'->>'project_id' = $2)
@@ -732,7 +742,7 @@ impl WorkflowRuntimeStore {
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter()
-            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .map(|(data, updated_at)| workflow_instance_from_row(data, updated_at))
             .collect()
     }
 

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -545,6 +545,30 @@ impl WorkflowRuntimeStore {
             .collect()
     }
 
+    pub async fn list_recent_instances_by_state(
+        &self,
+        definition_id: &str,
+        state: &str,
+        limit: i64,
+    ) -> anyhow::Result<Vec<WorkflowInstance>> {
+        let limit = limit.clamp(1, 500);
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data::text FROM workflow_instances
+             WHERE definition_id = $1
+               AND state = $2
+             ORDER BY updated_at DESC
+             LIMIT $3",
+        )
+        .bind(definition_id)
+        .bind(state)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| Ok(serde_json::from_str(&data)?))
+            .collect()
+    }
+
     pub async fn touch_instance(&self, workflow_id: &str) -> anyhow::Result<()> {
         sqlx::query("UPDATE workflow_instances SET updated_at = clock_timestamp() WHERE id = $1")
             .bind(workflow_id)

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -7,6 +7,7 @@ import type {
   EvalQualitySnapshotResponse,
   EvalRunsResponse,
   FullTask,
+  OperatorMonitorPayload,
   OperatorSnapshotPayload,
   OverviewPayload,
   StreamItem,
@@ -33,6 +34,14 @@ export function useOperatorSnapshot() {
   return useQuery<OperatorSnapshotPayload, Error>({
     queryKey: ["operator-snapshot"],
     queryFn: ({ signal }) => apiJson<OperatorSnapshotPayload>("/api/operator-snapshot", { signal }),
+    refetchInterval: 30_000,
+  });
+}
+
+export function useOperatorMonitor() {
+  return useQuery<OperatorMonitorPayload, Error>({
+    queryKey: ["operator-monitor"],
+    queryFn: ({ signal }) => apiJson<OperatorMonitorPayload>("/api/operator-monitor", { signal }),
     refetchInterval: 30_000,
   });
 }

--- a/web/src/routes/Overview.test.tsx
+++ b/web/src/routes/Overview.test.tsx
@@ -1,20 +1,22 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { Overview } from "./Overview";
 import { PaletteProvider } from "@/lib/palette";
 import { DOCS_URL } from "@/lib/links";
-import type { OperatorSnapshotPayload, OverviewPayload } from "@/types";
+import type { OperatorMonitorPayload, OperatorSnapshotPayload, OverviewPayload } from "@/types";
 
 vi.mock("@/lib/queries", () => ({
   useOverview: vi.fn(),
+  useOperatorMonitor: vi.fn(),
   useOperatorSnapshot: vi.fn(),
 }));
 
-import { useOperatorSnapshot, useOverview } from "@/lib/queries";
+import { useOperatorMonitor, useOperatorSnapshot, useOverview } from "@/lib/queries";
 
 const mockUseOverview = useOverview as ReturnType<typeof vi.fn>;
+const mockUseOperatorMonitor = useOperatorMonitor as ReturnType<typeof vi.fn>;
 const mockUseOperatorSnapshot = useOperatorSnapshot as ReturnType<typeof vi.fn>;
 
 function wrap(ui: React.ReactElement) {
@@ -106,7 +108,60 @@ function makeSnapshot(): OperatorSnapshotPayload {
   };
 }
 
+function makeMonitor(): OperatorMonitorPayload {
+  return {
+    generated_at: "2026-04-22T00:00:00Z",
+    sample_limit: 500,
+    health: {
+      status: "ok",
+      degraded_subsystems: [],
+      runtime_log_state: "disabled",
+      runtime_log_path: null,
+      uptime_secs: 1,
+      runtime_hosts_online: 0,
+      runtime_hosts_total: 0,
+    },
+    activity: {
+      runtime_workflows: {
+        pending: 0,
+        running: 1,
+        review: 0,
+        awaiting_dependencies: 0,
+        ready_to_merge: 0,
+        blocked: 0,
+        failed: 0,
+        done: 0,
+        other: 0,
+      },
+      legacy_queue: {
+        queued: 0,
+        running: 1,
+        stalled: 0,
+        failed: 0,
+        done: 0,
+      },
+      by_source: [],
+    },
+    operator_actions: [],
+    failures: [],
+    worktrees: {
+      used: 0,
+      capacity: 1,
+      stale: 0,
+      metrics_state: "unavailable",
+      cards: [],
+    },
+  };
+}
+
 describe("<Overview>", () => {
+  beforeEach(() => {
+    mockUseOperatorMonitor.mockReturnValue({
+      data: makeMonitor(),
+      isError: false,
+    });
+  });
+
   it("shows a degraded status badge when operator snapshot fails even if overview succeeds", () => {
     mockUseOverview.mockReturnValue({
       data: makeOverview(),

--- a/web/src/routes/Overview.tsx
+++ b/web/src/routes/Overview.tsx
@@ -14,6 +14,7 @@ import { EvolutionCard } from "@/components/EvolutionCard";
 import { useOperatorSnapshot, useOverview } from "@/lib/queries";
 import { DOCS_URL } from "@/lib/links";
 import { OperatorPanel } from "./overview/OperatorPanel";
+import { OperatorMonitorPanel } from "./overview/OperatorMonitorPanel";
 import { fmtInt, fmtPct, fmtScore } from "@/lib/format";
 
 const SERIES_COLORS = [
@@ -191,6 +192,8 @@ export function Overview() {
           </div>
 
           <EvolutionCard evolution={data?.evolution ?? null} />
+
+          <OperatorMonitorPanel />
 
           <OperatorPanel />
         </div>

--- a/web/src/routes/overview/OperatorMonitorPanel.test.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.test.tsx
@@ -52,6 +52,7 @@ function makeMonitor(): OperatorMonitorPayload {
       by_source: [
         {
           source: "github",
+          pending: 1,
           running: 2,
           review: 1,
           ready_to_merge: 1,

--- a/web/src/routes/overview/OperatorMonitorPanel.test.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.test.tsx
@@ -53,6 +53,7 @@ function makeMonitor(): OperatorMonitorPayload {
         {
           source: "github",
           running: 2,
+          review: 1,
           ready_to_merge: 1,
           blocked: 0,
           failed: 0,

--- a/web/src/routes/overview/OperatorMonitorPanel.test.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.test.tsx
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { OperatorMonitorPanel } from "./OperatorMonitorPanel";
+import type { OperatorMonitorPayload } from "@/types";
+
+vi.mock("@/lib/queries", () => ({
+  useOperatorMonitor: vi.fn(),
+}));
+
+import { useOperatorMonitor } from "@/lib/queries";
+
+const mockUseOperatorMonitor = useOperatorMonitor as ReturnType<typeof vi.fn>;
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+function makeMonitor(): OperatorMonitorPayload {
+  return {
+    generated_at: "2026-06-12T00:00:00Z",
+    sample_limit: 500,
+    health: {
+      status: "ok",
+      degraded_subsystems: [],
+      runtime_log_state: "enabled",
+      runtime_log_path: "/tmp/harness.log",
+      uptime_secs: 120,
+      runtime_hosts_online: 1,
+      runtime_hosts_total: 1,
+    },
+    activity: {
+      runtime_workflows: {
+        pending: 0,
+        running: 2,
+        review: 1,
+        awaiting_dependencies: 0,
+        ready_to_merge: 1,
+        blocked: 0,
+        failed: 0,
+        done: 4,
+        other: 0,
+      },
+      legacy_queue: {
+        queued: 0,
+        running: 0,
+        stalled: 0,
+        failed: 0,
+        done: 0,
+      },
+      by_source: [
+        {
+          source: "github",
+          running: 2,
+          ready_to_merge: 1,
+          blocked: 0,
+          failed: 0,
+        },
+      ],
+    },
+    operator_actions: [
+      {
+        kind: "ready_to_merge",
+        repo: "owner/repo",
+        issue: 42,
+        pr: 43,
+        task_id: "task-42",
+        workflow_id: "workflow-42",
+        state: "ready_to_merge",
+        age_secs: 900,
+        url: "https://github.com/owner/repo/pull/43",
+        evidence_url: "/tasks/task-42",
+        next_action: "Review and merge",
+        source: "github",
+      },
+    ],
+    failures: [
+      {
+        family: "github_fetch",
+        severity: "warn",
+        message: "git fetch origin main failed: SSL_ERROR_SYSCALL in connection to github.com:443",
+        first_seen: "2026-06-12T00:00:00Z",
+        last_seen: "2026-06-12T00:05:00Z",
+        count: 2,
+        repo: "repo",
+        task_id: "task-err",
+        retryable: true,
+        next_action: "Retry after GitHub connectivity recovers",
+      },
+    ],
+    worktrees: {
+      used: 1,
+      capacity: 4,
+      stale: 0,
+      metrics_state: "unavailable",
+      cards: [
+        {
+          task_id: "task-42",
+          branch: "harness/task-42",
+          workspace_path: "/tmp/workspaces/task-42",
+          path_short: "workspaces/task-42",
+          source_repo: "/tmp/repo",
+          repo: "owner/repo",
+          runtime_workflow_id: "workflow-42",
+          status: "implementing",
+          phase: "implement",
+          description: "Implement operator monitor",
+          turn: 1,
+          max_turns: 8,
+          created_at: "2026-06-12T00:00:00Z",
+          duration_secs: 120,
+          pr_url: "https://github.com/owner/repo/pull/43",
+          project: "/tmp/repo",
+        },
+      ],
+    },
+  };
+}
+
+describe("<OperatorMonitorPanel>", () => {
+  it("renders active runtime work and ready-to-merge operator actions", () => {
+    mockUseOperatorMonitor.mockReturnValue({
+      data: makeMonitor(),
+      isError: false,
+    });
+
+    wrap(<OperatorMonitorPanel />);
+
+    expect(screen.getByText("runtime running")).toBeInTheDocument();
+    expect(screen.getByText("ready to merge")).toBeInTheDocument();
+    expect(screen.getByText("#42 -> PR #43")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "open" })).toHaveAttribute(
+      "href",
+      "https://github.com/owner/repo/pull/43",
+    );
+  });
+
+  it("renders grouped retryable GitHub fetch failures", () => {
+    mockUseOperatorMonitor.mockReturnValue({
+      data: makeMonitor(),
+      isError: false,
+    });
+
+    wrap(<OperatorMonitorPanel />);
+
+    expect(screen.getByText("github_fetch")).toBeInTheDocument();
+    expect(screen.getByText(/SSL_ERROR_SYSCALL/)).toBeInTheDocument();
+    expect(screen.getByText("retryable")).toBeInTheDocument();
+  });
+
+  it("shows metrics-unavailable worktree state explicitly", () => {
+    mockUseOperatorMonitor.mockReturnValue({
+      data: makeMonitor(),
+      isError: false,
+    });
+
+    wrap(<OperatorMonitorPanel />);
+
+    expect(screen.getByText(/metrics unavailable/)).toBeInTheDocument();
+    expect(screen.getByText("workspaces/task-42")).toBeInTheDocument();
+  });
+
+  it("shows unavailable copy when the monitor query fails", () => {
+    mockUseOperatorMonitor.mockReturnValue({
+      data: undefined,
+      isError: true,
+    });
+
+    wrap(<OperatorMonitorPanel />);
+
+    expect(screen.getByText("Operator monitor unavailable.")).toBeInTheDocument();
+    expect(screen.queryByText("No current operator actions.")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/routes/overview/OperatorMonitorPanel.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.tsx
@@ -1,0 +1,176 @@
+import { Panel } from "@/components/Panel";
+import { useOperatorMonitor } from "@/lib/queries";
+import { fmtInt } from "@/lib/format";
+import type { FailureGroup, OperatorAction, OperatorMonitorPayload, SourceActivity } from "@/types";
+
+function fmtDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3_600)}h`;
+  return `${Math.floor(seconds / 86_400)}d`;
+}
+
+function sourceTotal(source: SourceActivity): number {
+  return source.running + source.blocked + source.failed + source.ready_to_merge;
+}
+
+function Metric({ label, value, tone = "default" }: { label: string; value: string | number; tone?: "default" | "ok" | "warn" | "err" }) {
+  const color = tone === "ok" ? "text-ok" : tone === "warn" ? "text-warn" : tone === "err" ? "text-danger" : "text-ink-1";
+  return (
+    <div className="min-w-0 border-r border-line px-4 py-3 last:border-r-0">
+      <div className={`font-mono text-lg font-semibold ${color}`}>{value}</div>
+      <div className="mt-0.5 truncate font-mono text-[10px] uppercase tracking-[0.1em] text-ink-4">{label}</div>
+    </div>
+  );
+}
+
+function ActionRow({ action }: { action: OperatorAction }) {
+  return (
+    <tr className="border-b border-line last:border-b-0">
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-2">{action.kind.replace(/_/g, " ")}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">{action.repo ?? "untracked"}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">
+        {action.issue ? `#${action.issue}` : "unknown"}
+        {action.pr ? ` -> PR #${action.pr}` : ""}
+      </td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-2">{action.state}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-4">{fmtDuration(action.age_secs)}</td>
+      <td className="px-3 py-2 text-right font-mono text-[11px]">
+        {action.url ? (
+          <a href={action.url} target="_blank" rel="noreferrer" className="text-rust hover:underline">
+            open
+          </a>
+        ) : action.evidence_url ? (
+          <a href={action.evidence_url} className="text-rust hover:underline">
+            evidence
+          </a>
+        ) : (
+          <span className="text-ink-4">unlinked</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function FailureRow({ failure }: { failure: FailureGroup }) {
+  const tone = failure.severity === "warn" ? "text-warn" : failure.severity === "critical" ? "text-danger" : "text-rust";
+  return (
+    <tr className="border-b border-line last:border-b-0">
+      <td className={`px-3 py-2 font-mono text-[11px] ${tone}`}>{failure.family}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">{failure.repo ?? "untracked"}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-2">
+        <span className="line-clamp-1">{failure.message}</span>
+      </td>
+      <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-3">{fmtInt(failure.count)}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-4">{failure.retryable ? "retryable" : "manual"}</td>
+    </tr>
+  );
+}
+
+function SourceRow({ source }: { source: SourceActivity }) {
+  return (
+    <tr className="border-b border-line last:border-b-0">
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-2">{source.source}</td>
+      <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-1">{fmtInt(source.running)}</td>
+      <td className="px-3 py-2 text-right font-mono text-[11px] text-sand">{fmtInt(source.ready_to_merge)}</td>
+      <td className="px-3 py-2 text-right font-mono text-[11px] text-warn">{fmtInt(source.blocked)}</td>
+      <td className="px-3 py-2 text-right font-mono text-[11px] text-danger">{fmtInt(source.failed)}</td>
+      <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-3">{fmtInt(sourceTotal(source))}</td>
+    </tr>
+  );
+}
+
+function MonitorBody({ data }: { data: OperatorMonitorPayload }) {
+  const runtime = data.activity.runtime_workflows;
+  const legacy = data.activity.legacy_queue;
+  const healthTone = data.health.status === "ok" ? "ok" : "warn";
+  const topWorktrees = data.worktrees.cards.slice(0, 4);
+
+  return (
+    <>
+      <div className="grid grid-cols-8 border-b border-line">
+        <Metric label="health" value={data.health.status} tone={healthTone} />
+        <Metric label="runtime running" value={fmtInt(runtime.running)} />
+        <Metric label="runtime review" value={fmtInt(runtime.review)} />
+        <Metric label="ready" value={fmtInt(runtime.ready_to_merge)} tone={runtime.ready_to_merge > 0 ? "warn" : "default"} />
+        <Metric label="blocked" value={fmtInt(runtime.blocked)} tone={runtime.blocked > 0 ? "err" : "default"} />
+        <Metric label="legacy running" value={fmtInt(legacy.running)} />
+        <Metric label="legacy queued" value={fmtInt(legacy.queued)} />
+        <Metric label="worktrees" value={`${fmtInt(data.worktrees.used)}/${fmtInt(data.worktrees.capacity)}`} />
+      </div>
+
+      <div className="grid grid-cols-[1.2fr_1fr] border-b border-line">
+        <div className="border-r border-line">
+          <div className="px-4 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3">Operator actions</div>
+          {data.operator_actions.length === 0 ? (
+            <p className="border-t border-line px-4 py-3 font-mono text-[11px] text-ink-4">No current operator actions.</p>
+          ) : (
+            <table className="w-full border-t border-line">
+              <tbody>{data.operator_actions.map((action) => <ActionRow key={action.workflow_id} action={action} />)}</tbody>
+            </table>
+          )}
+        </div>
+
+        <div>
+          <div className="px-4 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3">Source split</div>
+          {data.activity.by_source.length === 0 ? (
+            <p className="border-t border-line px-4 py-3 font-mono text-[11px] text-ink-4">No active source rows.</p>
+          ) : (
+            <table className="w-full border-t border-line">
+              <tbody>{data.activity.by_source.map((source) => <SourceRow key={source.source} source={source} />)}</tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-[1.2fr_1fr]">
+        <div className="border-r border-line">
+          <div className="px-4 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3">Grouped failures</div>
+          {data.failures.length === 0 ? (
+            <p className="border-t border-line px-4 py-3 font-mono text-[11px] text-ink-4">No recent failures.</p>
+          ) : (
+            <table className="w-full border-t border-line">
+              <tbody>{data.failures.map((failure) => <FailureRow key={`${failure.family}:${failure.repo}:${failure.message}`} failure={failure} />)}</tbody>
+            </table>
+          )}
+        </div>
+
+        <div>
+          <div className="px-4 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3">Worktrees</div>
+          <div className="border-t border-line px-4 py-3 font-mono text-[11px] text-ink-3">
+            metrics {data.worktrees.metrics_state === "available" ? "available" : "unavailable"}
+            {data.worktrees.stale != null ? ` · stale ${fmtInt(data.worktrees.stale)}` : " · stale unknown"}
+          </div>
+          {topWorktrees.length > 0 && (
+            <div className="border-t border-line">
+              {topWorktrees.map((card) => (
+                <div key={card.task_id} className="grid grid-cols-[1fr_auto] gap-3 border-b border-line px-4 py-2 last:border-b-0">
+                  <span className="truncate font-mono text-[11px] text-ink-2" title={card.workspace_path}>
+                    {card.path_short}
+                  </span>
+                  <span className="font-mono text-[11px] text-ink-4">{card.status}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function OperatorMonitorPanel() {
+  const { data, isError } = useOperatorMonitor();
+
+  return (
+    <Panel title="Operator monitor" sub="runtime · actions · failures · worktrees" id="operator-monitor">
+      {isError ? (
+        <p className="px-4 py-3 font-mono text-[11px] text-danger">Operator monitor unavailable.</p>
+      ) : data ? (
+        <MonitorBody data={data} />
+      ) : (
+        <p className="px-4 py-3 font-mono text-[11px] text-ink-4">Loading operator monitor.</p>
+      )}
+    </Panel>
+  );
+}

--- a/web/src/routes/overview/OperatorMonitorPanel.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.tsx
@@ -11,7 +11,7 @@ function fmtDuration(seconds: number): string {
 }
 
 function sourceTotal(source: SourceActivity): number {
-  return source.running + source.review + source.blocked + source.failed + source.ready_to_merge;
+  return source.pending + source.running + source.review + source.blocked + source.failed + source.ready_to_merge;
 }
 
 function Metric({ label, value, tone = "default" }: { label: string; value: string | number; tone?: "default" | "ok" | "warn" | "err" }) {
@@ -71,6 +71,7 @@ function SourceRow({ source }: { source: SourceActivity }) {
   return (
     <tr className="border-b border-line last:border-b-0">
       <td className="px-3 py-2 font-mono text-[11px] text-ink-2">{source.source}</td>
+      <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-3">{fmtInt(source.pending)}</td>
       <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-1">{fmtInt(source.running)}</td>
       <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-2">{fmtInt(source.review)}</td>
       <td className="px-3 py-2 text-right font-mono text-[11px] text-sand">{fmtInt(source.ready_to_merge)}</td>

--- a/web/src/routes/overview/OperatorMonitorPanel.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.tsx
@@ -11,7 +11,7 @@ function fmtDuration(seconds: number): string {
 }
 
 function sourceTotal(source: SourceActivity): number {
-  return source.running + source.blocked + source.failed + source.ready_to_merge;
+  return source.running + source.review + source.blocked + source.failed + source.ready_to_merge;
 }
 
 function Metric({ label, value, tone = "default" }: { label: string; value: string | number; tone?: "default" | "ok" | "warn" | "err" }) {
@@ -72,6 +72,7 @@ function SourceRow({ source }: { source: SourceActivity }) {
     <tr className="border-b border-line last:border-b-0">
       <td className="px-3 py-2 font-mono text-[11px] text-ink-2">{source.source}</td>
       <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-1">{fmtInt(source.running)}</td>
+      <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-2">{fmtInt(source.review)}</td>
       <td className="px-3 py-2 text-right font-mono text-[11px] text-sand">{fmtInt(source.ready_to_merge)}</td>
       <td className="px-3 py-2 text-right font-mono text-[11px] text-warn">{fmtInt(source.blocked)}</td>
       <td className="px-3 py-2 text-right font-mono text-[11px] text-danger">{fmtInt(source.failed)}</td>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from "./dashboard";
 export * from "./eval";
 export * from "./operator_snapshot";
+export * from "./operator_monitor";
 export * from "./overview";
 export * from "./task";
 export * from "./usage_monitor";

--- a/web/src/types/operator_monitor.ts
+++ b/web/src/types/operator_monitor.ts
@@ -1,0 +1,108 @@
+export interface OperatorMonitorPayload {
+  generated_at: string;
+  sample_limit: number;
+  health: OperatorHealth;
+  activity: OperatorActivity;
+  operator_actions: OperatorAction[];
+  failures: FailureGroup[];
+  worktrees: OperatorWorktreeSummary;
+}
+
+export interface OperatorHealth {
+  status: "ok" | "degraded";
+  degraded_subsystems: string[];
+  runtime_log_state: "disabled" | "enabled" | "degraded";
+  runtime_log_path: string | null;
+  uptime_secs: number;
+  runtime_hosts_online: number;
+  runtime_hosts_total: number;
+}
+
+export interface OperatorActivity {
+  runtime_workflows: RuntimeWorkflowCounts;
+  legacy_queue: LegacyQueueCounts;
+  by_source: SourceActivity[];
+}
+
+export interface RuntimeWorkflowCounts {
+  pending: number;
+  running: number;
+  review: number;
+  awaiting_dependencies: number;
+  ready_to_merge: number;
+  blocked: number;
+  failed: number;
+  done: number;
+  other: number;
+}
+
+export interface LegacyQueueCounts {
+  queued: number;
+  running: number;
+  stalled: number;
+  failed: number;
+  done: number;
+}
+
+export interface SourceActivity {
+  source: string;
+  running: number;
+  blocked: number;
+  failed: number;
+  ready_to_merge: number;
+}
+
+export interface OperatorAction {
+  kind: "ready_to_merge" | "awaiting_feedback" | "blocked" | string;
+  repo: string | null;
+  issue: number | null;
+  pr: number | null;
+  task_id: string | null;
+  workflow_id: string;
+  state: string;
+  age_secs: number;
+  url: string | null;
+  evidence_url: string | null;
+  next_action: string;
+  source: string;
+}
+
+export interface FailureGroup {
+  family: string;
+  severity: "info" | "warn" | "error" | "critical";
+  message: string;
+  first_seen: string | null;
+  last_seen: string | null;
+  count: number;
+  repo: string | null;
+  task_id: string | null;
+  retryable: boolean;
+  next_action: string;
+}
+
+export interface OperatorWorktreeSummary {
+  used: number;
+  capacity: number;
+  stale: number | null;
+  metrics_state: "unavailable" | "available";
+  cards: OperatorWorktreeCard[];
+}
+
+export interface OperatorWorktreeCard {
+  task_id: string;
+  branch: string;
+  workspace_path: string;
+  path_short: string;
+  source_repo: string;
+  repo: string | null;
+  runtime_workflow_id: string | null;
+  status: string;
+  phase: string;
+  description: string | null;
+  turn: number;
+  max_turns: number | null;
+  created_at: string;
+  duration_secs: number;
+  pr_url: string | null;
+  project: string | null;
+}

--- a/web/src/types/operator_monitor.ts
+++ b/web/src/types/operator_monitor.ts
@@ -47,6 +47,7 @@ export interface LegacyQueueCounts {
 export interface SourceActivity {
   source: string;
   running: number;
+  review: number;
   blocked: number;
   failed: number;
   ready_to_merge: number;

--- a/web/src/types/operator_monitor.ts
+++ b/web/src/types/operator_monitor.ts
@@ -46,6 +46,7 @@ export interface LegacyQueueCounts {
 
 export interface SourceActivity {
   source: string;
+  pending: number;
   running: number;
   review: number;
   blocked: number;


### PR DESCRIPTION
## Summary
- Add `/api/operator-monitor` with typed operator health, reconciled runtime/legacy activity, action rows, grouped failures, and worktree summary data.
- Add an Overview operator monitor panel and TypeScript contract/query hook for runtime activity, ready-to-merge actions, retryable failures, and metrics-unavailable worktrees.
- Add backend and frontend tests for state reconciliation, failure grouping, ready actions, and worktree metric availability.

Closes #1164

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p harness-server --all-targets`
- `cargo test -p harness-server operator_monitor`
- `cargo check`
- `env -u GH_TOKEN -u GITHUB_TOKEN cargo test` (main suite passed until `notification_delivery`; that test binary failed under full parallel DB pool pressure)
- `env -u GH_TOKEN -u GITHUB_TOKEN cargo test -p harness-server --test notification_delivery -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run typecheck`
- `bun run test -- src/routes/overview/OperatorMonitorPanel.test.tsx src/routes/Overview.test.tsx`
- `bun run test`