### PR TITLE
Add workflow watchdog and runtime retention

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -56,6 +56,14 @@ runtime_retry_policy:
   activity_retries: {}
 storage:
   schema_namespace: workflow
+  workflow_watchdog_enabled: false
+  workflow_watchdog_age_minutes: 240
+  workflow_watchdog_interval_secs: 300
+  workflow_watchdog_batch_size: 100
+  runtime_retention_enabled: false
+  runtime_retention_days: 30
+  runtime_retention_batch_size: 1000
+  runtime_retention_interval_secs: 3600
 activities:
   implement_issue:
     prompt: default

--- a/config/WORKFLOW.md
+++ b/config/WORKFLOW.md
@@ -61,6 +61,14 @@ runtime_retry_policy:
   activity_retries: {}
 storage:
   schema_namespace: workflow
+  workflow_watchdog_enabled: false
+  workflow_watchdog_age_minutes: 240
+  workflow_watchdog_interval_secs: 300
+  workflow_watchdog_batch_size: 100
+  runtime_retention_enabled: false
+  runtime_retention_days: 30
+  runtime_retention_batch_size: 1000
+  runtime_retention_interval_secs: 3600
 activities:
   implement_issue:
     prompt: default

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -262,6 +262,34 @@ pub struct WorkflowStoragePolicy {
     /// Interval, in seconds, between background orphan-schema reap passes.
     #[serde(default = "default_orphan_reaper_interval_secs")]
     pub orphan_reaper_interval_secs: u64,
+    /// Enable workflow-runtime stuck-instance reporting. Off by default so
+    /// existing deployments keep their current background behavior on upgrade.
+    #[serde(default)]
+    pub workflow_watchdog_enabled: bool,
+    /// Minimum age, in minutes, before blocked/awaiting-feedback workflows are
+    /// reported as stuck.
+    #[serde(default = "default_workflow_watchdog_age_minutes")]
+    pub workflow_watchdog_age_minutes: u64,
+    /// Interval, in seconds, between workflow watchdog scans.
+    #[serde(default = "default_workflow_watchdog_interval_secs")]
+    pub workflow_watchdog_interval_secs: u64,
+    /// Maximum stuck workflow rows scanned/logged per watchdog tick.
+    #[serde(default = "default_workflow_watchdog_batch_size")]
+    pub workflow_watchdog_batch_size: u32,
+    /// Enable pruning of terminal workflow-runtime history. Off by default
+    /// because deleted runtime history is not recoverable.
+    #[serde(default)]
+    pub runtime_retention_enabled: bool,
+    /// Terminal workflow families older than this many days are eligible for
+    /// retention pruning.
+    #[serde(default = "default_runtime_retention_days")]
+    pub runtime_retention_days: u64,
+    /// Maximum terminal root families pruned per retention tick.
+    #[serde(default = "default_runtime_retention_batch_size")]
+    pub runtime_retention_batch_size: u32,
+    /// Interval, in seconds, between retention prune passes.
+    #[serde(default = "default_runtime_retention_interval_secs")]
+    pub runtime_retention_interval_secs: u64,
 }
 
 impl Default for IssueWorkflowPolicy {
@@ -378,6 +406,14 @@ impl Default for WorkflowStoragePolicy {
             schema_namespace: default_workflow_schema_namespace(),
             orphan_reaper_enabled: true,
             orphan_reaper_interval_secs: default_orphan_reaper_interval_secs(),
+            workflow_watchdog_enabled: false,
+            workflow_watchdog_age_minutes: default_workflow_watchdog_age_minutes(),
+            workflow_watchdog_interval_secs: default_workflow_watchdog_interval_secs(),
+            workflow_watchdog_batch_size: default_workflow_watchdog_batch_size(),
+            runtime_retention_enabled: false,
+            runtime_retention_days: default_runtime_retention_days(),
+            runtime_retention_batch_size: default_runtime_retention_batch_size(),
+            runtime_retention_interval_secs: default_runtime_retention_interval_secs(),
         }
     }
 }
