### PR TITLE
fix(runtime): allow blocked reconciliation completion

### DIFF
--- a/crates/harness-server/src/reconciliation_blocked_done_tests.rs
+++ b/crates/harness-server/src/reconciliation_blocked_done_tests.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+#[tokio::test]
+async fn blocked_runtime_reconciliation_marks_merged_pr_done() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let api_base = github_state_server(vec![(
+        "/repos/owner/repo/pulls/103",
+        r#"{"state":"closed","merged_at":"2026-05-10T00:00:00Z"}"#,
+    )])
+    .await;
+    let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
+    let Some(stores) = open_runtime_stores().await? else {
+        return Ok(());
+    };
+
+    let project_root = stores.dir.path().join("project-blocked");
+    std::fs::create_dir(&project_root)?;
+    let project_id = project_root.to_string_lossy();
+    stores
+        .issue_store
+        .record_issue_scheduled(&project_id, Some("owner/repo"), 48, "task-7", &[], false)
+        .await?;
+    stores
+        .issue_store
+        .record_pr_detected(
+            &project_id,
+            Some("owner/repo"),
+            48,
+            "task-7",
+            103,
+            "https://github.com/owner/repo/pull/103",
+        )
+        .await?;
+
+    let workflow_id =
+        harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 48);
+    let instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "blocked",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:48"),
+    )
+    .with_id(&workflow_id)
+    .with_data(json!({
+        "project_id": project_id.as_ref(),
+        "repo": "owner/repo",
+        "issue_number": 48,
+        "task_id": "task-7",
+        "pr_number": 103,
+        "pr_url": "https://github.com/owner/repo/pull/103",
+    }));
+    stores.runtime_store.upsert_instance(&instance).await?;
+
+    let report = run_once_with_runtime_token(
+        &stores.task_store,
+        Some(&stores.runtime_store),
+        Some(&stores.issue_store),
+        20,
+        false,
+        None,
+    )
+    .await;
+
+    assert_eq!(report.workflow_transitions.len(), 1);
+    assert_eq!(report.workflow_transitions[0].from, "blocked");
+    assert_eq!(report.workflow_transitions[0].to, "done");
+    assert_eq!(
+        report.workflow_transitions[0].reason,
+        "reconciled: PR merged externally"
+    );
+    assert!(report.workflow_transitions[0].applied);
+
+    let updated = stores
+        .runtime_store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("workflow should remain persisted");
+    assert_eq!(updated.state, "done");
+    assert_eq!(updated.data["last_decision"], "reconcile_pr_merged");
+    assert_eq!(updated.data["external_pr_state"], "done");
+
+    let issue_workflow = stores
+        .issue_store
+        .get_by_issue(&project_id, Some("owner/repo"), 48)
+        .await?
+        .expect("issue workflow should exist");
+    assert_eq!(
+        issue_workflow.state,
+        harness_workflow::issue_lifecycle::IssueLifecycleState::Done
+    );
+
+    Ok(())
+}

--- a/crates/harness-server/src/reconciliation_blocked_done_tests.rs
+++ b/crates/harness-server/src/reconciliation_blocked_done_tests.rs
@@ -92,6 +92,95 @@ async fn blocked_runtime_reconciliation_marks_merged_pr_done() -> anyhow::Result
         issue_workflow.state,
         harness_workflow::issue_lifecycle::IssueLifecycleState::Done
     );
