### PR TITLE
storage: open reconcile task store from shared schema

### DIFF
--- a/crates/harness-cli/src/commands/reconcile.rs
+++ b/crates/harness-cli/src/commands/reconcile.rs
@@ -109,7 +109,7 @@ async fn open_task_store(config: &HarnessConfig) -> Result<Arc<TaskStore>> {
     let database_url = resolve_database_url(config.server.database_url.as_deref())?;
     let setup_pool = pg_open_pool(&database_url).await?;
     let task_context = harness_server::task_db::TaskDb::shared_schema_context(Some(&database_url))?;
-    TaskStore::open_shared_with_data_dir(
+    TaskStore::open_shared_for_reconciliation_with_data_dir(
         &db_path,
         &task_context,
         &setup_pool,
@@ -195,11 +195,23 @@ mod tests {
             TaskDb::open_shared_with_data_dir(&task_context, &setup_pool, &other_data_dir).await?;
         let target_id = TaskId("reconcile-shared-target".to_string());
         let other_id = TaskId("reconcile-shared-other".to_string());
+        let running_id = TaskId("reconcile-shared-running".to_string());
         target_db
-            .insert(&task_state(&target_id, &target_data_dir))
+            .insert(&task_state(
+                &target_id,
+                &target_data_dir,
+                TaskStatus::Pending,
+            ))
             .await?;
         other_db
-            .insert(&task_state(&other_id, &other_data_dir))
+            .insert(&task_state(&other_id, &other_data_dir, TaskStatus::Pending))
+            .await?;
+        target_db
+            .insert(&task_state(
+                &running_id,
+                &target_data_dir,
+                TaskStatus::Implementing,
+            ))
             .await?;
 
         let mut config = HarnessConfig::default();
@@ -215,15 +227,33 @@ mod tests {
             store.get_with_db_fallback(&other_id).await?.is_none(),
             "reconcile task store must not see tasks from another data_dir"
         );
+        let running_task = store
+            .get_with_db_fallback(&running_id)
+            .await?
+            .expect("reconcile task store should load active running tasks");
+        assert_eq!(
+            running_task.status,
+            TaskStatus::Implementing,
+            "reconcile task store must not run startup recovery side effects"
+        );
+        let persisted_running = target_db
+            .get(running_id.as_str())
+            .await?
+            .expect("running task should remain persisted");
+        assert_eq!(
+            persisted_running.status,
+            TaskStatus::Implementing,
+            "opening reconcile task store must not fail running tasks in storage"
+        );
 
         Ok(())
     }
 
-    fn task_state(id: &TaskId, project_root: &std::path::Path) -> TaskState {
+    fn task_state(id: &TaskId, project_root: &std::path::Path, status: TaskStatus) -> TaskState {
         TaskState {
             id: id.clone(),
             task_kind: TaskKind::Prompt,
-            status: TaskStatus::Pending,
+            status,
             failure_kind: None,
             turn: 0,
             pr_url: None,

--- a/crates/harness-cli/src/commands/reconcile.rs
+++ b/crates/harness-cli/src/commands/reconcile.rs
@@ -1,9 +1,12 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context as _, Result};
 use harness_core::config::dirs::default_db_path;
 use harness_core::config::HarnessConfig;
+use harness_core::db::{pg_open_pool, resolve_database_url};
+use harness_server::task_runner::TaskStore;
 use harness_workflow::issue_lifecycle::IssueWorkflowStore;
 use harness_workflow::runtime::WorkflowRuntimeStore;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig) -> Result<()> {
     if let Some(project_root) = project {
@@ -13,8 +16,7 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
         );
     }
 
-    let db_path = default_db_path(&config.server.data_dir, "tasks");
-    let store = harness_server::task_runner::TaskStore::open(&db_path).await?;
+    let store = open_task_store(config).await?;
     let (runtime_store, issue_workflow_store) = open_workflow_stores(config).await;
 
     let report = harness_server::reconciliation::run_once_with_runtime_config(
@@ -90,6 +92,33 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
     Ok(())
 }
 
+async fn open_task_store(config: &HarnessConfig) -> Result<Arc<TaskStore>> {
+    std::fs::create_dir_all(&config.server.data_dir).with_context(|| {
+        format!(
+            "failed to create data_dir {}",
+            config.server.data_dir.display()
+        )
+    })?;
+    let data_dir = config.server.data_dir.canonicalize().with_context(|| {
+        format!(
+            "failed to canonicalize data_dir {}",
+            config.server.data_dir.display()
+        )
+    })?;
+    let db_path = default_db_path(&data_dir, "tasks");
+    let database_url = resolve_database_url(config.server.database_url.as_deref())?;
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let task_context = harness_server::task_db::TaskDb::shared_schema_context(Some(&database_url))?;
+    TaskStore::open_shared_with_data_dir(
+        &db_path,
+        &task_context,
+        &setup_pool,
+        &data_dir,
+        Some(&database_url),
+    )
+    .await
+}
+
 async fn open_workflow_stores(
     config: &HarnessConfig,
 ) -> (Option<WorkflowRuntimeStore>, Option<IssueWorkflowStore>) {
@@ -131,4 +160,96 @@ async fn open_workflow_stores(
         };
 
     (runtime_store, issue_workflow_store)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::types::TaskId;
+    use harness_server::task_db::TaskDb;
+    use harness_server::task_runner::{
+        TaskKind, TaskPhase, TaskSchedulerState, TaskState, TaskStatus,
+    };
+
+    #[tokio::test]
+    async fn open_task_store_reads_shared_schema_scoped_to_data_dir() -> Result<()> {
+        let database_url = match resolve_database_url(None) {
+            Ok(database_url) => database_url,
+            Err(_) => return Ok(()),
+        };
+        let setup_pool = match pg_open_pool(&database_url).await {
+            Ok(pool) => pool,
+            Err(_) => return Ok(()),
+        };
+        let sandbox = tempfile::tempdir()?;
+        let target_data_dir = sandbox.path().join("target-data");
+        let other_data_dir = sandbox.path().join("other-data");
+        std::fs::create_dir_all(&target_data_dir)?;
+        std::fs::create_dir_all(&other_data_dir)?;
+
+        let task_context =
+            harness_server::task_db::TaskDb::shared_schema_context(Some(&database_url))?;
+        let target_db =
+            TaskDb::open_shared_with_data_dir(&task_context, &setup_pool, &target_data_dir).await?;
+        let other_db =
+            TaskDb::open_shared_with_data_dir(&task_context, &setup_pool, &other_data_dir).await?;
+        let target_id = TaskId("reconcile-shared-target".to_string());
+        let other_id = TaskId("reconcile-shared-other".to_string());
+        target_db
+            .insert(&task_state(&target_id, &target_data_dir))
+            .await?;
+        other_db
+            .insert(&task_state(&other_id, &other_data_dir))
+            .await?;
+
+        let mut config = HarnessConfig::default();
+        config.server.data_dir = target_data_dir;
+        config.server.database_url = Some(database_url);
+
+        let store = open_task_store(&config).await?;
+        assert!(
+            store.get_with_db_fallback(&target_id).await?.is_some(),
+            "reconcile task store should see tasks from its configured data_dir"
+        );
+        assert!(
+            store.get_with_db_fallback(&other_id).await?.is_none(),
+            "reconcile task store must not see tasks from another data_dir"
+        );
+
+        Ok(())
+    }
+
+    fn task_state(id: &TaskId, project_root: &std::path::Path) -> TaskState {
+        TaskState {
+            id: id.clone(),
+            task_kind: TaskKind::Prompt,
+            status: TaskStatus::Pending,
+            failure_kind: None,
+            turn: 0,
+            pr_url: None,
+            rounds: Vec::new(),
+            error: None,
+            source: Some("test".to_string()),
+            external_id: None,
+            parent_id: None,
+            depends_on: Vec::new(),
+            subtask_ids: Vec::new(),
+            project_root: Some(project_root.to_path_buf()),
+            workspace_path: None,
+            workspace_owner: None,
+            run_generation: 0,
+            issue: None,
+            repo: None,
+            description: Some("reconcile shared schema test task".to_string()),
+            created_at: None,
+            updated_at: None,
+            priority: 0,
+            phase: TaskPhase::Implement,
+            triage_output: None,
+            plan_output: None,
+            request_settings: None,
+            scheduler: TaskSchedulerState::queued(),
+            version: 0,
+        }
+    }
 }

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -158,30 +158,60 @@ impl TaskStore {
         Self::from_task_db(db, db_path).await
     }
 
+    pub async fn open_shared_for_reconciliation_with_data_dir(
+        db_path: &std::path::Path,
+        context: &PgStoreContext,
+        setup_pool: &sqlx::postgres::PgPool,
+        data_dir: &std::path::Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Arc<Self>> {
+        let db = TaskDb::open_shared_with_data_dir(context, setup_pool, data_dir).await?;
+        crate::task_db::migrate_legacy_task_db_if_needed(db_path, configured_database_url, &db)
+            .await?;
+        Self::from_task_db_without_startup_recovery(db, db_path).await
+    }
+
     async fn from_task_db(db: TaskDb, db_path: &std::path::Path) -> anyhow::Result<Arc<Self>> {
+        Self::from_task_db_with_startup_recovery(db, db_path, true).await
+    }
+
+    async fn from_task_db_without_startup_recovery(
+        db: TaskDb,
+        db_path: &std::path::Path,
+    ) -> anyhow::Result<Arc<Self>> {
+        Self::from_task_db_with_startup_recovery(db, db_path, false).await
+    }
+
+    async fn from_task_db_with_startup_recovery(
+        db: TaskDb,
+        db_path: &std::path::Path,
+        run_startup_recovery: bool,
+    ) -> anyhow::Result<Arc<Self>> {
         // 1. Event replay: runs BEFORE recover_in_progress so event-sourced
         //    data (pr_url, terminal status) wins over checkpoint data.
         let event_log_path = db_path
             .parent()
             .unwrap_or(std::path::Path::new("."))
             .join("task-events.jsonl");
-        if let Err(e) = crate::event_replay::replay_and_recover(&db, &event_log_path).await {
-            tracing::warn!("startup: event replay failed (non-fatal): {e}");
-        }
+        if run_startup_recovery {
+            if let Err(e) = crate::event_replay::replay_and_recover(&db, &event_log_path).await {
+                tracing::warn!("startup: event replay failed (non-fatal): {e}");
+            }
 
-        // 2. Legacy checkpoint-based recovery as fallback.
-        let recovery = db.recover_in_progress().await?;
-        if recovery.resumed > 0 {
-            tracing::info!(
-                "startup recovery: resumed {} task(s) from checkpoint",
-                recovery.resumed
-            );
-        }
-        if recovery.failed > 0 {
-            tracing::warn!(
-                "startup recovery: marked {} interrupted task(s) as failed (no fresh checkpoint)",
-                recovery.failed
-            );
+            // 2. Legacy checkpoint-based recovery as fallback.
+            let recovery = db.recover_in_progress().await?;
+            if recovery.resumed > 0 {
+                tracing::info!(
+                    "startup recovery: resumed {} task(s) from checkpoint",
+                    recovery.resumed
+                );
+            }
+            if recovery.failed > 0 {
+                tracing::warn!(
+                    "startup recovery: marked {} interrupted task(s) as failed (no fresh checkpoint)",
+                    recovery.failed
+                );
+            }
         }
 
         // 3. Open the event log for appending during this server session.


### PR DESCRIPTION
## Summary
- Open `harness reconcile` task storage through the shared `task_db` schema using the configured data dir store key.
- Create and canonicalize `server.data_dir` before opening the task store.
- Add a reconcile-specific shared task-store constructor that preserves legacy shared-schema backfill but skips startup event replay and `recover_in_progress` side effects.
- Add a Postgres-gated reconcile regression test proving configured-data-dir visibility, other-data-dir isolation, and that an active `Implementing` task is not failed during reconcile store open.

Closes #1355.
References #1206.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p harness-cli reconcile -- --nocapture`
- `cargo test -p harness-server task_db_shared_schema -- --nocapture`
- `cargo test -p harness-server --test task_db_shared_schema -- --nocapture`
- `cargo check -p harness-cli --all-targets`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Review follow-up
- Addressed the Codex review thread about startup recovery side effects in commit `dd17ef3f` and resolved the thread.