@@ -524,6 +560,30 @@ fn default_workflow_schema_namespace() -> String {
 
 fn default_orphan_reaper_interval_secs() -> u64 {
     3600
+}
+
+fn default_workflow_watchdog_age_minutes() -> u64 {
+    240
+}
+
+fn default_workflow_watchdog_interval_secs() -> u64 {
+    300
+}
+
+fn default_workflow_watchdog_batch_size() -> u32 {
+    100
+}
+
+fn default_runtime_retention_days() -> u64 {
+    30
+}
+
+fn default_runtime_retention_batch_size() -> u32 {
+    1_000
+}
+
+fn default_runtime_retention_interval_secs() -> u64 {
+    3_600
 }
 
 fn default_true() -> bool {

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -57,6 +57,16 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert_eq!(cfg.pr_scope_guard.max_files_changed, 30);
     assert_eq!(cfg.pr_scope_guard.max_lines_added, 1500);
     assert_eq!(cfg.storage.schema_namespace, "workflow");
+    assert!(cfg.storage.orphan_reaper_enabled);
+    assert_eq!(cfg.storage.orphan_reaper_interval_secs, 3600);
+    assert!(!cfg.storage.workflow_watchdog_enabled);
+    assert_eq!(cfg.storage.workflow_watchdog_age_minutes, 240);
+    assert_eq!(cfg.storage.workflow_watchdog_interval_secs, 300);
+    assert_eq!(cfg.storage.workflow_watchdog_batch_size, 100);
+    assert!(!cfg.storage.runtime_retention_enabled);
+    assert_eq!(cfg.storage.runtime_retention_days, 30);
+    assert_eq!(cfg.storage.runtime_retention_batch_size, 1000);
+    assert_eq!(cfg.storage.runtime_retention_interval_secs, 3600);
     assert!(!cfg.issue_workflow.require_human_gate_before_merge);
     assert!(cfg.activities.is_empty());
     Ok(())
@@ -184,6 +194,16 @@ runtime_retry_policy:
       max_retry_delay_secs: 60
 storage:
   schema_namespace: orchestration
+  orphan_reaper_enabled: false
+  orphan_reaper_interval_secs: 44
+  workflow_watchdog_enabled: true
+  workflow_watchdog_age_minutes: 12
+  workflow_watchdog_interval_secs: 13
+  workflow_watchdog_batch_size: 14
+  runtime_retention_enabled: true
+  runtime_retention_days: 45
+  runtime_retention_batch_size: 46
+  runtime_retention_interval_secs: 47
 activities:
   implement_issue:
     prompt: issue-default
@@ -330,6 +350,16 @@ Body
         Some(60)
     );
     assert_eq!(cfg.storage.schema_namespace, "orchestration");
+    assert!(!cfg.storage.orphan_reaper_enabled);
+    assert_eq!(cfg.storage.orphan_reaper_interval_secs, 44);
+    assert!(cfg.storage.workflow_watchdog_enabled);
+    assert_eq!(cfg.storage.workflow_watchdog_age_minutes, 12);
+    assert_eq!(cfg.storage.workflow_watchdog_interval_secs, 13);
+    assert_eq!(cfg.storage.workflow_watchdog_batch_size, 14);
+    assert!(cfg.storage.runtime_retention_enabled);
+    assert_eq!(cfg.storage.runtime_retention_days, 45);
+    assert_eq!(cfg.storage.runtime_retention_batch_size, 46);
+    assert_eq!(cfg.storage.runtime_retention_interval_secs, 47);
     let activity = cfg
         .activities
         .get("implement_issue")

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -42,6 +42,7 @@ struct OperatorMonitorPayload {
     health: OperatorHealth,
     activity: OperatorActivity,
     operator_actions: Vec<OperatorAction>,
+    stuck_workflows: Vec<StuckWorkflow>,
     failures: Vec<FailureGroup>,
     worktrees: WorktreeSummary,
 }
@@ -87,6 +88,20 @@ struct OperatorAction {
     url: Option<String>,
     evidence_url: Option<String>,
     next_action: &'static str,
+    source: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StuckWorkflow {
+    workflow_id: String,
+    definition_id: String,
+    state: String,
+    repo: Option<String>,
+    issue: Option<u64>,
+    pr: Option<u64>,
+    age_secs: u64,
+    updated_at: String,
+    url: Option<String>,
     source: String,
 }
 
@@ -184,6 +199,7 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
     );
     let by_source = source_activity(&workflows, &active_tasks);
     let operator_actions = operator_actions(&workflows, generated_at);
+    let stuck_workflows = list_stuck_workflows(state, generated_at).await?;
     let failures = grouped_failures(&recent_failures, &workflows);
     let capacity = state.concurrency.task_queue.global_limit() as u64;
     let local_live_worktrees = state
@@ -220,6 +236,7 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
             token_dispatch_by_repo: state.intake.github_token_dispatch_snapshot(),
         },
         operator_actions,
+        stuck_workflows,
         failures,
         worktrees: WorktreeSummary {
             used: worktree_used_count(local_live_worktrees, worktree_cards.len())
@@ -230,6 +247,66 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
             cards: worktree_cards,
         },
     })
+}
+
+async fn list_stuck_workflows(
+    state: &AppState,
+    generated_at: DateTime<Utc>,
+) -> anyhow::Result<Vec<StuckWorkflow>> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(Vec::new());
+    };
+    let workflow_cfg =
+        harness_core::config::workflow::load_workflow_config(&state.core.project_root)?;
+    if !workflow_cfg.storage.workflow_watchdog_enabled {
+        return Ok(Vec::new());
+    }
+    let cutoff = generated_at
+        - chrono::Duration::minutes(workflow_cfg.storage.workflow_watchdog_age_minutes as i64);
+    let workflows = store
+        .list_aged_wait_instances(
+            &["blocked", "awaiting_feedback"],
+            cutoff,
+            workflow_cfg.storage.workflow_watchdog_batch_size as i64,
+        )
+        .await?;
+    Ok(stuck_workflows_from_instances(&workflows, generated_at))
+}
+
+fn stuck_workflows_from_instances(
+    workflows: &[WorkflowInstance],
+    generated_at: DateTime<Utc>,
+) -> Vec<StuckWorkflow> {
+    let mut stuck = workflows
+        .iter()
+        .map(|workflow| {
+            let repo = string_field(&workflow.data, "repo");
+            let issue = u64_field(&workflow.data, "issue_number");
+            let pr = u64_field(&workflow.data, "pr_number");
+            let pr_url = string_field(&workflow.data, "pr_url");
+            let issue_url = repo
+                .as_ref()
+                .zip(issue)
+                .map(|(repo, issue)| format!("https://github.com/{repo}/issues/{issue}"));
+            StuckWorkflow {
+                workflow_id: workflow.id.clone(),
+                definition_id: workflow.definition_id.clone(),
+                state: workflow.state.clone(),
+                repo,
+                issue,
+                pr,
+                age_secs: generated_at
+                    .signed_duration_since(workflow.updated_at)
+                    .num_seconds()
+                    .max(0) as u64,
+                updated_at: workflow.updated_at.to_rfc3339(),
+                url: pr_url.or(issue_url),
+                source: workflow_source(workflow),
+            }
+        })
+        .collect::<Vec<_>>();
+    stuck.sort_by(|a, b| b.age_secs.cmp(&a.age_secs));
+    stuck
 }
 
 async fn list_runtime_workflows(state: &AppState) -> anyhow::Result<Vec<WorkflowInstance>> {

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -305,7 +305,7 @@ fn stuck_workflows_from_instances(
             }
         })
         .collect::<Vec<_>>();
-    stuck.sort_by(|a, b| b.age_secs.cmp(&a.age_secs));
+    stuck.sort_by_key(|workflow| std::cmp::Reverse(workflow.age_secs));
     stuck
 }
 

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -380,6 +380,70 @@ async fn endpoint_includes_failed_runtime_workflows_without_legacy_tasks() -> an
 }
 
 #[tokio::test]
