### PR TITLE
fix(storage): reap legacy path-derived schema rows

### DIFF
--- a/crates/harness-core/src/db_pg_schema_registry.rs
+++ b/crates/harness-core/src/db_pg_schema_registry.rs
@@ -8,6 +8,7 @@ pub const PG_SCHEMA_REGISTRY_TABLE: &str = "schema_ownership";
 
 const PATH_DERIVED_OWNER_KIND: &str = "path_derived_store";
 const PATH_DERIVED_DIRECTORY_OWNER_KIND: &str = "path_derived_directory_store";
+const LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND: &str = "path_derived_schema";
 const PATH_DERIVED_RETENTION_CLASS: &str = "path_derived";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -45,7 +46,9 @@ fn path_derived_owner_kind(path: &Path) -> &'static str {
 fn is_path_derived_owner_kind(owner_kind: &str) -> bool {
     matches!(
         owner_kind,
-        PATH_DERIVED_OWNER_KIND | PATH_DERIVED_DIRECTORY_OWNER_KIND
+        PATH_DERIVED_OWNER_KIND
+            | PATH_DERIVED_DIRECTORY_OWNER_KIND
+            | LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND
     )
 }
 
@@ -556,7 +559,8 @@ fn owner_path_is_orphaned_with_workspace_roots(
     workspace_roots: &[PathBuf],
 ) -> bool {
     let liveness_path = if owner_kind == PATH_DERIVED_DIRECTORY_OWNER_KIND
-        || (owner_kind == PATH_DERIVED_OWNER_KIND
+        || ((owner_kind == PATH_DERIVED_OWNER_KIND
+            || owner_kind == LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND)
             && is_legacy_workspace_directory_owner_path(owner_path, workspace_roots))
     {
         owner_path
@@ -573,24 +577,40 @@ fn owner_path_is_orphaned_with_workspace_roots(
 }
 
 fn orphaned_path_schema_names(
-    rows: Vec<(String, String, Option<String>)>,
+    rows: Vec<(String, String, Option<String>, Option<String>)>,
     workspace_roots: Vec<PathBuf>,
 ) -> Vec<String> {
     let mut orphans = Vec::new();
-    for (schema_name, owner_kind, owner_path) in rows {
+    for (schema_name, owner_kind, owner_key, owner_path) in rows {
         // No recorded path: cannot prove the schema is orphaned, so keep it.
-        let Some(owner_path) = owner_path else {
+        let Some(liveness_path) =
+            owner_liveness_path(&owner_kind, owner_key.as_deref(), owner_path.as_deref())
+        else {
             continue;
         };
         if owner_path_is_orphaned_with_workspace_roots(
             &owner_kind,
-            Path::new(&owner_path),
+            Path::new(liveness_path),
             &workspace_roots,
         ) {
             orphans.push(schema_name);
         }
     }
     orphans
+}
+
+fn owner_liveness_path<'a>(
+    owner_kind: &str,
+    owner_key: Option<&'a str>,
+    owner_path: Option<&'a str>,
+) -> Option<&'a str> {
+    owner_path.or_else(|| {
+        if owner_kind == LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND {
+            owner_key.filter(|key| Path::new(key).is_absolute())
+        } else {
+            None
+        }
+    })
 }
 
 /// Drop registered path-derived schemas whose owning workspace directory is gone.
@@ -616,13 +636,14 @@ pub async fn reap_orphaned_path_schemas_with_workspace_roots(
     workspace_roots: &[PathBuf],
 ) -> anyhow::Result<PgSchemaReapReport> {
     ensure_pg_schema_registry(pool).await?;
-    let rows: Vec<(String, String, Option<String>)> = sqlx::query_as(&format!(
-        "SELECT schema_name, owner_kind, owner_path
+    let rows: Vec<(String, String, Option<String>, Option<String>)> = sqlx::query_as(&format!(
+        "SELECT schema_name, owner_kind, owner_key, owner_path
          FROM \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
-         WHERE owner_kind IN ($1, $2)"
+         WHERE owner_kind IN ($1, $2, $3)"
     ))
     .bind(PATH_DERIVED_OWNER_KIND)
     .bind(PATH_DERIVED_DIRECTORY_OWNER_KIND)
+    .bind(LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND)
     .fetch_all(pool)
     .await?;
 

--- a/crates/harness-core/src/db_pg_schema_registry_tests.rs
+++ b/crates/harness-core/src/db_pg_schema_registry_tests.rs
@@ -1,10 +1,16 @@
 use super::*;
+use crate::db_pg::{pg_open_pool, resolve_database_url};
 use std::collections::HashSet;
 
 fn create_normalized_workspace_root(parent: &Path, name: &str) -> anyhow::Result<PathBuf> {
     let raw_workspace_root = parent.join(name);
     std::fs::create_dir(&raw_workspace_root)?;
     Ok(normalize_path_for_comparison(&raw_workspace_root))
+}
+
+fn unique_legacy_schema_name() -> String {
+    let unique = uuid::Uuid::new_v4().simple().to_string();
+    format!("h{}", &unique[..16])
 }
 
 #[test]
@@ -20,6 +26,23 @@ fn owner_path_is_orphaned_detects_missing_parent() -> anyhow::Result<()> {
     assert!(
         owner_path_is_orphaned(PATH_DERIVED_OWNER_KIND, &dead),
         "schema whose parent dir is gone must be reaped"
+    );
+    Ok(())
+}
+
+#[test]
+fn owner_path_is_orphaned_detects_legacy_schema_missing_parent() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let live = dir.path().join("threads");
+    assert!(
+        !owner_path_is_orphaned(LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND, &live),
+        "legacy schema owner whose parent dir exists must be kept"
+    );
+
+    let dead = dir.path().join("removed-workspace/threads");
+    assert!(
+        owner_path_is_orphaned(LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND, &dead),
+        "legacy schema owner whose parent dir is gone must be reaped"
     );
     Ok(())
 }
@@ -66,6 +89,34 @@ fn owner_path_is_orphaned_detects_legacy_workspace_directory_owner() -> anyhow::
             &workspace_roots
         ),
         "deleted legacy workspace directory owner path must be reaped"
+    );
+    Ok(())
+}
+
+#[test]
+fn owner_path_is_orphaned_detects_legacy_schema_workspace_directory_owner() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace_root = create_normalized_workspace_root(parent.path(), "workspaces")?;
+    let workspace = workspace_root.join("550e8400-e29b-41d4-a716-446655440000");
+    let workspace_roots = vec![normalize_path_for_comparison(&workspace_root)];
+    std::fs::create_dir(&workspace)?;
+    assert!(
+        !owner_path_is_orphaned_with_workspace_roots(
+            LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "live legacy schema workspace directory owner path must be kept"
+    );
+
+    std::fs::remove_dir(&workspace)?;
+    assert!(
+        owner_path_is_orphaned_with_workspace_roots(
+            LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND,
+            &workspace,
+            &workspace_roots
+        ),
+        "deleted legacy schema workspace directory owner path must be reaped"
     );
     Ok(())
 }
@@ -239,6 +290,124 @@ fn owner_path_is_orphaned_keeps_configured_root_fixed_store_path() -> anyhow::Re
 }
 
 #[test]
+fn orphaned_path_schema_names_includes_legacy_schema_owner_kind() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let live_parent = dir.path().join("live-workspace");
+    std::fs::create_dir(&live_parent)?;
+
+    let orphans = orphaned_path_schema_names(
+        vec![
+            (
+                "h1111111111111111".to_string(),
+                LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND.to_string(),
+                Some(
+                    dir.path()
+                        .join("missing-workspace/tasks-store")
+                        .to_string_lossy()
+                        .to_string(),
+                ),
+                None,
+            ),
+            (
+                "h2222222222222222".to_string(),
+                LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND.to_string(),
+                Some(
+                    live_parent
+                        .join("tasks-store")
+                        .to_string_lossy()
+                        .to_string(),
+                ),
+                None,
+            ),
+        ],
+        vec![],
+    );
+
+    assert_eq!(orphans, vec!["h1111111111111111"]);
+    Ok(())
+}
+
+#[test]
+fn orphaned_path_schema_names_ignores_opaque_legacy_schema_owner_key() {
+    let orphans = orphaned_path_schema_names(
+        vec![(
+            "h3333333333333333".to_string(),
+            LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND.to_string(),
+            Some("h3333333333333333".to_string()),
+            None,
+        )],
+        vec![],
+    );
+
+    assert!(orphans.is_empty());
+}
+
+#[tokio::test]
+async fn reaper_inventory_includes_legacy_path_derived_schema_owner_rows() -> anyhow::Result<()> {
+    let database_url = {
+        let _lock = crate::test_support::process_env_lock();
+        let Ok(database_url) = resolve_database_url(None) else {
+            return Ok(());
+        };
+        database_url
+    };
+    let pool = match pg_open_pool(&database_url).await {
+        Ok(pool) => pool,
+        Err(_) => return Ok(()),
+    };
+    ensure_pg_schema_registry(&pool).await?;
+
+    let dir = tempfile::tempdir()?;
+    let live_parent = dir.path().join("live-workspace");
+    std::fs::create_dir(&live_parent)?;
+    let missing_schema = unique_legacy_schema_name();
+    let live_schema = unique_legacy_schema_name();
+    let missing_owner_path = dir
+        .path()
+        .join("missing-workspace/tasks-store")
+        .to_string_lossy()
+        .to_string();
+    let live_owner_path = live_parent
+        .join("tasks-store")
+        .to_string_lossy()
+        .to_string();
+
+    for (schema, owner_key) in [
+        (&missing_schema, &missing_owner_path),
+        (&live_schema, &live_owner_path),
+    ] {
+        sqlx::query(&format!(
+            "INSERT INTO \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
+                (schema_name, owner_kind, owner_key, owner_path, retention_class)
+             VALUES ($1, $2, $3, NULL, $4)"
+        ))
+        .bind(schema)
+        .bind(LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND)
+        .bind(owner_key)
+        .bind(PATH_DERIVED_RETENTION_CLASS)
+        .execute(&pool)
+        .await?;
+    }
+
+    let report = reap_orphaned_path_schemas_with_workspace_roots(&pool, false, &[]).await?;
+
+    sqlx::query(&format!(
+        "DELETE FROM \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
+         WHERE schema_name = ANY($1)"
+    ))
+    .bind(vec![missing_schema.clone(), live_schema.clone()])
+    .execute(&pool)
+    .await?;
+    pool.close().await;
+
+    assert!(report.scanned >= 2);
+    assert!(report.orphans.contains(&missing_schema));
+    assert!(!report.orphans.contains(&live_schema));
+    assert!(!report.dropped);
+    Ok(())
+}
+
+#[test]
 fn normalize_path_lexically_preserves_root_and_leading_parent() {
     assert_eq!(
         normalize_path_lexically(Path::new("/../workspace")),
@@ -299,6 +468,28 @@ fn path_derived_ownership_records_directory_owner_kind() -> anyhow::Result<()> {
     );
     assert_eq!(ownership.retention_class, "path_derived");
     Ok(())
+}
+
+#[test]
+fn cleanup_keeps_legacy_path_derived_schema_in_manual_plan() {
+    let row = PgSchemaInventoryRow {
+        schema_name: "h6666666666666666".to_string(),
+        owner_kind: Some("path_derived_schema".to_string()),
+        owner_key: Some("/definitely/missing/harness/schema-owner".to_string()),
+        owner_path: Some("/definitely/missing/harness/schema-owner".to_string()),
+        retention_class: Some("path_derived".to_string()),
+        table_count: 1,
+        estimated_row_count: 0,
+    };
+
+    let candidate = classify_schema_cleanup_candidate(row);
+
+    assert!(candidate.registered);
+    assert_eq!(candidate.action, PgSchemaCleanupAction::Keep);
+    assert_eq!(
+        candidate.reason,
+        "registered path-derived schema; owner_path is an identity key, not a liveness check"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- closes #1385
- include legacy `path_derived_schema` owner rows in the orphan path-schema reaper scan
- treat that legacy owner kind with the same conservative file-style and workspace-directory liveness rules as existing path-derived rows
- add regression coverage for missing parent, workspace directory, orphan list, and manual cleanup classification behavior

## Verification

- `cargo test -p harness-core db_pg_schema_registry -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p harness-core --all-targets --quiet`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets --quiet`
- `cargo test --workspace --quiet`