+    assert_eq!(issue_workflow.pr_number, Some(103));
+    assert_eq!(
+        issue_workflow.pr_url.as_deref(),
+        Some("https://github.com/owner/repo/pull/103")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn blocked_runtime_reconciliation_marks_slug_only_merged_pr_done() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let api_base = github_state_server(vec![(
+        "/repos/owner/repo/pulls/104",
+        r#"{"state":"closed","merged_at":"2026-05-10T00:00:00Z"}"#,
+    )])
+    .await;
+    let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
+    let Some(stores) = open_runtime_stores().await? else {
+        return Ok(());
+    };
+
+    let project_root = stores.dir.path().join("project-blocked-slug");
+    std::fs::create_dir(&project_root)?;
+    let project_id = project_root.to_string_lossy();
+    stores
+        .issue_store
+        .record_issue_scheduled(&project_id, Some("owner/repo"), 49, "task-8", &[], false)
+        .await?;
+
+    let workflow_id =
+        harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 49);
+    let instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "blocked",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:49"),
+    )
+    .with_id(&workflow_id)
+    .with_data(json!({
+        "project_id": project_id.as_ref(),
+        "repo": "owner/repo",
+        "issue_number": 49,
+        "task_id": "task-8",
+        "pr_number": 104,
+    }));
+    stores.runtime_store.upsert_instance(&instance).await?;
+
+    let report = run_once_with_runtime_token(
+        &stores.task_store,
+        Some(&stores.runtime_store),
+        Some(&stores.issue_store),
+        20,
+        false,
+        None,
+    )
+    .await;
+
+    assert_eq!(report.workflow_transitions.len(), 1);
+    assert_eq!(report.workflow_transitions[0].from, "blocked");
+    assert_eq!(report.workflow_transitions[0].to, "done");
+    assert!(report.workflow_transitions[0].applied);
+
+    let updated = stores
+        .runtime_store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("workflow should remain persisted");
+    assert_eq!(updated.state, "done");
+    assert_eq!(updated.data["last_decision"], "reconcile_pr_merged");
+    assert_eq!(updated.data["external_pr_state"], "done");
+    assert_eq!(updated.data["repo"], "owner/repo");
+    assert!(updated.data.get("pr_url").is_none());
+
+    let issue_workflow = stores
+        .issue_store
+        .get_by_issue(&project_id, Some("owner/repo"), 49)
+        .await?
+        .expect("issue workflow should exist");
+    assert_eq!(
+        issue_workflow.state,
+        harness_workflow::issue_lifecycle::IssueLifecycleState::Done
+    );
+    assert_eq!(issue_workflow.pr_number, Some(104));
+    assert!(issue_workflow.pr_url.is_none());
 
     Ok(())
 }

--- a/crates/harness-server/src/reconciliation_tests.rs
+++ b/crates/harness-server/src/reconciliation_tests.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 use tokio::sync::Mutex;
 
+#[path = "reconciliation_blocked_done_tests.rs"]
+mod blocked_done_tests;
 #[path = "reconciliation_ready_to_merge_tests.rs"]
 mod ready_to_merge_tests;
 

