### PR TITLE
Fix PLAN_ISSUE replan prompt context

### DIFF
--- a/crates/harness-core/src/prompts/issue.rs
+++ b/crates/harness-core/src/prompts/issue.rs
@@ -89,8 +89,25 @@ pub fn plan_prompt(issue: u64, triage_assessment: &str) -> PromptParts {
 /// This is used when the current implementation plan proved incomplete or wrong
 /// during execution. The architect must produce a corrected plan rather than
 /// letting the executor silently diverge.
-pub fn replan_prompt(issue: u64, prior_plan: Option<&str>, plan_issue: &str) -> PromptParts {
+pub fn replan_prompt(
+    issue: u64,
+    issue_context: Option<&str>,
+    triage_output: Option<&str>,
+    prior_plan: Option<&str>,
+    plan_issue: &str,
+) -> PromptParts {
+    let issue_context_section = issue_context
+        .filter(|context| !context.trim().is_empty())
+        .map(wrap_external_data)
+        .map(|safe_context| format!("Original GitHub issue context:\n{safe_context}\n\n"))
+        .unwrap_or_default();
+    let triage_output_section = triage_output
+        .filter(|triage| !triage.trim().is_empty())
+        .map(wrap_external_data)
+        .map(|safe_triage| format!("Previous triage output:\n{safe_triage}\n\n"))
+        .unwrap_or_default();
     let prior_plan_section = prior_plan
+        .filter(|plan| !plan.trim().is_empty())
         .map(wrap_external_data)
         .map(|safe_plan| format!("Previous implementation plan:\n{safe_plan}\n\n"))
         .unwrap_or_default();
@@ -99,8 +116,11 @@ pub fn replan_prompt(issue: u64, prior_plan: Option<&str>, plan_issue: &str) -> 
         static_instructions: format!(
             "You are a Software Architect repairing the implementation plan for GitHub issue #{issue}.\n\n\
              A previous implementation attempt refused to proceed because the current plan was incomplete or wrong.\n\n\
+             The original GitHub issue contract is authoritative. Do not let the implementation concern redefine the issue requirements.\n\n\
+             {issue_context_section}\
+             {triage_output_section}\
              {prior_plan_section}\
-             Implementation concern raised by the executor:\n\
+             Implementation concern raised by the executor via PLAN_ISSUE:\n\
              {safe_plan_issue}\n\n\
              Produce a corrected implementation plan:\n\n\
              1. **Files to modify** — list each file with a one-line rationale\n\
@@ -272,9 +292,22 @@ mod tests {
 
     #[test]
     fn test_replan_prompt() {
-        let p = replan_prompt(42, Some("old plan"), "missed auth bypass").to_prompt_string();
+        let p = replan_prompt(
+            42,
+            Some("Title: original contract\nBody: keep route unauthenticated"),
+            Some("TRIAGE=PROCEED_WITH_PLAN"),
+            Some("old plan"),
+            "missed auth bypass",
+        )
+        .to_prompt_string();
         assert!(p.contains("repairing the implementation plan"));
+        assert!(p.contains("Original GitHub issue context"));
+        assert!(p.contains("keep route unauthenticated"));
+        assert!(p.contains("Previous triage output"));
+        assert!(p.contains("TRIAGE=PROCEED_WITH_PLAN"));
+        assert!(p.contains("old plan"));
         assert!(p.contains("missed auth bypass"));
+        assert!(p.contains("PLAN_ISSUE"));
         assert!(p.contains("PLAN=READY"));
     }
 

--- a/crates/harness-server/src/task_executor/run_task.rs
+++ b/crates/harness-server/src/task_executor/run_task.rs
@@ -472,6 +472,8 @@ pub(crate) async fn run_task(
                             store,
                             task_id,
                             issue,
+                            &repo_slug,
+                            server_config.server.github_token.as_deref(),
                             prior_plan.as_deref().or(current_plan_output.as_deref()),
                             &plan_issue,
                             &cargo_env,

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -6,6 +6,7 @@ use super::helpers::{
 use crate::task_runner::{
     mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskPhase, TaskStatus, TaskStore,
 };
+use anyhow::Context;
 use chrono::Utc;
 use harness_core::agent::{AgentRequest, CodeAgent};
 use harness_core::config::project::ProjectTriageConfig;
@@ -30,16 +31,25 @@ type IssueFetchFn = for<'a> fn(&'a str, u64, Option<&'a str>) -> IssueFetchFutur
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct TypedIssueSnapshot {
+    title: String,
     body: String,
     labels: Vec<String>,
+    state: Option<String>,
+    url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 struct GitHubIssueSnapshotResponse {
     #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
     body: Option<String>,
     #[serde(default)]
     labels: Vec<GitHubIssueLabel>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    html_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -326,12 +336,15 @@ async fn fetch_typed_issue_snapshot(
     }
     let snapshot: GitHubIssueSnapshotResponse = response.json().await?;
     Ok(TypedIssueSnapshot {
+        title: snapshot.title.unwrap_or_default(),
         body: snapshot.body.unwrap_or_default(),
         labels: snapshot
             .labels
             .into_iter()
             .map(|label| label.name)
             .collect(),
+        state: snapshot.state,
+        url: snapshot.html_url,
     })
 }
 
@@ -341,6 +354,38 @@ fn fetch_typed_issue_snapshot_boxed<'a>(
     github_token: Option<&'a str>,
 ) -> IssueFetchFuture<'a> {
     Box::pin(fetch_typed_issue_snapshot(repo_slug, issue, github_token))
+}
+
+fn format_replan_issue_context(
+    repo_slug: &str,
+    issue: u64,
+    snapshot: &TypedIssueSnapshot,
+) -> String {
+    let mut context = vec![
+        format!("Repository: {repo_slug}"),
+        format!("Issue: #{issue}"),
+    ];
+    if !snapshot.title.trim().is_empty() {
+        context.push(format!("Title: {}", snapshot.title.trim()));
+    }
+    if let Some(state) = snapshot
+        .state
+        .as_deref()
+        .filter(|state| !state.trim().is_empty())
+    {
+        context.push(format!("State: {}", state.trim()));
+    }
+    if let Some(url) = snapshot.url.as_deref().filter(|url| !url.trim().is_empty()) {
+        context.push(format!("URL: {}", url.trim()));
+    }
+    if !snapshot.labels.is_empty() {
+        context.push(format!("Labels: {}", snapshot.labels.join(", ")));
+    }
+    if !snapshot.body.trim().is_empty() {
+        context.push("Body:".to_string());
+        context.push(snapshot.body.clone());
+    }
+    context.join("\n")
 }
 
 async fn record_phase_observability(
@@ -972,11 +1017,14 @@ async fn run_triage_plan_pipeline_with_issue_fetcher(
 ///
 /// Returns the corrected plan text and advances the task phase back to
 /// `Implement`. The caller decides whether to retry implementation or fail.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_replan_for_issue(
     agent: &dyn CodeAgent,
     store: &TaskStore,
     task_id: &TaskId,
     issue: u64,
+    repo_slug: &str,
+    github_token: Option<&str>,
     prior_plan: Option<&str>,
     plan_issue: &str,
     cargo_env: &HashMap<String, String>,
@@ -985,13 +1033,72 @@ pub(crate) async fn run_replan_for_issue(
     skills: &RwLock<harness_skills::store::SkillStore>,
     events: &EventStore,
 ) -> anyhow::Result<String> {
+    run_replan_for_issue_with_issue_fetcher(
+        agent,
+        store,
+        task_id,
+        issue,
+        repo_slug,
+        github_token,
+        prior_plan,
+        plan_issue,
+        cargo_env,
+        project,
+        req,
+        skills,
+        events,
+        fetch_typed_issue_snapshot_boxed,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_replan_for_issue_with_issue_fetcher(
+    agent: &dyn CodeAgent,
+    store: &TaskStore,
+    task_id: &TaskId,
+    issue: u64,
+    repo_slug: &str,
+    github_token: Option<&str>,
+    prior_plan: Option<&str>,
+    plan_issue: &str,
+    cargo_env: &HashMap<String, String>,
+    project: &Path,
+    req: &CreateTaskRequest,
+    skills: &RwLock<harness_skills::store::SkillStore>,
+    events: &EventStore,
+    issue_fetcher: IssueFetchFn,
+) -> anyhow::Result<String> {
     tracing::info!(task_id = %task_id, issue, "pipeline: starting replan phase");
     mutate_and_persist(store, task_id, |state| {
         state.phase = TaskPhase::Plan;
     })
     .await?;
 
-    let prompt = prompts::replan_prompt(issue, prior_plan, plan_issue).to_prompt_string();
+    let saved_task = store.get(task_id);
+    let saved_triage_output = saved_task
+        .as_ref()
+        .and_then(|state| state.triage_output.as_deref());
+    let prior_plan = prior_plan.or_else(|| {
+        saved_task
+            .as_ref()
+            .and_then(|state| state.plan_output.as_deref())
+    });
+    let issue_snapshot = issue_fetcher(repo_slug, issue, github_token)
+        .await
+        .with_context(|| {
+            format!("failed to fetch GitHub issue context for {repo_slug}#{issue} before replan")
+        })?;
+    let issue_context = format_replan_issue_context(repo_slug, issue, &issue_snapshot);
+
+    let prompt = prompts::replan_prompt(
+        issue,
+        Some(&issue_context),
+        saved_triage_output,
+        prior_plan,
+        plan_issue,
+    )
+    .to_prompt_string();
     let prompt = augment_prompt_with_skills(skills, events, task_id, prompt).await;
     let plan_req = AgentRequest {
         prompt,

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -6,7 +6,6 @@ use super::helpers::{
 use crate::task_runner::{
     mutate_and_persist, CreateTaskRequest, RoundResult, TaskId, TaskPhase, TaskStatus, TaskStore,
 };
-use anyhow::Context;
 use chrono::Utc;
 use harness_core::agent::{AgentRequest, CodeAgent};
 use harness_core::config::project::ProjectTriageConfig;
@@ -356,6 +355,27 @@ fn fetch_typed_issue_snapshot_boxed<'a>(
     Box::pin(fetch_typed_issue_snapshot(repo_slug, issue, github_token))
 }
 
+fn usable_repo_slug(candidate: &str) -> Option<&str> {
+    let candidate = candidate.trim();
+    if candidate.is_empty() || candidate == UNKNOWN_REPO_SLUG {
+        None
+    } else {
+        Some(candidate)
+    }
+}
+
+fn resolve_replan_repo_slug(
+    detected_repo_slug: &str,
+    request_repo: Option<&str>,
+    task_repo: Option<&str>,
+) -> String {
+    usable_repo_slug(detected_repo_slug)
+        .or_else(|| request_repo.and_then(usable_repo_slug))
+        .or_else(|| task_repo.and_then(usable_repo_slug))
+        .unwrap_or(UNKNOWN_REPO_SLUG)
+        .to_string()
+}
+
 fn format_replan_issue_context(
     repo_slug: &str,
     issue: u64,
@@ -386,6 +406,22 @@ fn format_replan_issue_context(
         context.push(snapshot.body.clone());
     }
     context.join("\n")
+}
+
+fn format_unavailable_replan_issue_context(
+    repo_slug: &str,
+    issue: u64,
+    fetch_error: &anyhow::Error,
+) -> String {
+    [
+        format!("Repository: {repo_slug}"),
+        format!("Issue: #{issue}"),
+        "Live GitHub issue context unavailable before replan.".to_string(),
+        format!("Issue fetch error: {fetch_error:#}"),
+        "Continue from the saved triage output, previous implementation plan, and PLAN_ISSUE concern."
+            .to_string(),
+    ]
+    .join("\n")
 }
 
 async fn record_phase_observability(
@@ -1084,12 +1120,25 @@ async fn run_replan_for_issue_with_issue_fetcher(
             .as_ref()
             .and_then(|state| state.plan_output.as_deref())
     });
-    let issue_snapshot = issue_fetcher(repo_slug, issue, github_token)
-        .await
-        .with_context(|| {
-            format!("failed to fetch GitHub issue context for {repo_slug}#{issue} before replan")
-        })?;
-    let issue_context = format_replan_issue_context(repo_slug, issue, &issue_snapshot);
+    let replan_repo_slug = resolve_replan_repo_slug(
+        repo_slug,
+        req.repo.as_deref(),
+        saved_task.as_ref().and_then(|state| state.repo.as_deref()),
+    );
+    let issue_context = match issue_fetcher(&replan_repo_slug, issue, github_token).await {
+        Ok(issue_snapshot) => {
+            format_replan_issue_context(&replan_repo_slug, issue, &issue_snapshot)
+        }
+        Err(error) => {
+            tracing::warn!(
+                task_id = %task_id,
+                issue,
+                repo = %replan_repo_slug,
+                "failed to fetch GitHub issue context before replan; continuing from saved task context: {error:#}"
+            );
+            format_unavailable_replan_issue_context(&replan_repo_slug, issue, &error)
+        }
+    };
 
     let prompt = prompts::replan_prompt(
         issue,

--- a/crates/harness-server/src/task_executor/triage_pipeline.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline.rs
@@ -1112,14 +1112,35 @@ async fn run_replan_for_issue_with_issue_fetcher(
     .await?;
 
     let saved_task = store.get(task_id);
+    let checkpoint = match store.load_checkpoint(task_id).await {
+        Ok(checkpoint) => checkpoint,
+        Err(error) => {
+            tracing::warn!(
+                task_id = %task_id,
+                "failed to load replan checkpoint context; continuing from task state only: {error:#}"
+            );
+            None
+        }
+    };
     let saved_triage_output = saved_task
         .as_ref()
-        .and_then(|state| state.triage_output.as_deref());
-    let prior_plan = prior_plan.or_else(|| {
-        saved_task
-            .as_ref()
-            .and_then(|state| state.plan_output.as_deref())
-    });
+        .and_then(|state| state.triage_output.as_deref())
+        .or_else(|| {
+            checkpoint
+                .as_ref()
+                .and_then(|checkpoint| checkpoint.triage_output.as_deref())
+        });
+    let prior_plan = prior_plan
+        .or_else(|| {
+            saved_task
+                .as_ref()
+                .and_then(|state| state.plan_output.as_deref())
+        })
+        .or_else(|| {
+            checkpoint
+                .as_ref()
+                .and_then(|checkpoint| checkpoint.plan_output.as_deref())
+        });
     let replan_repo_slug = resolve_replan_repo_slug(
         repo_slug,
         req.repo.as_deref(),

--- a/crates/harness-server/src/task_executor/triage_pipeline_tests.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline_tests.rs
@@ -605,6 +605,64 @@ async fn run_replan_for_issue_uses_saved_context_when_issue_fetch_is_unavailable
 }
 
 #[tokio::test]
+async fn run_replan_for_issue_uses_checkpoint_context_after_recovery_when_issue_fetch_fails(
+) -> anyhow::Result<()> {
+    let (dir, store, events, task_id, mut req, skills) = setup_issue_task_harness().await?;
+    req.repo = Some("workflow/repo".to_string());
+    mutate_and_persist(&store, &task_id, |state| {
+        state.repo = Some("task-state/repo".to_string());
+        state.triage_output = None;
+        state.plan_output = None;
+    })
+    .await?;
+    store
+        .write_checkpoint(
+            &task_id,
+            Some("checkpoint triage\nCOMPLEXITY=medium\nTRIAGE=PROCEED_WITH_PLAN"),
+            Some("checkpoint implementation plan"),
+            None,
+            "plan_done",
+        )
+        .await?;
+
+    let captured_prompt = Arc::new(Mutex::new(None));
+    let agent = CapturingReplanAgent::new(captured_prompt.clone());
+    let cargo_env = HashMap::new();
+    let plan = run_replan_for_issue_with_issue_fetcher(
+        &agent,
+        &store,
+        &task_id,
+        988,
+        UNKNOWN_REPO_SLUG,
+        None,
+        None,
+        "PLAN_ISSUE=recovered task needs a safer plan",
+        &cargo_env,
+        dir.path(),
+        &req,
+        &skills,
+        &events,
+        failing_replan_issue_fetcher,
+    )
+    .await?;
+
+    assert_eq!(plan, "corrected plan\nPLAN=READY");
+    let prompt = captured_prompt
+        .lock()
+        .expect("capture prompt lock")
+        .clone()
+        .expect("replan prompt should be captured");
+    assert!(prompt.contains("Repository: workflow/repo"));
+    assert!(prompt.contains("Live GitHub issue context unavailable before replan."));
+    assert!(prompt.contains("Previous triage output"));
+    assert!(prompt.contains("checkpoint triage"));
+    assert!(prompt.contains("Previous implementation plan"));
+    assert!(prompt.contains("checkpoint implementation plan"));
+    assert!(prompt.contains("PLAN_ISSUE=recovered task needs a safer plan"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn actionable_review_issue_skip_is_promoted_to_plan() -> anyhow::Result<()> {
     let (dir, store, events, task_id, req, skills) = setup_issue_task_harness().await?;
     let agent = TriageStaticStreamAgent::new(

--- a/crates/harness-server/src/task_executor/triage_pipeline_tests.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline_tests.rs
@@ -418,6 +418,19 @@ fn failing_issue_fetcher<'a>(
     Box::pin(async { Err(anyhow::anyhow!("simulated GitHub failure")) })
 }
 
+fn failing_replan_issue_fetcher<'a>(
+    repo_slug: &'a str,
+    issue: u64,
+    github_token: Option<&'a str>,
+) -> IssueFetchFuture<'a> {
+    Box::pin(async move {
+        assert_eq!(repo_slug, "workflow/repo");
+        assert_eq!(issue, 988);
+        assert_eq!(github_token, None);
+        Err(anyhow::anyhow!("simulated GitHub failure"))
+    })
+}
+
 fn replan_issue_fetcher<'a>(
     repo_slug: &'a str,
     issue: u64,
@@ -513,6 +526,70 @@ async fn run_replan_for_issue_prompt_includes_issue_context_triage_plan_and_plan
     assert!(prompt.contains("previous implementation plan"));
     assert!(prompt.contains("Implementation concern raised by the executor"));
     assert!(prompt.contains("PLAN_ISSUE=agent wants to add auth"));
+
+    let state = store.get(&task_id).expect("task state");
+    assert_eq!(state.phase, TaskPhase::Implement);
+    assert_eq!(
+        state.plan_output.as_deref(),
+        Some("corrected plan\nPLAN=READY")
+    );
+    assert!(state
+        .rounds
+        .iter()
+        .any(|round| round.action == "replan" && round.result == "plan_ready"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_replan_for_issue_uses_saved_context_when_issue_fetch_is_unavailable(
+) -> anyhow::Result<()> {
+    let (dir, store, events, task_id, mut req, skills) = setup_issue_task_harness().await?;
+    req.repo = Some("workflow/repo".to_string());
+    mutate_and_persist(&store, &task_id, |state| {
+        state.repo = Some("task-state/repo".to_string());
+        state.triage_output =
+            Some("saved triage\nCOMPLEXITY=medium\nTRIAGE=PROCEED_WITH_PLAN".to_string());
+        state.plan_output = Some("saved fallback plan".to_string());
+    })
+    .await?;
+
+    let captured_prompt = Arc::new(Mutex::new(None));
+    let agent = CapturingReplanAgent::new(captured_prompt.clone());
+    let cargo_env = HashMap::new();
+    let plan = run_replan_for_issue_with_issue_fetcher(
+        &agent,
+        &store,
+        &task_id,
+        988,
+        UNKNOWN_REPO_SLUG,
+        None,
+        None,
+        "PLAN_ISSUE=implementation needs a safer plan",
+        &cargo_env,
+        dir.path(),
+        &req,
+        &skills,
+        &events,
+        failing_replan_issue_fetcher,
+    )
+    .await?;
+
+    assert_eq!(plan, "corrected plan\nPLAN=READY");
+    let prompt = captured_prompt
+        .lock()
+        .expect("capture prompt lock")
+        .clone()
+        .expect("replan prompt should be captured");
+    assert!(prompt.contains("Original GitHub issue context"));
+    assert!(prompt.contains("Repository: workflow/repo"));
+    assert!(prompt.contains("Issue: #988"));
+    assert!(prompt.contains("Live GitHub issue context unavailable before replan."));
+    assert!(prompt.contains("simulated GitHub failure"));
+    assert!(prompt.contains("Previous triage output"));
+    assert!(prompt.contains("saved triage"));
+    assert!(prompt.contains("Previous implementation plan"));
+    assert!(prompt.contains("saved fallback plan"));
+    assert!(prompt.contains("PLAN_ISSUE=implementation needs a safer plan"));
 
     let state = store.get(&task_id).expect("task state");
     assert_eq!(state.phase, TaskPhase::Implement);

--- a/crates/harness-server/src/task_executor/triage_pipeline_tests.rs
+++ b/crates/harness-server/src/task_executor/triage_pipeline_tests.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use harness_core::agent::{AgentResponse, StreamItem};
 use harness_core::error::HarnessError;
 use harness_core::types::{Capability, EventFilters, TokenUsage};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 struct PromptPlanningAgent;
 
@@ -13,11 +13,21 @@ struct TriageStaticStreamAgent {
     output: String,
 }
 
+struct CapturingReplanAgent {
+    prompt: Arc<Mutex<Option<String>>>,
+}
+
 impl TriageStaticStreamAgent {
     fn new(output: &str) -> Self {
         Self {
             output: output.to_string(),
         }
+    }
+}
+
+impl CapturingReplanAgent {
+    fn new(prompt: Arc<Mutex<Option<String>>>) -> Self {
+        Self { prompt }
     }
 }
 
@@ -119,6 +129,40 @@ impl CodeAgent for TriageStaticStreamAgent {
         })
         .await
         .map_err(|e| HarnessError::AgentExecution(format!("stream closed: {e}")))?;
+        tx.send(StreamItem::Done)
+            .await
+            .map_err(|e| HarnessError::AgentExecution(format!("stream closed: {e}")))?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl CodeAgent for CapturingReplanAgent {
+    fn name(&self) -> &str {
+        "capturing-replan-agent"
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![]
+    }
+
+    async fn execute(&self, req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+        *self.prompt.lock().expect("capture prompt lock") = Some(req.prompt);
+        Ok(AgentResponse {
+            output: "corrected plan\nPLAN=READY".to_string(),
+            stderr: String::new(),
+            items: vec![],
+            token_usage: TokenUsage::default(),
+            model: "mock".to_string(),
+            exit_code: Some(0),
+        })
+    }
+
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        tx: tokio::sync::mpsc::Sender<StreamItem>,
+    ) -> harness_core::error::Result<()> {
         tx.send(StreamItem::Done)
             .await
             .map_err(|e| HarnessError::AgentExecution(format!("stream closed: {e}")))?;
@@ -333,6 +377,7 @@ fn actionable_review_issue_fetcher<'a>(
         Ok(TypedIssueSnapshot {
             body: actionable_issue_body(),
             labels: vec!["review".to_string(), "P1".to_string()],
+            ..TypedIssueSnapshot::default()
         })
     })
 }
@@ -346,6 +391,7 @@ fn actionable_no_label_issue_fetcher<'a>(
         Ok(TypedIssueSnapshot {
             body: actionable_issue_body(),
             labels: vec![],
+            ..TypedIssueSnapshot::default()
         })
     })
 }
@@ -359,6 +405,7 @@ fn abstract_review_issue_fetcher<'a>(
         Ok(TypedIssueSnapshot {
             body: abstract_issue_body(),
             labels: vec!["review".to_string()],
+            ..TypedIssueSnapshot::default()
         })
     })
 }
@@ -369,6 +416,25 @@ fn failing_issue_fetcher<'a>(
     _github_token: Option<&'a str>,
 ) -> IssueFetchFuture<'a> {
     Box::pin(async { Err(anyhow::anyhow!("simulated GitHub failure")) })
+}
+
+fn replan_issue_fetcher<'a>(
+    repo_slug: &'a str,
+    issue: u64,
+    github_token: Option<&'a str>,
+) -> IssueFetchFuture<'a> {
+    Box::pin(async move {
+        assert_eq!(repo_slug, "owner/repo");
+        assert_eq!(issue, 988);
+        assert_eq!(github_token, Some("github-token"));
+        Ok(TypedIssueSnapshot {
+            title: "Keep public route contract".to_string(),
+            body: "The route must remain unauthenticated even if the agent disagrees.".to_string(),
+            labels: vec!["runtime".to_string(), "force-execute".to_string()],
+            state: Some("open".to_string()),
+            url: Some("https://github.com/owner/repo/issues/988".to_string()),
+        })
+    })
 }
 
 async fn setup_issue_task_harness() -> anyhow::Result<(
@@ -396,6 +462,69 @@ async fn setup_issue_task_harness() -> anyhow::Result<(
     };
     let skills = RwLock::new(harness_skills::store::SkillStore::new());
     Ok((dir, store, events, task_id, req, skills))
+}
+
+#[tokio::test]
+async fn run_replan_for_issue_prompt_includes_issue_context_triage_plan_and_plan_issue(
+) -> anyhow::Result<()> {
+    let (dir, store, events, task_id, req, skills) = setup_issue_task_harness().await?;
+    mutate_and_persist(&store, &task_id, |state| {
+        state.triage_output = Some(
+            "Complex enough for planning.\nCOMPLEXITY=medium\nTRIAGE=PROCEED_WITH_PLAN".to_string(),
+        );
+        state.plan_output = Some("persisted fallback plan".to_string());
+    })
+    .await?;
+
+    let captured_prompt = Arc::new(Mutex::new(None));
+    let agent = CapturingReplanAgent::new(captured_prompt.clone());
+    let cargo_env = HashMap::new();
+    let plan = run_replan_for_issue_with_issue_fetcher(
+        &agent,
+        &store,
+        &task_id,
+        988,
+        "owner/repo",
+        Some("github-token"),
+        Some("previous implementation plan"),
+        "PLAN_ISSUE=agent wants to add auth despite the issue contract",
+        &cargo_env,
+        dir.path(),
+        &req,
+        &skills,
+        &events,
+        replan_issue_fetcher,
+    )
+    .await?;
+
+    assert_eq!(plan, "corrected plan\nPLAN=READY");
+    let prompt = captured_prompt
+        .lock()
+        .expect("capture prompt lock")
+        .clone()
+        .expect("replan prompt should be captured");
+    assert!(prompt.contains("Original GitHub issue context"));
+    assert!(prompt.contains("Keep public route contract"));
+    assert!(prompt.contains("https://github.com/owner/repo/issues/988"));
+    assert!(prompt.contains("The route must remain unauthenticated"));
+    assert!(prompt.contains("Previous triage output"));
+    assert!(prompt.contains("TRIAGE=PROCEED_WITH_PLAN"));
+    assert!(prompt.contains("Previous implementation plan"));
+    assert!(prompt.contains("previous implementation plan"));
+    assert!(prompt.contains("Implementation concern raised by the executor"));
+    assert!(prompt.contains("PLAN_ISSUE=agent wants to add auth"));
+
+    let state = store.get(&task_id).expect("task state");
+    assert_eq!(state.phase, TaskPhase::Implement);
+    assert_eq!(
+        state.plan_output.as_deref(),
+        Some("corrected plan\nPLAN=READY")
+    );
+    assert!(state
+        .rounds
+        .iter()
+        .any(|round| round.action == "replan" && round.result == "plan_ready"));
+    Ok(())
 }
 
 #[tokio::test]
@@ -610,6 +739,7 @@ fn resolve_triage_decision_promotes_only_actionable_skip() {
     let actionable = TypedIssueSnapshot {
         body: actionable_issue_body(),
         labels: vec!["review".to_string()],
+        ..TypedIssueSnapshot::default()
     };
     let resolved = resolve_triage_decision(
         prompts::TriageDecision::Skip,
@@ -622,6 +752,7 @@ fn resolve_triage_decision_promotes_only_actionable_skip() {
     let abstract_issue = TypedIssueSnapshot {
         body: abstract_issue_body(),
         labels: vec!["review".to_string()],
+        ..TypedIssueSnapshot::default()
     };
     let resolved = resolve_triage_decision(
         prompts::TriageDecision::Skip,


### PR DESCRIPTION
Summary
- Add original GitHub issue context and saved triage output to the PLAN_ISSUE replan prompt.
- Reuse the GitHub issue snapshot fetch path for replan and fail closed if the issue contract cannot be fetched.
- Add focused prompt and task-executor regression coverage.

Validation
- cargo fmt --all -- --check
- cargo test -p harness-core test_replan_prompt
- cargo test -p harness-server run_replan
- cargo test -p harness-workflow issue_planning
- cargo test -p harness-workflow plan_issue_decision
- cargo check -p harness-server --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo test (full run hit local Postgres pool timeouts in harness-server --test notification_delivery; reran that integration test serially and it passed)
- cargo test -p harness-server --test notification_delivery -- --test-threads=1

Closes #907