### PR TITLE
Add workflow PR scope guard

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -19,6 +19,10 @@ hooks:
 issue_workflow:
   force_execute_label: force-execute
   auto_replan_on_plan_issue: true
+pr_scope_guard:
+  enabled: true
+  max_files_changed: 30
+  max_lines_added: 1500
 pr_feedback:
   enabled: true
   sweep_interval_secs: 60
@@ -96,8 +100,10 @@ Issue implementation flow:
 2. Reproduce or confirm the issue signal before changing code.
 3. Make the smallest correct code change.
 4. Run the activity validation commands that apply to the touched scope.
-5. Commit, push, and open or update a PR targeting the configured base branch.
-6. Include the issue closing line in the PR body when working from an issue.
+5. Run `pr_scope_guard` against the configured base before pushing or creating a PR.
+6. If `pr_scope_guard` exceeds `max_files_changed` or `max_lines_added`, do not create a PR; emit `SCOPE_TOO_LARGE` with counts and a decomposition skeleton.
+7. Commit, push, and open or update a PR targeting the configured base branch.
+8. Include the issue closing line in the PR body when working from an issue.
 
 PR feedback flow:
 

--- a/config/WORKFLOW.md
+++ b/config/WORKFLOW.md
@@ -26,6 +26,10 @@ hooks:
 issue_workflow:
   force_execute_label: force-execute
   auto_replan_on_plan_issue: true
+pr_scope_guard:
+  enabled: true
+  max_files_changed: 30
+  max_lines_added: 1500
 pr_feedback:
   enabled: true
   sweep_interval_secs: 60
@@ -97,8 +101,10 @@ Issue implementation flow:
 2. Reproduce or confirm the issue signal before changing code.
 3. Make the smallest correct code change.
 4. Run the activity validation commands that apply to the touched scope.
-5. Commit, push, and open or update a PR targeting the configured base branch.
-6. Include the issue closing line in the PR body when working from an issue.
+5. Run `pr_scope_guard` against the configured base before pushing or creating a PR.
+6. If `pr_scope_guard` exceeds `max_files_changed` or `max_lines_added`, do not create a PR; emit `SCOPE_TOO_LARGE` with counts and a decomposition skeleton.
+7. Commit, push, and open or update a PR targeting the configured base branch.
+8. Include the issue closing line in the PR body when working from an issue.
 
 PR feedback flow:
 

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -93,6 +93,16 @@ pub struct IssueWorkflowPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrScopeGuardPolicy {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_pr_scope_guard_max_files_changed")]
+    pub max_files_changed: u32,
+    #[serde(default = "default_pr_scope_guard_max_lines_added")]
+    pub max_lines_added: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrFeedbackPolicy {
     #[serde(default = "default_true")]
     pub enabled: bool,
@@ -235,6 +245,8 @@ pub struct WorkflowConfig {
     #[serde(default)]
     pub issue_workflow: IssueWorkflowPolicy,
     #[serde(default)]
+    pub pr_scope_guard: PrScopeGuardPolicy,
+    #[serde(default)]
     pub repo_backlog: RepoBacklogPolicy,
     #[serde(default)]
     pub pr_feedback: PrFeedbackPolicy,
@@ -270,6 +282,16 @@ impl Default for IssueWorkflowPolicy {
             force_execute_label: default_force_execute_label(),
             auto_replan_on_plan_issue: default_true(),
             require_human_gate_before_merge: false,
+        }
+    }
+}
+
+impl Default for PrScopeGuardPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_files_changed: default_pr_scope_guard_max_files_changed(),
+            max_lines_added: default_pr_scope_guard_max_lines_added(),
         }
     }
 }