--- a/crates/harness-server/src/workflow_runtime_repo_backlog.rs
+++ b/crates/harness-server/src/workflow_runtime_repo_backlog.rs
@@ -96,7 +96,7 @@ pub(crate) async fn record_merged_pr(
     ctx: MergedPrRuntimeContext<'_>,
 ) {
     if let Some(workflows) = issue_workflows {
-        if let Err(error) = workflows
+        match workflows
             .record_pr_merged(
                 &ctx.project_root.to_string_lossy(),
                 ctx.repo,
@@ -105,11 +105,36 @@ pub(crate) async fn record_merged_pr(
             )
             .await
         {
-            tracing::warn!(
-                pr = ctx.pr_number,
-                repo = ctx.repo,
-                "issue workflow merged PR update failed: {error}"
-            );
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                if let Some(issue_number) = ctx.issue_number {
+                    if let Err(error) = workflows
+                        .record_pr_merged_for_issue(
+                            &ctx.project_root.to_string_lossy(),
+                            ctx.repo,
+                            issue_number,
+                            ctx.pr_number,
+                            ctx.pr_url,
+                            Some(ctx.detail),
+                        )
+                        .await
+                    {
+                        tracing::warn!(
+                            issue = issue_number,
+                            pr = ctx.pr_number,
+                            repo = ctx.repo,
+                            "issue workflow merged PR fallback update failed: {error}"
+                        );
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    pr = ctx.pr_number,
+                    repo = ctx.repo,
+                    "issue workflow merged PR update failed: {error}"
+                );
+            }
         }
     }
 

--- a/crates/harness-workflow/src/issue_lifecycle.rs
+++ b/crates/harness-workflow/src/issue_lifecycle.rs
@@ -255,6 +255,12 @@ impl IssueWorkflowInstance {
             IssueLifecycleEventKind::WorkflowDone => {
                 self.state = IssueLifecycleState::Done;
                 self.feedback_claimed_at = None;
+                if event.pr_number.is_some() {
+                    self.pr_number = event.pr_number;
+                }
+                if event.pr_url.is_some() {
+                    self.pr_url = event.pr_url.clone();
+                }
             }
         }
         self.last_event = Some(event);

--- a/crates/harness-workflow/src/issue_workflow_store.rs
+++ b/crates/harness-workflow/src/issue_workflow_store.rs
@@ -421,6 +421,29 @@ impl IssueWorkflowStore {
         .await
     }
 
+    pub async fn record_pr_merged_for_issue(
+        &self,
+        project_id: &str,
+        repo: Option<&str>,
+        issue_number: u64,
+        pr_number: u64,
+        pr_url: Option<&str>,
+        detail: Option<&str>,
+    ) -> anyhow::Result<Option<IssueWorkflowInstance>> {
+        self.update_existing_issue(project_id, repo, issue_number, |workflow| {
+            let mut event = IssueLifecycleEvent::new(IssueLifecycleEventKind::WorkflowDone);
+            event.pr_number = Some(pr_number);
+            if let Some(pr_url) = pr_url {
+                event.pr_url = Some(pr_url.to_string());
+            }
+            if let Some(detail) = detail {
+                event = event.with_detail(detail.to_string());
+            }
+            workflow.apply_event(event);
+        })
+        .await
+    }
+
     pub async fn list_feedback_candidates(&self) -> anyhow::Result<Vec<IssueWorkflowInstance>> {
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT data FROM issue_workflows

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -3,6 +3,9 @@ use chrono::{DateTime, Utc};
 use std::collections::BTreeSet;
 use std::fmt;
 
+#[path = "validator_github_issue_pr.rs"]
+mod github_issue_pr_validation;
+
 #[cfg(test)]
 #[path = "validator_tests.rs"]
 mod tests;
@@ -216,7 +219,6 @@ impl TransitionAllowlist {
             .allow("quality_gate_pending", "quality_gate_pending", [Wait])
             .allow("ready_to_merge", "ready_to_merge", [Wait])
             .allow("ready_to_merge", "done", [MarkDone])
-            .allow("blocked", "done", [MarkDone])
             .allow_from_any("blocked", [MarkBlocked, RequestOperatorAttention, Wait])
             .allow_from_any("failed", [MarkFailed])
             .allow_from_any("cancelled", [MarkCancelled])
@@ -530,6 +532,10 @@ impl DecisionValidator {
             }
         }
 
+        if self.validate_hidden_workflow_transition(decision, context)? {
+            return Ok(());
+        }
+
         let Some(rule) = self
             .allowlist
             .rule_for(&decision.observed_state, &decision.next_state)
@@ -632,9 +638,26 @@ impl DecisionValidator {
         context: &ValidationContext,
     ) -> Result<(), WorkflowDecisionRejection> {
         if self.kind == DecisionValidatorKind::GithubIssuePr {
-            validate_github_issue_pr_decision(decision, context)?;
+            github_issue_pr_validation::validate_decision(decision, context)?;
         }
         Ok(())
+    }
+
+    fn validate_hidden_workflow_transition(
+        &self,
+        decision: &WorkflowDecision,
+        context: &ValidationContext,
+    ) -> Result<bool, WorkflowDecisionRejection> {
+        if self.kind != DecisionValidatorKind::GithubIssuePr
+            || !github_issue_pr_validation::is_blocked_done_transition(decision)
+        {
+            return Ok(false);
+        }
+
+        let rule = TransitionRule::new("blocked", "done", [WorkflowCommandType::MarkDone]);
+        self.validate_commands(&rule, decision, context)?;
+        github_issue_pr_validation::validate_blocked_done_reconciliation(decision, context)?;
+        Ok(true)
     }
 
     fn validate_command_payload(
@@ -707,65 +730,6 @@ impl DecisionValidator {
 
         Ok(())
     }
-}
-
-fn validate_github_issue_pr_decision(
-    decision: &WorkflowDecision,
-    context: &ValidationContext,
-) -> Result<(), WorkflowDecisionRejection> {
-    if decision.observed_state == "blocked" && decision.next_state == "done" {
-        validate_blocked_done_reconciliation(decision, context)?;
-    }
-    Ok(())
-}
-
-fn validate_blocked_done_reconciliation(
-    decision: &WorkflowDecision,
-    context: &ValidationContext,
-) -> Result<(), WorkflowDecisionRejection> {
-    if context.actor != "reconciliation" || decision.decision != "reconcile_pr_merged" {
-        return Err(missing_terminal_evidence(
-            "blocked issue workflows can only be marked done by PR-merge reconciliation",
-        ));
-    }
-
-    let has_pr_command = decision.commands.iter().any(|command| {
-        command.command_type == WorkflowCommandType::MarkDone
-            && command
-                .command
-                .get("pr_number")
-                .and_then(serde_json::Value::as_u64)
-                .is_some()
-            && command
-                .command
-                .get("pr_url")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|value| !value.trim().is_empty())
-    });
-    if !has_pr_command {
-        return Err(missing_terminal_evidence(
-            "blocked issue PR-merge reconciliation requires pr_number and pr_url evidence",
-        ));
-    }
-
-    if !decision
-        .evidence
-        .iter()
-        .any(|evidence| evidence.kind == "github_pr")
-    {
-        return Err(missing_terminal_evidence(
-            "blocked issue PR-merge reconciliation requires github_pr evidence",
-        ));
-    }
-
-    Ok(())
-}
-
-fn missing_terminal_evidence(message: impl Into<String>) -> WorkflowDecisionRejection {
-    WorkflowDecisionRejection::new(
-        WorkflowDecisionRejectionKind::MissingTerminalEvidence,
-        message,
-    )
 }
 
 fn is_replan_command(command: &WorkflowCommand) -> bool {

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -3,6 +3,10 @@ use chrono::{DateTime, Utc};
 use std::collections::BTreeSet;
 use std::fmt;
 
+#[cfg(test)]
+#[path = "validator_tests.rs"]
+mod tests;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransitionRule {
     pub from_state: Option<String>,
@@ -212,6 +216,7 @@ impl TransitionAllowlist {
             .allow("quality_gate_pending", "quality_gate_pending", [Wait])
             .allow("ready_to_merge", "ready_to_merge", [Wait])
             .allow("ready_to_merge", "done", [MarkDone])
+            .allow("blocked", "done", [MarkDone])
             .allow_from_any("blocked", [MarkBlocked, RequestOperatorAttention, Wait])
             .allow_from_any("failed", [MarkFailed])
             .allow_from_any("cancelled", [MarkCancelled])
@@ -401,6 +406,7 @@ pub enum WorkflowDecisionRejectionKind {
     TerminalReopenDenied,
     RequiredCommandMissing,
     InvalidCommandPayload,
+    MissingTerminalEvidence,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -429,15 +435,28 @@ impl std::error::Error for WorkflowDecisionRejection {}
 #[derive(Debug, Clone)]
 pub struct DecisionValidator {
     allowlist: TransitionAllowlist,
+    kind: DecisionValidatorKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DecisionValidatorKind {
+    Generic,
+    GithubIssuePr,
 }
 
 impl DecisionValidator {
     pub fn new(allowlist: TransitionAllowlist) -> Self {
-        Self { allowlist }
+        Self {
+            allowlist,
+            kind: DecisionValidatorKind::Generic,
+        }
     }
 
     pub fn github_issue_pr() -> Self {
-        Self::new(TransitionAllowlist::github_issue_pr_defaults())
+        Self {
+            allowlist: TransitionAllowlist::github_issue_pr_defaults(),
+            kind: DecisionValidatorKind::GithubIssuePr,
+        }
     }
 
     pub fn repo_backlog() -> Self {
@@ -524,7 +543,8 @@ impl DecisionValidator {
             ));
         };
 
-        self.validate_commands(rule, decision, context)
+        self.validate_commands(rule, decision, context)?;
+        self.validate_workflow_specific_rules(decision, context)
     }
 
     pub fn transition_rules_from<'a>(
@@ -606,6 +626,17 @@ impl DecisionValidator {
         Ok(())
     }
 
+    fn validate_workflow_specific_rules(
+        &self,
+        decision: &WorkflowDecision,
+        context: &ValidationContext,
+    ) -> Result<(), WorkflowDecisionRejection> {
+        if self.kind == DecisionValidatorKind::GithubIssuePr {
+            validate_github_issue_pr_decision(decision, context)?;
+        }
+        Ok(())
+    }
+
     fn validate_command_payload(
         &self,
         command: &WorkflowCommand,
@@ -676,6 +707,65 @@ impl DecisionValidator {
 
         Ok(())
     }
+}
+
+fn validate_github_issue_pr_decision(
+    decision: &WorkflowDecision,
+    context: &ValidationContext,
+) -> Result<(), WorkflowDecisionRejection> {
+    if decision.observed_state == "blocked" && decision.next_state == "done" {
+        validate_blocked_done_reconciliation(decision, context)?;
+    }
+    Ok(())
+}
+
+fn validate_blocked_done_reconciliation(
+    decision: &WorkflowDecision,
+    context: &ValidationContext,
+) -> Result<(), WorkflowDecisionRejection> {
+    if context.actor != "reconciliation" || decision.decision != "reconcile_pr_merged" {
+        return Err(missing_terminal_evidence(
+            "blocked issue workflows can only be marked done by PR-merge reconciliation",
+        ));
+    }
+
+    let has_pr_command = decision.commands.iter().any(|command| {
+        command.command_type == WorkflowCommandType::MarkDone
+            && command
+                .command
+                .get("pr_number")
+                .and_then(serde_json::Value::as_u64)
+                .is_some()
+            && command
+                .command
+                .get("pr_url")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| !value.trim().is_empty())
+    });
+    if !has_pr_command {
+        return Err(missing_terminal_evidence(
+            "blocked issue PR-merge reconciliation requires pr_number and pr_url evidence",
+        ));
+    }
+
+    if !decision
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "github_pr")
+    {
+        return Err(missing_terminal_evidence(
+            "blocked issue PR-merge reconciliation requires github_pr evidence",
+        ));
+    }
+
+    Ok(())
+}
+
+fn missing_terminal_evidence(message: impl Into<String>) -> WorkflowDecisionRejection {
+    WorkflowDecisionRejection::new(
+        WorkflowDecisionRejectionKind::MissingTerminalEvidence,
+        message,
+    )
 }
 
 fn is_replan_command(command: &WorkflowCommand) -> bool {

--- a/crates/harness-workflow/src/runtime/validator_github_issue_pr.rs
+++ b/crates/harness-workflow/src/runtime/validator_github_issue_pr.rs
@@ -1,0 +1,66 @@
+use super::{ValidationContext, WorkflowDecisionRejection, WorkflowDecisionRejectionKind};
+use crate::runtime::model::{WorkflowCommand, WorkflowCommandType, WorkflowDecision};
+
+pub(super) fn validate_decision(
+    decision: &WorkflowDecision,
+    context: &ValidationContext,
+) -> Result<(), WorkflowDecisionRejection> {
+    if is_blocked_done_transition(decision) {
+        validate_blocked_done_reconciliation(decision, context)?;
+    }
+    Ok(())
+}
+
+pub(super) fn is_blocked_done_transition(decision: &WorkflowDecision) -> bool {
+    decision.observed_state == "blocked" && decision.next_state == "done"
+}
+
+pub(super) fn validate_blocked_done_reconciliation(
+    decision: &WorkflowDecision,
+    context: &ValidationContext,
+) -> Result<(), WorkflowDecisionRejection> {
+    if context.actor != "reconciliation" || decision.decision != "reconcile_pr_merged" {
+        return Err(missing_terminal_evidence(
+            "blocked issue workflows can only be marked done by PR-merge reconciliation",
+        ));
+    }
+
+    if !decision.commands.iter().any(is_pr_merge_mark_done_command) {
+        return Err(missing_terminal_evidence(
+            "blocked issue PR-merge reconciliation requires pr_number and pr_url evidence",
+        ));
+    }
+
+    if !decision
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "github_pr")
+    {
+        return Err(missing_terminal_evidence(
+            "blocked issue PR-merge reconciliation requires github_pr evidence",
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_pr_merge_mark_done_command(command: &WorkflowCommand) -> bool {
+    command.command_type == WorkflowCommandType::MarkDone
+        && command
+            .command
+            .get("pr_number")
+            .and_then(serde_json::Value::as_u64)
+            .is_some()
+        && command
+            .command
+            .get("pr_url")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn missing_terminal_evidence(message: impl Into<String>) -> WorkflowDecisionRejection {
+    WorkflowDecisionRejection::new(
+        WorkflowDecisionRejectionKind::MissingTerminalEvidence,
+        message,
+    )
+}

--- a/crates/harness-workflow/src/runtime/validator_github_issue_pr.rs
+++ b/crates/harness-workflow/src/runtime/validator_github_issue_pr.rs
@@ -27,7 +27,7 @@ pub(super) fn validate_blocked_done_reconciliation(
 
     if !decision.commands.iter().any(is_pr_merge_mark_done_command) {
         return Err(missing_terminal_evidence(
-            "blocked issue PR-merge reconciliation requires pr_number and pr_url evidence",
+            "blocked issue PR-merge reconciliation requires pr_number plus pr_url or repo evidence",
         ));
     }
 
@@ -51,11 +51,16 @@ fn is_pr_merge_mark_done_command(command: &WorkflowCommand) -> bool {
             .get("pr_number")
             .and_then(serde_json::Value::as_u64)
             .is_some()
-        && command
-            .command
-            .get("pr_url")
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|value| !value.trim().is_empty())
+        && (has_non_empty_command_string(command, "pr_url")
+            || has_non_empty_command_string(command, "repo"))
+}
+
+fn has_non_empty_command_string(command: &WorkflowCommand, field: &str) -> bool {
+    command
+        .command
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
 }
 
 fn missing_terminal_evidence(message: impl Into<String>) -> WorkflowDecisionRejection {

--- a/crates/harness-workflow/src/runtime/validator_tests.rs
+++ b/crates/harness-workflow/src/runtime/validator_tests.rs
@@ -1,0 +1,97 @@
+use super::*;
+use crate::runtime::{WorkflowEvidence, WorkflowSubject};
+use serde_json::json;
+
+fn issue_instance(state: &str) -> WorkflowInstance {
+    WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        state,
+        WorkflowSubject::new("issue", "123"),
+    )
+}
+
+fn blocked_done_pr_merge_decision(instance: &WorkflowInstance) -> WorkflowDecision {
+    WorkflowDecision::new(
+        instance.id.clone(),
+        "blocked",
+        "reconcile_pr_merged",
+        "done",
+        "reconciled: PR merged externally",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkDone,
+        "runtime-reconcile:workflow-1:done:77",
+        json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77"
+        }),
+    ))
+    .with_evidence(WorkflowEvidence::new(
+        "github_pr",
+        "repo=owner/repo issue=123 pr=77 url=https://github.com/owner/repo/pull/77",
+    ))
+}
+
+#[test]
+fn github_issue_pr_validator_allows_blocked_done_for_pr_merge_reconciliation() {
+    let instance = issue_instance("blocked");
+    let decision = blocked_done_pr_merge_decision(&instance);
+
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("reconciliation", Utc::now()),
+        )
+        .expect("PR-merge reconciliation should finish a blocked issue workflow");
+}
+
+#[test]
+fn github_issue_pr_validator_rejects_non_reconciliation_blocked_done() {
+    let instance = issue_instance("blocked");
+    let decision = blocked_done_pr_merge_decision(&instance);
+
+    let err = DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("controller-1", Utc::now()),
+        )
+        .expect_err("non-reconciliation actors must not finish blocked issue workflows");
+
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::MissingTerminalEvidence
+    );
+}
+
+#[test]
+fn github_issue_pr_validator_rejects_unevidenced_blocked_done() {
+    let instance = issue_instance("blocked");
+    let decision = WorkflowDecision::new(
+        instance.id.clone(),
+        "blocked",
+        "agent_reported_done",
+        "done",
+        "The agent reported completion without external merge evidence.",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkDone,
+        "issue-123-done",
+        json!({ "reason": "done" }),
+    ));
+
+    let err = DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("reconciliation", Utc::now()),
+        )
+        .expect_err("blocked -> done requires merged PR evidence");
+
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::MissingTerminalEvidence
+    );
+}

