### PR TITLE
docs(specs): spec packets for GH1415, GH1416, GH1417 (audit top-3)

### DIFF
--- a/specs/GH1415/product.md
+++ b/specs/GH1415/product.md
@@ -1,0 +1,47 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1415
+
+## User Problem
+
+Operators who enable auto-merge trust harness to merge a PR only when the deterministic policy gate passes. Today the gate is server-side, but the merge action itself is delegated to an LLM agent that self-reports `merged=true`. A hallucinated or mistaken report marks the workflow as successfully merged while the PR is still open, and the discrepancy is only discovered later (if at all) by periodic reconciliation. Operators cannot currently distinguish "merged because GitHub says so" from "merged because the agent said so".
+
+## Goals
+
+- Terminal merge success is always backed by GitHub-observed state, never by agent output alone.
+- Operators can choose whether the merge action is executed by the server or by the agent, per deployment.
+- A false agent report is detected at completion time, not at the next reconciliation tick.
+
+## Non-Goals
+
+- Changing the auto-merge policy gate (required checks, approval, draft, review-thread rules stay as-is).
+- Supporting merge methods beyond what the repository allows (squash-only repositories stay squash-only).
+- Outbound notifications about merge outcomes.
+
+## User-Visible Behavior
+
+- With `merge_execution = "server"`: once the existing gate passes, harness merges the PR through the GitHub API directly. The workflow reaches `done` only after the API confirms the merged state. Agent involvement in the merge step is removed.
+- With `merge_execution = "agent"` (default at rollout): behavior looks like today, except that after the agent reports `merged=true`, harness re-reads the PR from the GitHub API before accepting the completion. If GitHub does not show the PR as merged, the activity fails with an explicit validation error instead of completing.
+- In both modes, task/workflow detail views show the merge evidence source (API-observed state and PR head SHA at merge time).
+
+## Acceptance Criteria
+
+- [ ] A workflow can reach terminal merge success only when the server has observed `merged=true` / `state=MERGED` from the GitHub API.
+- [ ] With a simulated agent that falsely reports `merged=true`, the activity fails validation and the workflow does not reach terminal success (test-covered).
+- [ ] `merge_execution` config selects `agent` or `server` mode; default is `agent` (verify-only) for a reversible rollout.
+- [ ] Documentation states the token permissions required for server-executed merges.
+
+## Edge Cases
+
+- PR was merged manually by a human between gate pass and merge execution: both modes must treat "already merged" as success, not as an error.
+- PR became unmergeable (new push, branch protection change) between gate pass and execution: server mode surfaces the GitHub error and routes the workflow through the existing failure/retry path; it must not retry the merge blindly.
+- GitHub API transiently unavailable during verification: completion is deferred/retried per the existing retryable-error classification, not accepted on trust.
+- Token lacks merge permission in server mode: fail with an actionable configuration error at merge time; log at error level.
+
+## Rollout Notes
+
+- Ship verify-on-completion first (agent mode); it hardens all existing deployments without changing who executes the merge.
+- Server-execution mode is opt-in per deployment via config; repositories opt into auto-merge exactly as today.
+- No data migration. Existing in-flight workflows complete under the mode active at completion time.

--- a/specs/GH1415/tasks.md
+++ b/specs/GH1415/tasks.md
@@ -1,0 +1,33 @@
+# GH1415 Tasks
+
+Issue: `#1415`
+Product spec: `specs/GH1415/product.md`
+Tech spec: `specs/GH1415/tech.md`
+
+## Status
+
+- [ ] `SP1415-T001` Owner: `config` | Done when: `merge_execution` ("agent"/"server", default "agent") and `verify_merge_completion` (default true) exist in intake/auto-merge config, are logged at startup, and are documented | Verify: `cargo test --package harness-server config`
+- [ ] `SP1415-T002` Owner: `runtime-worker` | Done when: merge_pr activity completions that report success are accepted only after a server-side `fetch_github_pr_snapshot` read confirms the PR is merged, and mismatches route through the invalid-agent-output failure path | Verify: `cargo test --package harness-server workflow_runtime_worker`
+- [ ] `SP1415-T003` Owner: `runtime-worker` | Done when: verification evidence (merged flag, PR state, snapshot timestamp, head SHA) is persisted into the activity-result artifacts and visible in decision records | Verify: `cargo test --package harness-server workflow_runtime_worker`
+- [ ] `SP1415-T004` Owner: `github-client` | Done when: `github_pr_merge.rs` implements the REST merge call reusing `resolve_github_token` and maps 200/405/409/422 and already-merged to the existing retryable/non-retryable error classes | Verify: `cargo test --package harness-server github_pr_merge`
+- [ ] `SP1415-T005` Owner: `dispatcher` | Done when: with `merge_execution = "server"`, merge_pr commands route to a builtin lifecycle activity (gate freshness re-check, merge call, confirmation read) instead of an agent prompt packet | Verify: `cargo test --package harness-server`
+- [ ] `SP1415-T006` Owner: `tests` | Done when: a simulated false `merged=true` agent report produces a blocked/failed decision and never a terminal success state, in both execution modes | Verify: `cargo test --package harness-server`
+- [ ] `SP1415-T007` Owner: `docs` | Done when: token permission requirements for server-executed merges and the rollout order (verify-first, then server mode) are documented | Verify: `test -s docs/usage-guide.md`
+
+## Parallelization
+
+- Lane A (T002, T003, T006): workflow runtime worker completion path.
+- Lane B (T004, T005): new merge client and dispatcher routing.
+- T001 lands first as a small standalone change so both lanes stay disjoint on files.
+
+## Verification
+
+- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
+- `cargo test --package harness-server`
+- Manual auto-merge run in both modes on a test repository, evidence captured in the implementation PR body.
+
+## Handoff Notes
+
+- Phase 1 (T001-T003, T006) is independently shippable; do not block it on Phase 2 (T004, T005).
+- No `gh`/`git` subprocesses in harness crates; HTTPS API only.
+- Reuse the reducer's blocked-decision path for invalid results; do not invent a new failure channel.

