### PR TITLE
storage: migrate q_value_store to shared schema

### DIFF
--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -138,27 +138,32 @@ pub(crate) async fn build_storage_with_database_url(
             None,
             StoreStartupResult::optional("q_value_store").failed(error),
         ),
-        None => match harness_core::db::PgStoreContext::from_path(
-            &q_values_db_path,
-            Some(&database_url),
-        ) {
-            Ok(q_value_context) => {
-                match QValueStore::open_with_context(&q_value_context, &setup_pool).await {
-                    Ok(store) => (
-                        Some(Arc::new(store)),
-                        StoreStartupResult::optional("q_value_store"),
-                    ),
-                    Err(error) => (
-                        None,
-                        StoreStartupResult::optional("q_value_store").failed(error.to_string()),
-                    ),
-                }
+        None => {
+            match async {
+                let q_value_context = QValueStore::shared_schema_context(Some(&database_url))?;
+                let store =
+                    QValueStore::open_shared_with_data_dir(&q_value_context, &setup_pool, data_dir)
+                        .await?;
+                crate::q_value_store::migrate_legacy_q_value_store_if_needed(
+                    &q_values_db_path,
+                    Some(&database_url),
+                    &store,
+                )
+                .await?;
+                Ok::<_, anyhow::Error>(store)
             }
-            Err(error) => (
-                None,
-                StoreStartupResult::optional("q_value_store").failed(error.to_string()),
-            ),
-        },
+            .await
+            {
+                Ok(store) => (
+                    Some(Arc::new(store)),
+                    StoreStartupResult::optional("q_value_store"),
+                ),
+                Err(error) => (
+                    None,
+                    StoreStartupResult::optional("q_value_store").failed(error.to_string()),
+                ),
+            }
+        }
     };
 
     if let Some(error) = q_value_result.error.as_deref() {
@@ -226,6 +231,28 @@ mod tests {
         assert_eq!(
             tasks.task_db_store_key_for_test(),
             crate::task_db::TaskDb::store_key_for_data_dir(dir.path()).expect("store key")
+        );
+    }
+
+    #[tokio::test]
+    async fn build_storage_opens_q_value_store_from_shared_schema() {
+        let database_url = match harness_core::db::resolve_database_url(None) {
+            Ok(url) => url,
+            Err(_) => return,
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bundle = build_storage_with_database_url(dir.path(), Some(&database_url))
+            .await
+            .expect("build_storage should succeed");
+        let q_values = bundle.q_values.expect("q_value store should be ready");
+
+        assert_eq!(
+            q_values.schema_for_test(),
+            crate::q_value_store::Q_VALUE_STORE_SCHEMA
+        );
+        assert_eq!(
+            q_values.store_key_for_test(),
+            crate::q_value_store::QValueStore::store_key_for_data_dir(dir.path())
         );
     }
 

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -253,6 +253,7 @@ mod tests {
         assert_eq!(
             q_values.store_key_for_test(),
             crate::q_value_store::QValueStore::store_key_for_data_dir(dir.path())
+                .expect("store key")
         );
     }
 

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -23,6 +23,7 @@
 //! - `unknown_closed`→ 0.2 (terminal state but outcome unclear)
 
 use harness_core::db::{Migration, PgStoreContext};
+use harness_core::store_backend::{PostgresBackend, StoreLocation};
 use sqlx::postgres::PgPool;
 use std::path::Path;
 
@@ -37,6 +38,8 @@ pub const REWARD_CLOSED: f64 = 0.0;
 
 /// Reward when PR terminal state is unknown (e.g. server outage during close).
 pub const REWARD_UNKNOWN_CLOSED: f64 = 0.2;
+
+pub const Q_VALUE_STORE_SCHEMA: &str = "q_value_store";
 
 static Q_VALUE_MIGRATIONS: &[Migration] = &[
     Migration {
@@ -67,11 +70,47 @@ static Q_VALUE_MIGRATIONS: &[Migration] = &[
         sql: "CREATE INDEX IF NOT EXISTS idx_pipeline_events_task_id \
               ON pipeline_events(task_id)",
     },
+    Migration {
+        version: 4,
+        description: "scope q-value rows within shared schema",
+        sql: "ALTER TABLE pipeline_events ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE pipeline_events
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE pipeline_events ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE pipeline_events ALTER COLUMN store_key SET NOT NULL;
+              DROP INDEX IF EXISTS idx_pipeline_events_task_id;
+              CREATE INDEX IF NOT EXISTS idx_pipeline_events_store_task_id
+              ON pipeline_events(store_key, task_id);
+
+              ALTER TABLE rule_experiences ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE rule_experiences
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE rule_experiences ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE rule_experiences ALTER COLUMN store_key SET NOT NULL;
+              ALTER TABLE rule_experiences DROP CONSTRAINT IF EXISTS rule_experiences_pkey;
+              ALTER TABLE rule_experiences ADD CONSTRAINT rule_experiences_pkey
+              PRIMARY KEY (store_key, rule_id)",
+    },
+    Migration {
+        version: 5,
+        description: "record legacy q-value store backfills",
+        sql: "CREATE TABLE IF NOT EXISTS q_value_store_legacy_backfills (
+            store_key     TEXT NOT NULL DEFAULT current_schema(),
+            legacy_schema TEXT NOT NULL,
+            copied_rows   BIGINT NOT NULL DEFAULT 0,
+            backfilled_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (store_key, legacy_schema)
+        )",
+    },
 ];
 
 /// Persistent store for pipeline events and rule Q-values.
 pub struct QValueStore {
     pool: PgPool,
+    schema: String,
+    store_key: String,
 }
 
 impl QValueStore {
@@ -85,18 +124,76 @@ impl QValueStore {
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
         let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let schema = context.schema().to_owned();
+        let store_key = schema.clone();
         let pool = context.open_migrated_pool(Q_VALUE_MIGRATIONS).await?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            schema,
+            store_key,
+        })
+    }
+
+    pub fn shared_schema_context(
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<PgStoreContext> {
+        PostgresBackend::new(configured_database_url.map(ToOwned::to_owned)).store_context(
+            &StoreLocation::SharedSchema(Q_VALUE_STORE_SCHEMA.to_string()),
+        )
     }
 
     pub async fn open_with_context(
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
+        Self::open_with_context_and_store_key(context, setup_pool, context.schema().to_owned())
+            .await
+    }
+
+    pub async fn open_shared_with_data_dir(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        data_dir: &Path,
+    ) -> anyhow::Result<Self> {
+        let store_key = Self::store_key_for_data_dir(data_dir);
+        Self::open_with_context_and_store_key(context, setup_pool, store_key).await
+    }
+
+    async fn open_with_context_and_store_key(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        store_key: String,
+    ) -> anyhow::Result<Self> {
+        let schema = context.schema().to_owned();
         let pool = context
             .open_migrated_pool_with_setup_pool(setup_pool, Q_VALUE_MIGRATIONS)
             .await?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            schema,
+            store_key,
+        })
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    pub fn store_key_for_data_dir(data_dir: &Path) -> String {
+        let path = data_dir.canonicalize().unwrap_or_else(|_| {
+            if data_dir.is_absolute() {
+                data_dir.to_path_buf()
+            } else {
+                std::env::current_dir()
+                    .map(|current| current.join(data_dir))
+                    .unwrap_or_else(|_| data_dir.to_path_buf())
+            }
+        });
+        path.to_string_lossy().into_owned()
+    }
+
+    pub fn store_key(&self) -> &str {
+        &self.store_key
     }
 
     /// Record which rule/experience IDs were used during a pipeline phase.
@@ -112,9 +209,10 @@ impl QValueStore {
         let experiences_json = serde_json::to_string(experience_ids)?;
         let mut tx = self.pool.begin().await?;
         sqlx::query(
-            "INSERT INTO pipeline_events (task_id, phase, experiences_used, created_at)
-             VALUES ($1, $2, $3, CURRENT_TIMESTAMP)",
+            "INSERT INTO pipeline_events (store_key, task_id, phase, experiences_used, created_at)
+             VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)",
         )
+        .bind(&self.store_key)
         .bind(task_id)
         .bind(phase)
         .bind(&experiences_json)
@@ -123,12 +221,13 @@ impl QValueStore {
 
         for rule_id in experience_ids {
             sqlx::query(
-                "INSERT INTO rule_experiences (rule_id, retrieval_count, updated_at)
-                 VALUES ($1, 1, CURRENT_TIMESTAMP)
-                 ON CONFLICT(rule_id) DO UPDATE SET
+                "INSERT INTO rule_experiences (store_key, rule_id, retrieval_count, updated_at)
+                 VALUES ($1, $2, 1, CURRENT_TIMESTAMP)
+                 ON CONFLICT(store_key, rule_id) DO UPDATE SET
                    retrieval_count = rule_experiences.retrieval_count + 1,
                    updated_at      = CURRENT_TIMESTAMP",
             )
+            .bind(&self.store_key)
             .bind(rule_id)
             .execute(&mut *tx)
             .await?;
@@ -139,11 +238,15 @@ impl QValueStore {
 
     /// Collect all distinct experience IDs referenced across all pipeline events for a task.
     pub async fn get_experiences_for_task(&self, task_id: &str) -> anyhow::Result<Vec<String>> {
-        let rows: Vec<(String,)> =
-            sqlx::query_as("SELECT experiences_used FROM pipeline_events WHERE task_id = $1")
-                .bind(task_id)
-                .fetch_all(&self.pool)
-                .await?;
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT experiences_used
+             FROM pipeline_events
+             WHERE store_key = $1 AND task_id = $2",
+        )
+        .bind(&self.store_key)
+        .bind(task_id)
+        .fetch_all(&self.pool)
+        .await?;
 
         let mut ids = Vec::new();
         for (json,) in rows {
@@ -190,13 +293,14 @@ impl QValueStore {
         let mut tx = self.pool.begin().await?;
         for rule_id in experience_ids {
             sqlx::query(
-                "INSERT INTO rule_experiences (rule_id, q_value, success_count, updated_at)
-                 VALUES ($1, 0.5 + $2 * ($3 - 0.5), $4, CURRENT_TIMESTAMP)
-                 ON CONFLICT(rule_id) DO UPDATE SET
-                   q_value       = rule_experiences.q_value + $2 * ($3 - rule_experiences.q_value),
-                   success_count = rule_experiences.success_count + $4,
+                "INSERT INTO rule_experiences (store_key, rule_id, q_value, success_count, updated_at)
+                 VALUES ($1, $2, 0.5 + $3 * ($4 - 0.5), $5, CURRENT_TIMESTAMP)
+                 ON CONFLICT(store_key, rule_id) DO UPDATE SET
+                   q_value       = rule_experiences.q_value + $3 * ($4 - rule_experiences.q_value),
+                   success_count = rule_experiences.success_count + $5,
                    updated_at    = CURRENT_TIMESTAMP",
             )
+            .bind(&self.store_key)
             .bind(rule_id)
             .bind(alpha)
             .bind(reward)
@@ -216,177 +320,132 @@ impl QValueStore {
 
     /// Return the current Q-value for a rule, or `None` if no record exists.
     pub async fn q_value_for(&self, rule_id: &str) -> anyhow::Result<Option<f64>> {
-        let row: Option<(f64,)> =
-            sqlx::query_as("SELECT q_value FROM rule_experiences WHERE rule_id = $1")
-                .bind(rule_id)
-                .fetch_optional(&self.pool)
-                .await?;
+        let row: Option<(f64,)> = sqlx::query_as(
+            "SELECT q_value
+             FROM rule_experiences
+             WHERE store_key = $1 AND rule_id = $2",
+        )
+        .bind(&self.store_key)
+        .bind(rule_id)
+        .fetch_optional(&self.pool)
+        .await?;
         Ok(row.map(|(v,)| v))
     }
+
+    #[cfg(test)]
+    pub(crate) fn schema_for_test(&self) -> &str {
+        &self.schema
+    }
+
+    #[cfg(test)]
+    pub(crate) fn store_key_for_test(&self) -> &str {
+        &self.store_key
+    }
+}
+
+pub async fn migrate_legacy_q_value_store_if_needed(
+    legacy_path: &Path,
+    configured_database_url: Option<&str>,
+    target_store: &QValueStore,
+) -> anyhow::Result<u64> {
+    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_schema = legacy_context.schema();
+    if legacy_schema == target_store.schema() {
+        return Ok(0);
+    }
+
+    let already_backfilled: Option<String> = sqlx::query_scalar(
+        "SELECT legacy_schema
+         FROM q_value_store_legacy_backfills
+         WHERE store_key = $1 AND legacy_schema = $2",
+    )
+    .bind(target_store.store_key())
+    .bind(legacy_schema)
+    .fetch_optional(&target_store.pool)
+    .await?;
+    if already_backfilled.is_some() {
+        return Ok(0);
+    }
+
+    let legacy_pipeline_events: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::text")
+        .bind(format!("{}.pipeline_events", quote_pg_ident(legacy_schema)))
+        .fetch_one(&target_store.pool)
+        .await?;
+    let legacy_rule_experiences: Option<String> =
+        sqlx::query_scalar("SELECT to_regclass($1)::text")
+            .bind(format!(
+                "{}.rule_experiences",
+                quote_pg_ident(legacy_schema)
+            ))
+            .fetch_one(&target_store.pool)
+            .await?;
+    if legacy_pipeline_events.is_none() && legacy_rule_experiences.is_none() {
+        return Ok(0);
+    }
+
+    let legacy_schema_sql = quote_pg_ident(legacy_schema);
+    let mut copied = 0;
+    let mut tx = target_store.pool.begin().await?;
+
+    if legacy_pipeline_events.is_some() {
+        let copy_pipeline_events_sql = format!(
+            "INSERT INTO pipeline_events (store_key, task_id, phase, experiences_used, created_at)
+             SELECT $1, task_id, phase, experiences_used, created_at
+             FROM {legacy_schema_sql}.pipeline_events
+             ORDER BY id"
+        );
+        copied += sqlx::query(&copy_pipeline_events_sql)
+            .bind(target_store.store_key())
+            .execute(&mut *tx)
+            .await?
+            .rows_affected();
+    }
+
+    if legacy_rule_experiences.is_some() {
+        let copy_rule_experiences_sql = format!(
+            "INSERT INTO rule_experiences (
+                store_key, rule_id, q_value, retrieval_count, success_count, updated_at
+             )
+             SELECT $1, rule_id, q_value, retrieval_count, success_count, updated_at
+             FROM {legacy_schema_sql}.rule_experiences
+             ON CONFLICT (store_key, rule_id) DO NOTHING"
+        );
+        copied += sqlx::query(&copy_rule_experiences_sql)
+            .bind(target_store.store_key())
+            .execute(&mut *tx)
+            .await?
+            .rows_affected();
+    }
+
+    sqlx::query(
+        "INSERT INTO q_value_store_legacy_backfills (store_key, legacy_schema, copied_rows)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (store_key, legacy_schema) DO NOTHING",
+    )
+    .bind(target_store.store_key())
+    .bind(legacy_schema)
+    .bind(copied as i64)
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+
+    if copied > 0 {
+        tracing::info!(
+            copied,
+            legacy_schema,
+            target_schema = target_store.schema(),
+            "q_value store migration: backfilled legacy rows into shared schema"
+        );
+    }
+
+    Ok(copied)
+}
+
+fn quote_pg_ident(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use harness_core::db::resolve_database_url;
-    use tempfile::tempdir;
-
-    async fn open_test_store() -> anyhow::Result<Option<(QValueStore, tempfile::TempDir)>> {
-        if resolve_database_url(None).is_err() {
-            return Ok(None);
-        }
-        let dir = tempdir()?;
-        let path = dir.path().join("q_values.db");
-        let store = QValueStore::open(&path).await?;
-        Ok(Some((store, dir)))
-    }
-
-    #[tokio::test]
-    async fn record_and_retrieve_pipeline_event() -> anyhow::Result<()> {
-        let Some((store, _dir)) = open_test_store().await? else {
-            return Ok(());
-        };
-        store
-            .record_pipeline_event("task-1", "implement", &["rule-A", "rule-B"])
-            .await?;
-        let ids = store.get_experiences_for_task("task-1").await?;
-        assert_eq!(ids, vec!["rule-A", "rule-B"]);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn get_experiences_deduplicates_across_phases() -> anyhow::Result<()> {
-        let Some((store, _dir)) = open_test_store().await? else {
-            return Ok(());
-        };
-        store
-            .record_pipeline_event("task-2", "triage", &["rule-A"])
-            .await?;
-        store
-            .record_pipeline_event("task-2", "implement", &["rule-A", "rule-B"])
-            .await?;
-        let ids = store.get_experiences_for_task("task-2").await?;
-        assert_eq!(ids, vec!["rule-A", "rule-B"]);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn q_value_update_merged_increases_q_value() -> anyhow::Result<()> {
-        let Some((store, _dir)) = open_test_store().await? else {
-            return Ok(());
-        };
-        store
-            .record_pipeline_event("task-3", "implement", &["rule-X"])
-            .await?;
-        let experiences = store.get_experiences_for_task("task-3").await?;
-        store
-            .apply_q_update(&experiences, REWARD_MERGED, DEFAULT_ALPHA)
-            .await?;
-        // Q_new = 0.5 + 0.1 * (1.0 - 0.5) = 0.55
-        let q = store
-            .q_value_for("rule-X")
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("rule-X row missing"))?;
-        assert!((q - 0.55).abs() < 1e-9, "expected ~0.55, got {q}");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn q_value_update_closed_decreases_q_value() -> anyhow::Result<()> {
-        let Some((store, _dir)) = open_test_store().await? else {
-            return Ok(());
-        };
-        store
-            .record_pipeline_event("task-4", "implement", &["rule-Y"])
-            .await?;
-        let experiences = store.get_experiences_for_task("task-4").await?;
-        store
-            .apply_q_update(&experiences, REWARD_CLOSED, DEFAULT_ALPHA)
-            .await?;
-        // Q_new = 0.5 + 0.1 * (0.0 - 0.5) = 0.45
-        let q = store
-            .q_value_for("rule-Y")
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("rule-Y row missing"))?;
-        assert!((q - 0.45).abs() < 1e-9, "expected ~0.45, got {q}");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn q_value_update_noop_for_empty_ids() -> anyhow::Result<()> {
-        let Some((store, _dir)) = open_test_store().await? else {
-            return Ok(());
-        };
-        store
-            .apply_q_update(&[], REWARD_MERGED, DEFAULT_ALPHA)
-            .await?;
-        let q = store.q_value_for("nonexistent").await?;
-        assert!(q.is_none());
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn retrieval_count_incremented_via_record_pipeline_event() -> anyhow::Result<()> {
-        let Some((store, _dir)) = open_test_store().await? else {
-            return Ok(());
-        };
-        store
-            .record_pipeline_event("task-5", "plan", &["rule-Z"])
-            .await?;
-        store
-            .record_pipeline_event("task-5", "implement", &["rule-Z"])
-            .await?;
-        let row: Option<(i64,)> =
-            sqlx::query_as("SELECT retrieval_count FROM rule_experiences WHERE rule_id = $1")
-                .bind("rule-Z")
-                .fetch_optional(&store.pool)
-                .await?;
-        assert_eq!(
-            row.ok_or_else(|| anyhow::anyhow!("rule-Z row missing"))?.0,
-            2
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn success_count_incremented_only_on_merged_reward() -> anyhow::Result<()> {
-        let Some((store, _dir)) = open_test_store().await? else {
-            return Ok(());
-        };
-        store
-            .record_pipeline_event("task-6", "implement", &["rule-W"])
-            .await?;
-        let experiences = store.get_experiences_for_task("task-6").await?;
-
-        // Apply closed reward — success_count should stay 0.
-        store
-            .apply_q_update(&experiences, REWARD_CLOSED, DEFAULT_ALPHA)
-            .await?;
-        let row: Option<(i64,)> =
-            sqlx::query_as("SELECT success_count FROM rule_experiences WHERE rule_id = $1")
-                .bind("rule-W")
-                .fetch_optional(&store.pool)
-                .await?;
-        assert_eq!(
-            row.ok_or_else(|| anyhow::anyhow!("rule-W row missing after closed"))?
-                .0,
-            0
-        );
-
-        // Apply merged reward — success_count should become 1.
-        store
-            .apply_q_update(&experiences, REWARD_MERGED, DEFAULT_ALPHA)
-            .await?;
-        let row: Option<(i64,)> =
-            sqlx::query_as("SELECT success_count FROM rule_experiences WHERE rule_id = $1")
-                .bind("rule-W")
-                .fetch_optional(&store.pool)
-                .await?;
-        assert_eq!(
-            row.ok_or_else(|| anyhow::anyhow!("rule-W row missing after merged"))?
-                .0,
-            1
-        );
-        Ok(())
-    }
-}
+#[path = "q_value_store_tests.rs"]
+mod tests;

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -155,7 +155,7 @@ impl QValueStore {
         setup_pool: &PgPool,
         data_dir: &Path,
     ) -> anyhow::Result<Self> {
-        let store_key = Self::store_key_for_data_dir(data_dir);
+        let store_key = Self::store_key_for_data_dir(data_dir)?;
         Self::open_with_context_and_store_key(context, setup_pool, store_key).await
     }
 
@@ -179,17 +179,14 @@ impl QValueStore {
         &self.schema
     }
 
-    pub fn store_key_for_data_dir(data_dir: &Path) -> String {
-        let path = data_dir.canonicalize().unwrap_or_else(|_| {
-            if data_dir.is_absolute() {
-                data_dir.to_path_buf()
-            } else {
-                std::env::current_dir()
-                    .map(|current| current.join(data_dir))
-                    .unwrap_or_else(|_| data_dir.to_path_buf())
-            }
-        });
-        path.to_string_lossy().into_owned()
+    pub fn store_key_for_data_dir(data_dir: &Path) -> anyhow::Result<String> {
+        let canonical = data_dir.canonicalize().map_err(|error| {
+            anyhow::anyhow!(
+                "failed to canonicalize q_value_store data_dir {}: {error}",
+                data_dir.display()
+            )
+        })?;
+        Ok(canonical.to_string_lossy().into_owned())
     }
 
     pub fn store_key(&self) -> &str {
@@ -351,6 +348,20 @@ pub async fn migrate_legacy_q_value_store_if_needed(
     let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
     if legacy_schema == target_store.schema() {
+        return Ok(0);
+    }
+
+    let legacy_schema_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS (
+             SELECT 1
+             FROM pg_catalog.pg_namespace
+             WHERE nspname = $1
+         )",
+    )
+    .bind(legacy_schema)
+    .fetch_one(&target_store.pool)
+    .await?;
+    if !legacy_schema_exists {
         return Ok(0);
     }
 

--- a/crates/harness-server/src/q_value_store_tests.rs
+++ b/crates/harness-server/src/q_value_store_tests.rs
@@ -1,0 +1,362 @@
+use super::*;
+use futures::FutureExt;
+use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
+use tempfile::tempdir;
+
+fn unique_test_schema(prefix: &str) -> String {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_nanos();
+    format!("{prefix}_{nanos}_{count}")
+}
+
+async fn open_test_store() -> anyhow::Result<Option<(QValueStore, tempfile::TempDir)>> {
+    if resolve_database_url(None).is_err() {
+        return Ok(None);
+    }
+    let dir = tempdir()?;
+    let path = dir.path().join("q_values.db");
+    let store = QValueStore::open(&path).await?;
+    Ok(Some((store, dir)))
+}
+
+#[test]
+fn shared_schema_context_uses_fixed_q_value_store_schema() -> anyhow::Result<()> {
+    let context =
+        QValueStore::shared_schema_context(Some("postgres://user:pass@localhost:5432/harness"))?;
+    assert_eq!(context.schema(), Q_VALUE_STORE_SCHEMA);
+    assert!(
+        context.ownership().is_none(),
+        "shared q_value_store schema must not register path-derived ownership"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn shared_schema_q_value_store_keeps_store_rows_isolated() -> anyhow::Result<()> {
+    let database_url = match resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempdir()?;
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let shared_schema = unique_test_schema("q_value_store_scope_test");
+    let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let store_a_dir = dir.path().join("store-a");
+    let store_b_dir = dir.path().join("store-b");
+    let store_a =
+        QValueStore::open_shared_with_data_dir(&shared_context, &setup_pool, &store_a_dir).await?;
+    let store_b =
+        QValueStore::open_shared_with_data_dir(&shared_context, &setup_pool, &store_b_dir).await?;
+
+    let result = std::panic::AssertUnwindSafe(async {
+        assert_ne!(store_a.store_key(), store_b.store_key());
+
+        store_a
+            .record_pipeline_event("same-task", "plan", &["rule-A"])
+            .await?;
+        store_b
+            .record_pipeline_event("same-task", "plan", &["rule-B"])
+            .await?;
+
+        assert_eq!(
+            store_a.get_experiences_for_task("same-task").await?,
+            vec!["rule-A"]
+        );
+        assert_eq!(
+            store_b.get_experiences_for_task("same-task").await?,
+            vec!["rule-B"]
+        );
+
+        let shared_rule = vec!["shared-rule".to_string()];
+        store_a
+            .apply_q_update(&shared_rule, REWARD_MERGED, DEFAULT_ALPHA)
+            .await?;
+        store_b
+            .apply_q_update(&shared_rule, REWARD_CLOSED, DEFAULT_ALPHA)
+            .await?;
+
+        let q_a = store_a
+            .q_value_for("shared-rule")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("store A shared-rule row missing"))?;
+        let q_b = store_b
+            .q_value_for("shared-rule")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("store B shared-rule row missing"))?;
+        assert!(
+            (q_a - 0.55).abs() < 1e-9,
+            "expected store A ~0.55, got {q_a}"
+        );
+        assert!(
+            (q_b - 0.45).abs() < 1e-9,
+            "expected store B ~0.45, got {q_b}"
+        );
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .catch_unwind()
+    .await;
+
+    store_a.pool.close().await;
+    store_b.pool.close().await;
+    let _ = sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{shared_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await;
+    setup_pool.close().await;
+
+    match result {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+#[tokio::test]
+async fn legacy_q_value_store_migration_backfills_once() -> anyhow::Result<()> {
+    let database_url = match resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempdir()?;
+    let target_data_dir = dir.path().join("target-data");
+    let other_data_dir = dir.path().join("other-data");
+    let legacy_path = target_data_dir.join("q_values.db");
+    let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
+        .schema()
+        .to_owned();
+    let target_schema = unique_test_schema("q_value_store_migration_test");
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let target_store =
+        QValueStore::open_shared_with_data_dir(&target_context, &setup_pool, &target_data_dir)
+            .await?;
+    let other_store =
+        QValueStore::open_shared_with_data_dir(&target_context, &setup_pool, &other_data_dir)
+            .await?;
+    let legacy_store =
+        QValueStore::open_with_database_url(&legacy_path, Some(&database_url)).await?;
+
+    let result = std::panic::AssertUnwindSafe(async {
+        legacy_store
+            .record_pipeline_event("legacy-task", "implement", &["legacy-rule"])
+            .await?;
+        let experiences = legacy_store.get_experiences_for_task("legacy-task").await?;
+        legacy_store
+            .apply_q_update(&experiences, REWARD_MERGED, DEFAULT_ALPHA)
+            .await?;
+
+        let copied = migrate_legacy_q_value_store_if_needed(
+            &legacy_path,
+            Some(&database_url),
+            &target_store,
+        )
+        .await?;
+        assert_eq!(copied, 2, "one event and one rule row should be copied");
+
+        let copied_again = migrate_legacy_q_value_store_if_needed(
+            &legacy_path,
+            Some(&database_url),
+            &target_store,
+        )
+        .await?;
+        assert_eq!(copied_again, 0, "migration must be idempotent");
+
+        assert_eq!(
+            target_store.get_experiences_for_task("legacy-task").await?,
+            vec!["legacy-rule"]
+        );
+        let q = target_store
+            .q_value_for("legacy-rule")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("legacy-rule row missing after backfill"))?;
+        assert!(
+            (q - 0.55).abs() < 1e-9,
+            "expected migrated q ~0.55, got {q}"
+        );
+        assert!(
+            other_store
+                .get_experiences_for_task("legacy-task")
+                .await?
+                .is_empty(),
+            "other data_dir scopes must not hydrate legacy q-value events"
+        );
+        assert!(
+            other_store.q_value_for("legacy-rule").await?.is_none(),
+            "other data_dir scopes must not hydrate legacy rule q-values"
+        );
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .catch_unwind()
+    .await;
+
+    legacy_store.pool.close().await;
+    target_store.pool.close().await;
+    other_store.pool.close().await;
+    let _ = sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{legacy_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await;
+    let _ = sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await;
+    setup_pool.close().await;
+
+    match result {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+#[tokio::test]
+async fn record_and_retrieve_pipeline_event() -> anyhow::Result<()> {
+    let Some((store, _dir)) = open_test_store().await? else {
+        return Ok(());
+    };
+    store
+        .record_pipeline_event("task-1", "implement", &["rule-A", "rule-B"])
+        .await?;
+    let ids = store.get_experiences_for_task("task-1").await?;
+    assert_eq!(ids, vec!["rule-A", "rule-B"]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_experiences_deduplicates_across_phases() -> anyhow::Result<()> {
+    let Some((store, _dir)) = open_test_store().await? else {
+        return Ok(());
+    };
+    store
+        .record_pipeline_event("task-2", "triage", &["rule-A"])
+        .await?;
+    store
+        .record_pipeline_event("task-2", "implement", &["rule-A", "rule-B"])
+        .await?;
+    let ids = store.get_experiences_for_task("task-2").await?;
+    assert_eq!(ids, vec!["rule-A", "rule-B"]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn q_value_update_merged_increases_q_value() -> anyhow::Result<()> {
+    let Some((store, _dir)) = open_test_store().await? else {
+        return Ok(());
+    };
+    store
+        .record_pipeline_event("task-3", "implement", &["rule-X"])
+        .await?;
+    let experiences = store.get_experiences_for_task("task-3").await?;
+    store
+        .apply_q_update(&experiences, REWARD_MERGED, DEFAULT_ALPHA)
+        .await?;
+    let q = store
+        .q_value_for("rule-X")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("rule-X row missing"))?;
+    assert!((q - 0.55).abs() < 1e-9, "expected ~0.55, got {q}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn q_value_update_closed_decreases_q_value() -> anyhow::Result<()> {
+    let Some((store, _dir)) = open_test_store().await? else {
+        return Ok(());
+    };
+    store
+        .record_pipeline_event("task-4", "implement", &["rule-Y"])
+        .await?;
+    let experiences = store.get_experiences_for_task("task-4").await?;
+    store
+        .apply_q_update(&experiences, REWARD_CLOSED, DEFAULT_ALPHA)
+        .await?;
+    let q = store
+        .q_value_for("rule-Y")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("rule-Y row missing"))?;
+    assert!((q - 0.45).abs() < 1e-9, "expected ~0.45, got {q}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn q_value_update_noop_for_empty_ids() -> anyhow::Result<()> {
+    let Some((store, _dir)) = open_test_store().await? else {
+        return Ok(());
+    };
+    store
+        .apply_q_update(&[], REWARD_MERGED, DEFAULT_ALPHA)
+        .await?;
+    let q = store.q_value_for("nonexistent").await?;
+    assert!(q.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn retrieval_count_incremented_via_record_pipeline_event() -> anyhow::Result<()> {
+    let Some((store, _dir)) = open_test_store().await? else {
+        return Ok(());
+    };
+    store
+        .record_pipeline_event("task-5", "plan", &["rule-Z"])
+        .await?;
+    store
+        .record_pipeline_event("task-5", "implement", &["rule-Z"])
+        .await?;
+    let row: Option<(i64,)> =
+        sqlx::query_as("SELECT retrieval_count FROM rule_experiences WHERE rule_id = $1")
+            .bind("rule-Z")
+            .fetch_optional(&store.pool)
+            .await?;
+    assert_eq!(
+        row.ok_or_else(|| anyhow::anyhow!("rule-Z row missing"))?.0,
+        2
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn success_count_incremented_only_on_merged_reward() -> anyhow::Result<()> {
+    let Some((store, _dir)) = open_test_store().await? else {
+        return Ok(());
+    };
+    store
+        .record_pipeline_event("task-6", "implement", &["rule-W"])
+        .await?;
+    let experiences = store.get_experiences_for_task("task-6").await?;
+
+    store
+        .apply_q_update(&experiences, REWARD_CLOSED, DEFAULT_ALPHA)
+        .await?;
+    let row: Option<(i64,)> =
+        sqlx::query_as("SELECT success_count FROM rule_experiences WHERE rule_id = $1")
+            .bind("rule-W")
+            .fetch_optional(&store.pool)
+            .await?;
+    assert_eq!(
+        row.ok_or_else(|| anyhow::anyhow!("rule-W row missing after closed"))?
+            .0,
+        0
+    );
+
+    store
+        .apply_q_update(&experiences, REWARD_MERGED, DEFAULT_ALPHA)
+        .await?;
+    let row: Option<(i64,)> =
+        sqlx::query_as("SELECT success_count FROM rule_experiences WHERE rule_id = $1")
+            .bind("rule-W")
+            .fetch_optional(&store.pool)
+            .await?;
+    assert_eq!(
+        row.ok_or_else(|| anyhow::anyhow!("rule-W row missing after merged"))?
+            .0,
+        1
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/q_value_store_tests.rs
+++ b/crates/harness-server/src/q_value_store_tests.rs
@@ -47,6 +47,8 @@ async fn shared_schema_q_value_store_keeps_store_rows_isolated() -> anyhow::Resu
     let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
     let store_a_dir = dir.path().join("store-a");
     let store_b_dir = dir.path().join("store-b");
+    std::fs::create_dir_all(&store_a_dir)?;
+    std::fs::create_dir_all(&store_b_dir)?;
     let store_a =
         QValueStore::open_shared_with_data_dir(&shared_context, &setup_pool, &store_a_dir).await?;
     let store_b =
@@ -125,6 +127,8 @@ async fn legacy_q_value_store_migration_backfills_once() -> anyhow::Result<()> {
     let dir = tempdir()?;
     let target_data_dir = dir.path().join("target-data");
     let other_data_dir = dir.path().join("other-data");
+    std::fs::create_dir_all(&target_data_dir)?;
+    std::fs::create_dir_all(&other_data_dir)?;
     let legacy_path = target_data_dir.join("q_values.db");
     let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
         .schema()
@@ -203,6 +207,64 @@ async fn legacy_q_value_store_migration_backfills_once() -> anyhow::Result<()> {
     ))
     .execute(&setup_pool)
     .await;
+    let _ = sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await;
+    setup_pool.close().await;
+
+    match result {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+#[test]
+fn store_key_for_missing_data_dir_errors() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let missing = dir.path().join("missing-data-dir");
+    let err = QValueStore::store_key_for_data_dir(&missing)
+        .expect_err("missing data dir should not produce a fallback store key");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("failed to canonicalize q_value_store data_dir"),
+        "error should mention q_value_store data_dir canonicalization, got: {msg}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn legacy_q_value_store_migration_ignores_missing_legacy_schema() -> anyhow::Result<()> {
+    let database_url = match resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempdir()?;
+    let target_data_dir = dir.path().join("target-data");
+    std::fs::create_dir_all(&target_data_dir)?;
+    let missing_legacy_path = dir.path().join("missing-legacy").join("q_values.db");
+    let target_schema = unique_test_schema("q_value_store_missing_legacy_test");
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let target_store =
+        QValueStore::open_shared_with_data_dir(&target_context, &setup_pool, &target_data_dir)
+            .await?;
+
+    let result = std::panic::AssertUnwindSafe(async {
+        let copied = migrate_legacy_q_value_store_if_needed(
+            &missing_legacy_path,
+            Some(&database_url),
+            &target_store,
+        )
+        .await?;
+        assert_eq!(copied, 0, "missing legacy schema should be a no-op");
+        Ok::<(), anyhow::Error>(())
+    })
+    .catch_unwind()
+    .await;
+
+    target_store.pool.close().await;
     let _ = sqlx::query(&format!(
         "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
     ))


### PR DESCRIPTION
Summary:
- Move production q_value_store startup to the fixed shared q_value_store Postgres schema with data_dir-derived store keys.
- Scope pipeline_events and rule_experiences reads/writes by store_key and add legacy backfill tracking from the old q_values.db path-derived schema.
- Add focused shared-schema isolation, legacy backfill, and storage-builder tests.

Validation:
- cargo fmt --all
- cargo fmt --all -- --check
- cargo test -p harness-server q_value_store
- cargo test -p harness-server build_storage_opens_q_value_store_from_shared_schema
- cargo check -p harness-server --all-targets
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test

References #1206.
Closes #1351.