### PR TITLE
Summarize workflow projection buckets

### DIFF
--- a/crates/harness-cli/src/commands/status.rs
+++ b/crates/harness-cli/src/commands/status.rs
@@ -11,6 +11,9 @@ const REQUEST_TIMEOUT_SECS: u64 = 5;
 #[derive(Debug, Default, PartialEq, Eq)]
 struct RuntimeTreeSummary {
     workflows: usize,
+    workflow_statuses: BTreeMap<String, usize>,
+    workflow_scheduler_states: BTreeMap<String, usize>,
+    workflow_active_buckets: BTreeMap<String, usize>,
     commands: usize,
     command_statuses: BTreeMap<String, usize>,
     jobs: usize,
@@ -214,6 +217,15 @@ fn print_summary(combined: &Value) {
         "Runtime workflows: {} workflows, {} commands, {} jobs",
         runtime_summary.workflows, runtime_summary.commands, runtime_summary.jobs
     );
+    print_count_map("Workflow statuses", &runtime_summary.workflow_statuses);
+    print_count_map(
+        "Workflow scheduler states",
+        &runtime_summary.workflow_scheduler_states,
+    );
+    print_count_map(
+        "Workflow active buckets",
+        &runtime_summary.workflow_active_buckets,
+    );
     print_count_map("Command statuses", &runtime_summary.command_statuses);
     print_count_map("Runtime job statuses", &runtime_summary.job_statuses);
     print_count_map(
@@ -239,6 +251,11 @@ fn summarize_runtime_tree(tree: &Value) -> RuntimeTreeSummary {
     };
     let has_server_summary = tree["summary"].is_object();
     if has_server_summary {
+        summary.workflow_statuses = count_map_from_value(&tree["summary"]["workflow_statuses"]);
+        summary.workflow_scheduler_states =
+            count_map_from_value(&tree["summary"]["workflow_scheduler_states"]);
+        summary.workflow_active_buckets =
+            count_map_from_value(&tree["summary"]["workflow_active_buckets"]);
         summary.commands = tree["summary"]["total_commands"].as_u64().unwrap_or(0) as usize;
         summary.jobs = tree["summary"]["total_runtime_jobs"].as_u64().unwrap_or(0) as usize;
         summary.command_statuses = count_map_from_value(&tree["summary"]["command_statuses"]);
@@ -259,6 +276,17 @@ fn summarize_runtime_tree(tree: &Value) -> RuntimeTreeSummary {
 }
 
 fn summarize_workflow_node(node: &Value, summary: &mut RuntimeTreeSummary, include_counts: bool) {
+    if include_counts {
+        if let Some(status) = node["projection"]["status"].as_str() {
+            increment(&mut summary.workflow_statuses, status);
+        }
+        if let Some(authority_state) = node["projection"]["scheduler"]["authority_state"].as_str() {
+            increment(&mut summary.workflow_scheduler_states, authority_state);
+        }
+        if let Some(active_bucket) = node["projection"]["active_bucket"].as_str() {
+            increment(&mut summary.workflow_active_buckets, active_bucket);
+        }
+    }
     if let Some(commands) = node["commands"].as_array() {
         for command in commands {
             if include_counts {
@@ -378,6 +406,13 @@ mod tests {
         let tree = json!({
             "total_workflows": 2,
             "workflows": [{
+                "projection": {
+                    "status": "implementing",
+                    "scheduler": {
+                        "authority_state": "running"
+                    },
+                    "active_bucket": "running"
+                },
                 "commands": [{
                     "status": "completed",
                         "runtime_jobs": [{
@@ -389,6 +424,13 @@ mod tests {
                     }]
                 }],
                 "children": [{
+                    "projection": {
+                        "status": "waiting",
+                        "scheduler": {
+                            "authority_state": "queued"
+                        },
+                        "active_bucket": "queued"
+                    },
                     "commands": [{
                         "status": "pending",
                         "runtime_jobs": [{
@@ -404,6 +446,12 @@ mod tests {
         let summary = summarize_runtime_tree(&tree);
 
         assert_eq!(summary.workflows, 2);
+        assert_eq!(summary.workflow_statuses["implementing"], 1);
+        assert_eq!(summary.workflow_statuses["waiting"], 1);
+        assert_eq!(summary.workflow_scheduler_states["queued"], 1);
+        assert_eq!(summary.workflow_scheduler_states["running"], 1);
+        assert_eq!(summary.workflow_active_buckets["queued"], 1);
+        assert_eq!(summary.workflow_active_buckets["running"], 1);
         assert_eq!(summary.commands, 2);
         assert_eq!(summary.jobs, 2);
         assert_eq!(summary.command_statuses["completed"], 1);
@@ -420,6 +468,18 @@ mod tests {
         let tree = json!({
             "total_workflows": 2,
             "summary": {
+                "workflow_statuses": {
+                    "implementing": 3,
+                    "waiting": 2
+                },
+                "workflow_scheduler_states": {
+                    "queued": 2,
+                    "running": 3
+                },
+                "workflow_active_buckets": {
+                    "queued": 2,
+                    "running": 3
+                },
                 "total_commands": 7,
                 "total_runtime_jobs": 42,
                 "command_statuses": {
@@ -457,6 +517,12 @@ mod tests {
         let summary = summarize_runtime_tree(&tree);
 
         assert_eq!(summary.workflows, 2);
+        assert_eq!(summary.workflow_statuses["implementing"], 3);
+        assert_eq!(summary.workflow_statuses["waiting"], 2);
+        assert_eq!(summary.workflow_scheduler_states["queued"], 2);
+        assert_eq!(summary.workflow_scheduler_states["running"], 3);
+        assert_eq!(summary.workflow_active_buckets["queued"], 2);
+        assert_eq!(summary.workflow_active_buckets["running"], 3);
         assert_eq!(summary.commands, 7);
         assert_eq!(summary.jobs, 42);
         assert_eq!(summary.command_statuses["completed"], 5);

--- a/crates/harness-server/src/http/misc_routes_runtime_tree.rs
+++ b/crates/harness-server/src/http/misc_routes_runtime_tree.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::http::state::AppState;
+use crate::runtime_projection::{RuntimeActiveBucket, RuntimeWorkflowProjection};
 #[path = "misc_routes_runtime_tree_nodes.rs"]
 mod nodes;
 #[cfg(test)]
@@ -24,7 +25,7 @@ use nodes::{
 };
 
 use harness_workflow::runtime::store::RuntimeEventSummary;
-use harness_workflow::runtime::WorkflowInstance;
+use harness_workflow::runtime::{WorkflowInstance, WorkflowSubject};
 
 const WORKFLOW_RUNTIME_TREE_DEFAULT_LIMIT: i64 = 100;
 const WORKFLOW_RUNTIME_TREE_MAX_LIMIT: i64 = 500;
@@ -118,6 +119,9 @@ impl WorkflowRuntimeTreePagination {
 
 #[derive(Debug, Default, serde::Serialize)]
 struct WorkflowRuntimeTreeSummary {
+    pub workflow_statuses: BTreeMap<String, usize>,
+    pub workflow_scheduler_states: BTreeMap<String, usize>,
+    pub workflow_active_buckets: BTreeMap<String, usize>,
     pub total_commands: usize,
     pub total_runtime_jobs: usize,
     pub command_statuses: BTreeMap<String, usize>,
@@ -328,7 +332,12 @@ async fn workflow_runtime_tree_summary(
             ACTIVITY_RESULT_ENVELOPE_SCHEMA,
         )
         .await?;
+    let (workflow_statuses, workflow_scheduler_states, workflow_active_buckets) =
+        workflow_projection_summary_counts(&aggregate_summary.workflow_states);
     Ok(WorkflowRuntimeTreeSummary {
+        workflow_statuses,
+        workflow_scheduler_states,
+        workflow_active_buckets,
         total_commands: aggregate_summary.total_commands,
         total_runtime_jobs: aggregate_summary.total_runtime_jobs,
         command_statuses: aggregate_summary.command_statuses,
@@ -337,6 +346,68 @@ async fn workflow_runtime_tree_summary(
         activity_outcomes: aggregate_summary.activity_outcomes,
         jobs_without_activity_envelope: aggregate_summary.jobs_without_activity_envelope,
     })
+}
+
+fn workflow_projection_summary_counts(
+    workflow_states: &[harness_workflow::runtime::store::WorkflowRuntimeStateCount],
+) -> (
+    BTreeMap<String, usize>,
+    BTreeMap<String, usize>,
+    BTreeMap<String, usize>,
+) {
+    let mut workflow_statuses = BTreeMap::new();
+    let mut workflow_scheduler_states = BTreeMap::new();
+    let mut workflow_active_buckets = BTreeMap::new();
+
+    for state_count in workflow_states {
+        let workflow = WorkflowInstance::new(
+            &state_count.definition_id,
+            1,
+            &state_count.state,
+            WorkflowSubject::new(
+                "summary",
+                format!("{}:{}", state_count.definition_id, state_count.state),
+            ),
+        );
+        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+        add_summary_count(
+            &mut workflow_statuses,
+            projection.task_status.as_str(),
+            state_count.count,
+        );
+        add_summary_count(
+            &mut workflow_scheduler_states,
+            projection.scheduler.authority_state.as_str(),
+            state_count.count,
+        );
+        if let Some(active_bucket) = projection.active_bucket() {
+            add_summary_count(
+                &mut workflow_active_buckets,
+                runtime_active_bucket_label(active_bucket),
+                state_count.count,
+            );
+        }
+    }
+
+    (
+        workflow_statuses,
+        workflow_scheduler_states,
+        workflow_active_buckets,
+    )
+}
+
+fn add_summary_count(counts: &mut BTreeMap<String, usize>, key: &str, count: usize) {
+    counts
+        .entry(key.to_string())
+        .and_modify(|current| *current += count)
+        .or_insert(count);
+}
+
+fn runtime_active_bucket_label(bucket: RuntimeActiveBucket) -> &'static str {
+    match bucket {
+        RuntimeActiveBucket::Running => "running",
+        RuntimeActiveBucket::Queued => "queued",
+    }
 }
 
 async fn build_full_workflow_runtime_nodes(

--- a/crates/harness-server/src/http/tests/runtime_tree_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_tree_tests.rs
@@ -563,6 +563,9 @@ async fn workflow_runtime_tree_endpoint_returns_summary_only_shape() -> anyhow::
     assert_eq!(body["pagination"]["next_offset"], serde_json::Value::Null);
     assert_eq!(body["pagination"]["summary_only"], true);
     assert_eq!(body["pagination"]["detail"], "compact");
+    assert_eq!(body["summary"]["workflow_statuses"]["implementing"], 1);
+    assert_eq!(body["summary"]["workflow_scheduler_states"]["running"], 1);
+    assert_eq!(body["summary"]["workflow_active_buckets"]["running"], 1);
     assert_eq!(body["summary"]["total_commands"], 1);
     assert_eq!(body["summary"]["total_runtime_jobs"], 1);
     assert_eq!(
@@ -624,6 +627,32 @@ async fn workflow_runtime_tree_endpoint_summarizes_all_project_workflows_when_pa
             )
             .await?;
     }
+    let quality_gate = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::QUALITY_GATE_DEFINITION_ID,
+        1,
+        "passed",
+        harness_workflow::runtime::WorkflowSubject::new("quality_gate", "issue:101"),
+    )
+    .with_id("quality-gate-101")
+    .with_data(serde_json::json!({
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 101,
+    }));
+    store.upsert_instance(&quality_gate).await?;
+    let non_terminal_passed_issue = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "passed",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:103"),
+    )
+    .with_id("issue-103")
+    .with_data(serde_json::json!({
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 103,
+    }));
+    store.upsert_instance(&non_terminal_passed_issue).await?;
 
     let response = workflow_runtime_app(state)
         .oneshot(
@@ -634,9 +663,9 @@ async fn workflow_runtime_tree_endpoint_summarizes_all_project_workflows_when_pa
         .await?;
     assert_eq!(response.status(), StatusCode::OK);
     let body = response_json(response).await?;
-    assert_eq!(body["total_workflows"], 2);
+    assert_eq!(body["total_workflows"], 4);
     assert_eq!(body["pagination"]["returned"], 1);
-    assert_eq!(body["pagination"]["total"], 2);
+    assert_eq!(body["pagination"]["total"], 4);
     assert_eq!(body["pagination"]["has_more"], true);
     assert_eq!(
         body["workflows"]
@@ -645,6 +674,14 @@ async fn workflow_runtime_tree_endpoint_summarizes_all_project_workflows_when_pa
             .len(),
         1
     );
+    assert_eq!(body["summary"]["workflow_statuses"]["done"], 1);
+    assert_eq!(body["summary"]["workflow_statuses"]["implementing"], 2);
+    assert_eq!(body["summary"]["workflow_statuses"]["waiting"], 1);
+    assert_eq!(body["summary"]["workflow_scheduler_states"]["done"], 1);
+    assert_eq!(body["summary"]["workflow_scheduler_states"]["queued"], 1);
+    assert_eq!(body["summary"]["workflow_scheduler_states"]["running"], 2);
+    assert_eq!(body["summary"]["workflow_active_buckets"]["queued"], 1);
+    assert_eq!(body["summary"]["workflow_active_buckets"]["running"], 2);
     assert_eq!(body["summary"]["total_commands"], 2);
     assert_eq!(body["summary"]["total_runtime_jobs"], 2);
     assert_eq!(body["summary"]["command_statuses"]["pending"], 2);

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -52,6 +52,7 @@ pub struct WorkflowRuntimeDetailCounts {
 }
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct WorkflowRuntimeSummaryCounts {
+    pub workflow_states: Vec<WorkflowRuntimeStateCount>,
     pub total_commands: usize,
     pub total_runtime_jobs: usize,
     pub command_statuses: BTreeMap<String, usize>,
@@ -59,6 +60,12 @@ pub struct WorkflowRuntimeSummaryCounts {
     pub running_job_lease_statuses: BTreeMap<String, usize>,
     pub activity_outcomes: BTreeMap<String, usize>,
     pub jobs_without_activity_envelope: usize,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowRuntimeStateCount {
+    pub definition_id: String,
+    pub state: String,
+    pub count: usize,
 }
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeJobCompactRecord {

--- a/crates/harness-workflow/src/runtime/store_summary.rs
+++ b/crates/harness-workflow/src/runtime/store_summary.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use super::store::{WorkflowRuntimeStore, WorkflowRuntimeSummaryCounts};
+use super::store::{WorkflowRuntimeStateCount, WorkflowRuntimeStore, WorkflowRuntimeSummaryCounts};
 
 impl WorkflowRuntimeStore {
     pub async fn runtime_summary_counts_for_instances(
@@ -9,6 +9,7 @@ impl WorkflowRuntimeStore {
         activity_envelope_artifact_type: &str,
         activity_envelope_schema: &str,
     ) -> anyhow::Result<WorkflowRuntimeSummaryCounts> {
+        let workflow_states = workflow_states_for_instances(self, project_id).await?;
         let command_statuses = command_statuses_for_instances(self, project_id).await?;
         let total_commands = command_statuses.values().sum();
         let runtime_job_statuses = runtime_job_statuses_for_instances(self, project_id).await?;
@@ -24,6 +25,7 @@ impl WorkflowRuntimeStore {
         .await?;
 
         Ok(WorkflowRuntimeSummaryCounts {
+            workflow_states,
             total_commands,
             total_runtime_jobs,
             command_statuses,
@@ -33,6 +35,30 @@ impl WorkflowRuntimeStore {
             jobs_without_activity_envelope,
         })
     }
+}
+
+async fn workflow_states_for_instances(
+    store: &WorkflowRuntimeStore,
+    project_id: Option<&str>,
+) -> anyhow::Result<Vec<WorkflowRuntimeStateCount>> {
+    let rows: Vec<(String, String, i64)> = sqlx::query_as(
+        "SELECT definition_id, state, COUNT(*)
+         FROM workflow_instances
+         WHERE ($1::text IS NULL OR data->'data'->>'project_id' = $1)
+         GROUP BY definition_id, state
+         ORDER BY definition_id ASC, state ASC",
+    )
+    .bind(project_id)
+    .fetch_all(store.pool())
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(definition_id, state, count)| WorkflowRuntimeStateCount {
+            definition_id,
+            state,
+            count: count.max(0) as usize,
+        })
+        .collect())
 }
 
 async fn command_statuses_for_instances(
@@ -219,6 +245,14 @@ mod tests {
             .await?;
 
         assert_eq!(summary.total_runtime_jobs, 2);
+        assert_eq!(
+            summary.workflow_states,
+            vec![WorkflowRuntimeStateCount {
+                definition_id: "github_issue_pr".to_string(),
+                state: "implementing".to_string(),
+                count: 1,
+            }]
+        );
         assert_eq!(summary.runtime_job_statuses["running"], 2);
         assert_eq!(summary.running_job_lease_statuses["active_leased"], 1);
         assert_eq!(summary.running_job_lease_statuses["expired_lease"], 1);


### PR DESCRIPTION
## Summary
- add workflow projection bucket counts to the runtime tree summary
- aggregate workflow status, scheduler state, and active bucket across all project workflows independent of pagination
- display the new workflow buckets in `harness status` and cover server-summary plus node-fallback parsing

Closes #1403
Parent: #1238
Related: #1226

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p harness-workflow runtime_summary -- --nocapture`
- `cargo test -p harness-cli status -- --nocapture`
- `cargo test -p harness-server workflow_runtime_tree_endpoint -- --nocapture`
- `cargo test -p harness-server workflow_runtime_tree_endpoint_summarizes_all_project_workflows_when_paginated -- --nocapture`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --workspace --quiet`

## Review
- Independent read-only thread Nash found no blocking findings.
- Follow-up coverage added for `quality_gate:passed => done` and `github_issue_pr:passed => waiting` in the same paginated summary.