--- a/specs/GH1415/tech.md
+++ b/specs/GH1415/tech.md
@@ -28,7 +28,7 @@ Phase 1 — verify-on-completion (mode `agent`, new default behavior):
 
 Phase 2 — server-executed merge (mode `server`, opt-in):
 
-1. Add `merge_pull_request` to a small REST client module next to `github_pr_snapshot.rs` (e.g. `github_pr_merge.rs`): `PUT https://api.github.com/repos/{owner}/{repo}/pulls/{number}/merge` with `merge_method` resolved from repository settings (squash for this project), using the same reqwest client pattern and `resolve_github_token`.
+1. Add `merge_pull_request` to a small REST client module next to `github_pr_snapshot.rs` (e.g. `github_pr_merge.rs`): `PUT https://api.github.com/repos/{owner}/{repo}/pulls/{number}/merge` with `merge_method` resolved from repository settings (squash for this project), reusing a shared `reqwest::Client` from `AppState` or a shared GitHub client manager plus `resolve_github_token`.
 2. In the dispatcher, when mode is `server`, route the `merge_pr` command to a builtin lifecycle activity (same mechanism as `mark_bound_issue_done`) instead of an agent prompt packet. The builtin: optional freshness re-check of the gate snapshot -> merge call -> confirmation read via `fetch_github_pr_snapshot` -> structured activity result.
 3. "Already merged" (HTTP 405/409 with merged state, or snapshot shows merged) is success. Other 4xx/5xx map to the existing retryable/non-retryable error classification (`reducer/runtime_failure.rs`).
 
@@ -52,7 +52,7 @@ Config: `merge_execution: "agent" | "server"` under the existing auto-merge/inta
 - Security: server mode requires a token with `contents: write` / merge permission; documented, and mode is opt-in. Verify-only mode needs no new permissions.
 - Compatibility: agents that previously "completed" merges dishonestly will now fail validation; this is the intended behavior change and is confined to the merge activity.
 - Performance: one extra GraphQL read per merge completion; negligible against agent runtime.
-- Maintenance: one new small REST module; reuses existing token, client, and error-classification machinery.
+- Maintenance: one new small REST module; reuses existing token, shared HTTP client, and error-classification machinery.
 
 ## Test Plan
 

