### PR TITLE
storage: migrate event store to shared schema

### DIFF
--- a/crates/harness-observe/src/event_store/legacy.rs
+++ b/crates/harness-observe/src/event_store/legacy.rs
@@ -1,0 +1,99 @@
+use super::{EventStore, EVENT_MIGRATIONS};
+use harness_core::db::PgStoreContext;
+use std::path::Path;
+
+pub async fn migrate_legacy_event_store_if_needed(
+    legacy_path: &Path,
+    configured_database_url: Option<&str>,
+    target_store: &EventStore,
+) -> anyhow::Result<u64> {
+    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_schema = legacy_context.schema();
+    if legacy_schema == target_store.schema() {
+        return Ok(0);
+    }
+
+    let already_backfilled: Option<String> = sqlx::query_scalar(
+        "SELECT legacy_schema
+         FROM event_store_legacy_backfills
+         WHERE store_key = $1 AND legacy_schema = $2",
+    )
+    .bind(target_store.store_key())
+    .bind(legacy_schema)
+    .fetch_optional(&target_store.pool)
+    .await?;
+    if already_backfilled.is_some() {
+        return Ok(0);
+    }
+
+    let legacy_events_table: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::text")
+        .bind(format!("{}.events", quote_pg_ident(legacy_schema)))
+        .fetch_one(&target_store.pool)
+        .await?;
+    if legacy_events_table.is_none() {
+        return Ok(0);
+    }
+
+    let legacy_pool = legacy_context.open_migrated_pool(EVENT_MIGRATIONS).await?;
+    legacy_pool.close().await;
+
+    let legacy_schema_sql = quote_pg_ident(legacy_schema);
+    let mut tx = target_store.pool.begin().await?;
+    let events_sql = format!(
+        "INSERT INTO events (
+            store_key, id, ts, session_id, hook, tool, decision, reason, detail,
+            duration_ms, content, metadata
+         )
+         SELECT $1, id, ts, session_id, hook, tool, decision, reason, detail,
+                duration_ms, content, metadata
+         FROM {legacy_schema_sql}.events
+         ON CONFLICT (store_key, id) DO NOTHING"
+    );
+    let copied_events = sqlx::query(&events_sql)
+        .bind(target_store.store_key())
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+
+    let watermarks_sql = format!(
+        "INSERT INTO scan_watermarks (store_key, project, agent_id, last_scan_ts)
+         SELECT $1, project, agent_id, last_scan_ts
+         FROM {legacy_schema_sql}.scan_watermarks
+         ON CONFLICT (store_key, project, agent_id) DO NOTHING"
+    );
+    let copied_watermarks = sqlx::query(&watermarks_sql)
+        .bind(target_store.store_key())
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+    let copied_rows = copied_events + copied_watermarks;
+
+    sqlx::query(
+        "INSERT INTO event_store_legacy_backfills (store_key, legacy_schema, copied_rows)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (store_key, legacy_schema) DO NOTHING",
+    )
+    .bind(target_store.store_key())
+    .bind(legacy_schema)
+    .bind(copied_rows as i64)
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+
+    if copied_rows > 0 {
+        tracing::info!(
+            copied_events,
+            copied_watermarks,
+            legacy_schema,
+            target_schema = target_store.schema(),
+            "event store migration: backfilled legacy rows into shared schema"
+        );
+    }
+
+    Ok(copied_rows)
+}
+
+fn quote_pg_ident(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}

