### PR TITLE
Runtime: guard workflow graph references

### DIFF
--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
@@ -5,12 +5,14 @@ use axum::{
     routing::post,
     Router,
 };
-use harness_workflow::runtime::{
-    ActivityResult, RuntimeJobStatus, RuntimeKind, WorkflowRuntimeStore,
-};
 use serde_json::json;
 use std::sync::Arc;
 use tower::ServiceExt;
+
+use harness_workflow::runtime::{
+    ActivityResult, RuntimeJob, RuntimeJobStatus, RuntimeKind, WorkflowCommand, WorkflowInstance,
+    WorkflowRuntimeStore, WorkflowSubject,
+};
 
 fn runtime_hosts_workflow_app(state: Arc<crate::http::AppState>) -> Router {
     Router::new()
@@ -64,6 +66,32 @@ async fn register_host(app: &Router, host_id: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+async fn enqueue_runtime_host_test_job(
+    store: &WorkflowRuntimeStore,
+    key: &str,
+    runtime_kind: RuntimeKind,
+    runtime_profile: &str,
+    input: serde_json::Value,
+) -> anyhow::Result<RuntimeJob> {
+    let workflow = WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        WorkflowSubject::new("issue", format!("issue:{key}")),
+    )
+    .with_id(format!("runtime-host-test-{key}"));
+    store.upsert_instance(&workflow).await?;
+    let activity = input
+        .get("activity")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("remote_check");
+    let command = WorkflowCommand::enqueue_activity(activity, format!("runtime-host-test-{key}"));
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    store
+        .enqueue_runtime_job(&command_id, runtime_kind, runtime_profile, input)
+        .await
+}
+
 async fn post_json(
     app: &Router,
     uri: String,
@@ -105,29 +133,29 @@ async fn runtime_job_claim_endpoint_claims_remote_host_jobs_only() -> anyhow::Re
     let app = runtime_hosts_workflow_app(state);
     register_host(&app, "host-a").await?;
 
-    let local_job = store
-        .enqueue_runtime_job(
-            "command-local",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": "local_check" }),
-        )
-        .await?;
-    let remote_job = store
-        .enqueue_runtime_job(
-            "command-remote",
-            RuntimeKind::RemoteHost,
-            "remote-host-default",
-            json!({
-                "activity": "remote_check",
-                "workflow_id": "wf-remote",
-                "runtime_profile": {
-                    "name": "remote-host-default",
-                    "kind": "remote_host"
-                }
-            }),
-        )
-        .await?;
+    let local_job = enqueue_runtime_host_test_job(
+        &store,
+        "command-local",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "local_check" }),
+    )
+    .await?;
+    let remote_job = enqueue_runtime_host_test_job(
+        &store,
+        "command-remote",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({
+            "activity": "remote_check",
+            "workflow_id": "wf-remote",
+            "runtime_profile": {
+                "name": "remote-host-default",
+                "kind": "remote_host"
+            }
+        }),
+    )
+    .await?;
 
     let json = post_json(
         &app,
@@ -162,14 +190,14 @@ async fn runtime_job_claim_endpoint_blocks_duplicate_claims() -> anyhow::Result<
     register_host(&app, "host-a").await?;
     register_host(&app, "host-b").await?;
 
-    let job = store
-        .enqueue_runtime_job(
-            "command-remote",
-            RuntimeKind::RemoteHost,
-            "remote-host-default",
-            json!({ "activity": "remote_check" }),
-        )
-        .await?;
+    let job = enqueue_runtime_host_test_job(
+        &store,
+        "command-remote",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({ "activity": "remote_check" }),
+    )
+    .await?;
     let first = post_json(
         &app,
         "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
@@ -198,14 +226,14 @@ async fn runtime_job_claim_endpoint_reclaims_expired_remote_job() -> anyhow::Res
     register_host(&app, "host-a").await?;
     register_host(&app, "host-b").await?;
 
-    let job = store
-        .enqueue_runtime_job(
-            "command-remote",
-            RuntimeKind::RemoteHost,
-            "remote-host-default",
-            json!({ "activity": "remote_check" }),
-        )
-        .await?;
+    let job = enqueue_runtime_host_test_job(
+        &store,
+        "command-remote",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({ "activity": "remote_check" }),
+    )
+    .await?;
     let first = post_json(
         &app,
         "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
@@ -246,14 +274,14 @@ async fn runtime_job_completion_endpoint_accepts_terminal_activity_result() -> a
     let app = runtime_hosts_workflow_app(state);
     register_host(&app, "host-a").await?;
 
-    let job = store
-        .enqueue_runtime_job(
-            "command-remote",
-            RuntimeKind::RemoteHost,
-            "remote-host-default",
-            json!({ "activity": "remote_check" }),
-        )
-        .await?;
+    let job = enqueue_runtime_host_test_job(
+        &store,
+        "command-remote",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({ "activity": "remote_check" }),
+    )
+    .await?;
     let claimed = post_json(
         &app,
         "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),

--- a/crates/harness-server/src/workflow_runtime_plan_issue.rs
+++ b/crates/harness-server/src/workflow_runtime_plan_issue.rs
@@ -201,13 +201,17 @@ async fn persist_replan_completed(
         harness_workflow::issue_lifecycle::workflow_id(&project_id, repo, issue_number);
     let mut instance = match store.get_instance(&workflow_id).await? {
         Some(instance) => instance,
-        None => issue_instance(
-            workflow_id,
-            project_id.clone(),
-            repo.map(ToOwned::to_owned),
-            issue_number,
-            "replanning",
-        ),
+        None => {
+            let instance = issue_instance(
+                workflow_id,
+                project_id.clone(),
+                repo.map(ToOwned::to_owned),
+                issue_number,
+                "replanning",
+            );
+            store.upsert_instance(&instance).await?;
+            instance
+        }
     };
     store
         .append_event(
@@ -405,5 +409,58 @@ Workflow policy
         .await;
 
         assert!(matches!(action, PlanIssueRuntimeAction::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn replan_completed_creates_missing_workflow_before_event() -> anyhow::Result<()> {
+        let Ok(database_url) = resolve_database_url(None) else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let store =
+            match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url))
+                .await
+            {
+                Ok(store) => Arc::new(store),
+                Err(_) => return Ok(()),
+            };
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let task_id = TaskId::from_str("task-2");
+
+        record_replan_completed(
+            Some(store.clone()),
+            &project_root,
+            Some("owner/repo"),
+            124,
+            &task_id,
+        )
+        .await;
+
+        let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+            &project_root.to_string_lossy(),
+            Some("owner/repo"),
+            124,
+        );
+        let Some(instance) = store.get_instance(&workflow_id).await? else {
+            anyhow::bail!("replan completion should create the workflow instance first");
+        };
+        assert_eq!(instance.state, "implementing");
+        assert_eq!(instance.version, 1);
+        assert_eq!(instance.data["task_id"], "task-2");
+        assert_eq!(instance.data["last_event"], "ReplanCompleted");
+
+        let events = store.events_for(&workflow_id).await?;
+        let Some(event) = events
+            .iter()
+            .find(|event| event.event_type == "ReplanCompleted")
+        else {
+            anyhow::bail!("replan completion event should be recorded");
+        };
+        assert_eq!(event.workflow_id, workflow_id);
+        assert_eq!(event.event["task_id"], "task-2");
+        assert_eq!(event.event["issue_number"], 124);
+        assert_eq!(event.event["repo"], "owner/repo");
+        Ok(())
     }
 }

--- a/crates/harness-server/src/workflow_runtime_plan_issue.rs
+++ b/crates/harness-server/src/workflow_runtime_plan_issue.rs
@@ -203,14 +203,21 @@ async fn persist_replan_completed(
         Some(instance) => instance,
         None => {
             let instance = issue_instance(
-                workflow_id,
+                workflow_id.clone(),
                 project_id.clone(),
                 repo.map(ToOwned::to_owned),
                 issue_number,
                 "replanning",
             );
-            store.upsert_instance(&instance).await?;
-            instance
+            if store.insert_instance_if_absent(&instance).await? {
+                instance
+            } else {
+                store.get_instance(&workflow_id).await?.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "workflow `{workflow_id}` disappeared after replan fallback insert conflict"
+                    )
+                })?
+            }
         }
     };
     store

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -126,6 +126,48 @@ fn runtime_task_id_from_instance(instance: &WorkflowInstance) -> String {
         .unwrap_or_else(|| format!("runtime:{}", instance.id))
 }
 
+fn pr_lifecycle_failure_instance(
+    project_root: &Path,
+    repo: Option<&str>,
+    issue_number: Option<u64>,
+    task_id: &TaskId,
+    pr_number: u64,
+    pr_url: Option<&str>,
+) -> WorkflowInstance {
+    let project_id = project_root.to_string_lossy().into_owned();
+    let mut instance = if let Some(issue_number) = issue_number {
+        let workflow_id =
+            harness_workflow::issue_lifecycle::workflow_id(&project_id, repo, issue_number);
+        issue_instance(
+            workflow_id,
+            project_id,
+            repo.map(ToOwned::to_owned),
+            issue_number,
+            "failed",
+        )
+    } else {
+        pr_scoped_instance(
+            pr_workflow_id(&project_id, repo, pr_number),
+            project_id,
+            repo.map(ToOwned::to_owned),
+            task_id,
+            pr_number,
+            pr_url,
+            "failed",
+        )
+    };
+    if let Some(data) = instance.data.as_object_mut() {
+        data.insert("task_id".to_string(), json!(task_id.as_str()));
+        data.insert("pr_number".to_string(), json!(pr_number));
+        data.insert("pr_url".to_string(), json!(pr_url));
+        data.insert(
+            "failure_kind".to_string(),
+            json!("pr_lifecycle_persistence"),
+        );
+    }
+    instance
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RuntimeMergeApprovalOutcome {
     Approved {
@@ -185,12 +227,21 @@ pub(crate) async fn record_pr_detected(
         "pr_number": ctx.pr_number,
         "pr_url": ctx.pr_url,
     });
+    let failure_instance = pr_lifecycle_failure_instance(
+        ctx.project_root,
+        ctx.repo,
+        Some(ctx.issue_number),
+        ctx.task_id,
+        ctx.pr_number,
+        Some(ctx.pr_url),
+    );
     if let Err(error) = persist_pr_lifecycle_with_retry(
         store,
         &workflow_id,
         "record_pr_detected",
         ctx.task_id,
         ctx.pr_number,
+        failure_instance,
         failure_payload,
         || persist_pr_detected(store, &ctx),
     )
@@ -230,12 +281,21 @@ pub(crate) async fn record_pr_feedback(
         "outcome": outcome_label(ctx.outcome),
         "summary": ctx.summary,
     });
+    let failure_instance = pr_lifecycle_failure_instance(
+        ctx.project_root,
+        ctx.repo,
+        ctx.issue_number,
+        ctx.task_id,
+        ctx.pr_number,
+        ctx.pr_url,
+    );
     if let Err(error) = persist_pr_lifecycle_with_retry(
         store,
         &workflow_id,
         "record_pr_feedback",
         ctx.task_id,
         ctx.pr_number,
+        failure_instance,
         failure_payload,
         || persist_pr_feedback(store, &ctx),
     )
@@ -290,12 +350,21 @@ pub(crate) async fn record_pr_merged(
         "pr_url": ctx.pr_url,
         "summary": ctx.summary,
     });
+    let failure_instance = pr_lifecycle_failure_instance(
+        ctx.project_root,
+        ctx.repo,
+        ctx.issue_number,
+        ctx.task_id,
+        ctx.pr_number,
+        ctx.pr_url,
+    );
     if let Err(error) = persist_pr_lifecycle_with_retry(
         store,
         &workflow_id,
         "record_pr_merged",
         ctx.task_id,
         ctx.pr_number,
+        failure_instance,
         failure_payload,
         || persist_pr_merged(store, &ctx),
     )

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/pr_lifecycle_persist.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/pr_lifecycle_persist.rs
@@ -157,9 +157,7 @@ async fn ensure_pr_lifecycle_failure_workflow(
             workflow_id
         );
     }
