### PR TITLE
fix(storage): scope task db in shared schema

### DIFF
--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -473,18 +473,17 @@ pub(crate) async fn build_registry(
     }
 
     // ── Workspace manager ─────────────────────────────────────────────────────
-    let tasks_db_path = harness_core::config::dirs::default_db_path(data_dir, "tasks");
-    let task_context =
-        harness_core::db::PgStoreContext::from_path(&tasks_db_path, Some(&database_url))?;
+    let task_context = crate::task_db::TaskDb::shared_schema_context(Some(&database_url))?;
     let workspace_lease_store = match super::forced_startup_error("workspace_lease_store") {
         Some(error) => {
             startup_results
                 .push(StoreStartupResult::optional("workspace_lease_store").failed(error));
             None
         }
-        None => match crate::workspace_lease_store::WorkspaceLeaseStore::open_with_context(
+        None => match crate::workspace_lease_store::WorkspaceLeaseStore::open_shared_with_data_dir(
             &task_context,
             &setup_pool,
+            data_dir,
         )
         .await
         {
@@ -497,7 +496,7 @@ pub(crate) async fn build_registry(
                     StoreStartupResult::optional("workspace_lease_store").failed(error.to_string()),
                 );
                 tracing::warn!(
-                    path = %tasks_db_path.display(),
+                    schema = %crate::task_db::TASK_DB_SCHEMA,
                     "workspace lease store init failed; workspace leases will not persist: {error}"
                 );
                 None

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -86,10 +86,18 @@ pub(crate) async fn build_storage_with_database_url(
         }
     };
 
-    let task_context = harness_core::db::PgStoreContext::from_path(&db_path, Some(&database_url))?;
+    let task_context = crate::task_db::TaskDb::shared_schema_context(Some(&database_url))?;
     let (tasks, task_result) = match super::forced_startup_error("tasks") {
         Some(error) => (None, StoreStartupResult::critical("tasks").failed(error)),
-        None => match TaskStore::open_with_context(&db_path, &task_context, &setup_pool).await {
+        None => match TaskStore::open_shared_with_data_dir(
+            &db_path,
+            &task_context,
+            &setup_pool,
+            data_dir,
+            Some(&database_url),
+        )
+        .await
+        {
             Ok(store) => (Some(store), StoreStartupResult::critical("tasks")),
             Err(error) => (
                 None,
@@ -197,6 +205,28 @@ mod tests {
             bundle.startup_results
         );
         drop(bundle.q_values);
+    }
+
+    #[tokio::test]
+    async fn build_storage_opens_task_store_from_shared_schema() {
+        let database_url = match harness_core::db::resolve_database_url(None) {
+            Ok(url) => url,
+            Err(_) => return,
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bundle = build_storage_with_database_url(dir.path(), Some(&database_url))
+            .await
+            .expect("build_storage should succeed");
+        let tasks = bundle.tasks.expect("tasks store should be ready");
+
+        assert_eq!(
+            tasks.task_db_schema_for_test(),
+            crate::task_db::TASK_DB_SCHEMA
+        );
+        assert_eq!(
+            tasks.task_db_store_key_for_test(),
+            crate::task_db::TaskDb::store_key_for_data_dir(dir.path()).expect("store key")
+        );
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -1,5 +1,6 @@
 mod migrations;
 mod queries_aux;
+mod queries_metrics;
 mod queries_recovery;
 mod queries_tasks;
 mod raw_column_test_overrides;
@@ -8,12 +9,17 @@ mod types;
 pub use types::{RecoveryResult, TaskArtifact, TaskCheckpoint, TaskPrompt};
 
 use harness_core::db::{PgMigrator, PgStoreContext};
+use harness_core::store_backend::{PostgresBackend, StoreLocation};
 use migrations::TASK_MIGRATIONS;
 use sqlx::postgres::PgPool;
 use std::path::Path;
 
+pub const TASK_DB_SCHEMA: &str = "task_db";
+
 pub struct TaskDb {
     pool: PgPool,
+    schema: String,
+    store_key: String,
 }
 
 impl TaskDb {
@@ -32,24 +38,85 @@ impl TaskDb {
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
         let context = PgStoreContext::from_path(db_path, configured_database_url)?;
+        let schema = context.schema().to_owned();
+        let store_key = schema.clone();
         let pool = context.open_migrated_pool(TASK_MIGRATIONS).await?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            schema,
+            store_key,
+        })
+    }
+
+    pub fn shared_schema_context(
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<PgStoreContext> {
+        PostgresBackend::new(configured_database_url.map(ToOwned::to_owned))
+            .store_context(&StoreLocation::SharedSchema(TASK_DB_SCHEMA.to_string()))
     }
 
     pub async fn open_with_context(
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
+        Self::open_with_context_and_store_key(context, setup_pool, context.schema().to_owned())
+            .await
+    }
+
+    pub async fn open_shared_with_data_dir(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        data_dir: &Path,
+    ) -> anyhow::Result<Self> {
+        let store_key = Self::store_key_for_data_dir(data_dir)?;
+        Self::open_with_context_and_store_key(context, setup_pool, store_key).await
+    }
+
+    async fn open_with_context_and_store_key(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        store_key: String,
+    ) -> anyhow::Result<Self> {
+        let schema = context.schema().to_owned();
         let pool = context
             .open_migrated_pool_with_setup_pool(setup_pool, TASK_MIGRATIONS)
             .await?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            schema,
+            store_key,
+        })
     }
 
     pub async fn from_pg_pool(pool: PgPool) -> anyhow::Result<Self> {
-        let db = Self { pool };
+        let schema: String = sqlx::query_scalar("SELECT current_schema()")
+            .fetch_one(&pool)
+            .await?;
+        let db = Self {
+            pool,
+            store_key: schema.clone(),
+            schema,
+        };
         PgMigrator::new(&db.pool, TASK_MIGRATIONS).run().await?;
         Ok(db)
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    pub fn store_key_for_data_dir(data_dir: &Path) -> anyhow::Result<String> {
+        let canonical = data_dir.canonicalize().map_err(|error| {
+            anyhow::anyhow!(
+                "failed to canonicalize task data_dir {}: {error}",
+                data_dir.display()
+            )
+        })?;
+        Ok(canonical.to_string_lossy().into_owned())
+    }
+
+    pub fn store_key(&self) -> &str {
+        &self.store_key
     }
 
     /// Generate Postgres-style positional placeholders: `$start, $start+1, ..., $start+count-1`.
@@ -59,6 +126,147 @@ impl TaskDb {
             .collect::<Vec<_>>()
             .join(", ")
     }
+}
+
+pub async fn migrate_legacy_task_db_if_needed(
+    legacy_path: &Path,
+    configured_database_url: Option<&str>,
+    target_db: &TaskDb,
+) -> anyhow::Result<u64> {
+    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_schema = legacy_context.schema();
+    if legacy_schema == target_db.schema() {
+        return Ok(0);
+    }
+
+    let already_backfilled: Option<String> = sqlx::query_scalar(
+        "SELECT legacy_schema
+         FROM task_db_legacy_backfills
+         WHERE store_key = $1 AND legacy_schema = $2",
+    )
+    .bind(target_db.store_key())
+    .bind(legacy_schema)
+    .fetch_optional(&target_db.pool)
+    .await?;
+    if already_backfilled.is_some() {
+        return Ok(0);
+    }
+
+    let legacy_table: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::text")
+        .bind(format!("{}.tasks", quote_pg_ident(legacy_schema)))
+        .fetch_one(&target_db.pool)
+        .await?;
+    if legacy_table.is_none() {
+        return Ok(0);
+    }
+
+    let legacy_pool = legacy_context.open_migrated_pool(TASK_MIGRATIONS).await?;
+    legacy_pool.close().await;
+
+    let legacy_schema_sql = quote_pg_ident(legacy_schema);
+    let mut tx = target_db.pool.begin().await?;
+
+    let tasks_sql = format!(
+        "INSERT INTO tasks (
+            store_key, id, task_kind, status, failure_kind, turn, pr_url, rounds, error, source,
+            external_id, parent_id, created_at, updated_at, repo, depends_on, project,
+            workspace_path, workspace_owner, run_generation, priority, phase, description,
+            request_settings, scheduler_state, version, system_input
+         )
+         SELECT $1, id, task_kind, status, failure_kind, turn, pr_url, rounds, error, source,
+                external_id, parent_id, created_at, updated_at, repo, depends_on, project,
+                workspace_path, workspace_owner, run_generation, priority, phase, description,
+                request_settings, scheduler_state, version, system_input
+         FROM {legacy_schema_sql}.tasks
+         ON CONFLICT (store_key, id) DO NOTHING"
+    );
+    let copied_tasks = sqlx::query(&tasks_sql)
+        .bind(target_db.store_key())
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+
+    let artifacts_sql = format!(
+        "INSERT INTO task_artifacts (store_key, task_id, turn, artifact_type, content, created_at)
+         SELECT $1, task_id, turn, artifact_type, content, created_at
+         FROM {legacy_schema_sql}.task_artifacts
+         ORDER BY id
+         ON CONFLICT DO NOTHING"
+    );
+    sqlx::query(&artifacts_sql)
+        .bind(target_db.store_key())
+        .execute(&mut *tx)
+        .await?;
+
+    let checkpoints_sql = format!(
+        "INSERT INTO task_checkpoints (
+            store_key, task_id, triage_output, plan_output, pr_url, last_phase, updated_at
+         )
+         SELECT $1, task_id, triage_output, plan_output, pr_url, last_phase, updated_at
+         FROM {legacy_schema_sql}.task_checkpoints
+         ON CONFLICT (store_key, task_id) DO NOTHING"
+    );
+    sqlx::query(&checkpoints_sql)
+        .bind(target_db.store_key())
+        .execute(&mut *tx)
+        .await?;
+
+    let prompts_sql = format!(
+        "INSERT INTO task_prompts (store_key, task_id, turn, phase, prompt, created_at)
+         SELECT $1, task_id, turn, phase, prompt, created_at
+         FROM {legacy_schema_sql}.task_prompts
+         ORDER BY id
+         ON CONFLICT (store_key, task_id, turn, phase) DO NOTHING"
+    );
+    sqlx::query(&prompts_sql)
+        .bind(target_db.store_key())
+        .execute(&mut *tx)
+        .await?;
+
+    let leases_sql = format!(
+        "INSERT INTO workspace_leases (
+            store_key, project_key, slot_index, task_id, workspace_key, workspace_path, source_repo,
+            repo, runtime_workflow_id, owner_session, run_generation, process_id,
+            process_started_at, state, acquired_at, released_at, last_used_at
+         )
+         SELECT $1, project_key, slot_index, task_id, workspace_key, workspace_path, source_repo,
+                repo, runtime_workflow_id, owner_session, run_generation, process_id,
+                process_started_at, state, acquired_at, released_at, last_used_at
+         FROM {legacy_schema_sql}.workspace_leases
+         ON CONFLICT (store_key, project_key, slot_index) DO NOTHING"
+    );
+    sqlx::query(&leases_sql)
+        .bind(target_db.store_key())
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query(
+        "INSERT INTO task_db_legacy_backfills (store_key, legacy_schema, copied_rows)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (store_key, legacy_schema) DO NOTHING",
+    )
+    .bind(target_db.store_key())
+    .bind(legacy_schema)
+    .bind(copied_tasks as i64)
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+
+    if copied_tasks > 0 {
+        tracing::info!(
+            copied = copied_tasks,
+            legacy_schema,
+            target_schema = target_db.schema(),
+            "task db migration: backfilled legacy tasks into shared schema"
+        );
+    }
+
+    Ok(copied_tasks)
+}
+
+fn quote_pg_ident(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/task_db/migrations.rs
+++ b/crates/harness-server/src/task_db/migrations.rs
@@ -20,6 +20,7 @@ use harness_core::db::Migration;
 /// v23 – add indexes for server-side task list filters.
 /// v24 – add persisted workspace lease rows for the per-project worktree pool.
 /// v25 – add process start-time proof to persisted workspace leases.
+/// v26 – scope task-owned tables within a fixed shared schema using store_key.
 pub(super) static TASK_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 1,
@@ -187,6 +188,88 @@ pub(super) static TASK_MIGRATIONS: &[Migration] = &[
         description: "add process start-time proof to workspace leases",
         sql: "ALTER TABLE workspace_leases ADD COLUMN process_started_at BIGINT NOT NULL DEFAULT 0",
     },
+    Migration {
+        version: 26,
+        description: "scope task db rows within shared schema",
+        sql: "ALTER TABLE tasks ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE tasks
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE tasks ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE tasks ALTER COLUMN store_key SET NOT NULL;
+              ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_pkey;
+              ALTER TABLE tasks ADD CONSTRAINT tasks_pkey PRIMARY KEY (store_key, id);
+              CREATE INDEX IF NOT EXISTS idx_tasks_store_created
+              ON tasks(store_key, created_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_tasks_store_status_updated
+              ON tasks(store_key, status, updated_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_tasks_store_project_status_updated
+              ON tasks(store_key, project, status, updated_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_tasks_store_repo_created
+              ON tasks(store_key, repo, created_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_tasks_store_source_created
+              ON tasks(store_key, source, created_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_tasks_store_kind_created
+              ON tasks(store_key, task_kind, created_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_tasks_store_scheduler_state_created
+              ON tasks(store_key, (scheduler_state::jsonb ->> 'authority_state'), created_at DESC);
+
+              ALTER TABLE task_artifacts ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE task_artifacts
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE task_artifacts ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE task_artifacts ALTER COLUMN store_key SET NOT NULL;
+              CREATE INDEX IF NOT EXISTS idx_task_artifacts_store_task_id
+              ON task_artifacts(store_key, task_id, turn, id);
+
+              ALTER TABLE task_checkpoints ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE task_checkpoints
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE task_checkpoints ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE task_checkpoints ALTER COLUMN store_key SET NOT NULL;
+              ALTER TABLE task_checkpoints DROP CONSTRAINT IF EXISTS task_checkpoints_pkey;
+              ALTER TABLE task_checkpoints
+              ADD CONSTRAINT task_checkpoints_pkey PRIMARY KEY (store_key, task_id);
+
+              ALTER TABLE task_prompts ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE task_prompts
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE task_prompts ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE task_prompts ALTER COLUMN store_key SET NOT NULL;
+              ALTER TABLE task_prompts
+              DROP CONSTRAINT IF EXISTS task_prompts_task_id_turn_phase_key;
+              CREATE UNIQUE INDEX IF NOT EXISTS idx_task_prompts_store_task_turn_phase
+              ON task_prompts(store_key, task_id, turn, phase);
+              CREATE INDEX IF NOT EXISTS idx_task_prompts_store_task_id
+              ON task_prompts(store_key, task_id, turn);
+
+              ALTER TABLE workspace_leases ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE workspace_leases
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE workspace_leases ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE workspace_leases ALTER COLUMN store_key SET NOT NULL;
+              ALTER TABLE workspace_leases DROP CONSTRAINT IF EXISTS workspace_leases_pkey;
+              ALTER TABLE workspace_leases
+              ADD CONSTRAINT workspace_leases_pkey PRIMARY KEY (store_key, project_key, slot_index);
+              CREATE INDEX IF NOT EXISTS idx_workspace_leases_store_task_state
+              ON workspace_leases(store_key, task_id, state);
+              CREATE INDEX IF NOT EXISTS idx_workspace_leases_store_workspace_key_state
+              ON workspace_leases(store_key, project_key, workspace_key, state);
+              CREATE INDEX IF NOT EXISTS idx_workspace_leases_store_state_owner
+              ON workspace_leases(store_key, state, owner_session);
+
+              CREATE TABLE IF NOT EXISTS task_db_legacy_backfills (
+                  store_key     TEXT NOT NULL DEFAULT current_schema(),
+                  legacy_schema TEXT NOT NULL,
+                  copied_rows   BIGINT NOT NULL DEFAULT 0,
+                  backfilled_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  PRIMARY KEY (store_key, legacy_schema)
+              )",
+    },
 ];
 
 #[cfg(test)]
@@ -226,6 +309,32 @@ mod tests {
             crate::workspace_lease_store::WORKSPACE_LEASES_TABLE_SQL
                 .contains("process_started_at  BIGINT NOT NULL DEFAULT 0"),
             "new workspace_leases tables should include process_started_at without v25"
+        );
+    }
+
+    #[test]
+    fn shared_schema_migration_scopes_task_owned_tables() {
+        let migration = TASK_MIGRATIONS
+            .iter()
+            .find(|migration| migration.version == 26)
+            .expect("v26 migration should exist");
+
+        for table in [
+            "tasks",
+            "task_artifacts",
+            "task_checkpoints",
+            "task_prompts",
+            "workspace_leases",
+        ] {
+            let needle = format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS store_key TEXT");
+            assert!(
+                migration.sql.contains(&needle),
+                "v26 should add store_key to {table}"
+            );
+        }
+        assert!(
+            migration.sql.contains("task_db_legacy_backfills"),
+            "v26 should create legacy backfill markers"
         );
     }
 }

--- a/crates/harness-server/src/task_db/queries_aux.rs
+++ b/crates/harness-server/src/task_db/queries_aux.rs
@@ -16,15 +16,16 @@ impl TaskDb {
     ) -> anyhow::Result<()> {
         sqlx::query(
             "INSERT INTO task_checkpoints \
-                 (task_id, triage_output, plan_output, pr_url, last_phase, updated_at) \
-             VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP) \
-             ON CONFLICT(task_id) DO UPDATE SET \
+                 (store_key, task_id, triage_output, plan_output, pr_url, last_phase, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP) \
+             ON CONFLICT(store_key, task_id) DO UPDATE SET \
                  triage_output = COALESCE(excluded.triage_output, task_checkpoints.triage_output), \
                  plan_output   = COALESCE(excluded.plan_output,   task_checkpoints.plan_output), \
                  pr_url        = COALESCE(excluded.pr_url,        task_checkpoints.pr_url), \
                  last_phase    = excluded.last_phase, \
                  updated_at    = excluded.updated_at",
         )
+        .bind(&self.store_key)
         .bind(task_id)
         .bind(triage_output)
         .bind(plan_output)
@@ -39,8 +40,9 @@ impl TaskDb {
         let row = sqlx::query_as::<_, TaskCheckpoint>(
             "SELECT task_id, triage_output, plan_output, pr_url, last_phase, \
                     TO_CHAR(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS updated_at \
-             FROM task_checkpoints WHERE task_id = $1",
+             FROM task_checkpoints WHERE store_key = $1 AND task_id = $2",
         )
+        .bind(&self.store_key)
         .bind(task_id)
         .fetch_optional(&self.pool)
         .await?;
@@ -69,9 +71,10 @@ impl TaskDb {
         };
 
         sqlx::query(
-            "INSERT INTO task_artifacts (task_id, turn, artifact_type, content) \
-             VALUES ($1, $2, $3, $4)",
+            "INSERT INTO task_artifacts (store_key, task_id, turn, artifact_type, content) \
+             VALUES ($1, $2, $3, $4, $5)",
         )
+        .bind(&self.store_key)
         .bind(task_id)
         .bind(turn as i64)
         .bind(artifact_type)
@@ -85,8 +88,9 @@ impl TaskDb {
         let rows = sqlx::query_as::<_, TaskArtifact>(
             "SELECT task_id, turn, artifact_type, content, \
                     TO_CHAR(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS created_at \
-             FROM task_artifacts WHERE task_id = $1 ORDER BY id ASC",
+             FROM task_artifacts WHERE store_key = $1 AND task_id = $2 ORDER BY id ASC",
         )
+        .bind(&self.store_key)
         .bind(task_id)
         .fetch_all(&self.pool)
         .await?;
@@ -110,10 +114,11 @@ impl TaskDb {
             prompt.to_string()
         };
         sqlx::query(
-            "INSERT INTO task_prompts (task_id, turn, phase, prompt) \
-             VALUES ($1, $2, $3, $4) \
-             ON CONFLICT (task_id, turn, phase) DO UPDATE SET prompt = excluded.prompt",
+            "INSERT INTO task_prompts (store_key, task_id, turn, phase, prompt) \
+             VALUES ($1, $2, $3, $4, $5) \
+             ON CONFLICT (store_key, task_id, turn, phase) DO UPDATE SET prompt = excluded.prompt",
         )
+        .bind(&self.store_key)
         .bind(task_id)
         .bind(turn as i64)
         .bind(phase)
@@ -127,8 +132,9 @@ impl TaskDb {
         let rows = sqlx::query_as::<_, TaskPrompt>(
             "SELECT task_id, turn, phase, prompt, \
                     TO_CHAR(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS created_at \
-             FROM task_prompts WHERE task_id = $1 ORDER BY turn ASC, id ASC",
+             FROM task_prompts WHERE store_key = $1 AND task_id = $2 ORDER BY turn ASC, id ASC",
         )
+        .bind(&self.store_key)
         .bind(task_id)
         .fetch_all(&self.pool)
         .await?;
@@ -147,11 +153,13 @@ impl TaskDb {
                     c.last_phase, \
                     TO_CHAR(c.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS ck_updated_at \
              FROM tasks t \
-             JOIN task_checkpoints c ON c.task_id = t.id \
-             WHERE t.status = 'pending' \
+             JOIN task_checkpoints c ON c.store_key = t.store_key AND c.task_id = t.id \
+             WHERE t.store_key = $1 \
+               AND t.status = 'pending' \
                AND t.pr_url IS NULL \
                AND (c.plan_output IS NOT NULL OR c.triage_output IS NOT NULL)",
         )
+        .bind(&self.store_key)
         .fetch_all(&self.pool)
         .await?;
 

--- a/crates/harness-server/src/task_db/queries_metrics.rs
+++ b/crates/harness-server/src/task_db/queries_metrics.rs
@@ -1,0 +1,312 @@
+use crate::task_runner::{TaskState, TaskStatus};
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
+use super::types::{RecentFailureRow, TaskRow, TASK_ROW_COLUMNS};
+use super::TaskDb;
+
+impl TaskDb {
+    /// Return `(task_id, first_token_latency_ms)` pairs for the 500 most-recently
+    /// completed terminal tasks. Latency extracted via jsonb correlated subquery.
+    pub async fn list_terminal_first_token_latencies_ms(
+        &self,
+    ) -> anyhow::Result<Vec<(String, Option<i64>)>> {
+        let rows: Vec<(String, Option<i64>)> = sqlx::query_as(
+            "SELECT id, \
+             (SELECT (r.value ->> 'first_token_latency_ms')::BIGINT \
+              FROM jsonb_array_elements(rounds::jsonb) AS r(value) \
+              WHERE r.value ->> 'result' != 'resumed_checkpoint' \
+                AND r.value ->> 'first_token_latency_ms' IS NOT NULL \
+              LIMIT 1) AS first_token_latency_ms \
+             FROM tasks \
+             WHERE store_key = $1 AND status IN ('done', 'failed') \
+             ORDER BY updated_at DESC \
+             LIMIT 500",
+        )
+        .bind(&self.store_key)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Return `(task_id, turn)` pairs for the 500 most-recently-completed terminal tasks.
+    pub async fn list_terminal_turn_counts(&self) -> anyhow::Result<Vec<(String, i64)>> {
+        let rows: Vec<(String, i64)> = sqlx::query_as(
+            "SELECT id, turn FROM tasks \
+             WHERE store_key = $1 AND status IN ('done', 'failed') \
+             ORDER BY updated_at DESC LIMIT 500",
+        )
+        .bind(&self.store_key)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Return `(id, status)` pairs for all tasks.
+    pub async fn list_id_status(&self) -> anyhow::Result<Vec<(String, String)>> {
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT id, status FROM tasks WHERE store_key = $1 ORDER BY created_at DESC",
+        )
+        .bind(&self.store_key)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Return only task IDs whose `status` matches any value in `statuses`.
+    pub async fn list_ids_by_status(&self, statuses: &[&str]) -> anyhow::Result<Vec<String>> {
+        if statuses.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = Self::numbered_placeholders(2, statuses.len());
+        let sql =
+            format!("SELECT id FROM tasks WHERE store_key = $1 AND status IN ({placeholders})");
+        let mut q = sqlx::query_as::<_, (String,)>(&sql).bind(&self.store_key);
+        for status in statuses {
+            q = q.bind(*status);
+        }
+        let rows = q.fetch_all(&self.pool).await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// Return the status of a single task, fetching only the `status` column.
+    pub async fn get_status_only(&self, id: &str) -> anyhow::Result<Option<String>> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT status FROM tasks WHERE store_key = $1 AND id = $2")
+                .bind(&self.store_key)
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(s,)| s))
+    }
+
+    /// Return the current optimistic-locking version of a single task.
+    pub(crate) async fn get_version_only(&self, id: &str) -> anyhow::Result<Option<i32>> {
+        let row: Option<(i32,)> =
+            sqlx::query_as("SELECT version FROM tasks WHERE store_key = $1 AND id = $2")
+                .bind(&self.store_key)
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(version,)| version))
+    }
+
+    /// Return `true` if a task row with the given ID exists in the database.
+    pub async fn exists_by_id(&self, id: &str) -> anyhow::Result<bool> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT id FROM tasks WHERE store_key = $1 AND id = $2")
+                .bind(&self.store_key)
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.is_some())
+    }
+
+    /// Return the `pr_url` of the most recently completed Done task that has one.
+    pub async fn latest_done_pr_url(&self) -> anyhow::Result<Option<String>> {
+        let row: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT pr_url FROM tasks \
+             WHERE store_key = $1 AND status = 'done' AND pr_url IS NOT NULL \
+             ORDER BY updated_at DESC LIMIT 1",
+        )
+        .bind(&self.store_key)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.and_then(|(pr_url,)| pr_url))
+    }
+
+    /// Return the `pr_url` of the most recent Done task for the given project root path.
+    pub async fn latest_done_pr_url_by_project(
+        &self,
+        project: &str,
+    ) -> anyhow::Result<Option<String>> {
+        let row: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT pr_url FROM tasks \
+             WHERE store_key = $1 AND status = 'done' AND pr_url IS NOT NULL AND project = $2 \
+             ORDER BY updated_at DESC LIMIT 1",
+        )
+        .bind(&self.store_key)
+        .bind(project)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.and_then(|(pr_url,)| pr_url))
+    }
+
+    /// Return the latest done PR URL for every project that has one, in a single query.
+    pub async fn latest_done_pr_urls_all_projects(
+        &self,
+    ) -> anyhow::Result<HashMap<String, String>> {
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT project, pr_url FROM (\
+               SELECT project, pr_url, \
+                      ROW_NUMBER() OVER (PARTITION BY project ORDER BY updated_at DESC) AS rn \
+               FROM tasks \
+               WHERE store_key = $1 \
+                 AND status = 'done' \
+                 AND pr_url IS NOT NULL \
+                 AND project IS NOT NULL\
+             ) AS subq WHERE rn = 1",
+        )
+        .bind(&self.store_key)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().collect())
+    }
+
+    /// Count done/failed tasks globally and per project.
+    pub async fn count_done_failed_by_project(
+        &self,
+    ) -> anyhow::Result<(u64, u64, Vec<(String, u64, u64)>)> {
+        let outcome_statuses = [TaskStatus::Done.as_ref(), TaskStatus::Failed.as_ref()];
+        let global_sql = format!(
+            "SELECT COUNT(CASE WHEN status = 'done' THEN 1 END), \
+                    COUNT(CASE WHEN status = 'failed' THEN 1 END) \
+             FROM tasks WHERE store_key = $1 AND status IN ({})",
+            Self::numbered_placeholders(2, outcome_statuses.len())
+        );
+        let global: (i64, i64) = outcome_statuses
+            .iter()
+            .fold(
+                sqlx::query_as(&global_sql).bind(&self.store_key),
+                |q, status| q.bind(*status),
+            )
+            .fetch_one(&self.pool)
+            .await?;
+        let rows_sql = format!(
+            "SELECT project, \
+                    COUNT(CASE WHEN status = 'done' THEN 1 END), \
+                    COUNT(CASE WHEN status = 'failed' THEN 1 END) \
+             FROM tasks \
+             WHERE store_key = $1 AND status IN ({}) AND project IS NOT NULL \
+             GROUP BY project",
+            Self::numbered_placeholders(2, outcome_statuses.len())
+        );
+        let rows: Vec<(String, i64, i64)> = outcome_statuses
+            .iter()
+            .fold(
+                sqlx::query_as(&rows_sql).bind(&self.store_key),
+                |q, status| q.bind(*status),
+            )
+            .fetch_all(&self.pool)
+            .await?;
+        let by_project = rows
+            .into_iter()
+            .map(|(p, d, f)| (p, d as u64, f as u64))
+            .collect();
+        Ok((global.0 as u64, global.1 as u64, by_project))
+    }
+
+    /// Count tasks that reached `done` status with `updated_at >= since`.
+    pub async fn count_done_since(&self, since: DateTime<Utc>) -> anyhow::Result<u64> {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM tasks \
+             WHERE store_key = $1 AND status = 'done' AND updated_at >= $2",
+        )
+        .bind(&self.store_key)
+        .bind(since)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0 as u64)
+    }
+
+    /// Per-(project, hour-bucket) count of tasks that reached `done` after `since`.
+    pub async fn done_per_project_hour_since(
+        &self,
+        since: DateTime<Utc>,
+    ) -> anyhow::Result<Vec<(String, String, u64)>> {
+        let rows: Vec<(Option<String>, String, i64)> = sqlx::query_as(
+            "SELECT project, \
+                    TO_CHAR(date_trunc('hour', updated_at AT TIME ZONE 'UTC'), \
+                            'YYYY-MM-DD\"T\"HH24:00:00\"Z\"') AS hour, \
+                    COUNT(*) \
+             FROM tasks \
+             WHERE store_key = $1 AND status = 'done' AND updated_at >= $2 \
+             GROUP BY project, date_trunc('hour', updated_at AT TIME ZONE 'UTC')",
+        )
+        .bind(&self.store_key)
+        .bind(since)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(p, h, c)| (p.unwrap_or_default(), h, c as u64))
+            .collect())
+    }
+
+    /// Return all tasks whose `parent_id` matches the given parent task ID.
+    pub async fn list_children(&self, parent_id: &str) -> anyhow::Result<Vec<TaskState>> {
+        let sql = format!(
+            "SELECT {TASK_ROW_COLUMNS} FROM tasks \
+             WHERE store_key = $1 AND parent_id = $2 ORDER BY created_at DESC"
+        );
+        let rows = sqlx::query_as::<_, TaskRow>(&sql)
+            .bind(&self.store_key)
+            .bind(parent_id)
+            .fetch_all(&self.pool)
+            .await?;
+        rows.into_iter().map(TaskRow::try_into_task_state).collect()
+    }
+
+    /// Return tasks that are active and have not been updated for at least `stale_threshold`.
+    pub async fn list_stalled_tasks(
+        &self,
+        stale_threshold: std::time::Duration,
+        project: Option<&str>,
+    ) -> anyhow::Result<Vec<TaskState>> {
+        let cutoff = Utc::now() - chrono::Duration::from_std(stale_threshold)?;
+        let sql = if project.is_some() {
+            format!(
+                "SELECT {TASK_ROW_COLUMNS} FROM tasks \
+                 WHERE store_key = $1 \
+                 AND status IN ('triaging', 'planning', 'implementing', \
+                                  'review_generating', 'review_waiting', \
+                                  'planner_generating', 'planner_waiting', 'agent_review', \
+                                  'waiting', 'reviewing') \
+                 AND external_id IS NOT NULL \
+                 AND updated_at < $2 AND project = $3 \
+                 ORDER BY updated_at ASC LIMIT 100"
+            )
+        } else {
+            format!(
+                "SELECT {TASK_ROW_COLUMNS} FROM tasks \
+                 WHERE store_key = $1 \
+                 AND status IN ('triaging', 'planning', 'implementing', \
+                                  'review_generating', 'review_waiting', \
+                                  'planner_generating', 'planner_waiting', 'agent_review', \
+                                  'waiting', 'reviewing') \
+                 AND external_id IS NOT NULL \
+                 AND updated_at < $2 \
+                 ORDER BY updated_at ASC LIMIT 100"
+            )
+        };
+        let mut q = sqlx::query_as::<_, TaskRow>(&sql)
+            .bind(&self.store_key)
+            .bind(cutoff);
+        if let Some(proj) = project {
+            q = q.bind(proj);
+        }
+        let rows = q.fetch_all(&self.pool).await?;
+        rows.into_iter().map(TaskRow::try_into_task_state).collect()
+    }
+
+    /// Return the most recent `limit` failed tasks, newest first.
+    pub async fn list_recent_failed(
+        &self,
+        limit: i64,
+    ) -> anyhow::Result<Vec<crate::task_runner::RecentFailureTask>> {
+        let rows = sqlx::query_as::<_, RecentFailureRow>(
+            "SELECT id, failure_kind, external_id, project, workspace_path, workspace_owner, \
+             run_generation, error, updated_at FROM tasks \
+             WHERE store_key = $1 AND status = 'failed' \
+             ORDER BY updated_at DESC LIMIT $2",
+        )
+        .bind(&self.store_key)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(RecentFailureRow::into_recent_failure)
+            .collect())
+    }
+}

