### PR TITLE
fix(runtime): project operator monitor buckets

### DIFF
--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -5,9 +5,12 @@
 //! questions across workflow runtime state, legacy task rows, failures, and
 //! worktrees.
 
+mod activity;
+
 use crate::http::AppState;
-use crate::runtime_projection::{RuntimeActiveBucket, RuntimeWorkflowProjection};
+use crate::runtime_projection::RuntimeWorkflowProjection;
 use crate::task_runner::{RecentFailureTask, SchedulerAuthorityState, TaskSummary};
+use activity::{runtime_workflow_counts, source_activity, RuntimeWorkflowCounts, SourceActivity};
 use axum::{extract::State, http::StatusCode, Json};
 use chrono::{DateTime, Utc};
 use harness_workflow::runtime::{WorkflowInstance, WorkflowRuntimeStore};
@@ -63,36 +66,12 @@ struct OperatorActivity {
 }
 
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
-struct RuntimeWorkflowCounts {
-    pending: u64,
-    running: u64,
-    review: u64,
-    awaiting_dependencies: u64,
-    ready_to_merge: u64,
-    blocked: u64,
-    failed: u64,
-    done: u64,
-    other: u64,
-}
-
-#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
 struct LegacyQueueCounts {
     queued: u64,
     running: u64,
     stalled: u64,
     failed: u64,
     done: u64,
-}
-
-#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
-struct SourceActivity {
-    source: String,
-    pending: u64,
-    running: u64,
-    review: u64,
-    blocked: u64,
-    failed: u64,
-    ready_to_merge: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -359,62 +338,6 @@ async fn list_recent_failed_workflows(
     Ok(workflows)
 }
 
-fn runtime_workflow_counts(workflows: &[WorkflowInstance]) -> RuntimeWorkflowCounts {
-    let mut counts = RuntimeWorkflowCounts::default();
-    for workflow in workflows {
-        match workflow_bucket(workflow) {
-            WorkflowBucket::Pending => counts.pending += 1,
-            WorkflowBucket::Running => counts.running += 1,
-            WorkflowBucket::Review => counts.review += 1,
-            WorkflowBucket::AwaitingDependencies => counts.awaiting_dependencies += 1,
-            WorkflowBucket::ReadyToMerge => counts.ready_to_merge += 1,
-            WorkflowBucket::Blocked => counts.blocked += 1,
-            WorkflowBucket::Failed => counts.failed += 1,
-            WorkflowBucket::Done => counts.done += 1,
-            WorkflowBucket::Other => counts.other += 1,
-        }
-    }
-    counts
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WorkflowBucket {
-    Pending,
-    Running,
-    Review,
-    AwaitingDependencies,
-    ReadyToMerge,
-    Blocked,
-    Failed,
-    Done,
-    Other,
-}
-
-fn workflow_bucket(workflow: &WorkflowInstance) -> WorkflowBucket {
-    match workflow.state.as_str() {
-        "scheduled" | "discovered" => WorkflowBucket::Pending,
-        "checking" | "dispatching" | "inspecting" | "planning_batch" | "reconciling"
-        | "scanning" => WorkflowBucket::Running,
-        "awaiting_dependencies" => WorkflowBucket::AwaitingDependencies,
-        "ready_to_merge" => WorkflowBucket::ReadyToMerge,
-        "blocked" => WorkflowBucket::Blocked,
-        "failed" => WorkflowBucket::Failed,
-        "done" | "passed" => WorkflowBucket::Done,
-        "idle" => WorkflowBucket::Other,
-        "pr_open" | "local_review_gate" | "awaiting_feedback" | "quality_gate_pending" => {
-            WorkflowBucket::Review
-        }
-        _ => {
-            let projection = RuntimeWorkflowProjection::from_workflow(workflow);
-            match projection.active_bucket() {
-                Some(RuntimeActiveBucket::Running) => WorkflowBucket::Running,
-                Some(RuntimeActiveBucket::Queued) => WorkflowBucket::Pending,
-                None => WorkflowBucket::Other,
-            }
-        }
-    }
-}
-
 fn legacy_queue_counts(
     active_tasks: &[TaskSummary],
     stalled: u64,
@@ -457,101 +380,6 @@ fn filter_workflow_backed_tasks(
         .into_iter()
         .filter(|task| !workflow_task_ids.contains(task.id.as_str()))
         .collect()
-}
-
-fn source_activity(
-    workflows: &[WorkflowInstance],
-    active_tasks: &[TaskSummary],
-) -> Vec<SourceActivity> {
-    let mut by_source: HashMap<String, SourceActivity> = HashMap::new();
-    let workflow_task_ids = workflow_legacy_task_ids(workflows);
-    for workflow in workflows {
-        add_workflow_source_activity(&mut by_source, workflow);
-    }
-    for task in active_tasks {
-        if task.workflow.is_some() || workflow_task_ids.contains(task.id.as_str()) {
-            continue;
-        }
-        add_legacy_source_activity(&mut by_source, task);
-    }
-    let mut rows: Vec<SourceActivity> = by_source.into_values().collect();
-    rows.sort_by(|a, b| {
-        source_total(b)
-            .cmp(&source_total(a))
-            .then_with(|| a.source.cmp(&b.source))
-    });
-    rows
-}
-
-fn add_workflow_source_activity(
-    by_source: &mut HashMap<String, SourceActivity>,
-    workflow: &WorkflowInstance,
-) {
-    let bucket = workflow_bucket(workflow);
-    if matches!(bucket, WorkflowBucket::Done | WorkflowBucket::Other) {
-        return;
-    }
-    let source = workflow_source(workflow);
-    let entry = by_source
-        .entry(source.clone())
-        .or_insert_with(|| SourceActivity {
-            source,
-            ..Default::default()
-        });
-    match bucket {
-        WorkflowBucket::Pending => entry.pending += 1,
-        WorkflowBucket::Running => entry.running += 1,
-        WorkflowBucket::Review => entry.review += 1,
-        WorkflowBucket::AwaitingDependencies | WorkflowBucket::Blocked => entry.blocked += 1,
-        WorkflowBucket::Failed => entry.failed += 1,
-        WorkflowBucket::ReadyToMerge => entry.ready_to_merge += 1,
-        _ => {}
-    }
-}
-
-fn add_legacy_source_activity(by_source: &mut HashMap<String, SourceActivity>, task: &TaskSummary) {
-    let update: fn(&mut SourceActivity) = if task.status.is_failure()
-        || task.scheduler.authority_state == SchedulerAuthorityState::Failed
-    {
-        |entry| entry.failed += 1
-    } else if matches!(
-        task.scheduler.authority_state,
-        SchedulerAuthorityState::Running
-            | SchedulerAuthorityState::Leased
-            | SchedulerAuthorityState::Recovering
-    ) {
-        |entry| entry.running += 1
-    } else if matches!(
-        task.scheduler.authority_state,
-        SchedulerAuthorityState::AwaitingDependencies | SchedulerAuthorityState::RetryBackoff
-    ) || matches!(task.status.as_ref(), "awaiting_deps" | "waiting")
-    {
-        |entry| entry.blocked += 1
-    } else {
-        return;
-    };
-    let source = task
-        .source
-        .as_deref()
-        .filter(|source| !source.trim().is_empty())
-        .unwrap_or("manual")
-        .to_string();
-    let entry = by_source
-        .entry(source.clone())
-        .or_insert_with(|| SourceActivity {
-            source,
-            ..Default::default()
-        });
-    update(entry);
-}
-
-fn source_total(source: &SourceActivity) -> u64 {
-    source.pending
-        + source.running
-        + source.review
-        + source.blocked
-        + source.failed
-        + source.ready_to_merge
 }
 
 fn operator_actions(

--- a/crates/harness-server/src/handlers/operator_monitor/activity.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/activity.rs
@@ -1,0 +1,179 @@
+use super::{workflow_legacy_task_ids, workflow_source, TaskSummary, WorkflowInstance};
+use crate::runtime_projection::{RuntimeActiveBucket, RuntimeWorkflowProjection};
+use crate::task_runner::{SchedulerAuthorityState, TaskPhase, TaskStatus};
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+pub(super) struct RuntimeWorkflowCounts {
+    pub(super) pending: u64,
+    pub(super) running: u64,
+    pub(super) review: u64,
+    pub(super) awaiting_dependencies: u64,
+    pub(super) ready_to_merge: u64,
+    pub(super) blocked: u64,
+    pub(super) failed: u64,
+    pub(super) done: u64,
+    pub(super) other: u64,
+}
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+pub(super) struct SourceActivity {
+    pub(super) source: String,
+    pub(super) pending: u64,
+    pub(super) running: u64,
+    pub(super) review: u64,
+    pub(super) blocked: u64,
+    pub(super) failed: u64,
+    pub(super) ready_to_merge: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkflowBucket {
+    Pending,
+    Running,
+    Review,
+    AwaitingDependencies,
+    ReadyToMerge,
+    Blocked,
+    Failed,
+    Done,
+    Other,
+}
+
+pub(super) fn runtime_workflow_counts(workflows: &[WorkflowInstance]) -> RuntimeWorkflowCounts {
+    let mut counts = RuntimeWorkflowCounts::default();
+    for workflow in workflows {
+        match workflow_bucket(workflow) {
+            WorkflowBucket::Pending => counts.pending += 1,
+            WorkflowBucket::Running => counts.running += 1,
+            WorkflowBucket::Review => counts.review += 1,
+            WorkflowBucket::AwaitingDependencies => counts.awaiting_dependencies += 1,
+            WorkflowBucket::ReadyToMerge => counts.ready_to_merge += 1,
+            WorkflowBucket::Blocked => counts.blocked += 1,
+            WorkflowBucket::Failed => counts.failed += 1,
+            WorkflowBucket::Done => counts.done += 1,
+            WorkflowBucket::Other => counts.other += 1,
+        }
+    }
+    counts
+}
+
+fn workflow_bucket(workflow: &WorkflowInstance) -> WorkflowBucket {
+    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+    match projection.task_status {
+        TaskStatus::Failed => return WorkflowBucket::Failed,
+        TaskStatus::Done => return WorkflowBucket::Done,
+        TaskStatus::AwaitingDeps => return WorkflowBucket::AwaitingDependencies,
+        _ => {}
+    }
+    if workflow.state == "ready_to_merge" {
+        return WorkflowBucket::ReadyToMerge;
+    }
+    if workflow.state == "blocked" {
+        return WorkflowBucket::Blocked;
+    }
+    if projection.phase == TaskPhase::Review {
+        return WorkflowBucket::Review;
+    }
+    match projection.active_bucket() {
+        Some(RuntimeActiveBucket::Running) => WorkflowBucket::Running,
+        Some(RuntimeActiveBucket::Queued) => WorkflowBucket::Pending,
+        None => WorkflowBucket::Other,
+    }
+}
+
+pub(super) fn source_activity(
+    workflows: &[WorkflowInstance],
+    active_tasks: &[TaskSummary],
+) -> Vec<SourceActivity> {
+    let mut by_source: HashMap<String, SourceActivity> = HashMap::new();
+    let workflow_task_ids = workflow_legacy_task_ids(workflows);
+    for workflow in workflows {
+        add_workflow_source_activity(&mut by_source, workflow);
+    }
+    for task in active_tasks {
+        if task.workflow.is_some() || workflow_task_ids.contains(task.id.as_str()) {
+            continue;
+        }
+        add_legacy_source_activity(&mut by_source, task);
+    }
+    let mut rows: Vec<SourceActivity> = by_source.into_values().collect();
+    rows.sort_by(|a, b| {
+        source_total(b)
+            .cmp(&source_total(a))
+            .then_with(|| a.source.cmp(&b.source))
+    });
+    rows
+}
+
+fn add_workflow_source_activity(
+    by_source: &mut HashMap<String, SourceActivity>,
+    workflow: &WorkflowInstance,
+) {
+    let bucket = workflow_bucket(workflow);
+    if matches!(bucket, WorkflowBucket::Done | WorkflowBucket::Other) {
+        return;
+    }
+    let source = workflow_source(workflow);
+    let entry = by_source
+        .entry(source.clone())
+        .or_insert_with(|| SourceActivity {
+            source,
+            ..Default::default()
+        });
+    match bucket {
+        WorkflowBucket::Pending => entry.pending += 1,
+        WorkflowBucket::Running => entry.running += 1,
+        WorkflowBucket::Review => entry.review += 1,
+        WorkflowBucket::AwaitingDependencies | WorkflowBucket::Blocked => entry.blocked += 1,
+        WorkflowBucket::Failed => entry.failed += 1,
+        WorkflowBucket::ReadyToMerge => entry.ready_to_merge += 1,
+        _ => {}
+    }
+}
+
+fn add_legacy_source_activity(by_source: &mut HashMap<String, SourceActivity>, task: &TaskSummary) {
+    let update: fn(&mut SourceActivity) = if task.status.is_failure()
+        || task.scheduler.authority_state == SchedulerAuthorityState::Failed
+    {
+        |entry| entry.failed += 1
+    } else if matches!(
+        task.scheduler.authority_state,
+        SchedulerAuthorityState::Running
+            | SchedulerAuthorityState::Leased
+            | SchedulerAuthorityState::Recovering
+    ) {
+        |entry| entry.running += 1
+    } else if matches!(
+        task.scheduler.authority_state,
+        SchedulerAuthorityState::AwaitingDependencies | SchedulerAuthorityState::RetryBackoff
+    ) || matches!(task.status.as_ref(), "awaiting_deps" | "waiting")
+    {
+        |entry| entry.blocked += 1
+    } else {
+        return;
+    };
+    let source = task
+        .source
+        .as_deref()
+        .filter(|source| !source.trim().is_empty())
+        .unwrap_or("manual")
+        .to_string();
+    let entry = by_source
+        .entry(source.clone())
+        .or_insert_with(|| SourceActivity {
+            source,
+            ..Default::default()
+        });
+    update(entry);
+}
+
+fn source_total(source: &SourceActivity) -> u64 {
+    source.pending
+        + source.running
+        + source.review
+        + source.blocked
+        + source.failed
+        + source.ready_to_merge
+}

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -39,8 +39,14 @@ fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
     let workflows = vec![
         workflow("implementing", json!({})),
         workflow("checking", json!({})),
+        workflow("dispatching", json!({})),
         workflow("inspecting", json!({})),
+        workflow("planning_batch", json!({})),
+        workflow("reconciling", json!({})),
+        workflow("scanning", json!({})),
         workflow("awaiting_feedback", json!({})),
+        workflow("feedback_found", json!({})),
+        workflow("no_actionable_feedback", json!({})),
         workflow("ready_to_merge", json!({})),
         workflow("awaiting_dependencies", json!({})),
         workflow("idle", json!({})),
@@ -50,7 +56,8 @@ fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
 
     let counts = runtime_workflow_counts(&workflows);
 
-    assert_eq!(counts.running, 3);
+    assert_eq!(counts.running, 7);
+    assert_eq!(counts.pending, 2);
     assert_eq!(counts.review, 1);
     assert_eq!(counts.ready_to_merge, 1);
     assert_eq!(counts.awaiting_dependencies, 1);
@@ -513,6 +520,8 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
             workflow("checking", json!({ "source": "github" })),
             workflow("inspecting", json!({ "source": "github" })),
             workflow("awaiting_feedback", json!({ "source": "github" })),
+            workflow("feedback_found", json!({ "source": "github" })),
+            workflow("no_actionable_feedback", json!({ "source": "github" })),
             workflow("scheduled", json!({ "source": "github" })),
         ],
         &[legacy_row, queued_row],
@@ -521,7 +530,7 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
     assert_eq!(by_source.len(), 1);
     let source = by_source.pop().expect("source row");
     assert_eq!(source.source, "github");
-    assert_eq!(source.pending, 1);
+    assert_eq!(source.pending, 3);
     assert_eq!(source.ready_to_merge, 1);
     assert_eq!(source.review, 1);
     assert_eq!(source.running, 2);

--- a/crates/harness-server/src/runtime_projection.rs
+++ b/crates/harness-server/src/runtime_projection.rs
@@ -15,6 +15,7 @@ pub(crate) struct RuntimeWorkflowProjection {
     pub(crate) failure_kind: Option<TaskFailureKind>,
     pub(crate) phase: TaskPhase,
     pub(crate) scheduler: TaskSchedulerState,
+    active_bucket: Option<RuntimeActiveBucket>,
     pub(crate) project_id: Option<String>,
     pub(crate) submission_handle: Option<TaskId>,
     pub(crate) legacy_dedupe_task_handle: Option<TaskId>,
@@ -25,11 +26,13 @@ impl RuntimeWorkflowProjection {
         let terminal_state = workflow.terminal_state();
         let task_status = workflow_state_to_task_status(workflow, terminal_state);
         let scheduler = workflow_scheduler_state(&workflow.state, &task_status, terminal_state);
+        let active_bucket = workflow_active_bucket(&workflow.state, &task_status, &scheduler);
         Self {
             failure_kind: task_status.is_failure().then_some(TaskFailureKind::Task),
             phase: workflow_state_to_task_phase(&workflow.state, terminal_state),
             task_status,
             scheduler,
+            active_bucket,
             project_id: runtime_string_field(&workflow.data, "project_id"),
             submission_handle: runtime_submission_handle(&workflow.data),
             legacy_dedupe_task_handle: legacy_dedupe_task_handle(&workflow.data),
@@ -37,15 +40,7 @@ impl RuntimeWorkflowProjection {
     }
 
     pub(crate) fn active_bucket(&self) -> Option<RuntimeActiveBucket> {
-        if self.task_status.is_terminal() {
-            return None;
-        }
-        match self.scheduler.authority_state {
-            SchedulerAuthorityState::Running
-            | SchedulerAuthorityState::Leased
-            | SchedulerAuthorityState::Recovering => Some(RuntimeActiveBucket::Running),
-            _ => Some(RuntimeActiveBucket::Queued),
-        }
+        self.active_bucket
     }
 }
 
@@ -69,8 +64,19 @@ pub(crate) fn workflow_state_to_task_status(
         "awaiting_dependencies" => TaskStatus::AwaitingDeps,
         "scheduled" | "discovered" => TaskStatus::Pending,
         "planning" => TaskStatus::Planning,
-        "implementing" | "replanning" | "addressing_feedback" => TaskStatus::Implementing,
-        "pr_open"
+        "checking"
+        | "dispatching"
+        | "implementing"
+        | "inspecting"
+        | "planning_batch"
+        | "reconciling"
+        | "replanning"
+        | "scanning"
+        | "addressing_feedback" => TaskStatus::Implementing,
+        "feedback_found"
+        | "idle"
+        | "no_actionable_feedback"
+        | "pr_open"
         | "local_review_gate"
         | "awaiting_feedback"
         | "quality_gate_pending"
@@ -111,7 +117,16 @@ fn workflow_scheduler_state(
     match state {
         "awaiting_dependencies" => TaskSchedulerState::awaiting_dependencies(),
         "scheduled" | "discovered" => TaskSchedulerState::queued(),
-        "planning" | "implementing" | "replanning" | "addressing_feedback" => TaskSchedulerState {
+        "checking"
+        | "dispatching"
+        | "implementing"
+        | "inspecting"
+        | "planning"
+        | "planning_batch"
+        | "reconciling"
+        | "replanning"
+        | "scanning"
+        | "addressing_feedback" => TaskSchedulerState {
             authority_state: SchedulerAuthorityState::Running,
             owner: None,
             run_generation: 0,
@@ -134,6 +149,22 @@ fn workflow_scheduler_state(
             }
             _ => TaskSchedulerState::queued(),
         },
+    }
+}
+
+fn workflow_active_bucket(
+    state: &str,
+    status: &TaskStatus,
+    scheduler: &TaskSchedulerState,
+) -> Option<RuntimeActiveBucket> {
+    if status.is_terminal() || state == "idle" {
+        return None;
+    }
+    match scheduler.authority_state {
+        SchedulerAuthorityState::Running
+        | SchedulerAuthorityState::Leased
+        | SchedulerAuthorityState::Recovering => Some(RuntimeActiveBucket::Running),
+        _ => Some(RuntimeActiveBucket::Queued),
     }
 }
 
@@ -335,5 +366,94 @@ mod tests {
         );
         assert_eq!(projection.phase, TaskPhase::Terminal);
         assert_eq!(projection.active_bucket(), None);
+    }
+
+    #[test]
+    fn projection_maps_runtime_execution_states_to_running() {
+        for state in [
+            "checking",
+            "dispatching",
+            "implementing",
+            "inspecting",
+            "planning_batch",
+            "reconciling",
+            "replanning",
+            "scanning",
+            "addressing_feedback",
+        ] {
+            let workflow = workflow(state, serde_json::json!({}));
+
+            let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+            assert_eq!(projection.task_status, TaskStatus::Implementing, "{state}");
+            assert_eq!(
+                projection.scheduler.authority_state,
+                SchedulerAuthorityState::Running,
+                "{state}"
+            );
+            assert_eq!(
+                projection.active_bucket(),
+                Some(RuntimeActiveBucket::Running),
+                "{state}"
+            );
+        }
+    }
+
+    #[test]
+    fn projection_preserves_planning_status_but_marks_scheduler_running() {
+        let workflow = workflow("planning", serde_json::json!({}));
+
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+        assert_eq!(projection.task_status, TaskStatus::Planning);
+        assert_eq!(projection.phase, TaskPhase::Plan);
+        assert_eq!(
+            projection.scheduler.authority_state,
+            SchedulerAuthorityState::Running
+        );
+        assert_eq!(
+            projection.active_bucket(),
+            Some(RuntimeActiveBucket::Running)
+        );
+    }
+
+    #[test]
+    fn projection_excludes_idle_workflows_from_active_counts() {
+        let workflow = workflow_with_definition(
+            harness_workflow::runtime::REPO_BACKLOG_DEFINITION_ID,
+            "idle",
+            serde_json::json!({}),
+        );
+
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+        assert_eq!(projection.task_status, TaskStatus::Waiting);
+        assert_eq!(
+            projection.scheduler.authority_state,
+            SchedulerAuthorityState::Queued
+        );
+        assert_eq!(projection.active_bucket(), None);
+    }
+
+    #[test]
+    fn projection_keeps_pr_feedback_outcomes_queued_without_review_phase() {
+        for state in ["feedback_found", "no_actionable_feedback"] {
+            let workflow = workflow(state, serde_json::json!({}));
+
+            let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+
+            assert_eq!(projection.task_status, TaskStatus::Waiting, "{state}");
+            assert_eq!(projection.phase, TaskPhase::Implement, "{state}");
+            assert_eq!(
+                projection.scheduler.authority_state,
+                SchedulerAuthorityState::Queued,
+                "{state}"
+            );
+            assert_eq!(
+                projection.active_bucket(),
+                Some(RuntimeActiveBucket::Queued),
+                "{state}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend `RuntimeWorkflowProjection` to classify runtime execution states used by repo backlog, PR feedback, and quality gate workflows
- preserve planning as `TaskStatus::Planning` while marking its scheduler/active bucket as running
- move operator-monitor activity bucketing into a focused submodule and route workflow buckets through the shared runtime projection

Fixes #1383

## Verification
- cargo fmt --all -- --check
- git diff --check
- CARGO_TERM_COLOR=never cargo test -p harness-server runtime_workflow_counts_reconcile_execution_review_and_terminal_states -- --nocapture
- CARGO_TERM_COLOR=never cargo test -p harness-server projection_ -- --nocapture
- CARGO_TERM_COLOR=never cargo test -p harness-server runtime_workflow_scheduler_state_only_marks_executing_states_running -- --nocapture
- CARGO_TERM_COLOR=never cargo test -p harness-server list_tasks_includes_runtime_issue_submissions -- --nocapture
- CARGO_TERM_COLOR=never cargo check -p harness-server --all-targets --quiet
- CARGO_TERM_COLOR=never RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets --quiet
- CARGO_TERM_COLOR=never cargo test --workspace --quiet (first run hit unrelated harness-agents timeout; exact rerun passed)
- CARGO_TERM_COLOR=never cargo test -p harness-agents codex::tests::execute_kills_descendant_that_keeps_output_pipe_open_after_root_exit -- --nocapture
- CARGO_TERM_COLOR=never cargo test --workspace --quiet