@@ -455,6 +477,14 @@ fn default_hook_timeout_secs() -> u64 {
 
 fn default_force_execute_label() -> String {
     "force-execute".to_string()
+}
+
+fn default_pr_scope_guard_max_files_changed() -> u32 {
+    30
+}
+
+fn default_pr_scope_guard_max_lines_added() -> u32 {
+    1500
 }
 
 fn default_feedback_sweep_interval_secs() -> u64 {

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -76,6 +76,9 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert_eq!(cfg.runtime_worker.lease_ttl_secs, 3900);
     assert!(cfg.runtime_retry_policy.is_empty());
     assert!(cfg.issue_workflow.auto_replan_on_plan_issue);
+    assert!(cfg.pr_scope_guard.enabled);
+    assert_eq!(cfg.pr_scope_guard.max_files_changed, 30);
+    assert_eq!(cfg.pr_scope_guard.max_lines_added, 1500);
     assert_eq!(cfg.storage.schema_namespace, "workflow");
     assert!(!cfg.issue_workflow.require_human_gate_before_merge);
     assert!(cfg.activities.is_empty());
@@ -144,6 +147,10 @@ issue_workflow:
   force_execute_label: do-not-second-guess
   auto_replan_on_plan_issue: false
   require_human_gate_before_merge: true
+pr_scope_guard:
+  enabled: false
+  max_files_changed: 12
+  max_lines_added: 345
 pr_feedback:
   enabled: false
   sweep_interval_secs: 15
@@ -250,6 +257,9 @@ Body
     );
     assert!(!cfg.issue_workflow.auto_replan_on_plan_issue);
     assert!(cfg.issue_workflow.require_human_gate_before_merge);
+    assert!(!cfg.pr_scope_guard.enabled);
+    assert_eq!(cfg.pr_scope_guard.max_files_changed, 12);
+    assert_eq!(cfg.pr_scope_guard.max_lines_added, 345);
     assert!(!cfg.pr_feedback.enabled);
     assert_eq!(cfg.pr_feedback.sweep_interval_secs, 15);
     assert_eq!(cfg.pr_feedback.claim_stale_after_secs, 45);

--- a/crates/harness-server/src/http/tests/runtime_worker_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_worker_tests.rs
@@ -124,12 +124,12 @@ async fn runtime_job_worker_tick_runs_registered_agent_and_completes_job() -> an
     assert_eq!(
         prompt_event.event["prompt_packet"]["activity_result_schema"]["transition_contract"]
             ["on_succeeded"]["reducer_next_state"],
-        "pr_open_with_pull_request_artifact_or_done_with_closed_issue_signal_else_blocked"
+        "pr_open_with_pull_request_artifact_or_done_with_closed_issue_signal_or_blocked_with_scope_too_large_signal_else_blocked"
     );
     assert_eq!(
         prompt_event.event["prompt_packet"]["activity_result_schema"]["agent_summary_contract"]
             ["must_include"][2],
-        "PR URL, closed issue evidence, or blocker"
+        "PR URL, closed issue evidence, SCOPE_TOO_LARGE decomposition evidence, or blocker"
     );
     assert_eq!(
         prompt_event.event["prompt_packet"]["activity_result_schema"]["agent_summary_contract"]

--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -5,7 +5,8 @@ use harness_workflow::runtime::{
     PR_FEEDBACK_INSPECT_ACTIVITY, PR_FEEDBACK_SNAPSHOT_ARTIFACT, PR_REPAIR_SNAPSHOT_ARTIFACT,
     QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
     QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL, REPO_BACKLOG_DEFINITION_ID,
-    REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY, SERVER_PR_SNAPSHOT_ARTIFACT,
+    REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY, SCOPE_TOO_LARGE_SIGNAL,
+    SERVER_PR_SNAPSHOT_ARTIFACT,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -123,13 +124,17 @@ pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> Ac
         }
         (GITHUB_ISSUE_PR_DEFINITION_ID, "implement_issue") => {
             ActivityContract::new(workflow_definition, activity)
-                .with_accepted_signals(vec![ISSUE_CLOSED_SIGNAL, ISSUE_ALREADY_RESOLVED_SIGNAL])
+                .with_accepted_signals(vec![
+                    ISSUE_CLOSED_SIGNAL,
+                    ISSUE_ALREADY_RESOLVED_SIGNAL,
+                    SCOPE_TOO_LARGE_SIGNAL,
+                ])
                 .with_accepted_artifacts(vec![
                     "pull_request",
                     ISSUE_STATE_ARTIFACT,
                     "workflow_decision",
                 ])
-                .requires("pull_request_artifact_or_closed_issue_signal")
+                .requires("pull_request_artifact_or_closed_issue_or_scope_too_large_signal")
         }
         (GITHUB_ISSUE_PR_DEFINITION_ID, ISSUE_PLAN_ACTIVITY) => {
             ActivityContract::new(workflow_definition, activity)

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -6,7 +6,7 @@ use harness_workflow::runtime::{
     PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
     PR_FEEDBACK_SNAPSHOT_ARTIFACT, QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL,
     QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
-    SERVER_PR_SNAPSHOT_ARTIFACT,
+    SCOPE_TOO_LARGE_SIGNAL, SERVER_PR_SNAPSHOT_ARTIFACT,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -426,11 +426,17 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
         }),
         ("github_issue_pr", "implement_issue") => json!({
             "on_succeeded": {
-                "reducer_next_state": "pr_open_with_pull_request_artifact_or_done_with_closed_issue_signal_else_blocked",
-                "accepted_signals": [ISSUE_CLOSED_SIGNAL, ISSUE_ALREADY_RESOLVED_SIGNAL],
+                "reducer_next_state": "pr_open_with_pull_request_artifact_or_done_with_closed_issue_signal_or_blocked_with_scope_too_large_signal_else_blocked",
+                "accepted_signals": [ISSUE_CLOSED_SIGNAL, ISSUE_ALREADY_RESOLVED_SIGNAL, SCOPE_TOO_LARGE_SIGNAL],
                 "accepted_artifacts": ["pull_request", ISSUE_STATE_ARTIFACT],
-                "success_requires": "A succeeded implement_issue result MUST include either a pull_request artifact with pr_number/pr_url, or structured closed-issue evidence with explicit closed/resolved state plus issue_number or issue_url. Empty success is blocked.",
-                "required_summary": "Include changed files, validation commands, and the PR URL or closed issue evidence."
+                "success_requires": "A succeeded implement_issue result MUST include either a pull_request artifact with pr_number/pr_url, structured closed-issue evidence with explicit closed/resolved state plus issue_number or issue_url, or SCOPE_TOO_LARGE with scope counts and a decomposition_skeleton. Empty success is blocked.",
+                "required_summary": "Include changed files, validation commands, and the PR URL, closed issue evidence, or SCOPE_TOO_LARGE decomposition evidence.",
+                "pr_scope_guard": {
+                    "when": "After edits and validation, before pushing or creating a PR.",
+                    "base_ref": "Use workflow_file.config.base remote/branch, for example origin/main.",
+                    "threshold_config": "workflow_file.config.pr_scope_guard; defaults are enabled=true, max_files_changed=30, max_lines_added=1500.",
+                    "on_exceeded": "Do not create a PR. Emit SCOPE_TOO_LARGE with files_changed, lines_added, max_files_changed, max_lines_added, base_ref, and decomposition_skeleton."
+                }
             },
             "follow_up_event": "PrDetected can still bind PR metadata, but a runtime result should emit pull_request directly when a PR exists."
         }),
@@ -501,7 +507,7 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             }
         }),
         ("github_issue_pr", "implement_issue") => json!({
-            "must_include": ["changed files", "validation commands", "PR URL, closed issue evidence, or blocker"],
+            "must_include": ["changed files", "validation commands", "PR URL, closed issue evidence, SCOPE_TOO_LARGE decomposition evidence, or blocker"],
             "must_not_include": ["workflow table mutations", "unverified merge claims"],
             "artifacts": {
                 "pull_request": {
@@ -515,7 +521,14 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
             },
             "signals": {
                 "IssueClosed": "Use when the GitHub issue is confirmed closed and no implementation PR is needed. Include state=closed or state=resolved plus issue_number or issue_url.",
-                "IssueAlreadyResolved": "Use when the task is already resolved before a PR is created. Include state=closed or state=resolved plus issue_number or issue_url."
+                "IssueAlreadyResolved": "Use when the task is already resolved before a PR is created. Include state=closed or state=resolved plus issue_number or issue_url.",
+                "SCOPE_TOO_LARGE": "Use when pr_scope_guard is enabled and the diff exceeds configured max_files_changed or max_lines_added. Include base_ref, files_changed, lines_added, max_files_changed, max_lines_added, and decomposition_skeleton."
+            },
+            "pr_scope_guard": {
+                "required_when": "workflow_file.config.pr_scope_guard.enabled is true.",
+                "check_timing": "Run after edits and validation but before pushing or creating a PR.",
+                "counting": "Compare the implementation diff against workflow_file.config.base remote/branch and count files changed plus added lines.",
+                "exceeded_result": "Emit SCOPE_TOO_LARGE instead of pull_request when files_changed > max_files_changed or lines_added > max_lines_added."
             }
         }),
         (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => json!({

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -27,24 +27,36 @@ fn activity_result_schema_describes_issue_implementation_terminal_evidence_contr
 
     assert_eq!(
         schema["transition_contract"]["on_succeeded"]["reducer_next_state"],
-        "pr_open_with_pull_request_artifact_or_done_with_closed_issue_signal_else_blocked"
+        "pr_open_with_pull_request_artifact_or_done_with_closed_issue_signal_or_blocked_with_scope_too_large_signal_else_blocked"
     );
     assert_eq!(
         schema["activity_contract"]["accepted_signals"][0],
         ISSUE_CLOSED_SIGNAL
     );
     assert_eq!(
+        schema["activity_contract"]["accepted_signals"][2],
+        SCOPE_TOO_LARGE_SIGNAL
+    );
+    assert_eq!(
         schema["activity_contract"]["success_requires"],
-        "pull_request_artifact_or_closed_issue_signal"
+        "pull_request_artifact_or_closed_issue_or_scope_too_large_signal"
     );
     assert_eq!(
         schema["agent_summary_contract"]["artifacts"]["issue_state"]["fields"][1],
         "state"
     );
     assert_eq!(
-            schema["agent_summary_contract"]["signals"]["IssueAlreadyResolved"],
-            "Use when the task is already resolved before a PR is created. Include state=closed or state=resolved plus issue_number or issue_url."
-        );
+        schema["agent_summary_contract"]["signals"]["IssueAlreadyResolved"],
+        "Use when the task is already resolved before a PR is created. Include state=closed or state=resolved plus issue_number or issue_url."
+    );
+    assert_eq!(
+        schema["transition_contract"]["on_succeeded"]["pr_scope_guard"]["threshold_config"],
+        "workflow_file.config.pr_scope_guard; defaults are enabled=true, max_files_changed=30, max_lines_added=1500."
+    );
+    assert_eq!(
+        schema["agent_summary_contract"]["signals"]["SCOPE_TOO_LARGE"],
+        "Use when pr_scope_guard is enabled and the diff exceeds configured max_files_changed or max_lines_added. Include base_ref, files_changed, lines_added, max_files_changed, max_lines_added, and decomposition_skeleton."
+    );
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -68,7 +68,7 @@ pub use reducer::{
     activity_result_has_closed_issue_evidence, activity_result_value_has_closed_issue_evidence,
     reduce_runtime_job_completed, value_has_closed_issue_evidence, GITHUB_ISSUE_PR_DEFINITION_ID,
     ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL, ISSUE_STATE_ARTIFACT,
-    RUNTIME_JOB_COMPLETED_EVENT,
+    RUNTIME_JOB_COMPLETED_EVENT, SCOPE_TOO_LARGE_SIGNAL,
 };
 pub use repo_backlog::{
     build_merged_pr_decision, build_open_issue_without_workflow_decision,

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -11,6 +11,7 @@ use self::github_issue_completion::{
     bind_pr_from_activity_result, closed_issue_evidence_from_activity_result,
     closed_issue_evidence_from_activity_result_value, closed_issue_evidence_from_value,
     github_issue_closed_decision, issue_implementation_missing_result_decision,
+    scope_too_large_decision,
 };
 use self::plan_issue_completion::issue_plan_decision_from_activity_result;
 use self::pr_feedback_completion::{
@@ -55,6 +56,7 @@ pub const GITHUB_ISSUE_PR_DEFINITION_ID: &str = "github_issue_pr";
 pub const ISSUE_CLOSED_SIGNAL: &str = "IssueClosed";
 pub const ISSUE_ALREADY_RESOLVED_SIGNAL: &str = "IssueAlreadyResolved";
 pub const ISSUE_STATE_ARTIFACT: &str = "issue_state";
+pub const SCOPE_TOO_LARGE_SIGNAL: &str = "SCOPE_TOO_LARGE";
 
 pub fn activity_result_has_closed_issue_evidence(result: &ActivityResult) -> bool {
     closed_issue_evidence_from_activity_result(result).is_some()
@@ -104,6 +106,9 @@ fn reduce_success(
         return Some(decision);
     }
     if let Some(decision) = issue_plan_decision_from_activity_result(instance, event, result) {
+        return Some(decision);
+    }
+    if let Some(decision) = scope_too_large_decision(instance, event, result) {
         return Some(decision);
     }
     if let Some(reason) =

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -86,6 +86,7 @@ pub fn reduce_runtime_job_completed(
     let decision = match result.status {
         ActivityStatus::Succeeded => reduce_success(instance, event, &result),
         ActivityStatus::Blocked => github_issue_closed_decision(instance, event, &result)
+            .or_else(|| scope_too_large_decision(instance, event, &result))
             .or_else(|| Some(runtime_blocked_decision(instance, event, &result))),
         ActivityStatus::Failed => Some(
             retry_failed_activity_decision(instance, event, &result)

--- a/crates/harness-workflow/src/runtime/reducer/github_issue_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/github_issue_completion.rs
@@ -1,7 +1,7 @@
 use super::support::{event_field_string, non_empty_json_string, runtime_completion_evidence};
 use super::{
     GITHUB_ISSUE_PR_DEFINITION_ID, ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL,
-    ISSUE_STATE_ARTIFACT,
+    ISSUE_STATE_ARTIFACT, SCOPE_TOO_LARGE_SIGNAL,
 };
 use crate::runtime::model::{
     ActivityResult, WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowEvent,
@@ -54,6 +54,58 @@ pub(super) fn issue_implementation_missing_result_decision(
                 "runtime_job_id": event_field_string(event, "runtime_job_id"),
             }),
         ))
+        .with_evidence(runtime_completion_evidence(event, result))
+        .high_confidence(),
+    )
+}
+
+pub(super) fn scope_too_large_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    if (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) != (
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        "implementing",
+        "implement_issue",
+    ) {
+        return None;
+    }
+
+    let scope = scope_too_large_evidence_from_activity_result(result)?;
+    let scope_summary = scope.summary;
+    let scope_payload = scope.payload;
+    let reason = format!(
+        "implement_issue reported SCOPE_TOO_LARGE before PR creation: {}",
+        scope_summary
+    );
+    Some(
+        WorkflowDecision::new(
+            &instance.id,
+            &instance.state,
+            "block_scope_too_large",
+            "blocked",
+            &reason,
+        )
+        .with_command(WorkflowCommand::mark_blocked(
+            reason.clone(),
+            format!("runtime-completion:{}:scope-too-large:block", event.id),
+        ))
+        .with_command(WorkflowCommand::new(
+            WorkflowCommandType::RequestOperatorAttention,
+            format!("runtime-completion:{}:scope-too-large:operator", event.id),
+            json!({
+                "reason": reason,
+                "activity": result.activity,
+                "runtime_job_id": event_field_string(event, "runtime_job_id"),
+                "scope_guard": scope_payload,
+            }),
+        ))
+        .with_evidence(WorkflowEvidence::new("scope_too_large", scope_summary))
         .with_evidence(runtime_completion_evidence(event, result))
         .high_confidence(),
     )
@@ -145,6 +197,56 @@ pub(super) fn bind_pr_from_activity_result(
         .with_evidence(runtime_completion_evidence(event, result))
         .high_confidence(),
     )
+}
+
+#[derive(Debug, Clone)]
+struct ScopeTooLargeEvidence {
+    summary: String,
+    payload: Value,
+}
+
+fn scope_too_large_evidence_from_activity_result(
+    result: &ActivityResult,
+) -> Option<ScopeTooLargeEvidence> {
+    result
+        .signals
+        .iter()
+        .filter(|signal| signal.signal_type == SCOPE_TOO_LARGE_SIGNAL)
+        .find_map(|signal| scope_too_large_evidence_from_value(&signal.signal))
+}
+
+fn scope_too_large_evidence_from_value(value: &Value) -> Option<ScopeTooLargeEvidence> {
+    let files_changed = value.get("files_changed").and_then(Value::as_u64)?;
+    let lines_added = value.get("lines_added").and_then(Value::as_u64)?;
+    let max_files_changed = value.get("max_files_changed").and_then(Value::as_u64)?;
+    let max_lines_added = value.get("max_lines_added").and_then(Value::as_u64)?;
+    let base_ref = value
+        .get("base_ref")
+        .and_then(non_empty_json_string)
+        .unwrap_or_else(|| "configured base".to_string());
+    value
+        .get("decomposition_skeleton")
+        .filter(|skeleton| decomposition_skeleton_is_non_empty(skeleton))?;
+
+    if files_changed <= max_files_changed && lines_added <= max_lines_added {
+        return None;
+    }
+
+    Some(ScopeTooLargeEvidence {
+        summary: format!(
+            "base_ref={base_ref}; files_changed={files_changed}/{max_files_changed}; lines_added={lines_added}/{max_lines_added}"
+        ),
+        payload: value.clone(),
+    })
+}
+
+fn decomposition_skeleton_is_non_empty(value: &Value) -> bool {
+    match value {
+        Value::Array(items) => !items.is_empty(),
+        Value::Object(fields) => !fields.is_empty(),
+        Value::String(text) => !text.trim().is_empty(),
+        _ => false,
+    }
 }
 
 fn pull_request_artifact(result: &ActivityResult) -> Option<(u64, String)> {

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -25,7 +25,7 @@ use super::{
     PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
     QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
     QUALITY_PASSED_SIGNAL, REPO_BACKLOG_DEFINITION_ID, REPO_BACKLOG_POLL_ACTIVITY,
-    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
+    REPO_BACKLOG_SPRINT_PLAN_ACTIVITY, SCOPE_TOO_LARGE_SIGNAL,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -779,6 +779,94 @@ fn runtime_completion_reducer_blocks_issue_implementation_success_without_pr() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("blocked implementation decision should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_blocks_scope_too_large_signal() {
+    let instance = issue_instance("implementing");
+    let result = ActivityResult::succeeded(
+        "implement_issue",
+        "Scope guard rejected the implementation before PR creation.",
+    )
+    .with_signal(ActivitySignal::new(
+        SCOPE_TOO_LARGE_SIGNAL,
+        json!({
+            "base_ref": "origin/main",
+            "files_changed": 31,
+            "lines_added": 200,
+            "max_files_changed": 30,
+            "max_lines_added": 1500,
+            "decomposition_skeleton": [
+                {
+                    "title": "Split workflow contract changes",
+                    "summary": "Handle prompt/schema changes separately from reducer behavior.",
+                    "target_files": ["crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs"]
+                }
+            ]
+        }),
+    ));
+    let event = runtime_completion_event(&instance, "implement_issue", result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("scope guard signal should block for decomposition");
+
+    assert_eq!(decision.decision, "block_scope_too_large");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::MarkBlocked));
+    let operator_command = decision
+        .commands
+        .iter()
+        .find(|command| command.command_type == WorkflowCommandType::RequestOperatorAttention)
+        .expect("operator attention should carry decomposition evidence");
+    assert_eq!(operator_command.command["scope_guard"]["files_changed"], 31);
+    assert!(decision
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "scope_too_large"));
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("scope-too-large block decision should validate");
+}
+
+#[test]
+fn runtime_completion_reducer_rejects_scope_too_large_signal_without_exceeded_threshold() {
+    let instance = issue_instance("implementing");
+    let result = ActivityResult::succeeded(
+        "implement_issue",
+        "Scope guard payload did not exceed configured thresholds.",
+    )
+    .with_signal(ActivitySignal::new(
+        SCOPE_TOO_LARGE_SIGNAL,
+        json!({
+            "base_ref": "origin/main",
+            "files_changed": 30,
+            "lines_added": 1500,
+            "max_files_changed": 30,
+            "max_lines_added": 1500,
+            "decomposition_skeleton": [
+                {
+                    "title": "No split needed",
+                    "summary": "The diff is within configured guard thresholds."
+                }
+            ]
+        }),
+    ));
+    let event = runtime_completion_event(&instance, "implement_issue", result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("non-exceeded scope guard signal should not satisfy implement_issue");
+
+    assert_eq!(decision.decision, "block_missing_implementation_result");
+    assert_eq!(decision.next_state, "blocked");
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -837,6 +837,67 @@ fn runtime_completion_reducer_blocks_scope_too_large_signal() {
 }
 
 #[test]
+fn runtime_completion_reducer_blocks_scope_too_large_signal_from_blocked_result() {
+    let instance = issue_instance("implementing");
+    let result = ActivityResult {
+        activity: "implement_issue".to_string(),
+        status: ActivityStatus::Blocked,
+        summary: "Scope guard rejected the implementation before PR creation.".to_string(),
+        artifacts: Vec::new(),
+        signals: Vec::new(),
+        validation: Vec::new(),
+        error: None,
+        error_kind: None,
+    }
+    .with_signal(ActivitySignal::new(
+        SCOPE_TOO_LARGE_SIGNAL,
+        json!({
+            "base_ref": "origin/main",
+            "files_changed": 42,
+            "lines_added": 1600,
+            "max_files_changed": 30,
+            "max_lines_added": 1500,
+            "decomposition_skeleton": [
+                {
+                    "title": "Split reducer behavior",
+                    "summary": "Keep workflow reducer changes separate from worker prompt updates.",
+                    "target_files": ["crates/harness-workflow/src/runtime/reducer.rs"]
+                }
+            ]
+        }),
+    ));
+    let event = runtime_completion_event(&instance, "implement_issue", result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("blocked scope guard signal should block with decomposition evidence");
+
+    assert_eq!(decision.decision, "block_scope_too_large");
+    assert_eq!(decision.next_state, "blocked");
+    let operator_command = decision
+        .commands
+        .iter()
+        .find(|command| command.command_type == WorkflowCommandType::RequestOperatorAttention)
+        .expect("operator attention should carry decomposition evidence");
+    assert_eq!(operator_command.command["scope_guard"]["files_changed"], 42);
+    assert_eq!(
+        operator_command.command["scope_guard"]["decomposition_skeleton"][0]["title"],
+        "Split reducer behavior"
+    );
+    assert!(decision
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "scope_too_large"));
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("blocked scope-too-large decision should validate");
+}
+
+#[test]
 fn runtime_completion_reducer_rejects_scope_too_large_signal_without_exceeded_threshold() {
     let instance = issue_instance("implementing");
     let result = ActivityResult::succeeded(


### PR DESCRIPTION
## Summary
- Add defaulted pr_scope_guard workflow config with 30-file and 1500-added-line thresholds.
- Teach implement_issue prompt packets and workflow prompts to emit SCOPE_TOO_LARGE before PR creation when guard thresholds are exceeded.
- Reduce SCOPE_TOO_LARGE into a blocked workflow decision carrying decomposition evidence for operator follow-up.

## Validation
- cargo fmt --all -- --check
- cargo test -p harness-core workflow_config
- cargo test -p harness-server prompt_packet
- cargo test -p harness-workflow scope_too_large
- cargo check -p harness-server --all-targets
- git diff --numstat origin/main | awk '{files += 1; added += $1} END {printf "base_ref=origin/main files_changed=%d lines_added=%d\\n", files, added}'\n- cargo clippy --workspace --all-targets -- -D warnings\n\nCloses #986