### PR TITLE
storage: migrate thread_db to shared schema

### DIFF
--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -1,5 +1,5 @@
-use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
-use sqlx::{Acquire as _, Postgres, Transaction};
+use sqlx::postgres::{PgConnectOptions, PgConnection, PgPool, PgPoolOptions};
+use sqlx::Acquire as _;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
@@ -583,15 +583,41 @@ impl<'a> PgMigrator<'a> {
     }
 
     pub async fn run(&self) -> anyhow::Result<()> {
-        let mut tx = self.pool.begin().await?;
+        let mut conn = self.pool.acquire().await?;
+        // Keep the schema-level lock and migration work on one connection; some
+        // deployments intentionally run store pools with a single session.
         sqlx::query(
-            "SELECT pg_advisory_xact_lock(
-                hashtextextended('harness_schema_migrations:' || current_schema(), 0)
-            )",
+            "SELECT pg_advisory_lock(hashtext(current_database()), hashtext(current_schema()))",
         )
-        .execute(&mut *tx)
+        .execute(&mut *conn)
         .await?;
 
+        let result = self.run_locked(&mut conn).await;
+        let unlock_result: Result<bool, sqlx::Error> = sqlx::query_scalar(
+            "SELECT pg_advisory_unlock(hashtext(current_database()), hashtext(current_schema()))",
+        )
+        .fetch_one(&mut *conn)
+        .await;
+
+        match (result, unlock_result) {
+            (Ok(()), Ok(true)) => Ok(()),
+            (Ok(()), Ok(false)) => Err(anyhow::anyhow!(
+                "Postgres migration advisory lock was not held at release time"
+            )),
+            (Ok(()), Err(error)) => Err(anyhow::anyhow!(
+                "failed to release Postgres migration advisory lock: {error}"
+            )),
+            (Err(error), Ok(true)) => Err(error),
+            (Err(error), Ok(false)) => Err(anyhow::anyhow!(
+                "{error}; Postgres migration advisory lock was not held at release time"
+            )),
+            (Err(error), Err(unlock_error)) => Err(anyhow::anyhow!(
+                "{error}; additionally failed to release Postgres migration advisory lock: {unlock_error}"
+            )),
+        }
+    }
+
+    async fn run_locked(&self, conn: &mut PgConnection) -> anyhow::Result<()> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS schema_migrations (
                 version     BIGINT PRIMARY KEY,
@@ -599,12 +625,12 @@ impl<'a> PgMigrator<'a> {
                 applied_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
             )",
         )
-        .execute(&mut *tx)
+        .execute(&mut *conn)
         .await?;
 
         let rows: Vec<(i64,)> =
             sqlx::query_as("SELECT version FROM schema_migrations ORDER BY version ASC")
-                .fetch_all(&mut *tx)
+                .fetch_all(&mut *conn)
                 .await?;
         let applied: HashSet<u32> = rows.into_iter().map(|(v,)| v as u32).collect();
 
@@ -616,18 +642,15 @@ impl<'a> PgMigrator<'a> {
         pending.sort_by_key(|m| m.version);
 
         for migration in pending {
-            Self::apply(&mut tx, migration).await?;
+            self.apply(conn, migration).await?;
         }
-        tx.commit().await?;
         Ok(())
     }
 