+async fn endpoint_includes_config_enabled_stuck_workflows() -> anyhow::Result<()> {
+    let _lock = test_helpers::HOME_LOCK.lock().await;
+    let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-stuck-workflow-")?;
+    std::fs::write(
+        dir.path().join("WORKFLOW.md"),
+        "---\nstorage:\n  workflow_watchdog_enabled: true\n  workflow_watchdog_age_minutes: 60\n---\nBody\n",
+    )?;
+    let mut state = test_helpers::make_test_state(dir.path()).await?;
+    let workflow_runtime_store = Arc::new(
+        WorkflowRuntimeStore::open_with_database_url(
+            &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
+            Some(&test_helpers::test_database_url()?),
+        )
+        .await?,
+    );
+    workflow_runtime_store
+        .upsert_instance(
+            &workflow(
+                "awaiting_feedback",
+                json!({
+                    "source": "github",
+                    "repo": "owner/repo",
+                    "issue_number": 44,
+                    "pr_number": 45,
+                    "pr_url": "https://github.com/owner/repo/pull/45",
+                }),
+            )
+            .with_id("stuck-awaiting-feedback".to_string()),
+        )
+        .await?;
+    sqlx::query(
+        "UPDATE workflow_instances SET updated_at = NOW() - INTERVAL '2 hours' WHERE id = $1",
+    )
+    .bind("stuck-awaiting-feedback")
+    .execute(workflow_runtime_store.pool())
+    .await?;
+    state.core.workflow_runtime_store = Some(workflow_runtime_store);
+
+    let app = Router::new()
+        .route("/api/operator-monitor", get(operator_monitor))
+        .with_state(Arc::new(state));
+
+    let req = axum::http::Request::builder()
+        .uri("/api/operator-monitor")
+        .body(axum::body::Body::empty())?;
+    let resp = tower::ServiceExt::oneshot(app, req).await?;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+    let body: Value = serde_json::from_slice(&bytes)?;
+    let stuck = body["stuck_workflows"]
+        .as_array()
+        .expect("stuck_workflows should be an array");
+
+    assert_eq!(stuck.len(), 1);
+    assert_eq!(stuck[0]["workflow_id"], "stuck-awaiting-feedback");
+    assert_eq!(stuck[0]["state"], "awaiting_feedback");
+    assert_eq!(stuck[0]["repo"], "owner/repo");
+    assert_eq!(stuck[0]["issue"], 44);
+    assert_eq!(stuck[0]["pr"], 45);
+    Ok(())
+}
+
+#[tokio::test]
 async fn recent_failed_workflow_sampling_prefers_newest_rows() -> anyhow::Result<()> {
     let _lock = test_helpers::HOME_LOCK.lock().await;
     let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-recent-failed-")?;

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -26,12 +26,14 @@ pub(crate) mod misc_routes;
 mod orphan_reaper;
 pub(crate) mod pr_hygiene_background;
 pub(crate) mod rate_limit;
+mod runtime_retention;
 pub(crate) mod sse_routes;
 pub(crate) mod state;
 pub(crate) mod task_mutation_routes;
 pub(crate) mod task_query_routes;
 pub(crate) mod task_routes;
 pub(crate) mod task_submission_routes;
+mod workflow_watchdog;
 
 #[cfg(test)]
 mod reviewer_resolution_tests;
@@ -249,6 +251,13 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     // Periodically reap orphaned path-derived Postgres schemas whose owning
     // workspace directory has been removed, bounding catalog growth (storage RFC).
     orphan_reaper::spawn_orphan_schema_reaper(&state);
+
+    // Periodically surface aged workflow wait states for operator attention.
+    workflow_watchdog::spawn_workflow_watchdog(&state);
+
+    // Periodically prune terminal workflow-runtime history when explicitly
+    // enabled by workflow storage policy.
+    runtime_retention::spawn_runtime_retention(&state);
 
     // Convert workflow command outbox rows into runtime jobs when the workflow
     // policy keeps the dispatcher enabled.

--- a/crates/harness-server/src/http/runtime_retention.rs
+++ b/crates/harness-server/src/http/runtime_retention.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use crate::http::AppState;
+
+const CONFIG_RETRY_SECS: u64 = 30;
+
+pub(super) fn spawn_runtime_retention(state: &Arc<AppState>) {
+    if state.core.workflow_runtime_store.is_none() {
+        tracing::debug!("runtime retention disabled: workflow runtime store unavailable");
+        return;
+    }
+
+    let weak_state = Arc::downgrade(state);
+    tokio::spawn(async move {
+        loop {
+            let Some(state) = weak_state.upgrade() else {
+                break;
+            };
+            let workflow_cfg = match harness_core::config::workflow::load_workflow_config(
+                &state.core.project_root,
+            ) {
+                Ok(config) => config,
+                Err(error) => {
+                    tracing::warn!("runtime retention config load failed: {error}");
+                    drop(state);
+                    tokio::time::sleep(std::time::Duration::from_secs(CONFIG_RETRY_SECS)).await;
+                    continue;
+                }
+            };
+            let interval = std::time::Duration::from_secs(
+                workflow_cfg.storage.runtime_retention_interval_secs.max(1),
+            );
+            if workflow_cfg.storage.runtime_retention_enabled {
+                warn_if_retention_undercuts_log_lookback(
+                    workflow_cfg.storage.runtime_retention_days,
+                    state.core.server.config.observe.log_retention_days.into(),
+                );
+                if let Some(store) = state.core.workflow_runtime_store.as_ref() {
+                    let cutoff = Utc::now()
+                        - chrono::Duration::days(
+                            workflow_cfg.storage.runtime_retention_days as i64,
+                        );
+                    match store
+                        .prune_terminal_runtime_history(
+                            cutoff,
+                            workflow_cfg.storage.runtime_retention_batch_size as i64,
+                        )
+                        .await
+                    {
+                        Ok(summary) if !summary.is_empty() => tracing::info!(
+                            workflow_instances = summary.workflow_instances_deleted,
+                            workflow_events = summary.workflow_events_deleted,
+                            workflow_decisions = summary.workflow_decisions_deleted,
+                            workflow_commands = summary.workflow_commands_deleted,
+                            runtime_jobs = summary.runtime_jobs_deleted,
+                            runtime_events = summary.runtime_events_deleted,
+                            workflow_artifacts = summary.workflow_artifacts_deleted,
+                            "runtime retention pruned terminal workflow history"
+                        ),
+                        Ok(_) => {}
+                        Err(error) => tracing::warn!("runtime retention tick failed: {error}"),
+                    }
+                }
+            } else {
+                tracing::debug!("runtime retention disabled by config; re-checking next interval");
+            }
+
+            drop(state);
+            tokio::time::sleep(interval).await;
+        }
+    });
+}
+
+fn warn_if_retention_undercuts_log_lookback(retention_days: u64, log_retention_days: u64) {
+    if retention_days < log_retention_days {
+        tracing::warn!(
+            runtime_retention_days = retention_days,
+            runtime_log_retention_days = log_retention_days,
+            "runtime retention window is shorter than runtime log retention lookback"
+        );
+    }
+}

--- a/crates/harness-server/src/http/workflow_watchdog.rs
+++ b/crates/harness-server/src/http/workflow_watchdog.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use crate::http::AppState;
+
+const CONFIG_RETRY_SECS: u64 = 30;
+const WAIT_STATES: &[&str] = &["blocked", "awaiting_feedback"];
+
+pub(super) fn spawn_workflow_watchdog(state: &Arc<AppState>) {
+    if state.core.workflow_runtime_store.is_none() {
+        tracing::debug!("workflow watchdog disabled: workflow runtime store unavailable");
+        return;
+    }
+
+    let weak_state = Arc::downgrade(state);
+    tokio::spawn(async move {
+        loop {
+            let Some(state) = weak_state.upgrade() else {
+                break;
+            };
+            let workflow_cfg = match harness_core::config::workflow::load_workflow_config(
+                &state.core.project_root,
+            ) {
+                Ok(config) => config,
+                Err(error) => {
+                    tracing::warn!("workflow watchdog config load failed: {error}");
+                    drop(state);
+                    tokio::time::sleep(std::time::Duration::from_secs(CONFIG_RETRY_SECS)).await;
+                    continue;
+                }
+            };
+            let interval = std::time::Duration::from_secs(
+                workflow_cfg.storage.workflow_watchdog_interval_secs.max(1),
+            );
+            if workflow_cfg.storage.workflow_watchdog_enabled {
+                if let Some(store) = state.core.workflow_runtime_store.as_ref() {
+                    let cutoff = Utc::now()
+                        - chrono::Duration::minutes(
+                            workflow_cfg.storage.workflow_watchdog_age_minutes as i64,
+                        );
+                    match store
+                        .list_aged_wait_instances(
+                            WAIT_STATES,
+                            cutoff,
+                            workflow_cfg.storage.workflow_watchdog_batch_size as i64,
+                        )
+                        .await
+                    {
+                        Ok(workflows) => {
+                            let now = Utc::now();
+                            for workflow in workflows {
+                                tracing::error!(
+                                    workflow_id = %workflow.id,
+                                    definition_id = %workflow.definition_id,
+                                    state = %workflow.state,
+                                    age_secs = now
+                                        .signed_duration_since(workflow.updated_at)
+                                        .num_seconds()
+                                        .max(0),
+                                    repo = workflow
+                                        .data
+                                        .get("repo")
+                                        .and_then(serde_json::Value::as_str),
+                                    issue = workflow
+                                        .data
+                                        .get("issue_number")
+                                        .and_then(serde_json::Value::as_u64),
+                                    "workflow watchdog found aged wait-state workflow"
+                                );
+                            }
+                        }
+                        Err(error) => tracing::warn!("workflow watchdog tick failed: {error}"),
+                    }
+                }
+            } else {
+                tracing::debug!("workflow watchdog disabled by config; re-checking next interval");
+            }
+
+            drop(state);
+            tokio::time::sleep(interval).await;
+        }
+    });
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -82,8 +82,8 @@ pub use state_registry::{
 };
 pub use status::WorkflowCommandStatus;
 pub use store::{
-    WorkflowDecisionTransition, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
-    WorkflowSubmissionDecisionCommit, WorkflowSubmissionDecisionTransition,
+    RuntimeHistoryPruneSummary, WorkflowDecisionTransition, WorkflowRejectedDecisionTransition,
+    WorkflowRuntimeStore, WorkflowSubmissionDecisionCommit, WorkflowSubmissionDecisionTransition,
     WorkflowSubmissionPromptPayload,
 };
 pub use submission::{

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -66,6 +66,28 @@ pub struct WorkflowRuntimeStateCount {
     pub state: String,
     pub count: usize,
 }
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RuntimeHistoryPruneSummary {
+    pub workflow_instances_deleted: usize,
+    pub workflow_events_deleted: usize,
+    pub workflow_decisions_deleted: usize,
+    pub workflow_commands_deleted: usize,
+    pub runtime_jobs_deleted: usize,
+    pub runtime_events_deleted: usize,
+    pub workflow_artifacts_deleted: usize,
+}
+
+impl RuntimeHistoryPruneSummary {
+    pub fn is_empty(&self) -> bool {
+        self.workflow_instances_deleted == 0
+            && self.workflow_events_deleted == 0
+            && self.workflow_decisions_deleted == 0
+            && self.workflow_commands_deleted == 0
+            && self.runtime_jobs_deleted == 0
+            && self.runtime_events_deleted == 0
+            && self.workflow_artifacts_deleted == 0
+    }
+}
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeJobCompactRecord {
     pub id: String,

--- a/crates/harness-workflow/src/runtime/store/instances.rs
+++ b/crates/harness-workflow/src/runtime/store/instances.rs
@@ -1,11 +1,13 @@
 use super::{
     command_store, insert_decision_record_tx, insert_event_tx, insert_instance_if_absent_tx,
     load_or_insert_initial_instance_tx, to_jsonb_string, workflow_instance_from_row,
-    WorkflowDecisionTransition, WorkflowInstancePage, WorkflowRejectedDecisionTransition,
-    WorkflowRuntimeStore,
+    RuntimeHistoryPruneSummary, WorkflowDecisionTransition, WorkflowInstancePage,
+    WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
 };
 use crate::runtime::model::{WorkflowDecisionRecord, WorkflowInstance};
-use crate::runtime::state_registry::workflow_terminal_state_names_for_definition;
+use crate::runtime::state_registry::{
+    known_workflow_definition_ids, workflow_terminal_state_names_for_definition,
+};
 use crate::runtime::status::WorkflowCommandStatus;
 use chrono::{DateTime, Utc};
 
@@ -321,6 +323,188 @@ impl WorkflowRuntimeStore {
             .collect()
     }
 
+    pub async fn list_aged_wait_instances(
+        &self,
+        states: &[&str],
+        older_than: DateTime<Utc>,
+        limit: i64,
+    ) -> anyhow::Result<Vec<WorkflowInstance>> {
+        if states.is_empty() {
+            return Ok(Vec::new());
+        }
+        let limit = limit.clamp(1, 500);
+        let rows: Vec<(String, DateTime<Utc>)> = sqlx::query_as(
+            "SELECT data::text, updated_at FROM workflow_instances
+             WHERE state = ANY($1::text[])
+               AND updated_at < $2
+             ORDER BY updated_at ASC, id ASC
+             LIMIT $3",
+        )
+        .bind(states)
+        .bind(older_than)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|(data, updated_at)| workflow_instance_from_row(data, updated_at))
+            .filter_map(|result| match result {
+                Ok(instance) if !instance.is_terminal() => Some(Ok(instance)),
+                Ok(_) => None,
+                Err(error) => Some(Err(error)),
+            })
+            .collect()
+    }
+
+    pub async fn prune_terminal_runtime_history(
+        &self,
+        terminal_before: DateTime<Utc>,
+        batch_limit: i64,
+    ) -> anyhow::Result<RuntimeHistoryPruneSummary> {
+        let batch_limit = batch_limit.clamp(1, 10_000);
+        let (terminal_definition_ids, terminal_states) = terminal_state_pairs();
+        if terminal_definition_ids.is_empty() {
+            return Ok(RuntimeHistoryPruneSummary::default());
+        }
+
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "WITH RECURSIVE terminal_states(definition_id, state) AS (
+                 SELECT * FROM unnest($1::text[], $2::text[])
+             ),
+             candidate_roots AS (
+                 SELECT root.id
+                 FROM workflow_instances AS root
+                 WHERE root.parent_workflow_id IS NULL
+                   AND root.updated_at < $3
+                   AND EXISTS (
+                       SELECT 1
+                       FROM terminal_states AS terminal
+                       WHERE terminal.definition_id = root.definition_id
+                         AND terminal.state = root.state
+                   )
+                 ORDER BY root.updated_at ASC, root.id ASC
+                 LIMIT $4
+             ),
+             family AS (
+                 SELECT root.id AS root_id,
+                        root.id,
+                        root.definition_id,
+                        root.state,
+                        root.updated_at
+                 FROM workflow_instances AS root
+                 JOIN candidate_roots ON candidate_roots.id = root.id
+                 UNION ALL
+                 SELECT family.root_id,
+                        child.id,
+                        child.definition_id,
+                        child.state,
+                        child.updated_at
+                 FROM workflow_instances AS child
+                 JOIN family ON child.parent_workflow_id = family.id
+             ),
+             eligible_roots AS (
+                 SELECT family.root_id
+                 FROM family
+                 GROUP BY family.root_id
+                 HAVING bool_and(family.updated_at < $3)
+                    AND bool_and(EXISTS (
+                        SELECT 1
+                        FROM terminal_states AS terminal
+                        WHERE terminal.definition_id = family.definition_id
+                          AND terminal.state = family.state
+                    ))
+             )
+             SELECT family.id
+             FROM family
+             JOIN eligible_roots ON eligible_roots.root_id = family.root_id
+             ORDER BY family.root_id ASC, family.id ASC",
+        )
+        .bind(&terminal_definition_ids)
+        .bind(&terminal_states)
+        .bind(terminal_before)
+        .bind(batch_limit)
+        .fetch_all(&self.pool)
+        .await?;
+        let workflow_ids: Vec<String> = rows.into_iter().map(|(id,)| id).collect();
+        if workflow_ids.is_empty() {
+            return Ok(RuntimeHistoryPruneSummary::default());
+        }
+
+        let mut summary = self
+            .runtime_history_counts_for_workflows(&workflow_ids)
+            .await?;
+        let result = sqlx::query("DELETE FROM workflow_instances WHERE id = ANY($1::text[])")
+            .bind(&workflow_ids)
+            .execute(&self.pool)
+            .await?;
+        summary.workflow_instances_deleted = result.rows_affected() as usize;
+        Ok(summary)
+    }
+
+    async fn runtime_history_counts_for_workflows(
+        &self,
+        workflow_ids: &[String],
+    ) -> anyhow::Result<RuntimeHistoryPruneSummary> {
+        let (workflow_instances,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM workflow_instances WHERE id = ANY($1::text[])")
+                .bind(workflow_ids)
+                .fetch_one(&self.pool)
+                .await?;
+        let (workflow_events,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM workflow_events WHERE workflow_id = ANY($1::text[])",
+        )
+        .bind(workflow_ids)
+        .fetch_one(&self.pool)
+        .await?;
+        let (workflow_decisions,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM workflow_decisions WHERE workflow_id = ANY($1::text[])",
+        )
+        .bind(workflow_ids)
+        .fetch_one(&self.pool)
+        .await?;
+        let (workflow_commands,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM workflow_commands WHERE workflow_id = ANY($1::text[])",
+        )
+        .bind(workflow_ids)
+        .fetch_one(&self.pool)
+        .await?;
+        let (runtime_jobs,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*)
+             FROM runtime_jobs AS job
+             JOIN workflow_commands AS command ON command.id = job.command_id
+             WHERE command.workflow_id = ANY($1::text[])",
+        )
+        .bind(workflow_ids)
+        .fetch_one(&self.pool)
+        .await?;
+        let (runtime_events,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*)
+             FROM runtime_events AS event
+             JOIN runtime_jobs AS job ON job.id = event.runtime_job_id
+             JOIN workflow_commands AS command ON command.id = job.command_id
+             WHERE command.workflow_id = ANY($1::text[])",
+        )
+        .bind(workflow_ids)
+        .fetch_one(&self.pool)
+        .await?;
+        let (workflow_artifacts,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM workflow_artifacts WHERE workflow_id = ANY($1::text[])",
+        )
+        .bind(workflow_ids)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(RuntimeHistoryPruneSummary {
+            workflow_instances_deleted: workflow_instances.max(0) as usize,
+            workflow_events_deleted: workflow_events.max(0) as usize,
+            workflow_decisions_deleted: workflow_decisions.max(0) as usize,
+            workflow_commands_deleted: workflow_commands.max(0) as usize,
+            runtime_jobs_deleted: runtime_jobs.max(0) as usize,
+            runtime_events_deleted: runtime_events.max(0) as usize,
+            workflow_artifacts_deleted: workflow_artifacts.max(0) as usize,
+        })
+    }
+
     pub async fn touch_instance(&self, workflow_id: &str) -> anyhow::Result<()> {
         sqlx::query("UPDATE workflow_instances SET updated_at = clock_timestamp() WHERE id = $1")
             .bind(workflow_id)
@@ -489,4 +673,16 @@ impl WorkflowRuntimeStore {
             .map(|(data, updated_at)| workflow_instance_from_row(data, updated_at))
             .collect()
     }
+}
+
+fn terminal_state_pairs() -> (Vec<&'static str>, Vec<&'static str>) {
+    let mut definition_ids = Vec::new();
+    let mut states = Vec::new();
+    for definition_id in known_workflow_definition_ids() {
+        for state in workflow_terminal_state_names_for_definition(definition_id) {
+            definition_ids.push(*definition_id);
+            states.push(state);
+        }
+    }
+    (definition_ids, states)
 }

