### PR TITLE
Type workflow command status write paths

### DIFF
--- a/crates/harness-server/src/workflow_runtime_submission/cancel.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/cancel.rs
@@ -1,6 +1,6 @@
 use harness_workflow::runtime::{
-    WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowInstance, WorkflowRuntimeStore,
-    PROMPT_TASK_DEFINITION_ID,
+    WorkflowCommand, WorkflowCommandStatus, WorkflowCommandType, WorkflowDecision,
+    WorkflowInstance, WorkflowRuntimeStore, PROMPT_TASK_DEFINITION_ID,
 };
 use serde_json::json;
 use std::fmt;
@@ -139,8 +139,10 @@ async fn cancel_submission_instance(
     let commands = store.commands_for(&cancelled.id).await?;
     for command in commands {
         if matches!(
-            command.status.as_str(),
-            "pending" | "dispatching" | "dispatched"
+            command.status,
+            WorkflowCommandStatus::Pending
+                | WorkflowCommandStatus::Dispatching
+                | WorkflowCommandStatus::Dispatched
         ) {
             store
                 .cancel_command_and_unfinished_runtime_jobs(

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -1184,18 +1184,18 @@ impl WorkflowRuntimeStore {
             "WITH candidates AS (
                  SELECT id
                  FROM workflow_commands
-                 WHERE status = 'pending'
+                 WHERE status = $3
                     OR (
-                        status = 'dispatching'
+                        status = $4
                         AND COALESCE(dispatch_lease_expires_at, '-infinity'::timestamptz)
                             <= CURRENT_TIMESTAMP
                     )
                  ORDER BY created_at ASC
-                 LIMIT $3
+                 LIMIT $5
                  FOR UPDATE SKIP LOCKED
              )
              UPDATE workflow_commands AS command
-             SET status = 'dispatching',
+             SET status = $4,
                  dispatch_owner = $1,
                  dispatch_lease_expires_at = $2,
                  updated_at = CURRENT_TIMESTAMP
@@ -1207,6 +1207,8 @@ impl WorkflowRuntimeStore {
         )
         .bind(owner)
         .bind(expires_at)
+        .bind(WorkflowCommandStatus::Pending.as_str())
+        .bind(WorkflowCommandStatus::Dispatching.as_str())
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
@@ -1249,10 +1251,11 @@ impl WorkflowRuntimeStore {
                  dispatch_owner = NULL,
                  dispatch_lease_expires_at = NULL,
                  updated_at = CURRENT_TIMESTAMP
-             WHERE id = $2 AND status = 'pending'",
+             WHERE id = $2 AND status = $3",
         )
         .bind(status.as_str())
         .bind(command_id)
+        .bind(WorkflowCommandStatus::Pending.as_str())
         .execute(&self.pool)
         .await?;
         Ok(result.rows_affected() > 0)
@@ -1392,13 +1395,14 @@ impl WorkflowRuntimeStore {
         if let Some(existing) = runtime_job_for_command_tx(&mut tx, command_id).await? {
             sqlx::query(
                 "UPDATE workflow_commands
-                 SET status = 'dispatched',
+                 SET status = $2,
                      dispatch_owner = NULL,
                      dispatch_lease_expires_at = NULL,
                      updated_at = CURRENT_TIMESTAMP
                  WHERE id = $1",
             )
             .bind(command_id)
+            .bind(WorkflowCommandStatus::Dispatched.as_str())
             .execute(&mut *tx)
             .await?;
             tx.commit().await?;
@@ -1421,13 +1425,14 @@ impl WorkflowRuntimeStore {
         .await?;
         sqlx::query(
             "UPDATE workflow_commands
-             SET status = 'dispatched',
+             SET status = $2,
                  dispatch_owner = NULL,
                  dispatch_lease_expires_at = NULL,
                  updated_at = CURRENT_TIMESTAMP
              WHERE id = $1",
         )
         .bind(command_id)
+        .bind(WorkflowCommandStatus::Dispatched.as_str())
         .execute(&mut *tx)
         .await?;
         tx.commit().await?;
@@ -1785,11 +1790,14 @@ impl WorkflowRuntimeStore {
                      WHERE workflow_id = $1
                        AND id <> $2
                        AND command_type = $3
-                       AND status IN ('pending', 'dispatching', 'dispatched')",
+                       AND status IN ($4, $5, $6)",
                 )
                 .bind(&command.workflow_id)
                 .bind(&command.id)
                 .bind(&command_type)
+                .bind(WorkflowCommandStatus::Pending.as_str())
+                .bind(WorkflowCommandStatus::Dispatching.as_str())
+                .bind(WorkflowCommandStatus::Dispatched.as_str())
                 .fetch_one(&mut *tx)
                 .await?;
                 count as usize
@@ -2049,14 +2057,18 @@ impl WorkflowRuntimeStore {
         }
         sqlx::query(
             "UPDATE workflow_commands
-             SET status = 'cancelled',
+             SET status = $2,
                  dispatch_owner = NULL,
                  dispatch_lease_expires_at = NULL,
                  updated_at = CURRENT_TIMESTAMP
              WHERE id = $1
-               AND status IN ('pending', 'dispatching', 'dispatched')",
+               AND status IN ($3, $4, $5)",
         )
         .bind(command_id)
+        .bind(WorkflowCommandStatus::Cancelled.as_str())
+        .bind(WorkflowCommandStatus::Pending.as_str())
+        .bind(WorkflowCommandStatus::Dispatching.as_str())
+        .bind(WorkflowCommandStatus::Dispatched.as_str())
         .execute(&mut *tx)
         .await?;
         tx.commit().await?;

--- a/crates/harness-workflow/src/runtime/store/commands.rs
+++ b/crates/harness-workflow/src/runtime/store/commands.rs
@@ -20,6 +20,7 @@ pub(super) async fn insert(
         .bind(&command.dedupe_key)
         .bind(status.as_str())
         .bind(&data)
+        .bind(WorkflowCommandStatus::Pending.as_str())
         .fetch_one(pool)
         .await?;
     Ok(id)
@@ -42,6 +43,7 @@ pub(super) async fn insert_tx(
         .bind(&command.dedupe_key)
         .bind(status.as_str())
         .bind(&data)
+        .bind(WorkflowCommandStatus::Pending.as_str())
         .fetch_one(&mut **tx)
         .await?;
     Ok(id)
@@ -53,23 +55,23 @@ fn insert_sql() -> &'static str {
      VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
      ON CONFLICT (workflow_id, dedupe_key) DO UPDATE SET
         decision_id = CASE
-            WHEN workflow_commands.status = 'pending' THEN EXCLUDED.decision_id
+            WHEN workflow_commands.status = $8 THEN EXCLUDED.decision_id
             ELSE workflow_commands.decision_id
         END,
         command_type = CASE
-            WHEN workflow_commands.status = 'pending' THEN EXCLUDED.command_type
+            WHEN workflow_commands.status = $8 THEN EXCLUDED.command_type
             ELSE workflow_commands.command_type
         END,
         data = CASE
-            WHEN workflow_commands.status = 'pending' THEN EXCLUDED.data
+            WHEN workflow_commands.status = $8 THEN EXCLUDED.data
             ELSE workflow_commands.data
         END,
         status = CASE
-            WHEN workflow_commands.status = 'pending' THEN EXCLUDED.status
+            WHEN workflow_commands.status = $8 THEN EXCLUDED.status
             ELSE workflow_commands.status
         END,
         updated_at = CASE
-            WHEN workflow_commands.status = 'pending'
+            WHEN workflow_commands.status = $8
                  AND (
                      workflow_commands.status <> EXCLUDED.status
                      OR workflow_commands.decision_id IS DISTINCT FROM EXCLUDED.decision_id


### PR DESCRIPTION
## Summary
- route workflow command status write/update paths through `WorkflowCommandStatus`
- keep persisted command status wire strings unchanged
- bind pending-status conflict checks through the typed boundary in command enqueue SQL
- match active cancellation command statuses through `WorkflowCommandStatus` instead of raw status strings

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

Part of #1226.