--- a/specs/GH1415/tech.md
+++ b/specs/GH1415/tech.md
@@ -1,0 +1,65 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1415
+
+## Product Spec
+
+See `specs/GH1415/product.md`.
+
+## Current System
+
+- Gate: `request_auto_merge_if_enabled` (`crates/harness-server/src/http/background.rs:963`) evaluates `auto_merge_snapshot_satisfies_policy` (`crates/harness-server/src/http/auto_merge.rs:82`) and, on pass, enqueues a `merge_pr` command.
+- Execution: the `merge_pr` activity is rendered into an agent prompt packet (`crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs:544-552`) whose success contract is the agent re-reading GitHub and reporting `state=merged or merged=true`.
+- Completion: the reducer accepts the structured activity result; no server-side confirmation read exists. Reconciliation later maps an observed `PrMerged` to `done` (`crates/harness-server/src/reconciliation.rs:388,401`).
+- Existing infrastructure to reuse: reqwest-based GitHub GraphQL snapshot fetcher `fetch_github_pr_snapshot` (`crates/harness-server/src/github_pr_snapshot.rs:135`, GraphQL URL at `:12`) and token resolution `resolve_github_token` (`crates/harness-server/src/github_auth.rs:1`).
+- Architecture constraint: harness crates must not spawn `gh`/`git` subprocesses; direct HTTPS API calls are the only permitted server-side GitHub interaction.
+
+## Proposed Design
+
+Two phases behind one config enum.
+
+Phase 1 — verify-on-completion (mode `agent`, new default behavior):
+
+1. Add a completion interceptor for `("github_issue_pr", "merge_pr")` activity results in the workflow runtime worker completion path (alongside the existing activity-result validation in `workflow_runtime_worker/activity_result.rs`).
+2. When the agent reports merge success, call `fetch_github_pr_snapshot` for the bound PR. Accept completion only if the snapshot shows the PR merged; otherwise convert the result into a validation failure (`invalid_agent_output` class) so the existing reducer failure/retry path applies.
+3. Record the verification evidence (merged flag, merge commit SHA / PR state, snapshot timestamp) into the activity result artifacts so the decision record is auditable.
+
+Phase 2 — server-executed merge (mode `server`, opt-in):
+
+1. Add `merge_pull_request` to a small REST client module next to `github_pr_snapshot.rs` (e.g. `github_pr_merge.rs`): `PUT https://api.github.com/repos/{owner}/{repo}/pulls/{number}/merge` with `merge_method` resolved from repository settings (squash for this project), using the same reqwest client pattern and `resolve_github_token`.
+2. In the dispatcher, when mode is `server`, route the `merge_pr` command to a builtin lifecycle activity (same mechanism as `mark_bound_issue_done`) instead of an agent prompt packet. The builtin: optional freshness re-check of the gate snapshot -> merge call -> confirmation read via `fetch_github_pr_snapshot` -> structured activity result.
+3. "Already merged" (HTTP 405/409 with merged state, or snapshot shows merged) is success. Other 4xx/5xx map to the existing retryable/non-retryable error classification (`reducer/runtime_failure.rs`).
+
+Config: `merge_execution: "agent" | "server"` under the existing auto-merge/intake config (`crates/harness-server/src/config/intake.rs`), default `agent`. Startup logs the active mode.
+
+## Data Flow
+
+- Inputs: workflow instance data (repo slug, PR number, expected head SHA), GitHub token from config/env.
+- External calls: GitHub GraphQL (existing snapshot query) for verification; GitHub REST merge endpoint (new) in server mode.
+- Outputs: structured activity result with verification evidence; decision record via the existing reducer transaction; no new tables.
+- Persistence: evidence stored in existing activity-result/decision artifacts; config persisted in server config file.
+
+## Alternatives Considered
+
+- Keep agent-executed merge and rely on faster reconciliation only: still leaves a window where the workflow is terminally "done" while the PR is open; rejected because terminal state should never be evidence-free.
+- GraphQL `mergePullRequest` mutation instead of REST: viable; REST chosen because the merge-method semantics and error surface are simpler and better documented. Revisit if the client consolidates on GraphQL.
+- Removing agent mode entirely in one step: rejected; verify-first rollout keeps behavior reversible and lets existing deployments harden without new token permissions.
+
+## Risks
+
+- Security: server mode requires a token with `contents: write` / merge permission; documented, and mode is opt-in. Verify-only mode needs no new permissions.
+- Compatibility: agents that previously "completed" merges dishonestly will now fail validation; this is the intended behavior change and is confined to the merge activity.
+- Performance: one extra GraphQL read per merge completion; negligible against agent runtime.
+- Maintenance: one new small REST module; reuses existing token, client, and error-classification machinery.
+
+## Test Plan
+
+- [ ] Unit tests: verification interceptor accepts merged snapshot, rejects open/closed-unmerged snapshot, defers on transient fetch error; merge client maps 200/405/409/422 correctly (mocked HTTP).
+- [ ] Integration tests: reducer path — false `merged=true` report produces a blocked/failed decision, not terminal success; server-mode builtin produces terminal success only after confirmation read (mock GitHub server).
+- [ ] Manual verification: on a test repository, run one auto-merge in each mode; confirm decision records contain API-observed evidence.
+
+## Rollback Plan
+
+`merge_execution = "agent"` plus a `verify_merge_completion = false` escape hatch restores today's exact behavior without code rollback. Both flags read at dispatch time, so no migration is needed to revert.

--- a/specs/GH1416/product.md
+++ b/specs/GH1416/product.md
@@ -1,0 +1,44 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1416
+
+## User Problem
+
+An operator who deploys harness without setting `HARNESS_API_TOKEN` (or the `api_token` config key) gets a server whose entire mutating API surface — task creation, cancellation, reconciliation, merge endpoints — is open to anyone who can reach the port. Nothing warns them. Because harness spawns code agents and can write to GitHub repositories, an unauthenticated server is effectively remote code execution for the local network. Security posture should not depend on remembering a config key.
+
+## Goals
+
+- A forgotten token can no longer silently produce an unauthenticated server.
+- Deliberate tokenless operation (local dev) remains possible with one explicit config line.
+- Operators get an actionable message telling them exactly what to set.
+
+## Non-Goals
+
+- New authentication schemes, users, or roles (stays a single bearer token).
+- Changes to webhook/signal HMAC verification or to the auth-exempt dashboard/static routes.
+- Network-level protections (bind address, TLS) — out of scope.
+
+## User-Visible Behavior
+
+- Starting the server with no API token and no explicit opt-in fails fast at startup with an error naming both the config key and the environment variable, plus the `allow_unauthenticated = true` escape hatch.
+- Starting with `allow_unauthenticated = true` and no token works like today, but logs a prominent startup warning that the API is unauthenticated.
+- Starting with a token behaves exactly as today (constant-time bearer check on non-exempt routes).
+
+## Acceptance Criteria
+
+- [ ] No token + no opt-in: server refuses to start; error message names `api_token`, `HARNESS_API_TOKEN`, and `allow_unauthenticated`.
+- [ ] No token + `allow_unauthenticated = true`: server starts, warns at startup, middleware passes through.
+- [ ] Token configured: enforcement unchanged (including the SSE `?token=` path and exempt routes).
+- [ ] README and usage docs describe the new default and the opt-in.
+
+## Edge Cases
+
+- Token set to an empty or whitespace-only string: treated as "no token configured", not as a valid empty token.
+- Both token and `allow_unauthenticated = true` set: token wins; enforcement is active and a warning notes the ignored opt-in.
+- Existing deployments upgrading without reading release notes: startup failure is the intended signal; the error message must make recovery a one-line change.
+
+## Rollout Notes
+
+This is a deliberate breaking default for tokenless deployments. Release note must carry an upgrade callout with the two recovery paths (set a token, or opt in explicitly). No data migration.

