### PR TITLE
feat(server): tag runtime GitHub issue intake

### DIFF
--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -32,6 +32,12 @@ const WORKFLOW_RUNTIME_TREE_MAX_COMMAND_LIMIT: i64 = 50;
 const WORKFLOW_RUNTIME_TREE_DEFAULT_REJECTED_DECISION_LIMIT: i64 = 3;
 const WORKFLOW_RUNTIME_TREE_MAX_REJECTED_DECISION_LIMIT: i64 = 20;
 
+#[derive(Debug)]
+struct IntakeRecentDispatch {
+    sort_at: Option<chrono::DateTime<chrono::Utc>>,
+    payload: serde_json::Value,
+}
+
 fn startup_error_code(error: Option<&str>) -> Option<&'static str> {
     let error = error?;
     let lower = error.to_ascii_lowercase();
@@ -1464,18 +1470,10 @@ pub(crate) async fn intake_status(State(state): State<Arc<AppState>>) -> Json<se
         "active": dashboard_active,
     });
 
-    let mut recent_dispatches: Vec<serde_json::Value> = all_tasks
+    let mut recent_dispatches: Vec<IntakeRecentDispatch> = all_tasks
         .iter()
         .filter(|t| t.source.is_some())
-        .map(|t| {
-            json!({
-                "source": t.source,
-                "external_id": t.external_id,
-                "task_id": t.id.0,
-                "status": serde_json::to_value(&t.status).unwrap_or(json!("unknown")),
-                "pr_url": t.pr_url,
-            })
-        })
+        .map(legacy_task_recent_dispatch)
         .collect();
     recent_dispatches.extend(
         runtime_issue_workflows
@@ -1483,7 +1481,12 @@ pub(crate) async fn intake_status(State(state): State<Arc<AppState>>) -> Json<se
             .filter(|workflow| runtime_workflow_intake_source(workflow).is_some())
             .filter_map(runtime_issue_recent_dispatch),
     );
