### PR TITLE
Fix startup health wait and runtime status summary

### DIFF
--- a/crates/harness-server/src/http/misc_routes_runtime_tree.rs
+++ b/crates/harness-server/src/http/misc_routes_runtime_tree.rs
@@ -201,6 +201,26 @@ pub(crate) async fn get_workflow_runtime_tree(
             WorkflowRuntimeTreeDetail::Full => WorkflowRuntimeTreeMode::Full,
         }
     };
+    if mode.summary_only() {
+        return match build_workflow_runtime_tree_summary_only(
+            store,
+            query.project_id.as_deref(),
+            limit,
+            offset,
+            job_limit as usize,
+            mode,
+        )
+        .await
+        {
+            Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response(),
+        };
+    }
+
     match store
         .list_instances_page(query.project_id.as_deref(), limit, offset)
         .await
@@ -229,6 +249,32 @@ pub(crate) async fn get_workflow_runtime_tree(
     }
 }
 
+async fn build_workflow_runtime_tree_summary_only(
+    store: &harness_workflow::runtime::WorkflowRuntimeStore,
+    project_id: Option<&str>,
+    limit: i64,
+    offset: i64,
+    job_limit: usize,
+    mode: WorkflowRuntimeTreeMode,
+) -> anyhow::Result<WorkflowRuntimeTreeResponse> {
+    let (summary, total_workflows) = workflow_runtime_tree_summary(store, project_id).await?;
+    Ok(WorkflowRuntimeTreeResponse {
+        total_workflows,
+        pagination: WorkflowRuntimeTreePagination::new(
+            limit,
+            offset,
+            0,
+            total_workflows as i64,
+            job_limit,
+            mode.command_limit(),
+            mode.detail(),
+            true,
+        ),
+        summary,
+        workflows: Vec::new(),
+    })
+}
+
 async fn build_workflow_runtime_tree(
     store: &harness_workflow::runtime::WorkflowRuntimeStore,
     page: harness_workflow::runtime::store::WorkflowInstancePage,
@@ -241,24 +287,7 @@ async fn build_workflow_runtime_tree(
         .iter()
         .map(|instance| instance.id.clone())
         .collect();
-    let summary = workflow_runtime_tree_summary(store, project_id).await?;
-    if mode.summary_only() {
-        return Ok(WorkflowRuntimeTreeResponse {
-            total_workflows: page.total.max(0) as usize,
-            pagination: WorkflowRuntimeTreePagination::new(
-                page.limit,
-                page.offset,
-                0,
-                page.total,
-                job_limit,
-                mode.command_limit(),
-                mode.detail(),
-                true,
-            ),
-            summary,
-            workflows: Vec::new(),
-        });
-    }
+    let (summary, _) = workflow_runtime_tree_summary(store, project_id).await?;
 
     let (mut by_id, children_by_parent) = match mode {
         WorkflowRuntimeTreeMode::Full => {
@@ -324,7 +353,7 @@ async fn build_workflow_runtime_tree(
 async fn workflow_runtime_tree_summary(
     store: &harness_workflow::runtime::WorkflowRuntimeStore,
     project_id: Option<&str>,
-) -> anyhow::Result<WorkflowRuntimeTreeSummary> {
+) -> anyhow::Result<(WorkflowRuntimeTreeSummary, usize)> {
     let aggregate_summary = store
         .runtime_summary_counts_for_instances(
             project_id,
@@ -332,20 +361,28 @@ async fn workflow_runtime_tree_summary(
             ACTIVITY_RESULT_ENVELOPE_SCHEMA,
         )
         .await?;
+    let total_workflows = aggregate_summary
+        .workflow_states
+        .iter()
+        .map(|state| state.count)
+        .sum();
     let (workflow_statuses, workflow_scheduler_states, workflow_active_buckets) =
         workflow_projection_summary_counts(&aggregate_summary.workflow_states);
-    Ok(WorkflowRuntimeTreeSummary {
-        workflow_statuses,
-        workflow_scheduler_states,
-        workflow_active_buckets,
-        total_commands: aggregate_summary.total_commands,
-        total_runtime_jobs: aggregate_summary.total_runtime_jobs,
-        command_statuses: aggregate_summary.command_statuses,
-        runtime_job_statuses: aggregate_summary.runtime_job_statuses,
-        running_job_lease_statuses: aggregate_summary.running_job_lease_statuses,
-        activity_outcomes: aggregate_summary.activity_outcomes,
-        jobs_without_activity_envelope: aggregate_summary.jobs_without_activity_envelope,
-    })
+    Ok((
+        WorkflowRuntimeTreeSummary {
+            workflow_statuses,
+            workflow_scheduler_states,
+            workflow_active_buckets,
+            total_commands: aggregate_summary.total_commands,
+            total_runtime_jobs: aggregate_summary.total_runtime_jobs,
+            command_statuses: aggregate_summary.command_statuses,
+            runtime_job_statuses: aggregate_summary.runtime_job_statuses,
+            running_job_lease_statuses: aggregate_summary.running_job_lease_statuses,
+            activity_outcomes: aggregate_summary.activity_outcomes,
+            jobs_without_activity_envelope: aggregate_summary.jobs_without_activity_envelope,
+        },
+        total_workflows,
+    ))
 }
 
 fn workflow_projection_summary_counts(

--- a/crates/harness-server/src/http/tests/runtime_tree_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_tree_tests.rs
@@ -579,6 +579,75 @@ async fn workflow_runtime_tree_endpoint_returns_summary_only_shape() -> anyhow::
 }
 
 #[tokio::test]
+async fn workflow_runtime_tree_summary_only_counts_all_project_workflows_with_tiny_limit(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    for (id, project_id, issue_number) in [
+        ("issue-1201", "/project-a", 1201),
+        ("issue-1202", "/project-a", 1202),
+        ("issue-2201", "/project-b", 2201),
+    ] {
+        let workflow = harness_workflow::runtime::WorkflowInstance::new(
+            "github_issue_pr",
+            1,
+            "implementing",
+            harness_workflow::runtime::WorkflowSubject::new(
+                "issue",
+                format!("issue:{issue_number}"),
+            ),
+        )
+        .with_id(id)
+        .with_data(serde_json::json!({
+            "project_id": project_id,
+            "repo": "owner/repo",
+            "issue_number": issue_number,
+        }));
+        store.upsert_instance(&workflow).await?;
+    }
+
+    let response = workflow_runtime_app(state)
+        .oneshot(
+            Request::builder()
+                .uri(
+                    "/api/workflows/runtime/tree?project_id=%2Fproject-a&summary_only=true&limit=1",
+                )
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["total_workflows"], 2);
+    assert_eq!(body["pagination"]["limit"], 1);
+    assert_eq!(body["pagination"]["returned"], 0);
+    assert_eq!(body["pagination"]["total"], 2);
+    assert_eq!(body["pagination"]["has_more"], false);
+    assert_eq!(body["pagination"]["summary_only"], true);
+    assert_eq!(body["summary"]["workflow_statuses"]["implementing"], 2);
+    assert_eq!(body["summary"]["workflow_scheduler_states"]["running"], 2);
+    assert_eq!(body["summary"]["workflow_active_buckets"]["running"], 2);
+    assert_eq!(body["summary"]["total_commands"], 0);
+    assert_eq!(body["summary"]["total_runtime_jobs"], 0);
+    assert_eq!(
+        body["workflows"]
+            .as_array()
+            .expect("workflows should be an array")
+            .len(),
+        0
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn workflow_runtime_tree_endpoint_summarizes_all_project_workflows_when_paginated(
 ) -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {

--- a/scripts/start-harness-codex-safe.sh
+++ b/scripts/start-harness-codex-safe.sh
@@ -12,6 +12,7 @@ Options:
   --config PATH         Optional Harness config file
   --bin PATH            Harness binary. Default: ./target/release/harness, then ./target/debug/harness
   --log-dir PATH        Log/PID directory. Default: .harness/local
+  --wait-secs N         Seconds to wait for /health in background mode. Default: 60
   --foreground          Run in the foreground instead of backgrounding
   --stop                Stop the PID recorded for this port
   --status              Print recorded PID and health status
@@ -40,6 +41,9 @@ PROJECT_ROOT_EXPLICIT=0
 CONFIG=""
 BIN="${HARNESS_BIN:-}"
 LOG_DIR=".harness/local"
+WAIT_SECS="${HARNESS_STARTER_WAIT_SECS:-60}"
+HEALTH_CURL_TIMEOUT_SECS="${HARNESS_STARTER_HEALTH_TIMEOUT_SECS:-2}"
+POLL_INTERVAL_SECS="${HARNESS_STARTER_POLL_INTERVAL_SECS:-1}"
 FOREGROUND=0
 STOP=0
 STATUS=0
@@ -72,6 +76,11 @@ while [[ $# -gt 0 ]]; do
       LOG_DIR="$2"
       shift 2
       ;;
+    --wait-secs)
+      require_value "$1" "${2:-}"
+      WAIT_SECS="$2"
+      shift 2
+      ;;
     --foreground)
       FOREGROUND=1
       shift
@@ -100,11 +109,76 @@ if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then
   echo "--port must be a number" >&2
   exit 2
 fi
+if ! [[ "$WAIT_SECS" =~ ^[0-9]+$ ]] || [[ "$WAIT_SECS" -lt 1 ]]; then
+  echo "--wait-secs must be a positive number" >&2
+  exit 2
+fi
+if ! [[ "$HEALTH_CURL_TIMEOUT_SECS" =~ ^[0-9]+$ ]] || [[ "$HEALTH_CURL_TIMEOUT_SECS" -lt 1 ]]; then
+  echo "HARNESS_STARTER_HEALTH_TIMEOUT_SECS must be a positive number" >&2
+  exit 2
+fi
+if ! [[ "$POLL_INTERVAL_SECS" =~ ^[0-9]+$ ]] || [[ "$POLL_INTERVAL_SECS" -lt 1 ]]; then
+  echo "HARNESS_STARTER_POLL_INTERVAL_SECS must be a positive number" >&2
+  exit 2
+fi
 
 mkdir -p "$LOG_DIR"
 PID_FILE="$LOG_DIR/harness-${PORT}.pid"
 LOG_FILE="$LOG_DIR/harness-${PORT}.log"
+STATUS_FILE="$LOG_DIR/harness-${PORT}.status"
+HEALTH_FILE="$LOG_DIR/harness-${PORT}.health.json"
+HEALTH_ERROR_FILE="$LOG_DIR/harness-${PORT}.health.err"
 TMUX_SESSION="harness-${PORT}"
+
+now_utc() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+record_start_status() {
+  local state_name="$1"
+  shift || true
+  local message="${*:-}"
+  {
+    printf 'updated_at=%s\n' "$(now_utc)"
+    printf 'state=%s\n' "$state_name"
+    printf 'port=%s\n' "$PORT"
+    printf 'health_url=%s\n' "$health_url"
+    printf 'pid_file=%s\n' "$PID_FILE"
+    printf 'log_file=%s\n' "$LOG_FILE"
+    printf 'health_file=%s\n' "$HEALTH_FILE"
+    printf 'tmux_session=%s\n' "$TMUX_SESSION"
+    printf 'wait_secs=%s\n' "$WAIT_SECS"
+    if [[ -n "$message" ]]; then
+      printf 'message=%s\n' "$message"
+    fi
+  } > "$STATUS_FILE"
+}
+
+check_health() {
+  curl -fsS --max-time "$HEALTH_CURL_TIMEOUT_SECS" "$health_url" \
+    > "$HEALTH_FILE" 2> "$HEALTH_ERROR_FILE"
+}
+
+print_health_error() {
+  if [[ -s "$HEALTH_ERROR_FILE" ]]; then
+    echo "last health check error:" >&2
+    sed -n '1,20p' "$HEALTH_ERROR_FILE" >&2 || true
+  fi
+}
+
+print_startup_diagnostics() {
+  echo "status: $STATUS_FILE" >&2
+  echo "health: $HEALTH_FILE" >&2
+  print_health_error
+  if [[ -f "$LOG_FILE" ]]; then
+    echo "last log lines:" >&2
+    tail -n 120 "$LOG_FILE" >&2 || true
+  fi
+  if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+    echo "tmux pane tail:" >&2
+    tmux capture-pane -pt "$TMUX_SESSION" -S -80 2>/dev/null >&2 || true
+  fi
+}
 
 pid_alive() {
   local pid="$1"
@@ -154,11 +228,16 @@ if [[ "$STOP" -eq 1 ]]; then
     echo "stopped tmux session $TMUX_SESSION"
   fi
   rm -f "$PID_FILE"
+  record_start_status "stopped" "stop requested"
   exit 0
 fi
 
 if [[ "$STATUS" -eq 1 ]]; then
   pid="$(recorded_pid)"
+  if [[ -f "$STATUS_FILE" ]]; then
+    echo "recorded_status=$STATUS_FILE"
+    sed -n '1,40p' "$STATUS_FILE"
+  fi
   if pid_alive "$pid"; then
     echo "$pid" > "$PID_FILE"
     echo "pid=$pid status=running log=$LOG_FILE"
@@ -175,7 +254,12 @@ if [[ "$STATUS" -eq 1 ]]; then
     fi
   fi
   if command -v curl >/dev/null 2>&1; then
-    curl -sS --max-time 2 "$health_url" || true
+    if check_health; then
+      cat "$HEALTH_FILE"
+    else
+      echo "health=unavailable url=$health_url"
+      print_health_error
+    fi
     echo
   fi
   if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
@@ -241,7 +325,10 @@ fi
 
 echo "starting harness server on $health_url"
 echo "log: $LOG_FILE"
+echo "status: $STATUS_FILE"
+echo "health wait: ${WAIT_SECS}s (curl timeout ${HEALTH_CURL_TIMEOUT_SECS}s)"
 echo "sanitized vars: ${unset_args[*]:-none}"
+record_start_status "starting" "launching server"
 
 if [[ "$FOREGROUND" -eq 1 ]]; then
   exec env "${unset_args[@]}" "${cmd[@]}"
@@ -270,14 +357,23 @@ if command -v tmux >/dev/null 2>&1 && [[ -z "${HARNESS_STARTER_NO_TMUX:-}" ]]; t
       tmux_command+=("--bin" "$BIN")
     fi
     printf -v quoted_pwd "%q" "$PWD"
+    printf -v quoted_log_file "%q" "$LOG_FILE"
     printf -v tmux_command_args "%q " "${tmux_command[@]}"
-    tmux_command_string="cd ${quoted_pwd} && ${tmux_command_args}"
+    tmux_command_string="cd ${quoted_pwd} && ${tmux_command_args} >> ${quoted_log_file} 2>&1"
     tmux new-session -d -s "$TMUX_SESSION" "$tmux_command_string"
     echo "started tmux session $TMUX_SESSION"
   fi
 
-  for _ in 1 2 3 4 5 6 7 8 9 10; do
-    if command -v curl >/dev/null 2>&1 && curl -sS --max-time 2 "$health_url" >/tmp/harness-health-"$PORT".json 2>/dev/null; then
+  start_seconds="$SECONDS"
+  next_progress=5
+  while [[ $((SECONDS - start_seconds)) -lt "$WAIT_SECS" ]]; do
+    if ! tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+      record_start_status "failed" "tmux session exited before health became ready"
+      echo "tmux session $TMUX_SESSION exited before /health became ready" >&2
+      print_startup_diagnostics
+      exit 4
+    fi
+    if check_health; then
       listener_pid="$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -1 || true)"
       if [[ -n "$listener_pid" ]]; then
         echo "$listener_pid" > "$PID_FILE"
@@ -285,16 +381,25 @@ if command -v tmux >/dev/null 2>&1 && [[ -z "${HARNESS_STARTER_NO_TMUX:-}" ]]; t
       else
         echo "harness server health is ready tmux_session=$TMUX_SESSION"
       fi
-      cat /tmp/harness-health-"$PORT".json
+      record_start_status "healthy" "health check succeeded"
+      cat "$HEALTH_FILE"
       echo
       exit 0
     fi
-    sleep 1
+    elapsed=$((SECONDS - start_seconds))
+    if [[ "$elapsed" -ge "$next_progress" ]]; then
+      echo "waiting for harness health (${elapsed}/${WAIT_SECS}s) url=$health_url"
+      record_start_status "starting" "waiting for health elapsed=${elapsed}s"
+      next_progress=$((next_progress + 5))
+    fi
+    sleep "$POLL_INTERVAL_SECS"
   done
 
-  echo "tmux session $TMUX_SESSION did not become healthy within 10s" >&2
+  record_start_status "timeout" "tmux session did not become healthy within ${WAIT_SECS}s"
+  echo "tmux session $TMUX_SESSION did not become healthy within ${WAIT_SECS}s" >&2
   echo "check: scripts/start-harness-codex-safe.sh --status --port $PORT" >&2
-  echo "inspect: tmux capture-pane -pt $TMUX_SESSION -S -120" >&2
+  echo "inspect: tail -n 120 $LOG_FILE" >&2
+  print_startup_diagnostics
   exit 4
 fi
 
@@ -302,23 +407,35 @@ nohup env "${unset_args[@]}" "${cmd[@]}" > "$LOG_FILE" 2>&1 &
 server_pid="$!"
 echo "$server_pid" > "$PID_FILE"
 
-for _ in 1 2 3 4 5; do
+start_seconds="$SECONDS"
+next_progress=5
+while [[ $((SECONDS - start_seconds)) -lt "$WAIT_SECS" ]]; do
   if ! pid_alive "$server_pid"; then
+    record_start_status "failed" "process exited during startup"
     echo "harness server exited during startup; last log lines:" >&2
     tail -n 80 "$LOG_FILE" >&2 || true
     rm -f "$PID_FILE"
     exit 4
   fi
-  if command -v curl >/dev/null 2>&1 && curl -sS --max-time 2 "$health_url" >/tmp/harness-health-"$PORT".json 2>/dev/null; then
+  if check_health; then
     echo "harness server started pid=$server_pid"
-    cat /tmp/harness-health-"$PORT".json
+    record_start_status "healthy" "health check succeeded"
+    cat "$HEALTH_FILE"
     echo
     exit 0
   fi
-  sleep 1
+  elapsed=$((SECONDS - start_seconds))
+  if [[ "$elapsed" -ge "$next_progress" ]]; then
+    echo "waiting for harness health (${elapsed}/${WAIT_SECS}s) pid=$server_pid url=$health_url"
+    record_start_status "starting" "waiting for health elapsed=${elapsed}s pid=${server_pid}"
+    next_progress=$((next_progress + 5))
+  fi
+  sleep "$POLL_INTERVAL_SECS"
 done
 
-echo "harness server pid=$server_pid did not become healthy within 5s" >&2
+record_start_status "timeout" "pid=${server_pid} did not become healthy within ${WAIT_SECS}s"
+echo "harness server pid=$server_pid did not become healthy within ${WAIT_SECS}s" >&2
 echo "check: scripts/start-harness-codex-safe.sh --status --port $PORT" >&2
 echo "inspect: tail -n 120 $LOG_FILE" >&2
+print_startup_diagnostics
 exit 4


### PR DESCRIPTION
Closes #1408.\n\n## Summary\n- Avoid loading workflow page nodes for `summary_only=true` runtime-tree requests; the endpoint now returns the aggregate summary directly.\n- Add regression coverage proving summary-only counts all matching project workflows even with `limit=1`.\n- Make `scripts/start-harness-codex-safe.sh` wait configurable, persist startup/health status files, redirect tmux output to the launcher log, and print useful diagnostics on timeout.\n\n## Verification\n- `cargo fmt --all -- --check`\n- `bash -n scripts/start-harness-codex-safe.sh`\n- `git diff --check`\n- `cargo test -p harness-server workflow_runtime_tree_summary_only -- --test-threads=1 --format terse`\n- `cargo test -p harness-cli status -- --test-threads=1 --format terse`\n- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`\n- Live smoke on port 9812: launcher returned `/health` status ok; `harness status --url http://127.0.0.1:9812` completed; `/api/workflows/runtime/tree?limit=20&summary_only=true` returned 980 bytes.