--- a/specs/GH1416/tasks.md
+++ b/specs/GH1416/tasks.md
@@ -1,0 +1,28 @@
+# GH1416 Tasks
+
+Issue: `#1416`
+Product spec: `specs/GH1416/product.md`
+Tech spec: `specs/GH1416/tech.md`
+
+## Status
+
+- [ ] `SP1416-T001` Owner: `config` | Done when: `allow_unauthenticated` (default false) exists in server HTTP config and empty/whitespace `api_token` values normalize to none at load | Verify: `cargo test --package harness-server config`
+- [ ] `SP1416-T002` Owner: `http-auth` | Done when: startup resolves an explicit auth mode — enforced with token, open with opt-in plus a prominent warning, and refusal to start with an actionable error naming `api_token`, `HARNESS_API_TOKEN`, and `allow_unauthenticated` when neither is set | Verify: `cargo test --package harness-server http::auth`
+- [ ] `SP1416-T003` Owner: `http-auth` | Done when: `api_auth_middleware` branches on the resolved auth mode, keeps the constant-time compare and exempt-path behavior unchanged, and warns when the opt-in is ignored because a token is set | Verify: `cargo test --package harness-server http::auth`
+- [ ] `SP1416-T004` Owner: `tests` | Done when: the config matrix (token / empty token / opt-in / both) and all three startup configurations are covered by unit and integration tests | Verify: `cargo test --package harness-server`
+- [ ] `SP1416-T005` Owner: `docs` | Done when: README and usage docs describe the fail-closed default, the opt-in, and the release-note upgrade callout with both recovery paths | Verify: `test -s README.md`
+
+## Parallelization
+
+Single lane — the change concentrates in `http/auth.rs`, config, and the `http/mod.rs` startup path; splitting would create shared-file conflicts.
+
+## Verification
+
+- `cargo test --package harness-server http::auth`
+- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
+- Manual: run `harness serve` under all three configurations and capture the startup output in the implementation PR body.
+
+## Handoff Notes
+
+- Do not touch webhook/signals HMAC paths or the exempt route list.
+- The startup error text is part of the acceptance criteria; treat its wording as contract.

--- a/specs/GH1416/tech.md
+++ b/specs/GH1416/tech.md
@@ -1,0 +1,55 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1416
+
+## Product Spec
+
+See `specs/GH1416/product.md`.
+
+## Current System
+
+- `api_auth_middleware` (`crates/harness-server/src/http/auth.rs:149`) is layered globally in `http_router.rs:176`. When no token is configured it returns pass-through: `auth.rs:162-165` ("skip auth for backward compatibility").
+- Token comparison uses constant-time `ct_eq` (`auth.rs:192`). Exempt paths are listed at `auth.rs:114` (health, webhooks/signals with their own HMAC, dashboard/static, `/ws` with its own origin+bearer check). SSE streams may pass the token via `?token=` (`auth.rs:178`).
+- Token sourcing: `api_token` config / `HARNESS_API_TOKEN` env (resolved in server config loading).
+
+## Proposed Design
+
+1. Add `allow_unauthenticated: bool` (default `false`) to the server HTTP config alongside `api_token`.
+2. Move the decision to startup, not per-request: during server construction (config validation in `http/mod.rs` startup path), evaluate:
+   - token present (non-empty after trim) -> `AuthMode::Enforced`
+   - no token + `allow_unauthenticated = true` -> `AuthMode::Open` + `warn!` (single prominent startup log)
+   - no token + no opt-in -> return a startup error (server refuses to bind) with the actionable message.
+3. `api_auth_middleware` keeps its current shape but branches on the resolved `AuthMode` instead of re-checking token presence; `Open` behaves exactly like today's pass-through.
+4. Normalize empty/whitespace tokens to `None` at config load so "empty string" cannot satisfy `Enforced` mode.
+5. If both token and opt-in are set, log that `allow_unauthenticated` is ignored.
+
+## Data Flow
+
+- Inputs: server config file + `HARNESS_API_TOKEN` env at startup.
+- Outputs: resolved `AuthMode` stored in `AppState`/router layer state; startup log line stating the mode; startup error on misconfiguration.
+- No persistence changes, no external calls.
+
+## Alternatives Considered
+
+- Refuse only mutating routes while serving read-only ones unauthenticated: more complex route classification for little benefit; read endpoints also leak task/repo data. Rejected.
+- Warn-only (no startup failure): preserves the silent-failure mode this change exists to eliminate. Rejected.
+- Auto-generate a random token and print it at startup: friendlier for dev, but printed secrets end up in logs; may be a later dev-mode convenience, out of scope here.
+
+## Risks
+
+- Security: strictly improves; no new surface.
+- Compatibility: breaking for tokenless deployments — intended; release-note callout plus a one-line recovery.
+- Performance: none (decision moves to startup).
+- Maintenance: small; auth logic becomes more explicit via `AuthMode`.
+
+## Test Plan
+
+- [ ] Unit tests: config resolution matrix (token / empty token / opt-in / both) -> `AuthMode` or startup error; middleware behavior per mode.
+- [ ] Integration tests: server construction fails with no token and no opt-in; starts with opt-in and serves unauthenticated; enforces 401 with token set (reuse existing auth tests at `http/auth.rs` test module).
+- [ ] Manual verification: run `harness serve` in all three configurations and capture the startup output.
+
+## Rollback Plan
+
+Setting `allow_unauthenticated = true` restores the previous behavior per deployment without code changes. Full rollback is reverting the change; no data migration involved either way.

