### PR TITLE
Project task submission status through runtime projection

### DIFF
--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -526,7 +526,14 @@ pub(crate) async fn github_webhook(
     let is_issue_submission = req.issue.is_some();
     match task_routes::enqueue_task(&state, req).await {
         Ok(task_id) => {
-            match task_routes::task_response_details(&state, &task_id, is_issue_submission).await {
+            match task_routes::task_response_details(
+                &state,
+                &task_id,
+                is_issue_submission,
+                task_routes::TaskResponseStatusMode::WorkflowState,
+            )
+            .await
+            {
                 Ok(details) => (
                     StatusCode::ACCEPTED,
                     Json(json!({

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -57,6 +57,7 @@ pub(crate) struct TaskResponseDetails {
     pub(crate) workflow_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TaskResponseStatusMode {
     RuntimeProjection,
     WorkflowState,

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -1,5 +1,6 @@
 use super::AppState;
 use crate::{
+    runtime_projection::RuntimeWorkflowProjection,
     services::execution::{EnqueueBackgroundOptions, EnqueueTaskError},
     task_runner,
     workflow_runtime_submission::{RuntimeSubmissionCancelError, RuntimeSubmissionCancelOutcome},
@@ -50,15 +51,22 @@ pub(crate) async fn enqueue_task_background_in_domain(
 
 pub(crate) struct TaskResponseDetails {
     pub(crate) status: String,
+    pub(crate) workflow_state: Option<String>,
     pub(crate) execution_path: &'static str,
     pub(crate) submission_id: Option<String>,
     pub(crate) workflow_id: Option<String>,
+}
+
+pub(crate) enum TaskResponseStatusMode {
+    RuntimeProjection,
+    WorkflowState,
 }
 
 pub(crate) async fn task_response_details(
     state: &AppState,
     task_id: &task_runner::TaskId,
     is_issue_submission: bool,
+    status_mode: TaskResponseStatusMode,
 ) -> Result<TaskResponseDetails, EnqueueTaskError> {
     if let Some(store) = state.core.workflow_runtime_store.as_ref() {
         if let Some(workflow) = store
@@ -70,8 +78,19 @@ pub(crate) async fn task_response_details(
                 crate::workflow_runtime_submission::runtime_issue_task_handle(&workflow)
                     .map(|task_id| task_id.0)
                     .unwrap_or_else(|| task_id.as_str().to_string());
+            let (status, workflow_state) = match status_mode {
+                TaskResponseStatusMode::RuntimeProjection => {
+                    let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+                    (
+                        projection.task_status.as_ref().to_string(),
+                        Some(workflow.state),
+                    )
+                }
+                TaskResponseStatusMode::WorkflowState => (workflow.state, None),
+            };
             return Ok(TaskResponseDetails {
-                status: workflow.state,
+                status,
+                workflow_state,
                 execution_path: "workflow_runtime",
                 submission_id: Some(submission_id),
                 workflow_id: Some(workflow.id),
@@ -82,6 +101,7 @@ pub(crate) async fn task_response_details(
     if !is_issue_submission {
         return Ok(TaskResponseDetails {
             status: "queued".to_string(),
+            workflow_state: None,
             execution_path: "task_runner",
             submission_id: None,
             workflow_id: None,
@@ -98,6 +118,7 @@ pub(crate) async fn task_response_details(
     {
         return Ok(TaskResponseDetails {
             status: "queued".to_string(),
+            workflow_state: None,
             execution_path: "task_runner",
             submission_id: None,
             workflow_id: None,
@@ -154,6 +175,9 @@ fn task_submission_response(
         "status": details.status,
         "execution_path": details.execution_path,
     });
+    if let Some(workflow_state) = details.workflow_state {
+        response["workflow_state"] = json!(workflow_state);
+    }
     if let Some(submission_id) = submission_id {
         response["submission_id"] = json!(submission_id);
     }
@@ -334,7 +358,14 @@ pub(super) async fn create_tasks_batch(
                     conflict_group_tail[group_idx] = Some(task_id.clone());
                 }
                 all_maintenance_window = false;
-                match task_response_details(&state, &task_id, is_issue_submission).await {
+                match task_response_details(
+                    &state,
+                    &task_id,
+                    is_issue_submission,
+                    TaskResponseStatusMode::RuntimeProjection,
+                )
+                .await
+                {
                     Ok(details) => {
                         let mut response = task_submission_response(&task_id, details);
                         if is_serialized {
@@ -386,7 +417,14 @@ pub(super) async fn create_task(
 ) -> Response {
     let is_issue_submission = req.issue.is_some();
     match enqueue_task_background(state.clone(), req, None).await {
-        Ok(task_id) => match task_response_details(&state, &task_id, is_issue_submission).await {
+        Ok(task_id) => match task_response_details(
+            &state,
+            &task_id,
+            is_issue_submission,
+            TaskResponseStatusMode::RuntimeProjection,
+        )
+        .await
+        {
             Ok(details) => (
                 StatusCode::ACCEPTED,
                 Json(task_submission_response(&task_id, details)),

--- a/crates/harness-server/src/http/task_routes_tests.rs
+++ b/crates/harness-server/src/http/task_routes_tests.rs
@@ -74,6 +74,7 @@ fn runtime_task_submission_response_uses_submission_id_as_handle() {
         &task_runner::TaskId::from_str("legacy-task-id"),
         TaskResponseDetails {
             status: "implementing".to_string(),
+            workflow_state: Some("implementing".to_string()),
             execution_path: "workflow_runtime",
             submission_id: Some("runtime-submission-id".to_string()),
             workflow_id: Some("runtime-workflow-id".to_string()),
@@ -84,6 +85,7 @@ fn runtime_task_submission_response_uses_submission_id_as_handle() {
     assert_eq!(response["submission_id"], "runtime-submission-id");
     assert_eq!(response["workflow_id"], "runtime-workflow-id");
     assert_eq!(response["execution_path"], "workflow_runtime");
+    assert_eq!(response["workflow_state"], "implementing");
 }
 
 #[test]
@@ -92,6 +94,7 @@ fn legacy_task_submission_response_keeps_task_id_handle() {
         &task_runner::TaskId::from_str("legacy-task-id"),
         TaskResponseDetails {
             status: "queued".to_string(),
+            workflow_state: None,
             execution_path: "task_runner",
             submission_id: None,
             workflow_id: None,
@@ -100,6 +103,7 @@ fn legacy_task_submission_response_keeps_task_id_handle() {
 
     assert_eq!(response["task_id"], "legacy-task-id");
     assert!(response.get("submission_id").is_none());
+    assert!(response.get("workflow_state").is_none());
     assert_eq!(response["execution_path"], "task_runner");
 }
 

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -1001,7 +1001,8 @@ async fn create_task_with_blocked_issue_returns_runtime_state() -> anyhow::Resul
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let resp = response_json(response).await?;
     assert!(resp["task_id"].is_string());
-    assert_eq!(resp["status"], "awaiting_dependencies");
+    assert_eq!(resp["status"], "awaiting_deps");
+    assert_eq!(resp["workflow_state"], "awaiting_dependencies");
     assert_eq!(resp["execution_path"], "workflow_runtime");
 
     let store = state

--- a/crates/harness-server/src/http/tests/webhook_task_tests.rs
+++ b/crates/harness-server/src/http/tests/webhook_task_tests.rs
@@ -608,6 +608,7 @@ async fn create_task_with_issue_returns_workflow_runtime_submission() -> anyhow:
     let resp = response_json(response).await?;
     assert!(resp["task_id"].is_string());
     assert_eq!(resp["status"], "planning");
+    assert_eq!(resp["workflow_state"], "planning");
     assert_eq!(resp["execution_path"], "workflow_runtime");
     let task_id = task_runner::TaskId::from_str(resp["task_id"].as_str().unwrap());
     assert!(state


### PR DESCRIPTION
## Summary
- route runtime-backed `POST /tasks` and batch task submission responses through `RuntimeWorkflowProjection` for their public `status`
- include the raw runtime lifecycle state as `workflow_state` on task submission responses
- keep GitHub webhook PR feedback responses on the existing workflow-state status contract

Closes #1369.
Part of #1238.

## Validation
- `cargo fmt --all`
- `git diff --check`
- `cargo check --workspace --all-targets`
- `cargo test -p harness-server webhook_pull_request_review_changes_requested_requests_local_review_gate -- --nocapture`
- `cargo test -p harness-server webhook_review_on_pr_requests_runtime_pr_feedback -- --nocapture`
- `cargo test -p harness-server create_task_with_blocked_issue_returns_runtime_state -- --nocapture`
- `cargo test -p harness-server create_task_with_issue_returns_workflow_runtime_submission -- --nocapture`
- `cargo test --workspace`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
