### PR TITLE
Guard startup stores against path-derived schemas

### DIFF
--- a/crates/harness-server/src/http/builders/engines.rs
+++ b/crates/harness-server/src/http/builders/engines.rs
@@ -104,6 +104,10 @@ pub(crate) async fn build_engines(
                             harness_observe::event_store::EventStore::shared_schema_context(Some(
                                 &database_url,
                             ))?;
+                        super::ensure_startup_context_not_path_derived(
+                            "event_store",
+                            &event_context,
+                        )?;
                         let store = harness_observe::event_store::EventStore::with_policies_and_otel_shared_with_context(
                             data_dir,
                             &event_context,

--- a/crates/harness-server/src/http/builders/mod.rs
+++ b/crates/harness-server/src/http/builders/mod.rs
@@ -124,6 +124,12 @@ mod tests {
                 "review_store",
                 crate::review_store::ReviewStore::shared_schema_context(Some(TEST_DATABASE_URL))?,
             ),
+            (
+                "event_store",
+                harness_observe::event_store::EventStore::shared_schema_context(Some(
+                    TEST_DATABASE_URL,
+                ))?,
+            ),
         ];
 
         for (opener, context) in contexts {

--- a/crates/harness-server/src/http/builders/mod.rs
+++ b/crates/harness-server/src/http/builders/mod.rs
@@ -7,6 +7,24 @@ pub(crate) mod services;
 pub(crate) mod storage;
 pub(crate) mod workspace_pool_config;
 
+pub(crate) fn ensure_startup_context_not_path_derived(
+    opener: &'static str,
+    context: &harness_core::db::PgStoreContext,
+) -> anyhow::Result<()> {
+    if matches!(
+        context.ownership(),
+        Some(ownership) if ownership.retention_class == "path_derived"
+    ) {
+        anyhow::bail!(
+            "startup opener '{opener}' attempted to use path-derived Postgres schema '{}'; \
+             normal production startup must use fixed shared schemas. Path-derived schemas \
+             are only allowed for legacy migration, backfill, and test compatibility.",
+            context.schema()
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 tokio::task_local! {
     static FORCED_STARTUP_FAILURES: std::collections::HashMap<&'static str, String>;
@@ -40,5 +58,98 @@ pub(crate) fn forced_startup_error(name: &'static str) -> Option<String> {
     {
         let _ = name;
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::db::PgStoreContext;
+    use std::path::Path;
+
+    const TEST_DATABASE_URL: &str = "postgres://user:pass@localhost:5432/harness";
+
+    #[test]
+    fn storage_path_schema_guard_allows_shared_startup_contexts() -> anyhow::Result<()> {
+        let contexts = [
+            (
+                "tasks",
+                crate::task_db::TaskDb::shared_schema_context(Some(TEST_DATABASE_URL))?,
+            ),
+            (
+                "eval_store",
+                crate::eval_store::EvalStore::shared_schema_context(Some(TEST_DATABASE_URL))?,
+            ),
+            (
+                "q_value_store",
+                crate::q_value_store::QValueStore::shared_schema_context(Some(TEST_DATABASE_URL))?,
+            ),
+            (
+                "thread_db",
+                crate::thread_db::ThreadDb::shared_schema_context(Some(TEST_DATABASE_URL))?,
+            ),
+            (
+                "plan_db",
+                crate::plan_db::PlanDb::shared_schema_context(Some(TEST_DATABASE_URL))?,
+            ),
+            (
+                "issue_workflow_store",
+                PgStoreContext::new(TEST_DATABASE_URL, "workflow_issue")?,
+            ),
+            (
+                "project_workflow_store",
+                PgStoreContext::new(TEST_DATABASE_URL, "workflow_project")?,
+            ),
+            (
+                "workflow_runtime_store",
+                PgStoreContext::new(TEST_DATABASE_URL, "workflow_runtime")?,
+            ),
+            (
+                "project_registry",
+                crate::project_registry::ProjectRegistry::shared_schema_context(Some(
+                    TEST_DATABASE_URL,
+                ))?,
+            ),
+            (
+                "workspace_lease_store",
+                crate::task_db::TaskDb::shared_schema_context(Some(TEST_DATABASE_URL))?,
+            ),
+            (
+                "runtime_state_store",
+                crate::runtime_state_store::RuntimeStateStore::shared_schema_context(Some(
+                    TEST_DATABASE_URL,
+                ))?,
+            ),
+            (
+                "review_store",
+                crate::review_store::ReviewStore::shared_schema_context(Some(TEST_DATABASE_URL))?,
+            ),
+        ];
+
+        for (opener, context) in contexts {
+            ensure_startup_context_not_path_derived(opener, &context)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn storage_path_schema_guard_rejects_path_derived_startup_context() -> anyhow::Result<()> {
+        let context = PgStoreContext::from_path(
+            Path::new("/tmp/harness/path-derived-startup.db"),
+            Some(TEST_DATABASE_URL),
+        )?;
+
+        let err = ensure_startup_context_not_path_derived("thread_db", &context)
+            .expect_err("path-derived startup context should be rejected");
+        let message = err.to_string();
+        assert!(
+            message.contains("thread_db"),
+            "error should name the startup opener: {message}"
+        );
+        assert!(
+            message.contains("path-derived Postgres schema"),
+            "error should describe the rejected schema class: {message}"
+        );
+        Ok(())
     }
 }

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -309,11 +309,12 @@ pub(crate) async fn build_registry(
                 let context =
                     harness_core::db::PgStoreContext::new(database_url.clone(), schema.clone())?;
                 super::ensure_startup_context_not_path_derived("workflow_runtime_store", &context)?;
-                harness_workflow::runtime::WorkflowRuntimeStore::open_with_context(
+                let store = harness_workflow::runtime::WorkflowRuntimeStore::open_with_context(
                     &context,
                     &setup_pool,
                 )
-                .await
+                .await?;
+                Ok::<_, anyhow::Error>(store)
             }
             .await
             {

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -61,6 +61,7 @@ pub(crate) async fn build_registry(
 
     let thread_db_path = harness_core::config::dirs::default_db_path(data_dir, "threads");
     let thread_context = crate::thread_db::ThreadDb::shared_schema_context(Some(&database_url))?;
+    super::ensure_startup_context_not_path_derived("thread_db", &thread_context)?;
     let thread_db = match super::forced_startup_error("thread_db") {
         Some(error) => {
             startup_results.push(StoreStartupResult::critical("thread_db").failed(error));
@@ -119,12 +120,19 @@ pub(crate) async fn build_registry(
             None
         }
         None => {
-            match PlanDb::open_shared_with_legacy_backfill(
-                Some(&database_url),
-                &setup_pool,
-                data_dir,
-                &plans_db_path,
-            )
+            match async {
+                let plan_context = PlanDb::shared_schema_context(Some(&database_url))?;
+                super::ensure_startup_context_not_path_derived("plan_db", &plan_context)?;
+                let plan_db =
+                    PlanDb::open_shared_with_data_dir(&plan_context, &setup_pool, data_dir).await?;
+                crate::plan_db::migrate_legacy_plan_db_if_needed(
+                    &plans_db_path,
+                    Some(&database_url),
+                    &plan_db,
+                )
+                .await?;
+                Ok::<_, anyhow::Error>(plan_db)
+            }
             .await
             {
                 Ok(plan_db) => {
@@ -177,55 +185,44 @@ pub(crate) async fn build_registry(
                     .push(StoreStartupResult::optional("issue_workflow_store").failed(error));
                 None
             }
-            None => match harness_core::db::PgStoreContext::new(
-                database_url.clone(),
-                schema.clone(),
-            ) {
-                Ok(context) => {
-                    match harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_context(
+            None => match async {
+                let context =
+                    harness_core::db::PgStoreContext::new(database_url.clone(), schema.clone())?;
+                super::ensure_startup_context_not_path_derived("issue_workflow_store", &context)?;
+                let store =
+                    harness_workflow::issue_lifecycle::IssueWorkflowStore::open_with_context(
                         &context,
                         &setup_pool,
                     )
-                    .await
-                    {
-                        Ok(store) => {
-                            startup_results
-                                .push(StoreStartupResult::optional("issue_workflow_store"));
-                            if let Err(e) = migrate_issue_workflows_if_needed(
-                                configured_database_url,
-                                &issue_workflows_db_path,
-                                &schema,
-                                &store,
-                            )
-                            .await
-                            {
-                                tracing::warn!(
-                                    schema = %schema,
-                                    "issue workflow migration check failed: {e}"
-                                );
-                            }
-                            let (rewritten, failed, skipped) =
-                                repair_corrupt_project_ids(&store, project_root).await;
-                            tracing::info!(
-                                rewritten,
-                                failed,
-                                skipped,
-                                "startup repair of corrupt issue workflow project_ids complete"
-                            );
-                            Some(Arc::new(store))
-                        }
-                        Err(e) => {
-                            startup_results.push(
-                                StoreStartupResult::optional("issue_workflow_store")
-                                    .failed(e.to_string()),
-                            );
-                            tracing::warn!(
-                                schema = %schema,
-                                "issue workflow store init failed, issue lifecycle state will not persist: {e}"
-                            );
-                            None
-                        }
-                    }
+                    .await?;
+                if let Err(e) = migrate_issue_workflows_if_needed(
+                    configured_database_url,
+                    &issue_workflows_db_path,
+                    &schema,
+                    &store,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        schema = %schema,
+                        "issue workflow migration check failed: {e}"
+                    );
+                }
+                let (rewritten, failed, skipped) =
+                    repair_corrupt_project_ids(&store, project_root).await;
+                tracing::info!(
+                    rewritten,
+                    failed,
+                    skipped,
+                    "startup repair of corrupt issue workflow project_ids complete"
+                );
+                Ok::<_, anyhow::Error>(store)
+            }
+            .await
+            {
+                Ok(store) => {
+                    startup_results.push(StoreStartupResult::optional("issue_workflow_store"));
+                    Some(Arc::new(store))
                 }
                 Err(error) => {
                     startup_results.push(
@@ -234,7 +231,7 @@ pub(crate) async fn build_registry(
                     );
                     tracing::warn!(
                         schema = %schema,
-                        "issue workflow store context init failed, issue lifecycle state will not persist: {error}"
+                        "issue workflow store init failed, issue lifecycle state will not persist: {error}"
                     );
                     None
                 }
@@ -253,47 +250,36 @@ pub(crate) async fn build_registry(
                     .push(StoreStartupResult::optional("project_workflow_store").failed(error));
                 None
             }
-            None => match harness_core::db::PgStoreContext::new(
-                database_url.clone(),
-                schema.clone(),
-            ) {
-                Ok(context) => {
-                    match harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_context(
+            None => match async {
+                let context =
+                    harness_core::db::PgStoreContext::new(database_url.clone(), schema.clone())?;
+                super::ensure_startup_context_not_path_derived("project_workflow_store", &context)?;
+                let store =
+                    harness_workflow::project_lifecycle::ProjectWorkflowStore::open_with_context(
                         &context,
                         &setup_pool,
                     )
-                    .await
-                    {
-                        Ok(store) => {
-                            startup_results
-                                .push(StoreStartupResult::optional("project_workflow_store"));
-                            if let Err(e) = migrate_project_workflows_if_needed(
-                                configured_database_url,
-                                &project_workflows_db_path,
-                                &schema,
-                                &store,
-                            )
-                            .await
-                            {
-                                tracing::warn!(
-                                    schema = %schema,
-                                    "project workflow migration check failed: {e}"
-                                );
-                            }
-                            Some(Arc::new(store))
-                        }
-                        Err(e) => {
-                            startup_results.push(
-                                StoreStartupResult::optional("project_workflow_store")
-                                    .failed(e.to_string()),
-                            );
-                            tracing::warn!(
-                                schema = %schema,
-                                "project workflow store init failed, project lifecycle state will not persist: {e}"
-                            );
-                            None
-                        }
-                    }
+                    .await?;
+                if let Err(e) = migrate_project_workflows_if_needed(
+                    configured_database_url,
+                    &project_workflows_db_path,
+                    &schema,
+                    &store,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        schema = %schema,
+                        "project workflow migration check failed: {e}"
+                    );
+                }
+                Ok::<_, anyhow::Error>(store)
+            }
+            .await
+            {
+                Ok(store) => {
+                    startup_results.push(StoreStartupResult::optional("project_workflow_store"));
+                    Some(Arc::new(store))
                 }
                 Err(error) => {
                     startup_results.push(
@@ -302,7 +288,7 @@ pub(crate) async fn build_registry(
                     );
                     tracing::warn!(
                         schema = %schema,
-                        "project workflow store context init failed, project lifecycle state will not persist: {error}"
+                        "project workflow store init failed, project lifecycle state will not persist: {error}"
                     );
                     None
                 }
@@ -319,46 +305,34 @@ pub(crate) async fn build_registry(
                     .push(StoreStartupResult::optional("workflow_runtime_store").failed(error));
                 None
             }
-            None => {
-                match harness_core::db::PgStoreContext::new(database_url.clone(), schema.clone()) {
-                    Ok(context) => {
-                        match harness_workflow::runtime::WorkflowRuntimeStore::open_with_context(
-                            &context,
-                            &setup_pool,
-                        )
-                        .await
-                        {
-                            Ok(store) => {
-                                startup_results
-                                    .push(StoreStartupResult::optional("workflow_runtime_store"));
-                                Some(Arc::new(store))
-                            }
-                            Err(e) => {
-                                startup_results.push(
-                                    StoreStartupResult::optional("workflow_runtime_store")
-                                        .failed(e.to_string()),
-                                );
-                                tracing::warn!(
-                                    schema = %schema,
-                                    "workflow runtime store init failed, generic workflow decisions will not persist: {e}"
-                                );
-                                None
-                            }
-                        }
-                    }
-                    Err(error) => {
-                        startup_results.push(
-                            StoreStartupResult::optional("workflow_runtime_store")
-                                .failed(error.to_string()),
-                        );
-                        tracing::warn!(
-                            schema = %schema,
-                            "workflow runtime store context init failed, generic workflow decisions will not persist: {error}"
-                        );
-                        None
-                    }
-                }
+            None => match async {
+                let context =
+                    harness_core::db::PgStoreContext::new(database_url.clone(), schema.clone())?;
+                super::ensure_startup_context_not_path_derived("workflow_runtime_store", &context)?;
+                harness_workflow::runtime::WorkflowRuntimeStore::open_with_context(
+                    &context,
+                    &setup_pool,
+                )
+                .await
             }
+            .await
+            {
+                Ok(store) => {
+                    startup_results.push(StoreStartupResult::optional("workflow_runtime_store"));
+                    Some(Arc::new(store))
+                }
+                Err(error) => {
+                    startup_results.push(
+                        StoreStartupResult::optional("workflow_runtime_store")
+                            .failed(error.to_string()),
+                    );
+                    tracing::warn!(
+                        schema = %schema,
+                        "workflow runtime store init failed, generic workflow decisions will not persist: {error}"
+                    );
+                    None
+                }
+            },
         }
     };
 
@@ -366,6 +340,7 @@ pub(crate) async fn build_registry(
     let projects_db_path = harness_core::config::dirs::default_db_path(data_dir, "projects");
     let project_context =
         crate::project_registry::ProjectRegistry::shared_schema_context(Some(&database_url))?;
+    super::ensure_startup_context_not_path_derived("project_registry", &project_context)?;
     let project_registry = match super::forced_startup_error("project_registry") {
         Some(error) => {
             startup_results.push(StoreStartupResult::critical("project_registry").failed(error));
@@ -474,6 +449,7 @@ pub(crate) async fn build_registry(
 
     // ── Workspace manager ─────────────────────────────────────────────────────
     let task_context = crate::task_db::TaskDb::shared_schema_context(Some(&database_url))?;
+    super::ensure_startup_context_not_path_derived("workspace_lease_store", &task_context)?;
     let workspace_lease_store = match super::forced_startup_error("workspace_lease_store") {
         Some(error) => {
             startup_results
@@ -573,6 +549,7 @@ pub(crate) async fn build_registry(
                 let context = crate::runtime_state_store::RuntimeStateStore::shared_schema_context(
                     Some(&database_url),
                 )?;
+                super::ensure_startup_context_not_path_derived("runtime_state_store", &context)?;
                 let store =
                     crate::runtime_state_store::RuntimeStateStore::open_shared_with_data_dir(
                         &context,

--- a/crates/harness-server/src/http/builders/storage.rs
+++ b/crates/harness-server/src/http/builders/storage.rs
@@ -91,6 +91,7 @@ pub(crate) async fn build_storage_with_database_url(
     };
 
     let task_context = crate::task_db::TaskDb::shared_schema_context(Some(&database_url))?;
+    super::ensure_startup_context_not_path_derived("tasks", &task_context)?;
     let (tasks, task_result) = match super::forced_startup_error("tasks") {
         Some(error) => (None, StoreStartupResult::critical("tasks").failed(error)),
         None => match TaskStore::open_shared_with_data_dir(
@@ -118,6 +119,7 @@ pub(crate) async fn build_storage_with_database_url(
         None => {
             match async {
                 let eval_context = EvalStore::shared_schema_context(Some(&database_url))?;
+                super::ensure_startup_context_not_path_derived("eval_store", &eval_context)?;
                 let store =
                     EvalStore::open_shared_with_data_dir(&eval_context, &setup_pool, data_dir)
                         .await?;
@@ -147,6 +149,7 @@ pub(crate) async fn build_storage_with_database_url(
         None => {
             match async {
                 let q_value_context = QValueStore::shared_schema_context(Some(&database_url))?;
+                super::ensure_startup_context_not_path_derived("q_value_store", &q_value_context)?;
                 let store =
                     QValueStore::open_shared_with_data_dir(&q_value_context, &setup_pool, data_dir)
                         .await?;

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -103,7 +103,18 @@ async fn build_review_store(
 
     let context = match crate::review_store::ReviewStore::shared_schema_context(Some(&database_url))
     {
-        Ok(context) => context,
+        Ok(context) => {
+            if let Err(error) =
+                builders::ensure_startup_context_not_path_derived("review_store", &context)
+            {
+                setup_pool.close().await;
+                return Ok((
+                    None,
+                    StoreStartupResult::optional("review_store").failed(error.to_string()),
+                ));
+            }
+            context
+        }
         Err(error) => {
             setup_pool.close().await;
             return Ok((


### PR DESCRIPTION
## Summary
- Add a startup PgStoreContext guard that rejects path-derived ownership metadata and names the startup opener.
- Wire the guard through production startup builders for task, eval, q-value, thread, plan, issue/project/workflow runtime, project registry, workspace lease, runtime-state, review, and event stores.
- Keep legacy migration and backfill openers allowed.

Closes #1357

## Validation
- `cargo fmt --all`
- `cargo test -p harness-server storage_path_schema_guard -- --nocapture`
- `cargo check -p harness-server --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test -p harness-server --test notification_delivery -- --test-threads=1 --nocapture`
- Scope guard: 5 files changed, 244 lines added, under 30 files/1500 lines

## Note
- `cargo test -p harness-server` passed the 1532-test lib suite, then `notification_delivery` failed on local Postgres pool acquisition under parallel integration execution; the same integration test passed single-threaded.