-    async fn apply(
-        tx: &mut Transaction<'_, Postgres>,
-        migration: &Migration,
-    ) -> anyhow::Result<()> {
+    async fn apply(&self, conn: &mut PgConnection, migration: &Migration) -> anyhow::Result<()> {
+        let mut tx = conn.begin().await?;
         for stmt in crate::db_pg_split::pg_split_statements(migration.sql) {
-            let mut statement_tx = (&mut *tx).begin().await?;
+            let mut statement_tx = (&mut tx).begin().await?;
             match sqlx::query(&stmt).execute(&mut *statement_tx).await {
                 Ok(_) => {
                     statement_tx.commit().await?;
@@ -651,8 +674,9 @@ impl<'a> PgMigrator<'a> {
         sqlx::query("INSERT INTO schema_migrations (version, description) VALUES ($1, $2)")
             .bind(migration.version as i64)
             .bind(migration.description)
-            .execute(&mut **tx)
+            .execute(&mut *tx)
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 }

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -1,5 +1,5 @@
 use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
-use sqlx::Acquire as _;
+use sqlx::{Acquire as _, Postgres, Transaction};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
@@ -583,6 +583,15 @@ impl<'a> PgMigrator<'a> {
     }
 
     pub async fn run(&self) -> anyhow::Result<()> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query(
+            "SELECT pg_advisory_xact_lock(
+                hashtextextended('harness_schema_migrations:' || current_schema(), 0)
+            )",
+        )
+        .execute(&mut *tx)
+        .await?;
+
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS schema_migrations (
                 version     BIGINT PRIMARY KEY,
@@ -590,12 +599,12 @@ impl<'a> PgMigrator<'a> {
                 applied_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
             )",
         )
-        .execute(self.pool)
+        .execute(&mut *tx)
         .await?;
 
         let rows: Vec<(i64,)> =
             sqlx::query_as("SELECT version FROM schema_migrations ORDER BY version ASC")
-                .fetch_all(self.pool)
+                .fetch_all(&mut *tx)
                 .await?;
         let applied: HashSet<u32> = rows.into_iter().map(|(v,)| v as u32).collect();
 
@@ -607,15 +616,18 @@ impl<'a> PgMigrator<'a> {
         pending.sort_by_key(|m| m.version);
 
         for migration in pending {
-            self.apply(migration).await?;
+            Self::apply(&mut tx, migration).await?;
         }
+        tx.commit().await?;
         Ok(())
     }
 
-    async fn apply(&self, migration: &Migration) -> anyhow::Result<()> {
-        let mut tx = self.pool.begin().await?;
+    async fn apply(
+        tx: &mut Transaction<'_, Postgres>,
+        migration: &Migration,
+    ) -> anyhow::Result<()> {
         for stmt in crate::db_pg_split::pg_split_statements(migration.sql) {
-            let mut statement_tx = (&mut tx).begin().await?;
+            let mut statement_tx = (&mut *tx).begin().await?;
             match sqlx::query(&stmt).execute(&mut *statement_tx).await {
                 Ok(_) => {
                     statement_tx.commit().await?;
@@ -639,9 +651,8 @@ impl<'a> PgMigrator<'a> {
         sqlx::query("INSERT INTO schema_migrations (version, description) VALUES ($1, $2)")
             .bind(migration.version as i64)
             .bind(migration.description)
-            .execute(&mut *tx)
+            .execute(&mut **tx)
             .await?;
-        tx.commit().await?;
         Ok(())
     }
 }

--- a/crates/harness-core/src/db_tests.rs
+++ b/crates/harness-core/src/db_tests.rs
@@ -241,6 +241,43 @@ db_test!(migrator_is_idempotent_on_rerun, {
     Ok(())
 });
 
+db_test!(migrator_serializes_concurrent_runs_for_same_schema, {
+    let path = db_path("mig-concurrent.db")?;
+    let pool_a = open_pool(&path).await?;
+    let pool_b = open_pool(&path).await?;
+    let migrations = [
+        Migration {
+            version: 1,
+            description: "create concurrent items table",
+            sql: "SELECT pg_sleep(0.05);
+                  CREATE TABLE IF NOT EXISTS concurrent_items (
+                      id TEXT PRIMARY KEY,
+                      value TEXT NOT NULL
+                  )",
+        },
+        Migration {
+            version: 2,
+            description: "add concurrent tag column",
+            sql: "ALTER TABLE concurrent_items ADD COLUMN IF NOT EXISTS tag TEXT",
+        },
+    ];
+
+    let migrator_a = Migrator::new(&pool_a, &migrations);
+    let migrator_b = Migrator::new(&pool_b, &migrations);
+    let run_a = migrator_a.run();
+    let run_b = migrator_b.run();
+    let (result_a, result_b) = tokio::join!(run_a, run_b);
+    result_a?;
+    result_b?;
+
+    assert_eq!(applied_versions(&pool_a).await?, vec![1, 2]);
+    assert_eq!(
+        table_columns(&pool_a, "concurrent_items").await?,
+        vec!["id", "value", "tag"]
+    );
+    Ok(())
+});
+
 db_test!(migrator_tolerates_duplicate_column_on_alter_table, {
     let pool = open_pool(&db_path("mig.db")?).await?;
     sqlx::query("CREATE TABLE items (id TEXT PRIMARY KEY, value TEXT NOT NULL, tag TEXT)")

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -59,25 +59,25 @@ pub(crate) async fn build_registry(
     };
 
     // ── Thread DB ─────────────────────────────────────────────────────────────
-    // Constructed through the storage `Backend` seam (RFC Phase 2.2 sample). This
-    // is behavior-identical to the previous inline `PgStoreContext::new(url,
-    // pg_schema_for_path(path))`, but routes the schema strategy through
-    // `StoreLocation` so it lives in one place. `PathDerivedSchema` preserves the
-    // legacy per-path schema for now; switching this store to a shared schema is a
-    // later, deliberate (behavior-changing) step.
     let thread_db_path = harness_core::config::dirs::default_db_path(data_dir, "threads");
-    let thread_context =
-        harness_core::store_backend::PostgresBackend::new(Some(database_url.clone()))
-            .store_context(
-                &harness_core::store_backend::StoreLocation::PathDerivedSchema(thread_db_path),
-            )?;
+    let thread_context = crate::thread_db::ThreadDb::shared_schema_context(Some(&database_url))?;
     let thread_db = match super::forced_startup_error("thread_db") {
         Some(error) => {
             startup_results.push(StoreStartupResult::critical("thread_db").failed(error));
             None
         }
-        None => match crate::thread_db::ThreadDb::open_with_context(&thread_context, &setup_pool)
-            .await
+        None => match async {
+            let thread_db =
+                crate::thread_db::ThreadDb::open_with_context(&thread_context, &setup_pool).await?;
+            crate::thread_db::migrate_legacy_thread_db_if_needed(
+                &thread_db_path,
+                Some(&database_url),
+                &thread_db,
+            )
+            .await?;
+            Ok::<_, anyhow::Error>(thread_db)
+        }
+        .await
         {
             Ok(thread_db) => Some(thread_db),
             Err(error) => {
@@ -612,6 +612,7 @@ mod tests {
     use crate::{server::HarnessServer, thread_manager::ThreadManager};
     use harness_agents::registry::AgentRegistry;
     use harness_core::config::HarnessConfig;
+    use harness_core::db::resolve_database_url;
 
     async fn make_test_server_and_tasks(
         dir: &Path,
@@ -677,6 +678,23 @@ mod tests {
             bundle.plan_cache.contains_key(&plan_id),
             "plan should be hydrated into cache"
         );
+    }
+
+    #[tokio::test]
+    async fn build_registry_opens_thread_db_from_shared_schema() {
+        if resolve_database_url(None).is_err() {
+            return;
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+        let bundle = build_registry(&server, dir.path(), dir.path(), &tasks)
+            .await
+            .expect("build_registry should succeed");
+        let thread_db = bundle
+            .thread_db
+            .as_ref()
+            .unwrap_or_else(|| panic!("thread db should be ready: {:?}", bundle.startup_results));
+        assert_eq!(thread_db.schema(), crate::thread_db::THREAD_DB_SCHEMA);
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -67,8 +67,12 @@ pub(crate) async fn build_registry(
             None
         }
         None => match async {
-            let thread_db =
-                crate::thread_db::ThreadDb::open_with_context(&thread_context, &setup_pool).await?;
+            let thread_db = crate::thread_db::ThreadDb::open_with_context_and_scope(
+                &thread_context,
+                &setup_pool,
+                crate::thread_db::ThreadDb::scope_for_data_dir(data_dir),
+            )
+            .await?;
             crate::thread_db::migrate_legacy_thread_db_if_needed(
                 &thread_db_path,
                 Some(&database_url),
@@ -612,7 +616,6 @@ mod tests {
     use crate::{server::HarnessServer, thread_manager::ThreadManager};
     use harness_agents::registry::AgentRegistry;
     use harness_core::config::HarnessConfig;
-    use harness_core::db::resolve_database_url;
 
     async fn make_test_server_and_tasks(
         dir: &Path,
@@ -682,9 +685,6 @@ mod tests {
 
     #[tokio::test]
     async fn build_registry_opens_thread_db_from_shared_schema() {
-        if resolve_database_url(None).is_err() {
-            return;
-        }
         let dir = tempfile::tempdir().expect("tempdir");
         let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
         let bundle = build_registry(&server, dir.path(), dir.path(), &tasks)
@@ -693,7 +693,7 @@ mod tests {
         let thread_db = bundle
             .thread_db
             .as_ref()
-            .unwrap_or_else(|| panic!("thread db should be ready: {:?}", bundle.startup_results));
+            .expect("thread db should be ready");
         assert_eq!(thread_db.schema(), crate::thread_db::THREAD_DB_SCHEMA);
     }
 

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -67,10 +67,10 @@ pub(crate) async fn build_registry(
             None
         }
         None => match async {
-            let thread_db = crate::thread_db::ThreadDb::open_with_context_and_scope(
+            let thread_db = crate::thread_db::ThreadDb::open_shared_with_data_dir(
                 &thread_context,
                 &setup_pool,
-                crate::thread_db::ThreadDb::scope_for_data_dir(data_dir),
+                data_dir,
             )
             .await?;
             crate::thread_db::migrate_legacy_thread_db_if_needed(

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -7,19 +7,30 @@ use std::path::Path;
 
 pub const THREAD_DB_SCHEMA: &str = "thread_db";
 
-static THREAD_MIGRATIONS: &[Migration] = &[Migration {
-    version: 1,
-    description: "create threads table",
-    sql: "CREATE TABLE IF NOT EXISTS threads (
-        id          TEXT PRIMARY KEY,
-        cwd         TEXT NOT NULL,
-        status      TEXT NOT NULL DEFAULT 'idle',
-        turns       TEXT NOT NULL DEFAULT '[]',
-        metadata    TEXT NOT NULL DEFAULT '{}',
-        created_at  TIMESTAMPTZ NOT NULL,
-        updated_at  TIMESTAMPTZ NOT NULL
-    )",
-}];
+static THREAD_MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        description: "create threads table",
+        sql: "CREATE TABLE IF NOT EXISTS threads (
+            id          TEXT PRIMARY KEY,
+            cwd         TEXT NOT NULL,
+            status      TEXT NOT NULL DEFAULT 'idle',
+            turns       TEXT NOT NULL DEFAULT '[]',
+            metadata    TEXT NOT NULL DEFAULT '{}',
+            created_at  TIMESTAMPTZ NOT NULL,
+            updated_at  TIMESTAMPTZ NOT NULL
+        )",
+    },
+    Migration {
+        version: 2,
+        description: "record legacy thread backfills",
+        sql: "CREATE TABLE IF NOT EXISTS thread_db_legacy_backfills (
+            legacy_schema TEXT PRIMARY KEY,
+            copied_rows   BIGINT NOT NULL DEFAULT 0,
+            backfilled_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    },
+];
 
 #[derive(Clone)]
 pub struct ThreadDb {
@@ -136,6 +147,16 @@ pub async fn migrate_legacy_thread_db_if_needed(
         return Ok(0);
     }
 
+    let already_backfilled: Option<String> = sqlx::query_scalar(
+        "SELECT legacy_schema FROM thread_db_legacy_backfills WHERE legacy_schema = $1",
+    )
+    .bind(legacy_schema)
+    .fetch_optional(&target_db.pool)
+    .await?;
+    if already_backfilled.is_some() {
+        return Ok(0);
+    }
+
     let legacy_table: Option<String> = sqlx::query_scalar(
         "SELECT table_name::text
          FROM information_schema.tables
@@ -160,6 +181,15 @@ pub async fn migrate_legacy_thread_db_if_needed(
         .execute(&target_db.pool)
         .await?
         .rows_affected();
+    sqlx::query(
+        "INSERT INTO thread_db_legacy_backfills (legacy_schema, copied_rows)
+         VALUES ($1, $2)
+         ON CONFLICT (legacy_schema) DO NOTHING",
+    )
+    .bind(legacy_schema)
+    .bind(copied as i64)
+    .execute(&target_db.pool)
+    .await?;
 
     if copied > 0 {
         tracing::info!(
@@ -428,6 +458,19 @@ mod tests {
                 .await?
                 .expect("legacy thread should be present in the shared schema");
             assert_eq!(loaded.project_root, PathBuf::from("/legacy/project"));
+
+            assert!(target_db.delete(thread_id.as_str()).await?);
+            let copied_after_delete =
+                migrate_legacy_thread_db_if_needed(&legacy_path, Some(&database_url), &target_db)
+                    .await?;
+            assert_eq!(
+                copied_after_delete, 0,
+                "completed migration must not recopy legacy threads"
+            );
+            assert!(
+                target_db.get(thread_id.as_str()).await?.is_none(),
+                "completed migration must not resurrect deleted shared threads"
+            );
             Ok::<(), anyhow::Error>(())
         })
         .catch_unwind()

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -33,9 +33,24 @@ static THREAD_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 3,
         description: "scope threads within shared schema",
-        sql: "ALTER TABLE threads ADD COLUMN store_scope TEXT NOT NULL DEFAULT '';
+        sql: "ALTER TABLE threads ADD COLUMN IF NOT EXISTS store_scope TEXT NOT NULL DEFAULT '';
               CREATE INDEX IF NOT EXISTS idx_threads_store_scope_created_at
               ON threads(store_scope, created_at DESC)",
+    },
+    Migration {
+        version: 4,
+        description: "promote thread scope into composite store key",
+        sql: "ALTER TABLE threads ADD COLUMN IF NOT EXISTS store_scope TEXT;
+              ALTER TABLE threads ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE threads
+              SET store_key = COALESCE(NULLIF(store_key, ''), NULLIF(store_scope, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE threads ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE threads ALTER COLUMN store_key SET NOT NULL;
+              ALTER TABLE threads DROP CONSTRAINT IF EXISTS threads_pkey;
+              ALTER TABLE threads ADD CONSTRAINT threads_pkey PRIMARY KEY (store_key, id);
+              CREATE INDEX IF NOT EXISTS idx_threads_store_created_at
+              ON threads (store_key, created_at DESC)",
     },
 ];
 
@@ -43,7 +58,7 @@ static THREAD_MIGRATIONS: &[Migration] = &[
 pub struct ThreadDb {
     pool: PgPool,
     schema: String,
-    store_scope: Option<String>,
+    store_key: String,
 }
 
 impl ThreadDb {
@@ -57,11 +72,12 @@ impl ThreadDb {
     ) -> anyhow::Result<Self> {
         let context = PgStoreContext::from_path(path, configured_database_url)?;
         let schema = context.schema().to_owned();
+        let store_key = schema.clone();
         let pool = context.open_migrated_pool(THREAD_MIGRATIONS).await?;
         Ok(Self {
             pool,
             schema,
-            store_scope: None,
+            store_key,
         })
     }
 
@@ -76,22 +92,23 @@ impl ThreadDb {
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
-        Self::open_with_context_and_optional_scope(context, setup_pool, None).await
-    }
-
-    pub async fn open_with_context_and_scope(
-        context: &PgStoreContext,
-        setup_pool: &PgPool,
-        store_scope: impl Into<String>,
-    ) -> anyhow::Result<Self> {
-        Self::open_with_context_and_optional_scope(context, setup_pool, Some(store_scope.into()))
+        Self::open_with_context_and_store_key(context, setup_pool, context.schema().to_owned())
             .await
     }
 
-    async fn open_with_context_and_optional_scope(
+    pub async fn open_shared_with_data_dir(
         context: &PgStoreContext,
         setup_pool: &PgPool,
-        store_scope: Option<String>,
+        data_dir: &Path,
+    ) -> anyhow::Result<Self> {
+        let store_key = Self::store_key_for_data_dir(data_dir);
+        Self::open_with_context_and_store_key(context, setup_pool, store_key).await
+    }
+
+    async fn open_with_context_and_store_key(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        store_key: String,
     ) -> anyhow::Result<Self> {
         let schema = context.schema().to_owned();
         let pool = context
@@ -100,7 +117,7 @@ impl ThreadDb {
         Ok(Self {
             pool,
             schema,
-            store_scope,
+            store_key,
         })
     }
 
@@ -108,7 +125,7 @@ impl ThreadDb {
         &self.schema
     }
 
-    pub fn scope_for_data_dir(data_dir: &Path) -> String {
+    pub fn store_key_for_data_dir(data_dir: &Path) -> String {
         data_dir
             .canonicalize()
             .unwrap_or_else(|_| data_dir.to_path_buf())
@@ -116,8 +133,8 @@ impl ThreadDb {
             .into_owned()
     }
 
-    fn store_scope_value(&self) -> &str {
-        self.store_scope.as_deref().unwrap_or("")
+    pub fn store_key(&self) -> &str {
+        &self.store_key
     }
 
     pub async fn insert(&self, thread: &Thread) -> anyhow::Result<()> {
@@ -125,12 +142,12 @@ impl ThreadDb {
         let metadata_json = serde_json::to_string(&thread.metadata)?;
         sqlx::query(
             "INSERT INTO threads (
-                id, store_scope, cwd, status, turns, metadata, created_at, updated_at
+                store_key, id, cwd, status, turns, metadata, created_at, updated_at
              )
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
         )
+        .bind(&self.store_key)
         .bind(thread.id.as_str())
-        .bind(self.store_scope_value())
         .bind(thread.project_root.to_string_lossy().as_ref())
         .bind(thread.status.as_ref())
         .bind(&turns_json)
@@ -145,88 +162,49 @@ impl ThreadDb {
     pub async fn update(&self, thread: &Thread) -> anyhow::Result<()> {
         let turns_json = serde_json::to_string(&thread.turns)?;
         let metadata_json = serde_json::to_string(&thread.metadata)?;
-        if let Some(store_scope) = self.store_scope.as_deref() {
-            sqlx::query(
-                "UPDATE threads
-                 SET cwd = $1, status = $2, turns = $3, metadata = $4, updated_at = $5
-                 WHERE id = $6 AND store_scope = $7",
-            )
-            .bind(thread.project_root.to_string_lossy().as_ref())
-            .bind(thread.status.as_ref())
-            .bind(&turns_json)
-            .bind(&metadata_json)
-            .bind(thread.updated_at)
-            .bind(thread.id.as_str())
-            .bind(store_scope)
-            .execute(&self.pool)
-            .await?;
-        } else {
-            sqlx::query(
-                "UPDATE threads
-                 SET cwd = $1, status = $2, turns = $3, metadata = $4, updated_at = $5
-                 WHERE id = $6",
-            )
-            .bind(thread.project_root.to_string_lossy().as_ref())
-            .bind(thread.status.as_ref())
-            .bind(&turns_json)
-            .bind(&metadata_json)
-            .bind(thread.updated_at)
-            .bind(thread.id.as_str())
-            .execute(&self.pool)
-            .await?;
-        }
+        sqlx::query(
+            "UPDATE threads SET cwd = $1, status = $2, turns = $3, metadata = $4, updated_at = $5
+             WHERE store_key = $6 AND id = $7",
+        )
+        .bind(thread.project_root.to_string_lossy().as_ref())
+        .bind(thread.status.as_ref())
+        .bind(&turns_json)
+        .bind(&metadata_json)
+        .bind(thread.updated_at)
+        .bind(&self.store_key)
+        .bind(thread.id.as_str())
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<Thread>> {
-        let row = if let Some(store_scope) = self.store_scope.as_deref() {
-            sqlx::query_as::<_, ThreadRow>(
-                "SELECT * FROM threads WHERE id = $1 AND store_scope = $2",
-            )
-            .bind(id)
-            .bind(store_scope)
-            .fetch_optional(&self.pool)
-            .await?
-        } else {
-            sqlx::query_as::<_, ThreadRow>("SELECT * FROM threads WHERE id = $1")
-                .bind(id)
-                .fetch_optional(&self.pool)
-                .await?
-        };
+        let row = sqlx::query_as::<_, ThreadRow>(
+            "SELECT * FROM threads WHERE store_key = $1 AND id = $2",
+        )
+        .bind(&self.store_key)
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
         row.map(|r| r.into_thread()).transpose()
     }
 
     pub async fn list(&self) -> anyhow::Result<Vec<Thread>> {
-        let rows = if let Some(store_scope) = self.store_scope.as_deref() {
-            sqlx::query_as::<_, ThreadRow>(
-                "SELECT * FROM threads
-                 WHERE store_scope = $1
-                 ORDER BY created_at DESC",
-            )
-            .bind(store_scope)
-            .fetch_all(&self.pool)
-            .await?
-        } else {
-            sqlx::query_as::<_, ThreadRow>("SELECT * FROM threads ORDER BY created_at DESC")
-                .fetch_all(&self.pool)
-                .await?
-        };
+        let rows = sqlx::query_as::<_, ThreadRow>(
+            "SELECT * FROM threads WHERE store_key = $1 ORDER BY created_at DESC",
+        )
+        .bind(&self.store_key)
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter().map(|r| r.into_thread()).collect()
     }
 
     pub async fn delete(&self, id: &str) -> anyhow::Result<bool> {
-        let result = if let Some(store_scope) = self.store_scope.as_deref() {
-            sqlx::query("DELETE FROM threads WHERE id = $1 AND store_scope = $2")
-                .bind(id)
-                .bind(store_scope)
-                .execute(&self.pool)
-                .await?
-        } else {
-            sqlx::query("DELETE FROM threads WHERE id = $1")
-                .bind(id)
-                .execute(&self.pool)
-                .await?
-        };
+        let result = sqlx::query("DELETE FROM threads WHERE store_key = $1 AND id = $2")
+            .bind(&self.store_key)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
         Ok(result.rows_affected() > 0)
     }
 }
@@ -266,14 +244,14 @@ pub async fn migrate_legacy_thread_db_if_needed(
 
     let copy_sql = format!(
         "INSERT INTO threads (
-            id, store_scope, cwd, status, turns, metadata, created_at, updated_at
+            store_key, id, cwd, status, turns, metadata, created_at, updated_at
          )
-         SELECT id, $1, cwd, status, turns, metadata, created_at, updated_at
+         SELECT $1, id, cwd, status, turns, metadata, created_at, updated_at
          FROM \"{legacy_schema}\".threads
-         ON CONFLICT (id) DO NOTHING"
+         ON CONFLICT (store_key, id) DO NOTHING"
     );
     let copied = sqlx::query(&copy_sql)
-        .bind(target_db.store_scope_value())
+        .bind(&target_db.store_key)
         .execute(&target_db.pool)
         .await?
         .rows_affected();
@@ -301,6 +279,7 @@ pub async fn migrate_legacy_thread_db_if_needed(
 
 #[derive(sqlx::FromRow)]
 struct ThreadRow {
+    store_key: String,
     id: String,
     cwd: String,
     status: String,
@@ -312,6 +291,7 @@ struct ThreadRow {
 
 impl ThreadRow {
     fn into_thread(self) -> anyhow::Result<Thread> {
+        let _store_key = self.store_key;
         let id = ThreadId::from_str(&self.id);
         let status = self
             .status
@@ -505,6 +485,92 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn shared_schema_thread_db_keeps_store_rows_isolated() -> anyhow::Result<()> {
+        let database_url = match resolve_database_url(None) {
+            Ok(url) => url,
+            Err(_) => return Ok(()),
+        };
+        let dir = tempfile::tempdir()?;
+        let setup_pool = pg_open_pool(&database_url).await?;
+        let shared_schema = unique_test_schema("thread_db_shared_scope_test");
+        let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+        let store_a_dir = dir.path().join("store-a");
+        let store_b_dir = dir.path().join("store-b");
+        let store_a =
+            ThreadDb::open_shared_with_data_dir(&shared_context, &setup_pool, &store_a_dir).await?;
+        let store_b =
+            ThreadDb::open_shared_with_data_dir(&shared_context, &setup_pool, &store_b_dir).await?;
+
+        let result = std::panic::AssertUnwindSafe(async {
+            assert_ne!(store_a.store_key(), store_b.store_key());
+
+            let mut thread_a = Thread::new(PathBuf::from("/project-a"));
+            thread_a.id = ThreadId::from_str("same-thread-id");
+            let mut thread_b = thread_a.clone();
+            thread_b.project_root = PathBuf::from("/project-b");
+
+            store_a.insert(&thread_a).await?;
+            store_b.insert(&thread_b).await?;
+
+            assert_eq!(store_a.list().await?.len(), 1);
+            assert_eq!(store_b.list().await?.len(), 1);
+            assert_eq!(
+                store_a
+                    .get("same-thread-id")
+                    .await?
+                    .expect("store a thread should exist")
+                    .project_root,
+                PathBuf::from("/project-a")
+            );
+            assert_eq!(
+                store_b
+                    .get("same-thread-id")
+                    .await?
+                    .expect("store b thread should exist")
+                    .project_root,
+                PathBuf::from("/project-b")
+            );
+
+            let mut wrong_store_update = thread_a.clone();
+            wrong_store_update.project_root = PathBuf::from("/wrong-store-update");
+            store_b.update(&wrong_store_update).await?;
+            assert_eq!(
+                store_a
+                    .get("same-thread-id")
+                    .await?
+                    .expect("store a thread should remain")
+                    .project_root,
+                PathBuf::from("/project-a"),
+                "updates must be scoped by store key"
+            );
+
+            assert!(!store_b.delete("missing-thread-id").await?);
+            assert!(store_b.delete("same-thread-id").await?);
+            assert!(
+                store_a.get("same-thread-id").await?.is_some(),
+                "deletes must not cross store keys"
+            );
+            Ok::<(), anyhow::Error>(())
+        })
+        .catch_unwind()
+        .await;
+
+        store_a.pool.close().await;
+        store_b.pool.close().await;
+        let _ = sqlx::query(&format!(
+            "DROP SCHEMA IF EXISTS \"{shared_schema}\" CASCADE"
+        ))
+        .execute(&setup_pool)
+        .await;
+        setup_pool.close().await;
+
+        match result {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
     #[test]
     fn shared_schema_context_uses_fixed_thread_db_schema() -> anyhow::Result<()> {
         let context =
@@ -524,7 +590,9 @@ mod tests {
             Err(_) => return Ok(()),
         };
         let dir = tempfile::tempdir()?;
-        let legacy_path = dir.path().join("threads.db");
+        let target_data_dir = dir.path().join("target-data");
+        let other_data_dir = dir.path().join("other-data");
+        let legacy_path = target_data_dir.join("threads.db");
         let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
             .schema()
             .to_owned();
@@ -532,10 +600,10 @@ mod tests {
         let setup_pool = pg_open_pool(&database_url).await?;
         let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
         let target_db =
-            ThreadDb::open_with_context_and_scope(&target_context, &setup_pool, "data-dir-a")
+            ThreadDb::open_shared_with_data_dir(&target_context, &setup_pool, &target_data_dir)
                 .await?;
         let other_scope_db =
-            ThreadDb::open_with_context_and_scope(&target_context, &setup_pool, "data-dir-b")
+            ThreadDb::open_shared_with_data_dir(&target_context, &setup_pool, &other_data_dir)
                 .await?;
         let legacy_db = ThreadDb::open_with_database_url(&legacy_path, Some(&database_url)).await?;
 

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -136,10 +136,14 @@ pub async fn migrate_legacy_thread_db_if_needed(
         return Ok(0);
     }
 
-    let legacy_table: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::text")
-        .bind(format!("\"{legacy_schema}\".threads"))
-        .fetch_one(&target_db.pool)
-        .await?;
+    let legacy_table: Option<String> = sqlx::query_scalar(
+        "SELECT table_name::text
+         FROM information_schema.tables
+         WHERE table_schema = $1 AND table_name = 'threads'",
+    )
+    .bind(legacy_schema)
+    .fetch_optional(&target_db.pool)
+    .await?;
     if legacy_table.is_none() {
         return Ok(0);
     }
@@ -202,15 +206,18 @@ impl ThreadRow {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::FutureExt;
     use harness_core::db::{pg_open_pool, resolve_database_url};
     use std::path::PathBuf;
 
     fn unique_test_schema(prefix: &str) -> String {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system clock before UNIX epoch")
             .as_nanos();
-        format!("{prefix}_{nanos}")
+        format!("{prefix}_{nanos}_{count}")
     }
 
     async fn open_test_db() -> anyhow::Result<Option<ThreadDb>> {
@@ -401,7 +408,7 @@ mod tests {
         let target_db = ThreadDb::open_with_context(&target_context, &setup_pool).await?;
         let legacy_db = ThreadDb::open_with_database_url(&legacy_path, Some(&database_url)).await?;
 
-        let result = async {
+        let result = std::panic::AssertUnwindSafe(async {
             let thread = Thread::new(PathBuf::from("/legacy/project"));
             let thread_id = thread.id.clone();
             legacy_db.insert(&thread).await?;
@@ -422,23 +429,27 @@ mod tests {
                 .expect("legacy thread should be present in the shared schema");
             assert_eq!(loaded.project_root, PathBuf::from("/legacy/project"));
             Ok::<(), anyhow::Error>(())
-        }
+        })
+        .catch_unwind()
         .await;
 
         legacy_db.pool.close().await;
         target_db.pool.close().await;
-        sqlx::query(&format!(
+        let _ = sqlx::query(&format!(
             "DROP SCHEMA IF EXISTS \"{legacy_schema}\" CASCADE"
         ))
         .execute(&setup_pool)
-        .await?;
-        sqlx::query(&format!(
+        .await;
+        let _ = sqlx::query(&format!(
             "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
         ))
         .execute(&setup_pool)
-        .await?;
+        .await;
         setup_pool.close().await;
 
-        result
+        match result {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }
 }

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -30,12 +30,20 @@ static THREAD_MIGRATIONS: &[Migration] = &[
             backfilled_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
         )",
     },
+    Migration {
+        version: 3,
+        description: "scope threads within shared schema",
+        sql: "ALTER TABLE threads ADD COLUMN store_scope TEXT NOT NULL DEFAULT '';
+              CREATE INDEX IF NOT EXISTS idx_threads_store_scope_created_at
+              ON threads(store_scope, created_at DESC)",
+    },
 ];
 
 #[derive(Clone)]
 pub struct ThreadDb {
     pool: PgPool,
     schema: String,
+    store_scope: Option<String>,
 }
 
 impl ThreadDb {
@@ -50,7 +58,11 @@ impl ThreadDb {
         let context = PgStoreContext::from_path(path, configured_database_url)?;
         let schema = context.schema().to_owned();
         let pool = context.open_migrated_pool(THREAD_MIGRATIONS).await?;
-        Ok(Self { pool, schema })
+        Ok(Self {
+            pool,
+            schema,
+            store_scope: None,
+        })
     }
 
     pub fn shared_schema_context(
@@ -64,25 +76,61 @@ impl ThreadDb {
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
+        Self::open_with_context_and_optional_scope(context, setup_pool, None).await
+    }
+
+    pub async fn open_with_context_and_scope(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        store_scope: impl Into<String>,
+    ) -> anyhow::Result<Self> {
+        Self::open_with_context_and_optional_scope(context, setup_pool, Some(store_scope.into()))
+            .await
+    }
+
+    async fn open_with_context_and_optional_scope(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        store_scope: Option<String>,
+    ) -> anyhow::Result<Self> {
         let schema = context.schema().to_owned();
         let pool = context
             .open_migrated_pool_with_setup_pool(setup_pool, THREAD_MIGRATIONS)
             .await?;
-        Ok(Self { pool, schema })
+        Ok(Self {
+            pool,
+            schema,
+            store_scope,
+        })
     }
 
     pub fn schema(&self) -> &str {
         &self.schema
     }
 
+    pub fn scope_for_data_dir(data_dir: &Path) -> String {
+        data_dir
+            .canonicalize()
+            .unwrap_or_else(|_| data_dir.to_path_buf())
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn store_scope_value(&self) -> &str {
+        self.store_scope.as_deref().unwrap_or("")
+    }
+
     pub async fn insert(&self, thread: &Thread) -> anyhow::Result<()> {
         let turns_json = serde_json::to_string(&thread.turns)?;
         let metadata_json = serde_json::to_string(&thread.metadata)?;
         sqlx::query(
-            "INSERT INTO threads (id, cwd, status, turns, metadata, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            "INSERT INTO threads (
+                id, store_scope, cwd, status, turns, metadata, created_at, updated_at
+             )
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
         )
         .bind(thread.id.as_str())
+        .bind(self.store_scope_value())
         .bind(thread.project_root.to_string_lossy().as_ref())
         .bind(thread.status.as_ref())
         .bind(&turns_json)
@@ -97,41 +145,88 @@ impl ThreadDb {
     pub async fn update(&self, thread: &Thread) -> anyhow::Result<()> {
         let turns_json = serde_json::to_string(&thread.turns)?;
         let metadata_json = serde_json::to_string(&thread.metadata)?;
-        sqlx::query(
-            "UPDATE threads SET cwd = $1, status = $2, turns = $3, metadata = $4, updated_at = $5
-             WHERE id = $6",
-        )
-        .bind(thread.project_root.to_string_lossy().as_ref())
-        .bind(thread.status.as_ref())
-        .bind(&turns_json)
-        .bind(&metadata_json)
-        .bind(thread.updated_at)
-        .bind(thread.id.as_str())
-        .execute(&self.pool)
-        .await?;
+        if let Some(store_scope) = self.store_scope.as_deref() {
+            sqlx::query(
+                "UPDATE threads
+                 SET cwd = $1, status = $2, turns = $3, metadata = $4, updated_at = $5
+                 WHERE id = $6 AND store_scope = $7",
+            )
+            .bind(thread.project_root.to_string_lossy().as_ref())
+            .bind(thread.status.as_ref())
+            .bind(&turns_json)
+            .bind(&metadata_json)
+            .bind(thread.updated_at)
+            .bind(thread.id.as_str())
+            .bind(store_scope)
+            .execute(&self.pool)
+            .await?;
+        } else {
+            sqlx::query(
+                "UPDATE threads
+                 SET cwd = $1, status = $2, turns = $3, metadata = $4, updated_at = $5
+                 WHERE id = $6",
+            )
+            .bind(thread.project_root.to_string_lossy().as_ref())
+            .bind(thread.status.as_ref())
+            .bind(&turns_json)
+            .bind(&metadata_json)
+            .bind(thread.updated_at)
+            .bind(thread.id.as_str())
+            .execute(&self.pool)
+            .await?;
+        }
         Ok(())
     }
 
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<Thread>> {
-        let row = sqlx::query_as::<_, ThreadRow>("SELECT * FROM threads WHERE id = $1")
+        let row = if let Some(store_scope) = self.store_scope.as_deref() {
+            sqlx::query_as::<_, ThreadRow>(
+                "SELECT * FROM threads WHERE id = $1 AND store_scope = $2",
+            )
             .bind(id)
+            .bind(store_scope)
             .fetch_optional(&self.pool)
-            .await?;
+            .await?
+        } else {
+            sqlx::query_as::<_, ThreadRow>("SELECT * FROM threads WHERE id = $1")
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?
+        };
         row.map(|r| r.into_thread()).transpose()
     }
 
     pub async fn list(&self) -> anyhow::Result<Vec<Thread>> {
-        let rows = sqlx::query_as::<_, ThreadRow>("SELECT * FROM threads ORDER BY created_at DESC")
+        let rows = if let Some(store_scope) = self.store_scope.as_deref() {
+            sqlx::query_as::<_, ThreadRow>(
+                "SELECT * FROM threads
+                 WHERE store_scope = $1
+                 ORDER BY created_at DESC",
+            )
+            .bind(store_scope)
             .fetch_all(&self.pool)
-            .await?;
+            .await?
+        } else {
+            sqlx::query_as::<_, ThreadRow>("SELECT * FROM threads ORDER BY created_at DESC")
+                .fetch_all(&self.pool)
+                .await?
+        };
         rows.into_iter().map(|r| r.into_thread()).collect()
     }
 
     pub async fn delete(&self, id: &str) -> anyhow::Result<bool> {
-        let result = sqlx::query("DELETE FROM threads WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+        let result = if let Some(store_scope) = self.store_scope.as_deref() {
+            sqlx::query("DELETE FROM threads WHERE id = $1 AND store_scope = $2")
+                .bind(id)
+                .bind(store_scope)
+                .execute(&self.pool)
+                .await?
+        } else {
+            sqlx::query("DELETE FROM threads WHERE id = $1")
+                .bind(id)
+                .execute(&self.pool)
+                .await?
+        };
         Ok(result.rows_affected() > 0)
     }
 }
@@ -171,13 +266,14 @@ pub async fn migrate_legacy_thread_db_if_needed(
 
     let copy_sql = format!(
         "INSERT INTO threads (
-            id, cwd, status, turns, metadata, created_at, updated_at
+            id, store_scope, cwd, status, turns, metadata, created_at, updated_at
          )
-         SELECT id, cwd, status, turns, metadata, created_at, updated_at
+         SELECT id, $1, cwd, status, turns, metadata, created_at, updated_at
          FROM \"{legacy_schema}\".threads
          ON CONFLICT (id) DO NOTHING"
     );
     let copied = sqlx::query(&copy_sql)
+        .bind(target_db.store_scope_value())
         .execute(&target_db.pool)
         .await?
         .rows_affected();
@@ -435,7 +531,12 @@ mod tests {
         let target_schema = unique_test_schema("thread_db_test");
         let setup_pool = pg_open_pool(&database_url).await?;
         let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
-        let target_db = ThreadDb::open_with_context(&target_context, &setup_pool).await?;
+        let target_db =
+            ThreadDb::open_with_context_and_scope(&target_context, &setup_pool, "data-dir-a")
+                .await?;
+        let other_scope_db =
+            ThreadDb::open_with_context_and_scope(&target_context, &setup_pool, "data-dir-b")
+                .await?;
         let legacy_db = ThreadDb::open_with_database_url(&legacy_path, Some(&database_url)).await?;
 
         let result = std::panic::AssertUnwindSafe(async {
@@ -458,6 +559,14 @@ mod tests {
                 .await?
                 .expect("legacy thread should be present in the shared schema");
             assert_eq!(loaded.project_root, PathBuf::from("/legacy/project"));
+            assert!(
+                other_scope_db.get(thread_id.as_str()).await?.is_none(),
+                "other data_dir scopes must not hydrate legacy threads"
+            );
+            assert!(
+                !other_scope_db.delete(thread_id.as_str()).await?,
+                "other data_dir scopes must not delete backfilled threads"
+            );
 
             assert!(target_db.delete(thread_id.as_str()).await?);
             let copied_after_delete =
@@ -478,6 +587,7 @@ mod tests {
 
         legacy_db.pool.close().await;
         target_db.pool.close().await;
+        other_scope_db.pool.close().await;
         let _ = sqlx::query(&format!(
             "DROP SCHEMA IF EXISTS \"{legacy_schema}\" CASCADE"
         ))

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -1,8 +1,11 @@
 use anyhow::Context;
 use harness_core::db::{Migration, PgStoreContext};
+use harness_core::store_backend::{PostgresBackend, StoreLocation};
 use harness_core::{types::Thread, types::ThreadId, types::ThreadStatus};
 use sqlx::postgres::PgPool;
 use std::path::Path;
+
+pub const THREAD_DB_SCHEMA: &str = "thread_db";
 
 static THREAD_MIGRATIONS: &[Migration] = &[Migration {
     version: 1,
@@ -21,6 +24,7 @@ static THREAD_MIGRATIONS: &[Migration] = &[Migration {
 #[derive(Clone)]
 pub struct ThreadDb {
     pool: PgPool,
+    schema: String,
 }
 
 impl ThreadDb {
@@ -33,18 +37,31 @@ impl ThreadDb {
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
         let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let schema = context.schema().to_owned();
         let pool = context.open_migrated_pool(THREAD_MIGRATIONS).await?;
-        Ok(Self { pool })
+        Ok(Self { pool, schema })
+    }
+
+    pub fn shared_schema_context(
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<PgStoreContext> {
+        PostgresBackend::new(configured_database_url.map(ToOwned::to_owned))
+            .store_context(&StoreLocation::SharedSchema(THREAD_DB_SCHEMA.to_string()))
     }
 
     pub async fn open_with_context(
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
+        let schema = context.schema().to_owned();
         let pool = context
             .open_migrated_pool_with_setup_pool(setup_pool, THREAD_MIGRATIONS)
             .await?;
-        Ok(Self { pool })
+        Ok(Self { pool, schema })
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema
     }
 
     pub async fn insert(&self, thread: &Thread) -> anyhow::Result<()> {
@@ -108,6 +125,50 @@ impl ThreadDb {
     }
 }
 
+pub async fn migrate_legacy_thread_db_if_needed(
+    legacy_path: &Path,
+    configured_database_url: Option<&str>,
+    target_db: &ThreadDb,
+) -> anyhow::Result<u64> {
+    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_schema = legacy_context.schema();
+    if legacy_schema == target_db.schema() {
+        return Ok(0);
+    }
+
+    let legacy_table: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::text")
+        .bind(format!("\"{legacy_schema}\".threads"))
+        .fetch_one(&target_db.pool)
+        .await?;
+    if legacy_table.is_none() {
+        return Ok(0);
+    }
+
+    let copy_sql = format!(
+        "INSERT INTO threads (
+            id, cwd, status, turns, metadata, created_at, updated_at
+         )
+         SELECT id, cwd, status, turns, metadata, created_at, updated_at
+         FROM \"{legacy_schema}\".threads
+         ON CONFLICT (id) DO NOTHING"
+    );
+    let copied = sqlx::query(&copy_sql)
+        .execute(&target_db.pool)
+        .await?
+        .rows_affected();
+
+    if copied > 0 {
+        tracing::info!(
+            copied,
+            legacy_schema,
+            target_schema = target_db.schema(),
+            "thread db migration: backfilled legacy threads into shared schema"
+        );
+    }
+
+    Ok(copied)
+}
+
 #[derive(sqlx::FromRow)]
 struct ThreadRow {
     id: String,
@@ -141,8 +202,16 @@ impl ThreadRow {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harness_core::db::resolve_database_url;
+    use harness_core::db::{pg_open_pool, resolve_database_url};
     use std::path::PathBuf;
+
+    fn unique_test_schema(prefix: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before UNIX epoch")
+            .as_nanos();
+        format!("{prefix}_{nanos}")
+    }
 
     async fn open_test_db() -> anyhow::Result<Option<ThreadDb>> {
         if resolve_database_url(None).is_err() {
@@ -301,5 +370,75 @@ mod tests {
 
         assert!(db.get("missing-id").await?.is_none());
         Ok(())
+    }
+
+    #[test]
+    fn shared_schema_context_uses_fixed_thread_db_schema() -> anyhow::Result<()> {
+        let context =
+            ThreadDb::shared_schema_context(Some("postgres://user:pass@localhost:5432/harness"))?;
+        assert_eq!(context.schema(), THREAD_DB_SCHEMA);
+        assert!(
+            context.ownership().is_none(),
+            "shared thread_db schema must not register path-derived ownership"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_thread_db_migration_backfills_shared_schema() -> anyhow::Result<()> {
+        let database_url = match resolve_database_url(None) {
+            Ok(url) => url,
+            Err(_) => return Ok(()),
+        };
+        let dir = tempfile::tempdir()?;
+        let legacy_path = dir.path().join("threads.db");
+        let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
+            .schema()
+            .to_owned();
+        let target_schema = unique_test_schema("thread_db_test");
+        let setup_pool = pg_open_pool(&database_url).await?;
+        let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+        let target_db = ThreadDb::open_with_context(&target_context, &setup_pool).await?;
+        let legacy_db = ThreadDb::open_with_database_url(&legacy_path, Some(&database_url)).await?;
+
+        let result = async {
+            let thread = Thread::new(PathBuf::from("/legacy/project"));
+            let thread_id = thread.id.clone();
+            legacy_db.insert(&thread).await?;
+
+            let copied =
+                migrate_legacy_thread_db_if_needed(&legacy_path, Some(&database_url), &target_db)
+                    .await?;
+            assert_eq!(copied, 1, "one legacy thread should be copied");
+
+            let copied_again =
+                migrate_legacy_thread_db_if_needed(&legacy_path, Some(&database_url), &target_db)
+                    .await?;
+            assert_eq!(copied_again, 0, "migration must be idempotent");
+
+            let loaded = target_db
+                .get(thread_id.as_str())
+                .await?
+                .expect("legacy thread should be present in the shared schema");
+            assert_eq!(loaded.project_root, PathBuf::from("/legacy/project"));
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+
+        legacy_db.pool.close().await;
+        target_db.pool.close().await;
+        sqlx::query(&format!(
+            "DROP SCHEMA IF EXISTS \"{legacy_schema}\" CASCADE"
+        ))
+        .execute(&setup_pool)
+        .await?;
+        sqlx::query(&format!(
+            "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
+        ))
+        .execute(&setup_pool)
+        .await?;
+        setup_pool.close().await;
+
+        result
     }
 }


### PR DESCRIPTION
## Summary
- open thread_db through a fixed shared Postgres schema instead of the legacy path-derived schema
- backfill existing legacy path-derived thread rows into the shared schema idempotently
- cover shared schema selection, idempotent backfill, and registry startup wiring

## Validation
- cargo fmt --all
- cargo test -p harness-server thread_db
- cargo test -p harness-server build_registry
- cargo fmt --all -- --check
- cargo check -p harness-server --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets

Closes #1339
Refs #1206