### PR TITLE
Fail closed when no API token is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **security:** HTTP API authentication now fails closed when neither
+  `api_token` nor `HARNESS_API_TOKEN` is configured. Operators must set a token
+  or explicitly opt in to tokenless local development with
+  `allow_unauthenticated = true`.
+
 ## [0.6.34] - 2026-05-30
 
 First release with a tracked changelog. This is a workflow-runtime reliability

--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ transport = "stdio"
 http_addr = "127.0.0.1:9800"
 data_dir = "~/.local/share/harness"
 project_root = "."
+# Set this or HARNESS_API_TOKEN before exposing HTTP routes.
+# api_token = "change-me"
+# Local-dev escape hatch for tokenless HTTP operation:
+# allow_unauthenticated = true
 
 [agents]
 default_agent = "auto"
@@ -297,6 +301,12 @@ environment = "production"
 exporter = "otlp-http"
 # endpoint = "http://127.0.0.1:4318"
 ```
+
+HTTP API authentication now fails closed by default. Starting `harness serve`
+without `server.api_token` or `HARNESS_API_TOKEN` exits with an actionable
+configuration error. For intentional tokenless local development, set
+`server.allow_unauthenticated = true`; if both a token and the opt-in are set,
+the token wins and bearer authentication stays enforced.
 
 ### Multi-Project Configuration
 

--- a/config/default.toml.example
+++ b/config/default.toml.example
@@ -15,6 +15,10 @@
 transport = "http"
 http_addr = "127.0.0.1:9800"
 database_url = "postgres://harness:harness@localhost:5432/harness"
+# Set this or HARNESS_API_TOKEN before exposing HTTP routes. Server startup
+# fails closed without a token unless allow_unauthenticated is explicitly true.
+# api_token = "change-me"
+# allow_unauthenticated = true
 # Harness opens separate Postgres pools per logical store. The default is
 # intentionally conservative; local Postgres can usually use a higher budget.
 # database_pool_max_connections = 16

--- a/crates/harness-cli/src/commands/status.rs
+++ b/crates/harness-cli/src/commands/status.rs
@@ -77,11 +77,13 @@ fn resolve_api_token(config: &HarnessConfig) -> Option<String> {
         .server
         .api_token
         .as_deref()
+        .map(str::trim)
         .filter(|token| !token.is_empty())
         .map(str::to_owned)
         .or_else(|| {
             std::env::var("HARNESS_API_TOKEN")
                 .ok()
+                .map(|token| token.trim().to_string())
                 .filter(|token| !token.is_empty())
         })
 }

--- a/crates/harness-core/CHANGELOG.md
+++ b/crates/harness-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *(config)* add the explicit `allow_unauthenticated` HTTP API opt-in and
+  normalize blank or whitespace-only `api_token` values as absent.
+
 ## [0.6.34](https://github.com/majiayu000/harness/compare/harness-core-v0.1.0...harness-core-v0.6.34) - 2026-06-29
 
 ### Added

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -86,6 +86,7 @@ impl HarnessConfig {
     /// Serde field defaults cannot see sibling fields, so cross-field defaults
     /// are resolved after loading, rebasing, and environment overrides.
     pub fn apply_derived_defaults(&mut self) {
+        self.server.normalize_api_token();
         self.workspace
             .use_data_dir_default_root(&self.server.data_dir);
     }

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -48,10 +48,16 @@ pub struct ServerConfig {
     ///
     /// When set (via this field or the `HARNESS_API_TOKEN` environment variable),
     /// all non-webhook and non-health HTTP endpoints require an
-    /// `Authorization: Bearer <token>` header. When not configured, authentication
-    /// is skipped for backward-compatible local development.
+    /// `Authorization: Bearer <token>` header. When not configured, HTTP startup
+    /// fails closed unless `allow_unauthenticated` is explicitly enabled.
     #[serde(default)]
     pub api_token: Option<String>,
+    /// Explicit opt-in for tokenless local development.
+    ///
+    /// This restores the legacy unauthenticated behavior when no API token is
+    /// configured. It is ignored when `api_token` or `HARNESS_API_TOKEN` is set.
+    #[serde(default)]
+    pub allow_unauthenticated: bool,
     /// Allowlist of base directories under which project roots may be registered.
     ///
     /// When non-empty, `POST /projects` rejects any root that is not a descendant
@@ -105,6 +111,7 @@ impl ServerConfig {
     /// - `GITHUB_TOKEN` / `GH_TOKEN` — `github_token`
     /// - `GITHUB_WEBHOOK_SECRET`   — `github_webhook_secret`
     pub fn apply_env_overrides(&mut self) -> anyhow::Result<()> {
+        self.normalize_api_token();
         if let Ok(v) = std::env::var("HARNESS_DATA_DIR") {
             if !v.is_empty() {
                 self.data_dir = std::path::PathBuf::from(v);
@@ -139,8 +146,9 @@ impl ServerConfig {
             }
         }
         if let Ok(v) = std::env::var("HARNESS_API_TOKEN") {
-            if !v.is_empty() {
-                self.api_token = Some(v);
+            let token = v.trim();
+            if !token.is_empty() {
+                self.api_token = Some(token.to_string());
             }
         }
         if self
@@ -165,7 +173,18 @@ impl ServerConfig {
                 self.github_webhook_secret = Some(v);
             }
         }
+        self.normalize_api_token();
         Ok(())
+    }
+
+    /// Normalize absent API tokens so blank/whitespace values cannot satisfy auth.
+    pub fn normalize_api_token(&mut self) {
+        self.api_token = self
+            .api_token
+            .as_deref()
+            .map(str::trim)
+            .filter(|token| !token.is_empty())
+            .map(str::to_string);
     }
 
     /// Apply the `HARNESS_HTTP_ADDR` env var override.
@@ -205,6 +224,7 @@ impl fmt::Debug for ServerConfig {
             ws_heartbeat_interval_secs,
             trusted_proxies,
             api_token,
+            allow_unauthenticated,
             allowed_project_roots,
             max_webhook_body_bytes,
             signal_rate_limit_per_minute,
@@ -239,6 +259,7 @@ impl fmt::Debug for ServerConfig {
             .field("ws_heartbeat_interval_secs", ws_heartbeat_interval_secs)
             .field("trusted_proxies", trusted_proxies)
             .field("api_token", &api_token.as_ref().map(|_| "[REDACTED]"))
+            .field("allow_unauthenticated", allow_unauthenticated)
             .field("allowed_project_roots", allowed_project_roots)
             .field("max_webhook_body_bytes", max_webhook_body_bytes)
             .field("signal_rate_limit_per_minute", signal_rate_limit_per_minute)
@@ -269,6 +290,7 @@ impl Default for ServerConfig {
             ws_heartbeat_interval_secs: default_ws_heartbeat_interval_secs(),
             trusted_proxies: Vec::new(),
             api_token: None,
+            allow_unauthenticated: false,
             allowed_project_roots: Vec::new(),
             max_webhook_body_bytes: default_max_webhook_body_bytes(),
             signal_rate_limit_per_minute: default_signal_rate_limit_per_minute(),
@@ -539,6 +561,32 @@ mod tests {
     }
 
     #[test]
+    fn env_override_whitespace_api_token_does_not_override_toml_token() {
+        temp_env::with_vars([("HARNESS_API_TOKEN", Some("   "))], || {
+            let mut cfg = ServerConfig {
+                api_token: Some("real-token".to_string()),
+                ..ServerConfig::default()
+            };
+            cfg.apply_env_overrides().unwrap();
+            assert_eq!(cfg.api_token, Some("real-token".to_string()));
+        });
+    }
+
+    #[test]
+    fn normalize_api_token_trims_and_removes_blank_token() {
+        let mut cfg = ServerConfig {
+            api_token: Some("  real-token  ".to_string()),
+            ..ServerConfig::default()
+        };
+        cfg.normalize_api_token();
+        assert_eq!(cfg.api_token.as_deref(), Some("real-token"));
+
+        cfg.api_token = Some("   ".to_string());
+        cfg.normalize_api_token();
+        assert_eq!(cfg.api_token, None);
+    }
+
+    #[test]
     fn env_override_empty_github_token_does_not_override_toml_token() {
         temp_env::with_vars(
             [("GITHUB_TOKEN", Some("")), ("GH_TOKEN", None::<&str>)],
@@ -633,6 +681,7 @@ mod tests {
             database_url = "postgres://harness:harness@localhost:5432/harness"
             database_pool_max_connections = 8
             database_pool_acquire_timeout_secs = 30
+            allow_unauthenticated = true
         "#;
         let config: ServerConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(
@@ -641,6 +690,7 @@ mod tests {
         );
         assert_eq!(config.database_pool_max_connections, Some(8));
         assert_eq!(config.database_pool_acquire_timeout_secs, Some(30));
+        assert!(config.allow_unauthenticated);
     }
 
     // --- existing tests ---

--- a/crates/harness-server/CHANGELOG.md
+++ b/crates/harness-server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *(security)* fail closed during server startup when neither `api_token` nor
+  `HARNESS_API_TOKEN` is configured; tokenless operation now requires
+  `allow_unauthenticated = true`, and a configured token wins over the opt-in.
+
 ## [0.6.34](https://github.com/majiayu000/harness/releases/tag/harness-server-v0.6.34) - 2026-06-29
 
 ### Added

--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -263,7 +263,8 @@ mod tests {
         make_test_state_with_config(config).await
     }
 
-    async fn make_test_state_with_config(config: HarnessConfig) -> anyhow::Result<AppState> {
+    async fn make_test_state_with_config(mut config: HarnessConfig) -> anyhow::Result<AppState> {
+        config.server.allow_unauthenticated = true;
         let server = Arc::new(HarnessServer::new(
             config,
             ThreadManager::new(),

--- a/crates/harness-server/src/handlers/health.rs
+++ b/crates/harness-server/src/handlers/health.rs
@@ -66,6 +66,7 @@ mod tests {
         let mut config = HarnessConfig::default();
         config.server.project_root = project_root.to_path_buf();
         config.server.data_dir = data_dir.to_path_buf();
+        config.server.allow_unauthenticated = true;
         let server = Arc::new(HarnessServer::new(
             config,
             ThreadManager::new(),

--- a/crates/harness-server/src/handlers/observe.rs
+++ b/crates/harness-server/src/handlers/observe.rs
@@ -100,6 +100,7 @@ mod tests {
         let mut config = HarnessConfig::default();
         config.server.project_root = project_root.to_path_buf();
         config.server.data_dir = data_dir.to_path_buf();
+        config.server.allow_unauthenticated = true;
         let server = Arc::new(HarnessServer::new(
             config,
             ThreadManager::new(),

--- a/crates/harness-server/src/handlers/projects.rs
+++ b/crates/harness-server/src/handlers/projects.rs
@@ -241,6 +241,7 @@ mod tests {
         let mut config = HarnessConfig::default();
         config.server.project_root = project_root.to_path_buf();
         config.server.data_dir = data_dir.to_path_buf();
+        config.server.allow_unauthenticated = true;
         let server = Arc::new(HarnessServer::new(
             config,
             ThreadManager::new(),
@@ -338,6 +339,7 @@ mod tests {
         let mut config = HarnessConfig::default();
         config.server.project_root = canonical_root.clone();
         config.server.data_dir = data_dir.path().to_path_buf();
+        config.server.allow_unauthenticated = true;
         config.concurrency.per_project.insert(queue_key.clone(), 3);
         let server = Arc::new(HarnessServer::new(
             config,

--- a/crates/harness-server/src/http/auth.rs
+++ b/crates/harness-server/src/http/auth.rs
@@ -1,10 +1,12 @@
 use super::AppState;
 use axum::{
     extract::State,
+    http::StatusCode,
     middleware::Next,
     response::{IntoResponse, Response},
     Json,
 };
+use harness_core::config::server::ServerConfig;
 use serde_json::json;
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
@@ -90,25 +92,100 @@ mod tests {
         assert!(is_auth_exempt_path("/usage"));
         assert!(!is_auth_exempt_path("/api/usage-monitor"));
     }
+
+    #[test]
+    fn resolve_auth_mode_refuses_tokenless_without_opt_in() {
+        let err = resolve_api_auth_mode(&ServerConfig::default()).unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("api_token"));
+        assert!(message.contains("HARNESS_API_TOKEN"));
+        assert!(message.contains("allow_unauthenticated"));
+    }
+
+    #[test]
+    fn resolve_auth_mode_allows_explicit_tokenless_opt_in() {
+        let config = ServerConfig {
+            allow_unauthenticated: true,
+            ..ServerConfig::default()
+        };
+
+        assert_eq!(resolve_api_auth_mode(&config).unwrap(), ApiAuthMode::Open);
+    }
+
+    #[test]
+    fn resolve_auth_mode_token_wins_over_opt_in() {
+        let config = ServerConfig {
+            api_token: Some(" secret ".to_string()),
+            allow_unauthenticated: true,
+            ..ServerConfig::default()
+        };
+
+        assert_eq!(
+            resolve_api_auth_mode(&config).unwrap(),
+            ApiAuthMode::Enforced("secret".to_string())
+        );
+    }
 }
 
-/// Resolve the effective API token from server config or `HARNESS_API_TOKEN` env var.
+/// Resolve the effective API token from server config.
 ///
-/// Filters empty strings *before* the env-var fallback so that an explicit
-/// `api_token = ""` in server.toml does not shadow `HARNESS_API_TOKEN`.
-pub(crate) fn resolve_api_token(
-    config: &harness_core::config::server::ServerConfig,
-) -> Option<String> {
+/// `HARNESS_API_TOKEN` is applied during config loading; request-time auth must
+/// use the startup config snapshot rather than process-global environment state.
+pub(crate) fn resolve_api_token(config: &ServerConfig) -> Option<String> {
     config
         .api_token
         .as_deref()
+        .map(str::trim)
         .filter(|t| !t.is_empty())
-        .map(|t| t.to_owned())
-        .or_else(|| {
-            std::env::var("HARNESS_API_TOKEN")
-                .ok()
-                .filter(|t| !t.is_empty())
-        })
+        .map(str::to_owned)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ApiAuthMode {
+    Enforced(String),
+    Open,
+}
+
+impl ApiAuthMode {
+    pub(crate) fn expected_token(&self) -> Option<&str> {
+        match self {
+            Self::Enforced(token) => Some(token.as_str()),
+            Self::Open => None,
+        }
+    }
+}
+
+pub(crate) fn resolve_api_auth_mode(config: &ServerConfig) -> anyhow::Result<ApiAuthMode> {
+    if let Some(token) = resolve_api_token(config) {
+        return Ok(ApiAuthMode::Enforced(token));
+    }
+
+    if config.allow_unauthenticated {
+        return Ok(ApiAuthMode::Open);
+    }
+
+    anyhow::bail!(
+        "API authentication is not configured: set server.api_token (api_token) in config or HARNESS_API_TOKEN, or explicitly set server.allow_unauthenticated = true for tokenless local development"
+    )
+}
+
+pub(crate) fn log_api_auth_mode(mode: &ApiAuthMode, config: &ServerConfig) {
+    match mode {
+        ApiAuthMode::Enforced(_) if config.allow_unauthenticated => {
+            tracing::warn!(
+                "server.allow_unauthenticated=true is ignored because an API token is configured; API bearer-token authentication is enforced"
+            );
+        }
+        ApiAuthMode::Enforced(_) => {
+            tracing::info!("API bearer-token authentication is enforced");
+        }
+        ApiAuthMode::Open => {
+            tracing::warn!(
+                "API authentication is disabled because server.allow_unauthenticated=true and no API token is configured"
+            );
+        }
+    }
 }
 
 pub(crate) fn is_auth_exempt_path(path: &str) -> bool {
@@ -143,9 +220,9 @@ pub(crate) fn is_auth_exempt_path(path: &str) -> bool {
 /// **all** clients (including those that present a localhost Origin) when a token
 /// is configured.  Origin alone is not trusted for auth because it can be forged
 /// by non-browser tools.
-/// All other endpoints require an `Authorization: Bearer <token>` header when
-/// `api_token` is configured. When no token is configured the middleware is a
-/// no-op (backward compat).
+/// All other endpoints require an `Authorization: Bearer <token>` header in
+/// enforced mode. Open mode is only reachable when startup accepted the explicit
+/// `allow_unauthenticated = true` opt-in.
 pub(crate) async fn api_auth_middleware(
     State(state): State<Arc<AppState>>,
     req: axum::extract::Request,
@@ -159,8 +236,21 @@ pub(crate) async fn api_auth_middleware(
         return next.run(req).await;
     }
 
-    let Some(expected) = resolve_api_token(&state.core.server.config.server) else {
-        // No token configured — skip auth for backward compatibility.
+    let auth_mode = match resolve_api_auth_mode(&state.core.server.config.server) {
+        Ok(mode) => mode,
+        Err(error) => {
+            tracing::error!("API authentication misconfigured after startup: {error}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": "authentication_misconfigured",
+                    "message": error.to_string(),
+                })),
+            )
+                .into_response();
+        }
+    };
+    let Some(expected) = auth_mode.expected_token() else {
         return next.run(req).await;
     };
 

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -163,6 +163,8 @@ async fn build_review_store(
 pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppState> {
     let dir = expand_tilde(&server.config.server.data_dir);
     let project_root = resolve_project_root(&server.config.server.project_root)?;
+    let api_auth_mode = super::auth::resolve_api_auth_mode(&server.config.server)?;
+    super::auth::log_api_auth_mode(&api_auth_mode, &server.config.server);
     #[cfg(test)]
     let db_setup_guard = crate::test_helpers::acquire_db_state_guard().await;
 
@@ -678,6 +680,7 @@ mod tests {
         let mut config = HarnessConfig::default();
         config.server.data_dir = root.to_path_buf();
         config.server.project_root = root.to_path_buf();
+        config.server.allow_unauthenticated = true;
         Arc::new(HarnessServer::new(
             config,
             ThreadManager::new(),

--- a/crates/harness-server/src/http/startup_tests.rs
+++ b/crates/harness-server/src/http/startup_tests.rs
@@ -11,6 +11,12 @@ use harness_core::{
 };
 use std::sync::Arc;
 
+fn unauthenticated_test_config() -> HarnessConfig {
+    let mut config = HarnessConfig::default();
+    config.server.allow_unauthenticated = true;
+    config
+}
+
 #[test]
 fn http_listener_starts_before_background_work() {
     let source = include_str!("mod.rs");
@@ -81,7 +87,7 @@ async fn persisted_skills_survive_restart() -> anyhow::Result<()> {
         let data_dir = data_dir.to_path_buf();
         let database_url = database_url.clone();
         async move {
-            let mut config = HarnessConfig::default();
+            let mut config = unauthenticated_test_config();
             config.server.project_root = project_root;
             config.server.data_dir = data_dir;
             config.server.database_url = Some(database_url);
@@ -138,13 +144,41 @@ async fn persisted_skills_survive_restart() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn build_app_state_refuses_tokenless_startup_without_opt_in() -> anyhow::Result<()> {
+    let sandbox = tempfile::tempdir()?;
+    let project_root = sandbox.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+
+    let mut config = HarnessConfig::default();
+    config.server.project_root = project_root;
+    config.server.data_dir = sandbox.path().join("data");
+    config.server.api_token = Some("   ".to_string());
+
+    let server = Arc::new(HarnessServer::new(
+        config,
+        ThreadManager::new(),
+        AgentRegistry::new("test"),
+    ));
+    let err = match build_app_state(server).await {
+        Ok(_) => anyhow::bail!("tokenless startup without opt-in should fail"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+
+    assert!(message.contains("api_token"));
+    assert!(message.contains("HARNESS_API_TOKEN"));
+    assert!(message.contains("allow_unauthenticated"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn build_app_state_auto_registers_builtin_guard() -> anyhow::Result<()> {
     let _lock = HOME_LOCK.lock().await;
     let sandbox = tempfile::tempdir()?;
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;
 
-    let mut config = HarnessConfig::default();
+    let mut config = unauthenticated_test_config();
     config.server.project_root = project_root;
     config.server.data_dir = sandbox.path().join("data");
 
@@ -173,7 +207,7 @@ async fn build_app_state_registers_startup_project_metadata() -> anyhow::Result<
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;
 
-    let mut config = HarnessConfig::default();
+    let mut config = unauthenticated_test_config();
     config.server.project_root = project_root.clone();
     config.server.data_dir = sandbox.path().join("data");
 
@@ -211,7 +245,7 @@ async fn build_app_state_registers_default_project_metadata_from_startup_entry(
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;
 
-    let mut config = HarnessConfig::default();
+    let mut config = unauthenticated_test_config();
     config.server.project_root = project_root.clone();
     config.server.data_dir = sandbox.path().join("data");
 
@@ -249,7 +283,7 @@ async fn build_app_state_preserves_partial_startup_project_metadata() -> anyhow:
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;
 
-    let mut config = HarnessConfig::default();
+    let mut config = unauthenticated_test_config();
     config.server.project_root = project_root.clone();
     config.server.data_dir = sandbox.path().join("data");
 
@@ -297,7 +331,7 @@ async fn build_app_state_ignores_stale_default_project_metadata_for_different_ro
     std::fs::create_dir_all(&startup_root)?;
     std::fs::create_dir_all(&override_root)?;
 
-    let mut config = HarnessConfig::default();
+    let mut config = unauthenticated_test_config();
     config.server.project_root = override_root.clone();
     config.server.data_dir = sandbox.path().join("data");
 

--- a/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
+++ b/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
@@ -410,6 +410,37 @@ async fn query_param_token_rejected_on_protected_endpoint() -> anyhow::Result<()
 }
 
 #[tokio::test]
+async fn query_param_token_still_authorizes_sse_stream_endpoint() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.api_token = Some("secret123".to_string());
+    let state = make_read_only_route_test_state_with(
+        dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let app = Router::new()
+        .route("/tasks/{id}/stream", get(|| async { StatusCode::OK }))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::api_auth_middleware,
+        ))
+        .with_state(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/tasks/task-1/stream?token=secret123")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    Ok(())
+}
+
+#[tokio::test]
 async fn dashboard_no_auth_configured_remains_public() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_read_only_route_test_state(dir.path()).await?;
@@ -428,6 +459,27 @@ async fn dashboard_no_auth_configured_remains_public() -> anyhow::Result<()> {
                 .uri("/dashboard?tab=submit")
                 .body(Body::empty())?,
         )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    Ok(())
+}
+
+#[tokio::test]
+async fn protected_route_passes_with_explicit_unauthenticated_opt_in() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.allow_unauthenticated = true;
+    let state = make_read_only_route_test_state_with(
+        dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let app = authed_app(state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/tasks").body(Body::empty())?)
         .await?;
 
     assert_eq!(response.status(), StatusCode::OK);

--- a/crates/harness-server/src/runtime_state_store_tests.rs
+++ b/crates/harness-server/src/runtime_state_store_tests.rs
@@ -42,6 +42,7 @@ async fn build_app_state_opens_runtime_state_store_from_shared_schema() -> anyho
     let mut config = HarnessConfig::default();
     config.server.project_root = project_root.path().to_path_buf();
     config.server.data_dir = data_dir.path().to_path_buf();
+    config.server.allow_unauthenticated = true;
 
     let server = Arc::new(HarnessServer::new(
         config,
@@ -188,6 +189,7 @@ async fn build_app_state_restores_runtime_snapshot() -> anyhow::Result<()> {
     let mut config = HarnessConfig::default();
     config.server.project_root = project_root.path().to_path_buf();
     config.server.data_dir = data_dir.path().to_path_buf();
+    config.server.allow_unauthenticated = true;
 
     let first_server = Arc::new(HarnessServer::new(
         config.clone(),

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -95,7 +95,15 @@ pub async fn ws_handler(
     // Layer 2: Bearer token auth for all clients when a token is configured.
     // Origin headers can be forged by non-browser tools, so they do not exempt
     // a client from token authentication.
-    if let Some(expected) = crate::http::auth::resolve_api_token(&state.core.server.config.server) {
+    let auth_mode = match crate::http::auth::resolve_api_auth_mode(&state.core.server.config.server)
+    {
+        Ok(mode) => mode,
+        Err(error) => {
+            tracing::error!("WebSocket auth misconfigured after startup: {error}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+    if let Some(expected) = auth_mode.expected_token() {
         let authorized = headers
             .get(axum::http::header::AUTHORIZATION)
             .and_then(|v| v.to_str().ok())
@@ -264,8 +272,9 @@ mod tests {
 
     async fn make_test_state_with_config(
         dir: &std::path::Path,
-        config: HarnessConfig,
+        mut config: HarnessConfig,
     ) -> anyhow::Result<AppState> {
+        config.server.allow_unauthenticated = true;
         let db_setup_guard = crate::test_helpers::acquire_db_state_guard().await;
         let notification_broadcast_capacity = config.server.notification_broadcast_capacity.max(1);
         let notification_lag_log_every = config.server.notification_lag_log_every;

--- a/crates/harness-server/tests/exec_policy_startup.rs
+++ b/crates/harness-server/tests/exec_policy_startup.rs
@@ -31,6 +31,7 @@ decision = "forbidden"
     let mut config = HarnessConfig::default();
     config.server.data_dir = sandbox.path().join("server-data");
     config.server.project_root = project_root;
+    config.server.allow_unauthenticated = true;
     config.rules.exec_policy_paths = vec![policy_path];
     config.rules.requirements_path = Some(requirements_path);
     let server = Arc::new(HarnessServer::new(

--- a/crates/harness-server/tests/gc_adopt_pipeline.rs
+++ b/crates/harness-server/tests/gc_adopt_pipeline.rs
@@ -95,6 +95,7 @@ async fn make_state_with_auto_pr(
     let mut config = HarnessConfig::default();
     config.server.data_dir = root.join("server-data");
     config.server.project_root = project_root;
+    config.server.allow_unauthenticated = true;
     config.agents.default_agent = "mock-pr".to_string();
     config.gc.auto_pr = auto_pr;
 
@@ -114,6 +115,7 @@ async fn make_state_without_default_agent(
     let mut config = HarnessConfig::default();
     config.server.data_dir = root.join("server-data");
     config.server.project_root = project_root;
+    config.server.allow_unauthenticated = true;
     config.agents.default_agent = "missing".to_string();
     config.gc.auto_pr = true;
 
@@ -403,6 +405,7 @@ async fn gc_adopt_task_uses_appstate_project_root() -> anyhow::Result<()> {
     let mut config = HarnessConfig::default();
     config.server.data_dir = sandbox.path().join("server-data");
     config.server.project_root = project_root.clone();
+    config.server.allow_unauthenticated = true;
     config.agents.default_agent = "capturing".to_string();
     config.gc.auto_pr = true;
     // Point workspace root at a path under the blocker file so create_dir_all fails.

--- a/crates/harness-server/tests/gc_project_root_cwd.rs
+++ b/crates/harness-server/tests/gc_project_root_cwd.rs
@@ -42,6 +42,7 @@ async fn gc_run_uses_configured_project_root_across_cwd() -> anyhow::Result<()> 
     let mut config = HarnessConfig::default();
     config.server.data_dir = sandbox.path().join("server-data");
     config.server.project_root = project_root.clone();
+    config.server.allow_unauthenticated = true;
     let server = Arc::new(HarnessServer::new(
         config,
         ThreadManager::new(),

--- a/crates/harness-server/tests/notification_delivery.rs
+++ b/crates/harness-server/tests/notification_delivery.rs
@@ -113,6 +113,7 @@ async fn make_state(root: &std::path::Path) -> anyhow::Result<harness_server::ht
     let mut config = HarnessConfig::default();
     config.server.data_dir = root.join("server-data");
     config.server.project_root = project_root;
+    config.server.allow_unauthenticated = true;
 
     let server = Arc::new(HarnessServer::new(
         config,
@@ -132,6 +133,7 @@ async fn make_state_with_mock(
     let mut config = HarnessConfig::default();
     config.server.data_dir = root.join("server-data");
     config.server.project_root = project_root;
+    config.server.allow_unauthenticated = true;
     config.agents.default_agent = "mock".to_string();
 
     let mut registry = AgentRegistry::new("mock");

--- a/crates/harness-server/tests/turn_start_lifecycle.rs
+++ b/crates/harness-server/tests/turn_start_lifecycle.rs
@@ -127,6 +127,7 @@ async fn make_state(
     let mut config = HarnessConfig::default();
     config.server.data_dir = root.join("server-data");
     config.server.project_root = project_root.clone();
+    config.server.allow_unauthenticated = true;
     config.agents.default_agent = "mock".to_string();
 
     let mut registry = AgentRegistry::new("mock");
@@ -316,6 +317,7 @@ async fn turn_fails_when_agent_not_registered() -> anyhow::Result<()> {
     let mut config = HarnessConfig::default();
     config.server.data_dir = sandbox.path().join("server-data");
     config.server.project_root = project_root.clone();
+    config.server.allow_unauthenticated = true;
     // "ghost" is the configured default agent but is never registered.
     config.agents.default_agent = "ghost".to_string();
 
@@ -355,6 +357,7 @@ async fn turn_fails_on_stall_timeout() -> anyhow::Result<()> {
     let mut config = HarnessConfig::default();
     config.server.data_dir = sandbox.path().join("server-data");
     config.server.project_root = project_root.clone();
+    config.server.allow_unauthenticated = true;
     config.agents.default_agent = "mock".to_string();
     // Use a very short stall timeout so the test completes quickly.
     config.concurrency.stall_timeout_secs = 1;

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -64,15 +64,17 @@ Runtime-host mutations, including watched-project sync, fail with
 but the runtime state store is unavailable. This prevents a successful response
 from hiding non-durable host state.
 
-Authentication: when `api_token` is configured, all routes require proof of the
-token; without a configured token the middleware is a no-op (backward
-compatibility).  Exempt routes that bypass auth entirely: `/health`,
-`/webhook`, `/webhook/feishu`, `/signals`, and `/favicon.ico` (these carry
-their own HMAC-based protection or are intentionally public).  For browser
-clients that cannot set `Authorization` headers on WebSocket upgrades or
-top-level navigation requests, `/ws` and `/` additionally accept a
-`?token=<value>` query parameter as a fallback; all other routes only accept
-`Authorization: Bearer <token>`.
+Authentication: `harness serve` fails closed unless `api_token` or
+`HARNESS_API_TOKEN` is configured, or `allow_unauthenticated = true` is set
+explicitly for tokenless local development. When a token is configured, all
+non-exempt routes require `Authorization: Bearer <token>`; if both a token and
+`allow_unauthenticated = true` are set, the token wins and the opt-in is
+ignored. Exempt routes that bypass auth entirely: `/health`, `/webhook`,
+`/webhook/feishu`, `/signals`, and `/favicon.ico` (these carry their own
+HMAC-based protection or are intentionally public). For browser clients that
+cannot set `Authorization` headers on SSE requests, `/tasks/{id}/stream`
+additionally accepts a `?token=<value>` query parameter as a fallback; all other
+routes only accept `Authorization: Bearer <token>`.
 
 ### JSON-RPC 2.0 — agent-facing (data plane)
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -46,6 +46,10 @@ Create or edit `config/default.toml`:
 transport = "stdio"
 http_addr = "127.0.0.1:9800"
 data_dir = "~/.local/share/harness"
+# Set this or HARNESS_API_TOKEN before using HTTP routes.
+# api_token = "change-me"
+# Intentional tokenless local-dev opt-in:
+# allow_unauthenticated = true
 
 [agents]
 default_agent = "auto"
@@ -320,6 +324,8 @@ curl -X DELETE http://127.0.0.1:9800/projects/new-project
 | `http_addr` | `"127.0.0.1:9800"` | HTTP listen address |
 | `data_dir` | `"~/.local/share/harness"` | Data directory for Harness server state, database metadata, and persisted `harness serve` runtime logs under `logs/` |
 | `project_root` | `"."` | Default project root (single-project mode) |
+| `api_token` | — | Bearer token for non-exempt HTTP routes. `HARNESS_API_TOKEN` can set the same value during config loading. |
+| `allow_unauthenticated` | `false` | Explicit local-dev opt-in for tokenless HTTP operation. Without this or a token, server startup fails closed. Ignored when a token is configured. |
 | `github_webhook_secret` | — | HMAC-SHA256 secret for GitHub webhook verification |
 | `notification_broadcast_capacity` | `256` | Internal notification channel capacity |
 
@@ -338,6 +344,11 @@ requests, typically a fine-grained token with repository contents write access
 and pull request read access, or an installation token with equivalent
 repository permissions. Agent mode does not add token requirements, but merge
 completion verification still needs read access to the pull request.
+
+Upgrade note: tokenless HTTP deployments that previously started
+unauthenticated now fail at startup. Recover by setting `api_token` /
+`HARNESS_API_TOKEN`, or by setting `allow_unauthenticated = true` for a
+deliberate local-only deployment.
 
 ### `[agents]`
 


### PR DESCRIPTION
# Summary
- Fail closed during app-state startup when no API token is configured unless `allow_unauthenticated = true` is set.
- Resolve auth mode explicitly for HTTP middleware and websocket auth; keep token enforcement and the SSE query-token exception.
- Document the breaking default, opt-in behavior, and release-note callout.

## Linked Work
- Fixes #1416
- Spec: `specs/GH1416/`

## Verification
- `cargo test -p harness-core config::server`
- `cargo test --package harness-server http::auth`
- `cargo test --package harness-server protected_route_passes_with_explicit_unauthenticated_opt_in`
- `cargo test --package harness-server query_param_token_still_authorizes_sse_stream_endpoint`
- `cargo test --package harness-server build_app_state_refuses_tokenless_startup_without_opt_in`
- `cargo test --package harness-server handlers::health::tests`
- `cargo test --package harness-server handlers::observe::tests`
- `cargo test --package harness-server handlers::projects::tests`
- `cargo test --package harness-server websocket::tests`
- `cargo test --package harness-server runtime_state_store_tests::build_app_state`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `env PYTHONDONTWRITEBYTECODE=1 python3 /Users/apple/Desktop/code/AI/tool/specrail/checks/check_workflow.py --repo /Users/apple/Desktop/code/AI/tool/specrail --spec-dir "$PWD/specs/GH1416"`
- `test -s README.md`

## Local Test Caveat
- `cargo test --package harness-server` failed locally after the auth fixture fixes because dashboard global-count assertions observed pre-existing rows in the shared local `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:55433/harness` database, for example expected running `1` and saw `4`. The changed auth/startup/websocket surfaces above pass targeted validation.

## Scope Guard
- `pr_scope_guard` was not available in the repo or PATH.
- Manual scope: 20 files changed, +334/-39.

## Agent Disclosure
- [ ] No agent was used.
- [x] Agent assisted; human author should review before merge.