--- a/specs/GH1416/tech.md
+++ b/specs/GH1416/tech.md
@@ -17,7 +17,7 @@ See `specs/GH1416/product.md`.
 ## Proposed Design
 
 1. Add `allow_unauthenticated: bool` (default `false`) to the server HTTP config alongside `api_token`.
-2. Move the decision to startup, not per-request: during server construction (config validation in `http/mod.rs` startup path), evaluate:
+2. Move the decision to startup, not per-request: during application state initialization in `crates/harness-server/src/http/init.rs` (`build_app_state`) or earlier `ServerConfig` loading in `harness-core`, evaluate:
    - token present (non-empty after trim) -> `AuthMode::Enforced`
    - no token + `allow_unauthenticated = true` -> `AuthMode::Open` + `warn!` (single prominent startup log)
    - no token + no opt-in -> return a startup error (server refuses to bind) with the actionable message.
@@ -28,7 +28,7 @@ See `specs/GH1416/product.md`.
 ## Data Flow
 
 - Inputs: server config file + `HARNESS_API_TOKEN` env at startup.
-- Outputs: resolved `AuthMode` stored in `AppState`/router layer state; startup log line stating the mode; startup error on misconfiguration.
+- Outputs: resolved `AuthMode` stored in `AppState`/router layer state during initialization; startup log line stating the mode; startup error on misconfiguration.
 - No persistence changes, no external calls.
 
 ## Alternatives Considered

--- a/specs/GH1417/product.md
+++ b/specs/GH1417/product.md
@@ -1,0 +1,49 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1417
+
+## User Problem
+
+Two long-horizon operational gaps compound each other:
+
+1. Workflow instances that reach `blocked` or sit in `awaiting_feedback` have no automated escalation. The operator dashboard can show stalled tasks on request, but nothing surfaces aged workflow instances proactively; a repo's intake can quietly stall for days behind one parked instance.
+2. The runtime's event and job tables grow forever. There is no retention or pruning, so long-running deployments accumulate unbounded history — the same only-grows failure class as the per-workspace schema leak fixed by the orphan reaper, one layer up.
+
+## Goals
+
+- No workflow instance can stay silently parked past a configurable age; aged instances appear in an explicit stuck/dead-letter list and in error-level logs.
+- Storage for terminal (finished) workflows is bounded by a configurable retention window.
+- Both behaviors follow the existing sweeper pattern: background timer, config-gated, observable.
+
+## Non-Goals
+
+- Outbound alert transports (Slack, PagerDuty, email) — surfacing here means a queryable list plus error-level logs; push notification is a separate feature.
+- Changing state-machine semantics for healthy workflows or adding new workflow states.
+- Archival of pruned events to external storage (possible later phase; this is bounded deletion only).
+- Retention for non-runtime tables (task history, eval runs).
+
+## User-Visible Behavior
+
+- A new watchdog sweeper runs on a timer. Instances in non-terminal wait states older than the threshold are listed by a new operator API endpoint (dead-letter/stuck list) and logged at error level with workflow id, definition, state, and age. Where a recoverable route exists, the watchdog can route the instance through the existing decision machinery instead of only reporting it.
+- A retention sweeper prunes events and jobs belonging to workflow instances that have been terminal longer than the retention window. Active instances are never touched. Each sweep logs what it deleted.
+- Both sweepers are off by default at first release, enabled by config, with documented enable guidance.
+
+## Acceptance Criteria
+
+- [ ] An instance stuck in `blocked`/`awaiting_feedback` beyond the threshold appears in the operator stuck list and produces an error-level log entry.
+- [ ] Retention pruning deletes events/jobs only for instances terminal longer than the window; a test covers the "instance still active" negative case.
+- [ ] Both sweepers are config-gated with sane defaults documented; disabled means bit-for-bit current behavior.
+- [ ] On a long-running dev deployment, table growth is measurably bounded (before/after row counts recorded in the implementation PR).
+
+## Edge Cases
+
+- Instance transitions out of the wait state between detection and reporting: report is best-effort snapshot; no action is taken on instances that moved on.
+- Terminal instance is a parent whose children are still active: prune only when the whole family is terminal, so parent-completion propagation evidence is never deleted mid-flight.
+- Retention window shorter than reconciliation lookback: config validation enforces retention >= the longest consumer lookback, or warns explicitly.
+- Very large backlogs on first enable: pruning works in bounded batches per tick so the first sweep cannot monopolize the database.
+
+## Rollout Notes
+
+Off-by-default sweeper flags mean zero behavior change on upgrade. Recommended enable order: watchdog first (read-only reporting), retention second once the stuck list is clean. Postgres and SQLite must both be covered or the limitation stated explicitly in config docs.

--- a/specs/GH1417/product.md
+++ b/specs/GH1417/product.md
@@ -46,4 +46,4 @@ Two long-horizon operational gaps compound each other:
 
 ## Rollout Notes
 
-Off-by-default sweeper flags mean zero behavior change on upgrade. Recommended enable order: watchdog first (read-only reporting), retention second once the stuck list is clean. Postgres and SQLite must both be covered or the limitation stated explicitly in config docs.
+Off-by-default sweeper flags mean zero behavior change on upgrade. Recommended enable order: watchdog first (read-only reporting), retention second once the stuck list is clean. The workflow runtime store is Postgres-only, so config docs must state that these sweepers operate on the Postgres runtime store.