-    recent_dispatches.truncate(10);
+    recent_dispatches.sort_by(|left, right| right.sort_at.cmp(&left.sort_at));
+    let recent_dispatches: Vec<serde_json::Value> = recent_dispatches
+        .into_iter()
+        .take(10)
+        .map(|dispatch| dispatch.payload)
+        .collect();
 
     let mut response = json!({
         "channels": [github_channel, feishu_channel, dashboard_channel],
@@ -1503,7 +1506,10 @@ async fn runtime_issue_workflows_for_intake_status(
     state: &AppState,
 ) -> (Vec<WorkflowInstance>, bool) {
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return (Vec::new(), false);
+        return (
+            Vec::new(),
+            workflow_runtime_submissions_expected_but_unavailable(state),
+        );
     };
     match store
         .list_instances_by_definition(
@@ -1521,19 +1527,51 @@ async fn runtime_issue_workflows_for_intake_status(
     }
 }
 
-fn runtime_issue_recent_dispatch(workflow: &WorkflowInstance) -> Option<serde_json::Value> {
+fn legacy_task_recent_dispatch(task: &task_runner::TaskState) -> IntakeRecentDispatch {
+    IntakeRecentDispatch {
+        sort_at: parse_rfc3339_utc(task.created_at.as_deref()),
+        payload: json!({
+            "source": task.source,
+            "external_id": task.external_id,
+            "task_id": task.id.0,
+            "status": serde_json::to_value(&task.status).unwrap_or(json!("unknown")),
+            "pr_url": task.pr_url,
+        }),
+    }
+}
+
+fn runtime_issue_recent_dispatch(workflow: &WorkflowInstance) -> Option<IntakeRecentDispatch> {
     let projection = RuntimeWorkflowProjection::from_workflow(workflow);
     let task_id = projection.submission_handle?;
     let source = runtime_workflow_intake_source(workflow)?;
-    Some(json!({
-        "source": source,
-        "external_id": runtime_workflow_external_id(workflow),
-        "tracker_source": runtime_workflow_tracker_source(workflow),
-        "tracker_external_id": runtime_workflow_tracker_external_id(workflow),
-        "task_id": task_id.0,
-        "status": serde_json::to_value(&projection.task_status).unwrap_or(json!("unknown")),
-        "pr_url": runtime_workflow_data_string(workflow, "pr_url"),
-    }))
+    Some(IntakeRecentDispatch {
+        sort_at: Some(workflow.created_at),
+        payload: json!({
+            "source": source,
+            "external_id": runtime_workflow_external_id(workflow),
+            "tracker_source": runtime_workflow_tracker_source(workflow),
+            "tracker_external_id": runtime_workflow_tracker_external_id(workflow),
+            "task_id": task_id.0,
+            "status": serde_json::to_value(&projection.task_status).unwrap_or(json!("unknown")),
+            "pr_url": runtime_workflow_data_string(workflow, "pr_url"),
+        }),
+    })
+}
+
+fn parse_rfc3339_utc(value: Option<&str>) -> Option<chrono::DateTime<chrono::Utc>> {
+    value
+        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&chrono::Utc))
+}
+
+fn workflow_runtime_submissions_expected_but_unavailable(state: &AppState) -> bool {
+    state
+        .degraded_subsystems
+        .contains(&"workflow_runtime_store")
+        || state
+            .startup_statuses
+            .iter()
+            .any(|status| status.name == "workflow_runtime_store" && !status.ready)
 }
 
 fn runtime_workflow_has_tracker_source(workflow: &WorkflowInstance, source: &str) -> bool {

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -12,6 +12,7 @@ use std::path::{Path as StdPath, PathBuf};
 use std::sync::Arc;
 
 use super::{state::AppState, task_routes};
+use crate::runtime_projection::RuntimeWorkflowProjection;
 use crate::{router, task_runner};
 use harness_workflow::runtime::store::{RuntimeEventSummary, RuntimeJobCompactRecord};
 use harness_workflow::runtime::{
@@ -1377,6 +1378,8 @@ pub(crate) async fn github_webhook(
 pub(crate) async fn intake_status(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
     let intake_config = &state.core.server.config.intake;
     let all_tasks = state.core.tasks.list_all();
+    let (runtime_issue_workflows, runtime_degraded) =
+        runtime_issue_workflows_for_intake_status(&state).await;
 
     let github_active: u64 = if let Some(store) = state.core.issue_workflow_store.as_ref() {
         match store.list().await {
@@ -1413,7 +1416,11 @@ pub(crate) async fn intake_status(State(state): State<Arc<AppState>>) -> Json<se
                     )
             })
             .count() as u64
-    };
+    } + runtime_issue_workflows
+        .iter()
+        .filter(|workflow| runtime_workflow_has_tracker_source(workflow, "github"))
+        .filter(|workflow| !workflow.is_terminal())
+        .count() as u64;
 
     let feishu_active: u64 = all_tasks
         .iter()
@@ -1470,12 +1477,96 @@ pub(crate) async fn intake_status(State(state): State<Arc<AppState>>) -> Json<se
             })
         })
         .collect();
+    recent_dispatches.extend(
+        runtime_issue_workflows
+            .iter()
+            .filter(|workflow| runtime_workflow_intake_source(workflow).is_some())
+            .filter_map(runtime_issue_recent_dispatch),
+    );
     recent_dispatches.truncate(10);
 
