### PR TITLE
Fix runtime submission id task route lookup

### DIFF
--- a/crates/harness-server/src/http/sse_routes.rs
+++ b/crates/harness-server/src/http/sse_routes.rs
@@ -153,7 +153,8 @@ async fn runtime_task_sse_stream(
         return Ok(None);
     };
     let Some(workflow) =
-        crate::workflow_runtime_submission::runtime_issue_by_task_id(&store, &task_id).await?
+        crate::workflow_runtime_submission::runtime_issue_by_submission_id(&store, &task_id)
+            .await?
     else {
         return Ok(None);
     };

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -14,6 +14,7 @@ struct FullTaskResponse {
 struct RuntimeTaskResponse {
     id: String,
     task_id: String,
+    submission_id: String,
     task_kind: TaskKind,
     status: String,
     execution_path: &'static str,
@@ -91,7 +92,10 @@ async fn runtime_task_response_by_handle(
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(None);
     };
-    let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+    let Some(workflow) = store
+        .get_instance_by_submission_id(task_id.as_str())
+        .await?
+    else {
         return Ok(None);
     };
     let issue = workflow
@@ -106,9 +110,13 @@ async fn runtime_task_response_by_handle(
         return Ok(None);
     };
     let external_id = runtime_external_id(task_kind, &workflow.data, issue);
+    let submission_id = crate::workflow_runtime_submission::runtime_issue_task_handle(&workflow)
+        .unwrap_or_else(|| task_id.clone())
+        .0;
     Ok(Some(RuntimeTaskResponse {
-        id: task_id.as_str().to_string(),
-        task_id: task_id.as_str().to_string(),
+        id: submission_id.clone(),
+        task_id: submission_id.clone(),
+        submission_id,
         task_kind,
         status: workflow.state.clone(),
         execution_path: "workflow_runtime",
@@ -412,7 +420,10 @@ async fn runtime_proof_by_handle(
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(RuntimeProofLookup::Missing);
     };
-    let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+    let Some(workflow) = store
+        .get_instance_by_submission_id(task_id.as_str())
+        .await?
+    else {
         return Ok(RuntimeProofLookup::Missing);
     };
     let status = RuntimeWorkflowProjection::from_workflow(&workflow).task_status;
@@ -421,8 +432,13 @@ async fn runtime_proof_by_handle(
     }
     let events = store.events_for(&workflow.id).await?;
     let decisions = store.decisions_for(&workflow.id).await?;
+    let proof_task_id = crate::workflow_runtime_submission::runtime_issue_task_handle(&workflow)
+        .unwrap_or_else(|| task_id.clone());
     Ok(RuntimeProofLookup::Terminal(proof_from_runtime_workflow(
-        task_id, &workflow, &events, &decisions,
+        &proof_task_id,
+        &workflow,
+        &events,
+        &decisions,
     )))
 }
 

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -62,7 +62,7 @@ pub(crate) async fn task_response_details(
 ) -> Result<TaskResponseDetails, EnqueueTaskError> {
     if let Some(store) = state.core.workflow_runtime_store.as_ref() {
         if let Some(workflow) = store
-            .get_instance_by_task_id(task_id.as_str())
+            .get_instance_by_submission_id(task_id.as_str())
             .await
             .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?
         {

--- a/crates/harness-server/src/http/task_submission_routes.rs
+++ b/crates/harness-server/src/http/task_submission_routes.rs
@@ -248,7 +248,10 @@ async fn runtime_workflow_by_handle(
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
         return Ok(None);
     };
-    let Some(workflow) = store.get_instance_by_task_id(task_id.as_str()).await? else {
+    let Some(workflow) = store
+        .get_instance_by_submission_id(task_id.as_str())
+        .await?
+    else {
         return Ok(None);
     };
     if is_runtime_submission_definition(&workflow.definition_id) {
@@ -516,6 +519,27 @@ mod tests {
     }
 
     #[test]
+    fn runtime_submission_handle_prefers_explicit_submission_id() {
+        let workflow = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            WorkflowSubject::new("issue", "issue:1129"),
+        )
+        .with_data(json!({
+            "submission_id": "stable-submission",
+            "task_id": "retry-handle",
+            "task_ids": ["stable-submission", "retry-handle"]
+        }));
+        let fallback = harness_core::types::TaskId::from_str("fallback-handle");
+
+        assert_eq!(
+            runtime_submission_handle(&workflow, &fallback),
+            "stable-submission"
+        );
+    }
+
+    #[test]
     fn runtime_job_artifacts_keep_submission_handle() -> anyhow::Result<()> {
         let result = ActivityResult::succeeded("implement_issue", "done").with_artifact(
             ActivityArtifact::new("pull_request", json!({"number": 1157})),
@@ -589,8 +613,8 @@ mod tests {
         state.core.workflow_runtime_store = Some(store.clone());
         let state = Arc::new(state);
 
-        let lookup_task_id = harness_core::types::TaskId::from_str("runtime-route-handle");
         let canonical_task_id = harness_core::types::TaskId::from_str("runtime-canonical-handle");
+        let retry_task_id = harness_core::types::TaskId::from_str("runtime-route-handle");
         let workflow = WorkflowInstance::new(
             GITHUB_ISSUE_PR_DEFINITION_ID,
             1,
@@ -599,8 +623,9 @@ mod tests {
         )
         .with_id("runtime-route-workflow")
         .with_data(json!({
-            "task_id": lookup_task_id.as_str(),
-            "task_ids": [canonical_task_id.as_str(), lookup_task_id.as_str()],
+            "submission_id": canonical_task_id.as_str(),
+            "task_id": retry_task_id.as_str(),
+            "task_ids": [canonical_task_id.as_str(), retry_task_id.as_str()],
             "issue_number": 1128,
             "repo": "owner/repo",
             "project_id": "/tmp/project"
@@ -638,7 +663,7 @@ mod tests {
         assert!(state
             .core
             .tasks
-            .get_with_db_fallback(&lookup_task_id)
+            .get_with_db_fallback(&canonical_task_id)
             .await?
             .is_none());
 
@@ -649,17 +674,17 @@ mod tests {
             .route("/tasks/{id}/prompts", get(get_task_prompts))
             .with_state(state);
 
-        let detail = get_json(&app, "/tasks/runtime-route-handle").await?;
-        assert_eq!(detail["id"], "runtime-route-handle");
+        let detail = get_json(&app, "/tasks/runtime-canonical-handle").await?;
+        assert_eq!(detail["id"], "runtime-canonical-handle");
         assert_eq!(detail["task_id"], "runtime-canonical-handle");
         assert_eq!(detail["submission_id"], "runtime-canonical-handle");
         assert_eq!(detail["workflow_id"], "runtime-route-workflow");
 
-        let artifacts = get_json(&app, "/tasks/runtime-route-handle/artifacts").await?;
+        let artifacts = get_json(&app, "/tasks/runtime-canonical-handle/artifacts").await?;
         assert_eq!(artifacts[0]["task_id"], "runtime-canonical-handle");
         assert_eq!(artifacts[0]["artifact_type"], "pull_request");
 
-        let prompts = get_json(&app, "/tasks/runtime-route-handle/prompts").await?;
+        let prompts = get_json(&app, "/tasks/runtime-canonical-handle/prompts").await?;
         assert_eq!(
             prompts
                 .as_array()

--- a/crates/harness-server/src/http/tests/webhook_task_tests.rs
+++ b/crates/harness-server/src/http/tests/webhook_task_tests.rs
@@ -611,3 +611,99 @@ async fn create_task_with_issue_returns_workflow_runtime_submission() -> anyhow:
     assert_eq!(commands[0].command.activity_name(), Some("plan_issue"));
     Ok(())
 }
+
+#[tokio::test]
+async fn create_task_with_terminal_issue_retry_returns_stable_submission_handle(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let before_count = state.core.tasks.count();
+    let app = task_app(state.clone());
+
+    let body = serde_json::json!({
+        "project": project_root.display().to_string(),
+        "repo": "owner/repo",
+        "issue": 42,
+        "labels": ["bug"]
+    });
+    let first_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(first_response.status(), StatusCode::ACCEPTED);
+    let first_json = response_json(first_response).await?;
+    let stable_submission_id = first_json["submission_id"]
+        .as_str()
+        .expect("first response should include submission id")
+        .to_string();
+
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let canonical_project_root = project_root.canonicalize()?;
+    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+        &canonical_project_root.to_string_lossy(),
+        Some("owner/repo"),
+        42,
+    );
+    let mut instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("runtime workflow should be persisted");
+    assert_eq!(instance.data["submission_id"], stable_submission_id);
+    instance.state = "failed".to_string();
+    store.upsert_instance(&instance).await?;
+
+    let retry_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(retry_response.status(), StatusCode::ACCEPTED);
+    let retry_json = response_json(retry_response).await?;
+    assert_eq!(retry_json["task_id"], stable_submission_id);
+    assert_eq!(retry_json["submission_id"], stable_submission_id);
+    assert_eq!(retry_json["workflow_id"], workflow_id);
+    assert_eq!(retry_json["execution_path"], "workflow_runtime");
+    assert_eq!(state.core.tasks.count(), before_count);
+
+    let retry_instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("runtime workflow should remain persisted");
+    assert_eq!(retry_instance.state, "planning");
+    assert_eq!(retry_instance.data["submission_id"], stable_submission_id);
+    let internal_retry_task_id = retry_instance.data["task_id"]
+        .as_str()
+        .expect("retry task id should be recorded");
+    assert_ne!(internal_retry_task_id, stable_submission_id);
+    assert_eq!(
+        retry_instance.data["task_ids"],
+        serde_json::json!([stable_submission_id, internal_retry_task_id])
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -841,13 +841,18 @@ impl DefaultExecutionService {
 
         match outcome {
             crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::Requested {
+                workflow_id,
                 task_id,
                 ..
             }
             | crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::ActiveCommandExists {
+                workflow_id,
                 task_id,
                 ..
-            } => Ok(TaskId::from_str(&task_id)),
+            } => {
+                runtime_submission_response_handle(store, &workflow_id, &TaskId::from_str(&task_id))
+                    .await
+            }
             crate::workflow_runtime_pr_feedback::PrFeedbackSweepRequestOutcome::NotCandidate {
                 workflow_id,
                 state,

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -16,7 +16,7 @@ use harness_skills::store::SkillStore;
 use harness_workflow::issue_lifecycle::{
     is_feedback_claim_placeholder, IssueLifecycleState, IssueWorkflowInstance,
 };
-use harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID;
+use harness_workflow::runtime::{WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{RwLock, Semaphore};
@@ -722,7 +722,7 @@ impl DefaultExecutionService {
             command_count = record.command_ids.len(),
             "execution service: accepted issue submission into workflow runtime"
         );
-        Ok(task_id)
+        runtime_submission_response_handle(store, &record.workflow_id, &task_id).await
     }
 
     async fn submit_prompt_to_workflow_runtime(
@@ -785,7 +785,7 @@ impl DefaultExecutionService {
             command_count = record.command_ids.len(),
             "execution service: accepted prompt submission into workflow runtime"
         );
-        Ok(task_id)
+        runtime_submission_response_handle(store, &record.workflow_id, &task_id).await
     }
 
     async fn submit_pr_feedback_to_workflow_runtime(
@@ -1023,6 +1023,26 @@ fn runtime_prompt_duplicate_allows_resubmission(
     instance: &harness_workflow::runtime::WorkflowInstance,
 ) -> bool {
     instance.is_terminal() || instance.state == "blocked"
+}
+
+async fn runtime_submission_response_handle(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    fallback_task_id: &TaskId,
+) -> Result<TaskId, EnqueueTaskError> {
+    let Some(instance) = store
+        .get_instance(workflow_id)
+        .await
+        .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?
+    else {
+        return Err(EnqueueTaskError::Internal(format!(
+            "workflow runtime accepted submission for missing workflow {workflow_id}"
+        )));
+    };
+    Ok(
+        crate::workflow_runtime_submission::runtime_issue_task_handle(&instance)
+            .unwrap_or_else(|| fallback_task_id.clone()),
+    )
 }
 
 fn workflow_runtime_loops_enabled(project_root: &Path) -> Result<bool, EnqueueTaskError> {

--- a/crates/harness-server/src/services/execution_tests.rs
+++ b/crates/harness-server/src/services/execution_tests.rs
@@ -630,10 +630,15 @@ async fn enqueue_background_prompt_submission_reopens_blocked_runtime_workflow(
         .await?
         .expect("blocked workflow should be reopened");
     assert_eq!(instance.state, "implementing");
-    assert_eq!(instance.data["task_id"], task_id.as_str());
+    assert_eq!(task_id.as_str(), "old-prompt-task");
+    assert_eq!(instance.data["submission_id"], task_id.as_str());
+    let retry_task_id = instance.data["task_id"]
+        .as_str()
+        .expect("retry task id should be recorded");
+    assert_ne!(retry_task_id, task_id.as_str());
     assert_eq!(
         instance.data["task_ids"],
-        serde_json::json!(["old-prompt-task", task_id.as_str()])
+        serde_json::json!(["old-prompt-task", retry_task_id])
     );
     assert!(instance.data.get("prompt").is_none());
     let prompt_ref = instance.data["prompt_ref"]

--- a/crates/harness-server/src/services/execution_tests.rs
+++ b/crates/harness-server/src/services/execution_tests.rs
@@ -469,7 +469,9 @@ async fn enqueue_background_pr_feedback_uses_bound_workflow_runtime_without_task
         "project_id": project_id,
         "repo": "owner/repo",
         "issue_number": 42,
-        "task_id": "runtime-issue-task",
+        "submission_id": "runtime-stable-submission",
+        "task_id": "runtime-issue-retry-task",
+        "task_ids": ["runtime-stable-submission", "runtime-issue-retry-task"],
         "pr_number": 77,
         "pr_url": "https://github.com/owner/repo/pull/77",
         "execution_path": "workflow_runtime"
@@ -485,7 +487,7 @@ async fn enqueue_background_pr_feedback_uses_bound_workflow_runtime_without_task
 
     let task_id = svc.enqueue_background(req).await?;
 
-    assert_eq!(task_id.as_str(), "runtime-issue-task");
+    assert_eq!(task_id.as_str(), "runtime-stable-submission");
     assert!(
         task_store.get_with_db_fallback(&task_id).await?.is_none(),
         "workflow runtime PR feedback submissions must not register legacy PR task rows"
@@ -495,6 +497,8 @@ async fn enqueue_background_pr_feedback_uses_bound_workflow_runtime_without_task
         .await?
         .expect("bound issue workflow should still exist");
     assert_eq!(updated.state, "local_review_gate");
+    assert_eq!(updated.data["task_id"], "runtime-issue-retry-task");
+    assert_eq!(updated.data["submission_id"], task_id.as_str());
     let commands = runtime_store.commands_for(&workflow_id).await?;
     assert_eq!(commands.len(), 1);
     assert_eq!(commands[0].status, "pending");

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -98,11 +98,13 @@ pub(crate) async fn record_prompt_submission(
     persist_prompt_submission(store, &ctx).await
 }
 
-pub(crate) async fn runtime_issue_by_task_id(
+pub(crate) async fn runtime_issue_by_submission_id(
     store: &WorkflowRuntimeStore,
-    task_id: &TaskId,
+    submission_id: &TaskId,
 ) -> anyhow::Result<Option<WorkflowInstance>> {
-    store.get_instance_by_task_id(task_id.as_str()).await
+    store
+        .get_instance_by_submission_id(submission_id.as_str())
+        .await
 }
 
 pub(crate) fn runtime_issue_task_handle(instance: &WorkflowInstance) -> Option<TaskId> {

--- a/crates/harness-server/src/workflow_runtime_submission/cancel.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/cancel.rs
@@ -44,14 +44,24 @@ impl From<anyhow::Error> for RuntimeSubmissionCancelError {
     }
 }
 
+pub(crate) async fn cancel_issue_submission_by_submission_id(
+    store: &WorkflowRuntimeStore,
+    submission_id: &crate::task_runner::TaskId,
+) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
+    let Some(instance) = store
+        .get_instance_by_submission_id(submission_id.as_str())
+        .await?
+    else {
+        return Ok(RuntimeSubmissionCancelOutcome::NotFound);
+    };
+    cancel_submission_instance(store, instance, submission_id.as_str()).await
+}
+
 pub(crate) async fn cancel_issue_submission_by_task_id(
     store: &WorkflowRuntimeStore,
     task_id: &crate::task_runner::TaskId,
 ) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
-    let Some(instance) = store.get_instance_by_task_id(task_id.as_str()).await? else {
-        return Ok(RuntimeSubmissionCancelOutcome::NotFound);
-    };
-    cancel_submission_instance(store, instance, task_id.as_str()).await
+    cancel_issue_submission_by_submission_id(store, task_id).await
 }
 
 pub(crate) async fn cancel_submission_by_workflow_id(

--- a/crates/harness-server/src/workflow_runtime_submission_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission_tests.rs
@@ -335,18 +335,17 @@ async fn issue_submission_preserves_prior_task_handles_for_lookup() -> anyhow::R
         "runtime-handle-first"
     );
     assert_eq!(
-        runtime_issue_by_task_id(&store, &first_task_id)
+        runtime_issue_by_submission_id(&store, &first_task_id)
             .await?
             .expect("first handle should resolve")
             .id,
         workflow.id
     );
-    assert_eq!(
-        runtime_issue_by_task_id(&store, &second_task_id)
+    assert!(
+        runtime_issue_by_submission_id(&store, &second_task_id)
             .await?
-            .expect("second handle should resolve")
-            .id,
-        workflow.id
+            .is_none(),
+        "retry task id should not remain a public lookup alias after submission_id is explicit"
     );
     Ok(())
 }

--- a/crates/harness-server/tests/runtime_submission_identity_contract.rs
+++ b/crates/harness-server/tests/runtime_submission_identity_contract.rs
@@ -31,7 +31,7 @@ fn identity_contract_doc_covers_runtime_submission_api_surface() {
 }
 
 #[tokio::test]
-async fn runtime_store_resolves_current_and_historical_submission_aliases() -> anyhow::Result<()> {
+async fn runtime_store_resolves_legacy_submission_aliases() -> anyhow::Result<()> {
     let Some(database_url) = harness_core::db::resolve_database_url(None).ok() else {
         return Ok(());
     };
@@ -56,11 +56,11 @@ async fn runtime_store_resolves_current_and_historical_submission_aliases() -> a
     store.upsert_instance(&workflow).await?;
 
     let current = store
-        .get_instance_by_task_id("runtime-handle-second")
+        .get_instance_by_submission_id("runtime-handle-second")
         .await?
         .expect("current submission handle should resolve");
     let historical = store
-        .get_instance_by_task_id("runtime-handle-first")
+        .get_instance_by_submission_id("runtime-handle-first")
         .await?
         .expect("historical submission alias should resolve");
 
@@ -70,6 +70,46 @@ async fn runtime_store_resolves_current_and_historical_submission_aliases() -> a
     assert_eq!(
         current.data["task_ids"],
         json!(["runtime-handle-first", "runtime-handle-second"])
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_store_uses_explicit_submission_id_as_public_handle() -> anyhow::Result<()> {
+    let Some(database_url) = harness_core::db::resolve_database_url(None).ok() else {
+        return Ok(());
+    };
+
+    let dir = tempfile::tempdir()?;
+    let store =
+        WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url)).await?;
+    let workflow = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "implementing",
+        WorkflowSubject::new("issue", "issue:1129"),
+    )
+    .with_id("explicit-submission-workflow")
+    .with_data(json!({
+        "submission_id": "stable-submission",
+        "task_id": "retry-task",
+        "task_ids": ["stable-submission", "retry-task"],
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 1129
+    }));
+    store.upsert_instance(&workflow).await?;
+
+    let current = store
+        .get_instance_by_submission_id("stable-submission")
+        .await?
+        .expect("explicit submission id should resolve");
+    let retry_alias = store.get_instance_by_submission_id("retry-task").await?;
+
+    assert_eq!(current.id, workflow.id);
+    assert!(
+        retry_alias.is_none(),
+        "task_id must not remain a public lookup alias once submission_id is explicit"
     );
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -483,14 +483,32 @@ impl WorkflowRuntimeStore {
         &self,
         task_id: &str,
     ) -> anyhow::Result<Option<WorkflowInstance>> {
+        self.get_instance_by_submission_id(task_id).await
+    }
+
+    pub async fn get_instance_by_submission_id(
+        &self,
+        submission_id: &str,
+    ) -> anyhow::Result<Option<WorkflowInstance>> {
         let row: Option<(String,)> = sqlx::query_as(
             "SELECT data::text FROM workflow_instances
-             WHERE data->'data'->>'task_id' = $1
-                OR data->'data'->'task_ids' ? $1
-             ORDER BY updated_at DESC
+             WHERE data->'data'->>'submission_id' = $1
+                OR (
+                    NULLIF(data->'data'->>'submission_id', '') IS NULL
+                    AND (
+                        data->'data'->>'task_id' = $1
+                        OR data->'data'->'task_ids' ? $1
+                    )
+                )
+             ORDER BY
+               CASE
+                 WHEN data->'data'->>'submission_id' = $1 THEN 0
+                 ELSE 1
+               END,
+               updated_at DESC
              LIMIT 1",
         )
-        .bind(task_id)
+        .bind(submission_id)
         .fetch_optional(&self.pool)
         .await?;
         row.map(|(data,)| serde_json::from_str(&data))
@@ -702,11 +720,11 @@ impl WorkflowRuntimeStore {
                    OR (data->>'created_at')::timestamptz < $3
                    OR (
                        (data->>'created_at')::timestamptz = $3
-                       AND COALESCE(data->'data'->'task_ids'->>0, data->'data'->>'task_id', id) < COALESCE($4::text, '')
+                       AND COALESCE(data->'data'->>'submission_id', data->'data'->'task_ids'->>0, data->'data'->>'task_id', id) < COALESCE($4::text, '')
                    )
                )
              ORDER BY (data->>'created_at')::timestamptz DESC,
-                      COALESCE(data->'data'->'task_ids'->>0, data->'data'->>'task_id', id) DESC
+                      COALESCE(data->'data'->>'submission_id', data->'data'->'task_ids'->>0, data->'data'->>'task_id', id) DESC
              LIMIT $5",
         )
         .bind(definition_id)

--- a/crates/harness-workflow/src/runtime/store_migrations.rs
+++ b/crates/harness-workflow/src/runtime/store_migrations.rs
@@ -216,4 +216,10 @@ pub(super) static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
                 END IF;
               END $$",
     },
+    Migration {
+        version: 12,
+        description: "index explicit runtime submission handles",
+        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_submission_id
+              ON workflow_instances ((data->'data'->>'submission_id'))",
+    },
 ];

--- a/docs/runtime-submission-identity-contract.md
+++ b/docs/runtime-submission-identity-contract.md
@@ -90,8 +90,9 @@ Legacy task rows keep `task_id` as the primary id and omit `workflow_id`.
 
 The `{id}` parameter addresses a submission handle during migration:
 
-- runtime-owned rows resolve by `submission_id` or any historical `task_id`
-  alias recorded in `data.task_ids`
+- runtime-owned rows with explicit `submission_id` resolve by `submission_id`
+- persisted runtime rows without `submission_id` continue to resolve by the
+  historical `task_id` alias recorded in `data.task_ids` or `data.task_id`
 - legacy rows resolve by real `TaskStore` task id
 
 The response for a runtime-owned row must include `workflow_id` so clients do
@@ -159,7 +160,8 @@ must not require a legacy `TaskStore` row once #1128 lands.
 
 - Remove runtime-owned reliance on `data.task_id` as the public handle.
 - Keep historical alias lookup only for persisted workflows that predate
-  `submission_id`, or remove it with an explicit migration.
+  `submission_id`; rows with explicit `submission_id` must not use retry
+  `task_id` values as public lookup aliases.
 - Remove `/tasks` compatibility branches that only exist to make runtime-owned
   workflows look like legacy task rows.
 
@@ -184,3 +186,6 @@ implementation:
   routes document their identity ownership
 - runtime-owned responses expose `workflow_id`
 - runtime-owned flows do not require a legacy `TaskStore` row
+- rows with explicit `submission_id` resolve through that handle, while
+  historical `task_id` aliases remain limited to rows that predate
+  `submission_id`


### PR DESCRIPTION
## Summary
- add explicit workflow runtime submission_id lookup/indexing and keep task_id/task_ids fallback limited to rows without submission_id
- route task detail, proof, stream, cancel, artifact, and prompt lookups through the canonical runtime submission handle
- update identity contract tests and docs for explicit submission ids vs legacy persisted aliases

## Validation
- cargo fmt --all -- --check
- cargo check -p harness-workflow --all-targets
- cargo check -p harness-server --all-targets
- cargo test -p harness-server --test runtime_submission_identity_contract
- cargo test -p harness-server workflow_runtime_submission
- cargo test -p harness-server task_submission_routes
- cargo test -p harness-server runtime_task_route_tests
- cargo test -p harness-server runtime_task_submission_response
- cargo test -p harness-server get_task_proof_returns_runtime_backed_terminal_task
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings

Closes #1129