--- a/specs/GH1417/tasks.md
+++ b/specs/GH1417/tasks.md
@@ -6,7 +6,7 @@ Tech spec: `specs/GH1417/tech.md`
 
 ## Status
 
-- [ ] `SP1417-T001` Owner: `storage` | Done when: a forward-only migration adds the `(state, updated_at)` index needed by the aged-instance query, on both Postgres and SQLite paths | Verify: `cargo test --package harness-workflow`
+- [ ] `SP1417-T001` Owner: `storage` | Done when: a forward-only migration adds the `(state, updated_at)` index needed by the aged-instance query on the Postgres workflow runtime store | Verify: `cargo test --package harness-workflow`
 - [ ] `SP1417-T002` Owner: `storage` | Done when: `list_aged_wait_instances(states, older_than, limit)` returns only non-terminal wait-state instances older than the threshold, with boundary tests | Verify: `cargo test --package harness-workflow`
 - [ ] `SP1417-T003` Owner: `server-sweeper` | Done when: a watchdog sweeper module is spawned from server startup, logs aged `blocked`/`awaiting_feedback` instances at error level with id, definition, state, age, and bound repo/issue, and is config-gated off by default | Verify: `cargo test --package harness-server`
 - [ ] `SP1417-T004` Owner: `operator-api` | Done when: the operator-monitor payload includes a `stuck_workflows` section fed by the watchdog snapshot and the web `operator_snapshot` types render it in the cockpit | Verify: `cargo test --package harness-server && (cd web && bun run test)`

--- a/specs/GH1417/tasks.md
+++ b/specs/GH1417/tasks.md
@@ -1,0 +1,34 @@
+# GH1417 Tasks
+
+Issue: `#1417`
+Product spec: `specs/GH1417/product.md`
+Tech spec: `specs/GH1417/tech.md`
+
+## Status
+
+- [ ] `SP1417-T001` Owner: `storage` | Done when: a forward-only migration adds the `(state, updated_at)` index needed by the aged-instance query, on both Postgres and SQLite paths | Verify: `cargo test --package harness-workflow`
+- [ ] `SP1417-T002` Owner: `storage` | Done when: `list_aged_wait_instances(states, older_than, limit)` returns only non-terminal wait-state instances older than the threshold, with boundary tests | Verify: `cargo test --package harness-workflow`
+- [ ] `SP1417-T003` Owner: `server-sweeper` | Done when: a watchdog sweeper module is spawned from server startup, logs aged `blocked`/`awaiting_feedback` instances at error level with id, definition, state, age, and bound repo/issue, and is config-gated off by default | Verify: `cargo test --package harness-server`
+- [ ] `SP1417-T004` Owner: `operator-api` | Done when: the operator-monitor payload includes a `stuck_workflows` section fed by the watchdog snapshot and the web `operator_snapshot` types render it in the cockpit | Verify: `cargo test --package harness-server && (cd web && bun run test)`
+- [ ] `SP1417-T005` Owner: `storage` | Done when: `prune_terminal_runtime_history(terminal_before, batch_limit)` deletes events/jobs only for fully-terminal parent/child families in bounded batches, with an active-child negative test | Verify: `cargo test --package harness-workflow`
+- [ ] `SP1417-T006` Owner: `server-sweeper` | Done when: a retention sweeper module is spawned from server startup, config-gated off by default, logs per-tick deletion counts, and startup validation warns when the retention window undercuts consumer lookbacks | Verify: `cargo test --package harness-server`
+- [ ] `SP1417-T007` Owner: `docs` | Done when: config reference documents both sweepers, their defaults, and the recommended enable order (watchdog first, retention second) | Verify: `test -s docs/usage-guide.md`
+
+## Parallelization
+
+- Lane A (T002, T003, T004): watchdog query, sweeper, operator surface.
+- Lane B (T005, T006): retention mutation and sweeper.
+- T001 plus config scaffolding land first as a small standalone change; after that the lanes are disjoint on files (`store_migrations.rs`, `http/mod.rs`, and config are the only shared files).
+
+## Verification
+
+- `cargo test --package harness-workflow --package harness-server`
+- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
+- Manual: seeded aged instance appears in the operator monitor; before/after row counts for a retention sweep captured in the implementation PR body.
+
+## Handoff Notes
+
+- Never mutate instance state from a sweeper; the only mutation channel is a decision routed through the reducer (stale-recovery precedent, commit `c6c4c15a`).
+- Pruning must respect parent/child families; deleting a terminal child's history while its parent is active breaks completion-propagation evidence.
+- Put each sweeper in its own module; `http/background.rs` is already at ~3.5k lines and must not grow.
+- The decision-routed recovery hook is phase 2 and belongs in a separate implementation PR.

