### PR TITLE
fix(runtime): centralize terminal state projection

### DIFF
--- a/crates/harness-server/src/runtime_projection.rs
+++ b/crates/harness-server/src/runtime_projection.rs
@@ -1,7 +1,7 @@
 use crate::task_runner::{
     SchedulerAuthorityState, TaskFailureKind, TaskId, TaskPhase, TaskSchedulerState, TaskStatus,
 };
-use harness_workflow::runtime::WorkflowInstance;
+use harness_workflow::runtime::{WorkflowInstance, WorkflowTerminalState};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RuntimeActiveBucket {
@@ -22,11 +22,12 @@ pub(crate) struct RuntimeWorkflowProjection {
 
 impl RuntimeWorkflowProjection {
     pub(crate) fn from_workflow(workflow: &WorkflowInstance) -> Self {
-        let task_status = workflow_state_to_task_status(&workflow.state);
-        let scheduler = workflow_scheduler_state(&workflow.state, &task_status);
+        let terminal_state = workflow.terminal_state();
+        let task_status = workflow_state_to_task_status(workflow, terminal_state);
+        let scheduler = workflow_scheduler_state(&workflow.state, &task_status, terminal_state);
         Self {
             failure_kind: task_status.is_failure().then_some(TaskFailureKind::Task),
-            phase: workflow_state_to_task_phase(&workflow.state),
+            phase: workflow_state_to_task_phase(&workflow.state, terminal_state),
             task_status,
             scheduler,
             project_id: runtime_string_field(&workflow.data, "project_id"),
@@ -54,8 +55,17 @@ pub(crate) fn runtime_string_field(data: &serde_json::Value, field: &str) -> Opt
         .map(ToOwned::to_owned)
 }
 
-pub(crate) fn workflow_state_to_task_status(state: &str) -> TaskStatus {
-    match state {
+pub(crate) fn workflow_state_to_task_status(
+    workflow: &WorkflowInstance,
+    terminal_state: Option<WorkflowTerminalState>,
+) -> TaskStatus {
+    match terminal_state {
+        Some(WorkflowTerminalState::Succeeded) => return TaskStatus::Done,
+        Some(WorkflowTerminalState::Failed) => return TaskStatus::Failed,
+        Some(WorkflowTerminalState::Cancelled) => return TaskStatus::Cancelled,
+        None => {}
+    }
+    match workflow.state.as_str() {
         "awaiting_dependencies" => TaskStatus::AwaitingDeps,
         "scheduled" | "discovered" => TaskStatus::Pending,
         "planning" => TaskStatus::Planning,
@@ -66,16 +76,18 @@ pub(crate) fn workflow_state_to_task_status(state: &str) -> TaskStatus {
         | "quality_gate_pending"
         | "ready_to_merge"
         | "blocked" => TaskStatus::Waiting,
-        "done" | "passed" => TaskStatus::Done,
-        "failed" => TaskStatus::Failed,
-        "cancelled" => TaskStatus::Cancelled,
         _ => TaskStatus::Waiting,
     }
 }
 
-fn workflow_state_to_task_phase(state: &str) -> TaskPhase {
+fn workflow_state_to_task_phase(
+    state: &str,
+    terminal_state: Option<WorkflowTerminalState>,
+) -> TaskPhase {
+    if terminal_state.is_some() {
+        return TaskPhase::Terminal;
+    }
     match state {
-        "done" | "passed" | "failed" | "cancelled" => TaskPhase::Terminal,
         "pr_open"
         | "local_review_gate"
         | "awaiting_feedback"
@@ -86,7 +98,16 @@ fn workflow_state_to_task_phase(state: &str) -> TaskPhase {
     }
 }
 
-fn workflow_scheduler_state(state: &str, status: &TaskStatus) -> TaskSchedulerState {
+fn workflow_scheduler_state(
+    state: &str,
+    status: &TaskStatus,
+    terminal_state: Option<WorkflowTerminalState>,
+) -> TaskSchedulerState {
+    if terminal_state.is_some() {
+        let mut scheduler = TaskSchedulerState::queued();
+        scheduler.mark_terminal(status);
+        return scheduler;
+    }
     match state {
         "awaiting_dependencies" => TaskSchedulerState::awaiting_dependencies(),
         "scheduled" | "discovered" => TaskSchedulerState::queued(),
@@ -97,11 +118,6 @@ fn workflow_scheduler_state(state: &str, status: &TaskStatus) -> TaskSchedulerSt
             recovery_generation: 0,
             lease_expires_at: None,
         },
-        "done" | "passed" | "failed" | "cancelled" => {
-            let mut scheduler = TaskSchedulerState::queued();
-            scheduler.mark_terminal(status);
-            scheduler
-        }
         "pr_open"
         | "local_review_gate"
         | "awaiting_feedback"
@@ -162,11 +178,25 @@ fn trimmed_string(value: &serde_json::Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harness_workflow::runtime::{WorkflowInstance, WorkflowSubject};
+    use harness_workflow::runtime::{
+        WorkflowInstance, WorkflowSubject, QUALITY_GATE_DEFINITION_ID,
+    };
 
     fn workflow(state: &str, data: serde_json::Value) -> WorkflowInstance {
-        WorkflowInstance::new(
+        workflow_with_definition(
             harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            state,
+            data,
+        )
+    }
+
+    fn workflow_with_definition(
+        definition_id: &str,
+        state: &str,
+        data: serde_json::Value,
+    ) -> WorkflowInstance {
+        WorkflowInstance::new(
+            definition_id,
             1,
             state,
             WorkflowSubject::new("issue", "issue:1"),
@@ -269,6 +299,39 @@ mod tests {
         assert_eq!(
             projection.scheduler.authority_state,
             SchedulerAuthorityState::Failed
+        );
+        assert_eq!(projection.phase, TaskPhase::Terminal);
+        assert_eq!(projection.active_bucket(), None);
+    }
+
+    #[test]
+    fn projection_uses_definition_specific_terminal_passed_state() {
+        let workflow =
+            workflow_with_definition(QUALITY_GATE_DEFINITION_ID, "passed", serde_json::json!({}));
+
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+        assert!(workflow.is_terminal());
+        assert_eq!(projection.task_status, TaskStatus::Done);
+        assert_eq!(
+            projection.scheduler.authority_state,
+            SchedulerAuthorityState::Done
+        );
+        assert_eq!(projection.phase, TaskPhase::Terminal);
+        assert_eq!(projection.active_bucket(), None);
+    }
+
+    #[test]
+    fn projection_preserves_passed_as_shared_success_terminal_state() {
+        let workflow = workflow("passed", serde_json::json!({}));
+
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+        assert!(workflow.is_terminal());
+        assert_eq!(projection.task_status, TaskStatus::Done);
+        assert_eq!(
+            projection.scheduler.authority_state,
+            SchedulerAuthorityState::Done
         );
         assert_eq!(projection.phase, TaskPhase::Terminal);
         assert_eq!(projection.active_bucket(), None);

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -21,6 +21,7 @@ pub mod store;
 mod store_migrations;
 mod store_summary;
 pub mod submission;
+pub mod terminal_state;
 pub mod validator;
 pub mod worker;
 
@@ -88,6 +89,7 @@ pub use submission::{
     build_issue_submission_decision, IssueSubmissionDecisionInput, IssueSubmissionDecisionOutput,
     IssueSubmissionWorkflowAction,
 };
+pub use terminal_state::{workflow_terminal_state, WorkflowTerminalState};
 pub use validator::{
     DecisionValidator, TransitionAllowlist, TransitionRule, ValidationContext,
     WorkflowDecisionRejection, WorkflowDecisionRejectionKind,

--- a/crates/harness-workflow/src/runtime/model.rs
+++ b/crates/harness-workflow/src/runtime/model.rs
@@ -1,4 +1,5 @@
 use super::status::WorkflowCommandStatus;
+use super::terminal_state::{workflow_terminal_state, WorkflowTerminalState};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -113,10 +114,11 @@ impl WorkflowInstance {
     }
 
     pub fn is_terminal(&self) -> bool {
-        matches!(
-            self.state.as_str(),
-            "done" | "passed" | "failed" | "cancelled"
-        )
+        self.terminal_state().is_some()
+    }
+
+    pub fn terminal_state(&self) -> Option<WorkflowTerminalState> {
+        workflow_terminal_state(&self.definition_id, &self.state)
     }
 
     pub fn with_id(mut self, id: impl Into<String>) -> Self {

--- a/crates/harness-workflow/src/runtime/terminal_state.rs
+++ b/crates/harness-workflow/src/runtime/terminal_state.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowTerminalState {
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+pub fn workflow_terminal_state(definition_id: &str, state: &str) -> Option<WorkflowTerminalState> {
+    match (definition_id, state) {
+        (_, "done" | "passed") => Some(WorkflowTerminalState::Succeeded),
+        (_, "failed") => Some(WorkflowTerminalState::Failed),
+        (_, "cancelled") => Some(WorkflowTerminalState::Cancelled),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_state_treats_done_failed_and_cancelled_as_shared_terminal_states() {
+        assert_eq!(
+            workflow_terminal_state("github_issue_pr", "done"),
+            Some(WorkflowTerminalState::Succeeded)
+        );
+        assert_eq!(
+            workflow_terminal_state("prompt_task", "failed"),
+            Some(WorkflowTerminalState::Failed)
+        );
+        assert_eq!(
+            workflow_terminal_state("repo_backlog", "cancelled"),
+            Some(WorkflowTerminalState::Cancelled)
+        );
+    }
+
+    #[test]
+    fn terminal_state_preserves_passed_as_shared_success_terminal_state() {
+        assert_eq!(
+            workflow_terminal_state("quality_gate", "passed"),
+            Some(WorkflowTerminalState::Succeeded)
+        );
+        assert_eq!(
+            workflow_terminal_state("github_issue_pr", "passed"),
+            Some(WorkflowTerminalState::Succeeded)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared workflow terminal-state helper and enum
- make `WorkflowInstance::is_terminal()` delegate to the shared helper
- route runtime projection status, phase, and scheduler terminal handling through the same helper
- preserve the existing `passed` success terminal behavior while removing duplicate terminal string matches

Fixes #1381

## Verification
- cargo fmt --all -- --check
- git diff --check
- CARGO_TERM_COLOR=never cargo test -p harness-workflow terminal_state -- --nocapture
- CARGO_TERM_COLOR=never cargo test -p harness-server projection_ -- --nocapture
- CARGO_TERM_COLOR=never cargo test -p harness-server runtime_submission_completion_task_maps_passed_via_projection -- --nocapture
- CARGO_TERM_COLOR=never cargo check -p harness-workflow --all-targets --quiet
- CARGO_TERM_COLOR=never cargo check -p harness-server --all-targets --quiet
- CARGO_TERM_COLOR=never RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets --quiet
- CARGO_TERM_COLOR=never cargo test --workspace --quiet