### PR TITLE
runtime: project webhook status through projection

### DIFF
--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -526,17 +526,9 @@ pub(crate) async fn github_webhook(
     let is_issue_submission = req.issue.is_some();
     match task_routes::enqueue_task(&state, req).await {
         Ok(task_id) => {
-            match task_routes::task_response_details(
-                &state,
-                &task_id,
-                is_issue_submission,
-                task_routes::TaskResponseStatusMode::WorkflowState,
-            )
-            .await
-            {
-                Ok(details) => (
-                    StatusCode::ACCEPTED,
-                    Json(json!({
+            match task_routes::task_response_details(&state, &task_id, is_issue_submission).await {
+                Ok(details) => {
+                    let mut response = json!({
                         "status": if details.execution_path == "workflow_runtime" {
                             details.status
                         } else {
@@ -545,8 +537,12 @@ pub(crate) async fn github_webhook(
                         "reason": reason,
                         "task_id": task_id.0,
                         "execution_path": details.execution_path,
-                    })),
-                ),
+                    });
+                    if let Some(workflow_state) = details.workflow_state {
+                        response["workflow_state"] = json!(workflow_state);
+                    }
+                    (StatusCode::ACCEPTED, Json(response))
+                }
                 Err(crate::services::execution::EnqueueTaskError::BadRequest(error)) => {
                     (StatusCode::BAD_REQUEST, Json(json!({ "error": error })))
                 }

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -57,17 +57,10 @@ pub(crate) struct TaskResponseDetails {
     pub(crate) workflow_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TaskResponseStatusMode {
-    RuntimeProjection,
-    WorkflowState,
-}
-
 pub(crate) async fn task_response_details(
     state: &AppState,
     task_id: &task_runner::TaskId,
     is_issue_submission: bool,
-    status_mode: TaskResponseStatusMode,
 ) -> Result<TaskResponseDetails, EnqueueTaskError> {
     if let Some(store) = state.core.workflow_runtime_store.as_ref() {
         if let Some(workflow) = store
@@ -79,19 +72,10 @@ pub(crate) async fn task_response_details(
                 crate::workflow_runtime_submission::runtime_issue_task_handle(&workflow)
                     .map(|task_id| task_id.0)
                     .unwrap_or_else(|| task_id.as_str().to_string());
-            let (status, workflow_state) = match status_mode {
-                TaskResponseStatusMode::RuntimeProjection => {
-                    let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
-                    (
-                        projection.task_status.as_ref().to_string(),
-                        Some(workflow.state),
-                    )
-                }
-                TaskResponseStatusMode::WorkflowState => (workflow.state, None),
-            };
+            let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
             return Ok(TaskResponseDetails {
-                status,
-                workflow_state,
+                status: projection.task_status.as_ref().to_string(),
+                workflow_state: Some(workflow.state),
                 execution_path: "workflow_runtime",
                 submission_id: Some(submission_id),
                 workflow_id: Some(workflow.id),
@@ -359,14 +343,7 @@ pub(super) async fn create_tasks_batch(
                     conflict_group_tail[group_idx] = Some(task_id.clone());
                 }
                 all_maintenance_window = false;
-                match task_response_details(
-                    &state,
-                    &task_id,
-                    is_issue_submission,
-                    TaskResponseStatusMode::RuntimeProjection,
-                )
-                .await
-                {
+                match task_response_details(&state, &task_id, is_issue_submission).await {
                     Ok(details) => {
                         let mut response = task_submission_response(&task_id, details);
                         if is_serialized {
@@ -418,14 +395,7 @@ pub(super) async fn create_task(
 ) -> Response {
     let is_issue_submission = req.issue.is_some();
     match enqueue_task_background(state.clone(), req, None).await {
-        Ok(task_id) => match task_response_details(
-            &state,
-            &task_id,
-            is_issue_submission,
-            TaskResponseStatusMode::RuntimeProjection,
-        )
-        .await
-        {
+        Ok(task_id) => match task_response_details(&state, &task_id, is_issue_submission).await {
             Ok(details) => (
                 StatusCode::ACCEPTED,
                 Json(task_submission_response(&task_id, details)),

--- a/crates/harness-server/src/http/tests/webhook_runtime_tests.rs
+++ b/crates/harness-server/src/http/tests/webhook_runtime_tests.rs
@@ -453,7 +453,8 @@ async fn webhook_pull_request_review_changes_requested_requests_local_review_gat
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let json = response_json(response).await?;
-    assert_eq!(json["status"], "local_review_gate");
+    assert_eq!(json["status"], "waiting");
+    assert_eq!(json["workflow_state"], "local_review_gate");
     assert_eq!(json["execution_path"], "workflow_runtime");
     let runtime_task_id = json["task_id"].as_str().expect("task id should be present");
     assert_eq!(state.core.tasks.count(), before_count);

--- a/crates/harness-server/src/http/tests/webhook_task_tests.rs
+++ b/crates/harness-server/src/http/tests/webhook_task_tests.rs
@@ -45,6 +45,7 @@ async fn webhook_issue_mention_schedules_runtime_issue() -> anyhow::Result<()> {
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let json = response_json(response).await?;
     assert_eq!(json["status"], "planning");
+    assert_eq!(json["workflow_state"], "planning");
     assert_eq!(json["execution_path"], "workflow_runtime");
     assert_eq!(state.core.tasks.count(), before_count);
     let task_id = json["task_id"]
@@ -140,7 +141,8 @@ async fn webhook_review_on_pr_requests_runtime_pr_feedback() -> anyhow::Result<(
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let json = response_json(response).await?;
-    assert_eq!(json["status"], "local_review_gate");
+    assert_eq!(json["status"], "waiting");
+    assert_eq!(json["workflow_state"], "local_review_gate");
     assert_eq!(json["execution_path"], "workflow_runtime");
     assert_eq!(json["task_id"], runtime_task_id);
     assert_eq!(state.core.tasks.count(), before_count);
@@ -204,6 +206,7 @@ async fn webhook_fix_ci_on_pr_creates_runtime_prompt_submission() -> anyhow::Res
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     let json = response_json(response).await?;
     assert_eq!(json["status"], "implementing");
+    assert_eq!(json["workflow_state"], "implementing");
     assert_eq!(json["execution_path"], "workflow_runtime");
     let runtime_task_id = json["task_id"].as_str().expect("task id should be present");
     assert_eq!(state.core.tasks.count(), before_count);


### PR DESCRIPTION
## Summary

- route GitHub webhook accepted responses through the shared runtime projection
- include raw workflow_state on runtime-owned webhook responses
- update issue mention, PR feedback, fix-CI, and pull_request_review webhook tests

Closes #1377.

Parent: #1238 remains open.

## Validation

- cargo fmt --all -- --check
- git diff --check
- CARGO_TERM_COLOR=never cargo test -p harness-server webhook_ -- --nocapture
- CARGO_TERM_COLOR=never cargo check -p harness-server --all-targets --quiet
- CARGO_TERM_COLOR=never RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets --quiet
- CARGO_TERM_COLOR=never cargo test -p harness-server --quiet
- CARGO_TERM_COLOR=never cargo test --workspace --quiet

Note: the first workspace test run hit a transient timeout in harness-agents codex::tests::execute_kills_descendant_that_keeps_output_pipe_open_after_root_exit; rerunning that exact test passed, and the subsequent full workspace test passed.