--- a/crates/harness-server/src/task_db/queries_recovery.rs
+++ b/crates/harness-server/src/task_db/queries_recovery.rs
@@ -20,11 +20,13 @@ impl TaskDb {
         terminal_status: Option<&str>,
     ) -> anyhow::Result<()> {
         if let Some(status) = terminal_status {
-            let scheduler_state_row: Option<(String, i32)> =
-                sqlx::query_as("SELECT scheduler_state, version FROM tasks WHERE id = $1")
-                    .bind(task_id)
-                    .fetch_optional(&self.pool)
-                    .await?;
+            let scheduler_state_row: Option<(String, i32)> = sqlx::query_as(
+                "SELECT scheduler_state, version FROM tasks WHERE store_key = $1 AND id = $2",
+            )
+            .bind(&self.store_key)
+            .bind(task_id)
+            .fetch_optional(&self.pool)
+            .await?;
             let Some((scheduler_state, expected_version)) = scheduler_state_row else {
                 return Ok(());
             };
@@ -34,18 +36,19 @@ impl TaskDb {
             }
             let scheduler_json = serde_json::to_string(&scheduler)?;
             let resumable = TaskStatus::resumable_statuses();
-            let placeholders = Self::numbered_placeholders(6, resumable.len());
+            let placeholders = Self::numbered_placeholders(7, resumable.len());
             let sql = format!(
                 "UPDATE tasks SET status = $1, pr_url = COALESCE($2, pr_url), \
                  scheduler_state = $3, updated_at = CURRENT_TIMESTAMP, \
                  version = version + 1 \
-                 WHERE id = $4 AND version = $5 AND status IN ({})",
+                 WHERE store_key = $4 AND id = $5 AND version = $6 AND status IN ({})",
                 placeholders
             );
             let query = sqlx::query(&sql)
                 .bind(status)
                 .bind(pr_url)
                 .bind(&scheduler_json)
+                .bind(&self.store_key)
                 .bind(task_id)
                 .bind(expected_version);
             let query = resumable
@@ -53,19 +56,22 @@ impl TaskDb {
                 .fold(query, |q, resumable| q.bind(*resumable));
             query.execute(&self.pool).await?;
         } else if let Some(url) = pr_url {
-            let version_row: Option<(i32,)> =
-                sqlx::query_as("SELECT version FROM tasks WHERE id = $1 AND pr_url IS NULL")
-                    .bind(task_id)
-                    .fetch_optional(&self.pool)
-                    .await?;
+            let version_row: Option<(i32,)> = sqlx::query_as(
+                "SELECT version FROM tasks WHERE store_key = $1 AND id = $2 AND pr_url IS NULL",
+            )
+            .bind(&self.store_key)
+            .bind(task_id)
+            .fetch_optional(&self.pool)
+            .await?;
             let Some((expected_version,)) = version_row else {
                 return Ok(());
             };
             sqlx::query(
                 "UPDATE tasks SET pr_url = $1, version = version + 1 \
-                 WHERE id = $2 AND pr_url IS NULL AND version = $3",
+                 WHERE store_key = $2 AND id = $3 AND pr_url IS NULL AND version = $4",
             )
             .bind(url)
+            .bind(&self.store_key)
             .bind(task_id)
             .bind(expected_version)
             .execute(&self.pool)
@@ -78,20 +84,19 @@ impl TaskDb {
     pub async fn recover_in_progress(&self) -> anyhow::Result<RecoveryResult> {
         let rows = {
             let resumable = TaskStatus::resumable_statuses();
-            let placeholders = Self::numbered_placeholders(1, resumable.len());
+            let placeholders = Self::numbered_placeholders(2, resumable.len());
             let sql = format!(
                 "SELECT t.id, t.status, t.turn, t.pr_url AS task_pr_url, t.scheduler_state, t.version, \
                         c.triage_output, c.plan_output, c.pr_url AS ck_pr_url \
                  FROM tasks t \
-                 LEFT JOIN task_checkpoints c ON t.id = c.task_id \
-                 WHERE t.status IN ({})",
+                 LEFT JOIN task_checkpoints c ON t.store_key = c.store_key AND t.id = c.task_id \
+                 WHERE t.store_key = $1 AND t.status IN ({})",
                 placeholders
             );
-            let query = resumable
-                .iter()
-                .fold(sqlx::query_as::<_, RecoveryRow>(&sql), |q, status| {
-                    q.bind(*status)
-                });
+            let query = resumable.iter().fold(
+                sqlx::query_as::<_, RecoveryRow>(&sql).bind(&self.store_key),
+                |q, status| q.bind(*status),
+            );
             query.fetch_all(&self.pool).await?
         };
 
@@ -142,10 +147,11 @@ impl TaskDb {
                     sqlx::query(
                         "UPDATE tasks SET status = 'pending', error = NULL, pr_url = $1, \
                          scheduler_state = $2, updated_at = CURRENT_TIMESTAMP, \
-                         version = version + 1 WHERE id = $3 AND version = $4",
+                         version = version + 1 WHERE store_key = $3 AND id = $4 AND version = $5",
                     )
                     .bind(effective_pr_url)
                     .bind(&scheduler_json)
+                    .bind(&self.store_key)
                     .bind(&row.id)
                     .bind(row.version)
                     .execute(&self.pool)
@@ -160,9 +166,10 @@ impl TaskDb {
                     sqlx::query(
                         "UPDATE tasks SET status = 'pending', error = NULL, \
                          scheduler_state = $1, updated_at = CURRENT_TIMESTAMP, \
-                         version = version + 1 WHERE id = $2 AND version = $3",
+                         version = version + 1 WHERE store_key = $2 AND id = $3 AND version = $4",
                     )
                     .bind(&scheduler_json)
+                    .bind(&self.store_key)
                     .bind(&row.id)
                     .bind(row.version)
                     .execute(&self.pool)
@@ -187,10 +194,11 @@ impl TaskDb {
                 sqlx::query(
                     "UPDATE tasks SET status = 'failed', error = $1, \
                      scheduler_state = $2, updated_at = CURRENT_TIMESTAMP, \
-                     version = version + 1 WHERE id = $3 AND version = $4",
+                     version = version + 1 WHERE store_key = $3 AND id = $4 AND version = $5",
                 )
                 .bind(&err)
                 .bind(&scheduler_json)
+                .bind(&self.store_key)
                 .bind(&row.id)
                 .bind(row.version)
                 .execute(&self.pool)
@@ -201,9 +209,11 @@ impl TaskDb {
 
         let transient_failed_rows: Vec<(String, Option<String>, String, i32)> = sqlx::query_as(
             "SELECT id, error, scheduler_state, version FROM tasks \
-             WHERE status = 'pending' \
+             WHERE store_key = $1 \
+               AND status = 'pending' \
                AND error LIKE 'retrying after transient failure%'",
         )
+        .bind(&self.store_key)
         .fetch_all(&self.pool)
         .await?;
         for (id, error, scheduler_state, expected_version) in &transient_failed_rows {
@@ -216,10 +226,12 @@ impl TaskDb {
             );
             sqlx::query(
                 "UPDATE tasks SET status = 'failed', error = $1, scheduler_state = $2, \
-                 updated_at = CURRENT_TIMESTAMP, version = version + 1 WHERE id = $3 AND version = $4",
+                 updated_at = CURRENT_TIMESTAMP, version = version + 1 \
+                 WHERE store_key = $3 AND id = $4 AND version = $5",
             )
             .bind(err)
             .bind(&scheduler_json)
+            .bind(&self.store_key)
             .bind(id)
             .bind(expected_version)
             .execute(&self.pool)

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -1,11 +1,8 @@
 use crate::task_runner::{TaskState, TaskStatus, TaskSummaryFilter, TaskSummaryPageCursor};
 use chrono::{DateTime, Utc};
 use sqlx::{Postgres, QueryBuilder};
-use std::collections::HashMap;
 
-use super::types::{
-    ExternalStatusRow, RecentFailureRow, TaskRow, TaskSummaryRow, TASK_ROW_COLUMNS,
-};
+use super::types::{ExternalStatusRow, TaskRow, TaskSummaryRow, TASK_ROW_COLUMNS};
 use super::TaskDb;
 
 impl TaskDb {
@@ -26,13 +23,14 @@ impl TaskDb {
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
             .map(|dt| dt.with_timezone(&Utc));
         sqlx::query(
-            "INSERT INTO tasks (id, task_kind, status, failure_kind, turn, pr_url, rounds, error, source, \
+            "INSERT INTO tasks (store_key, id, task_kind, status, failure_kind, turn, pr_url, rounds, error, source, \
              external_id, parent_id, created_at, repo, depends_on, project, workspace_path, \
              workspace_owner, run_generation, priority, phase, description, request_settings, scheduler_state) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, \
-                     COALESCE($12, CURRENT_TIMESTAMP), $13, $14, $15, $16, $17, $18, \
-                     $19, $20, $21, $22, $23)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, \
+                     COALESCE($13, CURRENT_TIMESTAMP), $14, $15, $16, $17, $18, $19, \
+                     $20, $21, $22, $23, $24)",
         )
+        .bind(&self.store_key)
         .bind(&state.id.0)
         .bind(task_kind)
         .bind(status)
@@ -88,7 +86,7 @@ impl TaskDb {
                     project = $12, workspace_path = $13, workspace_owner = $14, \
                     run_generation = $15, priority = $16, phase = $17, description = $18, \
                     request_settings = $19, scheduler_state = $20, updated_at = CURRENT_TIMESTAMP, \
-                    version = version + 1 WHERE id = $21 AND version = $22",
+                    version = version + 1 WHERE store_key = $21 AND id = $22 AND version = $23",
         )
         .bind(task_kind)
         .bind(status)
@@ -120,6 +118,7 @@ impl TaskDb {
         .bind(state.description.as_deref())
         .bind(settings_json.as_deref())
         .bind(&scheduler_json)
+        .bind(&self.store_key)
         .bind(&state.id.0)
         .bind(state.version)
         .execute(&self.pool)
@@ -135,8 +134,9 @@ impl TaskDb {
     }
 
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<TaskState>> {
-        let sql = format!("SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE id = $1");
+        let sql = format!("SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE store_key = $1 AND id = $2");
         let row = sqlx::query_as::<_, TaskRow>(&sql)
+            .bind(&self.store_key)
             .bind(id)
             .fetch_optional(&self.pool)
             .await?;
@@ -144,8 +144,11 @@ impl TaskDb {
     }
 
     pub async fn list(&self) -> anyhow::Result<Vec<TaskState>> {
-        let sql = format!("SELECT {TASK_ROW_COLUMNS} FROM tasks ORDER BY created_at DESC");
+        let sql = format!(
+            "SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE store_key = $1 ORDER BY created_at DESC"
+        );
         let rows = sqlx::query_as::<_, TaskRow>(&sql)
+            .bind(&self.store_key)
             .fetch_all(&self.pool)
             .await?;
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
@@ -158,11 +161,11 @@ impl TaskDb {
         if statuses.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders = Self::numbered_placeholders(1, statuses.len());
+        let placeholders = Self::numbered_placeholders(2, statuses.len());
         let sql = format!(
-            "SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE status IN ({placeholders}) ORDER BY created_at DESC"
+            "SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE store_key = $1 AND status IN ({placeholders}) ORDER BY created_at DESC"
         );
-        let mut q = sqlx::query_as::<_, TaskRow>(&sql);
+        let mut q = sqlx::query_as::<_, TaskRow>(&sql).bind(&self.store_key);
         for status in statuses {
             q = q.bind(*status);
         }
@@ -175,12 +178,17 @@ impl TaskDb {
         let sql = format!(
             "SELECT {TASK_ROW_COLUMNS} \
              FROM tasks t \
-             WHERE t.status = 'pending' \
+             WHERE t.store_key = $1 \
+               AND t.status = 'pending' \
                AND t.pr_url IS NULL \
-               AND NOT EXISTS (SELECT 1 FROM task_checkpoints c WHERE c.task_id = t.id) \
+               AND NOT EXISTS (
+                   SELECT 1 FROM task_checkpoints c
+                   WHERE c.store_key = t.store_key AND c.task_id = t.id
+               ) \
              ORDER BY t.created_at DESC"
         );
         let rows = sqlx::query_as::<_, TaskRow>(&sql)
+            .bind(&self.store_key)
             .fetch_all(&self.pool)
             .await?;
         rows.into_iter().map(TaskRow::try_into_task_state).collect()
@@ -197,10 +205,11 @@ impl TaskDb {
                  SELECT external_id, status, created_at, \
                         ROW_NUMBER() OVER (PARTITION BY external_id ORDER BY created_at DESC, id DESC) AS rn \
                  FROM tasks \
-                 WHERE project = $1 AND external_id IS NOT NULL";
+                 WHERE store_key = $1 AND project = $2 AND external_id IS NOT NULL";
         let rows: Vec<ExternalStatusRow> = if let Some(repo) = repo {
-            let sql = format!("{base_sql} AND repo = $2) latest WHERE rn = 1");
+            let sql = format!("{base_sql} AND repo = $3) latest WHERE rn = 1");
             sqlx::query_as::<_, ExternalStatusRow>(&sql)
+                .bind(&self.store_key)
                 .bind(project)
                 .bind(repo)
                 .fetch_all(&self.pool)
@@ -208,6 +217,7 @@ impl TaskDb {
         } else {
             let sql = format!("{base_sql} AND repo IS NULL) latest WHERE rn = 1");
             sqlx::query_as::<_, ExternalStatusRow>(&sql)
+                .bind(&self.store_key)
                 .bind(project)
                 .fetch_all(&self.pool)
                 .await?
@@ -235,12 +245,13 @@ impl TaskDb {
             .chain(std::iter::once(TaskStatus::AwaitingDeps.as_ref()))
             .chain(TaskStatus::resumable_statuses().iter().copied())
             .collect();
-        let placeholders = Self::numbered_placeholders(3, active_statuses.len());
+        let placeholders = Self::numbered_placeholders(4, active_statuses.len());
         let sql = format!(
-            "SELECT id FROM tasks WHERE project = $1 AND external_id = $2 \
+            "SELECT id FROM tasks WHERE store_key = $1 AND project = $2 AND external_id = $3 \
              AND status IN ({placeholders}) LIMIT 1"
         );
         let mut query = sqlx::query_as::<_, (String,)>(&sql)
+            .bind(&self.store_key)
             .bind(project)
             .bind(external_id);
         for status in active_statuses {
@@ -258,10 +269,11 @@ impl TaskDb {
     ) -> anyhow::Result<Option<(String, String)>> {
         let row: Option<(String, String)> = sqlx::query_as(
             "SELECT id, pr_url FROM tasks \
-             WHERE project = $1 AND external_id = $2 \
+             WHERE store_key = $1 AND project = $2 AND external_id = $3 \
                AND status = 'done' AND pr_url IS NOT NULL \
              ORDER BY created_at DESC LIMIT 1",
         )
+        .bind(&self.store_key)
         .bind(project)
         .bind(external_id)
         .fetch_optional(&self.pool)
@@ -281,10 +293,11 @@ impl TaskDb {
     ) -> anyhow::Result<()> {
         let result = sqlx::query(
             "UPDATE tasks SET status = $1, scheduler_state = $2, version = version + 1 \
-             WHERE id = $3 AND version = $4",
+             WHERE store_key = $3 AND id = $4 AND version = $5",
         )
         .bind(status)
         .bind(scheduler_state)
+        .bind(&self.store_key)
         .bind(id)
         .bind(expected_version)
         .execute(&self.pool)
@@ -309,9 +322,10 @@ impl TaskDb {
         let result = sqlx::query(
             "UPDATE tasks SET external_id = $1, updated_at = CURRENT_TIMESTAMP, \
              version = version + 1 \
-             WHERE id = $2 AND external_id IS NULL AND version = $3",
+             WHERE store_key = $2 AND id = $3 AND external_id IS NULL AND version = $4",
         )
         .bind(external_id)
+        .bind(&self.store_key)
         .bind(id)
         .bind(expected_version)
         .execute(&self.pool)
@@ -336,9 +350,10 @@ impl TaskDb {
         let result = sqlx::query(
             "UPDATE tasks SET external_id = $1, updated_at = CURRENT_TIMESTAMP, \
              version = version + 1 \
-             WHERE id = $2 AND source = 'auto-fix' AND version = $3",
+             WHERE store_key = $2 AND id = $3 AND source = 'auto-fix' AND version = $4",
         )
         .bind(external_id)
+        .bind(&self.store_key)
         .bind(id)
         .bind(expected_version)
         .execute(&self.pool)
@@ -359,8 +374,9 @@ impl TaskDb {
             "SELECT id, task_kind, status, failure_kind, turn, pr_url, error, source, external_id, parent_id, \
              created_at, repo, depends_on, project, workspace_path, workspace_owner, \
              run_generation, phase, description, scheduler_state \
-             FROM tasks ORDER BY created_at DESC",
+             FROM tasks WHERE store_key = $1 ORDER BY created_at DESC",
         )
+        .bind(&self.store_key)
         .fetch_all(&self.pool)
         .await?;
         Ok(decode_task_summary_rows(rows, "list_summaries"))
@@ -375,9 +391,11 @@ impl TaskDb {
              created_at, repo, depends_on, project, workspace_path, workspace_owner, \
              run_generation, phase, description, scheduler_state \
              FROM tasks \
-             WHERE status NOT IN ('done', 'failed', 'cancelled') \
+             WHERE store_key = $1 \
+               AND status NOT IN ('done', 'failed', 'cancelled') \
              ORDER BY created_at DESC",
         )
+        .bind(&self.store_key)
         .fetch_all(&self.pool)
         .await?;
         Ok(decode_task_summary_rows(rows, "list_active_summaries"))
@@ -392,7 +410,8 @@ impl TaskDb {
              created_at, repo, depends_on, project, workspace_path, workspace_owner, \
              run_generation, phase, description, scheduler_state FROM tasks",
         );
-        push_task_summary_filter(&mut query, filter);
+        let mut has_where = push_task_store_filter(&mut query, self.store_key.as_str());
+        push_task_summary_filter(&mut query, filter, &mut has_where);
         query.push(" ORDER BY created_at DESC, id DESC");
 
         let rows = query
@@ -426,7 +445,8 @@ impl TaskDb {
              created_at, repo, depends_on, project, workspace_path, workspace_owner, \
              run_generation, phase, description, scheduler_state FROM tasks",
         );
-        let mut has_where = push_task_summary_filter(&mut query, filter);
+        let mut has_where = push_task_store_filter(&mut query, self.store_key.as_str());
+        push_task_summary_filter(&mut query, filter, &mut has_where);
         if let Some(cursor) = cursor {
             push_where_prefix(&mut query, &mut has_where);
             query.push("(created_at < ");
@@ -460,275 +480,6 @@ impl TaskDb {
         Ok(summaries)
     }
 
-    /// Return `(task_id, first_token_latency_ms)` pairs for the 500 most-recently
-    /// completed terminal tasks. Latency extracted via jsonb correlated subquery.
-    pub async fn list_terminal_first_token_latencies_ms(
-        &self,
-    ) -> anyhow::Result<Vec<(String, Option<i64>)>> {
-        let rows: Vec<(String, Option<i64>)> = sqlx::query_as(
-            "SELECT id, \
-             (SELECT (r.value ->> 'first_token_latency_ms')::BIGINT \
-              FROM jsonb_array_elements(rounds::jsonb) AS r(value) \
-              WHERE r.value ->> 'result' != 'resumed_checkpoint' \
-                AND r.value ->> 'first_token_latency_ms' IS NOT NULL \
-              LIMIT 1) AS first_token_latency_ms \
-             FROM tasks \
-             WHERE status IN ('done', 'failed') \
-             ORDER BY updated_at DESC \
-             LIMIT 500",
-        )
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(rows)
-    }
-
-    /// Return `(task_id, turn)` pairs for the 500 most-recently-completed terminal tasks.
-    pub async fn list_terminal_turn_counts(&self) -> anyhow::Result<Vec<(String, i64)>> {
-        let rows: Vec<(String, i64)> = sqlx::query_as(
-            "SELECT id, turn FROM tasks \
-             WHERE status IN ('done', 'failed') \
-             ORDER BY updated_at DESC LIMIT 500",
-        )
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(rows)
-    }
-
-    /// Return `(id, status)` pairs for all tasks.
-    pub async fn list_id_status(&self) -> anyhow::Result<Vec<(String, String)>> {
-        let rows: Vec<(String, String)> =
-            sqlx::query_as("SELECT id, status FROM tasks ORDER BY created_at DESC")
-                .fetch_all(&self.pool)
-                .await?;
-        Ok(rows)
-    }
-
-    /// Return only task IDs whose `status` matches any value in `statuses`.
-    pub async fn list_ids_by_status(&self, statuses: &[&str]) -> anyhow::Result<Vec<String>> {
-        if statuses.is_empty() {
-            return Ok(Vec::new());
-        }
-        let placeholders = Self::numbered_placeholders(1, statuses.len());
-        let sql = format!("SELECT id FROM tasks WHERE status IN ({placeholders})");
-        let mut q = sqlx::query_as::<_, (String,)>(&sql);
-        for status in statuses {
-            q = q.bind(*status);
-        }
-        let rows = q.fetch_all(&self.pool).await?;
-        Ok(rows.into_iter().map(|(id,)| id).collect())
-    }
-
-    /// Return the status of a single task, fetching only the `status` column.
-    pub async fn get_status_only(&self, id: &str) -> anyhow::Result<Option<String>> {
-        let row: Option<(String,)> = sqlx::query_as("SELECT status FROM tasks WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?;
-        Ok(row.map(|(s,)| s))
-    }
-
-    /// Return the current optimistic-locking version of a single task.
-    pub(crate) async fn get_version_only(&self, id: &str) -> anyhow::Result<Option<i32>> {
-        let row: Option<(i32,)> = sqlx::query_as("SELECT version FROM tasks WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?;
-        Ok(row.map(|(version,)| version))
-    }
-
-    /// Return `true` if a task row with the given ID exists in the database.
-    pub async fn exists_by_id(&self, id: &str) -> anyhow::Result<bool> {
-        let row: Option<(String,)> = sqlx::query_as("SELECT id FROM tasks WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?;
-        Ok(row.is_some())
-    }
-
-    /// Return the `pr_url` of the most recently completed Done task that has one.
-    pub async fn latest_done_pr_url(&self) -> anyhow::Result<Option<String>> {
-        let row: Option<(Option<String>,)> = sqlx::query_as(
-            "SELECT pr_url FROM tasks WHERE status = 'done' AND pr_url IS NOT NULL \
-             ORDER BY updated_at DESC LIMIT 1",
-        )
-        .fetch_optional(&self.pool)
-        .await?;
-        Ok(row.and_then(|(pr_url,)| pr_url))
-    }
-
-    /// Return the `pr_url` of the most recent Done task for the given project root path.
-    pub async fn latest_done_pr_url_by_project(
-        &self,
-        project: &str,
-    ) -> anyhow::Result<Option<String>> {
-        let row: Option<(Option<String>,)> = sqlx::query_as(
-            "SELECT pr_url FROM tasks \
-             WHERE status = 'done' AND pr_url IS NOT NULL AND project = $1 \
-             ORDER BY updated_at DESC LIMIT 1",
-        )
-        .bind(project)
-        .fetch_optional(&self.pool)
-        .await?;
-        Ok(row.and_then(|(pr_url,)| pr_url))
-    }
-
-    /// Return the latest done PR URL for every project that has one, in a single query.
-    pub async fn latest_done_pr_urls_all_projects(
-        &self,
-    ) -> anyhow::Result<HashMap<String, String>> {
-        let rows: Vec<(String, String)> = sqlx::query_as(
-            "SELECT project, pr_url FROM (\
-               SELECT project, pr_url, \
-                      ROW_NUMBER() OVER (PARTITION BY project ORDER BY updated_at DESC) AS rn \
-               FROM tasks \
-               WHERE status = 'done' AND pr_url IS NOT NULL AND project IS NOT NULL\
-             ) AS subq WHERE rn = 1",
-        )
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(rows.into_iter().collect())
-    }
-
-    /// Count done/failed tasks globally and per project.
-    pub async fn count_done_failed_by_project(
-        &self,
-    ) -> anyhow::Result<(u64, u64, Vec<(String, u64, u64)>)> {
-        let outcome_statuses = [TaskStatus::Done.as_ref(), TaskStatus::Failed.as_ref()];
-        let global_sql = format!(
-            "SELECT COUNT(CASE WHEN status = 'done' THEN 1 END), \
-                    COUNT(CASE WHEN status = 'failed' THEN 1 END) \
-             FROM tasks WHERE status IN ({})",
-            Self::numbered_placeholders(1, outcome_statuses.len())
-        );
-        let global: (i64, i64) = outcome_statuses
-            .iter()
-            .fold(sqlx::query_as(&global_sql), |q, status| q.bind(*status))
-            .fetch_one(&self.pool)
-            .await?;
-        let rows_sql = format!(
-            "SELECT project, \
-                    COUNT(CASE WHEN status = 'done' THEN 1 END), \
-                    COUNT(CASE WHEN status = 'failed' THEN 1 END) \
-             FROM tasks \
-             WHERE status IN ({}) AND project IS NOT NULL \
-             GROUP BY project",
-            Self::numbered_placeholders(1, outcome_statuses.len())
-        );
-        let rows: Vec<(String, i64, i64)> = outcome_statuses
-            .iter()
-            .fold(sqlx::query_as(&rows_sql), |q, status| q.bind(*status))
-            .fetch_all(&self.pool)
-            .await?;
-        let by_project = rows
-            .into_iter()
-            .map(|(p, d, f)| (p, d as u64, f as u64))
-            .collect();
-        Ok((global.0 as u64, global.1 as u64, by_project))
-    }
-
-    /// Count tasks that reached `done` status with `updated_at >= since`.
-    pub async fn count_done_since(&self, since: DateTime<Utc>) -> anyhow::Result<u64> {
-        let row: (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM tasks WHERE status = 'done' AND updated_at >= $1")
-                .bind(since)
-                .fetch_one(&self.pool)
-                .await?;
-        Ok(row.0 as u64)
-    }
-
-    /// Per-(project, hour-bucket) count of tasks that reached `done` after `since`.
-    pub async fn done_per_project_hour_since(
-        &self,
-        since: DateTime<Utc>,
-    ) -> anyhow::Result<Vec<(String, String, u64)>> {
-        let rows: Vec<(Option<String>, String, i64)> = sqlx::query_as(
-            "SELECT project, \
-                    TO_CHAR(date_trunc('hour', updated_at AT TIME ZONE 'UTC'), \
-                            'YYYY-MM-DD\"T\"HH24:00:00\"Z\"') AS hour, \
-                    COUNT(*) \
-             FROM tasks \
-             WHERE status = 'done' AND updated_at >= $1 \
-             GROUP BY project, date_trunc('hour', updated_at AT TIME ZONE 'UTC')",
-        )
-        .bind(since)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(rows
-            .into_iter()
-            .map(|(p, h, c)| (p.unwrap_or_default(), h, c as u64))
-            .collect())
-    }
-
-    /// Return all tasks whose `parent_id` matches the given parent task ID.
-    pub async fn list_children(&self, parent_id: &str) -> anyhow::Result<Vec<TaskState>> {
-        let sql = format!(
-            "SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE parent_id = $1 ORDER BY created_at DESC"
-        );
-        let rows = sqlx::query_as::<_, TaskRow>(&sql)
-            .bind(parent_id)
-            .fetch_all(&self.pool)
-            .await?;
-        rows.into_iter().map(TaskRow::try_into_task_state).collect()
-    }
-
-    /// Return tasks that are active and have not been updated for at least `stale_threshold`.
-    pub async fn list_stalled_tasks(
-        &self,
-        stale_threshold: std::time::Duration,
-        project: Option<&str>,
-    ) -> anyhow::Result<Vec<TaskState>> {
-        let cutoff = Utc::now() - chrono::Duration::from_std(stale_threshold)?;
-        let sql = if project.is_some() {
-            format!(
-                "SELECT {TASK_ROW_COLUMNS} FROM tasks \
-                 WHERE status IN ('triaging', 'planning', 'implementing', \
-                                  'review_generating', 'review_waiting', \
-                                  'planner_generating', 'planner_waiting', 'agent_review', \
-                                  'waiting', 'reviewing') \
-                 AND external_id IS NOT NULL \
-                 AND updated_at < $1 AND project = $2 \
-                 ORDER BY updated_at ASC LIMIT 100"
-            )
-        } else {
-            format!(
-                "SELECT {TASK_ROW_COLUMNS} FROM tasks \
-                 WHERE status IN ('triaging', 'planning', 'implementing', \
-                                  'review_generating', 'review_waiting', \
-                                  'planner_generating', 'planner_waiting', 'agent_review', \
-                                  'waiting', 'reviewing') \
-                 AND external_id IS NOT NULL \
-                 AND updated_at < $1 \
-                 ORDER BY updated_at ASC LIMIT 100"
-            )
-        };
-        let mut q = sqlx::query_as::<_, TaskRow>(&sql).bind(cutoff);
-        if let Some(proj) = project {
-            q = q.bind(proj);
-        }
-        let rows = q.fetch_all(&self.pool).await?;
-        rows.into_iter().map(TaskRow::try_into_task_state).collect()
-    }
-
-    /// Return the most recent `limit` failed tasks, newest first.
-    pub async fn list_recent_failed(
-        &self,
-        limit: i64,
-    ) -> anyhow::Result<Vec<crate::task_runner::RecentFailureTask>> {
-        let rows = sqlx::query_as::<_, RecentFailureRow>(
-            "SELECT id, failure_kind, external_id, project, workspace_path, workspace_owner, \
-             run_generation, error, updated_at FROM tasks \
-             WHERE status = 'failed' \
-             ORDER BY updated_at DESC LIMIT $1",
-        )
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(rows
-            .into_iter()
-            .map(RecentFailureRow::into_recent_failure)
-            .collect())
-    }
-
     /// Expose the raw pool for test-only SQL setup (e.g. back-dating `updated_at`).
     #[cfg(test)]
     pub(crate) fn pool_for_test(&self) -> &sqlx::PgPool {
@@ -746,8 +497,9 @@ impl TaskDb {
         task_id: &str,
         raw_rounds: &str,
     ) -> anyhow::Result<()> {
-        sqlx::query("UPDATE tasks SET rounds = $1 WHERE id = $2")
+        sqlx::query("UPDATE tasks SET rounds = $1 WHERE store_key = $2 AND id = $3")
             .bind(raw_rounds)
+            .bind(&self.store_key)
             .bind(task_id)
             .execute(&self.pool)
             .await?;
@@ -775,11 +527,10 @@ fn decode_task_summary_rows(
 fn push_task_summary_filter<'a>(
     query: &mut QueryBuilder<'a, Postgres>,
     filter: &'a TaskSummaryFilter,
-) -> bool {
-    let mut has_where = false;
-
+    has_where: &mut bool,
+) {
     if !filter.statuses.is_empty() {
-        push_where_prefix(query, &mut has_where);
+        push_where_prefix(query, has_where);
         query.push("status IN (");
         let mut separated = query.separated(", ");
         for status in &filter.statuses {
@@ -789,7 +540,7 @@ fn push_task_summary_filter<'a>(
     }
 
     if filter.active {
-        push_where_prefix(query, &mut has_where);
+        push_where_prefix(query, has_where);
         query.push("status NOT IN (");
         let mut separated = query.separated(", ");
         for status in TaskStatus::terminal_statuses() {
@@ -799,7 +550,7 @@ fn push_task_summary_filter<'a>(
     }
 
     if !filter.scheduler_states.is_empty() {
-        push_where_prefix(query, &mut has_where);
+        push_where_prefix(query, has_where);
         query.push("(scheduler_state::jsonb ->> 'authority_state') IN (");
         let mut separated = query.separated(", ");
         for state in &filter.scheduler_states {
@@ -809,7 +560,7 @@ fn push_task_summary_filter<'a>(
     }
 
     if !filter.kinds.is_empty() {
-        push_where_prefix(query, &mut has_where);
+        push_where_prefix(query, has_where);
         query.push("task_kind IN (");
         let mut separated = query.separated(", ");
         for kind in &filter.kinds {
@@ -819,23 +570,29 @@ fn push_task_summary_filter<'a>(
     }
 
     if let Some(source) = filter.source.as_deref() {
-        push_where_prefix(query, &mut has_where);
+        push_where_prefix(query, has_where);
         query.push("source = ");
         query.push_bind(source.to_string());
     }
 
     if let Some(repo) = filter.repo.as_deref() {
-        push_where_prefix(query, &mut has_where);
+        push_where_prefix(query, has_where);
         query.push("repo = ");
         query.push_bind(repo.to_string());
     }
 
     if let Some(project) = filter.project.as_deref() {
-        push_where_prefix(query, &mut has_where);
+        push_where_prefix(query, has_where);
         query.push("project = ");
         query.push_bind(project.to_string());
     }
+}
 
+fn push_task_store_filter<'a>(query: &mut QueryBuilder<'a, Postgres>, store_key: &'a str) -> bool {
+    let mut has_where = false;
+    push_where_prefix(query, &mut has_where);
+    query.push("store_key = ");
+    query.push_bind(store_key);
     has_where
 }
 

--- a/crates/harness-server/src/task_db/raw_column_test_overrides.rs
+++ b/crates/harness-server/src/task_db/raw_column_test_overrides.rs
@@ -12,8 +12,9 @@ impl TaskDb {
         task_id: &str,
         raw_scheduler_state: &str,
     ) -> anyhow::Result<()> {
-        sqlx::query("UPDATE tasks SET scheduler_state = $1 WHERE id = $2")
+        sqlx::query("UPDATE tasks SET scheduler_state = $1 WHERE store_key = $2 AND id = $3")
             .bind(raw_scheduler_state)
+            .bind(&self.store_key)
             .bind(task_id)
             .execute(&self.pool)
             .await?;

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -145,6 +145,19 @@ impl TaskStore {
         Self::from_task_db(db, db_path).await
     }
 
+    pub async fn open_shared_with_data_dir(
+        db_path: &std::path::Path,
+        context: &PgStoreContext,
+        setup_pool: &sqlx::postgres::PgPool,
+        data_dir: &std::path::Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Arc<Self>> {
+        let db = TaskDb::open_shared_with_data_dir(context, setup_pool, data_dir).await?;
+        crate::task_db::migrate_legacy_task_db_if_needed(db_path, configured_database_url, &db)
+            .await?;
+        Self::from_task_db(db, db_path).await
+    }
+
     async fn from_task_db(db: TaskDb, db_path: &std::path::Path) -> anyhow::Result<Arc<Self>> {
         // 1. Event replay: runs BEFORE recover_in_progress so event-sourced
         //    data (pr_url, terminal status) wins over checkpoint data.
@@ -218,6 +231,16 @@ impl TaskStore {
             event_log,
         });
         Ok(store)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn task_db_schema_for_test(&self) -> &str {
+        self.db.schema()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn task_db_store_key_for_test(&self) -> &str {
+        self.db.store_key()
     }
 
     pub fn get(&self, id: &TaskId) -> Option<TaskState> {

--- a/crates/harness-server/src/workspace_lease_store.rs
+++ b/crates/harness-server/src/workspace_lease_store.rs
@@ -25,23 +25,35 @@ pub(crate) struct WorkspaceLeaseRecord {
 #[derive(Debug, Clone)]
 pub(crate) struct WorkspaceLeaseStore {
     pool: PgPool,
+    store_key: String,
 }
 
 impl WorkspaceLeaseStore {
-    pub(crate) async fn open_with_context(
+    pub(crate) async fn open_shared_with_data_dir(
         context: &PgStoreContext,
         setup_pool: &PgPool,
+        data_dir: &std::path::Path,
+    ) -> anyhow::Result<Self> {
+        let store_key = crate::task_db::TaskDb::store_key_for_data_dir(data_dir)?;
+        Self::open_with_context_and_store_key(context, setup_pool, store_key).await
+    }
+
+    async fn open_with_context_and_store_key(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        store_key: String,
     ) -> anyhow::Result<Self> {
         let pool = context.open_pool_with_setup_pool(setup_pool).await?;
-        Ok(Self { pool })
+        Ok(Self { pool, store_key })
     }
 
     #[cfg(test)]
     pub(crate) async fn open(path: &std::path::Path) -> anyhow::Result<Self> {
         let context = PgStoreContext::from_path(path, None)?;
+        let store_key = context.schema().to_owned();
         let pool = context.open_pool().await?;
         ensure_workspace_leases_table(&pool).await?;
-        Ok(Self { pool })
+        Ok(Self { pool, store_key })
     }
 
     pub(crate) async fn try_acquire_lease(
@@ -50,12 +62,12 @@ impl WorkspaceLeaseStore {
     ) -> anyhow::Result<bool> {
         let result = sqlx::query(
             "INSERT INTO workspace_leases (
-                project_key, slot_index, task_id, workspace_key, workspace_path, source_repo, repo,
-                runtime_workflow_id, owner_session, run_generation, process_id, process_started_at,
-                state, acquired_at, released_at, last_used_at
-             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'leased',
+                store_key, project_key, slot_index, task_id, workspace_key, workspace_path,
+                source_repo, repo, runtime_workflow_id, owner_session, run_generation,
+                process_id, process_started_at, state, acquired_at, released_at, last_used_at
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, 'leased',
                        CURRENT_TIMESTAMP, NULL, CURRENT_TIMESTAMP)
-             ON CONFLICT(project_key, slot_index) DO UPDATE SET
+             ON CONFLICT(store_key, project_key, slot_index) DO UPDATE SET
                 task_id = EXCLUDED.task_id,
                 workspace_key = EXCLUDED.workspace_key,
                 workspace_path = EXCLUDED.workspace_path,
@@ -76,6 +88,7 @@ impl WorkspaceLeaseStore {
                     AND workspace_leases.owner_session = EXCLUDED.owner_session
                 )",
         )
+        .bind(&self.store_key)
         .bind(&record.project_key)
         .bind(record.slot_index as i64)
         .bind(record.task_id.as_str())
@@ -100,9 +113,11 @@ impl WorkspaceLeaseStore {
         let rows: Vec<(i64,)> = sqlx::query_as(
             "SELECT slot_index
              FROM workspace_leases
-             WHERE project_key = $1
+             WHERE store_key = $1
+               AND project_key = $2
                AND state = 'leased'",
         )
+        .bind(&self.store_key)
         .bind(project_key)
         .fetch_all(&self.pool)
         .await?;
@@ -122,11 +137,13 @@ impl WorkspaceLeaseStore {
              SET state = 'released',
                  released_at = CURRENT_TIMESTAMP,
                  last_used_at = CURRENT_TIMESTAMP
-             WHERE project_key = $1
-               AND slot_index = $2
-               AND task_id = $3
+             WHERE store_key = $1
+               AND project_key = $2
+               AND slot_index = $3
+               AND task_id = $4
                AND state = 'leased'",
         )
+        .bind(&self.store_key)
         .bind(project_key)
         .bind(slot_index as i64)
         .bind(task_id.as_str())
@@ -141,9 +158,11 @@ impl WorkspaceLeaseStore {
              SET state = 'released',
                  released_at = CURRENT_TIMESTAMP,
                  last_used_at = CURRENT_TIMESTAMP
-             WHERE task_id = $1
+             WHERE store_key = $1
+               AND task_id = $2
                AND state = 'leased'",
         )
+        .bind(&self.store_key)
         .bind(task_id.as_str())
         .execute(&self.pool)
         .await?;
@@ -159,9 +178,11 @@ impl WorkspaceLeaseStore {
                     runtime_workflow_id, owner_session, run_generation, process_id,
                     process_started_at
              FROM workspace_leases
-             WHERE state = 'leased'
-               AND owner_session <> $1",
+             WHERE store_key = $1
+               AND state = 'leased'
+               AND owner_session <> $2",
         )
+        .bind(&self.store_key)
         .bind(current_owner_session)
         .fetch_all(&self.pool)
         .await?;
@@ -188,14 +209,16 @@ impl WorkspaceLeaseStore {
              SET state = 'released',
                  released_at = CURRENT_TIMESTAMP,
                  last_used_at = CURRENT_TIMESTAMP
-             WHERE project_key = $1
-               AND slot_index = $2
-               AND task_id = $3
-               AND owner_session = $4
-               AND process_id = $5
-               AND process_started_at = $6
+             WHERE store_key = $1
+               AND project_key = $2
+               AND slot_index = $3
+               AND task_id = $4
+               AND owner_session = $5
+               AND process_id = $6
+               AND process_started_at = $7
                AND state = 'leased'",
         )
+        .bind(&self.store_key)
         .bind(&record.project_key)
         .bind(record.slot_index as i64)
         .bind(record.task_id.as_str())
@@ -214,10 +237,12 @@ impl WorkspaceLeaseStore {
         let row: Option<(String,)> = sqlx::query_as(
             "SELECT workspace_path
              FROM workspace_leases
-             WHERE task_id = $1
+             WHERE store_key = $1
+               AND task_id = $2
              ORDER BY last_used_at DESC
              LIMIT 1",
         )
+        .bind(&self.store_key)
         .bind(task_id.as_str())
         .fetch_optional(&self.pool)
         .await?;
@@ -234,12 +259,14 @@ impl WorkspaceLeaseStore {
                     runtime_workflow_id, owner_session, run_generation, process_id,
                     process_started_at
              FROM workspace_leases
-             WHERE project_key = $1
-               AND workspace_key = $2
+             WHERE store_key = $1
+               AND project_key = $2
+               AND workspace_key = $3
                AND state = 'released'
              ORDER BY last_used_at DESC
              LIMIT 1",
         )
+        .bind(&self.store_key)
         .bind(project_key)
         .bind(workspace_key)
         .fetch_optional(&self.pool)
@@ -256,11 +283,13 @@ impl WorkspaceLeaseStore {
                     runtime_workflow_id, owner_session, run_generation, process_id,
                     process_started_at
              FROM workspace_leases
-             WHERE workspace_path = $1
+             WHERE store_key = $1
+               AND workspace_path = $2
                AND state = 'leased'
              ORDER BY last_used_at DESC
              LIMIT 1",
         )
+        .bind(&self.store_key)
         .bind(workspace_path.to_string_lossy().as_ref())
         .fetch_optional(&self.pool)
         .await?;
@@ -274,9 +303,11 @@ impl WorkspaceLeaseStore {
                     runtime_workflow_id, owner_session, run_generation, process_id,
                     process_started_at
              FROM workspace_leases
-             WHERE state = 'leased'
+             WHERE store_key = $1
+               AND state = 'leased'
              ORDER BY project_key, slot_index",
         )
+        .bind(&self.store_key)
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter().map(TryInto::try_into).collect()
@@ -358,6 +389,7 @@ async fn ensure_workspace_leases_table(pool: &PgPool) -> anyhow::Result<()> {
 
 #[cfg(test)]
 pub(crate) const WORKSPACE_LEASES_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS workspace_leases (
+    store_key           TEXT NOT NULL DEFAULT current_schema(),
     project_key         TEXT NOT NULL,
     slot_index          BIGINT NOT NULL,
     task_id             TEXT NOT NULL,
@@ -374,14 +406,14 @@ pub(crate) const WORKSPACE_LEASES_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS 
     acquired_at         TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     released_at         TIMESTAMPTZ,
     last_used_at        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY(project_key, slot_index)
+    PRIMARY KEY(store_key, project_key, slot_index)
 );
 CREATE INDEX IF NOT EXISTS idx_workspace_leases_task_state
-    ON workspace_leases(task_id, state);
+    ON workspace_leases(store_key, task_id, state);
 CREATE INDEX IF NOT EXISTS idx_workspace_leases_workspace_key_state
-    ON workspace_leases(project_key, workspace_key, state);
+    ON workspace_leases(store_key, project_key, workspace_key, state);
 CREATE INDEX IF NOT EXISTS idx_workspace_leases_state_owner
-    ON workspace_leases(state, owner_session)";
+    ON workspace_leases(store_key, state, owner_session)";
 
 pub(crate) const WORKSPACE_LEASES_TABLE_V24_SQL: &str =
     "CREATE TABLE IF NOT EXISTS workspace_leases (

--- a/crates/harness-server/src/workspace_lease_store_tests.rs
+++ b/crates/harness-server/src/workspace_lease_store_tests.rs
@@ -1,6 +1,16 @@
 use super::test_support::*;
 use super::*;
 
+fn unique_test_schema(prefix: &str) -> String {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_nanos();
+    format!("{prefix}_{nanos}_{count}")
+}
+
 #[tokio::test]
 async fn workspace_lease_store_persists_and_releases_active_slots() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
@@ -42,6 +52,74 @@ async fn workspace_lease_store_persists_and_releases_active_slots() -> anyhow::R
     );
     assert!(store.list_leased().await?.is_empty());
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_lease_store_shared_schema_keeps_data_dirs_isolated() -> anyhow::Result<()> {
+    let database_url = match harness_core::db::resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let setup_pool = harness_core::db::pg_open_pool(&database_url).await?;
+    let shared_schema = unique_test_schema("workspace_lease_scope_test");
+    let shared_context =
+        harness_core::db::PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let store_a_dir = dir.path().join("store-a");
+    let store_b_dir = dir.path().join("store-b");
+    std::fs::create_dir_all(&store_a_dir)?;
+    std::fs::create_dir_all(&store_b_dir)?;
+    crate::task_db::TaskDb::open_shared_with_data_dir(&shared_context, &setup_pool, &store_a_dir)
+        .await?;
+    crate::task_db::TaskDb::open_shared_with_data_dir(&shared_context, &setup_pool, &store_b_dir)
+        .await?;
+    let store_a =
+        WorkspaceLeaseStore::open_shared_with_data_dir(&shared_context, &setup_pool, &store_a_dir)
+            .await?;
+    let store_b =
+        WorkspaceLeaseStore::open_shared_with_data_dir(&shared_context, &setup_pool, &store_b_dir)
+            .await?;
+    let process_started_at = WorkspaceLeaseStore::current_process_started_at()?;
+    let record_a = WorkspaceLeaseRecord {
+        project_key: "project-a".to_string(),
+        slot_index: 0,
+        task_id: harness_core::types::TaskId("store-a-task".to_string()),
+        workspace_key: "workspace-a".to_string(),
+        workspace_path: dir.path().join("workspaces/store-a"),
+        source_repo: dir.path().join("repo-a"),
+        repo: Some("owner/repo-a".to_string()),
+        runtime_workflow_id: Some("workflow-a".to_string()),
+        owner_session: "session-a".to_string(),
+        run_generation: 1,
+        process_id: std::process::id(),
+        process_started_at,
+    };
+    let record_b = WorkspaceLeaseRecord {
+        task_id: harness_core::types::TaskId("store-b-task".to_string()),
+        workspace_key: "workspace-b".to_string(),
+        workspace_path: dir.path().join("workspaces/store-b"),
+        source_repo: dir.path().join("repo-b"),
+        repo: Some("owner/repo-b".to_string()),
+        runtime_workflow_id: Some("workflow-b".to_string()),
+        owner_session: "session-b".to_string(),
+        ..record_a.clone()
+    };
+
+    assert!(store_a.try_acquire_lease(&record_a).await?);
+    assert!(
+        store_b.try_acquire_lease(&record_b).await?,
+        "same project slot should be isolated by store_key"
+    );
+
+    let leased_a = store_a.list_leased().await?;
+    let leased_b = store_b.list_leased().await?;
+    assert_eq!(leased_a.len(), 1);
+    assert_eq!(leased_b.len(), 1);
+    assert_eq!(leased_a[0].task_id, record_a.task_id);
+    assert_eq!(leased_b[0].task_id, record_b.task_id);
+
+    setup_pool.close().await;
     Ok(())
 }
 

--- a/crates/harness-server/tests/task_db_shared_schema.rs
+++ b/crates/harness-server/tests/task_db_shared_schema.rs
@@ -1,0 +1,189 @@
+use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
+use harness_core::types::TaskId as CoreTaskId;
+use harness_server::task_db::{migrate_legacy_task_db_if_needed, TaskDb, TASK_DB_SCHEMA};
+use harness_server::task_runner::{TaskKind, TaskPhase, TaskSchedulerState, TaskState, TaskStatus};
+
+fn unique_test_schema(prefix: &str) -> String {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_nanos();
+    format!("{prefix}_{nanos}_{count}")
+}
+
+fn make_task(id: &str, description: &str) -> TaskState {
+    TaskState {
+        id: CoreTaskId(id.to_string()),
+        task_kind: TaskKind::Prompt,
+        status: TaskStatus::Pending,
+        failure_kind: None,
+        turn: 0,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: None,
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: None,
+        description: Some(description.to_string()),
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        repo: None,
+        request_settings: None,
+        scheduler: TaskSchedulerState::queued(),
+        version: 0,
+    }
+}
+
+#[test]
+fn shared_schema_context_uses_fixed_task_db_schema() -> anyhow::Result<()> {
+    let context =
+        TaskDb::shared_schema_context(Some("postgres://user:pass@localhost:5432/harness"))?;
+    assert_eq!(context.schema(), TASK_DB_SCHEMA);
+    assert!(
+        context.ownership().is_none(),
+        "shared task_db schema must not register path-derived ownership"
+    );
+    Ok(())
+}
+
+#[test]
+fn store_key_for_data_dir_fails_when_path_cannot_be_canonicalized() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let missing_data_dir = dir.path().join("missing-data-dir");
+
+    let error = TaskDb::store_key_for_data_dir(&missing_data_dir)
+        .expect_err("missing data_dir should not produce a fallback store key");
+
+    assert!(
+        error
+            .to_string()
+            .contains("failed to canonicalize task data_dir"),
+        "unexpected error: {error:#}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn shared_schema_task_db_keeps_data_dirs_isolated() -> anyhow::Result<()> {
+    let database_url = match resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempfile::tempdir()?;
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let shared_schema = unique_test_schema("task_db_scope_test");
+    let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let store_a_dir = dir.path().join("store-a");
+    let store_b_dir = dir.path().join("store-b");
+    std::fs::create_dir_all(&store_a_dir)?;
+    std::fs::create_dir_all(&store_b_dir)?;
+
+    let db_a =
+        TaskDb::open_shared_with_data_dir(&shared_context, &setup_pool, &store_a_dir).await?;
+    let db_b =
+        TaskDb::open_shared_with_data_dir(&shared_context, &setup_pool, &store_b_dir).await?;
+
+    assert_eq!(db_a.schema(), shared_schema);
+    assert_eq!(db_b.schema(), shared_schema);
+    assert_ne!(db_a.store_key(), db_b.store_key());
+
+    db_a.insert(&make_task("same-task-id", "store-a")).await?;
+    db_b.insert(&make_task("same-task-id", "store-b")).await?;
+
+    let task_a = db_a
+        .get("same-task-id")
+        .await?
+        .expect("store a task should exist");
+    let task_b = db_b
+        .get("same-task-id")
+        .await?
+        .expect("store b task should exist");
+    assert_eq!(task_a.description.as_deref(), Some("store-a"));
+    assert_eq!(task_b.description.as_deref(), Some("store-b"));
+    assert_eq!(db_a.list().await?.len(), 1);
+    assert_eq!(db_b.list().await?.len(), 1);
+
+    setup_pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn legacy_path_task_db_backfill_is_idempotent_and_one_time() -> anyhow::Result<()> {
+    let database_url = match resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempfile::tempdir()?;
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let legacy_path = dir.path().join("legacy").join("tasks.db");
+    let legacy_db = TaskDb::open_with_database_url(&legacy_path, Some(&database_url)).await?;
+    let legacy_task = make_task("legacy-task", "legacy");
+    legacy_db.insert(&legacy_task).await?;
+    legacy_db
+        .write_checkpoint(
+            "legacy-task",
+            Some("triage"),
+            Some("plan"),
+            None,
+            "plan_done",
+        )
+        .await?;
+    legacy_db
+        .insert_artifact("legacy-task", 1, "summary", "artifact")
+        .await?;
+    legacy_db
+        .save_task_prompt("legacy-task", 1, "plan", "prompt")
+        .await?;
+
+    let shared_schema = unique_test_schema("task_db_backfill_test");
+    let target_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let target_data_dir = dir.path().join("target");
+    std::fs::create_dir_all(&target_data_dir)?;
+    let target_db =
+        TaskDb::open_shared_with_data_dir(&target_context, &setup_pool, &target_data_dir).await?;
+
+    let copied =
+        migrate_legacy_task_db_if_needed(&legacy_path, Some(&database_url), &target_db).await?;
+    assert_eq!(copied, 1);
+    assert!(
+        target_db.get("legacy-task").await?.is_some(),
+        "legacy task should be copied into target store"
+    );
+    assert!(
+        target_db.load_checkpoint("legacy-task").await?.is_some(),
+        "checkpoint should be copied with the task"
+    );
+    assert_eq!(target_db.list_artifacts("legacy-task").await?.len(), 1);
+    assert_eq!(target_db.get_task_prompts("legacy-task").await?.len(), 1);
+
+    let copied_again =
+        migrate_legacy_task_db_if_needed(&legacy_path, Some(&database_url), &target_db).await?;
+    assert_eq!(copied_again, 0);
+
+    legacy_db
+        .insert(&make_task("stale-legacy-task", "stale"))
+        .await?;
+    let copied_after_stale_update =
+        migrate_legacy_task_db_if_needed(&legacy_path, Some(&database_url), &target_db).await?;
+    assert_eq!(copied_after_stale_update, 0);
+    assert!(
+        target_db.get("stale-legacy-task").await?.is_none(),
+        "backfill marker should prevent stale legacy reimport on later startup"
+    );
+
+    setup_pool.close().await;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- move production TaskDb startup to a fixed shared Postgres schema with a stable data_dir-derived store_key
- scope task, checkpoint, prompt, artifact, and workspace lease queries by store_key
- backfill legacy path-derived task schemas once and record backfill markers

## Validation
- cargo fmt --all -- --check
- cargo check -p harness-server --all-targets
- cargo test -p harness-server --test task_db_shared_schema
- cargo test -p harness-server workspace_lease_store
- cargo test -p harness-server build_storage
- cargo test -p harness-server
- cargo clippy --workspace --all-targets -- -D warnings

Closes #1347
Refs #1206