### PR TITLE
Add startup doctor preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ Harness is a Rust-native platform that wraps AI coding agents (Claude Code, Code
 - Rust 1.88+
 - Bun 1.1+ for release builds that embed the web dashboard. If `web/dist` is
   already built, release builds can reuse it.
-- At least one agent runtime:
+- Postgres 14+. For local development, `scripts/dev-db.sh` starts the bundled
+  Docker Compose Postgres service.
+- A GitHub token for issue/PR automation. Use `gh auth login`, `GITHUB_TOKEN`,
+  `GH_TOKEN`, or `server.github_token`.
+- At least one agent runtime for autonomous execution:
   - [`codex`](https://github.com/openai/codex) CLI
   - [`claude`](https://docs.anthropic.com/en/docs/claude-code) CLI
   - Anthropic API key (for direct API adapter)
@@ -85,8 +89,12 @@ Harness is a Rust-native platform that wraps AI coding agents (Claude Code, Code
 ```bash
 git clone https://github.com/majiayu000/harness.git
 cd harness
-cargo build
+cargo build --release -p harness-cli
 ```
+
+`./start-server.sh` also builds the release CLI automatically when
+`./target/release/harness` is missing, but running the build yourself keeps the
+startup prerequisite explicit.
 
 ### Rust API Facade
 
@@ -114,8 +122,11 @@ track internal crate layout changes.
 ### Database Setup
 
 Harness requires Postgres 14+ (SQLite was removed in v0.x). Configure
-`server.database_url` in your TOML config before starting the server —
-migrations run automatically on first connect.
+`server.database_url` in your TOML config or set `HARNESS_DATABASE_URL` before
+starting the server. When no config or environment database URL is present,
+`./start-server.sh` uses the local development default
+`postgres://harness:harness@localhost:5432/harness`. Migrations run
+automatically on first connect.
 
 **Option A — Docker Compose (recommended for local dev):**
 
@@ -178,9 +189,25 @@ coverage remains explicit and stable.
 **HTTP server:**
 
 ```bash
-cargo run -p harness-cli -- serve --transport http --port 9800
+bash scripts/doctor.sh
+./start-server.sh
 curl http://127.0.0.1:9800/health
 ```
+
+`scripts/doctor.sh` is non-mutating. It checks database URL resolution and
+Postgres reachability, the release binary/build prerequisite, GitHub token
+discovery, webhook secret readiness when webhook intake is enabled, local agent
+CLI availability, required `WORKFLOW.md` runtime flags, port occupancy, and
+unsafe non-local HTTP exposure before you start the server. Use
+`scripts/doctor.sh --dry-run` when you want a report without a failing exit
+code.
+
+`./start-server.sh` selects `HARNESS_CONFIG`, `config/default.toml`,
+`config/claude.toml`, a user config file, or built-in defaults in that order.
+It verifies the HTTP port, starts the local Docker Compose Postgres service when
+using the local fallback URL, loads `GITHUB_TOKEN` from `gh auth token` when
+available, and builds `./target/release/harness` with
+`cargo build --release -p harness-cli` if the release binary is missing.
 
 `harness serve` persists its runtime log under `server.data_dir/logs/` as
 `harness-serve-<startup-timestamp>-pid<PID>.log`. `/health` exposes a redacted
@@ -437,7 +464,7 @@ because the operator owns the process lifetime directly.
 
 ```bash
 # Single project (backward compatible)
-./target/release/harness serve --transport http --port 9800 --project-root /path/to/project
+./start-server.sh
 
 # Multi-project via config file (recommended)
 ./target/release/harness --config config/default.toml serve --transport http --port 9800
@@ -450,6 +477,11 @@ because the operator owns the process lifetime directly.
 # With GitHub token for auto-review
 GITHUB_TOKEN=ghp_xxx ./target/release/harness --config config/default.toml serve --transport http --port 9800
 ```
+
+Before using direct `./target/release/harness ... serve` commands, run
+`scripts/doctor.sh --config <path>` or confirm the same prerequisites manually.
+The direct binary commands do not start local Postgres or build the release
+binary for you.
 
 ## Task Execution Flow
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -380,9 +380,9 @@ PY
         return $?
     fi
 
-    if [[ "$host" == *:* && "$host" =~ ^[0-9A-Fa-f:.]+$ ]]; then
-        return 0
-    fi
+    # Without python3 there is no portable shell parser that reliably matches
+    # Rust SocketAddr IPv6 semantics, so fail closed instead of accepting a
+    # malformed IPv6 literal.
     return 1
 }
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -167,6 +167,19 @@ config_intake_github_value() {
     config_value "intake.github" "$1"
 }
 
+github_intake_mode() {
+    local mode
+    mode="$(config_intake_github_value "mode" || true)"
+    printf '%s\n' "${mode:-poll}"
+}
+
+github_intake_poller_enabled() {
+    case "$1" in
+        poll | hybrid | both) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 status_ok() {
     printf 'OK: %s\n' "$1"
 }
@@ -329,9 +342,21 @@ bind_port() {
 
 is_local_bind_host() {
     case "$1" in
-        "" | "localhost" | "127."* | "::1") return 0 ;;
+        "127."* | "::1") return 0 ;;
         *) return 1 ;;
     esac
+}
+
+is_ip_literal_host() {
+    local host="$1"
+
+    if [[ "$host" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+        return 0
+    fi
+    if [[ "$host" == *:* && "$host" =~ ^[0-9A-Fa-f:.]+$ ]]; then
+        return 0
+    fi
+    return 1
 }
 
 config_has_non_empty_server_array() {
@@ -413,6 +438,11 @@ check_http_exposure() {
 
     resolve_http_addr
     host="$(bind_host "$HTTP_ADDR")"
+    if ! is_ip_literal_host "$host"; then
+        fail "HTTP bind address must use an IP literal SocketAddr host, not a hostname: $HTTP_ADDR"
+        return 0
+    fi
+
     if is_local_bind_host "$host"; then
         status_ok "HTTP bind address is local: $HTTP_ADDR"
         return 0
@@ -546,6 +576,7 @@ workflow_enabled_value() {
 check_workflow_runtime_flags() {
     local section
     local value
+    local mode
     local missing=0
 
     if [ ! -f "WORKFLOW.md" ]; then
@@ -553,7 +584,14 @@ check_workflow_runtime_flags() {
         return 0
     fi
 
+    mode="$(github_intake_mode)"
+
     for section in repo_backlog runtime_dispatch runtime_worker; do
+        if [ "$section" = "repo_backlog" ] && ! github_intake_poller_enabled "$mode"; then
+            status_ok "GitHub intake mode '$mode' does not require repo_backlog polling"
+            continue
+        fi
+
         value="$(workflow_enabled_value "$section" || true)"
         if [ "$value" = "true" ]; then
             status_ok "WORKFLOW.md enables $section"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -209,7 +209,7 @@ database_host_port() {
     if [[ "$authority" == \[*\]* ]]; then
         host="${authority%%]*}"
         host="${host#[}"
-        rest="${authority#]}"
+        rest="${authority#*]}"
         if [[ "$rest" == :* ]]; then
             port="${rest#:}"
         else
@@ -362,6 +362,8 @@ config_has_non_empty_server_array() {
                 exit 1
             }
             if (value != "") {
+                found_array_value = 1
+                in_array = 0
                 exit 0
             }
             next
@@ -398,7 +400,7 @@ config_has_non_empty_server_array() {
             exit 0
         }
         END {
-            if (in_array) {
+            if (in_array && !found_array_value) {
                 exit 1
             }
         }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -129,6 +129,7 @@ config_value() {
     awk -v section="$section" -v key="$key" '
         /^[[:space:]]*\[/ {
             name = $0
+            sub(/[[:space:]]*#.*/, "", name)
             sub(/^[[:space:]]*\[/, "", name)
             sub(/\][[:space:]]*$/, "", name)
             sub(/^[[:space:]]+/, "", name)
@@ -419,6 +420,7 @@ config_has_non_empty_server_array() {
     awk -v key="$key" '
         /^[[:space:]]*\[/ {
             section = $0
+            sub(/[[:space:]]*#.*/, "", section)
             sub(/^[[:space:]]*\[/, "", section)
             sub(/\][[:space:]]*$/, "", section)
             sub(/^[[:space:]]+/, "", section)

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -126,24 +126,35 @@ config_value() {
 
     [ -n "$CONFIG_PATH" ] || return 1
 
-    awk -F= -v section="$section" -v key="$key" '
+    awk -v section="$section" -v key="$key" '
         /^[[:space:]]*\[/ {
             name = $0
             sub(/^[[:space:]]*\[/, "", name)
             sub(/\][[:space:]]*$/, "", name)
+            sub(/^[[:space:]]+/, "", name)
+            sub(/[[:space:]]+$/, "", name)
             in_section = (name == section)
             next
         }
-        in_section && $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
-            value = $2
-            sub(/^[[:space:]]*/, "", value)
-            sub(/[[:space:]]*#.*/, "", value)
-            sub(/[[:space:]]*$/, "", value)
-            if (value ~ /^".*"$/ || value ~ /^\047.*\047$/) {
-                value = substr(value, 2, length(value) - 2)
+        in_section {
+            idx = index($0, "=")
+            if (idx == 0) {
+                next
             }
-            print value
-            exit
+            name = substr($0, 1, idx - 1)
+            sub(/^[[:space:]]+/, "", name)
+            sub(/[[:space:]]+$/, "", name)
+            if (name == key) {
+                value = substr($0, idx + 1)
+                sub(/^[[:space:]]*/, "", value)
+                sub(/[[:space:]]*#.*/, "", value)
+                sub(/[[:space:]]*$/, "", value)
+                if (value ~ /^".*"$/ || value ~ /^\047.*\047$/) {
+                    value = substr(value, 2, length(value) - 2)
+                }
+                print value
+                exit
+            }
         }
     ' "$CONFIG_PATH"
 }
@@ -193,6 +204,7 @@ database_host_port() {
     esac
 
     authority="${rest%%/*}"
+    authority="${authority%%\?*}"
     authority="${authority##*@}"
     if [[ "$authority" == \[*\]* ]]; then
         host="${authority%%]*}"
@@ -324,9 +336,73 @@ is_local_bind_host() {
 
 config_has_non_empty_server_array() {
     local key="$1"
-    local value
-    value="$(config_server_value "$key" || true)"
-    [ -n "$value" ] && [ "$value" != "[]" ]
+
+    [ -n "$CONFIG_PATH" ] || return 1
+
+    awk -v key="$key" '
+        /^[[:space:]]*\[/ {
+            section = $0
+            sub(/^[[:space:]]*\[/, "", section)
+            sub(/\][[:space:]]*$/, "", section)
+            sub(/^[[:space:]]+/, "", section)
+            sub(/[[:space:]]+$/, "", section)
+            in_server = (section == "server")
+            in_array = 0
+            next
+        }
+        !in_server {
+            next
+        }
+        in_array {
+            value = $0
+            sub(/[[:space:]]*#.*/, "", value)
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            if (value ~ /^\]/) {
+                exit 1
+            }
+            if (value != "") {
+                exit 0
+            }
+            next
+        }
+        {
+            idx = index($0, "=")
+            if (idx == 0) {
+                next
+            }
+            name = substr($0, 1, idx - 1)
+            sub(/^[[:space:]]+/, "", name)
+            sub(/[[:space:]]+$/, "", name)
+            if (name != key) {
+                next
+            }
+            value = substr($0, idx + 1)
+            sub(/[[:space:]]*#.*/, "", value)
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            if (value == "" || value == "[]") {
+                exit 1
+            }
+            if (value == "[") {
+                in_array = 1
+                next
+            }
+            if (value ~ /^\[/) {
+                gsub(/[\[\]]/, "", value)
+                gsub(/,/, "", value)
+                sub(/^[[:space:]]+/, "", value)
+                sub(/[[:space:]]+$/, "", value)
+                exit(value == "" ? 1 : 0)
+            }
+            exit 0
+        }
+        END {
+            if (in_array) {
+                exit 1
+            }
+        }
+    ' "$CONFIG_PATH"
 }
 
 check_http_exposure() {

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,552 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/doctor.sh [options]
+
+Options:
+  --config PATH   Harness config file to inspect. Defaults to HARNESS_CONFIG,
+                  config/default.toml, config/claude.toml, then user config.
+  --http-addr ADDR
+                  HTTP bind address to inspect. Defaults to HARNESS_HTTP_ADDR,
+                  server.http_addr, then 127.0.0.1:9800.
+  --dry-run       Run non-mutating checks and always exit 0 after reporting.
+  -h, --help      Show this help.
+
+The doctor does not start services, build binaries, create config files, or
+write credentials. It reports whether the documented startup path is ready.
+EOF
+}
+
+CONFIG_PATH="${HARNESS_CONFIG:-}"
+HTTP_ADDR="${HARNESS_HTTP_ADDR:-}"
+DRY_RUN=0
+FAILURES=0
+WARNINGS=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --config)
+            if [ -z "${2:-}" ]; then
+                echo "--config requires a value" >&2
+                exit 2
+            fi
+            CONFIG_PATH="$2"
+            shift 2
+            ;;
+        --http-addr)
+            if [ -z "${2:-}" ]; then
+                echo "--http-addr requires a value" >&2
+                exit 2
+            fi
+            HTTP_ADDR="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+is_absolute_path() {
+    case "$1" in
+        /*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+discover_config_path() {
+    local candidate
+
+    if [ -n "${XDG_CONFIG_HOME:-}" ] && is_absolute_path "$XDG_CONFIG_HOME"; then
+        candidate="$XDG_CONFIG_HOME/harness/config.toml"
+        if [ -f "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    fi
+
+    if [ -n "${HOME:-}" ] && is_absolute_path "$HOME"; then
+        candidate="$HOME/.config/harness/config.toml"
+        if [ -f "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+
+        if [ "$(uname -s 2>/dev/null || true)" = "Darwin" ]; then
+            candidate="$HOME/Library/Application Support/harness/config.toml"
+            if [ -f "$candidate" ]; then
+                printf '%s\n' "$candidate"
+                return 0
+            fi
+        fi
+    fi
+
+    return 1
+}
+
+resolve_config_path() {
+    if [ -n "$CONFIG_PATH" ]; then
+        if [ ! -f "$CONFIG_PATH" ]; then
+            fail "config file not found: $CONFIG_PATH"
+            CONFIG_PATH=""
+            return 0
+        fi
+        return 0
+    fi
+
+    if [ -f "config/default.toml" ]; then
+        CONFIG_PATH="config/default.toml"
+    elif [ -f "config/claude.toml" ]; then
+        CONFIG_PATH="config/claude.toml"
+    elif CONFIG_PATH="$(discover_config_path)"; then
+        :
+    else
+        CONFIG_PATH=""
+    fi
+}
+
+config_value() {
+    local section="$1"
+    local key="$2"
+
+    [ -n "$CONFIG_PATH" ] || return 1
+
+    awk -F= -v section="$section" -v key="$key" '
+        /^[[:space:]]*\[/ {
+            name = $0
+            sub(/^[[:space:]]*\[/, "", name)
+            sub(/\][[:space:]]*$/, "", name)
+            in_section = (name == section)
+            next
+        }
+        in_section && $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
+            value = $2
+            sub(/^[[:space:]]*/, "", value)
+            sub(/[[:space:]]*#.*/, "", value)
+            sub(/[[:space:]]*$/, "", value)
+            if (value ~ /^".*"$/ || value ~ /^\047.*\047$/) {
+                value = substr(value, 2, length(value) - 2)
+            }
+            print value
+            exit
+        }
+    ' "$CONFIG_PATH"
+}
+
+config_server_value() {
+    config_value "server" "$1"
+}
+
+config_intake_github_value() {
+    config_value "intake.github" "$1"
+}
+
+status_ok() {
+    printf 'OK: %s\n' "$1"
+}
+
+warn() {
+    WARNINGS=$((WARNINGS + 1))
+    printf 'WARN: %s\n' "$1"
+}
+
+fail() {
+    FAILURES=$((FAILURES + 1))
+    printf 'FAIL: %s\n' "$1"
+}
+
+redact_database_url() {
+    local url="$1"
+    case "$url" in
+        postgres://*@*) printf 'postgres://***@%s\n' "${url#*@}" ;;
+        postgresql://*@*) printf 'postgresql://***@%s\n' "${url#*@}" ;;
+        *) printf '%s\n' "$url" ;;
+    esac
+}
+
+database_host_port() {
+    local url="$1"
+    local authority
+    local host
+    local port
+    local rest
+
+    case "$url" in
+        postgres://*) rest="${url#postgres://}" ;;
+        postgresql://*) rest="${url#postgresql://}" ;;
+        *) return 1 ;;
+    esac
+
+    authority="${rest%%/*}"
+    authority="${authority##*@}"
+    if [[ "$authority" == \[*\]* ]]; then
+        host="${authority%%]*}"
+        host="${host#[}"
+        rest="${authority#]}"
+        if [[ "$rest" == :* ]]; then
+            port="${rest#:}"
+        else
+            port="5432"
+        fi
+    else
+        host="${authority%%:*}"
+        if [[ "$authority" == *:* ]]; then
+            port="${authority#*:}"
+        else
+            port="5432"
+        fi
+    fi
+    port="${port%%\?*}"
+    [ -n "$host" ] || return 1
+    [ -n "$port" ] || port="5432"
+    printf '%s %s\n' "$host" "$port"
+}
+
+check_release_binary() {
+    if [ -x "./target/release/harness" ]; then
+        status_ok "release binary is executable: ./target/release/harness"
+        return 0
+    fi
+
+    if [ -e "./target/release/harness" ]; then
+        fail "release binary exists but is not executable: ./target/release/harness"
+        return 0
+    fi
+
+    if command -v cargo >/dev/null 2>&1; then
+        warn "release binary is missing; ./start-server.sh will run cargo build --release -p harness-cli before starting"
+    else
+        fail "release binary is missing and cargo is not available to build it"
+    fi
+}
+
+resolve_database_url() {
+    local configured
+
+    if [ -n "${HARNESS_DATABASE_URL:-}" ]; then
+        DATABASE_URL="$HARNESS_DATABASE_URL"
+        DATABASE_SOURCE="HARNESS_DATABASE_URL"
+        return 0
+    fi
+
+    configured="$(config_server_value "database_url" || true)"
+    if [ -n "$configured" ]; then
+        DATABASE_URL="$configured"
+        DATABASE_SOURCE="server.database_url in $CONFIG_PATH"
+        return 0
+    fi
+
+    DATABASE_URL="postgres://harness:harness@localhost:5432/harness"
+    DATABASE_SOURCE="./start-server.sh local Postgres fallback"
+}
+
+check_database() {
+    local host_port
+    local host
+    local port
+
+    resolve_database_url
+    status_ok "database URL resolved from $DATABASE_SOURCE: $(redact_database_url "$DATABASE_URL")"
+
+    if command -v pg_isready >/dev/null 2>&1; then
+        if pg_isready -d "$DATABASE_URL" -t 2 >/dev/null 2>&1; then
+            status_ok "Postgres is reachable with pg_isready"
+        else
+            fail "Postgres is not reachable with pg_isready; start it with scripts/dev-db.sh or fix the configured database URL"
+        fi
+        return 0
+    fi
+
+    if command -v nc >/dev/null 2>&1; then
+        if host_port="$(database_host_port "$DATABASE_URL")"; then
+            host="${host_port% *}"
+            port="${host_port#* }"
+            if nc -z -w 2 "$host" "$port" >/dev/null 2>&1 ||
+                nc -z -G 2 "$host" "$port" >/dev/null 2>&1; then
+                status_ok "Postgres TCP endpoint is reachable at $host:$port"
+            else
+                fail "Postgres TCP endpoint is not reachable at $host:$port; start it with scripts/dev-db.sh or fix the configured database URL"
+            fi
+        else
+            warn "database URL could not be parsed for TCP reachability; install pg_isready for an exact Postgres check"
+        fi
+        return 0
+    fi
+
+    warn "pg_isready and nc are unavailable; database reachability could not be verified"
+}
+
+resolve_http_addr() {
+    local configured
+
+    if [ -n "$HTTP_ADDR" ]; then
+        return 0
+    fi
+
+    configured="$(config_server_value "http_addr" || true)"
+    HTTP_ADDR="${configured:-127.0.0.1:9800}"
+}
+
+bind_host() {
+    local addr="$1"
+    local host="${addr%:*}"
+    host="${host#[}"
+    host="${host%]}"
+    printf '%s\n' "$host"
+}
+
+bind_port() {
+    local addr="$1"
+    printf '%s\n' "${addr##*:}"
+}
+
+is_local_bind_host() {
+    case "$1" in
+        "" | "localhost" | "127."* | "::1") return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+config_has_non_empty_server_array() {
+    local key="$1"
+    local value
+    value="$(config_server_value "$key" || true)"
+    [ -n "$value" ] && [ "$value" != "[]" ]
+}
+
+check_http_exposure() {
+    local host
+    local api_token
+
+    resolve_http_addr
+    host="$(bind_host "$HTTP_ADDR")"
+    if is_local_bind_host "$host"; then
+        status_ok "HTTP bind address is local: $HTTP_ADDR"
+        return 0
+    fi
+
+    api_token="${HARNESS_API_TOKEN:-}"
+    if [ -z "$api_token" ]; then
+        api_token="$(config_server_value "api_token" || true)"
+    fi
+
+    if [ -z "$api_token" ]; then
+        fail "non-local HTTP bind $HTTP_ADDR requires HARNESS_API_TOKEN or server.api_token before serving"
+    else
+        status_ok "API token is configured for non-local HTTP bind $HTTP_ADDR"
+    fi
+
+    if config_has_non_empty_server_array "allowed_project_roots"; then
+        status_ok "allowed_project_roots is configured for non-local project registration"
+    else
+        fail "non-local HTTP bind $HTTP_ADDR should configure server.allowed_project_roots to constrain project registration"
+    fi
+}
+
+check_port() {
+    local port
+    local pids
+
+    resolve_http_addr
+    port="$(bind_port "$HTTP_ADDR")"
+    if ! [[ "$port" =~ ^[0-9]+$ ]]; then
+        fail "HTTP address has an invalid port: $HTTP_ADDR"
+        return 0
+    fi
+
+    if ! command -v lsof >/dev/null 2>&1; then
+        warn "lsof is unavailable; port occupancy for $HTTP_ADDR could not be verified"
+        return 0
+    fi
+
+    pids="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | awk '!seen[$0]++' || true)"
+    if [ -z "$pids" ]; then
+        status_ok "port $port is available for $HTTP_ADDR"
+        return 0
+    fi
+
+    fail "port $port already has a listener; stop it or change HARNESS_HTTP_ADDR/server.http_addr"
+    ps -p "$(printf '%s' "$pids" | paste -sd, -)" -o pid=,comm=,command= || true
+}
+
+command_exists_or_executable() {
+    local path="$1"
+    if [[ "$path" == */* ]]; then
+        [ -x "$path" ]
+    else
+        command -v "$path" >/dev/null 2>&1
+    fi
+}
+
+check_agent_cli() {
+    local codex_cli
+    local claude_cli
+    local found=0
+
+    codex_cli="$(config_value "agents.codex" "cli_path" || true)"
+    claude_cli="$(config_value "agents.claude" "cli_path" || true)"
+    codex_cli="${codex_cli:-codex}"
+    claude_cli="${claude_cli:-claude}"
+
+    if command_exists_or_executable "$codex_cli"; then
+        status_ok "Codex CLI is available: $codex_cli"
+        found=1
+    else
+        warn "Codex CLI is not available on PATH/configured path: $codex_cli"
+    fi
+
+    if command_exists_or_executable "$claude_cli"; then
+        status_ok "Claude CLI is available: $claude_cli"
+        found=1
+    else
+        warn "Claude CLI is not available on PATH/configured path: $claude_cli"
+    fi
+
+    if [ "$found" -eq 0 ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+        fail "no common agent CLI was found and ANTHROPIC_API_KEY is not set; autonomous execution will not be able to run"
+    elif [ "$found" -eq 0 ]; then
+        status_ok "ANTHROPIC_API_KEY is set, so the Anthropic API adapter can be used without local agent CLIs"
+    fi
+}
+
+check_github_token() {
+    local configured
+
+    if [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${GH_TOKEN:-}" ]; then
+        status_ok "GitHub token is available from GITHUB_TOKEN/GH_TOKEN"
+        return 0
+    fi
+
+    configured="$(config_server_value "github_token" || true)"
+    if [ -n "$configured" ]; then
+        status_ok "GitHub token is configured in server.github_token"
+        return 0
+    fi
+
+    if command -v gh >/dev/null 2>&1 && gh auth token >/dev/null 2>&1; then
+        status_ok "GitHub token is discoverable from gh auth"
+        return 0
+    fi
+
+    warn "GitHub token was not found; issue/PR automation needs gh auth login, GITHUB_TOKEN, GH_TOKEN, or server.github_token"
+}
+
+workflow_enabled_value() {
+    local section="$1"
+
+    [ -f "WORKFLOW.md" ] || return 1
+
+    awk -v section="$section" '
+        $0 ~ "^" section ":" { in_section = 1; next }
+        in_section && $0 ~ /^[[:alnum:]_]+:/ { in_section = 0 }
+        in_section && $0 ~ /^[[:space:]]+enabled:[[:space:]]*/ {
+            value = $0
+            sub(/^[[:space:]]+enabled:[[:space:]]*/, "", value)
+            sub(/[[:space:]]*#.*/, "", value)
+            sub(/[[:space:]]*$/, "", value)
+            print value
+            exit
+        }
+    ' WORKFLOW.md
+}
+
+check_workflow_runtime_flags() {
+    local section
+    local value
+    local missing=0
+
+    if [ ! -f "WORKFLOW.md" ]; then
+        warn "WORKFLOW.md was not found; GitHub issue intake cannot prove runtime backlog ownership from this checkout"
+        return 0
+    fi
+
+    for section in repo_backlog runtime_dispatch runtime_worker; do
+        value="$(workflow_enabled_value "$section" || true)"
+        if [ "$value" = "true" ]; then
+            status_ok "WORKFLOW.md enables $section"
+        else
+            fail "WORKFLOW.md must set $section.enabled = true for autonomous GitHub issue intake and execution"
+            missing=1
+        fi
+    done
+
+    if [ "$missing" -eq 0 ]; then
+        status_ok "workflow runtime flags are ready for GitHub issue intake handoff"
+    fi
+}
+
+check_webhook_secret() {
+    local mode
+    local configured
+
+    mode="$(config_intake_github_value "mode" || true)"
+    mode="${mode:-poll}"
+
+    case "$mode" in
+        webhook | hybrid | both)
+            ;;
+        *)
+            status_ok "GitHub intake mode does not require a webhook secret: $mode"
+            return 0
+            ;;
+    esac
+
+    if [ -n "${GITHUB_WEBHOOK_SECRET:-}" ]; then
+        status_ok "GitHub webhook secret is available from GITHUB_WEBHOOK_SECRET"
+        return 0
+    fi
+
+    configured="$(config_server_value "github_webhook_secret" || true)"
+    if [ -n "$configured" ]; then
+        status_ok "GitHub webhook secret is configured in server.github_webhook_secret"
+        return 0
+    fi
+
+    fail "GitHub intake mode '$mode' requires GITHUB_WEBHOOK_SECRET or server.github_webhook_secret before receiving webhooks"
+}
+
+main() {
+    echo "Harness startup doctor"
+    resolve_config_path
+    if [ -n "$CONFIG_PATH" ]; then
+        status_ok "config file selected: $CONFIG_PATH"
+    else
+        warn "no config file selected; startup will use built-in defaults plus ./start-server.sh local Postgres fallback"
+    fi
+
+    check_database
+    check_release_binary
+    check_github_token
+    check_webhook_secret
+    check_agent_cli
+    check_workflow_runtime_flags
+    check_port
+    check_http_exposure
+
+    echo "summary: failures=$FAILURES warnings=$WARNINGS"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "dry run: no services were started, no binaries were built, and no files were written"
+        exit 0
+    fi
+
+    if [ "$FAILURES" -ne 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -327,19 +327,6 @@ resolve_http_addr() {
     HTTP_ADDR="${configured:-127.0.0.1:9800}"
 }
 
-bind_host() {
-    local addr="$1"
-    local host="${addr%:*}"
-    host="${host#[}"
-    host="${host%]}"
-    printf '%s\n' "$host"
-}
-
-bind_port() {
-    local addr="$1"
-    printf '%s\n' "${addr##*:}"
-}
-
 is_local_bind_host() {
     case "$1" in
         "127."* | "::1") return 0 ;;
@@ -347,16 +334,81 @@ is_local_bind_host() {
     esac
 }
 
-is_ip_literal_host() {
+is_valid_port() {
+    local port="$1"
+    [[ "$port" =~ ^[0-9]+$ ]] && [ "$port" -le 65535 ]
+}
+
+is_valid_ipv4_literal() {
+    local host="$1"
+    local a
+    local b
+    local c
+    local d
+    local extra
+    local part
+
+    IFS=. read -r a b c d extra <<EOF
+$host
+EOF
+    [ -z "${extra:-}" ] || return 1
+    for part in "$a" "$b" "$c" "$d"; do
+        [[ "$part" =~ ^[0-9]+$ ]] || return 1
+        [ "$part" -le 255 ] || return 1
+    done
+}
+
+is_valid_ip_literal_host() {
     local host="$1"
 
-    if [[ "$host" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
-        return 0
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$host" <<'PY' >/dev/null 2>&1
+import ipaddress
+import sys
+
+try:
+    ipaddress.ip_address(sys.argv[1])
+except ValueError:
+    sys.exit(1)
+PY
+        return $?
     fi
+
+    if [[ "$host" == *.* ]]; then
+        is_valid_ipv4_literal "$host"
+        return $?
+    fi
+
     if [[ "$host" == *:* && "$host" =~ ^[0-9A-Fa-f:.]+$ ]]; then
         return 0
     fi
     return 1
+}
+
+http_addr_host_port() {
+    local addr="$1"
+    local host
+    local rest
+    local port
+
+    if [[ "$addr" == \[* ]]; then
+        [[ "$addr" == *\]* ]] || return 1
+        host="${addr%%]*}"
+        host="${host#[}"
+        rest="${addr#*]}"
+        [[ "$rest" == :* ]] || return 1
+        port="${rest#:}"
+        [[ "$host" == *:* ]] || return 1
+    else
+        [[ "$addr" == *:* ]] || return 1
+        [[ "$addr" != *:*:* ]] || return 1
+        host="${addr%:*}"
+        port="${addr##*:}"
+    fi
+
+    is_valid_port "$port" || return 1
+    is_valid_ip_literal_host "$host" || return 1
+    printf '%s %s\n' "$host" "$port"
 }
 
 config_has_non_empty_server_array() {
@@ -434,14 +486,15 @@ config_has_non_empty_server_array() {
 
 check_http_exposure() {
     local host
+    local host_port
     local api_token
 
     resolve_http_addr
-    host="$(bind_host "$HTTP_ADDR")"
-    if ! is_ip_literal_host "$host"; then
-        fail "HTTP bind address must use an IP literal SocketAddr host, not a hostname: $HTTP_ADDR"
+    if ! host_port="$(http_addr_host_port "$HTTP_ADDR")"; then
+        fail "HTTP bind address must be a valid IP literal SocketAddr, not a hostname or malformed address: $HTTP_ADDR"
         return 0
     fi
+    host="${host_port% *}"
 
     if is_local_bind_host "$host"; then
         status_ok "HTTP bind address is local: $HTTP_ADDR"
@@ -467,15 +520,16 @@ check_http_exposure() {
 }
 
 check_port() {
+    local host_port
     local port
     local pids
 
     resolve_http_addr
-    port="$(bind_port "$HTTP_ADDR")"
-    if ! [[ "$port" =~ ^[0-9]+$ ]]; then
-        fail "HTTP address has an invalid port: $HTTP_ADDR"
+    if ! host_port="$(http_addr_host_port "$HTTP_ADDR")"; then
+        fail "HTTP address must be a valid IP literal SocketAddr: $HTTP_ADDR"
         return 0
     fi
+    port="${host_port#* }"
 
     if ! command -v lsof >/dev/null 2>&1; then
         warn "lsof is unavailable; port occupancy for $HTTP_ADDR could not be verified"

--- a/start-server.sh
+++ b/start-server.sh
@@ -5,6 +5,7 @@ cd "$(dirname "$0")"
 
 CONFIG_PATH="${HARNESS_CONFIG:-}"
 CONFIG_ARGS=()
+HARNESS_BIN="${HARNESS_BIN:-./target/release/harness}"
 
 is_absolute_path() {
     case "$1" in
@@ -156,8 +157,7 @@ listener_pids() {
         [[ "$line" == COMMAND* ]] && continue
         [[ "$line" == *" TCP "* ]] || continue
         [[ "$line" == *"(LISTEN)"* ]] || continue
-        set -- $line
-        pid="${2:-}"
+        read -r _ pid _ <<< "$line"
         [[ "$pid" =~ ^[0-9]+$ ]] || continue
         name="${line##* TCP }"
         name="${name% (LISTEN)}"
@@ -270,6 +270,44 @@ ensure_bind_port_available() {
 
 ensure_bind_port_available
 
+ensure_harness_binary() {
+    if [ -e "$HARNESS_BIN" ] && [ ! -x "$HARNESS_BIN" ]; then
+        echo "ERROR: Harness binary exists but is not executable: $HARNESS_BIN" >&2
+        echo "Remove it or rebuild with: cargo build --release -p harness-cli" >&2
+        exit 1
+    fi
+
+    if [ -x "$HARNESS_BIN" ]; then
+        return 0
+    fi
+
+    if [ "$HARNESS_BIN" != "./target/release/harness" ]; then
+        echo "ERROR: configured Harness binary not found or not executable: $HARNESS_BIN" >&2
+        echo "Set HARNESS_BIN to an executable harness binary or build the default release binary." >&2
+        exit 1
+    fi
+
+    if ! command -v cargo >/dev/null 2>&1; then
+        echo "ERROR: $HARNESS_BIN is missing and cargo is not available to build it." >&2
+        echo "Install Rust or build the release binary in another environment, then rerun ./start-server.sh." >&2
+        exit 1
+    fi
+
+    echo "Release Harness binary not found; building it with cargo build --release -p harness-cli..." >&2
+    if ! cargo build --release -p harness-cli; then
+        echo "ERROR: failed to build $HARNESS_BIN." >&2
+        echo "Install the build prerequisites, then rerun: cargo build --release -p harness-cli" >&2
+        exit 1
+    fi
+
+    if [ ! -x "$HARNESS_BIN" ]; then
+        echo "ERROR: cargo build completed but $HARNESS_BIN is still missing or not executable." >&2
+        exit 1
+    fi
+}
+
+ensure_harness_binary
+
 uses_local_postgres() {
     if [ -n "${HARNESS_DATABASE_URL:-}" ]; then
         return 1
@@ -305,4 +343,4 @@ if [ -z "${GITHUB_TOKEN:-}" ]; then
     fi
 fi
 
-exec ./target/release/harness serve "${CONFIG_ARGS[@]}" --transport http --project-root "$(pwd)"
+exec "$HARNESS_BIN" "${CONFIG_ARGS[@]}" serve --transport http --project-root "$(pwd)"


### PR DESCRIPTION
## Summary

- Add `scripts/doctor.sh`, a non-mutating startup preflight that checks database reachability, release binary/build readiness, GitHub credentials, webhook secret readiness for webhook intake, agent CLI availability, required `WORKFLOW.md` runtime flags, port occupancy, and unsafe non-local HTTP exposure.
- Make `start-server.sh` build the default release CLI when `./target/release/harness` is missing, while still failing fast for invalid custom `HARNESS_BIN` paths.
- Align README quick start with the real startup path and prerequisites.

Closes #1360.

## Verification

- `bash -n start-server.sh`
- `bash -n scripts/doctor.sh`
- `shellcheck start-server.sh scripts/doctor.sh`
- `scripts/doctor.sh --help`
- `scripts/doctor.sh --dry-run --http-addr 127.0.0.1:19800`
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
