### PR TITLE
storage: migrate eval_store to shared schema

### DIFF
--- a/crates/harness-server/src/eval_store.rs
+++ b/crates/harness-server/src/eval_store.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use harness_core::db::{Migration, PgStoreContext};
+use harness_core::store_backend::{PostgresBackend, StoreLocation};
 use harness_eval::{
     score_pr_repair_eval, EvalScenario, EvalTarget, PrRepairEvalInput, QualitySnapshot,
 };
@@ -7,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 use std::path::Path;
 use uuid::Uuid;
+
+pub const EVAL_STORE_SCHEMA: &str = "eval_store";
 
 static EVAL_MIGRATIONS: &[Migration] = &[
     Migration {
@@ -73,6 +76,78 @@ static EVAL_MIGRATIONS: &[Migration] = &[
               CREATE INDEX IF NOT EXISTS idx_quality_snapshots_pr
               ON quality_snapshots(target_repo, target_pr_number, created_at DESC)",
     },
+    Migration {
+        version: 5,
+        description: "scope eval rows within shared schema",
+        sql: "ALTER TABLE eval_runs ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE eval_runs
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE eval_runs ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE eval_runs ALTER COLUMN store_key SET NOT NULL;
+
+              ALTER TABLE eval_artifacts ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE eval_artifacts
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE eval_artifacts ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE eval_artifacts ALTER COLUMN store_key SET NOT NULL;
+
+              ALTER TABLE quality_snapshots ADD COLUMN IF NOT EXISTS store_key TEXT;
+              UPDATE quality_snapshots
+              SET store_key = COALESCE(NULLIF(store_key, ''), current_schema())
+              WHERE store_key IS NULL OR store_key = '';
+              ALTER TABLE quality_snapshots ALTER COLUMN store_key SET DEFAULT current_schema();
+              ALTER TABLE quality_snapshots ALTER COLUMN store_key SET NOT NULL;
+
+              ALTER TABLE eval_artifacts DROP CONSTRAINT IF EXISTS eval_artifacts_run_id_fkey;
+              ALTER TABLE eval_artifacts DROP CONSTRAINT IF EXISTS eval_artifacts_run_fk;
+              ALTER TABLE quality_snapshots DROP CONSTRAINT IF EXISTS quality_snapshots_run_id_fkey;
+              ALTER TABLE quality_snapshots DROP CONSTRAINT IF EXISTS quality_snapshots_run_fk;
+
+              ALTER TABLE eval_runs DROP CONSTRAINT IF EXISTS eval_runs_pkey;
+              ALTER TABLE eval_runs ADD CONSTRAINT eval_runs_pkey PRIMARY KEY (store_key, id);
+              ALTER TABLE eval_artifacts DROP CONSTRAINT IF EXISTS eval_artifacts_pkey;
+              ALTER TABLE eval_artifacts ADD CONSTRAINT eval_artifacts_pkey PRIMARY KEY (store_key, id);
+              ALTER TABLE quality_snapshots DROP CONSTRAINT IF EXISTS quality_snapshots_pkey;
+              ALTER TABLE quality_snapshots ADD CONSTRAINT quality_snapshots_pkey PRIMARY KEY (store_key, id);
+
+              ALTER TABLE eval_artifacts
+              ADD CONSTRAINT eval_artifacts_run_fk
+              FOREIGN KEY (store_key, run_id) REFERENCES eval_runs(store_key, id)
+              ON DELETE CASCADE;
+              ALTER TABLE quality_snapshots
+              ADD CONSTRAINT quality_snapshots_run_fk
+              FOREIGN KEY (store_key, run_id) REFERENCES eval_runs(store_key, id)
+              ON DELETE CASCADE;
+
+              DROP INDEX IF EXISTS idx_eval_runs_updated;
+              DROP INDEX IF EXISTS idx_eval_runs_pr;
+              DROP INDEX IF EXISTS idx_eval_artifacts_run;
+              DROP INDEX IF EXISTS idx_quality_snapshots_run;
+              DROP INDEX IF EXISTS idx_quality_snapshots_pr;
+              CREATE INDEX IF NOT EXISTS idx_eval_runs_store_updated
+              ON eval_runs(store_key, updated_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_eval_runs_store_pr
+              ON eval_runs(store_key, target_repo, target_pr_number, updated_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_eval_artifacts_store_run
+              ON eval_artifacts(store_key, run_id, created_at);
+              CREATE INDEX IF NOT EXISTS idx_quality_snapshots_store_run
+              ON quality_snapshots(store_key, run_id, created_at DESC);
+              CREATE INDEX IF NOT EXISTS idx_quality_snapshots_store_pr
+              ON quality_snapshots(store_key, target_repo, target_pr_number, created_at DESC)",
+    },
+    Migration {
+        version: 6,
+        description: "record legacy eval store backfills",
+        sql: "CREATE TABLE IF NOT EXISTS eval_store_legacy_backfills (
+            store_key     TEXT NOT NULL DEFAULT current_schema(),
+            legacy_schema TEXT NOT NULL,
+            copied_rows   BIGINT NOT NULL DEFAULT 0,
+            backfilled_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (store_key, legacy_schema)
+        )",
+    },
 ];
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -137,6 +212,8 @@ pub struct EvalScoreResult {
 
 pub struct EvalStore {
     pool: PgPool,
+    schema: String,
+    store_key: String,
 }
 
 impl EvalStore {
@@ -149,18 +226,72 @@ impl EvalStore {
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
         let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let schema = context.schema().to_owned();
+        let store_key = schema.clone();
         let pool = context.open_migrated_pool(EVAL_MIGRATIONS).await?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            schema,
+            store_key,
+        })
+    }
+
+    pub fn shared_schema_context(
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<PgStoreContext> {
+        PostgresBackend::new(configured_database_url.map(ToOwned::to_owned))
+            .store_context(&StoreLocation::SharedSchema(EVAL_STORE_SCHEMA.to_string()))
     }
 
     pub async fn open_with_context(
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
+        Self::open_with_context_and_store_key(context, setup_pool, context.schema().to_owned())
+            .await
+    }
+
+    pub async fn open_shared_with_data_dir(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        data_dir: &Path,
+    ) -> anyhow::Result<Self> {
+        let store_key = Self::store_key_for_data_dir(data_dir)?;
+        Self::open_with_context_and_store_key(context, setup_pool, store_key).await
+    }
+
+    async fn open_with_context_and_store_key(
+        context: &PgStoreContext,
+        setup_pool: &PgPool,
+        store_key: String,
+    ) -> anyhow::Result<Self> {
+        let schema = context.schema().to_owned();
         let pool = context
             .open_migrated_pool_with_setup_pool(setup_pool, EVAL_MIGRATIONS)
             .await?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            schema,
+            store_key,
+        })
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    pub fn store_key_for_data_dir(data_dir: &Path) -> anyhow::Result<String> {
+        let canonical = data_dir.canonicalize().map_err(|error| {
+            anyhow::anyhow!(
+                "failed to canonicalize eval_store data_dir {}: {error}",
+                data_dir.display()
+            )
+        })?;
+        Ok(canonical.to_string_lossy().into_owned())
+    }
+
+    pub fn store_key(&self) -> &str {
+        &self.store_key
     }
 
     pub async fn create_run(&self, input: CreateEvalRun) -> anyhow::Result<EvalRun> {
@@ -180,11 +311,12 @@ impl EvalStore {
         let fields = target_fields(&run.target)?;
         sqlx::query(
             "INSERT INTO eval_runs
-             (id, scenario, target_kind, target_repo, target_pr_number, target_issue_number,
+             (store_key, id, scenario, target_kind, target_repo, target_pr_number, target_issue_number,
               source_task_id, status, quality_snapshot_id, data, created_at, updated_at,
               completed_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
         )
+        .bind(&self.store_key)
         .bind(&run.id)
         .bind(scenario_key(&run.scenario))
         .bind(fields.kind)
@@ -204,10 +336,12 @@ impl EvalStore {
     }
 
     pub async fn get_run(&self, run_id: &str) -> anyhow::Result<Option<EvalRun>> {
-        let row: Option<(String,)> = sqlx::query_as("SELECT data FROM eval_runs WHERE id = $1")
-            .bind(run_id)
-            .fetch_optional(&self.pool)
-            .await?;
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data FROM eval_runs WHERE store_key = $1 AND id = $2")
+                .bind(&self.store_key)
+                .bind(run_id)
+                .fetch_optional(&self.pool)
+                .await?;
         row.map(|(data,)| serde_json::from_str(&data))
             .transpose()
             .map_err(Into::into)
@@ -215,11 +349,15 @@ impl EvalStore {
 
     pub async fn list_runs(&self, limit: i64) -> anyhow::Result<Vec<EvalRun>> {
         let limit = limit.clamp(1, 100);
-        let rows: Vec<(String,)> =
-            sqlx::query_as("SELECT data FROM eval_runs ORDER BY updated_at DESC LIMIT $1")
-                .bind(limit)
-                .fetch_all(&self.pool)
-                .await?;
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data FROM eval_runs
+                 WHERE store_key = $1
+                 ORDER BY updated_at DESC LIMIT $2",
+        )
+        .bind(&self.store_key)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter()
             .map(|(data,)| serde_json::from_str(&data).map_err(Into::into))
             .collect()
@@ -245,9 +383,10 @@ impl EvalStore {
         let data = serde_json::to_string(&artifact)?;
         sqlx::query(
             "INSERT INTO eval_artifacts
-             (id, run_id, artifact_type, label, content_type, body, data, created_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+             (store_key, id, run_id, artifact_type, label, content_type, body, data, created_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
         )
+        .bind(&self.store_key)
         .bind(&artifact.id)
         .bind(&artifact.run_id)
         .bind(&artifact.artifact_type)
@@ -262,11 +401,15 @@ impl EvalStore {
     }
 
     pub async fn list_artifacts(&self, run_id: &str) -> anyhow::Result<Vec<EvalArtifact>> {
-        let rows: Vec<(String,)> =
-            sqlx::query_as("SELECT data FROM eval_artifacts WHERE run_id = $1 ORDER BY created_at")
-                .bind(run_id)
-                .fetch_all(&self.pool)
-                .await?;
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data FROM eval_artifacts
+             WHERE store_key = $1 AND run_id = $2
+             ORDER BY created_at",
+        )
+        .bind(&self.store_key)
+        .bind(run_id)
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter()
             .map(|(data,)| serde_json::from_str(&data).map_err(Into::into))
             .collect()
@@ -302,10 +445,11 @@ impl EvalStore {
         let mut tx = self.pool.begin().await?;
         sqlx::query(
             "INSERT INTO quality_snapshots
-             (id, run_id, scenario, target_repo, target_pr_number, final_score, final_grade,
+             (store_key, id, run_id, scenario, target_repo, target_pr_number, final_score, final_grade,
               data, created_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
         )
+        .bind(&self.store_key)
         .bind(&record.id)
         .bind(&record.run_id)
         .bind(scenario_key(&run.scenario))
@@ -319,10 +463,11 @@ impl EvalStore {
         .await?;
         sqlx::query(
             "UPDATE eval_runs
-             SET status = $2, quality_snapshot_id = $3, data = $4, updated_at = $5,
-                 completed_at = $6
-             WHERE id = $1",
+             SET status = $3, quality_snapshot_id = $4, data = $5, updated_at = $6,
+                 completed_at = $7
+             WHERE store_key = $1 AND id = $2",
         )
+        .bind(&self.store_key)
         .bind(&run.id)
         .bind(status_key(&run.status))
         .bind(&run.quality_snapshot_id)
@@ -343,7 +488,8 @@ impl EvalStore {
         snapshot_id: &str,
     ) -> anyhow::Result<Option<QualitySnapshotRecord>> {
         let row: Option<(String,)> =
-            sqlx::query_as("SELECT data FROM quality_snapshots WHERE id = $1")
+            sqlx::query_as("SELECT data FROM quality_snapshots WHERE store_key = $1 AND id = $2")
+                .bind(&self.store_key)
                 .bind(snapshot_id)
                 .fetch_optional(&self.pool)
                 .await?;
@@ -362,10 +508,11 @@ impl EvalStore {
         let limit = limit.clamp(1, 100);
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT data FROM quality_snapshots
-             WHERE target_repo = $1 AND target_pr_number = $2
+             WHERE store_key = $1 AND target_repo = $2 AND target_pr_number = $3
              ORDER BY created_at DESC
-             LIMIT $3",
+             LIMIT $4",
         )
+        .bind(&self.store_key)
         .bind(repo)
         .bind(pr_number)
         .bind(limit)
@@ -375,6 +522,136 @@ impl EvalStore {
             .map(|(data,)| serde_json::from_str(&data).map_err(Into::into))
             .collect()
     }
+}
+
+pub async fn migrate_legacy_eval_store_if_needed(
+    legacy_path: &Path,
+    configured_database_url: Option<&str>,
+    target_store: &EvalStore,
+) -> anyhow::Result<u64> {
+    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_schema = legacy_context.schema();
+    if legacy_schema == target_store.schema() {
+        return Ok(0);
+    }
+
+    let legacy_schema_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS (
+             SELECT 1
+             FROM pg_catalog.pg_namespace
+             WHERE nspname = $1
+         )",
+    )
+    .bind(legacy_schema)
+    .fetch_one(&target_store.pool)
+    .await?;
+    if !legacy_schema_exists {
+        return Ok(0);
+    }
+
+    let already_backfilled: Option<String> = sqlx::query_scalar(
+        "SELECT legacy_schema
+         FROM eval_store_legacy_backfills
+         WHERE store_key = $1 AND legacy_schema = $2",
+    )
+    .bind(target_store.store_key())
+    .bind(legacy_schema)
+    .fetch_optional(&target_store.pool)
+    .await?;
+    if already_backfilled.is_some() {
+        return Ok(0);
+    }
+
+    let legacy_runs: Option<String> = sqlx::query_scalar("SELECT to_regclass($1)::text")
+        .bind(format!("{}.eval_runs", quote_pg_ident(legacy_schema)))
+        .fetch_one(&target_store.pool)
+        .await?;
+    if legacy_runs.is_none() {
+        return Ok(0);
+    }
+
+    let legacy_pool = legacy_context.open_migrated_pool(EVAL_MIGRATIONS).await?;
+    legacy_pool.close().await;
+
+    let legacy_schema_sql = quote_pg_ident(legacy_schema);
+    let mut copied = 0;
+    let mut tx = target_store.pool.begin().await?;
+
+    let copy_runs_sql = format!(
+        "INSERT INTO eval_runs (
+            store_key, id, scenario, target_kind, target_repo, target_pr_number,
+            target_issue_number, source_task_id, status, quality_snapshot_id, data,
+            created_at, updated_at, completed_at
+         )
+         SELECT $1, id, scenario, target_kind, target_repo, target_pr_number,
+                target_issue_number, source_task_id, status, quality_snapshot_id, data,
+                created_at, updated_at, completed_at
+         FROM {legacy_schema_sql}.eval_runs
+         ON CONFLICT (store_key, id) DO NOTHING"
+    );
+    copied += sqlx::query(&copy_runs_sql)
+        .bind(target_store.store_key())
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+
+    let copy_artifacts_sql = format!(
+        "INSERT INTO eval_artifacts (
+            store_key, id, run_id, artifact_type, label, content_type, body, data, created_at
+         )
+         SELECT $1, id, run_id, artifact_type, label, content_type, body, data, created_at
+         FROM {legacy_schema_sql}.eval_artifacts
+         ON CONFLICT (store_key, id) DO NOTHING"
+    );
+    copied += sqlx::query(&copy_artifacts_sql)
+        .bind(target_store.store_key())
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+
+    let copy_snapshots_sql = format!(
+        "INSERT INTO quality_snapshots (
+            store_key, id, run_id, scenario, target_repo, target_pr_number, final_score,
+            final_grade, data, created_at
+         )
+         SELECT $1, id, run_id, scenario, target_repo, target_pr_number, final_score,
+                final_grade, data, created_at
+         FROM {legacy_schema_sql}.quality_snapshots
+         ON CONFLICT (store_key, id) DO NOTHING"
+    );
+    copied += sqlx::query(&copy_snapshots_sql)
+        .bind(target_store.store_key())
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+
+    sqlx::query(
+        "INSERT INTO eval_store_legacy_backfills (store_key, legacy_schema, copied_rows)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (store_key, legacy_schema) DO NOTHING",
+    )
+    .bind(target_store.store_key())
+    .bind(legacy_schema)
+    .bind(copied as i64)
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+
+    if copied > 0 {
+        tracing::info!(
+            copied,
+            legacy_schema,
+            target_schema = target_store.schema(),
+            "eval store migration: backfilled legacy rows into shared schema"
+        );
+    }
+
+    Ok(copied)
+}
+
+fn quote_pg_ident(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
 }
 
 struct TargetFields<'a> {
@@ -422,3 +699,7 @@ fn status_key(status: &EvalRunStatus) -> &'static str {
         EvalRunStatus::Scored => "scored",
     }
 }
+
+#[cfg(test)]
+#[path = "eval_store_tests.rs"]
+mod tests;

--- a/crates/harness-server/src/eval_store_tests.rs
+++ b/crates/harness-server/src/eval_store_tests.rs
@@ -1,0 +1,413 @@
+use super::*;
+use futures::FutureExt;
+use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
+use serde_json::json;
+use tempfile::tempdir;
+
+fn unique_test_schema(prefix: &str) -> String {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_nanos();
+    format!("{prefix}_{nanos}_{count}")
+}
+
+#[test]
+fn shared_schema_context_uses_fixed_eval_store_schema() -> anyhow::Result<()> {
+    let context =
+        EvalStore::shared_schema_context(Some("postgres://user:pass@localhost:5432/harness"))?;
+    assert_eq!(context.schema(), EVAL_STORE_SCHEMA);
+    assert!(
+        context.ownership().is_none(),
+        "shared eval_store schema must not register path-derived ownership"
+    );
+    Ok(())
+}
+
+#[test]
+fn store_key_for_missing_data_dir_errors() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let missing = dir.path().join("missing-data-dir");
+    let err = EvalStore::store_key_for_data_dir(&missing)
+        .expect_err("missing data_dir should not produce a fallback store key");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("failed to canonicalize eval_store data_dir"),
+        "error should mention eval_store data_dir canonicalization, got: {msg}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn shared_schema_eval_store_keeps_store_rows_isolated() -> anyhow::Result<()> {
+    let database_url = match resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempdir()?;
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let shared_schema = unique_test_schema("eval_store_scope_test");
+    let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let store_a_dir = dir.path().join("store-a");
+    let store_b_dir = dir.path().join("store-b");
+    std::fs::create_dir_all(&store_a_dir)?;
+    std::fs::create_dir_all(&store_b_dir)?;
+    let store_a =
+        EvalStore::open_shared_with_data_dir(&shared_context, &setup_pool, &store_a_dir).await?;
+    let store_b =
+        EvalStore::open_shared_with_data_dir(&shared_context, &setup_pool, &store_b_dir).await?;
+
+    let result = std::panic::AssertUnwindSafe(async {
+        assert_eq!(store_a.schema(), shared_schema);
+        assert_eq!(store_b.schema(), shared_schema);
+        assert_ne!(store_a.store_key(), store_b.store_key());
+
+        let run_a = store_a.create_run(pr_repair_run()).await?;
+        assert!(
+            store_b.get_run(&run_a.id).await?.is_none(),
+            "store B must not see store A runs in the shared schema"
+        );
+        assert!(
+            store_b
+                .add_artifact(&run_a.id, artifact("foreign"))
+                .await?
+                .is_none(),
+            "store B must not attach artifacts to store A runs"
+        );
+
+        let run_b = store_b.create_run(pr_repair_run()).await?;
+        let artifact_a = store_a
+            .add_artifact(&run_a.id, artifact("store-a"))
+            .await?
+            .expect("store A artifact");
+        let artifact_b = store_b
+            .add_artifact(&run_b.id, artifact("store-b"))
+            .await?
+            .expect("store B artifact");
+
+        assert_eq!(store_a.list_runs(10).await?.len(), 1);
+        assert_eq!(store_b.list_runs(10).await?.len(), 1);
+        assert_eq!(store_a.list_artifacts(&run_a.id).await?, vec![artifact_a]);
+        assert_eq!(store_b.list_artifacts(&run_b.id).await?, vec![artifact_b]);
+
+        let score_a = store_a
+            .score_run(&run_a.id, pr_repair_input())
+            .await?
+            .expect("score store A run");
+        let score_b = store_b
+            .score_run(&run_b.id, pr_repair_input())
+            .await?
+            .expect("score store B run");
+        assert_eq!(
+            store_a
+                .get_quality_snapshot(&score_a.quality_snapshot.id)
+                .await?
+                .expect("store A snapshot")
+                .id,
+            score_a.quality_snapshot.id
+        );
+        assert!(
+            store_b
+                .get_quality_snapshot(&score_a.quality_snapshot.id)
+                .await?
+                .is_none(),
+            "store B must not see store A snapshots"
+        );
+
+        let snapshots_a = store_a
+            .list_quality_snapshots_for_pr("owner/repo", 7, 10)
+            .await?;
+        let snapshots_b = store_b
+            .list_quality_snapshots_for_pr("owner/repo", 7, 10)
+            .await?;
+        assert_eq!(snapshots_a.len(), 1);
+        assert_eq!(snapshots_b.len(), 1);
+        assert_eq!(snapshots_a[0].id, score_a.quality_snapshot.id);
+        assert_eq!(snapshots_b[0].id, score_b.quality_snapshot.id);
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .catch_unwind()
+    .await;
+
+    store_a.pool.close().await;
+    store_b.pool.close().await;
+    let _ = sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{shared_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await;
+    setup_pool.close().await;
+
+    match result {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+#[tokio::test]
+async fn legacy_eval_store_migration_backfills_once() -> anyhow::Result<()> {
+    let database_url = match resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempdir()?;
+    let target_data_dir = dir.path().join("target-data");
+    let other_data_dir = dir.path().join("other-data");
+    std::fs::create_dir_all(&target_data_dir)?;
+    std::fs::create_dir_all(&other_data_dir)?;
+    let legacy_path = target_data_dir.join("evals.db");
+    let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
+        .schema()
+        .to_owned();
+    let target_schema = unique_test_schema("eval_store_migration_test");
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let target_store =
+        EvalStore::open_shared_with_data_dir(&target_context, &setup_pool, &target_data_dir)
+            .await?;
+    let other_store =
+        EvalStore::open_shared_with_data_dir(&target_context, &setup_pool, &other_data_dir).await?;
+    let legacy_store = EvalStore::open_with_database_url(&legacy_path, Some(&database_url)).await?;
+
+    let result = std::panic::AssertUnwindSafe(async {
+        let legacy_run = legacy_store.create_run(pr_repair_run()).await?;
+        let legacy_artifact = legacy_store
+            .add_artifact(&legacy_run.id, artifact("legacy"))
+            .await?
+            .expect("legacy artifact");
+        let legacy_score = legacy_store
+            .score_run(&legacy_run.id, pr_repair_input())
+            .await?
+            .expect("legacy score");
+
+        let copied =
+            migrate_legacy_eval_store_if_needed(&legacy_path, Some(&database_url), &target_store)
+                .await?;
+        assert_eq!(
+            copied, 3,
+            "one run, one artifact, and one quality snapshot should be copied"
+        );
+
+        let copied_again =
+            migrate_legacy_eval_store_if_needed(&legacy_path, Some(&database_url), &target_store)
+                .await?;
+        assert_eq!(copied_again, 0, "migration must be idempotent");
+
+        assert_eq!(
+            target_store
+                .get_run(&legacy_run.id)
+                .await?
+                .expect("legacy run should be backfilled")
+                .id,
+            legacy_run.id
+        );
+        assert_eq!(
+            target_store.list_artifacts(&legacy_run.id).await?,
+            vec![legacy_artifact]
+        );
+        assert_eq!(
+            target_store
+                .get_quality_snapshot(&legacy_score.quality_snapshot.id)
+                .await?
+                .expect("legacy snapshot should be backfilled")
+                .id,
+            legacy_score.quality_snapshot.id
+        );
+        assert!(
+            other_store.get_run(&legacy_run.id).await?.is_none(),
+            "other data_dir scopes must not hydrate legacy eval runs"
+        );
+        assert!(
+            other_store
+                .list_quality_snapshots_for_pr("owner/repo", 7, 10)
+                .await?
+                .is_empty(),
+            "other data_dir scopes must not hydrate legacy eval snapshots"
+        );
+
+        let stale_legacy_run = legacy_store.create_run(pr_repair_run()).await?;
+        let copied_after_stale_update =
+            migrate_legacy_eval_store_if_needed(&legacy_path, Some(&database_url), &target_store)
+                .await?;
+        assert_eq!(copied_after_stale_update, 0);
+        assert!(
+            target_store.get_run(&stale_legacy_run.id).await?.is_none(),
+            "backfill marker should prevent stale legacy reimport on later startup"
+        );
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .catch_unwind()
+    .await;
+
+    legacy_store.pool.close().await;
+    target_store.pool.close().await;
+    other_store.pool.close().await;
+    let _ = sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{legacy_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await;
+    let _ = sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await;
+    setup_pool.close().await;
+
+    match result {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+#[tokio::test]
+async fn legacy_eval_store_migration_ignores_missing_legacy_schema() -> anyhow::Result<()> {
+    let database_url = match resolve_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempdir()?;
+    let target_data_dir = dir.path().join("target-data");
+    std::fs::create_dir_all(&target_data_dir)?;
+    let missing_legacy_path = dir.path().join("missing-legacy").join("evals.db");
+    let target_schema = unique_test_schema("eval_store_missing_legacy_test");
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let target_store =
+        EvalStore::open_shared_with_data_dir(&target_context, &setup_pool, &target_data_dir)
+            .await?;
+
+    let result = std::panic::AssertUnwindSafe(async {
+        let copied = migrate_legacy_eval_store_if_needed(
+            &missing_legacy_path,
+            Some(&database_url),
+            &target_store,
+        )
+        .await?;
+        assert_eq!(copied, 0, "missing legacy schema should be a no-op");
+        Ok::<(), anyhow::Error>(())
+    })
+    .catch_unwind()
+    .await;
+
+    target_store.pool.close().await;
+    let _ = sqlx::query(&format!(
+        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
+    ))
+    .execute(&setup_pool)
+    .await;
+    setup_pool.close().await;
+
+    match result {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+fn pr_repair_run() -> CreateEvalRun {
+    CreateEvalRun {
+        scenario: EvalScenario::PrRepair,
+        target: EvalTarget::PullRequest {
+            repo: "owner/repo".to_string(),
+            pr_number: 7,
+            base_ref: Some("main".to_string()),
+            head_ref: Some("fix/review".to_string()),
+        },
+        source_task_id: Some("task-7".to_string()),
+    }
+}
+
+fn artifact(label: &str) -> AddEvalArtifact {
+    AddEvalArtifact {
+        artifact_type: "pr_repair_eval_input".to_string(),
+        label: Some(label.to_string()),
+        content_type: Some("application/json".to_string()),
+        body: pr_repair_input_json().to_string(),
+    }
+}
+
+fn pr_repair_input() -> PrRepairEvalInput {
+    serde_json::from_value(pr_repair_input_json()).expect("valid PR repair input")
+}
+
+fn pr_repair_input_json() -> serde_json::Value {
+    json!({
+        "scenario": "pr_repair",
+        "run_mode": "live_run",
+        "target": {
+            "kind": "pull_request",
+            "repo": "owner/repo",
+            "pr_number": 7,
+            "base_ref": "main",
+            "head_ref": "fix/review"
+        },
+        "baseline_pr": pr_snapshot_json("base-head", true),
+        "final_pr": pr_snapshot_json("final-head", false),
+        "final_evidence_head_oid": "final-head",
+        "runtime": {
+            "task_id": "task-7",
+            "workflow_id": "workflow-7",
+            "workflow_state": "done",
+            "runtime_jobs": [{
+                "runtime_job_id": "job-7",
+                "state": "completed",
+                "artifact_count": 1,
+                "terminal_state": "succeeded"
+            }],
+            "latest_activity": "address_pr_feedback",
+            "terminal_state": "done",
+            "collected_at": "2026-06-05T00:00:00Z"
+        },
+        "usage": [],
+        "reviewer_judgment": {
+            "reviewer_kind": "llm",
+            "judged_head_oid": "final-head",
+            "code_quality_score": 90,
+            "trajectory_score": 90,
+            "findings": [],
+            "residual_risks": []
+        },
+        "created_unrelated_pr": false,
+        "scope_violations": []
+    })
+}
+
+fn pr_snapshot_json(head_oid: &str, unresolved_thread: bool) -> serde_json::Value {
+    let active_unresolved_review_threads = if unresolved_thread {
+        json!([{
+            "id": "thread-1",
+            "path": "src/lib.rs",
+            "is_resolved": false,
+            "is_outdated": false
+        }])
+    } else {
+        json!([])
+    };
+    json!({
+        "repo": "owner/repo",
+        "pr_number": 7,
+        "url": "https://github.com/owner/repo/pull/7",
+        "title": "Fix review feedback",
+        "base_ref": "main",
+        "head_ref": "fix/review",
+        "head_oid": head_oid,
+        "is_draft": false,
+        "merge_state": "clean",
+        "check_state": "passing",
+        "review_decision": "approved",
+        "active_unresolved_review_threads": active_unresolved_review_threads,
+        "review_threads_complete": true,
+        "changed_files": [{
+            "path": "src/lib.rs",
+            "additions": 4,
+            "deletions": 1,
+            "status": "modified"
+        }],
+        "changed_files_complete": true,
+        "collected_at": "2026-06-05T00:00:00Z"
+    })
+}

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -3,7 +3,11 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::http::state::StoreStartupResult;
-use crate::{eval_store::EvalStore, q_value_store::QValueStore, task_runner::TaskStore};
+use crate::{
+    eval_store::{migrate_legacy_eval_store_if_needed, EvalStore},
+    q_value_store::QValueStore,
+    task_runner::TaskStore,
+};
 
 /// Outputs of the storage initialization phase.
 pub(crate) struct StorageBundle {
@@ -112,19 +116,21 @@ pub(crate) async fn build_storage_with_database_url(
             StoreStartupResult::optional("eval_store").failed(error),
         ),
         None => {
-            match harness_core::db::PgStoreContext::from_path(&eval_db_path, Some(&database_url)) {
-                Ok(eval_context) => {
-                    match EvalStore::open_with_context(&eval_context, &setup_pool).await {
-                        Ok(store) => (
-                            Some(Arc::new(store)),
-                            StoreStartupResult::optional("eval_store"),
-                        ),
-                        Err(error) => (
-                            None,
-                            StoreStartupResult::optional("eval_store").failed(error.to_string()),
-                        ),
-                    }
-                }
+            match async {
+                let eval_context = EvalStore::shared_schema_context(Some(&database_url))?;
+                let store =
+                    EvalStore::open_shared_with_data_dir(&eval_context, &setup_pool, data_dir)
+                        .await?;
+                migrate_legacy_eval_store_if_needed(&eval_db_path, Some(&database_url), &store)
+                    .await?;
+                Ok::<_, anyhow::Error>(store)
+            }
+            .await
+            {
+                Ok(store) => (
+                    Some(Arc::new(store)),
+                    StoreStartupResult::optional("eval_store"),
+                ),
                 Err(error) => (
                     None,
                     StoreStartupResult::optional("eval_store").failed(error.to_string()),
@@ -254,6 +260,25 @@ mod tests {
             q_values.store_key_for_test(),
             crate::q_value_store::QValueStore::store_key_for_data_dir(dir.path())
                 .expect("store key")
+        );
+    }
+
+    #[tokio::test]
+    async fn build_storage_opens_eval_store_from_shared_schema() {
+        let database_url = match harness_core::db::resolve_database_url(None) {
+            Ok(url) => url,
+            Err(_) => return,
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bundle = build_storage_with_database_url(dir.path(), Some(&database_url))
+            .await
+            .expect("build_storage should succeed");
+        let eval_store = bundle.eval_store.expect("eval store should be ready");
+
+        assert_eq!(eval_store.schema(), crate::eval_store::EVAL_STORE_SCHEMA);
+        assert_eq!(
+            eval_store.store_key(),
+            crate::eval_store::EvalStore::store_key_for_data_dir(dir.path()).expect("store key")
         );
     }
 


### PR DESCRIPTION
Summary:
- move production eval_store startup onto the fixed shared Postgres schema `eval_store`
- add per-data-dir store scoping to eval runs, artifacts, and quality snapshots
- backfill legacy path-derived evals.db schemas once per store key

Validation:
- cargo fmt --all -- --check
- cargo test -p harness-server eval_store -- --nocapture
- cargo test -p harness-server evals_api -- --nocapture
- cargo check -p harness-server --all-targets
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- HARNESS_DATABASE_POOL_MAX_CONNECTIONS=1 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=120 cargo test
- cargo clippy --workspace --all-targets -- -D warnings

Closes #1353
Refs #1206