-    if store.get_instance(workflow_id).await?.is_none() {
-        store.upsert_instance(failure_instance).await?;
-    }
+    store.insert_instance_if_absent(failure_instance).await?;
     Ok(())
 }
 

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/pr_lifecycle_persist.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/pr_lifecycle_persist.rs
@@ -1,6 +1,6 @@
 use super::pr_workflow_id;
 use crate::task_runner::TaskId;
-use harness_workflow::runtime::WorkflowRuntimeStore;
+use harness_workflow::runtime::{WorkflowInstance, WorkflowRuntimeStore};
 use serde_json::json;
 use std::{future::Future, path::Path, time::Duration};
 
@@ -38,6 +38,7 @@ pub(super) async fn persist_pr_lifecycle_with_retry<F, Fut>(
     operation: &'static str,
     task_id: &TaskId,
     pr_number: u64,
+    failure_instance: WorkflowInstance,
     failure_payload: serde_json::Value,
     mut persist: F,
 ) -> anyhow::Result<()>
@@ -85,6 +86,7 @@ where
                     operation,
                     task_id,
                     pr_number,
+                    &failure_instance,
                     failure_payload,
                     &error,
                     attempt,
@@ -102,6 +104,7 @@ async fn record_pr_lifecycle_persist_failure(
     operation: &'static str,
     task_id: &TaskId,
     pr_number: u64,
+    failure_instance: &WorkflowInstance,
     mut payload: serde_json::Value,
     error: &anyhow::Error,
     attempts: usize,
@@ -110,6 +113,18 @@ async fn record_pr_lifecycle_persist_failure(
         object.insert("operation".to_string(), json!(operation));
         object.insert("attempts".to_string(), json!(attempts));
         object.insert("error".to_string(), json!(error.to_string()));
+    }
+    if let Err(instance_error) =
+        ensure_pr_lifecycle_failure_workflow(store, workflow_id, failure_instance).await
+    {
+        tracing::error!(
+            workflow_id,
+            operation,
+            pr = pr_number,
+            task_id = %task_id.0,
+            "workflow runtime PR lifecycle failure workflow write failed: {instance_error}"
+        );
+        return;
     }
     if let Err(event_error) = store
         .append_event(
@@ -128,6 +143,24 @@ async fn record_pr_lifecycle_persist_failure(
             "workflow runtime PR lifecycle failure event write failed: {event_error}"
         );
     }
+}
+
+async fn ensure_pr_lifecycle_failure_workflow(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    failure_instance: &WorkflowInstance,
+) -> anyhow::Result<()> {
+    if failure_instance.id != workflow_id {
+        anyhow::bail!(
+            "PR lifecycle failure instance `{}` does not match workflow `{}`",
+            failure_instance.id,
+            workflow_id
+        );
+    }
+    if store.get_instance(workflow_id).await?.is_none() {
+        store.upsert_instance(failure_instance).await?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
@@ -128,7 +128,13 @@ async fn persistent_pr_lifecycle_persist_failure_records_operator_event() -> any
         Some("owner/repo"),
         123,
     );
-    assert!(store.get_instance(&workflow_id).await?.is_none());
+    let instance = store.get_instance(&workflow_id).await?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "persistent failure should create a terminal workflow for operator-visible events"
+        )
+    })?;
+    assert_eq!(instance.state, "failed");
+    assert!(instance.is_terminal());
     let events = store.events_for(&workflow_id).await?;
     let failure_event = events
         .iter()

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
@@ -157,6 +157,70 @@ async fn persistent_pr_lifecycle_persist_failure_records_operator_event() -> any
 }
 
 #[tokio::test]
