### PR TITLE
fix(runtime): transact parent completion propagation

### DIFF
--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -7,11 +7,11 @@ use super::model::{
 use super::pr_feedback::PR_FEEDBACK_DEFINITION_ID;
 use super::prompt_task::PROMPT_TASK_DEFINITION_ID;
 use super::quality_gate::QUALITY_GATE_DEFINITION_ID;
-use super::reducer::{reduce_runtime_job_completed, GITHUB_ISSUE_PR_DEFINITION_ID};
+use super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID;
 use super::repo_backlog::REPO_BACKLOG_DEFINITION_ID;
 use super::status::WorkflowCommandStatus;
 use super::store_migrations::WORKFLOW_RUNTIME_MIGRATIONS;
-use super::validator::{DecisionValidator, ValidationContext};
+use super::validator::DecisionValidator;
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 use harness_core::db::PgStoreContext;
@@ -25,6 +25,8 @@ use std::path::Path;
 mod command_store;
 #[path = "store/instances.rs"]
 mod instances;
+#[path = "store/runtime_completion.rs"]
+mod runtime_completion;
 #[path = "store/submission_commit.rs"]
 mod submission_commit;
 pub use submission_commit::{
@@ -1378,73 +1380,13 @@ impl WorkflowRuntimeStore {
         .execute(&mut *tx)
         .await?;
 
-        let decision_record = match sqlx::query_as::<_, (String,)>(
-            "SELECT data::text FROM workflow_instances WHERE id = $1 FOR UPDATE",
+        let decision_record = runtime_completion::apply_runtime_completion_decision_tx(
+            &mut tx,
+            &command.workflow_id,
+            owner,
+            &event,
         )
-        .bind(&command.workflow_id)
-        .fetch_optional(&mut *tx)
-        .await?
-        {
-            Some((instance_data,)) => {
-                let mut instance: WorkflowInstance = serde_json::from_str(&instance_data)?;
-                match reduce_runtime_job_completed(&instance, &event)? {
-                    Some(decision) => {
-                        let validator = validator_for_definition(&instance.definition_id);
-                        let record = match validator {
-                            Some(validator) => {
-                                match validator.validate(
-                                    &instance,
-                                    &decision,
-                                    &ValidationContext::new(owner, event.created_at),
-                                ) {
-                                    Ok(()) => WorkflowDecisionRecord::accepted(
-                                        decision.clone(),
-                                        Some(event.id.clone()),
-                                    ),
-                                    Err(error) => WorkflowDecisionRecord::rejected(
-                                        decision,
-                                        Some(event.id.clone()),
-                                        error.to_string(),
-                                    ),
-                                }
-                            }
-                            None => WorkflowDecisionRecord::rejected(
-                                decision,
-                                Some(event.id.clone()),
-                                "unknown workflow definition for runtime completion",
-                            ),
-                        };
-                        insert_decision_record_tx(&mut tx, &record).await?;
-                        if record.accepted {
-                            for followup in &record.decision.commands {
-                                let status = if followup.requires_runtime_job() {
-                                    WorkflowCommandStatus::Pending
-                                } else {
-                                    WorkflowCommandStatus::HandledInline
-                                };
-                                command_store::insert_tx(
-                                    &mut tx,
-                                    &instance.id,
-                                    Some(&record.id),
-                                    followup,
-                                    status,
-                                )
-                                .await?;
-                                if !followup.requires_runtime_job() {
-                                    apply_inline_command_side_effect(&mut instance, followup)?;
-                                }
-                            }
-                            instance.state = record.decision.next_state.clone();
-                            instance.version = instance.version.saturating_add(1);
-                            upsert_instance_tx(&mut tx, &instance).await?;
-                        }
-                        Some(record)
-                    }
-                    None => None,
-                }
-            }
-            None => None,
-        };
+        .await?;
 
         tx.commit().await?;
         Ok(Some(RuntimeActivityCompletion {

--- a/crates/harness-workflow/src/runtime/store/runtime_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion.rs
@@ -1,0 +1,104 @@
+use super::{
+    apply_inline_command_side_effect, command_store, insert_decision_record_tx, insert_event_tx,
+    select_instance_for_update_tx, upsert_instance_tx, validator_for_definition,
+    WorkflowRuntimeStore,
+};
+use crate::runtime::model::{WorkflowDecisionRecord, WorkflowEvent, WorkflowInstance};
+use crate::runtime::reducer::reduce_runtime_job_completed;
+use crate::runtime::status::WorkflowCommandStatus;
+use crate::runtime::validator::ValidationContext;
+use serde_json::Value;
+
+impl WorkflowRuntimeStore {
+    pub async fn commit_parent_runtime_completion(
+        &self,
+        parent_workflow_id: &str,
+        source: &str,
+        payload: Value,
+    ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
+        let mut tx = self.pool.begin().await?;
+        let Some(instance) = select_instance_for_update_tx(&mut tx, parent_workflow_id).await?
+        else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+        // Keep the same lock order as workflow transitions: instance row first,
+        // workflow event sequence lock second.
+        let event = insert_event_tx(
+            &mut tx,
+            parent_workflow_id,
+            "RuntimeJobCompleted",
+            source,
+            payload,
+        )
+        .await?;
+        let decision =
+            apply_runtime_completion_decision_for_instance_tx(&mut tx, instance, source, &event)
+                .await?;
+        tx.commit().await?;
+        Ok(decision)
+    }
+}
+
+pub(super) async fn apply_runtime_completion_decision_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workflow_id: &str,
+    source: &str,
+    event: &WorkflowEvent,
+) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
+    let Some(instance) = select_instance_for_update_tx(tx, workflow_id).await? else {
+        return Ok(None);
+    };
+    apply_runtime_completion_decision_for_instance_tx(tx, instance, source, event).await
+}
+
+async fn apply_runtime_completion_decision_for_instance_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    mut instance: WorkflowInstance,
+    source: &str,
+    event: &WorkflowEvent,
+) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
+    let Some(decision) = reduce_runtime_job_completed(&instance, event)? else {
+        return Ok(None);
+    };
+
+    let record = match validator_for_definition(&instance.definition_id) {
+        Some(validator) => match validator.validate(
+            &instance,
+            &decision,
+            &ValidationContext::new(source, event.created_at),
+        ) {
+            Ok(()) => WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id.clone())),
+            Err(error) => WorkflowDecisionRecord::rejected(
+                decision,
+                Some(event.id.clone()),
+                error.to_string(),
+            ),
+        },
+        None => WorkflowDecisionRecord::rejected(
+            decision,
+            Some(event.id.clone()),
+            "unknown workflow definition for runtime completion",
+        ),
+    };
+    insert_decision_record_tx(tx, &record).await?;
+
+    if record.accepted {
+        for followup in &record.decision.commands {
+            let status = if followup.requires_runtime_job() {
+                WorkflowCommandStatus::Pending
+            } else {
+                WorkflowCommandStatus::HandledInline
+            };
+            command_store::insert_tx(tx, &instance.id, Some(&record.id), followup, status).await?;
+            if !followup.requires_runtime_job() {
+                apply_inline_command_side_effect(&mut instance, followup)?;
+            }
+        }
+        instance.state = record.decision.next_state.clone();
+        instance.version = instance.version.saturating_add(1);
+        upsert_instance_tx(tx, &instance).await?;
+    }
+
+    Ok(Some(record))
+}

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -5269,6 +5269,120 @@ async fn runtime_worker_propagates_pr_feedback_child_completion_to_parent() -> a
     Ok(())
 }
 