--- a/crates/harness-workflow/src/runtime/validator_tests.rs
+++ b/crates/harness-workflow/src/runtime/validator_tests.rs
@@ -33,6 +33,28 @@ fn blocked_done_pr_merge_decision(instance: &WorkflowInstance) -> WorkflowDecisi
     ))
 }
 
+fn blocked_done_slug_pr_merge_decision(instance: &WorkflowInstance) -> WorkflowDecision {
+    WorkflowDecision::new(
+        instance.id.clone(),
+        "blocked",
+        "reconcile_pr_merged",
+        "done",
+        "reconciled: PR merged externally",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkDone,
+        "runtime-reconcile:workflow-1:done:77",
+        json!({
+            "pr_number": 77,
+            "repo": "owner/repo"
+        }),
+    ))
+    .with_evidence(WorkflowEvidence::new(
+        "github_pr",
+        "repo=owner/repo issue=123 pr=77 url=<unknown>",
+    ))
+}
+
 #[test]
 fn github_issue_pr_validator_allows_blocked_done_for_pr_merge_reconciliation() {
     let instance = issue_instance("blocked");
@@ -45,6 +67,20 @@ fn github_issue_pr_validator_allows_blocked_done_for_pr_merge_reconciliation() {
             &ValidationContext::new("reconciliation", Utc::now()),
         )
         .expect("PR-merge reconciliation should finish a blocked issue workflow");
+}
+
+#[test]
+fn github_issue_pr_validator_allows_slug_only_blocked_done_reconciliation() {
+    let instance = issue_instance("blocked");
+    let decision = blocked_done_slug_pr_merge_decision(&instance);
+
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("reconciliation", Utc::now()),
+        )
+        .expect("PR-merge reconciliation can use repo plus pr_number without pr_url");
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/validator_tests.rs
+++ b/crates/harness-workflow/src/runtime/validator_tests.rs
@@ -48,6 +48,15 @@ fn github_issue_pr_validator_allows_blocked_done_for_pr_merge_reconciliation() {
 }
 
 #[test]
+fn github_issue_pr_validator_does_not_advertise_reconciliation_only_blocked_done() {
+    let validator = DecisionValidator::github_issue_pr();
+
+    assert!(!validator
+        .transition_rules_from("blocked")
+        .any(|rule| rule.to_state == "done"));
+}
+
+#[test]
 fn github_issue_pr_validator_rejects_non_reconciliation_blocked_done() {
     let instance = issue_instance("blocked");
     let decision = blocked_done_pr_merge_decision(&instance);


### PR DESCRIPTION
## Summary
- allow github_issue_pr reconciliation to mark blocked workflows done only when PR-merge evidence is present
- add validator tests for evidence-gated blocked -> done transitions
- add server reconciliation coverage for a blocked runtime workflow whose bound PR was externally merged

Closes #1329

## Validation
- cargo fmt --all
- cargo test -p harness-workflow github_issue_pr_validator -- --nocapture
- cargo test -p harness-server blocked_runtime_reconciliation_marks_merged_pr_done -- --nocapture
- cargo fmt --all -- --check
- cargo check -p harness-server --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- env -u GITHUB_TOKEN -u GH_TOKEN cargo test -- --test-threads=1