+async fn persistent_pr_lifecycle_persist_failure_preserves_existing_workflow() -> anyhow::Result<()>
+{
+    let Ok(database_url) = resolve_database_url(None) else {
+        return Ok(());
+    };
+    let dir = tempfile::tempdir()?;
+    let store =
+        match WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url)).await {
+            Ok(store) => store,
+            Err(_) => return Ok(()),
+        };
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("existing-pr-lifecycle-persist-failure");
+    let workflow_id = harness_workflow::issue_lifecycle::workflow_id(
+        &project_root.to_string_lossy(),
+        Some("owner/repo"),
+        123,
+    );
+    let existing = issue_instance(
+        workflow_id.clone(),
+        project_root.to_string_lossy().into_owned(),
+        Some("owner/repo".to_string()),
+        123,
+        "awaiting_feedback",
+    )
+    .with_data(json!({
+        "project_id": project_root.to_string_lossy(),
+        "repo": "owner/repo",
+        "issue_number": 123,
+        "marker": "real",
+    }));
+    store.upsert_instance(&existing).await?;
+    let _guard =
+        set_pr_lifecycle_persist_test_failures(task_id.as_str(), PR_LIFECYCLE_PERSIST_MAX_ATTEMPTS);
+
+    record_pr_detected(
+        Some(&store),
+        PrDetectedRuntimeContext {
+            project_root: &project_root,
+            repo: Some("owner/repo"),
+            issue_number: 123,
+            task_id: &task_id,
+            pr_number: 77,
+            pr_url: "https://github.com/owner/repo/pull/77",
+        },
+    )
+    .await;
+
+    let Some(instance) = store.get_instance(&workflow_id).await? else {
+        anyhow::bail!("existing workflow should still be present after failure recording");
+    };
+    assert_eq!(instance.state, "awaiting_feedback");
+    assert_eq!(instance.data["marker"], "real");
+    assert!(instance.data.get("failure_kind").is_none());
+
+    let events = store.events_for(&workflow_id).await?;
+    assert!(events
+        .iter()
+        .any(|event| event.event_type == "PrLifecyclePersistenceFailed"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn rejected_new_runtime_decision_persists_initial_instance() -> anyhow::Result<()> {
     let Ok(database_url) = resolve_database_url(None) else {
         return Ok(());

--- a/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
@@ -53,7 +53,11 @@ async fn rejected_new_issue_submission_does_not_persist_live_instance_or_command
 
     assert!(!result.accepted);
     assert!(result.rejection_reason.is_some());
-    assert!(store.get_instance(&workflow_id).await?.is_none());
+    let persisted = store.get_instance(&workflow_id).await?.ok_or_else(|| {
+        anyhow::anyhow!("rejected new issue should persist a terminal workflow for audit rows")
+    })?;
+    assert_eq!(persisted.state, "failed");
+    assert!(persisted.is_terminal());
     assert!(store.commands_for(&workflow_id).await?.is_empty());
     let decisions = store.decisions_for(&workflow_id).await?;
     assert_eq!(decisions.len(), 1);

--- a/crates/harness-server/src/workflow_runtime_submission/commit.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/commit.rs
@@ -57,6 +57,8 @@ pub(super) async fn apply_decision(
             DecisionValidator::github_issue_pr().validate(&instance, &decision, &validation_context)
         {
             let reason = error.to_string();
+            let rejected_instance = new_instance
+                .then(|| rejected_submission_instance(instance.clone(), accepted_data, &reason));
             let outcome = store
                 .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
                     workflow_id: &instance.id,
@@ -71,7 +73,7 @@ pub(super) async fn apply_decision(
                     decision: &decision,
                     existing_record: None,
                     rejection_reason: Some(&reason),
-                    final_instance: None,
+                    final_instance: rejected_instance.as_ref(),
                     command_status: WorkflowCommandStatus::Pending,
                     prompt_payload: None,
                 })
@@ -166,6 +168,8 @@ pub(super) async fn apply_prompt_decision(
             DecisionValidator::prompt_task().validate(&instance, &decision, &validation_context)
         {
             let reason = error.to_string();
+            let rejected_instance = new_instance
+                .then(|| rejected_submission_instance(instance.clone(), accepted_data, &reason));
             let outcome = store
                 .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
                     workflow_id: &instance.id,
@@ -180,7 +184,7 @@ pub(super) async fn apply_prompt_decision(
                     decision: &decision,
                     existing_record: None,
                     rejection_reason: Some(&reason),
-                    final_instance: None,
+                    final_instance: rejected_instance.as_ref(),
                     command_status: WorkflowCommandStatus::Pending,
                     prompt_payload: None,
                 })
@@ -326,6 +330,24 @@ fn accepted_submission_instance(
     instance.state = decision.next_state.clone();
     instance.version = instance.version.saturating_add(1);
     instance.data = merge_last_decision(accepted_data, &decision.decision);
+    instance
+}
+
+fn rejected_submission_instance(
+    mut instance: WorkflowInstance,
+    mut rejected_data: serde_json::Value,
+    reason: &str,
+) -> WorkflowInstance {
+    instance.state = "failed".to_string();
+    instance.version = instance.version.saturating_add(1);
+    if let Some(data) = rejected_data.as_object_mut() {
+        data.insert("rejection_reason".to_string(), json!(reason));
+        data.insert(
+            "rejected_at".to_string(),
+            json!(chrono::Utc::now().to_rfc3339()),
+        );
+    }
+    instance.data = merge_last_decision(rejected_data, "submission_rejected");
     instance
 }
 

--- a/crates/harness-workflow/src/runtime/job_claim.rs
+++ b/crates/harness-workflow/src/runtime/job_claim.rs
@@ -38,34 +38,37 @@ impl WorkflowRuntimeStore {
             .transpose()?;
         let mut tx = self.pool.begin().await?;
         let row: Option<(String, String)> = sqlx::query_as(
-            "SELECT id, data::text FROM runtime_jobs
+            "SELECT job.id, job.data::text
+             FROM runtime_jobs AS job
+             JOIN workflow_commands AS command ON command.id = job.command_id
+             JOIN workflow_instances AS workflow ON workflow.id = command.workflow_id
              WHERE (
                  (
-                     status = 'pending'
-                     AND (not_before IS NULL OR not_before <= CURRENT_TIMESTAMP)
+                     job.status = 'pending'
+                     AND (job.not_before IS NULL OR job.not_before <= CURRENT_TIMESTAMP)
                  ) OR (
-                     status = 'running'
-                     AND data ? 'lease'
-                     AND (data->'lease' ? 'expires_at')
-                     AND (data->'lease'->>'expires_at')::timestamptz <= CURRENT_TIMESTAMP
+                     job.status = 'running'
+                     AND job.data ? 'lease'
+                     AND (job.data->'lease' ? 'expires_at')
+                     AND (job.data->'lease'->>'expires_at')::timestamptz <= CURRENT_TIMESTAMP
                  )
              )
-             AND ($1::text IS NULL OR runtime_kind = $1)
-             AND ($2::text IS NULL OR runtime_kind <> $2)
+             AND ($1::text IS NULL OR job.runtime_kind = $1)
+             AND ($2::text IS NULL OR job.runtime_kind <> $2)
              ORDER BY
                  CASE
-                     WHEN COALESCE(data #>> '{input,activity}', '') IN (
+                     WHEN COALESCE(job.data #>> '{input,activity}', '') IN (
                          'implement_issue',
                          'implement_prompt',
                          'inspect_pr_feedback',
                          'address_pr_feedback'
                      ) THEN 0
-                     WHEN COALESCE(data #>> '{input,activity}', '') = 'poll_repo_backlog' THEN 2
+                     WHEN COALESCE(job.data #>> '{input,activity}', '') = 'poll_repo_backlog' THEN 2
                      ELSE 1
                  END ASC,
-                 created_at ASC
+                 job.created_at ASC
              LIMIT 1
-             FOR UPDATE SKIP LOCKED",
+             FOR UPDATE OF job SKIP LOCKED",
         )
         .bind(only_runtime_kind.as_deref())
         .bind(excluded_runtime_kind.as_deref())

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -701,11 +701,13 @@ impl WorkflowRuntimeStore {
     pub async fn pending_commands(&self, limit: i64) -> anyhow::Result<Vec<WorkflowCommandRecord>> {
         let limit = limit.clamp(1, 500);
         let rows: Vec<WorkflowCommandRecordRow> = sqlx::query_as(
-            "SELECT id, workflow_id, decision_id, status, dispatch_owner,
-                    dispatch_lease_expires_at, data::text, created_at, updated_at
-             FROM workflow_commands
-             WHERE status = 'pending'
-             ORDER BY created_at ASC
+            "SELECT command.id, command.workflow_id, command.decision_id, command.status,
+                    command.dispatch_owner, command.dispatch_lease_expires_at,
+                    command.data::text, command.created_at, command.updated_at
+             FROM workflow_commands AS command
+             JOIN workflow_instances AS workflow ON workflow.id = command.workflow_id
+             WHERE command.status = 'pending'
+             ORDER BY command.created_at ASC
              LIMIT $1",
         )
         .bind(limit)
@@ -725,17 +727,18 @@ impl WorkflowRuntimeStore {
         let limit = limit.clamp(1, 500);
         let rows: Vec<WorkflowCommandRecordRow> = sqlx::query_as(
             "WITH candidates AS (
-                 SELECT id
-                 FROM workflow_commands
-                 WHERE status = $3
+                 SELECT command.id
+                 FROM workflow_commands AS command
+                 JOIN workflow_instances AS workflow ON workflow.id = command.workflow_id
+                 WHERE command.status = $3
                     OR (
-                        status = $4
-                        AND COALESCE(dispatch_lease_expires_at, '-infinity'::timestamptz)
+                        command.status = $4
+                        AND COALESCE(command.dispatch_lease_expires_at, '-infinity'::timestamptz)
                             <= CURRENT_TIMESTAMP
                     )
-                 ORDER BY created_at ASC
+                 ORDER BY command.created_at ASC
                  LIMIT $5
-                 FOR UPDATE SKIP LOCKED
+                 FOR UPDATE OF command SKIP LOCKED
              )
              UPDATE workflow_commands AS command
              SET status = $4,
@@ -989,30 +992,33 @@ impl WorkflowRuntimeStore {
     ) -> anyhow::Result<Option<RuntimeJob>> {
         let mut tx = self.pool.begin().await?;
         let row: Option<(String, String)> = sqlx::query_as(
-            "SELECT id, data::text FROM runtime_jobs
+            "SELECT job.id, job.data::text
+             FROM runtime_jobs AS job
+             JOIN workflow_commands AS command ON command.id = job.command_id
+             JOIN workflow_instances AS workflow ON workflow.id = command.workflow_id
              WHERE (
-                 status = 'pending'
-                 AND (not_before IS NULL OR not_before <= CURRENT_TIMESTAMP)
+                 job.status = 'pending'
+                 AND (job.not_before IS NULL OR job.not_before <= CURRENT_TIMESTAMP)
              ) OR (
-                 status = 'running'
-                 AND data ? 'lease'
-                 AND (data->'lease' ? 'expires_at')
-                 AND (data->'lease'->>'expires_at')::timestamptz <= CURRENT_TIMESTAMP
+                 job.status = 'running'
+                 AND job.data ? 'lease'
+                 AND (job.data->'lease' ? 'expires_at')
+                 AND (job.data->'lease'->>'expires_at')::timestamptz <= CURRENT_TIMESTAMP
              )
              ORDER BY
                  CASE
-                     WHEN COALESCE(data #>> '{input,activity}', '') IN (
+                     WHEN COALESCE(job.data #>> '{input,activity}', '') IN (
                          'implement_issue',
                          'implement_prompt',
                          'inspect_pr_feedback',
                          'address_pr_feedback'
                      ) THEN 0
-                     WHEN COALESCE(data #>> '{input,activity}', '') = 'poll_repo_backlog' THEN 2
+                     WHEN COALESCE(job.data #>> '{input,activity}', '') = 'poll_repo_backlog' THEN 2
                      ELSE 1
                  END ASC,
-                 created_at ASC
+                 job.created_at ASC
              LIMIT 1
-             FOR UPDATE SKIP LOCKED",
+             FOR UPDATE OF job SKIP LOCKED",
         )
         .fetch_optional(&mut *tx)
         .await?;
@@ -1324,6 +1330,21 @@ impl WorkflowRuntimeStore {
         command.status = command_status;
         command.dispatch_owner = None;
         command.dispatch_lease_expires_at = None;
+
+        let (workflow_exists,): (bool,) =
+            sqlx::query_as("SELECT EXISTS (SELECT 1 FROM workflow_instances WHERE id = $1)")
+                .bind(&command.workflow_id)
+                .fetch_one(&mut *tx)
+                .await?;
+        if !workflow_exists {
+            tx.commit().await?;
+            return Ok(Some(RuntimeActivityCompletion {
+                runtime_job: job,
+                command: Some(command),
+                workflow_event: None,
+                decision: None,
+            }));
+        }
 
         let active_start_child_workflow_commands =
             if command.command.command_type == WorkflowCommandType::StartChildWorkflow {

--- a/crates/harness-workflow/src/runtime/store/instances.rs
+++ b/crates/harness-workflow/src/runtime/store/instances.rs
@@ -1,7 +1,8 @@
 use super::{
-    command_store, insert_decision_record_tx, insert_event_tx, load_or_insert_initial_instance_tx,
-    to_jsonb_string, workflow_instance_from_row, WorkflowDecisionTransition, WorkflowInstancePage,
-    WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
+    command_store, insert_decision_record_tx, insert_event_tx, insert_instance_if_absent_tx,
+    load_or_insert_initial_instance_tx, to_jsonb_string, workflow_instance_from_row,
+    WorkflowDecisionTransition, WorkflowInstancePage, WorkflowRejectedDecisionTransition,
+    WorkflowRuntimeStore,
 };
 use crate::runtime::model::{WorkflowDecisionRecord, WorkflowInstance};
 use crate::runtime::state_registry::workflow_terminal_state_names_for_definition;
@@ -9,6 +10,16 @@ use crate::runtime::status::WorkflowCommandStatus;
 use chrono::{DateTime, Utc};
 
 impl WorkflowRuntimeStore {
+    pub async fn insert_instance_if_absent(
+        &self,
+        instance: &WorkflowInstance,
+    ) -> anyhow::Result<bool> {
+        let mut tx = self.pool.begin().await?;
+        let inserted = insert_instance_if_absent_tx(&mut tx, instance).await?;
+        tx.commit().await?;
+        Ok(inserted)
+    }
+
     pub async fn upsert_instance(&self, instance: &WorkflowInstance) -> anyhow::Result<()> {
         let data = to_jsonb_string(instance)?;
         sqlx::query(

--- a/crates/harness-workflow/src/runtime/store/submission_commit.rs
+++ b/crates/harness-workflow/src/runtime/store/submission_commit.rs
@@ -73,15 +73,19 @@ impl WorkflowRuntimeStore {
                 );
             }
         }
+        if transition.rejection_reason.is_some()
+            && transition.create_if_missing.is_some()
+            && transition.final_instance.is_none()
+        {
+            anyhow::bail!(
+                "rejected new workflow submission `{}` requires a terminal final instance",
+                transition.workflow_id
+            );
+        }
 
         let mut tx = self.pool.begin().await?;
         lock_submission_tx(&mut tx, transition.workflow_id).await?;
-        let accepted = transition
-            .existing_record
-            .map(|record| record.accepted)
-            .unwrap_or_else(|| transition.rejection_reason.is_none());
-        let Some(current) = load_submission_instance_tx(&mut tx, &transition, accepted).await?
-        else {
+        let Some(current) = load_submission_instance_tx(&mut tx, &transition).await? else {
             return Ok(None);
         };
         if current.state != transition.expected_state
@@ -130,30 +134,35 @@ impl WorkflowRuntimeStore {
         insert_decision_record_tx(&mut tx, &record).await?;
 
         let mut command_ids = Vec::new();
-        if record.accepted {
-            let final_instance = transition.final_instance.ok_or_else(|| {
-                anyhow::anyhow!("accepted workflow submission requires a final instance")
-            })?;
-            if let Some(prompt_payload) = transition.prompt_payload {
-                upsert_prompt_payload_tx(&mut tx, prompt_payload.prompt_ref, prompt_payload.prompt)
+        if let Some(final_instance) = transition.final_instance {
+            if record.accepted {
+                if let Some(prompt_payload) = transition.prompt_payload {
+                    upsert_prompt_payload_tx(
+                        &mut tx,
+                        prompt_payload.prompt_ref,
+                        prompt_payload.prompt,
+                    )
                     .await?;
-                if let Some(previous_prompt_ref) = prompt_payload.previous_prompt_ref {
-                    delete_prompt_payload_tx(&mut tx, previous_prompt_ref).await?;
+                    if let Some(previous_prompt_ref) = prompt_payload.previous_prompt_ref {
+                        delete_prompt_payload_tx(&mut tx, previous_prompt_ref).await?;
+                    }
+                }
+                for command in &record.decision.commands {
+                    command_ids.push(
+                        command_store::insert_tx(
+                            &mut tx,
+                            transition.workflow_id,
+                            Some(&record.id),
+                            command,
+                            transition.command_status,
+                        )
+                        .await?,
+                    );
                 }
             }
-            for command in &record.decision.commands {
-                command_ids.push(
-                    command_store::insert_tx(
-                        &mut tx,
-                        transition.workflow_id,
-                        Some(&record.id),
-                        command,
-                        transition.command_status,
-                    )
-                    .await?,
-                );
-            }
             upsert_instance_tx(&mut tx, final_instance).await?;
+        } else if record.accepted {
+            anyhow::bail!("accepted workflow submission requires a final instance");
         }
 
         tx.commit().await?;
@@ -178,7 +187,6 @@ async fn lock_submission_tx(
 async fn load_submission_instance_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     transition: &WorkflowSubmissionDecisionTransition<'_>,
-    accepted: bool,
 ) -> anyhow::Result<Option<WorkflowInstance>> {
     if let Some(current) = select_instance_for_update_tx(tx, transition.workflow_id).await? {
         return Ok(Some(current));
@@ -198,10 +206,6 @@ async fn load_submission_instance_tx(
     {
         return Ok(None);
     }
-    if !accepted {
-        return Ok(Some(initial.clone()));
-    }
-
     if insert_instance_if_absent_tx(tx, initial).await? {
         return Ok(Some(initial.clone()));
     }

--- a/crates/harness-workflow/src/runtime/store_migrations.rs
+++ b/crates/harness-workflow/src/runtime/store_migrations.rs
@@ -239,4 +239,127 @@ pub(super) static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
                   'failed', 'cancelled'
                 ))",
     },
+    Migration {
+        version: 14,
+        description: "guard workflow runtime graph references",
+        sql: "DO $$
+              BEGIN
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'workflow_events_workflow_id_fkey'
+                    AND conrelid = 'workflow_events'::regclass
+                ) THEN
+                  ALTER TABLE workflow_events
+                    ADD CONSTRAINT workflow_events_workflow_id_fkey
+                    FOREIGN KEY (workflow_id)
+                    REFERENCES workflow_instances(id)
+                    ON DELETE CASCADE
+                    NOT VALID;
+                END IF;
+
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'workflow_decisions_workflow_id_fkey'
+                    AND conrelid = 'workflow_decisions'::regclass
+                ) THEN
+                  ALTER TABLE workflow_decisions
+                    ADD CONSTRAINT workflow_decisions_workflow_id_fkey
+                    FOREIGN KEY (workflow_id)
+                    REFERENCES workflow_instances(id)
+                    ON DELETE CASCADE
+                    NOT VALID;
+                END IF;
+
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'workflow_decisions_event_id_fkey'
+                    AND conrelid = 'workflow_decisions'::regclass
+                ) THEN
+                  ALTER TABLE workflow_decisions
+                    ADD CONSTRAINT workflow_decisions_event_id_fkey
+                    FOREIGN KEY (event_id)
+                    REFERENCES workflow_events(id)
+                    ON DELETE SET NULL
+                    NOT VALID;
+                END IF;
+
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'workflow_commands_workflow_id_fkey'
+                    AND conrelid = 'workflow_commands'::regclass
+                ) THEN
+                  ALTER TABLE workflow_commands
+                    ADD CONSTRAINT workflow_commands_workflow_id_fkey
+                    FOREIGN KEY (workflow_id)
+                    REFERENCES workflow_instances(id)
+                    ON DELETE CASCADE
+                    NOT VALID;
+                END IF;
+
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'workflow_commands_decision_id_fkey'
+                    AND conrelid = 'workflow_commands'::regclass
+                ) THEN
+                  ALTER TABLE workflow_commands
+                    ADD CONSTRAINT workflow_commands_decision_id_fkey
+                    FOREIGN KEY (decision_id)
+                    REFERENCES workflow_decisions(id)
+                    ON DELETE SET NULL
+                    NOT VALID;
+                END IF;
+
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'runtime_jobs_command_id_fkey'
+                    AND conrelid = 'runtime_jobs'::regclass
+                ) THEN
+                  ALTER TABLE runtime_jobs
+                    ADD CONSTRAINT runtime_jobs_command_id_fkey
+                    FOREIGN KEY (command_id)
+                    REFERENCES workflow_commands(id)
+                    ON DELETE CASCADE
+                    NOT VALID;
+                END IF;
+
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'runtime_events_runtime_job_id_fkey'
+                    AND conrelid = 'runtime_events'::regclass
+                ) THEN
+                  ALTER TABLE runtime_events
+                    ADD CONSTRAINT runtime_events_runtime_job_id_fkey
+                    FOREIGN KEY (runtime_job_id)
+                    REFERENCES runtime_jobs(id)
+                    ON DELETE CASCADE
+                    NOT VALID;
+                END IF;
+
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'workflow_artifacts_workflow_id_fkey'
+                    AND conrelid = 'workflow_artifacts'::regclass
+                ) THEN
+                  ALTER TABLE workflow_artifacts
+                    ADD CONSTRAINT workflow_artifacts_workflow_id_fkey
+                    FOREIGN KEY (workflow_id)
+                    REFERENCES workflow_instances(id)
+                    ON DELETE CASCADE
+                    NOT VALID;
+                END IF;
+
+                IF NOT EXISTS (
+                  SELECT 1 FROM pg_constraint
+                  WHERE conname = 'workflow_artifacts_runtime_job_id_fkey'
+                    AND conrelid = 'workflow_artifacts'::regclass
+                ) THEN
+                  ALTER TABLE workflow_artifacts
+                    ADD CONSTRAINT workflow_artifacts_runtime_job_id_fkey
+                    FOREIGN KEY (runtime_job_id)
+                    REFERENCES runtime_jobs(id)
+                    ON DELETE SET NULL
+                    NOT VALID;
+                END IF;
+              END $$",
+    },
 ];

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -94,6 +94,74 @@ fn project_issue_instance(project_id: &str, issue_number: u64, state: &str) -> W
     }))
 }
 
+async fn enqueue_test_runtime_job(
+    store: &WorkflowRuntimeStore,
+    command_key: &str,
+    runtime_kind: RuntimeKind,
+    runtime_profile: &str,
+    input: serde_json::Value,
+) -> anyhow::Result<RuntimeJob> {
+    enqueue_test_runtime_job_with_not_before(
+        store,
+        command_key,
+        runtime_kind,
+        runtime_profile,
+        input,
+        None,
+    )
+    .await
+}
+
+async fn enqueue_test_runtime_job_with_not_before(
+    store: &WorkflowRuntimeStore,
+    command_key: &str,
+    runtime_kind: RuntimeKind,
+    runtime_profile: &str,
+    input: serde_json::Value,
+    not_before: Option<DateTime<Utc>>,
+) -> anyhow::Result<RuntimeJob> {
+    let workflow = issue_instance("implementing").with_id(format!("test-workflow-{command_key}"));
+    store.upsert_instance(&workflow).await?;
+    enqueue_workflow_runtime_job(
+        store,
+        &workflow.id,
+        command_key,
+        runtime_kind,
+        runtime_profile,
+        input,
+        not_before,
+    )
+    .await
+}
+
+async fn enqueue_workflow_runtime_job(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    command_key: &str,
+    runtime_kind: RuntimeKind,
+    runtime_profile: &str,
+    input: serde_json::Value,
+    not_before: Option<DateTime<Utc>>,
+) -> anyhow::Result<RuntimeJob> {
+    let activity = input
+        .get("activity")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("test_activity")
+        .to_string();
+    let command =
+        WorkflowCommand::enqueue_activity(activity, format!("test-command-{command_key}"));
+    let command_id = store.enqueue_command(workflow_id, None, &command).await?;
+    store
+        .enqueue_runtime_job_with_not_before(
+            &command_id,
+            runtime_kind,
+            runtime_profile,
+            input,
+            not_before,
+        )
+        .await
+}
+
 fn runtime_completion_event(
     instance: &WorkflowInstance,
     activity: &str,
@@ -4284,14 +4352,14 @@ async fn runtime_worker_claims_one_job_once_and_records_events() -> anyhow::Resu
 
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
-    let job = store
-        .enqueue_runtime_job(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": "check" }),
-        )
-        .await?;
+    let job = enqueue_test_runtime_job(
+        &store,
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "check" }),
+    )
+    .await?;
     let worker = RuntimeWorker::new(&store, "runtime-1").with_lease_ttl(Duration::minutes(5));
     let executor = StaticRuntimeExecutor {
         result: ActivityResult::succeeded("check", "Validation passed."),
@@ -4399,15 +4467,15 @@ async fn runtime_worker_skips_runtime_jobs_before_not_before() -> anyhow::Result
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
     let not_before = Utc::now() + Duration::minutes(5);
-    let job = store
-        .enqueue_runtime_job_with_not_before(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": "check" }),
-            Some(not_before),
-        )
-        .await?;
+    let job = enqueue_test_runtime_job_with_not_before(
+        &store,
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "check" }),
+        Some(not_before),
+    )
+    .await?;
     let calls = Arc::new(AtomicUsize::new(0));
     let executor = CountingRuntimeExecutor {
         result: ActivityResult::succeeded("check", "Validation passed."),
@@ -4440,14 +4508,14 @@ async fn runtime_store_reclaims_expired_running_job() -> anyhow::Result<()> {
 
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
-    let job = store
-        .enqueue_runtime_job(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": "check" }),
-        )
-        .await?;
+    let job = enqueue_test_runtime_job(
+        &store,
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "check" }),
+    )
+    .await?;
 
     let first_claim = store
         .claim_next_runtime_job("runtime-1", Utc::now() - Duration::minutes(1))
@@ -4533,32 +4601,32 @@ async fn runtime_store_prioritizes_ready_work_over_older_backlog_jobs() -> anyho
 
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
-    let backlog = store
-        .enqueue_runtime_job(
-            "command-backlog",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": REPO_BACKLOG_POLL_ACTIVITY }),
-        )
-        .await?;
+    let backlog = enqueue_test_runtime_job(
+        &store,
+        "command-backlog",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": REPO_BACKLOG_POLL_ACTIVITY }),
+    )
+    .await?;
     tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-    let sprint_plan = store
-        .enqueue_runtime_job(
-            "command-sprint-plan",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY }),
-        )
-        .await?;
+    let sprint_plan = enqueue_test_runtime_job(
+        &store,
+        "command-sprint-plan",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": REPO_BACKLOG_SPRINT_PLAN_ACTIVITY }),
+    )
+    .await?;
     tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-    let implementation = store
-        .enqueue_runtime_job(
-            "command-implement",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": "implement_issue" }),
-        )
-        .await?;
+    let implementation = enqueue_test_runtime_job(
+        &store,
+        "command-implement",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "implement_issue" }),
+    )
+    .await?;
 
     let first = store
         .claim_next_runtime_job("runtime-1", Utc::now() + Duration::minutes(5))
@@ -4592,14 +4660,14 @@ async fn runtime_store_does_not_reclaim_unexpired_running_job() -> anyhow::Resul
 
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
-    let job = store
-        .enqueue_runtime_job(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": "check" }),
-        )
-        .await?;
+    let job = enqueue_test_runtime_job(
+        &store,
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "check" }),
+    )
+    .await?;
 
     let first_claim = store
         .claim_next_runtime_job("runtime-1", Utc::now() + Duration::minutes(5))
@@ -4623,14 +4691,14 @@ async fn runtime_worker_renews_running_job_lease_until_completion() -> anyhow::R
     let dir = tempfile::tempdir()?;
     let store =
         Arc::new(WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?);
-    let job = store
-        .enqueue_runtime_job(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": "check" }),
-        )
-        .await?;
+    let job = enqueue_test_runtime_job(
+        store.as_ref(),
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "check" }),
+    )
+    .await?;
     let (started_tx, started_rx) = tokio::sync::oneshot::channel();
     let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
     let blocking_calls = Arc::new(AtomicUsize::new(0));
@@ -5870,14 +5938,14 @@ async fn runtime_worker_records_failed_activity_result() -> anyhow::Result<()> {
 
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
-    store
-        .enqueue_runtime_job(
-            "command-2",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": "implement" }),
-        )
-        .await?;
+    enqueue_test_runtime_job(
+        &store,
+        "command-2",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "implement" }),
+    )
+    .await?;
     let worker = RuntimeWorker::new(&store, "runtime-1");
     let executor = StaticRuntimeExecutor {
         result: ActivityResult::failed(
@@ -5911,14 +5979,14 @@ async fn runtime_worker_cancelled_result_releases_lease() -> anyhow::Result<()> 
 
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
-    store
-        .enqueue_runtime_job(
-            "command-3",
-            RuntimeKind::ClaudeCode,
-            "claude-default",
-            json!({ "activity": "review" }),
-        )
-        .await?;
+    enqueue_test_runtime_job(
+        &store,
+        "command-3",
+        RuntimeKind::ClaudeCode,
+        "claude-default",
+        json!({ "activity": "review" }),
+    )
+    .await?;
     let worker = RuntimeWorker::new(&store, "runtime-1");
     let executor = StaticRuntimeExecutor {
         result: ActivityResult::cancelled("review", "Runtime job was cancelled."),

--- a/crates/harness-workflow/src/runtime/tests/p1_followups.rs
+++ b/crates/harness-workflow/src/runtime/tests/p1_followups.rs
@@ -55,14 +55,16 @@ async fn runtime_worker_completes_job_when_workflow_already_done() -> anyhow::Re
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
     let instance = issue_instance("done");
     store.upsert_instance(&instance).await?;
-    let job = store
-        .enqueue_runtime_job(
-            "command-terminal-done",
-            RuntimeKind::ClaudeCode,
-            "claude-default",
-            json!({ "activity": "implement_issue", "workflow_id": instance.id }),
-        )
-        .await?;
+    let job = enqueue_workflow_runtime_job(
+        &store,
+        &instance.id,
+        "command-terminal-done",
+        RuntimeKind::ClaudeCode,
+        "claude-default",
+        json!({ "activity": "implement_issue", "workflow_id": instance.id }),
+        None,
+    )
+    .await?;
     let calls = Arc::new(AtomicUsize::new(0));
     let worker = RuntimeWorker::new(&store, "runtime-1");
     let executor = CountingRuntimeExecutor {
@@ -99,6 +101,18 @@ async fn runtime_store_pending_dedupe_refreshes_command_payload() -> anyhow::Res
         "implement_issue",
         "repo-backlog:owner/repo:issue:1200:start",
     );
+    let mut old_decision = WorkflowDecisionRecord::accepted(
+        WorkflowDecision::new(
+            instance.id.clone(),
+            "dispatching",
+            "enqueue_old_command",
+            "dispatching",
+            "Record the original pending command.",
+        ),
+        None,
+    );
+    old_decision.id = "decision-old".to_string();
+    store.record_decision(&old_decision).await?;
     let command_id = store
         .enqueue_command(&instance.id, Some("decision-old"), &first)
         .await?;
@@ -107,6 +121,18 @@ async fn runtime_store_pending_dedupe_refreshes_command_payload() -> anyhow::Res
         "issue:1200",
         "repo-backlog:owner/repo:issue:1200:start",
     );
+    let mut new_decision = WorkflowDecisionRecord::accepted(
+        WorkflowDecision::new(
+            instance.id.clone(),
+            "dispatching",
+            "refresh_command_payload",
+            "dispatching",
+            "Refresh the pending command payload.",
+        ),
+        None,
+    );
+    new_decision.id = "decision-new".to_string();
+    store.record_decision(&new_decision).await?;
     let duplicate_id = store
         .enqueue_command(&instance.id, Some("decision-new"), &updated)
         .await?;
@@ -135,14 +161,14 @@ async fn runtime_store_running_lease_match_accepts_renewed_generation() -> anyho
 
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
-    store
-        .enqueue_runtime_job(
-            "command-renewed-lease",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": "start_child_workflow" }),
-        )
-        .await?;
+    enqueue_test_runtime_job(
+        &store,
+        "command-renewed-lease",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "start_child_workflow" }),
+    )
+    .await?;
     let initial_expires_at = Utc::now() - Duration::seconds(1);
     let claimed = store
         .claim_next_runtime_job("runtime-1", initial_expires_at)
@@ -178,14 +204,14 @@ async fn runtime_store_running_lease_match_rejects_expired_same_owner_reclaim() 
 
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
-    store
-        .enqueue_runtime_job(
-            "command-stale-lease",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({ "activity": "start_child_workflow" }),
-        )
-        .await?;
+    enqueue_test_runtime_job(
+        &store,
+        "command-stale-lease",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "start_child_workflow" }),
+    )
+    .await?;
     let expired_expires_at = Utc::now() - Duration::minutes(1);
     let stale_claim = store
         .claim_next_runtime_job("runtime-1", expired_expires_at)