--- a/crates/harness-observe/src/event_store/migrations.rs
+++ b/crates/harness-observe/src/event_store/migrations.rs
@@ -1,0 +1,89 @@
+use harness_core::db::Migration;
+
+pub const EVENT_STORE_SCHEMA: &str = "event_store";
+
+pub(super) static EVENT_MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        description: "create events table with indexes",
+        sql: "CREATE TABLE IF NOT EXISTS events (
+        id          TEXT PRIMARY KEY,
+        ts          TEXT NOT NULL,
+        session_id  TEXT NOT NULL,
+        hook        TEXT NOT NULL,
+        tool        TEXT NOT NULL,
+        decision    TEXT NOT NULL,
+        reason      TEXT,
+        detail      TEXT,
+        duration_ms BIGINT
+    );
+    CREATE INDEX IF NOT EXISTS idx_events_session_id ON events (session_id);
+    CREATE INDEX IF NOT EXISTS idx_events_hook ON events (hook);
+    CREATE INDEX IF NOT EXISTS idx_events_decision ON events (decision);
+    CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts)",
+    },
+    Migration {
+        version: 2,
+        description: "add content column to events table",
+        sql: "ALTER TABLE events ADD COLUMN content TEXT",
+    },
+    Migration {
+        version: 3,
+        description: "create scan_watermarks table",
+        sql: "CREATE TABLE IF NOT EXISTS scan_watermarks (
+            project      TEXT NOT NULL,
+            agent_id     TEXT NOT NULL,
+            last_scan_ts TEXT NOT NULL,
+            PRIMARY KEY (project, agent_id)
+        )",
+    },
+    Migration {
+        version: 4,
+        description: "add metadata column to events table",
+        sql: "ALTER TABLE events ADD COLUMN metadata TEXT",
+    },
+    Migration {
+        version: 5,
+        description: "scope events and scan watermarks within shared schema",
+        sql: "ALTER TABLE events ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE events
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE events ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE events ALTER COLUMN store_key SET NOT NULL;
+              ALTER TABLE events DROP CONSTRAINT IF EXISTS events_pkey;
+              ALTER TABLE events ADD CONSTRAINT events_pkey PRIMARY KEY (store_key, id);
+              DROP INDEX IF EXISTS idx_events_session_id;
+              DROP INDEX IF EXISTS idx_events_hook;
+              DROP INDEX IF EXISTS idx_events_decision;
+              DROP INDEX IF EXISTS idx_events_ts;
+              CREATE INDEX IF NOT EXISTS idx_events_store_session_id
+              ON events (store_key, session_id);
+              CREATE INDEX IF NOT EXISTS idx_events_store_hook
+              ON events (store_key, hook);
+              CREATE INDEX IF NOT EXISTS idx_events_store_decision
+              ON events (store_key, decision);
+              CREATE INDEX IF NOT EXISTS idx_events_store_ts
+              ON events (store_key, ts);
+              ALTER TABLE scan_watermarks ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE scan_watermarks
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE scan_watermarks ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE scan_watermarks ALTER COLUMN store_key SET NOT NULL;
+              ALTER TABLE scan_watermarks DROP CONSTRAINT IF EXISTS scan_watermarks_pkey;
+              ALTER TABLE scan_watermarks ADD CONSTRAINT scan_watermarks_pkey
+              PRIMARY KEY (store_key, project, agent_id)",
+    },
+    Migration {
+        version: 6,
+        description: "record legacy event store backfills",
+        sql: "CREATE TABLE IF NOT EXISTS event_store_legacy_backfills (
+            store_key     TEXT NOT NULL DEFAULT current_schema(),
+            legacy_schema TEXT NOT NULL,
+            copied_rows   BIGINT NOT NULL DEFAULT 0,
+            backfilled_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (store_key, legacy_schema)
+        )",
+    },
+];