--- a/specs/GH1417/tech.md
+++ b/specs/GH1417/tech.md
@@ -1,0 +1,66 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1417
+
+## Product Spec
+
+See `specs/GH1417/product.md`.
+
+## Current System
+
+- `blocked` has one modeled exit, `blocked -> done` (`crates/harness-workflow/src/runtime/validator_github_issue_pr.rs:15`); projection maps it to `Waiting` (`crates/harness-server/src/runtime_projection.rs:91`). No sweeper re-activates or escalates aged instances.
+- `periodic_retry.rs:72-335` implements retries/stuck handling for the legacy task model only. `runtime_summary_counts_for_instances` (`crates/harness-workflow/src/runtime/store_summary.rs:6`) counts states but no consumer alerts on age.
+- Stall detection for tasks is computed on operator-endpoint request with a 30-minute threshold (`crates/harness-server/src/handlers/operator_monitor.rs:29,142-145`) — pull-only.
+- `runtime_events`, `workflow_events`, `runtime_jobs` have no delete path; `compact_runtime_jobs_for_commands_limited` (`crates/harness-workflow/src/runtime/store.rs:1685`) is a read-side limiter.
+- Sweeper prior art: pr_feedback / pr_hygiene sweepers and the orphan schema reaper are spawned at startup from `crates/harness-server/src/http/mod.rs:243-260`.
+- Existing recovery precedent: stale recovery is routed through decision records (commit `c6c4c15a` "route stale recovery through decisions"), which is the pattern the watchdog must follow for any mutating action.
+
+## Proposed Design
+
+Two sweepers, one new store surface, one operator endpoint.
+
+Watchdog sweeper (`spawn_workflow_watchdog` in harness-server, following the orphan-reaper shape):
+
+1. New store query `list_aged_wait_instances(states, older_than, limit)` in `harness-workflow/src/runtime/store.rs` — indexed on `(state, updated_at)`; add the index in a new forward-only migration in `store_migrations.rs`.
+2. Each tick: fetch aged instances in `blocked` / `awaiting_feedback`; for each, `error!`-log (workflow id, definition, state, age, bound repo/issue) and upsert into an in-memory + queryable snapshot used by the operator API.
+3. Optional recovery hook (second phase, config-gated separately): for definitions where a safe route exists, enqueue a recovery decision through the existing reducer/decision machinery — never mutate instance state directly from the sweeper.
+4. Operator surface: `GET /api/operator-monitor` gains a `stuck_workflows` section (extend `handlers/operator_monitor.rs` and the web `operator_snapshot` types), so the web cockpit shows it without a new page.
+
+Retention sweeper (`spawn_runtime_retention`):
+
+1. New store mutation `prune_terminal_runtime_history(terminal_before, batch_limit)` deleting from `runtime_jobs`, `runtime_events`, `workflow_events` for instances whose terminal transition is older than the window — guarded by a family check (parent and all children terminal) implemented as a single SQL predicate over the parent/child linkage.
+2. Batched deletes (`LIMIT` per tick) inside one transaction per batch; returns deleted counts which the sweeper logs per tick.
+3. Config validation: `retention_days` must be >= reconciliation/summary lookback windows or startup emits a warning naming both values.
+
+Config (new `[runtime.sweepers]` section or alongside existing storage config): `watchdog_enabled` (default false), `watchdog_age_minutes` (default 240), `retention_enabled` (default false), `retention_days` (default 30), `retention_batch_size` (default 1000), tick intervals.
+
+## Data Flow
+
+- Inputs: workflow instance/event/job tables; config thresholds.
+- Outputs: error-level logs, operator-monitor JSON section, decision records (recovery hook only), batched DELETEs.
+- External calls: none. Both Postgres and SQLite paths must implement the queries (same sqlx surface as existing store code).
+
+## Alternatives Considered
+
+- Extend `periodic_retry.rs` to also cover workflow instances: rejected — that module is legacy-task-scoped and already 2.4k+ lines-adjacent territory; runtime concerns belong in runtime-owned sweepers.
+- Event-table partitioning (Postgres native partitions) instead of delete-based retention: better at very large scale but heavier migration and no SQLite story; revisit if delete batches prove insufficient.
+- Watchdog auto-transitions stuck instances (e.g. force `blocked -> failed`): rejected — mutating state outside the validator/decision path breaks the event-sourced audit trail; the decision-routed recovery hook is the only mutation channel.
+
+## Risks
+
+- Security: none new; operator endpoint already behind API auth.
+- Compatibility: off-by-default flags preserve existing behavior; pruning only touches terminal families, and the family predicate is the main correctness risk — covered by dedicated tests.
+- Performance: aged-instance query needs the new index; deletes are batched. First-enable backlogs bounded by batch size.
+- Maintenance: two more sweepers in `http/mod.rs` startup — acceptable, follows the established pattern; keep each in its own module rather than growing `background.rs`.
+
+## Test Plan
+
+- [ ] Unit tests: aged-instance query boundary conditions (threshold, terminal exclusion); family-terminal predicate (active child blocks pruning); batch-limit behavior.
+- [ ] Integration tests: watchdog tick surfaces a seeded aged `blocked` instance into the operator snapshot and error log; retention tick prunes a terminal family and leaves an active one intact (both Postgres via test harness and SQLite).
+- [ ] Manual verification: enable both sweepers on a dev deployment seeded with aged instances; capture row counts before/after and the operator-monitor payload.
+
+## Rollback Plan
+
+Disable via config flags (`watchdog_enabled = false`, `retention_enabled = false`) — no code rollback needed. Pruned history is not recoverable; that is why retention ships off-by-default and after the watchdog, with the batch/window guards above.