--- a/crates/harness-workflow/src/runtime/tests/runtime_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_store.rs
@@ -49,6 +49,214 @@ async fn runtime_jobs_reject_legacy_invalid_status_values() -> anyhow::Result<()
 }
 
 #[tokio::test]
+async fn runtime_graph_rejects_orphan_references() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let workflow = issue_instance("implementing").with_id("fk-workflow");
+    store.upsert_instance(&workflow).await?;
+    let command = WorkflowCommand::enqueue_activity("fk_activity", "fk-command");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    let runtime_job = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "fk_activity" }),
+        )
+        .await?;
+
+    let error = sqlx::query(
+        "INSERT INTO workflow_events (id, workflow_id, sequence, event_type, source, data)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
+    )
+    .bind("orphan-event")
+    .bind("missing-workflow")
+    .bind(1_i64)
+    .bind("OrphanEvent")
+    .bind("test")
+    .bind("{}")
+    .execute(store.pool())
+    .await
+    .expect_err("workflow event without a workflow should be rejected");
+    assert_constraint_error(error, "workflow_events_workflow_id_fkey");
+
+    let error = sqlx::query(
+        "INSERT INTO workflow_decisions (id, workflow_id, event_id, accepted, data)
+         VALUES ($1, $2, $3, $4, $5::jsonb)",
+    )
+    .bind("orphan-decision-workflow")
+    .bind("missing-workflow")
+    .bind(Option::<String>::None)
+    .bind(true)
+    .bind("{}")
+    .execute(store.pool())
+    .await
+    .expect_err("workflow decision without a workflow should be rejected");
+    assert_constraint_error(error, "workflow_decisions_workflow_id_fkey");
+
+    let error = sqlx::query(
+        "INSERT INTO workflow_decisions (id, workflow_id, event_id, accepted, data)
+         VALUES ($1, $2, $3, $4, $5::jsonb)",
+    )
+    .bind("orphan-decision-event")
+    .bind(&workflow.id)
+    .bind("missing-event")
+    .bind(true)
+    .bind("{}")
+    .execute(store.pool())
+    .await
+    .expect_err("workflow decision without an event should be rejected");
+    assert_constraint_error(error, "workflow_decisions_event_id_fkey");
+
+    let error = sqlx::query(
+        "INSERT INTO workflow_commands
+            (id, workflow_id, decision_id, command_type, dedupe_key, status, data)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)",
+    )
+    .bind("orphan-command-workflow")
+    .bind("missing-workflow")
+    .bind(Option::<String>::None)
+    .bind("enqueue_activity")
+    .bind("orphan-command-workflow")
+    .bind("pending")
+    .bind("{}")
+    .execute(store.pool())
+    .await
+    .expect_err("workflow command without a workflow should be rejected");
+    assert_constraint_error(error, "workflow_commands_workflow_id_fkey");
+
+    let error = sqlx::query(
+        "INSERT INTO workflow_commands
+            (id, workflow_id, decision_id, command_type, dedupe_key, status, data)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)",
+    )
+    .bind("orphan-command-decision")
+    .bind(&workflow.id)
+    .bind("missing-decision")
+    .bind("enqueue_activity")
+    .bind("orphan-command-decision")
+    .bind("pending")
+    .bind("{}")
+    .execute(store.pool())
+    .await
+    .expect_err("workflow command without a decision should be rejected");
+    assert_constraint_error(error, "workflow_commands_decision_id_fkey");
+
+    let error = sqlx::query(
+        "INSERT INTO runtime_jobs
+            (id, command_id, runtime_kind, runtime_profile, status, data)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
+    )
+    .bind("orphan-runtime-job")
+    .bind("missing-command")
+    .bind("codex_jsonrpc")
+    .bind("codex-default")
+    .bind("pending")
+    .bind("{}")
+    .execute(store.pool())
+    .await
+    .expect_err("runtime job without a command should be rejected");
+    assert_constraint_error(error, "runtime_jobs_command_id_fkey");
+
+    let error = sqlx::query(
+        "INSERT INTO runtime_events (id, runtime_job_id, sequence, event_type, data)
+         VALUES ($1, $2, $3, $4, $5::jsonb)",
+    )
+    .bind("orphan-runtime-event")
+    .bind("missing-runtime-job")
+    .bind(1_i64)
+    .bind("RuntimePromptPrepared")
+    .bind("{}")
+    .execute(store.pool())
+    .await
+    .expect_err("runtime event without a runtime job should be rejected");
+    assert_constraint_error(error, "runtime_events_runtime_job_id_fkey");
+
+    let error = sqlx::query(
+        "INSERT INTO workflow_artifacts (id, workflow_id, runtime_job_id, artifact_type, data)
+         VALUES ($1, $2, $3, $4, $5::jsonb)",
+    )
+    .bind("orphan-artifact-workflow")
+    .bind("missing-workflow")
+    .bind(Option::<String>::None)
+    .bind("test")
+    .bind("{}")
+    .execute(store.pool())
+    .await
+    .expect_err("workflow artifact without a workflow should be rejected");
+    assert_constraint_error(error, "workflow_artifacts_workflow_id_fkey");
+
+    let error = sqlx::query(
+        "INSERT INTO workflow_artifacts (id, workflow_id, runtime_job_id, artifact_type, data)
+         VALUES ($1, $2, $3, $4, $5::jsonb)",
+    )
+    .bind("orphan-artifact-runtime-job")
+    .bind(&workflow.id)
+    .bind("missing-runtime-job")
+    .bind("test")
+    .bind("{}")
+    .execute(store.pool())
+    .await
+    .expect_err("workflow artifact without a runtime job should be rejected");
+    assert_constraint_error(error, "workflow_artifacts_runtime_job_id_fkey");
+
+    store
+        .record_runtime_event(
+            &runtime_job.id,
+            "RuntimePromptPrepared",
+            json!({ "ok": true }),
+        )
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_graph_fk_migration_allows_existing_orphan_rows() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let db_path = dir.path().join("workflow_runtime.db");
+    let store = WorkflowRuntimeStore::open(&db_path).await?;
+    drop_runtime_graph_fk_constraints(&store).await?;
+    sqlx::query("DELETE FROM schema_migrations WHERE version = 14")
+        .execute(store.pool())
+        .await?;
+    insert_legacy_orphan_runtime_graph_rows(&store).await?;
+    drop(store);
+
+    let store = WorkflowRuntimeStore::open(&db_path).await?;
+    let (orphan_event_count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM workflow_events WHERE id = $1")
+            .bind("legacy-orphan-event")
+            .fetch_one(store.pool())
+            .await?;
+    assert_eq!(orphan_event_count, 1);
+
+    let error = sqlx::query(
+        "INSERT INTO runtime_jobs
+            (id, command_id, runtime_kind, runtime_profile, status, data)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
+    )
+    .bind("new-orphan-runtime-job-after-v14")
+    .bind("missing-command-after-v14")
+    .bind("codex_jsonrpc")
+    .bind("codex-default")
+    .bind("pending")
+    .bind("{}")
+    .execute(store.pool())
+    .await
+    .expect_err("v14 should reject new orphan runtime jobs after migration");
+    assert_constraint_error(error, "runtime_jobs_command_id_fkey");
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_jobs_migration_rewrites_legacy_expired_statuses() -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {
         return Ok(());
@@ -57,14 +265,14 @@ async fn runtime_jobs_migration_rewrites_legacy_expired_statuses() -> anyhow::Re
     let dir = tempfile::tempdir()?;
     let db_path = dir.path().join("workflow_runtime.db");
     let store = WorkflowRuntimeStore::open(&db_path).await?;
-    let job = store
-        .enqueue_runtime_job(
-            "legacy-expired-command",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({"legacy": true}),
-        )
-        .await?;
+    let job = enqueue_test_runtime_job(
+        &store,
+        "legacy-expired-command",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({"legacy": true}),
+    )
+    .await?;
     sqlx::query("ALTER TABLE runtime_jobs DROP CONSTRAINT IF EXISTS runtime_jobs_status_check")
         .execute(store.pool())
         .await?;
@@ -174,18 +382,127 @@ fn runtime_job_status_str(status: RuntimeJobStatus) -> anyhow::Result<String> {
         .ok_or_else(|| anyhow::anyhow!("runtime job status did not serialize to a string"))
 }
 
+fn assert_constraint_error(error: sqlx::Error, constraint_name: &str) {
+    let error = format!("{error:#}");
+    assert!(
+        error.contains(constraint_name),
+        "expected {constraint_name}, got: {error}"
+    );
+}
+
+async fn drop_runtime_graph_fk_constraints(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
+    for statement in [
+        "ALTER TABLE workflow_events DROP CONSTRAINT IF EXISTS workflow_events_workflow_id_fkey",
+        "ALTER TABLE workflow_decisions DROP CONSTRAINT IF EXISTS workflow_decisions_workflow_id_fkey",
+        "ALTER TABLE workflow_decisions DROP CONSTRAINT IF EXISTS workflow_decisions_event_id_fkey",
+        "ALTER TABLE workflow_commands DROP CONSTRAINT IF EXISTS workflow_commands_workflow_id_fkey",
+        "ALTER TABLE workflow_commands DROP CONSTRAINT IF EXISTS workflow_commands_decision_id_fkey",
+        "ALTER TABLE runtime_jobs DROP CONSTRAINT IF EXISTS runtime_jobs_command_id_fkey",
+        "ALTER TABLE runtime_events DROP CONSTRAINT IF EXISTS runtime_events_runtime_job_id_fkey",
+        "ALTER TABLE workflow_artifacts DROP CONSTRAINT IF EXISTS workflow_artifacts_workflow_id_fkey",
+        "ALTER TABLE workflow_artifacts DROP CONSTRAINT IF EXISTS workflow_artifacts_runtime_job_id_fkey",
+    ] {
+        sqlx::query(statement).execute(store.pool()).await?;
+    }
+    Ok(())
+}
+
+async fn insert_legacy_orphan_runtime_graph_rows(
+    store: &WorkflowRuntimeStore,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO workflow_events (id, workflow_id, sequence, event_type, source, data)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
+    )
+    .bind("legacy-orphan-event")
+    .bind("missing-legacy-workflow")
+    .bind(1_i64)
+    .bind("LegacyOrphanEvent")
+    .bind("test")
+    .bind("{}")
+    .execute(store.pool())
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO workflow_decisions (id, workflow_id, event_id, accepted, data)
+         VALUES ($1, $2, $3, $4, $5::jsonb)",
+    )
+    .bind("legacy-orphan-decision")
+    .bind("missing-legacy-workflow")
+    .bind("missing-legacy-event")
+    .bind(true)
+    .bind("{}")
+    .execute(store.pool())
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO workflow_commands
+            (id, workflow_id, decision_id, command_type, dedupe_key, status, data)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)",
+    )
+    .bind("legacy-orphan-command")
+    .bind("missing-legacy-workflow")
+    .bind("missing-legacy-decision")
+    .bind("enqueue_activity")
+    .bind("legacy-orphan-command")
+    .bind("pending")
+    .bind("{}")
+    .execute(store.pool())
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO runtime_jobs
+            (id, command_id, runtime_kind, runtime_profile, status, data)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
+    )
+    .bind("legacy-orphan-runtime-job")
+    .bind("missing-legacy-command")
+    .bind("codex_jsonrpc")
+    .bind("codex-default")
+    .bind("pending")
+    .bind("{}")
+    .execute(store.pool())
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO runtime_events (id, runtime_job_id, sequence, event_type, data)
+         VALUES ($1, $2, $3, $4, $5::jsonb)",
+    )
+    .bind("legacy-orphan-runtime-event")
+    .bind("missing-legacy-runtime-job")
+    .bind(1_i64)
+    .bind("RuntimePromptPrepared")
+    .bind("{}")
+    .execute(store.pool())
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO workflow_artifacts (id, workflow_id, runtime_job_id, artifact_type, data)
+         VALUES ($1, $2, $3, $4, $5::jsonb)",
+    )
+    .bind("legacy-orphan-artifact")
+    .bind("missing-legacy-workflow")
+    .bind("missing-legacy-runtime-job")
+    .bind("test")
+    .bind("{}")
+    .execute(store.pool())
+    .await?;
+    Ok(())
+}
+
 async fn insert_runtime_job_with_status(
     store: &WorkflowRuntimeStore,
     id: &str,
     status: &str,
-) -> Result<(), sqlx::Error> {
+) -> anyhow::Result<()> {
+    let command_id = test_runtime_job_command_id(store, id).await?;
     sqlx::query(
         "INSERT INTO runtime_jobs
             (id, command_id, runtime_kind, runtime_profile, status, data)
          VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
     )
     .bind(id)
-    .bind(format!("command-{id}"))
+    .bind(command_id)
     .bind("codex_jsonrpc")
     .bind("codex-default")
     .bind(status)
@@ -193,6 +510,16 @@ async fn insert_runtime_job_with_status(
     .execute(store.pool())
     .await?;
     Ok(())
+}
+
+async fn test_runtime_job_command_id(
+    store: &WorkflowRuntimeStore,
+    id: &str,
+) -> anyhow::Result<String> {
+    let workflow = issue_instance("implementing").with_id(format!("status-test-workflow-{id}"));
+    store.upsert_instance(&workflow).await?;
+    let command = WorkflowCommand::enqueue_activity("status_test", format!("status-test-{id}"));
+    store.enqueue_command(&workflow.id, None, &command).await
 }
 
 #[tokio::test]

--- a/crates/harness-workflow/src/runtime/tests/runtime_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_store.rs
@@ -246,6 +246,74 @@ async fn insert_instance_if_absent_does_not_overwrite_existing_workflow() -> any
 }
 
 #[tokio::test]
