### PR TITLE
Fix worktrees empty-state dashboard CTA

### DIFF
--- a/crates/harness-server/src/http/auth.rs
+++ b/crates/harness-server/src/http/auth.rs
@@ -121,6 +121,7 @@ pub(crate) fn is_auth_exempt_path(path: &str) -> bool {
             | "/favicon.ico"
             | "/auth/reset-password"
             | "/"
+            | "/dashboard"
             | "/overview"
             | "/usage"
             | "/worktrees"
@@ -131,7 +132,7 @@ pub(crate) fn is_auth_exempt_path(path: &str) -> bool {
 /// Bearer token authentication middleware.
 ///
 /// Exempts `/health`, `/webhook`, `/webhook/feishu`, `/signals`, `/favicon.ico`,
-/// `/auth/reset-password`, `/` (dashboard HTML), `/overview` and `/usage`
+/// `/auth/reset-password`, `/` and `/dashboard` (dashboard HTML), `/overview` and `/usage`
 /// (React SPA HTML), `/assets/*` (hashed React bundle assets), and `/ws` (WebSocket
 /// upgrade).
 /// The dashboard HTML no longer embeds the token, so it is safe to serve without

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -17,6 +17,7 @@ use super::{
 pub(super) fn build_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/", get(crate::dashboard::index))
+        .route("/dashboard", get(crate::dashboard::index))
         .route("/overview", get(crate::overview::index))
         .route("/usage", get(crate::dashboard::index))
         .route("/worktrees", get(crate::dashboard::index))

--- a/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
+++ b/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
@@ -158,6 +158,7 @@ fn authed_app(state: Arc<AppState>) -> Router {
     use axum::middleware;
     Router::new()
         .route("/", get(crate::dashboard::index))
+        .route("/dashboard", get(crate::dashboard::index))
         .route("/health", get(health_check))
         .route("/tasks", get(list_tasks))
         .layer(middleware::from_fn_with_state(
@@ -167,7 +168,7 @@ fn authed_app(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
-/// / is now exempt from auth — dashboard HTML embeds no secrets.
+/// / and /dashboard are exempt from auth because dashboard HTML embeds no secrets.
 #[tokio::test]
 async fn dashboard_exempt_from_auth_when_token_configured() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
@@ -182,10 +183,20 @@ async fn dashboard_exempt_from_auth_when_token_configured() -> anyhow::Result<()
     let app = authed_app(state);
 
     let response = app
+        .clone()
         .oneshot(Request::builder().uri("/").body(Body::empty())?)
         .await?;
 
-    // Dashboard is now exempt from auth — HTML contains no secrets.
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/dashboard?tab=submit")
+                .body(Body::empty())?,
+        )
+        .await?;
+
     assert_eq!(response.status(), StatusCode::OK);
     Ok(())
 }
@@ -223,7 +234,18 @@ async fn dashboard_no_auth_configured_remains_public() -> anyhow::Result<()> {
     let app = authed_app(state);
 
     let response = app
+        .clone()
         .oneshot(Request::builder().uri("/").body(Body::empty())?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/dashboard?tab=submit")
+                .body(Body::empty())?,
+        )
         .await?;
 
     assert_eq!(response.status(), StatusCode::OK);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,7 @@ export function App() {
         <ScrollToHash />
         <Routes>
           <Route path="/" element={<Dashboard />} />
+          <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/overview" element={<Overview />} />
           <Route path="/usage" element={<UsageMonitor />} />
           <Route path="/worktrees" element={<Worktrees />} />

--- a/web/src/routes/Worktrees.test.tsx
+++ b/web/src/routes/Worktrees.test.tsx
@@ -304,7 +304,7 @@ describe("<Worktrees>", () => {
 
     expect(screen.getByRole("link", { name: "Submit task" })).toHaveAttribute(
       "href",
-      "/?tab=submit",
+      "/dashboard?tab=submit",
     );
   });
 });

--- a/web/src/routes/Worktrees.tsx
+++ b/web/src/routes/Worktrees.tsx
@@ -259,7 +259,7 @@ export function Worktrees() {
               <div className="flex flex-col items-center justify-center gap-3 py-24 text-ink-3">
                 <span className="font-mono text-[13px]">No active worktrees</span>
                 <Link
-                  to="/?tab=submit"
+                  to="/dashboard?tab=submit"
                   className="font-mono text-[11.5px] px-3 py-1 border border-line-2 text-ink-2 rounded-[3px] hover:bg-bg-2 hover:text-ink"
                 >
                   Submit task


### PR DESCRIPTION
## Summary
- add `/dashboard` as a React Router and server-rendered dashboard alias
- exempt `/dashboard` HTML from API-token middleware like the existing dashboard shell routes
- point the Worktrees empty-state CTA at `/dashboard?tab=submit` and cover the alias in tests

## Validation
- bun run test -- Worktrees.test.tsx
- bun run test -- queries.test.ts
- bun run typecheck
- cargo test -p harness-server dashboard_
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings

Closes #882