### PR TITLE
Project task detail status through runtime projection

### DIFF
--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -124,23 +124,29 @@ async fn runtime_task_response_by_handle(
     }) else {
         return Ok(None);
     };
-    let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+    let RuntimeWorkflowProjection {
+        task_status,
+        failure_kind,
+        phase,
+        scheduler,
+        project_id,
+        submission_handle,
+        ..
+    } = RuntimeWorkflowProjection::from_workflow(&workflow);
     let external_id = runtime_external_id(task_kind, &workflow.data, issue);
-    let submission_id = projection
-        .submission_handle
-        .clone()
-        .unwrap_or_else(|| task_id.clone())
-        .0;
+    let submission_id = submission_handle
+        .map(|handle| handle.0)
+        .unwrap_or_else(|| task_id.0.clone());
     Ok(Some(RuntimeTaskResponse {
         id: submission_id.clone(),
         task_id: submission_id.clone(),
         submission_id,
         task_kind,
-        status: projection.task_status,
+        status: task_status,
         workflow_state: workflow.state.clone(),
-        failure_kind: projection.failure_kind,
-        phase: projection.phase,
-        scheduler: projection.scheduler,
+        failure_kind,
+        phase,
+        scheduler,
         turn: 0,
         execution_path: "workflow_runtime",
         workflow_id: workflow.id.clone(),
@@ -153,7 +159,7 @@ async fn runtime_task_response_by_handle(
             .get("repo")
             .and_then(|value| value.as_str())
             .map(ToOwned::to_owned),
-        project: projection.project_id,
+        project: project_id,
         issue,
         error: runtime_string_field(&workflow.data, "failure_reason"),
         depends_on: runtime_task_id_array(&workflow.data, "depends_on"),

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -16,7 +16,12 @@ struct RuntimeTaskResponse {
     task_id: String,
     submission_id: String,
     task_kind: TaskKind,
-    status: String,
+    status: TaskStatus,
+    workflow_state: String,
+    failure_kind: Option<crate::task_runner::TaskFailureKind>,
+    phase: crate::task_runner::TaskPhase,
+    scheduler: crate::task_runner::TaskSchedulerState,
+    turn: u32,
     execution_path: &'static str,
     workflow_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -35,6 +40,10 @@ struct RuntimeTaskResponse {
     issue: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    depends_on: Vec<TaskId>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    subtask_ids: Vec<TaskId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     workflow: Option<TaskWorkflowSummary>,
 }
@@ -115,8 +124,11 @@ async fn runtime_task_response_by_handle(
     }) else {
         return Ok(None);
     };
+    let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
     let external_id = runtime_external_id(task_kind, &workflow.data, issue);
-    let submission_id = crate::workflow_runtime_submission::runtime_issue_task_handle(&workflow)
+    let submission_id = projection
+        .submission_handle
+        .clone()
         .unwrap_or_else(|| task_id.clone())
         .0;
     Ok(Some(RuntimeTaskResponse {
@@ -124,7 +136,12 @@ async fn runtime_task_response_by_handle(
         task_id: submission_id.clone(),
         submission_id,
         task_kind,
-        status: workflow.state.clone(),
+        status: projection.task_status,
+        workflow_state: workflow.state.clone(),
+        failure_kind: projection.failure_kind,
+        phase: projection.phase,
+        scheduler: projection.scheduler,
+        turn: 0,
         execution_path: "workflow_runtime",
         workflow_id: workflow.id.clone(),
         source: runtime_string_field(&workflow.data, "source"),
@@ -136,13 +153,11 @@ async fn runtime_task_response_by_handle(
             .get("repo")
             .and_then(|value| value.as_str())
             .map(ToOwned::to_owned),
-        project: workflow
-            .data
-            .get("project_id")
-            .and_then(|value| value.as_str())
-            .map(ToOwned::to_owned),
+        project: projection.project_id,
         issue,
         error: runtime_string_field(&workflow.data, "failure_reason"),
+        depends_on: runtime_task_id_array(&workflow.data, "depends_on"),
+        subtask_ids: Vec::new(),
         workflow: Some(TaskWorkflowSummary::from_runtime(&workflow)),
     }))
 }

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -198,6 +198,111 @@ async fn get_task_runtime_issue_exposes_tracker_identity() -> anyhow::Result<()>
 }
 
 #[tokio::test]
+async fn get_task_runtime_issue_projects_detail_status_from_shared_projection() -> anyhow::Result<()>
+{
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let cases = [
+        (
+            "detail-active-workflow",
+            "detail-active-task",
+            "implementing",
+            "implementing",
+            "implement",
+            "running",
+            None,
+        ),
+        (
+            "detail-review-wait-workflow",
+            "detail-review-wait-task",
+            "awaiting_feedback",
+            "waiting",
+            "review",
+            "queued",
+            None,
+        ),
+        (
+            "detail-terminal-workflow",
+            "detail-terminal-task",
+            "failed",
+            "failed",
+            "terminal",
+            "failed",
+            Some("task"),
+        ),
+    ];
+
+    for &(workflow_id, task_id, workflow_state, _, _, _, _) in &cases {
+        let workflow = harness_workflow::runtime::WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            workflow_state,
+            harness_workflow::runtime::WorkflowSubject::new("issue", workflow_id),
+        )
+        .with_id(workflow_id)
+        .with_data(serde_json::json!({
+            "project_id": project_root.to_string_lossy(),
+            "repo": "owner/repo",
+            "issue_number": 70,
+            "submission_id": task_id,
+            "task_id": format!("{task_id}-legacy"),
+        }));
+        store.upsert_instance(&workflow).await?;
+    }
+
+    let app = Router::new()
+        .route("/tasks/{id}", get(get_task))
+        .with_state(state);
+
+    for &(_, task_id, workflow_state, status, phase, scheduler_state, failure_kind) in &cases {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/tasks/{task_id}"))
+                    .body(Body::empty())?,
+            )
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await?;
+        assert_eq!(body["id"], task_id);
+        assert_eq!(body["task_id"], task_id);
+        assert_eq!(body["submission_id"], task_id);
+        assert_eq!(body["workflow_state"], workflow_state);
+        assert_eq!(body["workflow"]["state"], workflow_state);
+        assert_eq!(body["status"], status);
+        assert_eq!(body["phase"], phase);
+        assert_eq!(body["scheduler"]["authority_state"], scheduler_state);
+        match failure_kind {
+            Some(kind) => assert_eq!(body["failure_kind"], *kind),
+            None => assert!(body
+                .get("failure_kind")
+                .is_none_or(serde_json::Value::is_null)),
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn merge_task_accepts_runtime_workflow_task_handle() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -8,6 +8,8 @@ export interface Task {
   submission_id?: string | null;
   task_kind: string;
   status: string;
+  workflow_state?: string | null;
+  failure_kind?: string | null;
   execution_path?: string | null;
   workflow_id?: string | null;
   turn: number;


### PR DESCRIPTION
## Summary
- route runtime-only `GET /tasks/{id}` status, phase, scheduler, failure kind, project, and handles through `RuntimeWorkflowProjection`
- preserve raw workflow lifecycle as `workflow_state` instead of overloading task `status`
- update the dashboard task type contract for runtime detail projection fields

## Tests
- `cargo test -p harness-server get_task_runtime_issue_projects_detail_status_from_shared_projection -- --nocapture`
- `cargo test -p harness-server runtime_task_route_tests -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `bun run typecheck`
- `cargo test --workspace`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `bun run build`

Closes #1367.
Part of #1238.