+async fn runtime_dispatch_skips_legacy_orphan_commands_and_jobs() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    drop_runtime_graph_fk_constraints(&store).await?;
+    let command_id = "legacy-orphan-dispatch-command";
+    let workflow_id = "missing-legacy-workflow";
+    let command = WorkflowCommand::enqueue_activity("orphan_activity", "legacy-orphan-dedupe");
+    insert_legacy_orphan_command(
+        &store,
+        command_id,
+        workflow_id,
+        &command,
+        WorkflowCommandStatus::Pending,
+    )
+    .await?;
+
+    assert!(store.pending_commands(10).await?.is_empty());
+    assert!(store
+        .claim_pending_commands(
+            "legacy-orphan-dispatcher",
+            Utc::now() + Duration::minutes(5),
+            10,
+        )
+        .await?
+        .is_empty());
+
+    sqlx::query("UPDATE workflow_commands SET status = $1 WHERE id = $2")
+        .bind(WorkflowCommandStatus::Dispatched.as_str())
+        .bind(command_id)
+        .execute(store.pool())
+        .await?;
+    let lease_expires_at = Utc::now() + Duration::minutes(5);
+    let mut job = RuntimeJob::pending(
+        command_id,
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({"activity": "orphan_activity"}),
+    );
+    insert_runtime_job_record(&store, &job).await?;
+
+    assert!(store
+        .claim_next_runtime_job("legacy-orphan-worker", lease_expires_at)
+        .await?
+        .is_none());
+
+    job.claim("legacy-orphan-worker", lease_expires_at);
+    update_runtime_job_record(&store, &job).await?;
+    let Some(completion) = store
+        .commit_runtime_activity_completion_if_owned(
+            &job.id,
+            "legacy-orphan-worker",
+            lease_expires_at,
+            &ActivityResult::succeeded("orphan_activity", "Legacy orphan completed."),
+        )
+        .await?
+    else {
+        anyhow::bail!("orphan runtime job completion should be acknowledged");
+    };
+    assert!(completion.workflow_event.is_none());
+    assert!(store.events_for(workflow_id).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_graph_fk_migration_allows_existing_orphan_rows() -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {
         return Ok(());
@@ -411,6 +479,72 @@ fn runtime_job_status_str(status: RuntimeJobStatus) -> anyhow::Result<String> {
         .as_str()
         .map(str::to_string)
         .ok_or_else(|| anyhow::anyhow!("runtime job status did not serialize to a string"))
+}
+
+async fn insert_legacy_orphan_command(
+    store: &WorkflowRuntimeStore,
+    command_id: &str,
+    workflow_id: &str,
+    command: &WorkflowCommand,
+    status: WorkflowCommandStatus,
+) -> anyhow::Result<()> {
+    let data = serde_json::to_string(command)?;
+    sqlx::query(
+        "INSERT INTO workflow_commands
+            (id, workflow_id, decision_id, command_type, dedupe_key, status, data)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)",
+    )
+    .bind(command_id)
+    .bind(workflow_id)
+    .bind(Option::<String>::None)
+    .bind("enqueue_activity")
+    .bind(&command.dedupe_key)
+    .bind(status.as_str())
+    .bind(&data)
+    .execute(store.pool())
+    .await?;
+    Ok(())
+}
+
+async fn insert_runtime_job_record(
+    store: &WorkflowRuntimeStore,
+    job: &RuntimeJob,
+) -> anyhow::Result<()> {
+    let data = serde_json::to_string(job)?;
+    sqlx::query(
+        "INSERT INTO runtime_jobs
+            (id, command_id, runtime_kind, runtime_profile, status, not_before, data)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)",
+    )
+    .bind(&job.id)
+    .bind(&job.command_id)
+    .bind("codex_jsonrpc")
+    .bind(&job.runtime_profile)
+    .bind(runtime_job_status_str(job.status)?)
+    .bind(job.not_before)
+    .bind(&data)
+    .execute(store.pool())
+    .await?;
+    Ok(())
+}
+
+async fn update_runtime_job_record(
+    store: &WorkflowRuntimeStore,
+    job: &RuntimeJob,
+) -> anyhow::Result<()> {
+    let data = serde_json::to_string(job)?;
+    sqlx::query(
+        "UPDATE runtime_jobs
+         SET status = $1, not_before = $2, data = $3::jsonb, updated_at = CURRENT_TIMESTAMP
+         WHERE id = $4",
+    )
+    .bind(runtime_job_status_str(job.status)?)
+    .bind(job.not_before)
+    .bind(&data)
+    .bind(&job.id)
+    .execute(store.pool())
+    .await?;
+    Ok(())
 }
 
 fn assert_constraint_error(error: sqlx::Error, constraint_name: &str) {

--- a/crates/harness-workflow/src/runtime/tests/runtime_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_store.rs
@@ -294,6 +294,22 @@ async fn runtime_dispatch_skips_legacy_orphan_commands_and_jobs() -> anyhow::Res
         .claim_next_runtime_job("legacy-orphan-worker", lease_expires_at)
         .await?
         .is_none());