--- a/crates/harness-workflow/src/runtime/store_migrations.rs
+++ b/crates/harness-workflow/src/runtime/store_migrations.rs
@@ -386,4 +386,10 @@ pub(super) static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
         CREATE INDEX IF NOT EXISTS idx_remote_fact_snapshots_fact_hash
           ON remote_fact_snapshots (fact_hash)",
     },
+    Migration {
+        version: 16,
+        description: "index aged workflow wait-state scans",
+        sql: "CREATE INDEX IF NOT EXISTS idx_workflow_instances_state_updated_at
+              ON workflow_instances (state, updated_at)",
+    },
 ];

--- a/crates/harness-workflow/src/runtime/tests/runtime_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_store.rs
@@ -489,6 +489,134 @@ async fn nonterminal_listing_uses_definition_specific_terminal_states() -> anyho
     Ok(())
 }
 
+#[tokio::test]
+async fn aged_wait_listing_filters_by_age_and_terminal_state() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let old_blocked = project_issue_instance("/project-a", 301, "blocked");
+    let old_feedback = project_issue_instance("/project-a", 302, "awaiting_feedback");
+    let fresh_blocked = project_issue_instance("/project-a", 303, "blocked");
+    let old_done = project_issue_instance("/project-a", 304, "done");
+    for instance in [&old_blocked, &old_feedback, &fresh_blocked, &old_done] {
+        store.upsert_instance(instance).await?;
+    }
+    sqlx::query("UPDATE workflow_instances SET updated_at = $2 WHERE id = ANY($1::text[])")
+        .bind(vec![
+            old_blocked.id.clone(),
+            old_feedback.id.clone(),
+            old_done.id.clone(),
+        ])
+        .bind(Utc::now() - Duration::hours(2))
+        .execute(store.pool())
+        .await?;
+
+    let ids: std::collections::HashSet<_> = store
+        .list_aged_wait_instances(
+            &["blocked", "awaiting_feedback", "done"],
+            Utc::now() - Duration::hours(1),
+            10,
+        )
+        .await?
+        .into_iter()
+        .map(|instance| instance.id)
+        .collect();
+
+    assert!(ids.contains(&old_blocked.id));
+    assert!(ids.contains(&old_feedback.id));
+    assert!(!ids.contains(&fresh_blocked.id));
+    assert!(!ids.contains(&old_done.id));
+    Ok(())
+}
+
+#[tokio::test]
+async fn retention_prunes_only_terminal_workflow_families() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let terminal_parent = project_issue_instance("/project-a", 401, "done");
+    let terminal_child = quality_gate_instance("passed")
+        .with_id("terminal-family-child")
+        .with_parent(&terminal_parent.id);
+    let active_parent = project_issue_instance("/project-a", 402, "done");
+    let active_child = quality_gate_instance("checking")
+        .with_id("active-family-child")
+        .with_parent(&active_parent.id);
+    for instance in [
+        &terminal_parent,
+        &terminal_child,
+        &active_parent,
+        &active_child,
+    ] {
+        store.upsert_instance(instance).await?;
+    }
+    store
+        .append_event(&terminal_parent.id, "TerminalEvent", "test", json!({}))
+        .await?;
+    store
+        .append_event(&active_parent.id, "ActiveFamilyEvent", "test", json!({}))
+        .await?;
+    let command = WorkflowCommand::enqueue_activity("quality_gate", "terminal-family-command");
+    let command_id = store
+        .enqueue_command(&terminal_parent.id, None, &command)
+        .await?;
+    let runtime_job = store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "quality_gate" }),
+        )
+        .await?;
+    store
+        .record_runtime_event(&runtime_job.id, "RuntimePromptPrepared", json!({}))
+        .await?;
+    sqlx::query(
+        "INSERT INTO workflow_artifacts (id, workflow_id, runtime_job_id, artifact_type, data)
+         VALUES ($1, $2, $3, $4, $5::jsonb)",
+    )
+    .bind("terminal-family-artifact")
+    .bind(&terminal_parent.id)
+    .bind(&runtime_job.id)
+    .bind("test")
+    .bind("{}")
+    .execute(store.pool())
+    .await?;
+    sqlx::query("UPDATE workflow_instances SET updated_at = $2 WHERE id = ANY($1::text[])")
+        .bind(vec![
+            terminal_parent.id.clone(),
+            terminal_child.id.clone(),
+            active_parent.id.clone(),
+            active_child.id.clone(),
+        ])
+        .bind(Utc::now() - Duration::days(45))
+        .execute(store.pool())
+        .await?;
+
+    let summary = store
+        .prune_terminal_runtime_history(Utc::now() - Duration::days(30), 100)
+        .await?;
+
+    assert_eq!(summary.workflow_instances_deleted, 2);
+    assert_eq!(summary.workflow_events_deleted, 1);
+    assert_eq!(summary.workflow_commands_deleted, 1);
+    assert_eq!(summary.runtime_jobs_deleted, 1);
+    assert_eq!(summary.runtime_events_deleted, 1);
+    assert_eq!(summary.workflow_artifacts_deleted, 1);
+    assert!(store.get_instance(&terminal_parent.id).await?.is_none());
+    assert!(store.get_instance(&terminal_child.id).await?.is_none());
+    assert!(store.get_instance(&active_parent.id).await?.is_some());
+    assert!(store.get_instance(&active_child.id).await?.is_some());
+    assert_eq!(store.events_for(&active_parent.id).await?.len(), 1);
+    Ok(())
+}
+
 fn runtime_job_status_str(status: RuntimeJobStatus) -> anyhow::Result<String> {
     let value = serde_json::to_value(status)?;
     value

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -470,7 +470,7 @@ If no new commits have landed since the last review, the cycle is skipped.
 
 ## Scheduled Background Systems
 
-Harness runs four background schedulers automatically when the server starts:
+Harness runs several background schedulers automatically when the server starts:
 
 ### 1. Periodic Review (`[review]`)
 
@@ -497,6 +497,33 @@ Every 24 hours, runs `RuleEngine::scan()` on the project root:
 - Persists violations as `rule_check` events
 - Generates a health report with quality grade and violation summary
 - Logged as `scheduler: periodic health report`
+
+### Workflow Runtime Sweepers
+
+Workflow-runtime watchdog and retention sweepers are configured in
+`WORKFLOW.md` under `storage`. Both are disabled by default on first rollout:
+
+```yaml
+storage:
+  workflow_watchdog_enabled: false
+  workflow_watchdog_age_minutes: 240
+  workflow_watchdog_interval_secs: 300
+  workflow_watchdog_batch_size: 100
+  runtime_retention_enabled: false
+  runtime_retention_days: 30
+  runtime_retention_batch_size: 1000
+  runtime_retention_interval_secs: 3600
+```
+
+Enable `workflow_watchdog_enabled` first. It is read-only: aged `blocked` and
+`awaiting_feedback` workflow instances appear in `/api/operator-monitor` under
+`stuck_workflows` and are logged at error level.
+
+Enable `runtime_retention_enabled` only after the stuck list is clean. Retention
+deletes terminal workflow families older than `runtime_retention_days` in
+bounded batches and relies on the Postgres runtime-store cascade constraints to
+remove events, decisions, commands, jobs, runtime events, and artifacts. Active
+workflow families are never pruned.
 
 ### 3. GC Runner (always on)
 

--- a/web/src/routes/Overview.test.tsx
+++ b/web/src/routes/Overview.test.tsx
@@ -141,8 +141,10 @@ function makeMonitor(): OperatorMonitorPayload {
         done: 0,
       },
       by_source: [],
+      token_dispatch_by_repo: [],
     },
     operator_actions: [],
