### PR TITLE
Make path-derived schema openings explicit legacy APIs

### DIFF
--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -17,13 +17,15 @@ pub use crate::db_pg_schema_registry::{
     PG_SCHEMA_REGISTRY_SCHEMA, PG_SCHEMA_REGISTRY_TABLE,
 };
 
-/// Create a Postgres connection pool for the logical store at `path`.
+/// Create a legacy path-derived Postgres connection pool for the logical store at `path`.
 ///
 /// Historical stores accepted SQLite file paths as their identity boundary.
 /// The Postgres backend preserves that boundary by hashing each path to a
 /// stable schema name.
-pub async fn open_pool(path: &Path) -> anyhow::Result<PgPool> {
-    PgStoreContext::from_path(path, None)?.open_pool().await
+pub async fn open_legacy_path_schema_pool(path: &Path) -> anyhow::Result<PgPool> {
+    PgStoreContext::from_legacy_path_schema(path, None)?
+        .open_pool()
+        .await
 }
 
 /// Marker trait for entities that can be stored as JSON blobs.
@@ -50,15 +52,15 @@ pub trait DbEntity: Serialize + for<'de> Deserialize<'de> + Send + Unpin + 'stat
 ///
 /// Use this when entities do not need queryable columns beyond `id`.
 /// For entities requiring SQL-level filtering, keep a specialised store and
-/// call [`open_pool`] for pool creation.
+/// call [`open_legacy_path_schema_pool`] only for legacy path-derived schemas.
 pub struct Db<T: DbEntity> {
     pub(crate) pool: PgPool,
     _phantom: std::marker::PhantomData<T>,
 }
 
 impl<T: DbEntity> Db<T> {
-    pub async fn open(path: &Path) -> anyhow::Result<Self> {
-        let pool = open_pool(path).await?;
+    pub async fn open_legacy_path_schema(path: &Path) -> anyhow::Result<Self> {
+        let pool = open_legacy_path_schema_pool(path).await?;
         let db = Self {
             pool,
             _phantom: std::marker::PhantomData,

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -329,7 +329,15 @@ impl std::fmt::Debug for PgStoreContext {
 }
 
 impl PgStoreContext {
-    pub fn from_path(path: &Path, configured_database_url: Option<&str>) -> anyhow::Result<Self> {
+    /// Open the legacy schema derived from a store identity path.
+    ///
+    /// This preserves the historical `pg_schema_for_path` naming exactly for
+    /// migrations, backfills, compatibility paths, and tests that intentionally
+    /// read path-derived schemas.
+    pub fn from_legacy_path_schema(
+        path: &Path,
+        configured_database_url: Option<&str>,
+    ) -> anyhow::Result<Self> {
         let database_url = resolve_database_url(configured_database_url)?;
         let hash_path = schema_hash_path(path)?;
         let schema = pg_schema_for_path(&hash_path)?;

--- a/crates/harness-core/src/db_pg_tests.rs
+++ b/crates/harness-core/src/db_pg_tests.rs
@@ -160,8 +160,9 @@ fn pg_schema_for_path_normalizes_absolute_aliases() {
 }
 
 #[test]
-fn pg_store_context_from_path_uses_configured_url_and_path_schema() -> anyhow::Result<()> {
-    let context = PgStoreContext::from_path(
+fn pg_store_context_from_legacy_path_schema_uses_configured_url_and_path_schema(
+) -> anyhow::Result<()> {
+    let context = PgStoreContext::from_legacy_path_schema(
         Path::new("/tmp/harness/tasks.db"),
         Some(" postgres://user:pass@localhost:5432/harness "),
     )
@@ -263,9 +264,11 @@ fn pg_store_context_can_reuse_shared_setup_pool() {
             Ok(pool) => pool,
             Err(_) => return,
         };
-        let context =
-            PgStoreContext::from_path(Path::new("/tmp/harness/shared.db"), Some(&database_url))
-                .expect("context should resolve");
+        let context = PgStoreContext::from_legacy_path_schema(
+            Path::new("/tmp/harness/shared.db"),
+            Some(&database_url),
+        )
+        .expect("context should resolve");
         let pool = context
             .open_pool_with_setup_pool(&setup_pool)
             .await
@@ -294,7 +297,7 @@ async fn pg_store_context_registers_path_schema_with_shared_setup_pool() -> anyh
         std::process::id(),
         uuid::Uuid::new_v4()
     ));
-    let context = PgStoreContext::from_path(&store_path, Some(&database_url))?;
+    let context = PgStoreContext::from_legacy_path_schema(&store_path, Some(&database_url))?;
     let schema = context.schema().to_string();
     let expected_owner_path = context
         .ownership()

--- a/crates/harness-core/src/db_tests.rs
+++ b/crates/harness-core/src/db_tests.rs
@@ -104,7 +104,7 @@ static SIMPLE_MIGRATIONS: &[Migration] = &[
 ];
 
 db_test!(upsert_and_get_roundtrip, {
-    let db = Db::<Note>::open(&db_path("notes.db")?).await?;
+    let db = Db::<Note>::open_legacy_path_schema(&db_path("notes.db")?).await?;
 
     let note = Note::new("n1", "hello");
     db.upsert(&note).await?;
@@ -118,14 +118,14 @@ db_test!(upsert_and_get_roundtrip, {
 });
 
 db_test!(get_returns_none_for_missing, {
-    let db = Db::<Note>::open(&db_path("notes.db")?).await?;
+    let db = Db::<Note>::open_legacy_path_schema(&db_path("notes.db")?).await?;
 
     assert!(db.get("missing").await?.is_none());
     Ok(())
 });
 
 db_test!(upsert_overwrites_existing_and_list_does_not_duplicate, {
-    let db = Db::<Note>::open(&db_path("notes.db")?).await?;
+    let db = Db::<Note>::open_legacy_path_schema(&db_path("notes.db")?).await?;
 
     db.upsert(&Note::new("n1", "original")).await?;
     db.upsert(&Note::new("n1", "updated")).await?;
@@ -143,7 +143,7 @@ db_test!(upsert_overwrites_existing_and_list_does_not_duplicate, {
 });
 
 db_test!(list_returns_all_entities, {
-    let db = Db::<Note>::open(&db_path("notes.db")?).await?;
+    let db = Db::<Note>::open_legacy_path_schema(&db_path("notes.db")?).await?;
 
     db.upsert(&Note::new("n1", "a")).await?;
     db.upsert(&Note::new("n2", "b")).await?;
@@ -155,7 +155,7 @@ db_test!(list_returns_all_entities, {
 });
 
 db_test!(delete_roundtrip, {
-    let db = Db::<Note>::open(&db_path("notes.db")?).await?;
+    let db = Db::<Note>::open_legacy_path_schema(&db_path("notes.db")?).await?;
 
     db.upsert(&Note::new("n1", "bye")).await?;
     assert!(db.delete("n1").await?);
@@ -168,12 +168,12 @@ db_test!(survives_reopen_for_same_path, {
     let db_path = db_path("notes.db")?;
 
     {
-        let db = Db::<Note>::open(&db_path).await?;
+        let db = Db::<Note>::open_legacy_path_schema(&db_path).await?;
         db.upsert(&Note::new("n1", "persisted")).await?;
     }
 
     {
-        let db = Db::<Note>::open(&db_path).await?;
+        let db = Db::<Note>::open_legacy_path_schema(&db_path).await?;
         let loaded = db
             .get("n1")
             .await?
@@ -184,8 +184,8 @@ db_test!(survives_reopen_for_same_path, {
 });
 
 db_test!(different_paths_are_schema_isolated, {
-    let db_a = Db::<Note>::open(&db_path("notes-a.db")?).await?;
-    let db_b = Db::<Note>::open(&db_path("notes-b.db")?).await?;
+    let db_a = Db::<Note>::open_legacy_path_schema(&db_path("notes-a.db")?).await?;
+    let db_b = Db::<Note>::open_legacy_path_schema(&db_path("notes-b.db")?).await?;
 
     db_a.upsert(&Note::new("shared-id", "alpha")).await?;
     db_b.upsert(&Note::new("shared-id", "beta")).await?;
@@ -206,10 +206,10 @@ db_test!(different_paths_are_schema_isolated, {
     Ok(())
 });
 
-db_test!(db_open_uses_deterministic_schema_name, {
+db_test!(db_legacy_path_schema_open_uses_deterministic_schema_name, {
     let path = db_path("notes.db")?;
     let expected_schema = pg_schema_for_path(&path)?;
-    let db = Db::<Note>::open(&path).await?;
+    let db = Db::<Note>::open_legacy_path_schema(&path).await?;
 
     let (actual_schema,): (String,) = sqlx::query_as("SELECT current_schema()")
         .fetch_one(db.pool())
@@ -219,7 +219,7 @@ db_test!(db_open_uses_deterministic_schema_name, {
 });
 
 db_test!(migrator_applies_pending_migrations, {
-    let pool = open_pool(&db_path("mig.db")?).await?;
+    let pool = open_legacy_path_schema_pool(&db_path("mig.db")?).await?;
 
     Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
 
@@ -232,7 +232,7 @@ db_test!(migrator_applies_pending_migrations, {
 });
 
 db_test!(migrator_is_idempotent_on_rerun, {
-    let pool = open_pool(&db_path("mig.db")?).await?;
+    let pool = open_legacy_path_schema_pool(&db_path("mig.db")?).await?;
 
     Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
     Migrator::new(&pool, SIMPLE_MIGRATIONS).run().await?;
@@ -243,8 +243,8 @@ db_test!(migrator_is_idempotent_on_rerun, {
 
 db_test!(migrator_serializes_concurrent_runs_for_same_schema, {
     let path = db_path("mig-concurrent.db")?;
-    let pool_a = open_pool(&path).await?;
-    let pool_b = open_pool(&path).await?;
+    let pool_a = open_legacy_path_schema_pool(&path).await?;
+    let pool_b = open_legacy_path_schema_pool(&path).await?;
     let migrations = [
         Migration {
             version: 1,
@@ -279,7 +279,7 @@ db_test!(migrator_serializes_concurrent_runs_for_same_schema, {
 });
 
 db_test!(migrator_tolerates_duplicate_column_on_alter_table, {
-    let pool = open_pool(&db_path("mig.db")?).await?;
+    let pool = open_legacy_path_schema_pool(&db_path("mig.db")?).await?;
     sqlx::query("CREATE TABLE items (id TEXT PRIMARY KEY, value TEXT NOT NULL, tag TEXT)")
         .execute(&pool)
         .await?;
@@ -301,7 +301,7 @@ db_test!(migrator_tolerates_duplicate_column_on_alter_table, {
 });
 
 db_test!(failing_migration_is_not_recorded, {
-    let pool = open_pool(&db_path("mig.db")?).await?;
+    let pool = open_legacy_path_schema_pool(&db_path("mig.db")?).await?;
     let migrations = [Migration {
         version: 1,
         description: "bad migration",

--- a/crates/harness-core/src/store_backend.rs
+++ b/crates/harness-core/src/store_backend.rs
@@ -110,7 +110,9 @@ impl PostgresBackend {
         let url = self.configured_database_url.as_deref();
         match loc {
             StoreLocation::SharedSchema(schema) => PgStoreContext::from_schema(schema, url),
-            StoreLocation::PathDerivedSchema(path) => PgStoreContext::from_path(path, url),
+            StoreLocation::PathDerivedSchema(path) => {
+                PgStoreContext::from_legacy_path_schema(path, url)
+            }
             StoreLocation::LocalFile(path) => Err(anyhow::anyhow!(
                 "PostgresBackend cannot open a LocalFile location ({}); use LocalFileBackend",
                 path.display()

--- a/crates/harness-observe/src/event_store/legacy.rs
+++ b/crates/harness-observe/src/event_store/legacy.rs
@@ -7,7 +7,8 @@ pub async fn migrate_legacy_event_store_if_needed(
     configured_database_url: Option<&str>,
     target_store: &EventStore,
 ) -> anyhow::Result<u64> {
-    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_context =
+        PgStoreContext::from_legacy_path_schema(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
     if legacy_schema == target_store.schema() {
         return Ok(0);

--- a/crates/harness-observe/src/event_store/shared_schema_tests.rs
+++ b/crates/harness-observe/src/event_store/shared_schema_tests.rs
@@ -219,7 +219,8 @@ async fn shared_schema_backfills_legacy_path_schema_once() -> anyhow::Result<()>
     let legacy_data_dir = dir.path().join("legacy-data");
     std::fs::create_dir_all(&legacy_data_dir)?;
     let legacy_path = legacy_data_dir.join("events.db");
-    let legacy_context = PgStoreContext::from_path(&legacy_path, Some(&database_url))?;
+    let legacy_context =
+        PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?;
 
     let legacy_store =
         EventStore::new_with_context(&legacy_data_dir, &legacy_context, &setup_pool).await?;

--- a/crates/harness-server/src/eval_store.rs
+++ b/crates/harness-server/src/eval_store.rs
@@ -225,7 +225,7 @@ impl EvalStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let context = PgStoreContext::from_legacy_path_schema(path, configured_database_url)?;
         let schema = context.schema().to_owned();
         let store_key = schema.clone();
         let pool = context.open_migrated_pool(EVAL_MIGRATIONS).await?;
@@ -529,7 +529,8 @@ pub async fn migrate_legacy_eval_store_if_needed(
     configured_database_url: Option<&str>,
     target_store: &EvalStore,
 ) -> anyhow::Result<u64> {
-    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_context =
+        PgStoreContext::from_legacy_path_schema(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
     if legacy_schema == target_store.schema() {
         return Ok(0);

--- a/crates/harness-server/src/eval_store_tests.rs
+++ b/crates/harness-server/src/eval_store_tests.rs
@@ -159,7 +159,7 @@ async fn legacy_eval_store_migration_backfills_once() -> anyhow::Result<()> {
     std::fs::create_dir_all(&target_data_dir)?;
     std::fs::create_dir_all(&other_data_dir)?;
     let legacy_path = target_data_dir.join("evals.db");
-    let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
+    let legacy_schema = PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
         .schema()
         .to_owned();
     let target_schema = unique_test_schema("eval_store_migration_test");

--- a/crates/harness-server/src/http/builders/mod.rs
+++ b/crates/harness-server/src/http/builders/mod.rs
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn storage_path_schema_guard_rejects_path_derived_startup_context() -> anyhow::Result<()> {
-        let context = PgStoreContext::from_path(
+        let context = PgStoreContext::from_legacy_path_schema(
             Path::new("/tmp/harness/path-derived-startup.db"),
             Some(TEST_DATABASE_URL),
         )?;

--- a/crates/harness-server/src/project_registry.rs
+++ b/crates/harness-server/src/project_registry.rs
@@ -102,7 +102,7 @@ impl ProjectRegistry {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Arc<Self>> {
-        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let context = PgStoreContext::from_legacy_path_schema(path, configured_database_url)?;
         let schema = context.schema().to_owned();
         let store_key = schema.clone();
         let pool = context.open_migrated_pool(PROJECT_MIGRATIONS).await?;
@@ -284,7 +284,8 @@ pub async fn migrate_legacy_project_registry_if_needed(
     configured_database_url: Option<&str>,
     target_registry: &ProjectRegistry,
 ) -> anyhow::Result<u64> {
-    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_context =
+        PgStoreContext::from_legacy_path_schema(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
     if legacy_schema == target_registry.schema() {
         return Ok(0);

--- a/crates/harness-server/src/project_registry_tests.rs
+++ b/crates/harness-server/src/project_registry_tests.rs
@@ -147,7 +147,7 @@ async fn legacy_project_registry_migration_backfills_once() -> anyhow::Result<()
     let target_data_dir = dir.path().join("target-data");
     let other_data_dir = dir.path().join("other-data");
     let legacy_path = target_data_dir.join("projects.db");
-    let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
+    let legacy_schema = PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
         .schema()
         .to_owned();
     let target_schema = unique_test_schema("project_registry_migration_test");

--- a/crates/harness-server/src/q_value_store.rs
+++ b/crates/harness-server/src/q_value_store.rs
@@ -123,7 +123,7 @@ impl QValueStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let context = PgStoreContext::from_legacy_path_schema(path, configured_database_url)?;
         let schema = context.schema().to_owned();
         let store_key = schema.clone();
         let pool = context.open_migrated_pool(Q_VALUE_MIGRATIONS).await?;
@@ -345,7 +345,8 @@ pub async fn migrate_legacy_q_value_store_if_needed(
     configured_database_url: Option<&str>,
     target_store: &QValueStore,
 ) -> anyhow::Result<u64> {
-    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_context =
+        PgStoreContext::from_legacy_path_schema(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
     if legacy_schema == target_store.schema() {
         return Ok(0);

--- a/crates/harness-server/src/q_value_store_tests.rs
+++ b/crates/harness-server/src/q_value_store_tests.rs
@@ -130,7 +130,7 @@ async fn legacy_q_value_store_migration_backfills_once() -> anyhow::Result<()> {
     std::fs::create_dir_all(&target_data_dir)?;
     std::fs::create_dir_all(&other_data_dir)?;
     let legacy_path = target_data_dir.join("q_values.db");
-    let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
+    let legacy_schema = PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
         .schema()
         .to_owned();
     let target_schema = unique_test_schema("q_value_store_migration_test");

--- a/crates/harness-server/src/review_store/mod.rs
+++ b/crates/harness-server/src/review_store/mod.rs
@@ -110,7 +110,7 @@ impl ReviewStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let context = PgStoreContext::from_legacy_path_schema(path, configured_database_url)?;
         let pool = context.open_migrated_pool(REVIEW_MIGRATIONS).await?;
         Ok(Self { pool })
     }
@@ -559,7 +559,8 @@ pub async fn migrate_legacy_review_store_if_needed(
     configured_database_url: Option<&str>,
     target_store: &ReviewStore,
 ) -> anyhow::Result<u64> {
-    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_context =
+        PgStoreContext::from_legacy_path_schema(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
     if legacy_schema == REVIEW_STORE_SCHEMA {
         return Ok(0);

--- a/crates/harness-server/src/review_store/store_tests.rs
+++ b/crates/harness-server/src/review_store/store_tests.rs
@@ -44,7 +44,7 @@ async fn legacy_review_store_migration_backfills_shared_schema() -> anyhow::Resu
     };
     let dir = tempfile::tempdir()?;
     let legacy_path = dir.path().join("reviews.db");
-    let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
+    let legacy_schema = PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
         .schema()
         .to_owned();
     let target_schema = unique_test_schema("review_store_test");

--- a/crates/harness-server/src/runtime_state_store.rs
+++ b/crates/harness-server/src/runtime_state_store.rs
@@ -119,7 +119,7 @@ impl RuntimeStateStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let context = PgStoreContext::from_legacy_path_schema(path, configured_database_url)?;
         let schema = context.schema().to_owned();
         let store_key = schema.clone();
         let pool = context.open_migrated_pool(RUNTIME_STATE_MIGRATIONS).await?;
@@ -257,7 +257,8 @@ pub async fn migrate_legacy_runtime_state_store_if_needed(
     configured_database_url: Option<&str>,
     target_store: &RuntimeStateStore,
 ) -> anyhow::Result<u64> {
-    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_context =
+        PgStoreContext::from_legacy_path_schema(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
     if legacy_schema == target_store.schema() {
         return Ok(0);

--- a/crates/harness-server/src/runtime_state_store_tests.rs
+++ b/crates/harness-server/src/runtime_state_store_tests.rs
@@ -68,7 +68,7 @@ async fn legacy_runtime_state_migration_backfills_once() -> anyhow::Result<()> {
     let target_data_dir = dir.path().join("target-data");
     let other_data_dir = dir.path().join("other-data");
     let legacy_path = target_data_dir.join("runtime_state.db");
-    let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
+    let legacy_schema = PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
         .schema()
         .to_owned();
     let target_schema = unique_test_schema("runtime_state_store_test");

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -37,7 +37,7 @@ impl TaskDb {
         db_path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let context = PgStoreContext::from_path(db_path, configured_database_url)?;
+        let context = PgStoreContext::from_legacy_path_schema(db_path, configured_database_url)?;
         let schema = context.schema().to_owned();
         let store_key = schema.clone();
         let pool = context.open_migrated_pool(TASK_MIGRATIONS).await?;
@@ -133,7 +133,8 @@ pub async fn migrate_legacy_task_db_if_needed(
     configured_database_url: Option<&str>,
     target_db: &TaskDb,
 ) -> anyhow::Result<u64> {
-    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_context =
+        PgStoreContext::from_legacy_path_schema(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
     if legacy_schema == target_db.schema() {
         return Ok(0);

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -70,7 +70,7 @@ impl ThreadDb {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let context = PgStoreContext::from_legacy_path_schema(path, configured_database_url)?;
         let schema = context.schema().to_owned();
         let store_key = schema.clone();
         let pool = context.open_migrated_pool(THREAD_MIGRATIONS).await?;
@@ -214,7 +214,8 @@ pub async fn migrate_legacy_thread_db_if_needed(
     configured_database_url: Option<&str>,
     target_db: &ThreadDb,
 ) -> anyhow::Result<u64> {
-    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_context =
+        PgStoreContext::from_legacy_path_schema(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
     if legacy_schema == target_db.schema() {
         return Ok(0);
@@ -593,9 +594,10 @@ mod tests {
         let target_data_dir = dir.path().join("target-data");
         let other_data_dir = dir.path().join("other-data");
         let legacy_path = target_data_dir.join("threads.db");
-        let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
-            .schema()
-            .to_owned();
+        let legacy_schema =
+            PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
+                .schema()
+                .to_owned();
         let target_schema = unique_test_schema("thread_db_test");
         let setup_pool = pg_open_pool(&database_url).await?;
         let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;

--- a/crates/harness-server/src/workspace_lease_store.rs
+++ b/crates/harness-server/src/workspace_lease_store.rs
@@ -49,7 +49,7 @@ impl WorkspaceLeaseStore {
 
     #[cfg(test)]
     pub(crate) async fn open(path: &std::path::Path) -> anyhow::Result<Self> {
-        let context = PgStoreContext::from_path(path, None)?;
+        let context = PgStoreContext::from_legacy_path_schema(path, None)?;
         let store_key = context.schema().to_owned();
         let pool = context.open_pool().await?;
         ensure_workspace_leases_table(&pool).await?;

--- a/crates/harness-workflow/src/plan_db.rs
+++ b/crates/harness-workflow/src/plan_db.rs
@@ -78,7 +78,7 @@ impl PlanDb {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let context = PgStoreContext::from_legacy_path_schema(path, configured_database_url)?;
         let schema = context.schema().to_owned();
         let store_key = schema.clone();
         let pool = context.open_migrated_pool(PLAN_MIGRATIONS).await?;
@@ -320,7 +320,8 @@ pub async fn migrate_legacy_plan_db_if_needed(
     configured_database_url: Option<&str>,
     target_db: &PlanDb,
 ) -> anyhow::Result<u64> {
-    let legacy_context = PgStoreContext::from_path(legacy_path, configured_database_url)?;
+    let legacy_context =
+        PgStoreContext::from_legacy_path_schema(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
     if legacy_schema == target_db.schema() {
         return Ok(0);
@@ -646,9 +647,10 @@ mod tests {
         let target_data_dir = dir.path().join("target-data");
         let other_data_dir = dir.path().join("other-data");
         let legacy_path = target_data_dir.join("plans.db");
-        let legacy_schema = PgStoreContext::from_path(&legacy_path, Some(&database_url))?
-            .schema()
-            .to_owned();
+        let legacy_schema =
+            PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
+                .schema()
+                .to_owned();
         let target_schema = unique_test_schema("plan_db_backfill_test");
         let setup_pool = pg_open_pool(&database_url).await?;
         let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -188,7 +188,7 @@ impl WorkflowRuntimeStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
-        let context = PgStoreContext::from_path(path, configured_database_url)?;
+        let context = PgStoreContext::from_legacy_path_schema(path, configured_database_url)?;
         let pool = context
             .open_migrated_pool(WORKFLOW_RUNTIME_MIGRATIONS)
             .await?;


### PR DESCRIPTION
## Summary
- rename the core path-derived schema constructor to `PgStoreContext::from_legacy_path_schema`
- rename generic path-derived helpers to `open_legacy_path_schema_pool` and `Db::open_legacy_path_schema`
- update existing migration/backfill/compatibility/test call sites without changing legacy schema names

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

Closes #1363.
Part of #1206.