+    assert!(store
+        .claim_next_runtime_job_for_runtime_kind(
+            RuntimeKind::CodexJsonrpc,
+            "legacy-orphan-remote-worker",
+            lease_expires_at,
+        )
+        .await?
+        .is_none());
+    assert!(store
+        .claim_next_runtime_job_excluding_runtime_kind(
+            RuntimeKind::RemoteHost,
+            "legacy-orphan-local-worker",
+            lease_expires_at,
+        )
+        .await?
+        .is_none());
 
     job.claim("legacy-orphan-worker", lease_expires_at);
     update_runtime_job_record(&store, &job).await?;

--- a/crates/harness-workflow/src/runtime/tests/runtime_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_store.rs
@@ -215,6 +215,37 @@ async fn runtime_graph_rejects_orphan_references() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn insert_instance_if_absent_does_not_overwrite_existing_workflow() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let workflow_id = "insert-if-absent-existing-workflow";
+    let existing = issue_instance("implementing")
+        .with_id(workflow_id)
+        .with_data(json!({"marker": "real"}));
+    store.upsert_instance(&existing).await?;
+
+    let fallback = issue_instance("failed")
+        .with_id(workflow_id)
+        .with_data(json!({"marker": "fallback"}));
+    let inserted = store.insert_instance_if_absent(&fallback).await?;
+
+    assert!(!inserted);
+    let Some(persisted) = store.get_instance(workflow_id).await? else {
+        anyhow::bail!("existing workflow should still be present");
+    };
+    assert_eq!(persisted.state, "implementing");
+    assert_eq!(persisted.data["marker"], "real");
+
+    let new_workflow = issue_instance("failed").with_id("insert-if-absent-new-workflow");
+    assert!(store.insert_instance_if_absent(&new_workflow).await?);
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_graph_fk_migration_allows_existing_orphan_rows() -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {
         return Ok(());

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -426,7 +426,8 @@ fn runtime_budget_blocked_result(
 mod tests {
     use super::*;
     use crate::runtime::{
-        RuntimeJobStatus, RuntimeKind, WorkflowCommandType, WorkflowRuntimeStore,
+        RuntimeJobStatus, RuntimeKind, WorkflowCommand, WorkflowCommandType, WorkflowInstance,
+        WorkflowRuntimeStore, WorkflowSubject,
     };
     use async_trait::async_trait;
     use harness_core::db::resolve_database_url;
@@ -453,6 +454,33 @@ mod tests {
         }
     }
 
+    async fn enqueue_test_runtime_job(
+        store: &WorkflowRuntimeStore,
+        key: &str,
+        runtime_kind: RuntimeKind,
+        runtime_profile: &str,
+        input: serde_json::Value,
+    ) -> anyhow::Result<RuntimeJob> {
+        let workflow = WorkflowInstance::new(
+            "github_issue_pr",
+            1,
+            "implementing",
+            WorkflowSubject::new("issue", format!("issue:{key}")),
+        )
+        .with_id(format!("runtime-worker-test-{key}"));
+        store.upsert_instance(&workflow).await?;
+        let activity = input
+            .get("activity")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("test_activity");
+        let command =
+            WorkflowCommand::enqueue_activity(activity, format!("runtime-worker-test-{key}"));
+        let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+        store
+            .enqueue_runtime_job(&command_id, runtime_kind, runtime_profile, input)
+            .await
+    }
+
     #[tokio::test]
     async fn preflight_result_completes_job_before_runtime_turn_starts() -> anyhow::Result<()> {
         if resolve_database_url(None).is_err() {
@@ -465,14 +493,14 @@ mod tests {
             "workflow_runtime",
         ))
         .await?;
-        let job = store
-            .enqueue_runtime_job(
-                "command-1",
-                RuntimeKind::CodexJsonrpc,
-                "codex-default",
-                json!({ "activity": "check" }),
-            )
-            .await?;
+        let job = enqueue_test_runtime_job(
+            &store,
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "check" }),
+        )
+        .await?;
         let executions = Arc::new(AtomicUsize::new(0));
         let executor = PreflightRuntimeExecutor {
             result: ActivityResult::cancelled("check", "Runtime worker disabled."),
@@ -507,22 +535,22 @@ mod tests {
             "workflow_runtime",
         ))
         .await?;
-        let remote_job = store
-            .enqueue_runtime_job(
-                "command-remote",
-                RuntimeKind::RemoteHost,
-                "remote-host-default",
-                json!({ "activity": "remote_check" }),
-            )
-            .await?;
-        let local_job = store
-            .enqueue_runtime_job(
-                "command-local",
-                RuntimeKind::CodexJsonrpc,
-                "codex-default",
-                json!({ "activity": "local_check" }),
-            )
-            .await?;
+        let remote_job = enqueue_test_runtime_job(
+            &store,
+            "command-remote",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({ "activity": "remote_check" }),
+        )
+        .await?;
+        let local_job = enqueue_test_runtime_job(
+            &store,
+            "command-local",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "local_check" }),
+        )
+        .await?;
         let executions = Arc::new(AtomicUsize::new(0));
         let executor = PreflightRuntimeExecutor {
             result: ActivityResult::succeeded("local_check", "Local worker completed."),


### PR DESCRIPTION
## Summary
- add v14 workflow runtime graph foreign-key guards as NOT VALID constraints
- keep rejected/new submission audit rows valid by persisting terminal failed workflow placeholders
- update runtime job tests to create real workflow commands before enqueueing jobs
- add regression coverage for both new orphan-row rejection and pre-v14 dirty-data migration compatibility

Closes #1405

## Verification
- cargo fmt --all -- --check
- git diff --check
- python3 scripts/check_storage_legacy_openers.py --self-test
- python3 scripts/check_storage_legacy_openers.py
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- cargo test -p harness-workflow runtime_graph_ -- --nocapture
- cargo test -p harness-workflow runtime_store -- --nocapture
- cargo test -p harness-server persistent_pr_lifecycle_persist_failure_records_operator_event -- --nocapture
- cargo test -p harness-server rejected_new_issue_submission_does_not_persist_live_instance_or_commands -- --nocapture
- cargo test -p harness-server --lib --quiet
- cargo test --workspace --quiet

## Notes
- Existing orphan rows remain allowed through the v14 migration by design; the new constraints enforce valid references for new writes. A later cleanup can validate constraints after live dirty data is remediated.