+#[tokio::test]
+async fn runtime_store_commits_parent_completion_event_decision_and_command() -> anyhow::Result<()>
+{
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let parent = issue_instance("awaiting_feedback")
+        .with_id("issue-parent-transaction")
+        .with_data(json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "task_id": "runtime-task-77",
+        }));
+    store.upsert_instance(&parent).await?;
+    let result = ActivityResult::succeeded(
+        PR_FEEDBACK_INSPECT_ACTIVITY,
+        "Runtime child workflow found actionable PR feedback.",
+    )
+    .with_signal(ActivitySignal::new(
+        "FeedbackFound",
+        json!({ "pr_number": 77, "count": 1 }),
+    ));
+
+    let record = store
+        .commit_parent_runtime_completion(
+            &parent.id,
+            "runtime-1",
+            json!({
+                "command_id": "child-command-1",
+                "runtime_job_id": "child-job-1",
+                "child_workflow_id": "pr-feedback-child-transaction",
+                "activity_result": result,
+            }),
+        )
+        .await?
+        .expect("parent completion should produce a decision");
+
+    assert!(record.accepted);
+    assert_eq!(record.decision.decision, "address_pr_feedback");
+    let parent_after = store
+        .get_instance(&parent.id)
+        .await?
+        .expect("parent workflow should still exist");
+    assert_eq!(parent_after.state, "addressing_feedback");
+    let parent_events = store.events_for(&parent.id).await?;
+    assert!(parent_events.iter().any(|event| {
+        event.event_type == "RuntimeJobCompleted"
+            && event.event["child_workflow_id"] == "pr-feedback-child-transaction"
+    }));
+    let parent_decisions = store.decisions_for(&parent.id).await?;
+    assert_eq!(parent_decisions.len(), 1);
+    assert_eq!(parent_decisions[0].id, record.id);
+    let parent_commands = store.commands_for(&parent.id).await?;
+    assert_eq!(parent_commands.len(), 1);
+    assert_eq!(
+        parent_commands[0].command.activity_name(),
+        Some("address_pr_feedback")
+    );
+    assert_eq!(
+        parent_commands[0].decision_id.as_deref(),
+        Some(record.id.as_str())
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_store_rolls_back_parent_completion_when_reducer_fails() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let parent = issue_instance("awaiting_feedback")
+        .with_id("issue-parent-rollback")
+        .with_data(json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "task_id": "runtime-task-77",
+        }));
+    store.upsert_instance(&parent).await?;
+
+    let error = store
+        .commit_parent_runtime_completion(
+            &parent.id,
+            "runtime-1",
+            json!({
+                "command_id": "child-command-rollback",
+                "runtime_job_id": "child-job-rollback",
+                "child_workflow_id": "pr-feedback-child-rollback",
+                "activity_result": "not an activity result",
+            }),
+        )
+        .await
+        .expect_err("malformed activity_result should fail the parent completion transaction");
+
+    assert!(
+        error.to_string().contains("invalid type"),
+        "unexpected error: {error:#}"
+    );
+    let parent_after = store
+        .get_instance(&parent.id)
+        .await?
+        .expect("parent workflow should still exist");
+    assert_eq!(parent_after.state, "awaiting_feedback");
+    assert!(store.events_for(&parent.id).await?.is_empty());
+    assert!(store.decisions_for(&parent.id).await?.is_empty());
+    assert!(store.commands_for(&parent.id).await?.is_empty());
+    Ok(())
+}
+
 async fn seed_quality_gate_child_job(
     store: &WorkflowRuntimeStore,
     parent_id: &str,

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -1,18 +1,13 @@
 use super::model::{
     ActivityResult, ActivityStatus, RuntimeJob, RuntimeKind, RuntimeProfile, WorkflowCommand,
-    WorkflowCommandRecord, WorkflowCommandType, WorkflowInstance,
+    WorkflowCommandRecord, WorkflowInstance,
 };
-use super::reducer::reduce_runtime_job_completed;
-use super::status::WorkflowCommandStatus;
 use super::store::WorkflowRuntimeStore;
-use super::validator::{DecisionValidator, ValidationContext};
 use anyhow::Context;
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
 use serde_json::{json, Value};
 use std::time::Duration as StdDuration;
-
-const COMMAND_STATUS_HANDLED_INLINE: WorkflowCommandStatus = WorkflowCommandStatus::HandledInline;
 
 #[async_trait]
 pub trait RuntimeJobExecutor: Send + Sync {
@@ -240,17 +235,14 @@ impl<'a> RuntimeWorker<'a> {
         let Some(parent_workflow_id) = child.parent_workflow_id.as_deref() else {
             return Ok(());
         };
-        let parent_event = self
-            .store
-            .append_event(
+        self.store
+            .commit_parent_runtime_completion(
                 parent_workflow_id,
-                "RuntimeJobCompleted",
                 &self.owner,
                 merge_child_completion_payload(event, &child.id),
             )
             .await?;
-        self.apply_runtime_completion_reducer(parent_workflow_id, &parent_event)
-            .await
+        Ok(())
     }
 
     async fn propagate_quality_gate_child_completion(
@@ -273,81 +265,14 @@ impl<'a> RuntimeWorker<'a> {
         let Some(parent_workflow_id) = child.parent_workflow_id.as_deref() else {
             return Ok(());
         };
-        let parent_event = self
-            .store
-            .append_event(
+        self.store
+            .commit_parent_runtime_completion(
                 parent_workflow_id,
-                "RuntimeJobCompleted",
                 &self.owner,
                 merge_child_completion_payload(event, &child.id),
             )
             .await?;
-        self.apply_runtime_completion_reducer(parent_workflow_id, &parent_event)
-            .await
-    }
-
-    async fn apply_runtime_completion_reducer(
-        &self,
-        workflow_id: &str,
-        event: &super::model::WorkflowEvent,
-    ) -> anyhow::Result<()> {
-        let Some(mut instance) = self.store.get_instance(workflow_id).await? else {
-            return Ok(());
-        };
-        let Some(decision) = reduce_runtime_job_completed(&instance, event)? else {
-            return Ok(());
-        };
-
-        let validator = match instance.definition_id.as_str() {
-            super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID => DecisionValidator::github_issue_pr(),
-            super::quality_gate::QUALITY_GATE_DEFINITION_ID => DecisionValidator::quality_gate(),
-            super::pr_feedback::PR_FEEDBACK_DEFINITION_ID => DecisionValidator::pr_feedback(),
-            super::prompt_task::PROMPT_TASK_DEFINITION_ID => DecisionValidator::prompt_task(),
-            super::repo_backlog::REPO_BACKLOG_DEFINITION_ID => DecisionValidator::repo_backlog(),
-            _ => return Ok(()),
-        };
-        let validation = validator.validate(
-            &instance,
-            &decision,
-            &ValidationContext::new(&self.owner, event.created_at),
-        );
-        let record = match validation {
-            Ok(()) => super::model::WorkflowDecisionRecord::accepted(
-                decision.clone(),
-                Some(event.id.clone()),
-            ),
-            Err(error) => {
-                let record = super::model::WorkflowDecisionRecord::rejected(
-                    decision,
-                    Some(event.id.clone()),
-                    error.to_string(),
-                );
-                self.store.record_decision(&record).await?;
-                return Ok(());
-            }
-        };
-
-        self.store.record_decision(&record).await?;
-        for command in &decision.commands {
-            if command.requires_runtime_job() {
-                self.store
-                    .enqueue_command(&instance.id, Some(&record.id), command)
-                    .await?;
-            } else {
-                self.store
-                    .enqueue_command_with_status(
-                        &instance.id,
-                        Some(&record.id),
-                        command,
-                        COMMAND_STATUS_HANDLED_INLINE,
-                    )
-                    .await?;
-                apply_inline_command_side_effect(&mut instance, command)?;
-            }
-        }
-        instance.state = decision.next_state.clone();
-        instance.version = instance.version.saturating_add(1);
-        self.store.upsert_instance(&instance).await
+        Ok(())
     }
 
     async fn max_turns_budget_result(
@@ -437,20 +362,6 @@ fn merge_child_completion_payload(
     payload
 }
 
-fn apply_inline_command_side_effect(
-    instance: &mut WorkflowInstance,
-    command: &WorkflowCommand,
-) -> anyhow::Result<()> {
-    match command.command_type {
-        WorkflowCommandType::BindPr => apply_bind_pr_side_effect(instance, command),
-        WorkflowCommandType::MarkDone => apply_mark_done_side_effect(instance, command),
-        WorkflowCommandType::MarkFailed
-        | WorkflowCommandType::MarkBlocked
-        | WorkflowCommandType::MarkCancelled => apply_failure_reason_side_effect(instance, command),
-        _ => Ok(()),
-    }
-}
-
 /// Persist the terminal-failure `reason` into the instance `data` under
 /// `failure_reason` so task queries surface it as the task `error`. Without
 /// this the reason lives only in the command payload/event log and the task
@@ -476,51 +387,6 @@ pub(super) fn apply_failure_reason_side_effect(
         .as_object_mut()
         .context("workflow instance data is not an object")?;
     data.insert("failure_reason".to_string(), json!(reason));
-    Ok(())
-}
-
-fn apply_bind_pr_side_effect(
-    instance: &mut WorkflowInstance,
-    command: &WorkflowCommand,
-) -> anyhow::Result<()> {
-    let pr_number = command
-        .command
-        .get("pr_number")
-        .and_then(Value::as_u64)
-        .context("bind_pr command missing pr_number")?;
-    let pr_url = command
-        .command
-        .get("pr_url")
-        .and_then(Value::as_str)
-        .context("bind_pr command missing pr_url")?;
-
-    if !instance.data.is_object() {
-        instance.data = json!({});
-    }
-    let data = instance
-        .data
-        .as_object_mut()
-        .context("workflow instance data is not an object")?;
-    data.insert("pr_number".to_string(), json!(pr_number));
-    data.insert("pr_url".to_string(), json!(pr_url));
-    Ok(())
-}
-
-fn apply_mark_done_side_effect(
-    instance: &mut WorkflowInstance,
-    command: &WorkflowCommand,
-) -> anyhow::Result<()> {
-    let Some(closed_issue_evidence) = command.command.get("closed_issue_evidence").cloned() else {
-        return Ok(());
-    };
-    if !instance.data.is_object() {
-        instance.data = json!({});
-    }
-    let data = instance
-        .data
-        .as_object_mut()
-        .context("workflow instance data is not an object")?;
-    data.insert("closed_issue_evidence".to_string(), closed_issue_evidence);
     Ok(())
 }
 
@@ -559,7 +425,9 @@ fn runtime_budget_blocked_result(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::{RuntimeJobStatus, RuntimeKind, WorkflowRuntimeStore};
+    use crate::runtime::{
+        RuntimeJobStatus, RuntimeKind, WorkflowCommandType, WorkflowRuntimeStore,
+    };
     use async_trait::async_trait;
     use harness_core::db::resolve_database_url;
     use serde_json::json;
@@ -694,7 +562,7 @@ mod tests {
             json!({ "reason": "Agent turn timed out after 900s" }),
         );
 
-        apply_inline_command_side_effect(&mut instance, &command).unwrap();
+        apply_failure_reason_side_effect(&mut instance, &command).unwrap();
 
         assert_eq!(
             instance.data.get("failure_reason").and_then(Value::as_str),
@@ -719,7 +587,7 @@ mod tests {
             json!({}),
         );
 
-        apply_inline_command_side_effect(&mut instance, &command).unwrap();
+        apply_failure_reason_side_effect(&mut instance, &command).unwrap();
 
         assert!(instance.data.get("failure_reason").is_none());
     }


### PR DESCRIPTION
## Summary
- add a store-owned parent RuntimeJobCompleted transaction helper
- route PR-feedback and quality-gate child propagation through the store transaction boundary
- add store-level success and rollback coverage for parent completion propagation

Closes #1391

## Tests
- cargo check -p harness-workflow
- cargo fmt --all -- --check
- cargo test -p harness-workflow runtime_store_commits_parent_completion_event_decision_and_command -- --nocapture
- cargo test -p harness-workflow runtime_store_rolls_back_parent_completion_when_reducer_fails -- --nocapture
- cargo test -p harness-workflow runtime_worker_propagates_pr_feedback_child_completion_to_parent -- --nocapture
- cargo test -p harness-workflow runtime_worker_propagates_quality_gate_child -- --nocapture
- cargo test -p harness-workflow runtime_worker_does_not_propagate_still_inspecting_pr_feedback_child -- --nocapture
- cargo test -p harness-workflow runtime_worker_does_not_propagate_retrying_pr_feedback_child -- --nocapture
- cargo test -p harness-workflow runtime_worker_does_not_propagate_terminal_pr_feedback_child_failure -- --nocapture
- cargo test -p harness-workflow
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo test --workspace --quiet