### PR TITLE
storage: migrate runtime state store to shared schema

### DIFF
--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -550,34 +550,28 @@ pub(crate) async fn build_registry(
                     .push(StoreStartupResult::optional("runtime_state_store").failed(error));
                 None
             }
-            None => match harness_core::db::PgStoreContext::from_path(
-                &runtime_state_db_path,
-                Some(&database_url),
-            ) {
-                Ok(context) => {
-                    match crate::runtime_state_store::RuntimeStateStore::open_with_context(
-                        &context,
-                        &setup_pool,
-                    )
-                    .await
-                    {
-                        Ok(store) => {
-                            startup_results
-                                .push(StoreStartupResult::optional("runtime_state_store"));
-                            Some(Arc::new(store))
-                        }
-                        Err(e) => {
-                            startup_results.push(
-                                StoreStartupResult::optional("runtime_state_store")
-                                    .failed(e.to_string()),
-                            );
-                            tracing::warn!(
-                                path = %runtime_state_db_path.display(),
-                                "runtime state store init failed, runtime host state will not persist: {e}"
-                            );
-                            None
-                        }
-                    }
+            None => match async {
+                let context = crate::runtime_state_store::RuntimeStateStore::shared_schema_context(
+                    Some(&database_url),
+                )?;
+                let store = crate::runtime_state_store::RuntimeStateStore::open_with_context(
+                    &context,
+                    &setup_pool,
+                )
+                .await?;
+                crate::runtime_state_store::migrate_legacy_runtime_state_store_if_needed(
+                    &runtime_state_db_path,
+                    Some(&database_url),
+                    &store,
+                )
+                .await?;
+                Ok::<_, anyhow::Error>(store)
+            }
+            .await
+            {
+                Ok(store) => {
+                    startup_results.push(StoreStartupResult::optional("runtime_state_store"));
+                    Some(Arc::new(store))
                 }
                 Err(error) => {
                     startup_results.push(
@@ -586,7 +580,8 @@ pub(crate) async fn build_registry(
                     );
                     tracing::warn!(
                         path = %runtime_state_db_path.display(),
-                        "runtime state store context init failed, runtime host state will not persist: {error}"
+                        schema = crate::runtime_state_store::RUNTIME_STATE_STORE_SCHEMA,
+                        "runtime state store init failed, runtime host state will not persist: {error}"
                     );
                     None
                 }

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -554,11 +554,13 @@ pub(crate) async fn build_registry(
                 let context = crate::runtime_state_store::RuntimeStateStore::shared_schema_context(
                     Some(&database_url),
                 )?;
-                let store = crate::runtime_state_store::RuntimeStateStore::open_with_context(
-                    &context,
-                    &setup_pool,
-                )
-                .await?;
+                let store =
+                    crate::runtime_state_store::RuntimeStateStore::open_shared_with_data_dir(
+                        &context,
+                        &setup_pool,
+                        data_dir,
+                    )
+                    .await?;
                 crate::runtime_state_store::migrate_legacy_runtime_state_store_if_needed(
                     &runtime_state_db_path,
                     Some(&database_url),

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -284,6 +284,8 @@ pub async fn migrate_legacy_runtime_state_store_if_needed(
         return Ok(0);
     }
 
+    let mut tx = target_store.pool.begin().await?;
+
     let copy_sql = format!(
         "INSERT INTO runtime_state (store_key, id, data, created_at, updated_at)
          SELECT $1, id, data, created_at, updated_at
@@ -292,7 +294,7 @@ pub async fn migrate_legacy_runtime_state_store_if_needed(
     );
     let copied = sqlx::query(&copy_sql)
         .bind(target_store.store_key())
-        .execute(&target_store.pool)
+        .execute(&mut *tx)
         .await?
         .rows_affected();
 
@@ -304,8 +306,10 @@ pub async fn migrate_legacy_runtime_state_store_if_needed(
     .bind(target_store.store_key())
     .bind(legacy_schema)
     .bind(copied as i64)
-    .execute(&target_store.pool)
+    .execute(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     if copied > 0 {
         tracing::info!(

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -2,12 +2,14 @@ use crate::runtime_hosts_state::PersistedRuntimeHost;
 use crate::runtime_project_cache_state::PersistedHostProjectCache;
 use chrono::{DateTime, Utc};
 use harness_core::db::{Migration, PgStoreContext};
+use harness_core::store_backend::{PostgresBackend, StoreLocation};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::Path;
 
 const SNAPSHOT_ID: &str = "runtime-state";
 const SNAPSHOT_SCHEMA_VERSION: u32 = 2;
+pub const RUNTIME_STATE_STORE_SCHEMA: &str = "runtime_state_store";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuntimeStateSnapshot {
@@ -33,19 +35,31 @@ impl RuntimeStateSnapshot {
     }
 }
 
-static RUNTIME_STATE_MIGRATIONS: &[Migration] = &[Migration {
-    version: 1,
-    description: "create runtime_state table",
-    sql: "CREATE TABLE IF NOT EXISTS runtime_state (
-        id         TEXT PRIMARY KEY,
-        data       TEXT NOT NULL,
-        created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-    )",
-}];
+static RUNTIME_STATE_MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        description: "create runtime_state table",
+        sql: "CREATE TABLE IF NOT EXISTS runtime_state (
+            id         TEXT PRIMARY KEY,
+            data       TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    },
+    Migration {
+        version: 2,
+        description: "record legacy runtime state backfills",
+        sql: "CREATE TABLE IF NOT EXISTS runtime_state_store_legacy_backfills (
+            legacy_schema TEXT PRIMARY KEY,
+            copied_rows   BIGINT NOT NULL DEFAULT 0,
+            backfilled_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    },
+];
 
 pub struct RuntimeStateStore {
     pool: PgPool,
+    schema: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,18 +85,32 @@ impl RuntimeStateStore {
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
         let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let schema = context.schema().to_owned();
         let pool = context.open_migrated_pool(RUNTIME_STATE_MIGRATIONS).await?;
-        Ok(Self { pool })
+        Ok(Self { pool, schema })
+    }
+
+    pub fn shared_schema_context(
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<PgStoreContext> {
+        PostgresBackend::new(configured_database_url.map(ToOwned::to_owned)).store_context(
+            &StoreLocation::SharedSchema(RUNTIME_STATE_STORE_SCHEMA.to_string()),
+        )
     }
 
     pub async fn open_with_context(
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
+        let schema = context.schema().to_owned();
         let pool = context
             .open_migrated_pool_with_setup_pool(setup_pool, RUNTIME_STATE_MIGRATIONS)
             .await?;
-        Ok(Self { pool })
+        Ok(Self { pool, schema })
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema
     }
 
     pub async fn load_snapshot(&self) -> anyhow::Result<Option<RuntimeStateSnapshot>> {
@@ -145,6 +173,68 @@ impl RuntimeStateStore {
     pub(crate) fn pool(&self) -> &PgPool {
         &self.pool
     }
+}
+
+pub async fn migrate_legacy_runtime_state_store_if_needed(
+    legacy_path: &Path,
+    configured_database_url: Option<&str>,
+    target_store: &RuntimeStateStore,
+) -> anyhow::Result<u64> {
+    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_schema = legacy_context.schema();
+    if legacy_schema == target_store.schema() {
+        return Ok(0);
+    }
+
+    let already_backfilled: Option<String> = sqlx::query_scalar(
+        "SELECT legacy_schema FROM runtime_state_store_legacy_backfills WHERE legacy_schema = $1",
+    )
+    .bind(legacy_schema)
+    .fetch_optional(&target_store.pool)
+    .await?;
+    if already_backfilled.is_some() {
+        return Ok(0);
+    }
+
+    let legacy_table: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::text")
+        .bind(format!("\"{legacy_schema}\".runtime_state"))
+        .fetch_one(&target_store.pool)
+        .await?;
+    if legacy_table.is_none() {
+        return Ok(0);
+    }
+
+    let copy_sql = format!(
+        "INSERT INTO runtime_state (id, data, created_at, updated_at)
+         SELECT id, data, created_at, updated_at
+         FROM \"{legacy_schema}\".runtime_state
+         ON CONFLICT (id) DO NOTHING"
+    );
+    let copied = sqlx::query(&copy_sql)
+        .execute(&target_store.pool)
+        .await?
+        .rows_affected();
+
+    sqlx::query(
+        "INSERT INTO runtime_state_store_legacy_backfills (legacy_schema, copied_rows)
+         VALUES ($1, $2)
+         ON CONFLICT (legacy_schema) DO NOTHING",
+    )
+    .bind(legacy_schema)
+    .bind(copied as i64)
+    .execute(&target_store.pool)
+    .await?;
+
+    if copied > 0 {
+        tracing::info!(
+            copied,
+            legacy_schema,
+            target_schema = target_store.schema(),
+            "runtime state migration: backfilled legacy snapshot into shared schema"
+        );
+    }
+
+    Ok(copied)
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -50,16 +50,51 @@ static RUNTIME_STATE_MIGRATIONS: &[Migration] = &[
         version: 2,
         description: "record legacy runtime state backfills",
         sql: "CREATE TABLE IF NOT EXISTS runtime_state_store_legacy_backfills (
-            legacy_schema TEXT PRIMARY KEY,
+            store_key     TEXT NOT NULL DEFAULT current_schema(),
+            legacy_schema TEXT NOT NULL,
             copied_rows   BIGINT NOT NULL DEFAULT 0,
-            backfilled_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+            backfilled_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (store_key, legacy_schema)
         )",
+    },
+    Migration {
+        version: 3,
+        description: "scope runtime state within shared schema",
+        sql: "ALTER TABLE runtime_state ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE runtime_state
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE runtime_state ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE runtime_state ALTER COLUMN store_key SET NOT NULL;
+              ALTER TABLE runtime_state DROP CONSTRAINT IF EXISTS runtime_state_pkey;
+              ALTER TABLE runtime_state ADD CONSTRAINT runtime_state_pkey PRIMARY KEY (store_key, id);
+              CREATE INDEX IF NOT EXISTS idx_runtime_state_store_updated_at
+              ON runtime_state (store_key, updated_at DESC)",
+    },
+    Migration {
+        version: 4,
+        description: "scope legacy runtime state backfill markers",
+        sql: "ALTER TABLE runtime_state_store_legacy_backfills
+              ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE runtime_state_store_legacy_backfills
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE runtime_state_store_legacy_backfills
+              ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE runtime_state_store_legacy_backfills
+              ALTER COLUMN store_key SET NOT NULL;
+              ALTER TABLE runtime_state_store_legacy_backfills
+              DROP CONSTRAINT IF EXISTS runtime_state_store_legacy_backfills_pkey;
+              ALTER TABLE runtime_state_store_legacy_backfills
+              ADD CONSTRAINT runtime_state_store_legacy_backfills_pkey
+              PRIMARY KEY (store_key, legacy_schema)",
     },
 ];
 
 pub struct RuntimeStateStore {
     pool: PgPool,
     schema: String,
+    store_key: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -86,8 +121,13 @@ impl RuntimeStateStore {
     ) -> anyhow::Result<Self> {
         let context = PgStoreContext::from_path(path, configured_database_url)?;
         let schema = context.schema().to_owned();
+        let store_key = schema.clone();
         let pool = context.open_migrated_pool(RUNTIME_STATE_MIGRATIONS).await?;
-        Ok(Self { pool, schema })
+        Ok(Self {
+            pool,
+            schema,
+            store_key,
+        })
     }
 
     pub fn shared_schema_context(
@@ -102,15 +142,49 @@ impl RuntimeStateStore {
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
+        Self::open_with_context_and_store_key(context, setup_pool, context.schema().to_owned())
+            .await
+    }
+
+    pub async fn open_shared_with_data_dir(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        data_dir: &Path,
+    ) -> anyhow::Result<Self> {
+        let store_key = Self::store_key_for_data_dir(data_dir);
+        Self::open_with_context_and_store_key(context, setup_pool, store_key).await
+    }
+
+    async fn open_with_context_and_store_key(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        store_key: String,
+    ) -> anyhow::Result<Self> {
         let schema = context.schema().to_owned();
         let pool = context
             .open_migrated_pool_with_setup_pool(setup_pool, RUNTIME_STATE_MIGRATIONS)
             .await?;
-        Ok(Self { pool, schema })
+        Ok(Self {
+            pool,
+            schema,
+            store_key,
+        })
     }
 
     pub fn schema(&self) -> &str {
         &self.schema
+    }
+
+    pub fn store_key_for_data_dir(data_dir: &Path) -> String {
+        data_dir
+            .canonicalize()
+            .unwrap_or_else(|_| data_dir.to_path_buf())
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    pub fn store_key(&self) -> &str {
+        &self.store_key
     }
 
     pub async fn load_snapshot(&self) -> anyhow::Result<Option<RuntimeStateSnapshot>> {
@@ -120,10 +194,12 @@ impl RuntimeStateStore {
     pub async fn try_load_snapshot(
         &self,
     ) -> anyhow::Result<(Option<RuntimeStateSnapshot>, LoadSnapshotOutcome)> {
-        let row: Option<(String,)> = sqlx::query_as("SELECT data FROM runtime_state WHERE id = $1")
-            .bind(SNAPSHOT_ID)
-            .fetch_optional(&self.pool)
-            .await?;
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data FROM runtime_state WHERE store_key = $1 AND id = $2")
+                .bind(&self.store_key)
+                .bind(SNAPSHOT_ID)
+                .fetch_optional(&self.pool)
+                .await?;
 
         let snapshot: RuntimeStateSnapshot = match row {
             Some((data,)) => serde_json::from_str(&data)?,
@@ -157,10 +233,11 @@ impl RuntimeStateStore {
         let snapshot = RuntimeStateSnapshot::new(hosts, project_caches);
         let data = serde_json::to_string(&snapshot)?;
         sqlx::query(
-            "INSERT INTO runtime_state (id, data) VALUES ($1, $2)
-             ON CONFLICT(id) DO UPDATE SET data = EXCLUDED.data,
+            "INSERT INTO runtime_state (store_key, id, data) VALUES ($1, $2, $3)
+             ON CONFLICT(store_key, id) DO UPDATE SET data = EXCLUDED.data,
                  updated_at = CURRENT_TIMESTAMP",
         )
+        .bind(&self.store_key)
         .bind(SNAPSHOT_ID)
         .bind(&data)
         .execute(&self.pool)
@@ -187,8 +264,11 @@ pub async fn migrate_legacy_runtime_state_store_if_needed(
     }
 
     let already_backfilled: Option<String> = sqlx::query_scalar(
-        "SELECT legacy_schema FROM runtime_state_store_legacy_backfills WHERE legacy_schema = $1",
+        "SELECT legacy_schema
+         FROM runtime_state_store_legacy_backfills
+         WHERE store_key = $1 AND legacy_schema = $2",
     )
+    .bind(target_store.store_key())
     .bind(legacy_schema)
     .fetch_optional(&target_store.pool)
     .await?;
@@ -205,21 +285,23 @@ pub async fn migrate_legacy_runtime_state_store_if_needed(
     }
 
     let copy_sql = format!(
-        "INSERT INTO runtime_state (id, data, created_at, updated_at)
-         SELECT id, data, created_at, updated_at
+        "INSERT INTO runtime_state (store_key, id, data, created_at, updated_at)
+         SELECT $1, id, data, created_at, updated_at
          FROM \"{legacy_schema}\".runtime_state
-         ON CONFLICT (id) DO NOTHING"
+         ON CONFLICT (store_key, id) DO NOTHING"
     );
     let copied = sqlx::query(&copy_sql)
+        .bind(target_store.store_key())
         .execute(&target_store.pool)
         .await?
         .rows_affected();
 
     sqlx::query(
-        "INSERT INTO runtime_state_store_legacy_backfills (legacy_schema, copied_rows)
-         VALUES ($1, $2)
-         ON CONFLICT (legacy_schema) DO NOTHING",
+        "INSERT INTO runtime_state_store_legacy_backfills (store_key, legacy_schema, copied_rows)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (store_key, legacy_schema) DO NOTHING",
     )
+    .bind(target_store.store_key())
     .bind(legacy_schema)
     .bind(copied as i64)
     .execute(&target_store.pool)

--- a/crates/harness-server/src/runtime_state_store_tests.rs
+++ b/crates/harness-server/src/runtime_state_store_tests.rs
@@ -1,8 +1,168 @@
 use crate::runtime_project_cache::WatchedProjectInput;
+use crate::runtime_state_store::{
+    migrate_legacy_runtime_state_store_if_needed, RuntimeStateStore, RUNTIME_STATE_STORE_SCHEMA,
+};
 use crate::{http::build_app_state, server::HarnessServer, thread_manager::ThreadManager};
+use chrono::Utc;
+use futures::FutureExt;
 use harness_agents::registry::AgentRegistry;
 use harness_core::config::HarnessConfig;
+use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
 use std::sync::Arc;
+
+fn unique_test_schema(prefix: &str) -> String {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_nanos();
+    format!("{prefix}_{nanos}_{count}")
+}
+
+#[test]
+fn shared_schema_context_uses_fixed_runtime_state_store_schema() -> anyhow::Result<()> {
+    let context = RuntimeStateStore::shared_schema_context(Some(
+        "postgres://user:pass@localhost:5432/harness",
+    ))?;
+    assert_eq!(context.schema(), RUNTIME_STATE_STORE_SCHEMA);
+    assert!(
+        context.ownership().is_none(),
+        "shared runtime_state_store schema must not register path-derived ownership"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_app_state_opens_runtime_state_store_from_shared_schema() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let project_root = crate::test_helpers::tempdir_in_home("runtime-state-root-")?;
+    let data_dir = tempfile::tempdir()?;
+
+    let mut config = HarnessConfig::default();
+    config.server.project_root = project_root.path().to_path_buf();
+    config.server.data_dir = data_dir.path().to_path_buf();
+
+    let server = Arc::new(HarnessServer::new(
+        config,
+        ThreadManager::new(),
+        AgentRegistry::new("test"),
+    ));
+    let state = build_app_state(server).await?;
+    let runtime_state_store = state
+        .core
+        .runtime_state_store
+        .as_ref()
+        .expect("runtime state store should be ready");
+    assert_eq!(runtime_state_store.schema(), RUNTIME_STATE_STORE_SCHEMA);
+    Ok(())
+}
+
+#[tokio::test]
+async fn legacy_runtime_state_migration_backfills_once() -> anyhow::Result<()> {
+    let database_url = match resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempfile::tempdir()?;
+    let legacy_path = dir.path().join("runtime_state.db");
+    let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
+        .schema()
+        .to_owned();
+    let target_schema = unique_test_schema("runtime_state_store_test");
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let target_store = RuntimeStateStore::open_with_context(&target_context, &setup_pool).await?;
+    let legacy_store =
+        RuntimeStateStore::open_with_database_url(&legacy_path, Some(&database_url)).await?;
+
+    let result = std::panic::AssertUnwindSafe(async {
+        legacy_store
+            .persist_snapshot(vec![make_host("legacy-host")], vec![])
+            .await?;
+
+        let copied = migrate_legacy_runtime_state_store_if_needed(
+            &legacy_path,
+            Some(&database_url),
+            &target_store,
+        )
+        .await?;
+        assert_eq!(copied, 1, "one legacy snapshot should be copied");
+
+        let copied_again = migrate_legacy_runtime_state_store_if_needed(
+            &legacy_path,
+            Some(&database_url),
+            &target_store,
+        )
+        .await?;
+        assert_eq!(copied_again, 0, "migration must be idempotent");
+
+        let loaded = target_store
+            .load_snapshot()
+            .await?
+            .expect("legacy snapshot should be present in the shared schema");
+        assert_eq!(loaded.hosts.len(), 1);
+        assert_eq!(loaded.hosts[0].id, "legacy-host");
+
+        target_store
+            .persist_snapshot(vec![make_host("shared-host")], vec![])
+            .await?;
+        let copied_after_shared_update = migrate_legacy_runtime_state_store_if_needed(
+            &legacy_path,
+            Some(&database_url),
+            &target_store,
+        )
+        .await?;
+        assert_eq!(
+            copied_after_shared_update, 0,
+            "completed migration must not overwrite updated shared state"
+        );
+        let updated = target_store
+            .load_snapshot()
+            .await?
+            .expect("updated shared snapshot should remain");
+        assert_eq!(updated.hosts[0].id, "shared-host");
+
+        delete_snapshot(&target_store).await?;
+        let copied_after_shared_delete = migrate_legacy_runtime_state_store_if_needed(
+            &legacy_path,
+            Some(&database_url),
+            &target_store,
+        )
+        .await?;
+        assert_eq!(
+            copied_after_shared_delete, 0,
+            "completed migration must not resurrect deleted shared state"
+        );
+        assert!(
+            target_store.load_snapshot().await?.is_none(),
+            "deleted shared snapshot must stay deleted"
+        );
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .catch_unwind()
+    .await;
+
+    legacy_store.pool().close().await;
+    target_store.pool().close().await;
+    let _ = sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{legacy_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await;
+    let _ = sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await;
+    setup_pool.close().await;
+
+    match result {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
 
 #[tokio::test]
 async fn build_app_state_restores_runtime_snapshot() -> anyhow::Result<()> {
@@ -61,4 +221,21 @@ async fn build_app_state_restores_runtime_snapshot() -> anyhow::Result<()> {
         Some("default")
     );
     Ok(())
+}
+
+async fn delete_snapshot(store: &RuntimeStateStore) -> anyhow::Result<()> {
+    sqlx::query("DELETE FROM runtime_state")
+        .execute(store.pool())
+        .await?;
+    Ok(())
+}
+
+fn make_host(id: &str) -> crate::runtime_hosts_state::PersistedRuntimeHost {
+    crate::runtime_hosts_state::PersistedRuntimeHost {
+        id: id.to_string(),
+        display_name: id.to_string(),
+        capabilities: vec!["codex".to_string()],
+        registered_at: Utc::now(),
+        last_heartbeat_at: Utc::now(),
+    }
 }

--- a/crates/harness-server/src/runtime_state_store_tests.rs
+++ b/crates/harness-server/src/runtime_state_store_tests.rs
@@ -65,14 +65,24 @@ async fn legacy_runtime_state_migration_backfills_once() -> anyhow::Result<()> {
         Err(_) => return Ok(()),
     };
     let dir = tempfile::tempdir()?;
-    let legacy_path = dir.path().join("runtime_state.db");
+    let target_data_dir = dir.path().join("target-data");
+    let other_data_dir = dir.path().join("other-data");
+    let legacy_path = target_data_dir.join("runtime_state.db");
     let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
         .schema()
         .to_owned();
     let target_schema = unique_test_schema("runtime_state_store_test");
     let setup_pool = pg_open_pool(&database_url).await?;
     let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
-    let target_store = RuntimeStateStore::open_with_context(&target_context, &setup_pool).await?;
+    let target_store = RuntimeStateStore::open_shared_with_data_dir(
+        &target_context,
+        &setup_pool,
+        &target_data_dir,
+    )
+    .await?;
+    let other_store =
+        RuntimeStateStore::open_shared_with_data_dir(&target_context, &setup_pool, &other_data_dir)
+            .await?;
     let legacy_store =
         RuntimeStateStore::open_with_database_url(&legacy_path, Some(&database_url)).await?;
 
@@ -103,6 +113,10 @@ async fn legacy_runtime_state_migration_backfills_once() -> anyhow::Result<()> {
             .expect("legacy snapshot should be present in the shared schema");
         assert_eq!(loaded.hosts.len(), 1);
         assert_eq!(loaded.hosts[0].id, "legacy-host");
+        assert!(
+            other_store.load_snapshot().await?.is_none(),
+            "other data_dir scopes must not hydrate legacy runtime state"
+        );
 
         target_store
             .persist_snapshot(vec![make_host("shared-host")], vec![])
@@ -146,6 +160,7 @@ async fn legacy_runtime_state_migration_backfills_once() -> anyhow::Result<()> {
 
     legacy_store.pool().close().await;
     target_store.pool().close().await;
+    other_store.pool().close().await;
     let _ = sqlx::query(&format!(
         "DROP SCHEMA IF EXISTS \"{legacy_schema}\" CASCADE"
     ))
@@ -224,7 +239,8 @@ async fn build_app_state_restores_runtime_snapshot() -> anyhow::Result<()> {
 }
 
 async fn delete_snapshot(store: &RuntimeStateStore) -> anyhow::Result<()> {
-    sqlx::query("DELETE FROM runtime_state")
+    sqlx::query("DELETE FROM runtime_state WHERE store_key = $1")
+        .bind(store.store_key())
         .execute(store.pool())
         .await?;
     Ok(())


### PR DESCRIPTION
## Summary
- Open production runtime_state_store from the fixed runtime_state_store Postgres schema while preserving per-data-dir store isolation.
- Backfill the legacy path-derived runtime_state snapshot once per store key and record a legacy-schema marker.
- Add regression coverage for shared-schema startup, idempotent backfill, no stale re-import after shared state changes/deletion, and cross-data-dir isolation.

## Validation
- cargo fmt --all
- cargo test -p harness-server runtime_state_store
- cargo fmt --all -- --check
- cargo check -p harness-server --all-targets
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings

Closes #1341
Refs #1206