--- a/crates/harness-observe/src/event_store/mod.rs
+++ b/crates/harness-observe/src/event_store/mod.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use harness_core::config::misc::OtelConfig;
-use harness_core::db::{Migration, PgStoreContext};
+use harness_core::db::{pg_open_pool, PgStoreContext};
 use harness_core::types::{
     AutoFixReport, Decision, Event, EventFilters, EventId, ExternalSignal, ExternalSignalId, Grade,
     SessionId, Severity, Violation,
@@ -9,47 +9,12 @@ use sqlx::postgres::PgPool;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-static EVENT_MIGRATIONS: &[Migration] = &[
-    Migration {
-        version: 1,
-        description: "create events table with indexes",
-        sql: "CREATE TABLE IF NOT EXISTS events (
-        id          TEXT PRIMARY KEY,
-        ts          TEXT NOT NULL,
-        session_id  TEXT NOT NULL,
-        hook        TEXT NOT NULL,
-        tool        TEXT NOT NULL,
-        decision    TEXT NOT NULL,
-        reason      TEXT,
-        detail      TEXT,
-        duration_ms BIGINT
-    );
-    CREATE INDEX IF NOT EXISTS idx_events_session_id ON events (session_id);
-    CREATE INDEX IF NOT EXISTS idx_events_hook ON events (hook);
-    CREATE INDEX IF NOT EXISTS idx_events_decision ON events (decision);
-    CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts)",
-    },
-    Migration {
-        version: 2,
-        description: "add content column to events table",
-        sql: "ALTER TABLE events ADD COLUMN content TEXT",
-    },
-    Migration {
-        version: 3,
-        description: "create scan_watermarks table",
-        sql: "CREATE TABLE IF NOT EXISTS scan_watermarks (
-            project      TEXT NOT NULL,
-            agent_id     TEXT NOT NULL,
-            last_scan_ts TEXT NOT NULL,
-            PRIMARY KEY (project, agent_id)
-        )",
-    },
-    Migration {
-        version: 4,
-        description: "add metadata column to events table",
-        sql: "ALTER TABLE events ADD COLUMN metadata TEXT",
-    },
-];
+mod legacy;
+mod migrations;
+
+pub use legacy::migrate_legacy_event_store_if_needed;
+use migrations::EVENT_MIGRATIONS;
+pub use migrations::EVENT_STORE_SCHEMA;
 
 /// Event store backed by Postgres.
 ///