-    Json(json!({
+    let mut response = json!({
         "channels": [github_channel, feishu_channel, dashboard_channel],
         "recent_dispatches": recent_dispatches,
+    });
+    if runtime_degraded {
+        response["degraded"] = json!({
+            "partial": true,
+            "missing": ["workflow_runtime_submissions"],
+            "reason": "runtime_submission_summaries_unavailable",
+        });
+    }
+    Json(response)
+}
+
+async fn runtime_issue_workflows_for_intake_status(
+    state: &AppState,
+) -> (Vec<WorkflowInstance>, bool) {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return (Vec::new(), false);
+    };
+    match store
+        .list_instances_by_definition(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            None,
+            None,
+        )
+        .await
+    {
+        Ok(workflows) => (workflows, false),
+        Err(error) => {
+            tracing::error!("intake_status: workflow runtime lookup failed: {error}");
+            (Vec::new(), true)
+        }
+    }
+}
+
+fn runtime_issue_recent_dispatch(workflow: &WorkflowInstance) -> Option<serde_json::Value> {
+    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+    let task_id = projection.submission_handle?;
+    let source = runtime_workflow_intake_source(workflow)?;
+    Some(json!({
+        "source": source,
+        "external_id": runtime_workflow_external_id(workflow),
+        "tracker_source": runtime_workflow_tracker_source(workflow),
+        "tracker_external_id": runtime_workflow_tracker_external_id(workflow),
+        "task_id": task_id.0,
+        "status": serde_json::to_value(&projection.task_status).unwrap_or(json!("unknown")),
+        "pr_url": runtime_workflow_data_string(workflow, "pr_url"),
     }))
+}
+
+fn runtime_workflow_has_tracker_source(workflow: &WorkflowInstance, source: &str) -> bool {
+    runtime_workflow_tracker_source(workflow)
+        .or_else(|| runtime_workflow_data_string(workflow, "source"))
+        .as_deref()
+        == Some(source)
+}
+
+fn runtime_workflow_intake_source(workflow: &WorkflowInstance) -> Option<String> {
+    runtime_workflow_data_string(workflow, "source")
+        .or_else(|| runtime_workflow_tracker_source(workflow))
+}
+
+fn runtime_workflow_external_id(workflow: &WorkflowInstance) -> Option<String> {
+    runtime_workflow_data_string(workflow, "external_id")
+        .or_else(|| runtime_workflow_tracker_external_id(workflow))
+}
+
+fn runtime_workflow_tracker_source(workflow: &WorkflowInstance) -> Option<String> {
+    runtime_workflow_data_string(workflow, "tracker_source")
+}
+
+fn runtime_workflow_tracker_external_id(workflow: &WorkflowInstance) -> Option<String> {
+    runtime_workflow_data_string(workflow, "tracker_external_id")
+}
+
+fn runtime_workflow_data_string(workflow: &WorkflowInstance, field: &str) -> Option<String> {
+    workflow
+        .data
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -34,7 +34,7 @@ const WORKFLOW_RUNTIME_TREE_MAX_REJECTED_DECISION_LIMIT: i64 = 20;
 
 #[derive(Debug)]
 struct IntakeRecentDispatch {
-    sort_at: Option<chrono::DateTime<chrono::Utc>>,
+    sort_at: Option<i64>,
     payload: serde_json::Value,
 }
 
@@ -1481,7 +1481,7 @@ pub(crate) async fn intake_status(State(state): State<Arc<AppState>>) -> Json<se
             .filter(|workflow| runtime_workflow_intake_source(workflow).is_some())
             .filter_map(runtime_issue_recent_dispatch),
     );
-    recent_dispatches.sort_by(|left, right| right.sort_at.cmp(&left.sort_at));
+    recent_dispatches.sort_by_key(|dispatch| std::cmp::Reverse(dispatch.sort_at));
     let recent_dispatches: Vec<serde_json::Value> = recent_dispatches
         .into_iter()
         .take(10)
@@ -1545,7 +1545,7 @@ fn runtime_issue_recent_dispatch(workflow: &WorkflowInstance) -> Option<IntakeRe
     let task_id = projection.submission_handle?;
     let source = runtime_workflow_intake_source(workflow)?;
     Some(IntakeRecentDispatch {
-        sort_at: Some(workflow.created_at),
+        sort_at: Some(workflow.created_at.timestamp_micros()),
         payload: json!({
             "source": source,
             "external_id": runtime_workflow_external_id(workflow),
@@ -1558,10 +1558,10 @@ fn runtime_issue_recent_dispatch(workflow: &WorkflowInstance) -> Option<IntakeRe
     })
 }
 
-fn parse_rfc3339_utc(value: Option<&str>) -> Option<chrono::DateTime<chrono::Utc>> {
+fn parse_rfc3339_utc(value: Option<&str>) -> Option<i64> {
     value
         .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
-        .map(|value| value.with_timezone(&chrono::Utc))
+        .map(|value| value.timestamp_micros())
 }
 
 fn workflow_runtime_submissions_expected_but_unavailable(state: &AppState) -> bool {

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -20,7 +20,13 @@ struct RuntimeTaskResponse {
     execution_path: &'static str,
     workflow_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     external_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tracker_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tracker_external_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     repo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -121,7 +127,10 @@ async fn runtime_task_response_by_handle(
         status: workflow.state.clone(),
         execution_path: "workflow_runtime",
         workflow_id: workflow.id.clone(),
+        source: runtime_string_field(&workflow.data, "source"),
         external_id,
+        tracker_source: runtime_string_field(&workflow.data, "tracker_source"),
+        tracker_external_id: runtime_string_field(&workflow.data, "tracker_external_id"),
         repo: workflow
             .data
             .get("repo")

--- a/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
+++ b/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
@@ -128,6 +128,82 @@ async fn intake_status_recent_dispatches_empty_initially() -> anyhow::Result<()>
 }
 
 #[tokio::test]
+async fn intake_status_includes_runtime_github_issue_dispatches() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+        enabled: true,
+        repo: "owner/repo".to_string(),
+        ..Default::default()
+    });
+    let state = make_test_state_with_workflow_runtime_config_and_registry(
+        dir.path(),
+        &project_root,
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let task_id = task_runner::TaskId::from_str("runtime-github-intake-status");
+    crate::workflow_runtime_submission::record_issue_submission(
+        store,
+        crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 65,
+            task_id: &task_id,
+            labels: &[],
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("github"),
+            external_id: Some("issue:65"),
+        },
+    )
+    .await?;
+    let app = intake_app(state);
+
+    use http_body_util::BodyExt;
+    let response = app
+        .oneshot(Request::builder().uri("/api/intake").body(Body::empty())?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await?.to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body)?;
+    let github = json["channels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["name"] == "github")
+        .expect("github channel present");
+    assert_eq!(github["active"], 1);
+    let dispatch = json["recent_dispatches"]
+        .as_array()
+        .expect("recent dispatches should be an array")
+        .iter()
+        .find(|dispatch| dispatch["task_id"] == "runtime-github-intake-status")
+        .expect("runtime GitHub issue dispatch should be listed");
+    assert_eq!(dispatch["source"], "github");
+    assert_eq!(dispatch["external_id"], "issue:65");
+    assert_eq!(dispatch["tracker_source"], "github");
+    assert_eq!(dispatch["tracker_external_id"], "issue:65");
+    Ok(())
+}
+
+#[tokio::test]
 async fn intake_status_disables_feishu_when_verification_token_missing() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_test_state_with_feishu(dir.path(), None).await?;

--- a/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
+++ b/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
@@ -204,6 +204,110 @@ async fn intake_status_includes_runtime_github_issue_dispatches() -> anyhow::Res
 }
 
 #[tokio::test]
+async fn intake_status_merges_runtime_dispatches_by_recency_before_limit() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let old_created_at = Utc::now() - chrono::Duration::hours(2);
+    for index in 0..10 {
+        let mut task = task_runner::TaskState::new(task_runner::TaskId::from_str(&format!(
+            "legacy-github-intake-{index}"
+        )));
+        task.source = Some("github".to_string());
+        task.external_id = Some(format!("issue:{index}"));
+        task.created_at = Some((old_created_at - chrono::Duration::minutes(index)).to_rfc3339());
+        state.core.tasks.insert(&task).await;
+    }
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let task_id = task_runner::TaskId::from_str("runtime-newest-intake-status");
+    crate::workflow_runtime_submission::record_issue_submission(
+        store,
+        crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 165,
+            task_id: &task_id,
+            labels: &[],
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("github"),
+            external_id: Some("issue:165"),
+        },
+    )
+    .await?;
+    let app = intake_app(state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/intake").body(Body::empty())?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = response_json(response).await?;
+    let dispatches = json["recent_dispatches"]
+        .as_array()
+        .expect("recent dispatches should be an array");
+    assert_eq!(dispatches.len(), 10);
+    assert_eq!(dispatches[0]["task_id"], "runtime-newest-intake-status");
+    assert!(
+        dispatches
+            .iter()
+            .any(|dispatch| dispatch["task_id"] == "runtime-newest-intake-status"),
+        "newer runtime dispatch should not be truncated by older legacy rows"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn intake_status_marks_runtime_submissions_degraded_when_store_unavailable(
+) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut state = make_read_only_route_test_state(dir.path()).await?;
+    let state_mut =
+        Arc::get_mut(&mut state).ok_or_else(|| anyhow::anyhow!("expected unique state"))?;
+    state_mut.startup_statuses =
+        vec![
+            crate::http::state::StoreStartupResult::optional("workflow_runtime_store")
+                .failed("failed to connect to Postgres"),
+        ];
+    state_mut.degraded_subsystems = vec!["workflow_runtime_store"];
+    let app = intake_app(state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/intake").body(Body::empty())?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = response_json(response).await?;
+    assert_eq!(json["degraded"]["partial"], true);
+    assert_eq!(
+        json["degraded"]["missing"],
+        serde_json::json!(["workflow_runtime_submissions"])
+    );
+    assert_eq!(
+        json["degraded"]["reason"],
+        "runtime_submission_summaries_unavailable"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn intake_status_disables_feishu_when_verification_token_missing() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_test_state_with_feishu(dir.path(), None).await?;

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -113,6 +113,9 @@ async fn list_tasks_includes_runtime_issue_submissions() -> anyhow::Result<()> {
     assert_eq!(runtime_task["workflow"]["definition_id"], "github_issue_pr");
     assert_eq!(runtime_task["workflow"]["state"], "planning");
     assert_eq!(runtime_task["workflow"]["issue_number"], 52);
+    assert!(runtime_task
+        .get("source")
+        .is_none_or(serde_json::Value::is_null));
 
     let planning_response = app
         .oneshot(
@@ -130,6 +133,67 @@ async fn list_tasks_includes_runtime_issue_submissions() -> anyhow::Result<()> {
         planning_tasks.iter().any(|task| task["id"] == task_id),
         "status=planning should include runtime-backed planning workflows"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_task_runtime_issue_exposes_tracker_identity() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let task_id = harness_core::types::TaskId::from_str("runtime-github-issue-detail");
+
+    crate::workflow_runtime_submission::record_issue_submission(
+        store,
+        crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 64,
+            task_id: &task_id,
+            labels: &[],
+            force_execute: false,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("github"),
+            external_id: Some("issue:64"),
+        },
+    )
+    .await?;
+    let app = Router::new()
+        .route("/tasks/{id}", get(get_task))
+        .with_state(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks/runtime-github-issue-detail")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["source"], "github");
+    assert_eq!(body["external_id"], "issue:64");
+    assert_eq!(body["tracker_source"], "github");
+    assert_eq!(body["tracker_external_id"], "issue:64");
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests/webhook_task_tests.rs
+++ b/crates/harness-server/src/http/tests/webhook_task_tests.rs
@@ -47,14 +47,46 @@ async fn webhook_issue_mention_schedules_runtime_issue() -> anyhow::Result<()> {
     assert_eq!(json["status"], "planning");
     assert_eq!(json["execution_path"], "workflow_runtime");
     assert_eq!(state.core.tasks.count(), before_count);
-    assert_runtime_issue_submission(
+    let task_id = json["task_id"]
+        .as_str()
+        .expect("task id should be present")
+        .to_string();
+    let workflow_id = assert_runtime_issue_submission(
         &state,
         dir.path(),
         Some("majiayu000/harness"),
         106,
-        json["task_id"].as_str().expect("task id should be present"),
+        &task_id,
     )
     .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("runtime workflow should be persisted");
+    assert_eq!(instance.data["source"], "github");
+    assert_eq!(instance.data["external_id"], "issue:106");
+    assert_eq!(instance.data["tracker_source"], "github");
+    assert_eq!(instance.data["tracker_external_id"], "issue:106");
+
+    let detail_response = task_app(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/tasks/{task_id}"))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(detail_response.status(), StatusCode::OK);
+    let detail = response_json(detail_response).await?;
+    assert_eq!(detail["source"], "github");
+    assert_eq!(detail["external_id"], "issue:106");
+    assert_eq!(detail["tracker_source"], "github");
+    assert_eq!(detail["tracker_external_id"], "issue:106");
     Ok(())
 }
 

--- a/crates/harness-server/src/webhook.rs
+++ b/crates/harness-server/src/webhook.rs
@@ -86,6 +86,8 @@ fn issue_task_request(issue_number: u64, repo: &str) -> CreateTaskRequest {
     let mut req = CreateTaskRequest::default();
     req.issue = Some(issue_number);
     req.repo = Some(repo.to_string());
+    req.source = Some("github".to_string());
+    req.external_id = Some(format!("issue:{issue_number}"));
     req
 }
 

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -16,6 +16,7 @@ use harness_workflow::runtime::WorkflowCommandType;
 const GITHUB_ISSUE_PR_DEFINITION_ID: &str = "github_issue_pr";
 const EXECUTION_PATH_WORKFLOW_RUNTIME: &str = "workflow_runtime";
 const PROMPT_TASK_DESCRIPTION: &str = "prompt task";
+const GITHUB_TRACKER_SOURCE: &str = "github";
 
 #[path = "workflow_runtime_submission/cancel.rs"]
 mod cancel;
@@ -357,8 +358,43 @@ fn issue_submission_data(
             "dependencies_blocked": ctx.dependencies_blocked,
             "source": ctx.source,
             "external_id": ctx.external_id,
+            "tracker_source": issue_tracker_source(ctx),
+            "tracker_external_id": issue_tracker_external_id(ctx),
         }),
     )
+}
+
+pub(super) fn issue_tracker_source(
+    ctx: &IssueSubmissionRuntimeContext<'_>,
+) -> Option<&'static str> {
+    ctx.source
+        .filter(|source| source.eq_ignore_ascii_case(GITHUB_TRACKER_SOURCE))
+        .map(|_| GITHUB_TRACKER_SOURCE)
+}
+
+pub(super) fn issue_tracker_external_id(ctx: &IssueSubmissionRuntimeContext<'_>) -> Option<String> {
+    issue_tracker_source(ctx)?;
+    Some(canonical_issue_external_id(
+        ctx.external_id,
+        ctx.issue_number,
+    ))
+}
+
+fn canonical_issue_external_id(external_id: Option<&str>, issue_number: u64) -> String {
+    let external_id = external_id
+        .map(str::trim)
+        .filter(|external_id| !external_id.is_empty())
+        .unwrap_or("");
+    if external_id.is_empty() {
+        return format!("issue:{issue_number}");
+    }
+    if external_id.starts_with("issue:") {
+        external_id.to_string()
+    } else if external_id.chars().all(|ch| ch.is_ascii_digit()) {
+        format!("issue:{external_id}")
+    } else {
+        external_id.to_string()
+    }
 }
 
 fn prompt_submission_data(
@@ -407,6 +443,8 @@ struct IssueSubmissionFields {
     labels: Vec<String>,
     force_execute: bool,
     additional_prompt: Option<String>,
+    tracker_source: Option<String>,
+    tracker_external_id: Option<String>,
 }
 
 fn issue_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<IssueSubmissionFields> {
@@ -425,6 +463,8 @@ fn issue_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<IssueS
             .and_then(|value| value.as_bool())
             .unwrap_or(false),
         additional_prompt: optional_string_field(&instance.data, "additional_prompt"),
+        tracker_source: optional_string_field(&instance.data, "tracker_source"),
+        tracker_external_id: optional_string_field(&instance.data, "tracker_external_id"),
     })
 }
 

--- a/crates/harness-server/src/workflow_runtime_submission/commit.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/commit.rs
@@ -293,6 +293,10 @@ fn issue_submission_event_payload(ctx: &IssueSubmissionRuntimeContext<'_>) -> se
         "additional_prompt": ctx.additional_prompt,
         "depends_on": depends_on_strings(ctx.depends_on),
         "dependencies_blocked": ctx.dependencies_blocked,
+        "source": ctx.source,
+        "external_id": ctx.external_id,
+        "tracker_source": super::issue_tracker_source(ctx),
+        "tracker_external_id": super::issue_tracker_external_id(ctx),
         "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
     })
 }

--- a/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
@@ -353,6 +353,8 @@ async fn release_issue_after_dependencies(
                 "repo": fields.repo,
                 "issue_number": fields.issue_number,
                 "depends_on": depends_on_strings(depends_on),
+                "tracker_source": fields.tracker_source,
+                "tracker_external_id": fields.tracker_external_id,
                 "execution_path": super::EXECUTION_PATH_WORKFLOW_RUNTIME,
             }),
         )

--- a/crates/harness-server/src/workflow_runtime_submission/identity_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/identity_tests.rs
@@ -45,12 +45,25 @@ async fn issue_submission_records_explicit_submission_id() -> anyhow::Result<()>
         .await?
         .expect("issue workflow should be persisted");
     assert_eq!(instance.data["submission_id"], "issue-submission-id");
+    assert_eq!(instance.data["source"], "github");
+    assert_eq!(instance.data["external_id"], "issue:1129");
+    assert_eq!(instance.data["tracker_source"], "github");
+    assert_eq!(instance.data["tracker_external_id"], "issue:1129");
     assert_eq!(
         runtime_issue_task_handle(&instance)
             .expect("issue workflow should expose submission id")
             .as_str(),
         "issue-submission-id"
     );
+    let events = store.events_for(&workflow_id).await?;
+    let submitted = events
+        .iter()
+        .find(|event| event.event_type == "IssueSubmitted")
+        .expect("issue submission event should be recorded");
+    assert_eq!(submitted.event["source"], "github");
+    assert_eq!(submitted.event["external_id"], "issue:1129");
+    assert_eq!(submitted.event["tracker_source"], "github");
+    assert_eq!(submitted.event["tracker_external_id"], "issue:1129");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- tag GitHub webhook issue submissions with explicit source/external identity
- persist tracker identity on runtime issue submission data and events
- expose runtime tracker identity from task detail and intake status APIs
- merge legacy and runtime intake dispatches by recency before applying the recent-dispatch cap
- mark intake status degraded when workflow runtime submissions are expected but the runtime store is unavailable

## Validation
- cargo fmt --all -- --check
- cargo check -p harness-server --all-targets
- cargo test -p harness-server intake_auth_list_tests
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo test -p harness-agents codex::tests::execute_kills_descendant_that_keeps_output_pipe_open_after_root_exit
- cargo test -p harness-server --test notification_delivery -- --test-threads=1

Note: default parallel `cargo test` hit local Postgres pool timeouts in `notification_delivery`; the same integration test passed with `--test-threads=1`.

Closes #875
