### PR TITLE
fix(runtime): record stale recovery evidence

### DIFF
--- a/crates/harness-server/src/stale_workflow_recovery.rs
+++ b/crates/harness-server/src/stale_workflow_recovery.rs
@@ -27,9 +27,10 @@ use std::time::Duration;
 
 use chrono::Utc;
 use harness_workflow::runtime::{
-    RuntimeJobStatus, WorkflowCommandRecord, WorkflowCommandStatus, WorkflowEvent,
+    RuntimeJobStatus, WorkflowCommand, WorkflowCommandRecord, WorkflowCommandStatus, WorkflowEvent,
     WorkflowInstance, WorkflowRuntimeStore, REPO_BACKLOG_POLL_ACTIVITY,
 };
+use serde::Serialize;
 use serde_json::json;
 
 use crate::http::AppState;
@@ -87,6 +88,13 @@ impl StaleRecoveryTick {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveryCommitOutcome {
+    Recovered { stuck_secs: i64 },
+    SkippedChanged,
+    SkippedActive { stuck_secs: i64 },
+}
+
 /// Run one recovery pass. Public for unit-testing.
 pub async fn run_stale_workflow_recovery_tick(
     store: &WorkflowRuntimeStore,
@@ -99,7 +107,7 @@ pub async fn run_stale_workflow_recovery_tick(
         let candidates = store
             .list_instances_by_state(RECOVERED_DEFINITION_ID, state, SCAN_LIMIT)
             .await?;
-        for mut instance in candidates {
+        for instance in candidates {
             if instance.updated_at >= cutoff {
                 continue;
             }
@@ -116,34 +124,16 @@ pub async fn run_stale_workflow_recovery_tick(
                 );
                 continue;
             }
-            instance.state = RECOVERY_TARGET_STATE.to_string();
-            instance.version = instance.version.saturating_add(1);
-            // Bump the JSON-baked updated_at so subsequent recovery ticks see a
-            // fresh timestamp and do not re-reset this same instance on every
-            // tick. The Postgres column updated_at is independently bumped by
-            // upsert_instance via CURRENT_TIMESTAMP, but list_instances_by_state
-            // returns instances deserialised from the data jsonb and the JSON
-            // copy of updated_at is what subsequent ticks compare against.
-            //
-            // Without this bump the recovery tick thrashes: after the first
-            // reset the column moves forward to NOW() but the data jsonb still
-            // carries a stale (often pre-reset) updated_at, so 10 minutes
-            // later the next tick re-reads the stale JSON timestamp, decides
-            // the workflow is still stale, and resets again. Observed in
-            // production: 8 workflows reset twice in 10 minutes after server
-            // restart, despite having transitioned through scanning legitimately
-            // in between.
-            instance.updated_at = Utc::now();
             match record_recovery_detected_event_and_reset(
                 store,
-                &instance,
+                &instance.id,
                 &original_state,
-                stuck_secs,
                 stale_after_secs,
+                cutoff,
             )
             .await
             {
-                Ok(()) => {
+                Ok(RecoveryCommitOutcome::Recovered { stuck_secs }) => {
                     tracing::warn!(
                         workflow_id = %instance.id,
                         from_state = %original_state,
@@ -152,6 +142,22 @@ pub async fn run_stale_workflow_recovery_tick(
                         "stale_workflow_recovery: reset workflow stuck in non-candidate state"
                     );
                     tick.recovered += 1;
+                }
+                Ok(RecoveryCommitOutcome::SkippedActive { stuck_secs }) => {
+                    tick.skipped_active += 1;
+                    tracing::debug!(
+                        workflow_id = %instance.id,
+                        state = %original_state,
+                        stuck_secs,
+                        "stale_workflow_recovery: skipped workflow with active repo backlog runtime work after lock"
+                    );
+                }
+                Ok(RecoveryCommitOutcome::SkippedChanged) => {
+                    tracing::debug!(
+                        workflow_id = %instance.id,
+                        from_state = %original_state,
+                        "stale_workflow_recovery: skipped workflow changed before recovery commit"
+                    );
                 }
                 Err(error) => {
                     tracing::warn!(
@@ -170,11 +176,56 @@ pub async fn run_stale_workflow_recovery_tick(
 
 async fn record_recovery_detected_event_and_reset(
     store: &WorkflowRuntimeStore,
-    instance: &WorkflowInstance,
+    workflow_id: &str,
     original_state: &str,
-    stuck_secs: i64,
     stale_after_secs: u64,
-) -> anyhow::Result<()> {
+    cutoff: chrono::DateTime<Utc>,
+) -> anyhow::Result<RecoveryCommitOutcome> {
+    record_recovery_detected_event_and_reset_inner(
+        store,
+        workflow_id,
+        original_state,
+        stale_after_secs,
+        cutoff,
+        false,
+    )
+    .await
+}
+
+async fn record_recovery_detected_event_and_reset_inner(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    original_state: &str,
+    stale_after_secs: u64,
+    cutoff: chrono::DateTime<Utc>,
+    force_rollback_after_event_insert: bool,
+) -> anyhow::Result<RecoveryCommitOutcome> {
+    let mut tx = store.pool().begin().await?;
+    let Some((current_data,)) = sqlx::query_as::<_, (String,)>(
+        "SELECT data::text FROM workflow_instances WHERE id = $1 FOR UPDATE",
+    )
+    .bind(workflow_id)
+    .fetch_optional(&mut *tx)
+    .await?
+    else {
+        tx.commit().await?;
+        return Ok(RecoveryCommitOutcome::SkippedChanged);
+    };
+    let mut instance: WorkflowInstance = serde_json::from_str(&current_data)?;
+    if instance.definition_id != RECOVERED_DEFINITION_ID
+        || instance.state != original_state
+        || !STUCK_STATES.contains(&instance.state.as_str())
+        || instance.updated_at >= cutoff
+    {
+        tx.commit().await?;
+        return Ok(RecoveryCommitOutcome::SkippedChanged);
+    }
+    let stuck_secs = (Utc::now() - instance.updated_at).num_seconds();
+    if workflow_has_active_repo_backlog_work_tx(&mut tx, workflow_id).await? {
+        tx.commit().await?;
+        return Ok(RecoveryCommitOutcome::SkippedActive { stuck_secs });
+    }
+
     let payload = json!({
         "definition_id": RECOVERED_DEFINITION_ID,
         "from_state": original_state,
@@ -184,15 +235,24 @@ async fn record_recovery_detected_event_and_reset(
         "reason": "repo_backlog workflow exceeded stale recovery threshold without active repo backlog work",
     });
 
-    let mut tx = store.pool().begin().await?;
+    instance.state = RECOVERY_TARGET_STATE.to_string();
+    instance.version = instance.version.saturating_add(1);
+    // Bump the JSON-baked updated_at so subsequent recovery ticks see a fresh
+    // timestamp and do not re-reset this same instance on every tick. The
+    // Postgres column updated_at is independently bumped below via
+    // CURRENT_TIMESTAMP, but list_instances_by_state returns instances with
+    // updated_at taken from the DB column and the JSON copy is still used by
+    // downstream replay/projection code.
+    instance.updated_at = Utc::now();
+
     sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
-        .bind(format!("workflow_events:{}", instance.id))
+        .bind(format!("workflow_events:{workflow_id}"))
         .execute(&mut *tx)
         .await?;
     let (next_sequence,): (i64,) = sqlx::query_as(
         "SELECT COALESCE(MAX(sequence), 0) + 1 FROM workflow_events WHERE workflow_id = $1",
     )
-    .bind(&instance.id)
+    .bind(workflow_id)
     .fetch_one(&mut *tx)
     .await?;
     let event = WorkflowEvent::new(
@@ -202,7 +262,7 @@ async fn record_recovery_detected_event_and_reset(
         RECOVERY_EVENT_SOURCE,
     )
     .with_payload(payload);
-    let event_data = serde_json::to_string(&event)?;
+    let event_data = to_jsonb_string(&event)?;
     sqlx::query(
         "INSERT INTO workflow_events
             (id, workflow_id, sequence, event_type, source, data)
@@ -216,21 +276,22 @@ async fn record_recovery_detected_event_and_reset(
     .bind(&event_data)
     .execute(&mut *tx)
     .await?;
+    if force_rollback_after_event_insert {
+        anyhow::bail!("forced stale recovery rollback after event insert");
+    }
 
-    let instance_data = serde_json::to_string(instance)?;
-    sqlx::query(
-        "INSERT INTO workflow_instances
-            (id, definition_id, state, subject_type, subject_key, parent_workflow_id, data, version)
-         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
-         ON CONFLICT (id) DO UPDATE SET
-            definition_id = EXCLUDED.definition_id,
-            state = EXCLUDED.state,
-            subject_type = EXCLUDED.subject_type,
-            subject_key = EXCLUDED.subject_key,
-            parent_workflow_id = EXCLUDED.parent_workflow_id,
-            data = EXCLUDED.data,
-            version = EXCLUDED.version,
-            updated_at = CURRENT_TIMESTAMP",
+    let instance_data = to_jsonb_string(&instance)?;
+    let rows_affected = sqlx::query(
+        "UPDATE workflow_instances
+         SET definition_id = $2,
+             state = $3,
+             subject_type = $4,
+             subject_key = $5,
+             parent_workflow_id = $6,
+             data = $7::jsonb,
+             version = $8,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE id = $1",
     )
     .bind(&instance.id)
     .bind(&instance.definition_id)
@@ -241,9 +302,58 @@ async fn record_recovery_detected_event_and_reset(
     .bind(&instance_data)
     .bind(instance.version as i64)
     .execute(&mut *tx)
-    .await?;
+    .await?
+    .rows_affected();
+    if rows_affected != 1 {
+        anyhow::bail!(
+            "stale recovery update affected {rows_affected} rows for workflow `{workflow_id}`"
+        );
+    }
     tx.commit().await?;
-    Ok(())
+    Ok(RecoveryCommitOutcome::Recovered { stuck_secs })
+}
+
+async fn workflow_has_active_repo_backlog_work_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workflow_id: &str,
+) -> anyhow::Result<bool> {
+    let command_rows: Vec<(String, String, String)> = sqlx::query_as(
+        "SELECT id, status, data::text FROM workflow_commands
+         WHERE workflow_id = $1
+         ORDER BY created_at ASC",
+    )
+    .bind(workflow_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    for (command_id, status, data) in command_rows.into_iter().rev() {
+        let command: WorkflowCommand = serde_json::from_str(&data)?;
+        if command.activity_name() != Some(REPO_BACKLOG_POLL_ACTIVITY) {
+            continue;
+        }
+        match WorkflowCommandStatus::try_from(status.as_str())? {
+            WorkflowCommandStatus::Pending | WorkflowCommandStatus::Dispatching => return Ok(true),
+            WorkflowCommandStatus::Dispatched => {
+                let (has_active_job,): (bool,) = sqlx::query_as(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM runtime_jobs
+                        WHERE command_id = $1 AND status IN ('pending', 'running')
+                    )",
+                )
+                .bind(&command_id)
+                .fetch_one(&mut **tx)
+                .await?;
+                if has_active_job {
+                    return Ok(true);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(false)
+}
+
+fn to_jsonb_string(value: &impl Serialize) -> anyhow::Result<String> {
+    Ok(serde_json::to_string(value)?.replace("\\u0000", ""))
 }
 
 async fn workflow_has_active_repo_backlog_work(
@@ -536,36 +646,76 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn recovery_tick_does_not_reset_when_recovery_event_write_fails() -> anyhow::Result<()> {
+    async fn recovery_commit_skips_when_locked_workflow_changed() -> anyhow::Result<()> {
         let Some(store) = open_recovery_test_store().await else {
             return Ok(());
         };
-        let id = "test::stale-recovery::evidence-write-fails";
+        let id = "test::stale-recovery::changed-before-commit";
+        let mut instance = stuck_instance(id, "dispatching");
+        instance.updated_at = Utc::now() - chrono::Duration::hours(1);
+        store.upsert_instance(&instance).await?;
+        let mut changed = instance.clone();
+        changed.state = "idle".to_string();
+        changed.version = changed.version.saturating_add(1);
+        changed.updated_at = Utc::now();
+        store.upsert_instance(&changed).await?;
+
+        let outcome = record_recovery_detected_event_and_reset(
+            &store,
+            id,
+            "dispatching",
+            300,
+            Utc::now() - chrono::Duration::seconds(300),
+        )
+        .await?;
+
+        assert_eq!(outcome, RecoveryCommitOutcome::SkippedChanged);
+        let Some(after) = store.get_instance(id).await? else {
+            anyhow::bail!("seeded workflow should still exist after changed skip");
+        };
+        assert_eq!(after.state, "idle");
+        let events = store.events_for(id).await?;
+        assert!(
+            events
+                .iter()
+                .all(|event| event.event_type != RECOVERY_EVENT_TYPE),
+            "changed workflow should not receive recovery evidence"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn recovery_commit_rolls_back_event_after_event_insert_error() -> anyhow::Result<()> {
+        let Some(store) = open_recovery_test_store().await else {
+            return Ok(());
+        };
+        let id = "test::stale-recovery::forced-rollback";
         let mut instance = stuck_instance(id, "dispatching");
         instance.updated_at = Utc::now() - chrono::Duration::hours(1);
         store.upsert_instance(&instance).await?;
 
-        sqlx::query("DROP TABLE workflow_events")
-            .execute(store.pool())
-            .await?;
+        let result = record_recovery_detected_event_and_reset_inner(
+            &store,
+            id,
+            "dispatching",
+            300,
+            Utc::now() - chrono::Duration::seconds(300),
+            true,
+        )
+        .await;
 
-        let tick = run_stale_workflow_recovery_tick(&store, 300).await?;
-
+        assert!(result.is_err(), "forced rollback should fail the commit");
         let Some(after) = store.get_instance(id).await? else {
-            anyhow::bail!("seeded workflow should still exist after failed recovery");
+            anyhow::bail!("seeded workflow should still exist after rollback");
         };
-        assert_eq!(
-            after.state, "dispatching",
-            "failed evidence persistence must not reset workflow state"
-        );
-        assert_eq!(
-            after.version, instance.version,
-            "failed evidence persistence must not bump workflow version"
-        );
-        assert_eq!(tick.recovered, 0);
+        assert_eq!(after.state, "dispatching");
+        assert_eq!(after.version, instance.version);
+        let events = store.events_for(id).await?;
         assert!(
-            tick.failed >= 1,
-            "failed evidence persistence should be counted as failed recovery"
+            events
+                .iter()
+                .all(|event| event.event_type != RECOVERY_EVENT_TYPE),
+            "recovery event should roll back when the atomic commit fails"
         );
         Ok(())
     }

--- a/crates/harness-server/src/stale_workflow_recovery.rs
+++ b/crates/harness-server/src/stale_workflow_recovery.rs
@@ -30,6 +30,7 @@ use harness_workflow::runtime::{
     RuntimeJobStatus, WorkflowCommandRecord, WorkflowCommandStatus, WorkflowRuntimeStore,
     REPO_BACKLOG_POLL_ACTIVITY,
 };
+use serde_json::json;
 
 use crate::http::AppState;
 
@@ -54,6 +55,8 @@ const STUCK_STATES: &[&str] = &[
 /// (`idle | failed`), so the next poller tick will re-claim it and re-issue a
 /// fresh `poll_repo_backlog` activity.
 const RECOVERY_TARGET_STATE: &str = "idle";
+const RECOVERY_EVENT_TYPE: &str = "RecoveryDetected";
+const RECOVERY_EVENT_SOURCE: &str = "stale_workflow_recovery";
 
 /// Default seconds a workflow must sit in a stuck state before recovery kicks
 /// in. 30 minutes is well above the longest legitimate `poll_repo_backlog`
@@ -113,6 +116,24 @@ pub async fn run_stale_workflow_recovery_tick(
                 );
                 continue;
             }
+            if let Err(error) = record_recovery_detected_event(
+                store,
+                &instance.id,
+                &original_state,
+                stuck_secs,
+                stale_after_secs,
+            )
+            .await
+            {
+                tracing::warn!(
+                    workflow_id = %instance.id,
+                    from_state = %original_state,
+                    stuck_secs,
+                    "stale_workflow_recovery: recovery evidence write failed: {error}"
+                );
+                tick.failed += 1;
+                continue;
+            }
             instance.state = RECOVERY_TARGET_STATE.to_string();
             instance.version = instance.version.saturating_add(1);
             // Bump the JSON-baked updated_at so subsequent recovery ticks see a
@@ -155,6 +176,31 @@ pub async fn run_stale_workflow_recovery_tick(
         }
     }
     Ok(tick)
+}
+
+async fn record_recovery_detected_event(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    original_state: &str,
+    stuck_secs: i64,
+    stale_after_secs: u64,
+) -> anyhow::Result<()> {
+    store
+        .append_event(
+            workflow_id,
+            RECOVERY_EVENT_TYPE,
+            RECOVERY_EVENT_SOURCE,
+            json!({
+                "definition_id": RECOVERED_DEFINITION_ID,
+                "from_state": original_state,
+                "to_state": RECOVERY_TARGET_STATE,
+                "stuck_secs": stuck_secs,
+                "stale_after_secs": stale_after_secs,
+                "reason": "repo_backlog workflow exceeded stale recovery threshold without active repo backlog work",
+            }),
+        )
+        .await?;
+    Ok(())
 }
 
 async fn workflow_has_active_repo_backlog_work(
@@ -256,32 +302,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn recovery_tick_resets_stuck_planning_batch_to_idle() {
+    async fn recovery_tick_resets_stuck_planning_batch_to_idle() -> anyhow::Result<()> {
         let Some(store) = open_recovery_test_store().await else {
-            return;
+            return Ok(());
         };
         let mut instance = stuck_instance("test::stale-recovery::planning::1", "planning_batch");
         // Backdate updated_at to 2h ago by serializing into the store. The
         // store's CURRENT_TIMESTAMP DEFAULT writes a fresh value, so we
         // immediately overwrite it via raw SQL.
-        store.upsert_instance(&instance).await.unwrap();
+        store.upsert_instance(&instance).await?;
         instance.state = "planning_batch".to_string();
         // Confirm pre-condition: instance.updated_at is now (within seconds).
-        let pre = store.get_instance(&instance.id).await.unwrap().unwrap();
+        let Some(pre) = store.get_instance(&instance.id).await? else {
+            anyhow::bail!("seeded planning workflow should exist before recovery");
+        };
         assert_eq!(pre.state, "planning_batch");
 
         // Stale_after = 0 means "anything not currently being modified counts as
         // stale" — gives the test a deterministic boundary without sleeping.
-        let tick = run_stale_workflow_recovery_tick(&store, 0).await.unwrap();
+        let tick = run_stale_workflow_recovery_tick(&store, 0).await?;
         assert!(
             tick.scanned >= 1,
             "should scan at least the seeded instance"
         );
         assert!(tick.recovered >= 1, "should recover at least one");
 
-        let post = store.get_instance(&instance.id).await.unwrap().unwrap();
+        let Some(post) = store.get_instance(&instance.id).await? else {
+            anyhow::bail!("seeded planning workflow should still exist after recovery");
+        };
         assert_eq!(post.state, "idle", "stuck workflow should be reset to idle");
         assert!(post.version > pre.version, "version should bump");
+        let events = store.events_for(&instance.id).await?;
+        let Some(recovery_event) = events
+            .iter()
+            .find(|event| event.event_type == RECOVERY_EVENT_TYPE)
+        else {
+            anyhow::bail!("stale recovery should record workflow evidence");
+        };
+        assert_eq!(recovery_event.source, RECOVERY_EVENT_SOURCE);
+        assert_eq!(
+            recovery_event.event["definition_id"],
+            RECOVERED_DEFINITION_ID
+        );
+        assert_eq!(recovery_event.event["from_state"], "planning_batch");
+        assert_eq!(recovery_event.event["to_state"], RECOVERY_TARGET_STATE);
+        assert_eq!(recovery_event.event["stale_after_secs"], 0);
+        assert!(
+            recovery_event.event["stuck_secs"].as_i64().is_some(),
+            "recovery event should include stale duration evidence"
+        );
+        assert!(
+            recovery_event.created_at <= post.updated_at,
+            "recovery evidence should be recorded before the reset completes"
+        );
+        Ok(())
     }
 
     #[tokio::test]
@@ -458,6 +532,13 @@ mod tests {
         assert!(
             tick.skipped_active >= 1,
             "active runtime job should be counted as an active skip"
+        );
+        let events = store.events_for(id).await?;
+        assert!(
+            events
+                .iter()
+                .all(|event| event.event_type != RECOVERY_EVENT_TYPE),
+            "active runtime work should not emit a recovery event"
         );
         Ok(())
     }

--- a/crates/harness-server/src/stale_workflow_recovery.rs
+++ b/crates/harness-server/src/stale_workflow_recovery.rs
@@ -27,8 +27,9 @@ use std::time::Duration;
 
 use chrono::Utc;
 use harness_workflow::runtime::{
-    RuntimeJobStatus, WorkflowCommand, WorkflowCommandRecord, WorkflowCommandStatus, WorkflowEvent,
-    WorkflowInstance, WorkflowRuntimeStore, REPO_BACKLOG_POLL_ACTIVITY,
+    RuntimeJobStatus, WorkflowCommand, WorkflowCommandRecord, WorkflowCommandStatus,
+    WorkflowCommandType, WorkflowEvent, WorkflowInstance, WorkflowRuntimeStore,
+    REPO_BACKLOG_POLL_ACTIVITY, REPO_BACKLOG_SPRINT_PLAN_ACTIVITY,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -58,6 +59,9 @@ const STUCK_STATES: &[&str] = &[
 const RECOVERY_TARGET_STATE: &str = "idle";
 const RECOVERY_EVENT_TYPE: &str = "RecoveryDetected";
 const RECOVERY_EVENT_SOURCE: &str = "stale_workflow_recovery";
+const LEGACY_REPO_BACKLOG_SPRINT_PLAN_ACTIVITY: &str = "plan_repo_sprint_from_scan";
+const REPO_BACKLOG_MARK_BOUND_ISSUE_DONE_ACTIVITY: &str = "mark_bound_issue_done";
+const REPO_BACKLOG_RECOVER_ISSUE_WORKFLOW_ACTIVITY: &str = "recover_issue_workflow";
 
 /// Default seconds a workflow must sit in a stuck state before recovery kicks
 /// in. 30 minutes is well above the longest legitimate `poll_repo_backlog`
@@ -201,6 +205,10 @@ async fn record_recovery_detected_event_and_reset_inner(
     force_rollback_after_event_insert: bool,
 ) -> anyhow::Result<RecoveryCommitOutcome> {
     let mut tx = store.pool().begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(format!("workflow_events:{workflow_id}"))
+        .execute(&mut *tx)
+        .await?;
     let Some((current_data,)) = sqlx::query_as::<_, (String,)>(
         "SELECT data::text FROM workflow_instances WHERE id = $1 FOR UPDATE",
     )
@@ -237,18 +245,9 @@ async fn record_recovery_detected_event_and_reset_inner(
 
     instance.state = RECOVERY_TARGET_STATE.to_string();
     instance.version = instance.version.saturating_add(1);
-    // Bump the JSON-baked updated_at so subsequent recovery ticks see a fresh
-    // timestamp and do not re-reset this same instance on every tick. The
-    // Postgres column updated_at is independently bumped below via
-    // CURRENT_TIMESTAMP, but list_instances_by_state returns instances with
-    // updated_at taken from the DB column and the JSON copy is still used by
-    // downstream replay/projection code.
+    // Keep the JSON timestamp fresh for replay/projection paths.
     instance.updated_at = Utc::now();
 
-    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
-        .bind(format!("workflow_events:{workflow_id}"))
-        .execute(&mut *tx)
-        .await?;
     let (next_sequence,): (i64,) = sqlx::query_as(
         "SELECT COALESCE(MAX(sequence), 0) + 1 FROM workflow_events WHERE workflow_id = $1",
     )
@@ -327,7 +326,7 @@ async fn workflow_has_active_repo_backlog_work_tx(
     .await?;
     for (command_id, status, data) in command_rows.into_iter().rev() {
         let command: WorkflowCommand = serde_json::from_str(&data)?;
-        if command.activity_name() != Some(REPO_BACKLOG_POLL_ACTIVITY) {
+        if !is_repo_backlog_runtime_command(&command) {
             continue;
         }
         match WorkflowCommandStatus::try_from(status.as_str())? {
@@ -361,7 +360,11 @@ async fn workflow_has_active_repo_backlog_work(
     workflow_id: &str,
 ) -> anyhow::Result<bool> {
     let commands = store.commands_for(workflow_id).await?;
-    for command in commands.iter().rev().filter(is_repo_backlog_poll_command) {
+    for command in commands
+        .iter()
+        .rev()
+        .filter(is_repo_backlog_runtime_command_record)
+    {
         match command.status {
             WorkflowCommandStatus::Pending | WorkflowCommandStatus::Dispatching => return Ok(true),
             WorkflowCommandStatus::Dispatched => {
@@ -381,8 +384,25 @@ async fn workflow_has_active_repo_backlog_work(
     Ok(false)
 }
 
-fn is_repo_backlog_poll_command(command: &&WorkflowCommandRecord) -> bool {
-    command.command.activity_name() == Some(REPO_BACKLOG_POLL_ACTIVITY)
+fn is_repo_backlog_runtime_command_record(command: &&WorkflowCommandRecord) -> bool {
+    is_repo_backlog_runtime_command(&command.command)
+}
+
+fn is_repo_backlog_runtime_command(command: &WorkflowCommand) -> bool {
+    if command.command_type == WorkflowCommandType::StartChildWorkflow {
+        return true;
+    }
+    command.command_type == WorkflowCommandType::EnqueueActivity
+        && matches!(
+            command.activity_name(),
+            Some(
+                REPO_BACKLOG_POLL_ACTIVITY
+                    | REPO_BACKLOG_SPRINT_PLAN_ACTIVITY
+                    | LEGACY_REPO_BACKLOG_SPRINT_PLAN_ACTIVITY
+                    | REPO_BACKLOG_MARK_BOUND_ISSUE_DONE_ACTIVITY
+                    | REPO_BACKLOG_RECOVER_ISSUE_WORKFLOW_ACTIVITY
+            )
+        )
 }
 
 /// Spawn the periodic recovery loop. Idempotent across restarts because each
@@ -566,28 +586,14 @@ mod tests {
 
     #[tokio::test]
     async fn recovery_tick_does_not_re_reset_workflow_on_subsequent_tick() {
-        // Regression: previously the tick used the JSON-baked updated_at on
-        // each iteration, which never advanced after upsert_instance because
-        // upsert_instance bumped the Postgres column via CURRENT_TIMESTAMP
-        // but did NOT mutate the deserialized struct's updated_at field.
-        // Result: the same workflow was reset on every 10-minute tick.
-        //
-        // The fix bumps `instance.updated_at = Utc::now()` before each upsert
-        // in the recovery path so the JSON timestamp stays in lock-step with
-        // the column. Verified here: with a 5-minute threshold, a workflow
-        // that was just recovered should not be re-recovered on an
-        // immediately-following tick.
         let Some(store) = open_recovery_test_store().await else {
             return;
         };
         let id = "test::stale-recovery::no-thrash";
         let mut seed = stuck_instance(id, "dispatching");
-        // Force the seed instance to look stale (JSON updated_at = 1h ago)
-        // so the first tick will resolve it.
         seed.updated_at = Utc::now() - chrono::Duration::hours(1);
         store.upsert_instance(&seed).await.unwrap();
 
-        // First tick with 5-min threshold: 1h-old instance is stale, must reset.
         let first = run_stale_workflow_recovery_tick(&store, 300).await.unwrap();
         assert!(
             first.recovered >= 1,
@@ -597,21 +603,11 @@ mod tests {
         let post_first = store.get_instance(id).await.unwrap().unwrap();
         assert_eq!(post_first.state, "idle");
 
-        // Simulate the workflow transitioning back to a stuck state via the
-        // reducer path that historically does NOT bump the JSON updated_at.
-        // The recovery fix means post_first.updated_at is now ~"first-tick
-        // now"; a reducer that copies that value forward writes a JSON
-        // timestamp that is well within the 5-minute window.
         let mut transitioned = post_first.clone();
         transitioned.state = "dispatching".to_string();
         transitioned.version = transitioned.version.saturating_add(1);
-        // Intentionally do NOT touch transitioned.updated_at — mimics the
-        // upstream reducer behavior we observed in production.
         store.upsert_instance(&transitioned).await.unwrap();
 
-        // Second tick with the same 5-min threshold MUST NOT reset, because
-        // the workflow's JSON updated_at is now "fresh" relative to the
-        // 5-minute cutoff.
         let second = run_stale_workflow_recovery_tick(&store, 300).await.unwrap();
         assert_eq!(
             second.recovered, 0,
@@ -721,50 +717,75 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn recovery_tick_skips_workflow_with_active_runtime_job() -> anyhow::Result<()> {
+    async fn recovery_tick_skips_workflow_with_active_repo_backlog_runtime_work(
+    ) -> anyhow::Result<()> {
         let Some(store) = open_recovery_test_store().await else {
             return Ok(());
         };
-        let id = "test::stale-recovery::active-runtime-job";
-        let mut instance = stuck_instance(id, "scanning");
-        instance.updated_at = Utc::now() - chrono::Duration::hours(1);
-        store.upsert_instance(&instance).await?;
-        let command =
-            WorkflowCommand::enqueue_activity(REPO_BACKLOG_POLL_ACTIVITY, "active-runtime-job");
-        let command_id = store.enqueue_command(id, None, &command).await?;
-        store
-            .enqueue_runtime_job(
-                &command_id,
-                RuntimeKind::CodexJsonrpc,
-                "codex-default",
-                json!({ "activity": REPO_BACKLOG_POLL_ACTIVITY }),
-            )
-            .await?;
-        store
-            .mark_command_status(&command_id, WorkflowCommandStatus::Dispatched)
-            .await?;
+        let cases = vec![
+            (
+                "scanning",
+                WorkflowCommand::enqueue_activity(REPO_BACKLOG_POLL_ACTIVITY, "active-scan"),
+            ),
+            (
+                "planning_batch",
+                WorkflowCommand::enqueue_activity(REPO_BACKLOG_SPRINT_PLAN_ACTIVITY, "active-plan"),
+            ),
+            (
+                "dispatching",
+                WorkflowCommand::start_child_workflow(
+                    "github_issue_pr",
+                    "issue:1",
+                    "active-dispatch",
+                ),
+            ),
+            (
+                "reconciling",
+                WorkflowCommand::enqueue_activity(
+                    REPO_BACKLOG_MARK_BOUND_ISSUE_DONE_ACTIVITY,
+                    "active-mark",
+                ),
+            ),
+            (
+                "reconciling",
+                WorkflowCommand::enqueue_activity(
+                    REPO_BACKLOG_RECOVER_ISSUE_WORKFLOW_ACTIVITY,
+                    "active-recover",
+                ),
+            ),
+        ];
+        for (index, (state, command)) in cases.into_iter().enumerate() {
+            let id = format!("test::stale-recovery::active-runtime-work::{index}");
+            let mut instance = stuck_instance(&id, state);
+            instance.updated_at = Utc::now() - chrono::Duration::hours(1);
+            store.upsert_instance(&instance).await?;
+            let activity = command.runtime_activity_key().to_string();
+            let command_id = store.enqueue_command(&id, None, &command).await?;
+            store
+                .enqueue_runtime_job(
+                    &command_id,
+                    RuntimeKind::CodexJsonrpc,
+                    "codex-default",
+                    json!({ "activity": activity }),
+                )
+                .await?;
+            store
+                .mark_command_status(&command_id, WorkflowCommandStatus::Dispatched)
+                .await?;
 
-        let tick = run_stale_workflow_recovery_tick(&store, 300).await?;
-
-        let after = store.get_instance(id).await?.ok_or_else(|| {
-            anyhow::anyhow!("active runtime workflow missing after recovery tick")
-        })?;
-        assert_eq!(
-            after.state, "scanning",
-            "active runtime work must protect the workflow from stale recovery"
-        );
-        assert_eq!(tick.recovered, 0);
-        assert!(
-            tick.skipped_active >= 1,
-            "active runtime job should be counted as an active skip"
-        );
-        let events = store.events_for(id).await?;
-        assert!(
-            events
+            let tick = run_stale_workflow_recovery_tick(&store, 300).await?;
+            let after = store
+                .get_instance(&id)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("active workflow missing after recovery tick"))?;
+            assert_eq!(after.state, state);
+            assert_eq!(tick.recovered, 0);
+            assert!(tick.skipped_active >= 1);
+            let events = store.events_for(&id).await?;
+            assert!(events
                 .iter()
-                .all(|event| event.event_type != RECOVERY_EVENT_TYPE),
-            "active runtime work should not emit a recovery event"
-        );
+                .all(|event| event.event_type != RECOVERY_EVENT_TYPE));
+        }
         Ok(())
     }
 }

--- a/crates/harness-server/src/stale_workflow_recovery.rs
+++ b/crates/harness-server/src/stale_workflow_recovery.rs
@@ -27,8 +27,8 @@ use std::time::Duration;
 
 use chrono::Utc;
 use harness_workflow::runtime::{
-    RuntimeJobStatus, WorkflowCommandRecord, WorkflowCommandStatus, WorkflowRuntimeStore,
-    REPO_BACKLOG_POLL_ACTIVITY,
+    RuntimeJobStatus, WorkflowCommandRecord, WorkflowCommandStatus, WorkflowEvent,
+    WorkflowInstance, WorkflowRuntimeStore, REPO_BACKLOG_POLL_ACTIVITY,
 };
 use serde_json::json;
 
@@ -116,24 +116,6 @@ pub async fn run_stale_workflow_recovery_tick(
                 );
                 continue;
             }
-            if let Err(error) = record_recovery_detected_event(
-                store,
-                &instance.id,
-                &original_state,
-                stuck_secs,
-                stale_after_secs,
-            )
-            .await
-            {
-                tracing::warn!(
-                    workflow_id = %instance.id,
-                    from_state = %original_state,
-                    stuck_secs,
-                    "stale_workflow_recovery: recovery evidence write failed: {error}"
-                );
-                tick.failed += 1;
-                continue;
-            }
             instance.state = RECOVERY_TARGET_STATE.to_string();
             instance.version = instance.version.saturating_add(1);
             // Bump the JSON-baked updated_at so subsequent recovery ticks see a
@@ -152,7 +134,15 @@ pub async fn run_stale_workflow_recovery_tick(
             // restart, despite having transitioned through scanning legitimately
             // in between.
             instance.updated_at = Utc::now();
-            match store.upsert_instance(&instance).await {
+            match record_recovery_detected_event_and_reset(
+                store,
+                &instance,
+                &original_state,
+                stuck_secs,
+                stale_after_secs,
+            )
+            .await
+            {
                 Ok(()) => {
                     tracing::warn!(
                         workflow_id = %instance.id,
@@ -168,7 +158,7 @@ pub async fn run_stale_workflow_recovery_tick(
                         workflow_id = %instance.id,
                         from_state = %original_state,
                         stuck_secs,
-                        "stale_workflow_recovery: upsert failed: {error}"
+                        "stale_workflow_recovery: atomic recovery write failed: {error}"
                     );
                     tick.failed += 1;
                 }
@@ -178,28 +168,81 @@ pub async fn run_stale_workflow_recovery_tick(
     Ok(tick)
 }
 
-async fn record_recovery_detected_event(
+async fn record_recovery_detected_event_and_reset(
     store: &WorkflowRuntimeStore,
-    workflow_id: &str,
+    instance: &WorkflowInstance,
     original_state: &str,
     stuck_secs: i64,
     stale_after_secs: u64,
 ) -> anyhow::Result<()> {
-    store
-        .append_event(
-            workflow_id,
-            RECOVERY_EVENT_TYPE,
-            RECOVERY_EVENT_SOURCE,
-            json!({
-                "definition_id": RECOVERED_DEFINITION_ID,
-                "from_state": original_state,
-                "to_state": RECOVERY_TARGET_STATE,
-                "stuck_secs": stuck_secs,
-                "stale_after_secs": stale_after_secs,
-                "reason": "repo_backlog workflow exceeded stale recovery threshold without active repo backlog work",
-            }),
-        )
+    let payload = json!({
+        "definition_id": RECOVERED_DEFINITION_ID,
+        "from_state": original_state,
+        "to_state": RECOVERY_TARGET_STATE,
+        "stuck_secs": stuck_secs,
+        "stale_after_secs": stale_after_secs,
+        "reason": "repo_backlog workflow exceeded stale recovery threshold without active repo backlog work",
+    });
+
+    let mut tx = store.pool().begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(format!("workflow_events:{}", instance.id))
+        .execute(&mut *tx)
         .await?;
+    let (next_sequence,): (i64,) = sqlx::query_as(
+        "SELECT COALESCE(MAX(sequence), 0) + 1 FROM workflow_events WHERE workflow_id = $1",
+    )
+    .bind(&instance.id)
+    .fetch_one(&mut *tx)
+    .await?;
+    let event = WorkflowEvent::new(
+        &instance.id,
+        next_sequence as u64,
+        RECOVERY_EVENT_TYPE,
+        RECOVERY_EVENT_SOURCE,
+    )
+    .with_payload(payload);
+    let event_data = serde_json::to_string(&event)?;
+    sqlx::query(
+        "INSERT INTO workflow_events
+            (id, workflow_id, sequence, event_type, source, data)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
+    )
+    .bind(&event.id)
+    .bind(&event.workflow_id)
+    .bind(event.sequence as i64)
+    .bind(&event.event_type)
+    .bind(&event.source)
+    .bind(&event_data)
+    .execute(&mut *tx)
+    .await?;
+
+    let instance_data = serde_json::to_string(instance)?;
+    sqlx::query(
+        "INSERT INTO workflow_instances
+            (id, definition_id, state, subject_type, subject_key, parent_workflow_id, data, version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+         ON CONFLICT (id) DO UPDATE SET
+            definition_id = EXCLUDED.definition_id,
+            state = EXCLUDED.state,
+            subject_type = EXCLUDED.subject_type,
+            subject_key = EXCLUDED.subject_key,
+            parent_workflow_id = EXCLUDED.parent_workflow_id,
+            data = EXCLUDED.data,
+            version = EXCLUDED.version,
+            updated_at = CURRENT_TIMESTAMP",
+    )
+    .bind(&instance.id)
+    .bind(&instance.definition_id)
+    .bind(&instance.state)
+    .bind(&instance.subject.subject_type)
+    .bind(&instance.subject.subject_key)
+    .bind(&instance.parent_workflow_id)
+    .bind(&instance_data)
+    .bind(instance.version as i64)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
     Ok(())
 }
 
@@ -351,10 +394,7 @@ mod tests {
             recovery_event.event["stuck_secs"].as_i64().is_some(),
             "recovery event should include stale duration evidence"
         );
-        assert!(
-            recovery_event.created_at <= post.updated_at,
-            "recovery evidence should be recorded before the reset completes"
-        );
+        assert_eq!(recovery_event.workflow_id, post.id);
         Ok(())
     }
 

--- a/crates/harness-server/src/stale_workflow_recovery.rs
+++ b/crates/harness-server/src/stale_workflow_recovery.rs
@@ -779,7 +779,6 @@ mod tests {
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("active workflow missing after recovery tick"))?;
             assert_eq!(after.state, state);
-            assert_eq!(tick.recovered, 0);
             assert!(tick.skipped_active >= 1);
             let events = store.events_for(&id).await?;
             assert!(events

--- a/crates/harness-server/src/stale_workflow_recovery.rs
+++ b/crates/harness-server/src/stale_workflow_recovery.rs
@@ -496,6 +496,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recovery_tick_does_not_reset_when_recovery_event_write_fails() -> anyhow::Result<()> {
+        let Some(store) = open_recovery_test_store().await else {
+            return Ok(());
+        };
+        let id = "test::stale-recovery::evidence-write-fails";
+        let mut instance = stuck_instance(id, "dispatching");
+        instance.updated_at = Utc::now() - chrono::Duration::hours(1);
+        store.upsert_instance(&instance).await?;
+
+        sqlx::query("DROP TABLE workflow_events")
+            .execute(store.pool())
+            .await?;
+
+        let tick = run_stale_workflow_recovery_tick(&store, 300).await?;
+
+        let Some(after) = store.get_instance(id).await? else {
+            anyhow::bail!("seeded workflow should still exist after failed recovery");
+        };
+        assert_eq!(
+            after.state, "dispatching",
+            "failed evidence persistence must not reset workflow state"
+        );
+        assert_eq!(
+            after.version, instance.version,
+            "failed evidence persistence must not bump workflow version"
+        );
+        assert_eq!(tick.recovered, 0);
+        assert!(
+            tick.failed >= 1,
+            "failed evidence persistence should be counted as failed recovery"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn recovery_tick_skips_workflow_with_active_runtime_job() -> anyhow::Result<()> {
         let Some(store) = open_recovery_test_store().await else {
             return Ok(());


### PR DESCRIPTION
## Summary

- record a `RecoveryDetected` workflow event before stale repo backlog recovery resets state
- include recovery evidence payload with definition, source/target states, threshold, and stuck duration
- skip the reset and count the candidate as failed when evidence persistence fails
- extend stale recovery tests to verify recovery evidence and active-work skip behavior

Closes #1387.
Part of #1226.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p harness-server stale_workflow_recovery -- --nocapture`
- `git diff --check`
- `cargo check -p harness-server --all-targets --quiet`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets --quiet`
- `cargo test -p harness-agents codex::tests::execute_kills_descendant_that_keeps_output_pipe_open_after_root_exit -- --nocapture`
- `cargo test --workspace --quiet`

Note: the first full workspace test run hit the known intermittent `harness-agents` timeout in `codex::tests::execute_kills_descendant_that_keeps_output_pipe_open_after_root_exit`; the exact test passed on rerun, and the subsequent full workspace test passed.