+    stuck_workflows: [],
     failures: [],
     worktrees: {
       used: 0,

--- a/web/src/routes/overview/OperatorMonitorPanel.test.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.test.tsx
@@ -60,6 +60,7 @@ function makeMonitor(): OperatorMonitorPayload {
           failed: 0,
         },
       ],
+      token_dispatch_by_repo: [],
     },
     operator_actions: [
       {
@@ -74,6 +75,20 @@ function makeMonitor(): OperatorMonitorPayload {
         url: "https://github.com/owner/repo/pull/43",
         evidence_url: "/tasks/task-42",
         next_action: "Review and merge",
+        source: "github",
+      },
+    ],
+    stuck_workflows: [
+      {
+        workflow_id: "workflow-stuck",
+        definition_id: "github_issue_pr",
+        state: "awaiting_feedback",
+        repo: "owner/repo",
+        issue: 44,
+        pr: 45,
+        age_secs: 18_000,
+        updated_at: "2026-06-11T19:00:00Z",
+        url: "https://github.com/owner/repo/pull/45",
         source: "github",
       },
     ],
@@ -132,10 +147,12 @@ describe("<OperatorMonitorPanel>", () => {
     expect(screen.getByText("runtime running")).toBeInTheDocument();
     expect(screen.getByText("ready to merge")).toBeInTheDocument();
     expect(screen.getByText("#42 -> PR #43")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "open" })).toHaveAttribute(
+    expect(screen.getAllByRole("link", { name: "open" })[0]).toHaveAttribute(
       "href",
       "https://github.com/owner/repo/pull/43",
     );
+    expect(screen.getByText("awaiting feedback")).toBeInTheDocument();
+    expect(screen.getByText("#44 -> PR #45")).toBeInTheDocument();
   });
 
   it("renders grouped retryable GitHub fetch failures", () => {

--- a/web/src/routes/overview/OperatorMonitorPanel.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.tsx
@@ -1,7 +1,7 @@
 import { Panel } from "@/components/Panel";
 import { useOperatorMonitor } from "@/lib/queries";
 import { fmtInt } from "@/lib/format";
-import type { FailureGroup, OperatorAction, OperatorMonitorPayload, SourceActivity } from "@/types";
+import type { FailureGroup, OperatorAction, OperatorMonitorPayload, SourceActivity, StuckWorkflow } from "@/types";
 
 function fmtDuration(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
@@ -67,6 +67,29 @@ function FailureRow({ failure }: { failure: FailureGroup }) {
   );
 }
 
+function StuckWorkflowRow({ workflow }: { workflow: StuckWorkflow }) {
+  return (
+    <tr className="border-b border-line last:border-b-0">
+      <td className="px-3 py-2 font-mono text-[11px] text-warn">{workflow.state.replace(/_/g, " ")}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">{workflow.repo ?? "untracked"}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">
+        {workflow.issue ? `#${workflow.issue}` : workflow.workflow_id}
+        {workflow.pr ? ` -> PR #${workflow.pr}` : ""}
+      </td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-4">{fmtDuration(workflow.age_secs)}</td>
+      <td className="px-3 py-2 text-right font-mono text-[11px]">
+        {workflow.url ? (
+          <a href={workflow.url} target="_blank" rel="noreferrer" className="text-rust hover:underline">
+            open
+          </a>
+        ) : (
+          <span className="text-ink-4">unlinked</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
 function SourceRow({ source }: { source: SourceActivity }) {
   return (
     <tr className="border-b border-line last:border-b-0">
@@ -127,6 +150,16 @@ function MonitorBody({ data }: { data: OperatorMonitorPayload }) {
 
       <div className="grid grid-cols-[1.2fr_1fr]">
         <div className="border-r border-line">
+          <div className="border-b border-line">
+            <div className="px-4 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3">Stuck workflows</div>
+            {data.stuck_workflows.length === 0 ? (
+              <p className="border-t border-line px-4 py-3 font-mono text-[11px] text-ink-4">No aged stuck workflows.</p>
+            ) : (
+              <table className="w-full border-t border-line">
+                <tbody>{data.stuck_workflows.map((workflow) => <StuckWorkflowRow key={workflow.workflow_id} workflow={workflow} />)}</tbody>
+              </table>
+            )}
+          </div>
           <div className="px-4 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3">Grouped failures</div>
           {data.failures.length === 0 ? (
             <p className="border-t border-line px-4 py-3 font-mono text-[11px] text-ink-4">No recent failures.</p>

--- a/web/src/types/operator_monitor.ts
+++ b/web/src/types/operator_monitor.ts
@@ -4,6 +4,7 @@ export interface OperatorMonitorPayload {
   health: OperatorHealth;
   activity: OperatorActivity;
   operator_actions: OperatorAction[];
+  stuck_workflows: StuckWorkflow[];
   failures: FailureGroup[];
   worktrees: OperatorWorktreeSummary;
 }
@@ -22,6 +23,7 @@ export interface OperatorActivity {
   runtime_workflows: RuntimeWorkflowCounts;
   legacy_queue: LegacyQueueCounts;
   by_source: SourceActivity[];
+  token_dispatch_by_repo: GitHubTokenDispatchCounter[];
 }
 
 export interface RuntimeWorkflowCounts {
@@ -67,6 +69,30 @@ export interface OperatorAction {
   evidence_url: string | null;
   next_action: string;
   source: string;
+}
+
+export interface StuckWorkflow {
+  workflow_id: string;
+  definition_id: string;
+  state: string;
+  repo: string | null;
+  issue: number | null;
+  pr: number | null;
+  age_secs: number;
+  updated_at: string;
+  url: string | null;
+  source: string;
+}
+
+export interface GitHubTokenDispatchCounter {
+  repo: string;
+  server_github_poll_count: number;
+  agent_implement_issue_count: number;
+  agent_address_feedback_count: number;
+  agent_merge_pr_count: number;
+  agent_dependency_analysis_count: number;
+  agent_skipped_covered_issue_count: number;
+  agent_skipped_same_fact_hash_count: number;
 }
 
 export interface FailureGroup {


### PR DESCRIPTION
# Summary
Linked Work: #1417

Implements GH-1417 workflow-runtime watchdog and retention foundations.

## Linked Work
- Refs #1417
- Spec: `specs/GH1417/`

## Scope
- Adds workflow-runtime storage support for aged wait-state scans and terminal-family retention pruning.
- Adds the `(state, updated_at)` runtime instance index.
- Adds off-by-default watchdog and retention storage config, central/repo workflow defaults, and usage docs.
- Spawns separate watchdog and retention sweepers from server startup.
- Surfaces config-enabled aged `blocked` / `awaiting_feedback` workflows in `/api/operator-monitor` as `stuck_workflows` and in the web operator monitor panel.
- Adds tests for aged wait-state selection, retention active-child protection, operator API stuck rows, config parsing, and web rendering.

## Retention Row-Count Evidence
- Seeded retention test before prune: eligible terminal family had `workflow_instances=2`, `workflow_events=1`, `workflow_commands=1`, `runtime_jobs=1`, `runtime_events=1`, `workflow_artifacts=1`.
- Seeded retention test after prune: those eligible family rows were deleted, while the active-child family and its workflow event remained.
- Long-running dev deployment before/after counts were not captured in this runtime workspace; the PR keeps retention off by default until operators enable it and can collect deployment-specific counts.

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p harness-workflow --all-targets`
- `cargo check -p harness-core --all-targets`
- `cargo check -p harness-server --all-targets`
- `cargo test -p harness-core load_workflow_config_defaults_when_missing`
- `cargo test -p harness-core load_workflow_config_reads_front_matter`
- `cargo test -p harness-workflow runtime_store`
- `cargo test -p harness-server endpoint_includes_config_enabled_stuck_workflows`
- `(cd web && bun run test -- OperatorMonitorPanel.test.tsx)`
- `(cd web && bun run test -- Overview.test.tsx)`
- `(cd web && bun run tsc --noEmit)`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1417`
- `python3 checks/check_workflow.py --repo .`
- `git diff --check`
- `cargo check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Scope Guard
- Configured guard: max 30 files, max 1500 added lines.
- Staged scope before commit: 19 files changed, 889 insertions, 8 deletions.

## Agent Disclosure
- [ ] No agent was used.
- [x] Agent assisted; human author should review before merge.

