### PR TITLE
fix(runtime): accept structured result with skill warning

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
@@ -9,6 +9,15 @@ use std::path::Path;
 use super::data_helpers::activity_name;
 use super::prompt_packet::workflow_prompt_artifact;
 
+const CODEX_SKILL_BUDGET_WARNING: &str =
+    "Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
+const CODEX_SKILL_BUDGET_AGENT_ERROR: &str =
+    "agent execution failed: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
+const CODEX_SKILL_BUDGET_STRUCTURED_AGENT_ERROR: &str =
+    "agent execution failed: codex structured error: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
+const CODEX_SKILL_BUDGET_STRUCTURED_AGENT_ERROR_PREFIX: &str =
+    "agent execution failed: codex structured error: exit ";
+
 pub(super) fn activity_result_from_turn(
     job: &RuntimeJob,
     status: &TurnStatus,
@@ -59,6 +68,18 @@ pub(super) fn activity_result_from_turn(
                 );
             }
         }
+        ActivityResultEnvelopeOutcome::AcceptedWithTurnWarning => {
+            if let Some(error) = envelope.extraction_error.as_deref() {
+                tracing::warn!(
+                    runtime_job_id = %job.id,
+                    activity = %activity,
+                    agent = %agent_name,
+                    turn_status = ?status,
+                    items = items.len(),
+                    "accepted structured activity result despite non-fatal turn warning: {error}"
+                );
+            }
+        }
         ActivityResultEnvelopeOutcome::Accepted | ActivityResultEnvelopeOutcome::TurnCancelled => {}
     }
     let envelope_artifact = envelope.to_artifact();