--- a/specs/GH1417/tech.md
+++ b/specs/GH1417/tech.md
@@ -30,7 +30,7 @@ Watchdog sweeper (`spawn_workflow_watchdog` in harness-server, following the orp
 
 Retention sweeper (`spawn_runtime_retention`):
 
-1. New store mutation `prune_terminal_runtime_history(terminal_before, batch_limit)` deleting from `runtime_jobs`, `runtime_events`, `workflow_events` for instances whose terminal transition is older than the window — guarded by a family check (parent and all children terminal) implemented as a single SQL predicate over the parent/child linkage.
+1. New store mutation `prune_terminal_runtime_history(terminal_before, batch_limit)` deleting eligible rows from `workflow_instances` whose terminal transition is older than the window. Migration 14 already defines `ON DELETE CASCADE` from `workflow_instances` to dependent runtime/workflow tables, so one parent delete prunes associated events, decisions, commands, jobs, runtime events, and artifacts. The mutation is guarded by a family check (parent and all children terminal) implemented as a single SQL predicate over the parent/child linkage.
 2. Batched deletes (`LIMIT` per tick) inside one transaction per batch; returns deleted counts which the sweeper logs per tick.
 3. Config validation: `retention_days` must be >= reconciliation/summary lookback windows or startup emits a warning naming both values.
 
@@ -40,12 +40,12 @@ Config (new `[runtime.sweepers]` section or alongside existing storage config): 
 
 - Inputs: workflow instance/event/job tables; config thresholds.
 - Outputs: error-level logs, operator-monitor JSON section, decision records (recovery hook only), batched DELETEs.
-- External calls: none. Both Postgres and SQLite paths must implement the queries (same sqlx surface as existing store code).
+- External calls: none. The workflow runtime store is Postgres-only, so the Postgres path implements the queries through the same sqlx surface as existing runtime store code.
 
 ## Alternatives Considered
 
 - Extend `periodic_retry.rs` to also cover workflow instances: rejected — that module is legacy-task-scoped and already 2.4k+ lines-adjacent territory; runtime concerns belong in runtime-owned sweepers.
-- Event-table partitioning (Postgres native partitions) instead of delete-based retention: better at very large scale but heavier migration and no SQLite story; revisit if delete batches prove insufficient.
+- Event-table partitioning (Postgres native partitions) instead of delete-based retention: better at very large scale but heavier migration; revisit if delete batches prove insufficient.
 - Watchdog auto-transitions stuck instances (e.g. force `blocked -> failed`): rejected — mutating state outside the validator/decision path breaks the event-sourced audit trail; the decision-routed recovery hook is the only mutation channel.
 
 ## Risks
@@ -58,7 +58,7 @@ Config (new `[runtime.sweepers]` section or alongside existing storage config): 
 ## Test Plan
 
 - [ ] Unit tests: aged-instance query boundary conditions (threshold, terminal exclusion); family-terminal predicate (active child blocks pruning); batch-limit behavior.
-- [ ] Integration tests: watchdog tick surfaces a seeded aged `blocked` instance into the operator snapshot and error log; retention tick prunes a terminal family and leaves an active one intact (both Postgres via test harness and SQLite).
+- [ ] Integration tests: watchdog tick surfaces a seeded aged `blocked` instance into the operator snapshot and error log; retention tick prunes a terminal family and leaves an active one intact on the Postgres workflow runtime store.
 - [ ] Manual verification: enable both sweepers on a dev deployment seeded with aged instances; capture row counts before/after and the operator-monitor payload.
 
 ## Rollback Plan


### PR DESCRIPTION
# Summary

Adds SpecRail spec packets (`product.md`, `tech.md`, `tasks.md`) for the top three reliability findings from the v0.6.34 design audit: server-side deterministic merge execution (#1415), fail-closed API auth (#1416), and workflow-layer watchdog plus event-log retention (#1417). Docs-only change; no code paths touched.

## Linked Work

- Issue: #1415, #1416, #1417
- Spec packet: `specs/GH1415/`, `specs/GH1416/`, `specs/GH1417/`

## Readiness Gate

- [x] Linked issues carry `ready_to_spec`; this PR is the `spec_pr_open` step for all three.
- [x] Product/tech spec is linked when required (this PR adds them).
- [x] Security-sensitive changes were routed privately or approved by maintainers — the auth finding (#1416) describes a fail-open default, not an exploitable secret; tracked publicly by maintainer choice.

## Review Gate

- [ ] Agent first-pass review completed or explicitly skipped with reason.
- [ ] Human final review requested — maintainer review of the three specs is the `spec_review` state.
- [ ] Owner approval identified when ownership rules apply.

## Merge Gate

- [ ] PR head SHA recorded.
- [ ] CI/check rollup is complete and passing.
- [ ] Review threads were checked and unresolved actionable threads are addressed.
- [ ] Merge state is clean.
- [ ] Human merge authorization is recorded before merge.
- [ ] `python3 checks/github_pr_evidence.py --github-repo majiayu000/harness --pr <pr-number> --json > pr-evidence.json` result: pending
- [ ] `python3 checks/pr_gate.py --repo . --evidence pr-evidence.json` result: pending

## Verification

- [x] Tests: `python3 checks/check_workflow.py --repo .` passed; `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1415|GH1416|GH1417` all passed.
- [x] Manual proof: `python3 checks/route_gate.py --repo . --route write_spec --issue <n> --state ready_to_spec --json` returned `decision: allowed` for 1415, 1416, and 1417.
- [x] Screenshots or logs when user-visible: not user-visible (repository docs only).

## Release Notes

- [x] Not user-visible.

## Agent Disclosure

- [x] Agent assisted; human author reviewed the full diff.