@@ -58,6 +23,8 @@ static EVENT_MIGRATIONS: &[Migration] = &[
 /// an archive.
 pub struct EventStore {
     pool: PgPool,
+    schema: String,
+    store_key: String,
     data_dir: PathBuf,
     otel_pipeline: Mutex<Option<crate::otel_export::OtelPipeline>>,
     session_renewal_secs: u64,
@@ -72,21 +39,17 @@ impl EventStore {
         data_dir: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        std::fs::create_dir_all(data_dir)?;
-        let data_dir = data_dir.to_path_buf();
-        let context =
-            PgStoreContext::from_path(&data_dir.join("events.db"), configured_database_url)?;
-        let pool = context.open_migrated_pool(EVENT_MIGRATIONS).await?;
+        let context = Self::shared_schema_context(configured_database_url)?;
+        let setup_pool = pg_open_pool(context.database_url()).await?;
+        let store = Self::new_shared_with_context(data_dir, &context, &setup_pool).await;
+        setup_pool.close().await;
+        store
+    }
 
-        let store = Self {
-            pool,
-            data_dir,
-            otel_pipeline: Mutex::new(None),
-            session_renewal_secs: 1800,
-        };
-
-        store.migrate_from_jsonl().await;
-        Ok(store)
+    pub fn shared_schema_context(
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<PgStoreContext> {
+        PgStoreContext::from_schema(EVENT_STORE_SCHEMA, configured_database_url)
     }
 
     pub async fn new_with_context(
@@ -94,18 +57,68 @@ impl EventStore {
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
+        let store_key = context.schema().to_owned();
+        let store =
+            Self::new_with_context_and_store_key(data_dir, context, setup_pool, store_key).await?;
+        store.migrate_from_jsonl().await;
+        Ok(store)
+    }
+
+    pub async fn new_shared_with_context(
+        data_dir: &Path,
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+    ) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(data_dir)?;
+        let store_key = Self::store_key_for_data_dir(data_dir)?;
+        let store =
+            Self::new_with_context_and_store_key(data_dir, context, setup_pool, store_key).await?;
+        migrate_legacy_event_store_if_needed(
+            &data_dir.join("events.db"),
+            Some(context.database_url()),
+            &store,
+        )
+        .await?;
+        store.migrate_from_jsonl().await;
+        Ok(store)
+    }
+
+    async fn new_with_context_and_store_key(
+        data_dir: &Path,
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        store_key: String,
+    ) -> anyhow::Result<Self> {
         std::fs::create_dir_all(data_dir)?;
         let pool = context
             .open_migrated_pool_with_setup_pool(setup_pool, EVENT_MIGRATIONS)
             .await?;
-        let store = Self {
+        Ok(Self {
             pool,
+            schema: context.schema().to_owned(),
+            store_key,
             data_dir: data_dir.to_path_buf(),
             otel_pipeline: Mutex::new(None),
             session_renewal_secs: 1800,
-        };
-        store.migrate_from_jsonl().await;
-        Ok(store)
+        })
+    }
+
+    pub fn store_key_for_data_dir(data_dir: &Path) -> anyhow::Result<String> {
+        let canonical = data_dir.canonicalize().map_err(|error| {
+            anyhow::anyhow!(
+                "failed to canonicalize event store data_dir {}: {error}",
+                data_dir.display()
+            )
+        })?;
+        Ok(canonical.to_string_lossy().into_owned())
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    pub fn store_key(&self) -> &str {
+        &self.store_key
     }
 
     /// Close the connection pool.
@@ -125,6 +138,8 @@ impl EventStore {
         };
         Self {
             pool,
+            schema: String::new(),
+            store_key: String::new(),
             data_dir: PathBuf::new(),
             otel_pipeline: Mutex::new(None),
             session_renewal_secs: 1800,
@@ -152,14 +167,16 @@ impl EventStore {
 
         loop {
             let result = sqlx::query(
-                "DELETE FROM events WHERE id IN (
+                "DELETE FROM events WHERE store_key = $1 AND id IN (
                     SELECT id FROM events
-                    WHERE ts < $1
+                    WHERE store_key = $1
+                      AND ts < $2
                       AND hook NOT LIKE 'periodic_review:%'
                       AND hook NOT LIKE 'periodic_retry:%'
                     LIMIT 500
                 )",
             )
+            .bind(&self.store_key)
             .bind(&cutoff_str)
             .execute(&self.pool)
             .await?;
@@ -173,15 +190,18 @@ impl EventStore {
 
         loop {
             let result = sqlx::query(
-                "DELETE FROM events WHERE id IN (
+                "DELETE FROM events WHERE store_key = $1 AND id IN (
                     SELECT e.id FROM events e
-                    WHERE (e.hook LIKE 'periodic_review:%' OR e.hook = 'periodic_retry:summary')
+                    WHERE e.store_key = $1
+                    AND (e.hook LIKE 'periodic_review:%' OR e.hook = 'periodic_retry:summary')
                     AND e.ts < (
-                        SELECT MAX(e2.ts) FROM events e2 WHERE e2.hook = e.hook
+                        SELECT MAX(e2.ts) FROM events e2
+                        WHERE e2.store_key = $1 AND e2.hook = e.hook
                     )
                     LIMIT 500
                 )",
             )
+            .bind(&self.store_key)
             .execute(&self.pool)
             .await?;
             let batch = result.rows_affected();
@@ -247,6 +267,21 @@ impl EventStore {
         Ok(store)
     }
 
+    pub async fn with_policies_and_otel_shared_with_context(
+        data_dir: &Path,
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        session_renewal_secs: u64,
+        log_retention_days: u32,
+        otel_config: &OtelConfig,
+    ) -> anyhow::Result<Self> {
+        let mut store = Self::new_shared_with_context(data_dir, context, setup_pool).await?;
+        store
+            .apply_policies_and_otel(session_renewal_secs, log_retention_days, otel_config)
+            .await?;
+        Ok(store)
+    }
+
     async fn apply_policies_and_otel(
         &mut self,
         session_renewal_secs: u64,
@@ -286,9 +321,10 @@ impl EventStore {
     async fn migrate_from_jsonl(&self) {
         use std::io::BufRead as _;
 
-        // Fast-path: if any events are already in the DB, assume a prior
-        // successful migration and skip the per-line replay entirely.
-        match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM events")
+        // Fast-path only for this data directory. Other store keys in the
+        // shared schema must not suppress this store's legacy import.
+        match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM events WHERE store_key = $1")
+            .bind(&self.store_key)
             .fetch_one(&self.pool)
             .await
         {
@@ -350,10 +386,11 @@ impl EventStore {
         };
         sqlx::query(
             "INSERT INTO events
-                (id, ts, session_id, hook, tool, decision, reason, detail, duration_ms, content, metadata)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-             ON CONFLICT (id) DO NOTHING",
+                (store_key, id, ts, session_id, hook, tool, decision, reason, detail, duration_ms, content, metadata)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+             ON CONFLICT (store_key, id) DO NOTHING",
         )
+        .bind(&self.store_key)
         .bind(event.id.as_str())
         .bind(&ts)
         .bind(event.session_id.as_str())
@@ -387,9 +424,9 @@ impl EventStore {
         };
         let mut sql = format!(
             "SELECT id, ts, session_id, hook, tool, decision, reason, detail, duration_ms, {content_col}, metadata
-             FROM events WHERE 1=1",
+             FROM events WHERE store_key = $1",
         );
-        let mut param_count = 0usize;
+        let mut param_count = 1usize;
         if filters.session_id.is_some() {
             param_count += 1;
             sql.push_str(&format!(" AND session_id = ${param_count}"));
@@ -421,7 +458,7 @@ impl EventStore {
             sql.push_str(&format!(" LIMIT {limit}"));
         }
 
-        let mut q = sqlx::query(&sql);
+        let mut q = sqlx::query(&sql).bind(&self.store_key);
 
         if let Some(ref sid) = filters.session_id {
             q = q.bind(sid.as_str());
@@ -651,8 +688,10 @@ impl EventStore {
         agent_id: &str,
     ) -> anyhow::Result<Option<DateTime<Utc>>> {
         let row: Option<(String,)> = sqlx::query_as(
-            "SELECT last_scan_ts FROM scan_watermarks WHERE project = $1 AND agent_id = $2",
+            "SELECT last_scan_ts FROM scan_watermarks
+             WHERE store_key = $1 AND project = $2 AND agent_id = $3",
         )
+        .bind(&self.store_key)
         .bind(project)
         .bind(agent_id)
         .fetch_optional(&self.pool)
@@ -675,10 +714,12 @@ impl EventStore {
         ts: DateTime<Utc>,
     ) -> anyhow::Result<()> {
         sqlx::query(
-            "INSERT INTO scan_watermarks (project, agent_id, last_scan_ts)
-             VALUES ($1, $2, $3)
-             ON CONFLICT (project, agent_id) DO UPDATE SET last_scan_ts = EXCLUDED.last_scan_ts",
+            "INSERT INTO scan_watermarks (store_key, project, agent_id, last_scan_ts)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (store_key, project, agent_id)
+             DO UPDATE SET last_scan_ts = EXCLUDED.last_scan_ts",
         )
+        .bind(&self.store_key)
         .bind(project)
         .bind(agent_id)
         .bind(ts.to_rfc3339())
@@ -748,6 +789,9 @@ impl EventStore {
             .is_none()
     }
 }
+
+#[cfg(test)]
+mod shared_schema_tests;
 
 #[cfg(test)]
 mod store_tests;

--- a/crates/harness-observe/src/event_store/shared_schema_tests.rs
+++ b/crates/harness-observe/src/event_store/shared_schema_tests.rs
@@ -1,0 +1,269 @@
+use super::*;
+use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
+use harness_core::types::EventId;
+use sqlx::postgres::PgPool;
+use std::path::Path;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+static DB_SEMAPHORE: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
+
+fn db_semaphore() -> Arc<tokio::sync::Semaphore> {
+    DB_SEMAPHORE
+        .get_or_init(|| Arc::new(tokio::sync::Semaphore::new(1)))
+        .clone()
+}
+
+fn unique_test_schema(prefix: &str) -> String {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_nanos();
+    format!("{prefix}_{nanos}_{count}")
+}
+
+fn is_db_unavailable(err: &anyhow::Error) -> bool {
+    let msg = format!("{:#}", err);
+    msg.contains("pool timed out while waiting for an open connection")
+        || msg.contains("EMAXCONNSESSION")
+        || msg.contains("SSLRequest")
+        || msg.contains("terminating connection due to administrator command")
+}
+
+async fn setup_pool() -> anyhow::Result<Option<(String, PgPool, tokio::sync::OwnedSemaphorePermit)>>
+{
+    let Ok(database_url) = resolve_database_url(None) else {
+        return Ok(None);
+    };
+    let permit = db_semaphore()
+        .acquire_owned()
+        .await
+        .expect("semaphore never closed");
+    match tokio::time::timeout(Duration::from_secs(2), pg_open_pool(&database_url)).await {
+        Ok(Ok(pool)) => Ok(Some((database_url, pool, permit))),
+        Ok(Err(err)) if is_db_unavailable(&err) => Ok(None),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Ok(None),
+    }
+}
+
+async fn open_shared_store(
+    data_dir: &Path,
+    context: &PgStoreContext,
+    setup_pool: &PgPool,
+) -> anyhow::Result<Option<EventStore>> {
+    match EventStore::new_shared_with_context(data_dir, context, setup_pool).await {
+        Ok(store) => Ok(Some(store)),
+        Err(err) if is_db_unavailable(&err) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+fn make_test_event(id: &str, detail: &str) -> Event {
+    let mut event = Event::new(SessionId::new(), "shared_schema", "test", Decision::Pass);
+    event.id = EventId::from_str(id);
+    event.detail = Some(detail.to_string());
+    event
+}
+
+#[test]
+fn shared_schema_context_uses_fixed_event_store_schema() -> anyhow::Result<()> {
+    let context =
+        EventStore::shared_schema_context(Some("postgres://user:pass@localhost:5432/harness"))?;
+    assert_eq!(context.schema(), EVENT_STORE_SCHEMA);
+    assert!(
+        context.ownership().is_none(),
+        "shared event_store schema must not register path-derived ownership"
+    );
+    Ok(())
+}
+
+#[test]
+fn store_key_for_missing_data_dir_errors() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let missing_data_dir = dir.path().join("missing-data-dir");
+
+    let error = EventStore::store_key_for_data_dir(&missing_data_dir)
+        .expect_err("missing data_dir should not produce a fallback store key");
+
+    assert!(
+        error
+            .to_string()
+            .contains("failed to canonicalize event store data_dir"),
+        "unexpected error: {error:#}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn shared_schema_keeps_events_and_watermarks_isolated() -> anyhow::Result<()> {
+    let Some((database_url, setup_pool, _permit)) = setup_pool().await? else {
+        return Ok(());
+    };
+    let dir = tempfile::tempdir()?;
+    let shared_schema = unique_test_schema("event_store_scope_test");
+    let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let store_a_dir = dir.path().join("store-a");
+    let store_b_dir = dir.path().join("store-b");
+
+    let Some(store_a) = open_shared_store(&store_a_dir, &shared_context, &setup_pool).await? else {
+        setup_pool.close().await;
+        return Ok(());
+    };
+    let Some(store_b) = open_shared_store(&store_b_dir, &shared_context, &setup_pool).await? else {
+        store_a.close().await;
+        setup_pool.close().await;
+        return Ok(());
+    };
+
+    assert_eq!(store_a.schema(), shared_schema);
+    assert_eq!(store_b.schema(), shared_schema);
+    assert_ne!(store_a.store_key(), store_b.store_key());
+
+    store_a
+        .log(&make_test_event("same-event-id", "store-a"))
+        .await?;
+    store_b
+        .log(&make_test_event("same-event-id", "store-b"))
+        .await?;
+
+    let events_a = store_a.query(&EventFilters::default()).await?;
+    let events_b = store_b.query(&EventFilters::default()).await?;
+    assert_eq!(events_a.len(), 1);
+    assert_eq!(events_b.len(), 1);
+    assert_eq!(events_a[0].detail.as_deref(), Some("store-a"));
+    assert_eq!(events_b[0].detail.as_deref(), Some("store-b"));
+
+    let ts_a = chrono::Utc::now() - chrono::Duration::minutes(5);
+    let ts_b = chrono::Utc::now();
+    store_a.set_scan_watermark("project", "gc", ts_a).await?;
+    store_b.set_scan_watermark("project", "gc", ts_b).await?;
+    assert_eq!(
+        store_a
+            .get_scan_watermark("project", "gc")
+            .await?
+            .expect("store a watermark")
+            .timestamp(),
+        ts_a.timestamp()
+    );
+    assert_eq!(
+        store_b
+            .get_scan_watermark("project", "gc")
+            .await?
+            .expect("store b watermark")
+            .timestamp(),
+        ts_b.timestamp()
+    );
+
+    store_a.close().await;
+    store_b.close().await;
+    setup_pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn jsonl_migration_is_idempotent_per_store_key() -> anyhow::Result<()> {
+    let Some((database_url, setup_pool, _permit)) = setup_pool().await? else {
+        return Ok(());
+    };
+    let dir = tempfile::tempdir()?;
+    let shared_schema = unique_test_schema("event_store_jsonl_test");
+    let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let store_a_dir = dir.path().join("store-a");
+    let store_b_dir = dir.path().join("store-b");
+    std::fs::create_dir_all(&store_a_dir)?;
+    std::fs::create_dir_all(&store_b_dir)?;
+
+    let event_a = make_test_event("jsonl-a", "store-a");
+    let event_b = make_test_event("jsonl-b", "store-b");
+    std::fs::write(
+        store_a_dir.join("events.jsonl"),
+        format!("{}\n", serde_json::to_string(&event_a)?),
+    )?;
+    std::fs::write(
+        store_b_dir.join("events.jsonl"),
+        format!("{}\n", serde_json::to_string(&event_b)?),
+    )?;
+
+    let Some(store_a) = open_shared_store(&store_a_dir, &shared_context, &setup_pool).await? else {
+        setup_pool.close().await;
+        return Ok(());
+    };
+    let Some(store_b) = open_shared_store(&store_b_dir, &shared_context, &setup_pool).await? else {
+        store_a.close().await;
+        setup_pool.close().await;
+        return Ok(());
+    };
+
+    let events_a = store_a.query(&EventFilters::default()).await?;
+    let events_b = store_b.query(&EventFilters::default()).await?;
+    assert_eq!(events_a.len(), 1);
+    assert_eq!(events_b.len(), 1);
+    assert_eq!(events_a[0].id, event_a.id);
+    assert_eq!(events_b[0].id, event_b.id);
+
+    store_a.close().await;
+    store_b.close().await;
+    setup_pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn shared_schema_backfills_legacy_path_schema_once() -> anyhow::Result<()> {
+    let Some((database_url, setup_pool, _permit)) = setup_pool().await? else {
+        return Ok(());
+    };
+    let dir = tempfile::tempdir()?;
+    let legacy_data_dir = dir.path().join("legacy-data");
+    std::fs::create_dir_all(&legacy_data_dir)?;
+    let legacy_path = legacy_data_dir.join("events.db");
+    let legacy_context = PgStoreContext::from_path(&legacy_path, Some(&database_url))?;
+
+    let legacy_store =
+        EventStore::new_with_context(&legacy_data_dir, &legacy_context, &setup_pool).await?;
+    let legacy_event = make_test_event("legacy-event", "legacy");
+    legacy_store.log(&legacy_event).await?;
+    let legacy_watermark = chrono::Utc::now() - chrono::Duration::hours(1);
+    legacy_store
+        .set_scan_watermark("project", "gc", legacy_watermark)
+        .await?;
+    legacy_store.close().await;
+
+    let target_schema = unique_test_schema("event_store_backfill_test");
+    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let target_store =
+        EventStore::new_shared_with_context(&legacy_data_dir, &target_context, &setup_pool).await?;
+
+    let copied_events = target_store.query(&EventFilters::default()).await?;
+    assert_eq!(copied_events.len(), 1);
+    assert_eq!(copied_events[0].id, legacy_event.id);
+    assert_eq!(
+        target_store
+            .get_scan_watermark("project", "gc")
+            .await?
+            .expect("legacy watermark should be copied")
+            .timestamp(),
+        legacy_watermark.timestamp()
+    );
+
+    let stale_legacy_store =
+        EventStore::new_with_context(&legacy_data_dir, &legacy_context, &setup_pool).await?;
+    stale_legacy_store
+        .log(&make_test_event("stale-legacy-event", "stale"))
+        .await?;
+    stale_legacy_store.close().await;
+
+    let copied_again =
+        migrate_legacy_event_store_if_needed(&legacy_path, Some(&database_url), &target_store)
+            .await?;
+    assert_eq!(copied_again, 0);
+    let events_after_second_backfill = target_store.query(&EventFilters::default()).await?;
+    assert_eq!(events_after_second_backfill.len(), 1);
+    assert_eq!(events_after_second_backfill[0].id, legacy_event.id);
+
+    target_store.close().await;
+    setup_pool.close().await;
+    Ok(())
+}

--- a/crates/harness-observe/src/event_store/store_tests.rs
+++ b/crates/harness-observe/src/event_store/store_tests.rs
@@ -176,9 +176,10 @@ async fn query_deserializes_rows_without_metadata() -> anyhow::Result<()> {
 
     sqlx::query(
         "INSERT INTO events
-            (id, ts, session_id, hook, tool, decision, reason, detail, duration_ms, content, metadata)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+            (store_key, id, ts, session_id, hook, tool, decision, reason, detail, duration_ms, content, metadata)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
     )
+    .bind(store.store_key())
     .bind("legacy-event")
     .bind(chrono::Utc::now().to_rfc3339())
     .bind(SessionId::new().as_str())

--- a/crates/harness-server/src/http/builders/engines.rs
+++ b/crates/harness-server/src/http/builders/engines.rs
@@ -100,11 +100,11 @@ pub(crate) async fn build_engines(
             match database_url {
                 Ok(database_url) => match harness_core::db::pg_open_pool(&database_url).await {
                     Ok(setup_pool) => {
-                        let event_context = harness_core::db::PgStoreContext::from_path(
-                            &data_dir.join("events.db"),
-                            Some(&database_url),
-                        )?;
-                        let store = harness_observe::event_store::EventStore::with_policies_and_otel_with_context(
+                        let event_context =
+                            harness_observe::event_store::EventStore::shared_schema_context(Some(
+                                &database_url,
+                            ))?;
+                        let store = harness_observe::event_store::EventStore::with_policies_and_otel_shared_with_context(
                             data_dir,
                             &event_context,
                             &setup_pool,


### PR DESCRIPTION
## Summary
- move EventStore startup to the fixed shared Postgres schema `event_store`
- scope events and scan_watermarks by canonical data-dir store_key
- backfill legacy path-derived `events.db` schema rows once per store key
- add shared-schema isolation, JSONL idempotence, and legacy backfill tests

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p harness-observe --all-targets`
- `cargo test -p harness-observe event_store -- --nocapture`
- `cargo check -p harness-server --all-targets`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

Closes #1349
Refs #1206