@@ -95,6 +116,7 @@ enum ActivityResultExtractionStrategy {
 #[serde(rename_all = "snake_case")]
 enum ActivityResultEnvelopeOutcome {
     Accepted,
+    AcceptedWithTurnWarning,
     MissingStructuredOutput,
     InvalidStructuredOutput,
     TurnCancelled,
@@ -123,6 +145,21 @@ impl ActivityResultEnvelope {
             raw_status,
             extracted_activity: Some(result.activity.clone()),
             extraction_error: None,
+            final_result: result,
+        }
+    }
+
+    fn accepted_with_turn_warning(
+        raw_status: TurnStatus,
+        result: ActivityResult,
+        warning: String,
+    ) -> Self {
+        Self {
+            extraction_strategy: ActivityResultExtractionStrategy::FencedActivityResult,
+            outcome: ActivityResultEnvelopeOutcome::AcceptedWithTurnWarning,
+            raw_status,
+            extracted_activity: Some(result.activity.clone()),
+            extraction_error: Some(warning),
             final_result: result,
         }
     }
@@ -248,7 +285,32 @@ fn activity_result_envelope_from_turn(
         TurnStatus::Cancelled => {
             ActivityResultEnvelope::cancelled(*status, activity.to_string(), summary)
         }
-        TurnStatus::Failed | TurnStatus::Running => {
+        TurnStatus::Failed => {
+            let error = failed_turn_error(items);
+            if let Some(warning) = failed_turn_warning_allows_structured_result(items) {
+                match structured_activity_result(items, activity) {
+                    StructuredActivityResult::Parsed(result) => {
+                        return ActivityResultEnvelope::accepted_with_turn_warning(
+                            *status, result, warning,
+                        );
+                    }
+                    StructuredActivityResult::Invalid {
+                        error: parse_error,
+                        extracted_activity,
+                    } => {
+                        return ActivityResultEnvelope::invalid_structured_output(
+                            *status,
+                            activity.to_string(),
+                            parse_error,
+                            extracted_activity,
+                        );
+                    }
+                    StructuredActivityResult::Missing => {}
+                }
+            }
+            ActivityResultEnvelope::failed(*status, activity.to_string(), summary, error)
+        }
+        TurnStatus::Running => {
             let error = last_error(items).unwrap_or_else(|| "agent turn failed".to_string());
             ActivityResultEnvelope::failed(*status, activity.to_string(), summary, error)
         }
@@ -263,6 +325,54 @@ fn turn_error_is_timeout(error: &str) -> bool {
 fn turn_error_is_non_retryable_agent_limit(error: &str) -> bool {
     harness_core::error::is_quota_failure_message(error)
         || harness_core::error::is_billing_failure_message(error)
+}
+
+fn failed_turn_error(items: &[Item]) -> String {
+    items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Error { message, .. } if !failed_turn_error_allows_structured_result(message) => {
+                Some(truncate_summary(message.trim()))
+            }
+            _ => None,
+        })
+        .next_back()
+        .or_else(|| last_error(items))
+        .unwrap_or_else(|| "agent turn failed".to_string())
+}
+
+fn failed_turn_warning_allows_structured_result(items: &[Item]) -> Option<String> {
+    let mut warning = None;
+    for item in items {
+        if let Item::Error { message, .. } = item {
+            if !failed_turn_error_allows_structured_result(message) {
+                return None;
+            }
+            warning = Some(message.clone());
+        }
+    }
+    warning
+}
+
+fn failed_turn_error_allows_structured_result(error: &str) -> bool {
+    let error = error.trim();
+    error == CODEX_SKILL_BUDGET_WARNING
+        || error == CODEX_SKILL_BUDGET_AGENT_ERROR
+        || error == CODEX_SKILL_BUDGET_STRUCTURED_AGENT_ERROR
+        || codex_structured_skill_budget_error_allows_structured_result(error)
+}
+
+fn codex_structured_skill_budget_error_allows_structured_result(error: &str) -> bool {
+    let Some(rest) = error.strip_prefix(CODEX_SKILL_BUDGET_STRUCTURED_AGENT_ERROR_PREFIX) else {
+        return false;
+    };
+    let Some(status_prefix) = rest.strip_suffix(CODEX_SKILL_BUDGET_WARNING) else {
+        return false;
+    };
+    let Some(status_text) = status_prefix.strip_suffix(": ") else {
+        return false;
+    };
+    !status_text.trim().is_empty() && !status_text.contains(['\n', '\r'])
 }
 
 enum StructuredActivityResult {
@@ -395,387 +505,8 @@ fn truncate_summary(value: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use harness_workflow::runtime::{ActivityStatus, RuntimeKind};
-
-    #[test]
-    fn activity_result_from_turn_fails_when_no_fenced_block_present() {
-        // P0-1: a completed agent turn that emits no `harness-activity-result`
-        // fenced block must NOT be silently treated as success. Returning
-        // succeeded here historically caused state-machine no-progress loops:
-        // an agent could return prose, the reducer would observe no structured
-        // state transition, and the next tick would re-dispatch.
-        let job = RuntimeJob::pending(
-            "command-1",
-            RuntimeKind::ClaudeCode,
-            "claude-default",
-            json!({
-                "activity": "implement_issue"
-            }),
-        );
-        let items = vec![Item::AgentReasoning {
-            content: "I scanned the repo and saw no new issues. Done.".to_string(),
-        }];
-
-        let result = activity_result_from_turn(
-            &job,
-            &TurnStatus::Completed,
-            &items,
-            &ThreadId::from_str("thread-1"),
-            &TurnId::from_str("turn-1"),
-            "claude",
-            Path::new("/project"),
-            "digest-1",
-        );
-
-        assert_eq!(result.activity, "implement_issue");
-        assert_eq!(
-            result.status,
-            ActivityStatus::Failed,
-            "missing structured result MUST surface as failed"
-        );
-        assert_eq!(
-            result.error_kind,
-            Some(ActivityErrorKind::Configuration),
-            "missing structured result is a configuration-class failure (prompt or agent contract issue)"
-        );
-        assert!(
-            result
-                .error
-                .as_deref()
-                .is_some_and(|e| e.contains("harness-activity-result")),
-            "error message MUST mention the missing block so operators can diagnose"
-        );
-        let envelope = envelope_artifact(&result);
-        assert_eq!(envelope["outcome"], "missing_structured_output");
-        assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
-        assert_eq!(envelope["raw_status"], "completed");
-    }
-
-    #[test]
-    fn activity_result_from_turn_parses_structured_activity_result_block() {
-        let job = RuntimeJob::pending(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({
-                "activity": "implement_issue"
-            }),
-        );
-        let items = vec![Item::AgentReasoning {
-            content: r#"Work completed.
-
-```harness-activity-result
-{"activity":"implement_issue","status":"succeeded","summary":"stale summary","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":66,"pr_url":"https://github.com/owner/repo/pull/66"}}]}
-```
-
-Final result:
-
-```harness-activity-result
-{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":77,"pr_url":"https://github.com/owner/repo/pull/77"}}]}
-```"#
-                .to_string(),
-        }];
-
-        let result = activity_result_from_turn(
-            &job,
-            &TurnStatus::Completed,
-            &items,
-            &ThreadId::from_str("thread-1"),
-            &TurnId::from_str("turn-1"),
-            "codex",
-            Path::new("/project"),
-            "digest-1",
-        );
-
-        assert_eq!(result.activity, "implement_issue");
-        assert_eq!(result.status, ActivityStatus::Succeeded);
-        assert_eq!(result.summary, "Implementation completed.");
-        let pr_artifact = result
-            .artifacts
-            .iter()
-            .find(|artifact| artifact.artifact_type == "pull_request")
-            .expect("structured pull request artifact should be preserved");
-        assert_eq!(pr_artifact.artifact["pr_number"], 77);
-        assert_eq!(
-            pr_artifact.artifact["pr_url"],
-            "https://github.com/owner/repo/pull/77"
-        );
-        let prompt_artifact = result
-            .artifacts
-            .iter()
-            .find(|artifact| artifact.artifact_type == "runtime_prompt_packet")
-            .expect("runtime prompt artifact should be appended");
-        assert_eq!(prompt_artifact.artifact["digest"], "digest-1");
-        let turn_artifact = result
-            .artifacts
-            .iter()
-            .find(|artifact| artifact.artifact_type == "runtime_turn")
-            .expect("runtime turn artifact should be appended");
-        assert_eq!(turn_artifact.artifact["thread_id"], "thread-1");
-        assert_eq!(turn_artifact.artifact["turn_id"], "turn-1");
-        let envelope = envelope_artifact(&result);
-        assert_eq!(envelope["outcome"], "accepted");
-        assert_eq!(envelope["extracted_activity"], "implement_issue");
-        assert_eq!(envelope["final_result"]["status"], "succeeded");
-        assert!(result
-            .signals
-            .iter()
-            .any(|signal| signal.signal_type == "RuntimeTurnCompleted"));
-    }
-
-    #[test]
-    fn activity_result_from_turn_rejects_generic_json_activity_result_block() {
-        let job = RuntimeJob::pending(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({
-                "activity": "implement_issue"
-            }),
-        );
-        let items = vec![Item::AgentReasoning {
-            content: r#"Work completed.
-
-```json
-{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed from generic JSON.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":88,"pr_url":"https://github.com/owner/repo/pull/88"}}]}
-```"#
-                .to_string(),
-        }];
-
-        let result = activity_result_from_turn(
-            &job,
-            &TurnStatus::Completed,
-            &items,
-            &ThreadId::from_str("thread-1"),
-            &TurnId::from_str("turn-1"),
-            "codex",
-            Path::new("/project"),
-            "digest-1",
-        );
-
-        assert_eq!(result.activity, "implement_issue");
-        assert_eq!(result.status, ActivityStatus::Failed);
-        assert_eq!(
-            result.error_kind,
-            Some(ActivityErrorKind::Configuration),
-            "generic JSON fences must not satisfy the final output contract"
-        );
-        assert!(!result
-            .artifacts
-            .iter()
-            .any(|artifact| artifact.artifact_type == "pull_request"));
-        let envelope = envelope_artifact(&result);
-        assert_eq!(envelope["outcome"], "missing_structured_output");
-        assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
-        assert!(envelope["extracted_activity"].is_null());
-        assert!(envelope["extraction_error"]
-            .as_str()
-            .is_some_and(|error| error.contains("harness-activity-result")));
-    }
-
-    #[test]
-    fn activity_result_from_turn_does_not_repair_ambiguous_json_block() {
-        let job = RuntimeJob::pending(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({
-                "activity": "implement_issue"
-            }),
-        );
-        let items = vec![Item::AgentReasoning {
-            content: r#"Work completed.
-
-```json
-{"summary":"Done, but this is not an ActivityResult."}
-```"#
-                .to_string(),
-        }];
-
-        let result = activity_result_from_turn(
-            &job,
-            &TurnStatus::Completed,
-            &items,
-            &ThreadId::from_str("thread-1"),
-            &TurnId::from_str("turn-1"),
-            "codex",
-            Path::new("/project"),
-            "digest-1",
-        );
-
-        assert_eq!(result.activity, "implement_issue");
-        assert_eq!(result.status, ActivityStatus::Failed);
-        assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
-        let envelope = envelope_artifact(&result);
-        assert_eq!(envelope["outcome"], "missing_structured_output");
-        assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
-    }
-
-    #[test]
-    fn activity_result_from_turn_fails_mismatched_structured_activity() {
-        let job = RuntimeJob::pending(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({
-                "activity": "implement_issue"
-            }),
-        );
-        let content = r#"Wrong activity result.
-
-```harness-activity-result
-{"activity":"replan_issue","status":"succeeded","summary":"Wrong activity.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":77,"pr_url":"https://github.com/owner/repo/pull/77"}}]}
-```"#;
-        let items = vec![Item::AgentReasoning {
-            content: content.to_string(),
-        }];
-
-        let result = activity_result_from_turn(
-            &job,
-            &TurnStatus::Completed,
-            &items,
-            &ThreadId::from_str("thread-1"),
-            &TurnId::from_str("turn-1"),
-            "codex",
-            Path::new("/project"),
-            "digest-1",
-        );
-
-        assert_eq!(result.activity, "implement_issue");
-        assert_eq!(result.status, ActivityStatus::Failed);
-        assert_eq!(result.summary, "Structured activity result was invalid.");
-        assert_eq!(
-            result.error.as_deref(),
-            Some("activity result block reported activity `replan_issue`, expected `implement_issue`")
-        );
-        assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
-        assert!(!result
-            .artifacts
-            .iter()
-            .any(|artifact| artifact.artifact_type == "pull_request"));
-        let envelope = envelope_artifact(&result);
-        assert_eq!(envelope["outcome"], "invalid_structured_output");
-        assert_eq!(envelope["extracted_activity"], "replan_issue");
-        assert!(result
-            .artifacts
-            .iter()
-            .any(|artifact| artifact.artifact_type == "runtime_prompt_packet"));
-        assert!(result
-            .artifacts
-            .iter()
-            .any(|artifact| artifact.artifact_type == "runtime_turn"));
-    }
-
-    #[test]
-    fn activity_result_from_turn_fails_latest_malformed_structured_activity() {
-        let job = RuntimeJob::pending(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({
-                "activity": "implement_issue"
-            }),
-        );
-        let items = vec![Item::AgentReasoning {
-            content: r#"Work completed.
-
-```harness-activity-result
-{"activity":"implement_issue","status":"succeeded","summary":"stale summary","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":66,"pr_url":"https://github.com/owner/repo/pull/66"}}]}
-```
-
-Final result:
-
-```harness-activity-result
-{"activity":"implement_issue","status":"succeeded","summary":
-```"#
-                .to_string(),
-        }];
-
-        let result = activity_result_from_turn(
-            &job,
-            &TurnStatus::Completed,
-            &items,
-            &ThreadId::from_str("thread-1"),
-            &TurnId::from_str("turn-1"),
-            "codex",
-            Path::new("/project"),
-            "digest-1",
-        );
-
-        assert_eq!(result.activity, "implement_issue");
-        assert_eq!(result.status, ActivityStatus::Failed);
-        assert_eq!(result.summary, "Structured activity result was invalid.");
-        assert!(result
-            .error
-            .as_deref()
-            .is_some_and(|error| error.starts_with("activity result block is invalid JSON:")));
-        assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
-        assert!(!result
-            .artifacts
-            .iter()
-            .any(|artifact| artifact.artifact_type == "pull_request"));
-        let envelope = envelope_artifact(&result);
-        assert_eq!(envelope["outcome"], "invalid_structured_output");
-        assert!(envelope["extracted_activity"].is_null());
-        assert!(result
-            .artifacts
-            .iter()
-            .any(|artifact| artifact.artifact_type == "runtime_prompt_packet"));
-        assert!(result
-            .artifacts
-            .iter()
-            .any(|artifact| artifact.artifact_type == "runtime_turn"));
-    }
-
-    #[test]
-    fn activity_result_from_turn_classifies_timeout_error_kind() {
-        let job = RuntimeJob::pending(
-            "command-1",
-            RuntimeKind::CodexJsonrpc,
-            "codex-default",
-            json!({
-                "activity": "implement_issue"
-            }),
-        );
-        let items = vec![Item::Error {
-            code: 1,
-            message: "Agent turn timed out after 30s".to_string(),
-        }];
-
-        let result = activity_result_from_turn(
-            &job,
-            &TurnStatus::Failed,
-            &items,
-            &ThreadId::from_str("thread-1"),
-            &TurnId::from_str("turn-1"),
-            "codex",
-            Path::new("/project"),
-            "digest-1",
-        );
-
-        assert_eq!(result.activity, "implement_issue");
-        assert_eq!(result.status, ActivityStatus::Failed);
-        assert_eq!(result.error_kind, Some(ActivityErrorKind::Timeout));
-        assert_eq!(
-            result.error.as_deref(),
-            Some("Agent turn timed out after 30s")
-        );
-        let envelope = envelope_artifact(&result);
-        assert_eq!(envelope["outcome"], "turn_failed");
-        assert_eq!(envelope["extraction_strategy"], "not_attempted");
-    }
-
-    fn envelope_artifact(result: &ActivityResult) -> &serde_json::Value {
-        &result
-            .artifacts
-            .iter()
-            .find(|artifact| artifact.artifact_type == "activity_result_envelope")
-            .expect("activity result envelope artifact should be appended")
-            .artifact
-    }
-}
+#[path = "activity_result_tests.rs"]
+mod tests;
 
 #[cfg(test)]
 #[path = "activity_result_limit_tests.rs"]

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result_limit_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result_limit_tests.rs
@@ -1,6 +1,12 @@
 use super::*;
 use harness_workflow::runtime::{ActivityStatus, RuntimeKind};
 
+const SKILL_BUDGET_AGENT_ERROR: &str = "agent execution failed: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
+const SKILL_BUDGET_AGENT_ERROR_WITH_STDERR: &str = "agent execution failed: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.; stderr=[adapter failed]";
+const SKILL_BUDGET_CODEX_STRUCTURED_AGENT_ERROR: &str = "agent execution failed: codex structured error: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
+const SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR: &str = "agent execution failed: codex structured error: exit exit status: 1: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
+const SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR_WITH_STDERR: &str = "agent execution failed: codex structured error: exit exit status: 1: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.; stderr=[adapter failed]";
+
 #[test]
 fn activity_result_from_turn_marks_quota_failure_non_retryable() {
     let job = RuntimeJob::pending(
@@ -34,4 +40,389 @@ fn activity_result_from_turn_marks_quota_failure_non_retryable() {
         result.error.as_deref(),
         Some("agent quota exhausted: codex structured error: usage limit reached")
     );
+}
+
+#[test]
+fn failed_skill_budget_warning_accepts_structured_activity_result() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![
+        Item::AgentReasoning {
+            content: r#"The agent completed the PR before the wrapper warning.
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
+```"#
+                .to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: SKILL_BUDGET_AGENT_ERROR.to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: SKILL_BUDGET_CODEX_STRUCTURED_AGENT_ERROR.to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR.to_string(),
+        },
+    ];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Failed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Succeeded);
+    assert_eq!(result.summary, "Implementation completed.");
+    assert!(result.error.is_none());
+    assert!(result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "pull_request"));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "accepted_with_turn_warning");
+    assert_eq!(envelope["raw_status"], "failed");
+    assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
+    assert!(envelope["extraction_error"]
+        .as_str()
+        .is_some_and(|error| error.contains("Skill descriptions were shortened")));
+    assert_eq!(envelope["final_result"]["status"], "succeeded");
+}
+
+#[test]
+fn failed_wrapped_skill_budget_warning_accepts_structured_activity_result() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![
+        Item::AgentReasoning {
+            content: r#"The agent completed the PR before the structured wrapper warning.
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
+```"#
+                .to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR.to_string(),
+        },
+    ];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Failed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Succeeded);
+    assert_eq!(result.summary, "Implementation completed.");
+    assert!(result.error.is_none());
+    assert!(result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "pull_request"));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "accepted_with_turn_warning");
+    assert_eq!(envelope["raw_status"], "failed");
+    assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
+    assert_eq!(
+        envelope["extraction_error"],
+        SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR
+    );
+    assert_eq!(envelope["final_result"]["status"], "succeeded");
+}
+
+#[test]
+fn failed_timeout_ignores_stale_structured_activity_result() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![
+        Item::AgentReasoning {
+            content: r#"An old result should not override a real timeout.
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
+```"#
+                .to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: "Agent turn timed out after 30s".to_string(),
+        },
+    ];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Failed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(result.error_kind, Some(ActivityErrorKind::Timeout));
+    assert_eq!(
+        result.error.as_deref(),
+        Some("Agent turn timed out after 30s")
+    );
+    assert!(!result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "pull_request"));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "turn_failed");
+    assert_eq!(envelope["extraction_strategy"], "not_attempted");
+}
+
+#[test]
+fn failed_real_error_before_skill_budget_warning_ignores_structured_activity_result() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![
+        Item::AgentReasoning {
+            content: r#"A stale success must not hide a real failure.
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
+```"#
+                .to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: "Agent turn timed out after 30s".to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: SKILL_BUDGET_AGENT_ERROR.to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: SKILL_BUDGET_CODEX_STRUCTURED_AGENT_ERROR.to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR.to_string(),
+        },
+    ];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Failed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(result.error_kind, Some(ActivityErrorKind::Timeout));
+    assert_eq!(
+        result.error.as_deref(),
+        Some("Agent turn timed out after 30s")
+    );
+    assert!(!result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "pull_request"));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "turn_failed");
+    assert_eq!(envelope["extraction_strategy"], "not_attempted");
+}
+
+#[test]
+fn failed_skill_budget_warning_with_stderr_ignores_structured_activity_result() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![
+        Item::AgentReasoning {
+            content: r#"A warning with stderr diagnostics is still a failed turn.
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
+```"#
+                .to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: SKILL_BUDGET_AGENT_ERROR_WITH_STDERR.to_string(),
+        },
+    ];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Failed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(
+        result.error.as_deref(),
+        Some(SKILL_BUDGET_AGENT_ERROR_WITH_STDERR)
+    );
+    assert!(!result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "pull_request"));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "turn_failed");
+    assert_eq!(envelope["extraction_strategy"], "not_attempted");
+}
+
+#[test]
+fn failed_wrapped_skill_budget_warning_with_stderr_ignores_structured_activity_result() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![
+        Item::AgentReasoning {
+            content: r#"A structured wrapper warning with stderr diagnostics is still a failed turn.
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
+```"#
+                .to_string(),
+        },
+        Item::Error {
+            code: 1,
+            message: SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR_WITH_STDERR.to_string(),
+        },
+    ];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Failed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(
+        result.error.as_deref(),
+        Some(SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR_WITH_STDERR)
+    );
+    assert!(!result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "pull_request"));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "turn_failed");
+    assert_eq!(envelope["extraction_strategy"], "not_attempted");
+}
+
+#[test]
+fn failed_real_error_is_truncated_before_envelope_storage() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let long_error = format!("adapter failure: {}", "x".repeat(1400));
+    let items = vec![Item::Error {
+        code: 1,
+        message: long_error,
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Failed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    let error = match result.error.as_deref() {
+        Some(error) => error,
+        None => panic!("failed activity result should include an error"),
+    };
+    assert!(error.starts_with("adapter failure: "));
+    assert!(error.ends_with("..."));
+    assert_eq!(error.len(), 1203);
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "turn_failed");
+    assert_eq!(envelope["extraction_error"], error);
+}
+
+fn envelope_artifact(result: &ActivityResult) -> &serde_json::Value {
+    match result
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.artifact_type == "activity_result_envelope")
+    {
+        Some(artifact) => &artifact.artifact,
+        None => panic!("activity result envelope artifact should be appended"),
+    }
 }

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
@@ -1,0 +1,373 @@
+use super::*;
+use harness_workflow::runtime::{ActivityStatus, RuntimeKind};
+
+#[test]
+fn activity_result_from_turn_fails_when_no_fenced_block_present() {
+    // P0-1: a completed agent turn that emits no `harness-activity-result`
+    // fenced block must NOT be silently treated as success. Returning
+    // succeeded here historically caused state-machine no-progress loops:
+    // an agent could return prose, the reducer would observe no structured
+    // state transition, and the next tick would re-dispatch.
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::ClaudeCode,
+        "claude-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![Item::AgentReasoning {
+        content: "I scanned the repo and saw no new issues. Done.".to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "claude",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(
+        result.status,
+        ActivityStatus::Failed,
+        "missing structured result MUST surface as failed"
+    );
+    assert_eq!(
+        result.error_kind,
+        Some(ActivityErrorKind::Configuration),
+        "missing structured result is a configuration-class failure (prompt or agent contract issue)"
+    );
+    assert!(
+        result
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("harness-activity-result")),
+        "error message MUST mention the missing block so operators can diagnose"
+    );
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "missing_structured_output");
+    assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
+    assert_eq!(envelope["raw_status"], "completed");
+}
+
+#[test]
+fn activity_result_from_turn_parses_structured_activity_result_block() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![Item::AgentReasoning {
+        content: r#"Work completed.
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":"stale summary","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":66,"pr_url":"https://github.com/owner/repo/pull/66"}}]}
+```
+
+Final result:
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":77,"pr_url":"https://github.com/owner/repo/pull/77"}}]}
+```"#
+            .to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Succeeded);
+    assert_eq!(result.summary, "Implementation completed.");
+    let pr_artifact = artifact_by_type(&result, "pull_request");
+    assert_eq!(pr_artifact.artifact["pr_number"], 77);
+    assert_eq!(
+        pr_artifact.artifact["pr_url"],
+        "https://github.com/owner/repo/pull/77"
+    );
+    let prompt_artifact = artifact_by_type(&result, "runtime_prompt_packet");
+    assert_eq!(prompt_artifact.artifact["digest"], "digest-1");
+    let turn_artifact = artifact_by_type(&result, "runtime_turn");
+    assert_eq!(turn_artifact.artifact["thread_id"], "thread-1");
+    assert_eq!(turn_artifact.artifact["turn_id"], "turn-1");
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "accepted");
+    assert_eq!(envelope["extracted_activity"], "implement_issue");
+    assert_eq!(envelope["final_result"]["status"], "succeeded");
+    assert!(result
+        .signals
+        .iter()
+        .any(|signal| signal.signal_type == "RuntimeTurnCompleted"));
+}
+
+#[test]
+fn activity_result_from_turn_rejects_generic_json_activity_result_block() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![Item::AgentReasoning {
+        content: r#"Work completed.
+
+```json
+{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed from generic JSON.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":88,"pr_url":"https://github.com/owner/repo/pull/88"}}]}
+```"#
+            .to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(
+        result.error_kind,
+        Some(ActivityErrorKind::Configuration),
+        "generic JSON fences must not satisfy the final output contract"
+    );
+    assert!(!result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "pull_request"));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "missing_structured_output");
+    assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
+    assert!(envelope["extracted_activity"].is_null());
+    assert!(envelope["extraction_error"]
+        .as_str()
+        .is_some_and(|error| error.contains("harness-activity-result")));
+}
+
+#[test]
+fn activity_result_from_turn_does_not_repair_ambiguous_json_block() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![Item::AgentReasoning {
+        content: r#"Work completed.
+
+```json
+{"summary":"Done, but this is not an ActivityResult."}
+```"#
+            .to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "missing_structured_output");
+    assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
+}
+
+#[test]
+fn activity_result_from_turn_fails_mismatched_structured_activity() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let content = r#"Wrong activity result.
+
+```harness-activity-result
+{"activity":"replan_issue","status":"succeeded","summary":"Wrong activity.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":77,"pr_url":"https://github.com/owner/repo/pull/77"}}]}
+```"#;
+    let items = vec![Item::AgentReasoning {
+        content: content.to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(result.summary, "Structured activity result was invalid.");
+    assert_eq!(
+        result.error.as_deref(),
+        Some("activity result block reported activity `replan_issue`, expected `implement_issue`")
+    );
+    assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
+    assert!(!result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "pull_request"));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "invalid_structured_output");
+    assert_eq!(envelope["extracted_activity"], "replan_issue");
+    assert!(result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "runtime_prompt_packet"));
+    assert!(result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "runtime_turn"));
+}
+
+#[test]
+fn activity_result_from_turn_fails_latest_malformed_structured_activity() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![Item::AgentReasoning {
+        content: r#"Work completed.
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":"stale summary","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":66,"pr_url":"https://github.com/owner/repo/pull/66"}}]}
+```
+
+Final result:
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":
+```"#
+            .to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(result.summary, "Structured activity result was invalid.");
+    assert!(result
+        .error
+        .as_deref()
+        .is_some_and(|error| error.starts_with("activity result block is invalid JSON:")));
+    assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
+    assert!(!result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "pull_request"));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "invalid_structured_output");
+    assert!(envelope["extracted_activity"].is_null());
+    assert!(result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "runtime_prompt_packet"));
+    assert!(result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.artifact_type == "runtime_turn"));
+}
+
+#[test]
+fn activity_result_from_turn_classifies_timeout_error_kind() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![Item::Error {
+        code: 1,
+        message: "Agent turn timed out after 30s".to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Failed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(result.error_kind, Some(ActivityErrorKind::Timeout));
+    assert_eq!(
+        result.error.as_deref(),
+        Some("Agent turn timed out after 30s")
+    );
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "turn_failed");
+    assert_eq!(envelope["extraction_strategy"], "not_attempted");
+}
+
+fn envelope_artifact(result: &ActivityResult) -> &serde_json::Value {
+    &artifact_by_type(result, "activity_result_envelope").artifact
+}
+
+fn artifact_by_type<'a>(result: &'a ActivityResult, artifact_type: &str) -> &'a ActivityArtifact {
+    match result
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.artifact_type == artifact_type)
+    {
+        Some(artifact) => artifact,
+        None => panic!("{artifact_type} artifact should be appended"),
+    }
+}


### PR DESCRIPTION
## Summary
- Accept a valid fenced `harness-activity-result` when a failed turn only contains the exact known Codex skill-budget warning, including both direct `codex structured error:` and wrapped `codex structured error: exit <status>:` runtime shapes.
- Preserve real failures, stderr-bearing warning errors, and long adapter errors instead of masking them with stale structured output.
- Split the remaining activity-result unit tests out of the main implementation file and restore the original extraction coverage.

Fixes #1410

## Verification
- `cargo fmt --all`
- `git diff --check`
- `cargo check`
- `cargo test -p harness-server activity_result -- --test-threads=1 --format terse`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `HARNESS_DATABASE_URL=postgres://harness:harness@127.0.0.1:55433/harness_test_activity_result_structured_20260626192603 HARNESS_DATABASE_POOL_MAX_CONNECTIONS=16 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=60 cargo test --workspace -- --test-threads=1 --format terse`

Note: running the full workspace test suite against the long-lived local `harness` database reproduced unrelated dashboard count pollution from existing active rows. The full suite passed against the fresh temporary database above.
