### PR TITLE
Execute auto merges through GitHub API

### DIFF
--- a/crates/harness-server/src/github_pr_merge.rs
+++ b/crates/harness-server/src/github_pr_merge.rs
@@ -1,0 +1,306 @@
+use crate::github_pr_snapshot::GitHubPrSnapshotTarget;
+use harness_core::config::intake::GitHubMergeMethod;
+use harness_workflow::runtime::ActivityErrorKind;
+use reqwest::header::{ACCEPT, USER_AGENT};
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use std::fmt;
+use std::time::Duration;
+
+const GITHUB_MERGE_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubPrMergeOptions {
+    pub method: GitHubMergeMethod,
+    pub expected_head_sha: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct GitHubPrMergeOutcome {
+    pub merged: bool,
+    pub message: Option<String>,
+    pub sha: Option<String>,
+    pub raw: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubPrMergeError {
+    pub error_kind: ActivityErrorKind,
+    pub message: String,
+    pub status_code: Option<u16>,
+    pub response_body: Option<String>,
+}
+
+impl GitHubPrMergeError {
+    fn configuration(message: impl Into<String>) -> Self {
+        Self {
+            error_kind: ActivityErrorKind::Configuration,
+            message: message.into(),
+            status_code: None,
+            response_body: None,
+        }
+    }
+
+    fn external(message: impl Into<String>) -> Self {
+        Self {
+            error_kind: ActivityErrorKind::ExternalDependency,
+            message: message.into(),
+            status_code: None,
+            response_body: None,
+        }
+    }
+
+    fn status(status: StatusCode, body: String) -> Self {
+        let message = github_error_message(&body)
+            .unwrap_or_else(|| format!("GitHub pull request merge failed with status {status}"));
+        Self {
+            error_kind: merge_error_kind_for_status(status),
+            message,
+            status_code: Some(status.as_u16()),
+            response_body: Some(body),
+        }
+    }
+}
+
+impl fmt::Display for GitHubPrMergeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.status_code {
+            Some(status) => write!(
+                f,
+                "GitHub merge failed with status {status}: {}",
+                self.message
+            ),
+            None => f.write_str(&self.message),
+        }
+    }
+}
+
+impl std::error::Error for GitHubPrMergeError {}
+
+pub(crate) async fn merge_pull_request(
+    target: &GitHubPrSnapshotTarget,
+    github_token: Option<&str>,
+    options: &GitHubPrMergeOptions,
+) -> Result<GitHubPrMergeOutcome, GitHubPrMergeError> {
+    let client = reqwest::Client::new();
+    merge_pull_request_with_client(
+        &client,
+        &crate::reconciliation::github_api_base_url(),
+        target,
+        github_token,
+        options,
+    )
+    .await
+}
+
+pub(crate) async fn merge_pull_request_with_client(
+    client: &reqwest::Client,
+    api_base_url: &str,
+    target: &GitHubPrSnapshotTarget,
+    github_token: Option<&str>,
+    options: &GitHubPrMergeOptions,
+) -> Result<GitHubPrMergeOutcome, GitHubPrMergeError> {
+    let token = crate::github_auth::resolve_github_token(github_token).ok_or_else(|| {
+        GitHubPrMergeError::configuration(
+            "server-executed merge requires a GitHub token with pull request merge permission",
+        )
+    })?;
+    let Some((owner, repo)) = target.repo_slug.split_once('/') else {
+        return Err(GitHubPrMergeError::configuration(format!(
+            "invalid GitHub repo slug `{}`",
+            target.repo_slug
+        )));
+    };
+    let mut body = json!({
+        "merge_method": options.method.to_string(),
+    });
+    if let Some(expected_head_sha) = options
+        .expected_head_sha
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        body["sha"] = json!(expected_head_sha);
+    }
+    let url = format!(
+        "{}/repos/{owner}/{repo}/pulls/{}/merge",
+        api_base_url.trim_end_matches('/'),
+        target.pr_number
+    );
+    let request = client
+        .put(url)
+        .header(ACCEPT, "application/vnd.github+json")
+        .header(USER_AGENT, "harness-server")
+        .bearer_auth(token)
+        .json(&body);
+    let response = tokio::time::timeout(GITHUB_MERGE_TIMEOUT, request.send())
+        .await
+        .map_err(|_| GitHubPrMergeError::external("GitHub pull request merge timed out"))?
+        .map_err(|error| {
+            GitHubPrMergeError::external(format!(
+                "GitHub pull request merge request failed: {error}"
+            ))
+        })?;
+    let status = response.status();
+    let body = response.text().await.map_err(|error| {
+        GitHubPrMergeError::external(format!(
+            "GitHub pull request merge response could not be read: {error}"
+        ))
+    })?;
+    if !status.is_success() {
+        return Err(GitHubPrMergeError::status(status, body));
+    }
+    Ok(merge_outcome_from_body(&body))
+}
+
+fn merge_outcome_from_body(body: &str) -> GitHubPrMergeOutcome {
+    let raw = serde_json::from_str::<Value>(body).unwrap_or_else(|_| json!({ "raw": body }));
+    GitHubPrMergeOutcome {
+        merged: raw.get("merged").and_then(Value::as_bool).unwrap_or(false),
+        message: raw
+            .get("message")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(ToOwned::to_owned),
+        sha: raw
+            .get("sha")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(ToOwned::to_owned),
+        raw,
+    }
+}
+
+fn github_error_message(body: &str) -> Option<String> {
+    serde_json::from_str::<Value>(body).ok().and_then(|value| {
+        value
+            .get("message")
+            .and_then(Value::as_str)
+            .filter(|message| !message.trim().is_empty())
+            .map(ToOwned::to_owned)
+    })
+}
+
+fn merge_error_kind_for_status(status: StatusCode) -> ActivityErrorKind {
+    match status.as_u16() {
+        401 | 403 => ActivityErrorKind::Configuration,
+        405 | 409 | 422 => ActivityErrorKind::Fatal,
+        408 | 429 | 500..=599 => ActivityErrorKind::ExternalDependency,
+        _ if status.is_client_error() => ActivityErrorKind::Fatal,
+        _ => ActivityErrorKind::ExternalDependency,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::{Path, State};
+    use axum::http::{HeaderMap, StatusCode as AxumStatusCode};
+    use axum::routing::put;
+    use axum::{Json, Router};
+    use serde_json::json;
+    use std::sync::{Arc, Mutex};
+
+    #[tokio::test]
+    async fn merge_pull_request_sends_rest_merge_request() -> anyhow::Result<()> {
+        #[derive(Clone, Default)]
+        struct Captured {
+            payload: Arc<Mutex<Option<Value>>>,
+            authorization: Arc<Mutex<Option<String>>>,
+        }
+
+        async fn handler(
+            State(captured): State<Captured>,
+            Path((owner, repo, pr)): Path<(String, String, u64)>,
+            headers: HeaderMap,
+            Json(payload): Json<Value>,
+        ) -> Json<Value> {
+            assert_eq!(owner, "owner");
+            assert_eq!(repo, "repo");
+            assert_eq!(pr, 77);
+            *captured.payload.lock().expect("payload lock") = Some(payload);
+            *captured.authorization.lock().expect("authorization lock") = headers
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .map(ToOwned::to_owned);
+            Json(json!({
+                "merged": true,
+                "message": "Pull Request successfully merged",
+                "sha": "merge-sha"
+            }))
+        }
+
+        let captured = Captured::default();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let app = Router::new()
+            .route("/repos/{owner}/{repo}/pulls/{pr}/merge", put(handler))
+            .with_state(captured.clone());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+        let target = GitHubPrSnapshotTarget::new("owner/repo", 77)?;
+        let outcome = merge_pull_request_with_client(
+            &reqwest::Client::new(),
+            &format!("http://{addr}"),
+            &target,
+            Some("cfg-token"),
+            &GitHubPrMergeOptions {
+                method: GitHubMergeMethod::Squash,
+                expected_head_sha: Some("head-sha".to_string()),
+            },
+        )
+        .await?;
+
+        assert!(outcome.merged);
+        assert_eq!(outcome.sha.as_deref(), Some("merge-sha"));
+        assert_eq!(
+            captured.payload.lock().expect("payload lock").as_ref(),
+            Some(&json!({
+                "merge_method": "squash",
+                "sha": "head-sha",
+            }))
+        );
+        assert_eq!(
+            captured
+                .authorization
+                .lock()
+                .expect("authorization lock")
+                .as_deref(),
+            Some("Bearer cfg-token")
+        );
+        server.abort();
+        Ok(())
+    }
+
+    #[test]
+    fn merge_statuses_map_to_existing_error_kinds() {
+        assert_eq!(
+            merge_error_kind_for_status(StatusCode::UNAUTHORIZED),
+            ActivityErrorKind::Configuration
+        );
+        assert_eq!(
+            merge_error_kind_for_status(StatusCode::FORBIDDEN),
+            ActivityErrorKind::Configuration
+        );
+        assert_eq!(
+            merge_error_kind_for_status(StatusCode::METHOD_NOT_ALLOWED),
+            ActivityErrorKind::Fatal
+        );
+        assert_eq!(
+            merge_error_kind_for_status(StatusCode::CONFLICT),
+            ActivityErrorKind::Fatal
+        );
+        assert_eq!(
+            merge_error_kind_for_status(StatusCode::UNPROCESSABLE_ENTITY),
+            ActivityErrorKind::Fatal
+        );
+        assert_eq!(
+            merge_error_kind_for_status(StatusCode::INTERNAL_SERVER_ERROR),
+            ActivityErrorKind::ExternalDependency
+        );
+        assert_eq!(
+            merge_error_kind_for_status(AxumStatusCode::TOO_MANY_REQUESTS),
+            ActivityErrorKind::ExternalDependency
+        );
+    }
+}

--- a/crates/harness-server/src/http/auto_merge.rs
+++ b/crates/harness-server/src/http/auto_merge.rs
@@ -87,7 +87,7 @@ pub(crate) fn prepare_auto_merge_workflow_from_snapshot(
     Ok(AutoMergeSnapshotGate::Ready(Box::new(workflow)))
 }
 
-fn auto_merge_snapshot_satisfies_policy(
+pub(crate) fn auto_merge_snapshot_satisfies_policy(
     snapshot: &Value,
     policy: &ResolvedGitHubAutoMergePolicy,
     expected_base_ref: Option<&str>,

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -22,6 +22,7 @@ pub mod eval_store;
 pub mod event_replay;
 pub(crate) mod github_auth;
 pub(crate) mod github_pr_hygiene;
+pub(crate) mod github_pr_merge;
 pub(crate) mod github_pr_snapshot;
 pub mod handlers;
 pub mod hook_enforcer;

--- a/crates/harness-server/src/reconciliation.rs
+++ b/crates/harness-server/src/reconciliation.rs
@@ -30,7 +30,8 @@ use self::reconciliation_github::{
     classify_issue_state, classify_pr_state, GitHubIssueState, GitHubPullState,
 };
 pub(crate) use self::reconciliation_github::{
-    fetch_issue_state_with_token, fetch_pr_state_by_slug_with_token, GitHubState,
+    fetch_issue_state_with_token, fetch_pr_state_by_slug_with_token, github_api_base_url,
+    GitHubState,
 };
 use self::reconciliation_legacy::{apply_transition, resolve_github_state};
 #[cfg(test)]

--- a/crates/harness-server/src/reconciliation_github.rs
+++ b/crates/harness-server/src/reconciliation_github.rs
@@ -23,7 +23,7 @@ pub(super) struct GitHubIssueState {
     pub(super) state: String,
 }
 
-fn github_api_base_url() -> String {
+pub(crate) fn github_api_base_url() -> String {
     std::env::var("HARNESS_GITHUB_API_BASE_URL")
         .ok()
         .filter(|s| !s.trim().is_empty())

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -10,6 +10,7 @@ mod pr_feedback_inspection;
 mod prompt_input_telemetry;
 mod prompt_packet;
 mod runtime_profile;
+mod server_merge;
 mod workspace;
 
 use crate::http::AppState;

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -17,10 +17,7 @@ use super::data_helpers::{
     activity_name, is_builtin_lifecycle_activity, prompt_payload_unavailable_result,
     prompt_task_request_for_job, PromptTaskRequest,
 };
-use super::merge_completion::{
-    server_merge_execution_enabled, server_merge_execution_unavailable_result,
-    verify_merge_completion_if_needed,
-};
+use super::merge_completion::verify_merge_completion_if_needed;
 use super::pr_feedback_inspection::{
     execute_pr_feedback_inspection, is_server_owned_pr_feedback_inspection,
 };
@@ -34,6 +31,7 @@ use super::runtime_profile::{
     agent_name_for_runtime_kind, runtime_profile_approval_policy, runtime_profile_for_job,
     runtime_profile_sandbox_mode,
 };
+use super::server_merge::{execute_server_merge, server_merge_execution_enabled};
 use super::workspace::{finish_runtime_workspace, prepare_runtime_workspace};
 
 const DEFAULT_RUNTIME_TURN_TIMEOUT_SECS: u64 = 3600;
@@ -245,7 +243,7 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                 Some(execute_pr_feedback_inspection(self.state, job, parent).await),
             ),
             "merge_pr" if server_merge_execution_enabled(self.state, job, parent) => {
-                Ok(Some(server_merge_execution_unavailable_result(job, parent)))
+                Ok(Some(execute_server_merge(self.state, job, parent).await))
             }
             _ => Ok(None),
         }

--- a/crates/harness-server/src/workflow_runtime_worker/merge_completion.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/merge_completion.rs
@@ -3,7 +3,7 @@ use crate::github_pr_snapshot::{
     GitHubPrSnapshotTarget, GITHUB_PR_SNAPSHOT_ARTIFACT, SERVER_PR_SNAPSHOT_ERROR_ARTIFACT,
 };
 use crate::http::AppState;
-use harness_core::config::intake::{GitHubAutoMergeConfig, GitHubMergeExecution};
+use harness_core::config::intake::GitHubAutoMergeConfig;
 use harness_workflow::runtime::{
     ActivityArtifact, ActivityErrorKind, ActivityResult, ActivityStatus, RuntimeJob,
     WorkflowInstance, GITHUB_ISSUE_PR_DEFINITION_ID, SERVER_PR_SNAPSHOT_ARTIFACT,
@@ -15,38 +15,6 @@ use super::data_helpers::activity_name;
 const MERGE_COMPLETION_VERIFICATION_ARTIFACT: &str = "merge_completion_verification";
 const MERGE_COMPLETION_VERIFICATION_SCHEMA: &str =
     "harness.github.merge_completion_verification.v1";
-
-pub(super) fn server_merge_execution_enabled(
-    state: &AppState,
-    job: &RuntimeJob,
-    workflow: Option<&WorkflowInstance>,
-) -> bool {
-    merge_activity_matches(job, workflow)
-        && auto_merge_config(state).merge_execution == GitHubMergeExecution::Server
-}
-
-pub(super) fn server_merge_execution_unavailable_result(
-    job: &RuntimeJob,
-    workflow: Option<&WorkflowInstance>,
-) -> ActivityResult {
-    let activity = activity_name(job);
-    let error = "merge_execution = \"server\" is configured, but server-executed merge is not implemented in this Phase 1 slice";
-    let mut result =
-        ActivityResult::failed(activity, "Server-executed merge is not available.", error)
-            .with_error_kind(ActivityErrorKind::Configuration);
-    result.artifacts.push(ActivityArtifact::new(
-        MERGE_COMPLETION_VERIFICATION_ARTIFACT,
-        json!({
-            "schema": MERGE_COMPLETION_VERIFICATION_SCHEMA,
-            "verified": false,
-            "outcome": "server_execution_unavailable",
-            "workflow_id": workflow.map(|workflow| workflow.id.as_str()),
-            "reason": error,
-        }),
-    ));
-    result
-}
-
 pub(super) async fn verify_merge_completion_if_needed(
     state: &AppState,
     job: &RuntimeJob,
@@ -59,15 +27,6 @@ pub(super) async fn verify_merge_completion_if_needed(
     let config = auto_merge_config(state);
     if !config.verify_merge_completion {
         return result;
-    }
-    if config.merge_execution == GitHubMergeExecution::Server {
-        return merge_completion_failed(
-            result,
-            ActivityErrorKind::Configuration,
-            "Server-side merge completion verification failed.",
-            "merge_execution = \"server\" is configured, but server-executed merge is not implemented in this Phase 1 slice",
-            None,
-        );
     }
     let target = match merge_completion_target(job, workflow, &result) {
         Ok(target) => target,
@@ -107,7 +66,7 @@ pub(super) async fn verify_merge_completion_if_needed(
     }
 }
 
-fn auto_merge_config(state: &AppState) -> GitHubAutoMergeConfig {
+pub(super) fn auto_merge_config(state: &AppState) -> GitHubAutoMergeConfig {
     state
         .core
         .server
@@ -129,7 +88,10 @@ fn merge_completion_needs_verification(
         && result_reports_merged(result)
 }
 
-fn merge_activity_matches(job: &RuntimeJob, workflow: Option<&WorkflowInstance>) -> bool {
+pub(super) fn merge_activity_matches(
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+) -> bool {
     activity_name(job) == "merge_pr"
         && workflow
             .map(|workflow| workflow.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID)
@@ -141,6 +103,26 @@ fn merge_completion_target(
     workflow: Option<&WorkflowInstance>,
     result: &ActivityResult,
 ) -> Result<GitHubPrSnapshotTarget, String> {
+    merge_activity_target(
+        job,
+        workflow,
+        merged_pull_request_artifact(result)
+            .and_then(|artifact| value_u64(artifact.get("pr_number"))),
+    )
+}
+
+pub(super) fn merge_execution_target(
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+) -> Result<GitHubPrSnapshotTarget, String> {
+    merge_activity_target(job, workflow, None)
+}
+
+fn merge_activity_target(
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+    reported_pr_number: Option<u64>,
+) -> Result<GitHubPrSnapshotTarget, String> {
     let workflow_data = workflow.map(|workflow| &workflow.data);
     let repo_slug = workflow_data
         .and_then(|data| value_string(data.get("repo")))
@@ -149,8 +131,6 @@ fn merge_completion_target(
     let bound_pr_number = workflow_data
         .and_then(|data| value_u64(data.get("pr_number")))
         .or_else(|| value_u64(job.input.get("pr_number")));
-    let reported_pr_number = merged_pull_request_artifact(result)
-        .and_then(|artifact| value_u64(artifact.get("pr_number")));
     if let (Some(bound), Some(reported)) = (bound_pr_number, reported_pr_number) {
         if bound != reported {
             return Err(format!(
@@ -192,7 +172,7 @@ fn pull_request_artifact_is_merged(value: &Value) -> bool {
             .is_some_and(|state| state.eq_ignore_ascii_case("merged"))
 }
 
-fn snapshot_observes_merged(snapshot: &Value) -> bool {
+pub(super) fn snapshot_observes_merged(snapshot: &Value) -> bool {
     snapshot.get("merged").and_then(Value::as_bool) == Some(true)
         || snapshot
             .get("state")
@@ -200,7 +180,7 @@ fn snapshot_observes_merged(snapshot: &Value) -> bool {
             .is_some_and(|state| state.eq_ignore_ascii_case("MERGED"))
 }
 
-fn merge_completion_verified(
+pub(super) fn merge_completion_verified(
     mut result: ActivityResult,
     target: &GitHubPrSnapshotTarget,
     snapshot: GitHubPrSnapshotArtifacts,

--- a/crates/harness-server/src/workflow_runtime_worker/server_merge.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/server_merge.rs
@@ -1,0 +1,593 @@
+use crate::github_pr_merge::{merge_pull_request, GitHubPrMergeError, GitHubPrMergeOptions};
+use crate::github_pr_snapshot::{
+    fetch_github_pr_snapshot, value_string, GitHubPrSnapshotArtifacts, GitHubPrSnapshotTarget,
+    GITHUB_PR_SNAPSHOT_ARTIFACT, SERVER_PR_SNAPSHOT_ERROR_ARTIFACT,
+};
+use crate::http::AppState;
+use harness_core::config::intake::{
+    GitHubAutoMergeConfig, GitHubMergeExecution, GitHubMergeMethod, ResolvedGitHubAutoMergePolicy,
+};
+use harness_workflow::runtime::{
+    ActivityArtifact, ActivityErrorKind, ActivityResult, RuntimeJob, WorkflowInstance,
+    SERVER_PR_SNAPSHOT_ARTIFACT,
+};
+use serde_json::{json, Value};
+
+use super::data_helpers::activity_name;
+use super::merge_completion::{
+    auto_merge_config, merge_activity_matches, merge_completion_verified, merge_execution_target,
+    snapshot_observes_merged,
+};
+
+const SERVER_MERGE_EXECUTION_ARTIFACT: &str = "server_merge_execution";
+const SERVER_MERGE_EXECUTION_SCHEMA: &str = "harness.github.server_merge_execution.v1";
+
+pub(super) fn server_merge_execution_enabled(
+    state: &AppState,
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+) -> bool {
+    merge_activity_matches(job, workflow)
+        && auto_merge_config(state).merge_execution == GitHubMergeExecution::Server
+}
+
+pub(super) async fn execute_server_merge(
+    state: &AppState,
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+) -> ActivityResult {
+    let activity = activity_name(job);
+    let target = match merge_execution_target(job, workflow) {
+        Ok(target) => target,
+        Err(error) => {
+            return server_merge_failed(
+                activity,
+                None,
+                ActivityErrorKind::Configuration,
+                "Server-side merge could not resolve the target pull request.",
+                error,
+                None,
+                None,
+                "target_invalid",
+            );
+        }
+    };
+    let resolved_github_token = crate::github_auth::resolve_github_token(
+        state.core.server.config.server.github_token.as_deref(),
+    );
+    let Some(github_token) = resolved_github_token.as_deref() else {
+        let error =
+            "server-executed merge requires a GitHub token with pull request merge permission";
+        tracing::error!(
+            repo = %target.repo_slug,
+            pr_number = target.pr_number,
+            "server-executed GitHub merge failed due to configuration: {error}"
+        );
+        return server_merge_failed(
+            activity,
+            Some(&target),
+            ActivityErrorKind::Configuration,
+            "Server-side merge configuration is invalid.",
+            error,
+            None,
+            None,
+            "missing_github_token",
+        );
+    };
+    let before_snapshot = match fetch_github_pr_snapshot(&target, Some(github_token)).await {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            return server_merge_fetch_failed(
+                activity,
+                &target,
+                "Server-side merge could not read the pull request before merging.",
+                "pre_merge_snapshot_failed",
+                &error,
+            );
+        }
+    };
+    if snapshot_observes_merged(&before_snapshot.normalized_snapshot) {
+        return server_merge_succeeded(
+            activity,
+            &target,
+            before_snapshot,
+            "already_merged_before_merge",
+            None,
+        );
+    }
+    let config = auto_merge_config(state);
+    let policy = match server_merge_policy(&config, job, workflow) {
+        Ok(policy) => policy,
+        Err(error) => {
+            return server_merge_failed(
+                activity,
+                Some(&target),
+                ActivityErrorKind::Configuration,
+                "Server-side merge configuration is invalid.",
+                error,
+                Some(before_snapshot),
+                None,
+                "configuration_invalid",
+            );
+        }
+    };
+    let expected_base_ref = workflow.and_then(|workflow| {
+        crate::http::auto_merge::expected_base_ref_from_workflow_data(&workflow.data)
+    });
+    if !crate::http::auto_merge::auto_merge_snapshot_satisfies_policy(
+        &before_snapshot.normalized_snapshot,
+        &policy,
+        expected_base_ref.as_deref(),
+    ) {
+        return server_merge_failed(
+            activity,
+            Some(&target),
+            ActivityErrorKind::Fatal,
+            "Server-side merge gate rejected the current pull request state.",
+            format!(
+                "PR #{} in {} no longer satisfies the auto-merge gate",
+                target.pr_number, target.repo_slug
+            ),
+            Some(before_snapshot),
+            None,
+            "gate_rejected",
+        );
+    }
+    let expected_head_sha = expected_head_sha_for_merge(job, workflow);
+    if !snapshot_head_matches_expected(
+        &before_snapshot.normalized_snapshot,
+        expected_head_sha.as_deref(),
+    ) {
+        return server_merge_failed(
+            activity,
+            Some(&target),
+            ActivityErrorKind::Fatal,
+            "Server-side merge gate rejected a stale pull request head.",
+            format!(
+                "PR #{} in {} head did not match expected_head_sha {:?}",
+                target.pr_number, target.repo_slug, expected_head_sha
+            ),
+            Some(before_snapshot),
+            None,
+            "head_mismatch",
+        );
+    }
+    let merge_call = match merge_pull_request(
+        &target,
+        Some(github_token),
+        &GitHubPrMergeOptions {
+            method: policy.method,
+            expected_head_sha,
+        },
+    )
+    .await
+    {
+        Ok(outcome) => json!({
+            "status": "ok",
+            "merged": outcome.merged,
+            "message": outcome.message,
+            "sha": outcome.sha,
+            "response": outcome.raw,
+        }),
+        Err(error) => {
+            if error.error_kind == ActivityErrorKind::Configuration {
+                tracing::error!(
+                    repo = %target.repo_slug,
+                    pr_number = target.pr_number,
+                    "server-executed GitHub merge failed due to configuration: {error}"
+                );
+            }
+            return merge_error_result(activity, &target, Some(github_token), error).await;
+        }
+    };
+    match fetch_github_pr_snapshot(&target, Some(github_token)).await {
+        Ok(snapshot) if snapshot_observes_merged(&snapshot.normalized_snapshot) => {
+            server_merge_succeeded(activity, &target, snapshot, "merged", Some(merge_call))
+        }
+        Ok(snapshot) => server_merge_failed(
+            activity,
+            Some(&target),
+            ActivityErrorKind::ExternalDependency,
+            "Server-side merge could not confirm GitHub merged state.",
+            format!(
+                "GitHub merge API returned success for PR #{} in {}, but the confirmation snapshot was not merged",
+                target.pr_number, target.repo_slug
+            ),
+            Some(snapshot),
+            Some(merge_call),
+            "confirmation_not_merged",
+        ),
+        Err(error) => server_merge_fetch_failed(
+            activity,
+            &target,
+            "Server-side merge could not confirm GitHub merged state.",
+            "confirmation_snapshot_failed",
+            &error,
+        ),
+    }
+}
+
+async fn merge_error_result(
+    activity: String,
+    target: &GitHubPrSnapshotTarget,
+    github_token: Option<&str>,
+    error: GitHubPrMergeError,
+) -> ActivityResult {
+    match fetch_github_pr_snapshot(target, github_token).await {
+        Ok(snapshot) if snapshot_observes_merged(&snapshot.normalized_snapshot) => {
+            server_merge_succeeded(
+                activity,
+                target,
+                snapshot,
+                "already_merged_after_merge_error",
+                Some(server_merge_error_payload(&error)),
+            )
+        }
+        Ok(snapshot) => server_merge_failed(
+            activity,
+            Some(target),
+            error.error_kind,
+            "Server-side merge call failed.",
+            error.to_string(),
+            Some(snapshot),
+            Some(server_merge_error_payload(&error)),
+            "merge_call_failed",
+        ),
+        Err(snapshot_error) => server_merge_failed(
+            activity,
+            Some(target),
+            error.error_kind,
+            "Server-side merge call failed and confirmation read also failed.",
+            format!("{error}; confirmation read failed: {snapshot_error}"),
+            None,
+            Some(server_merge_error_payload(&error)),
+            "merge_call_and_confirmation_failed",
+        ),
+    }
+}
+
+fn server_merge_policy(
+    config: &GitHubAutoMergeConfig,
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+) -> Result<ResolvedGitHubAutoMergePolicy, String> {
+    Ok(ResolvedGitHubAutoMergePolicy {
+        enabled: true,
+        method: merge_method_for_activity(config, job, workflow)?,
+        delete_branch: activity_bool(job, workflow, "delete_branch")
+            .or_else(|| activity_bool(job, workflow, "merge_delete_branch"))
+            .unwrap_or(config.delete_branch),
+        require_review_threads_resolved: activity_bool(
+            job,
+            workflow,
+            "require_review_threads_resolved",
+        )
+        .or_else(|| activity_bool(job, workflow, "merge_require_review_threads_resolved"))
+        .unwrap_or(config.require_review_threads_resolved),
+        require_clean_merge_state: activity_bool(job, workflow, "require_clean_merge_state")
+            .or_else(|| activity_bool(job, workflow, "merge_require_clean_merge_state"))
+            .unwrap_or(config.require_clean_merge_state),
+        merge_execution: GitHubMergeExecution::Server,
+        verify_merge_completion: config.verify_merge_completion,
+    })
+}
+
+fn merge_method_for_activity(
+    config: &GitHubAutoMergeConfig,
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+) -> Result<GitHubMergeMethod, String> {
+    let Some(raw) = activity_string(job, workflow, "merge_method") else {
+        return Ok(config.method);
+    };
+    parse_merge_method(&raw).ok_or_else(|| format!("unsupported merge_method `{raw}`"))
+}
+
+fn parse_merge_method(raw: &str) -> Option<GitHubMergeMethod> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "squash" => Some(GitHubMergeMethod::Squash),
+        "merge" => Some(GitHubMergeMethod::Merge),
+        "rebase" => Some(GitHubMergeMethod::Rebase),
+        _ => None,
+    }
+}
+
+fn expected_head_sha_for_merge(
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+) -> Option<String> {
+    activity_string(job, workflow, "expected_head_sha")
+        .or_else(|| activity_string(job, workflow, "merge_attempted_head_sha"))
+        .or_else(|| activity_string(job, workflow, "pr_head_sha"))
+        .or_else(|| activity_string(job, workflow, "head_sha"))
+}
+
+fn activity_string(
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+    field: &str,
+) -> Option<String> {
+    value_string(job.input.get(field))
+        .or_else(|| workflow.and_then(|workflow| value_string(workflow.data.get(field))))
+}
+
+fn activity_bool(
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+    field: &str,
+) -> Option<bool> {
+    job.input
+        .get(field)
+        .and_then(Value::as_bool)
+        .or_else(|| workflow.and_then(|workflow| workflow.data.get(field).and_then(Value::as_bool)))
+}
+
+fn snapshot_head_matches_expected(snapshot: &Value, expected_head_sha: Option<&str>) -> bool {
+    let Some(expected_head_sha) = expected_head_sha
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return true;
+    };
+    value_string(snapshot.get("head_oid")).is_some_and(|head_oid| head_oid == expected_head_sha)
+}
+
+fn server_merge_succeeded(
+    activity: String,
+    target: &GitHubPrSnapshotTarget,
+    snapshot: GitHubPrSnapshotArtifacts,
+    outcome: &str,
+    merge_call: Option<Value>,
+) -> ActivityResult {
+    let result = ActivityResult::succeeded(activity, server_merge_success_summary(outcome))
+        .with_artifact(server_merge_pull_request_artifact(
+            target,
+            &snapshot.normalized_snapshot,
+        ))
+        .with_artifact(server_merge_execution_artifact(
+            Some(target),
+            outcome,
+            None,
+            merge_call,
+        ));
+    merge_completion_verified(result, target, snapshot)
+}
+
+fn server_merge_success_summary(outcome: &str) -> &'static str {
+    match outcome {
+        "already_merged_before_merge" | "already_merged_after_merge_error" => {
+            "Pull request was already merged according to GitHub."
+        }
+        _ => "Server merged the pull request and confirmed GitHub merged state.",
+    }
+}
+
+fn server_merge_pull_request_artifact(
+    target: &GitHubPrSnapshotTarget,
+    snapshot: &Value,
+) -> ActivityArtifact {
+    let pr_url = value_string(snapshot.get("pr_url")).unwrap_or_else(|| {
+        format!(
+            "https://github.com/{}/pull/{}",
+            target.repo_slug, target.pr_number
+        )
+    });
+    ActivityArtifact::new(
+        "pull_request",
+        json!({
+            "pr_number": target.pr_number,
+            "pr_url": pr_url,
+            "state": snapshot.get("state").cloned().unwrap_or_else(|| json!("MERGED")),
+            "merged": true,
+            "merge_commit_sha": snapshot.get("merge_commit_sha").cloned().unwrap_or(Value::Null),
+            "head_sha": snapshot.get("head_oid").cloned().unwrap_or(Value::Null),
+            "server_verified": true,
+            "verification_source": "server_github_graphql",
+        }),
+    )
+}
+
+fn server_merge_failed(
+    activity: String,
+    target: Option<&GitHubPrSnapshotTarget>,
+    error_kind: ActivityErrorKind,
+    summary: impl Into<String>,
+    error: impl Into<String>,
+    snapshot: Option<GitHubPrSnapshotArtifacts>,
+    merge_call: Option<Value>,
+    outcome: &str,
+) -> ActivityResult {
+    let error = error.into();
+    let mut result =
+        ActivityResult::failed(activity, summary, error.clone()).with_error_kind(error_kind);
+    result.artifacts.push(server_merge_execution_artifact(
+        target,
+        outcome,
+        Some(error),
+        merge_call,
+    ));
+    if let Some(snapshot) = snapshot {
+        result.artifacts.push(ActivityArtifact::new(
+            SERVER_PR_SNAPSHOT_ARTIFACT,
+            snapshot.normalized_snapshot,
+        ));
+        result.artifacts.push(ActivityArtifact::new(
+            GITHUB_PR_SNAPSHOT_ARTIFACT,
+            snapshot.raw_pr,
+        ));
+    }
+    result
+}
+
+fn server_merge_fetch_failed(
+    activity: String,
+    target: &GitHubPrSnapshotTarget,
+    summary: &str,
+    outcome: &str,
+    error: &anyhow::Error,
+) -> ActivityResult {
+    let mut result = server_merge_failed(
+        activity,
+        Some(target),
+        ActivityErrorKind::ExternalDependency,
+        summary,
+        error.to_string(),
+        None,
+        None,
+        outcome,
+    );
+    result.artifacts.push(ActivityArtifact::new(
+        SERVER_PR_SNAPSHOT_ERROR_ARTIFACT,
+        json!({
+            "schema": "harness.github.pr_snapshot_error.v1",
+            "repo": target.repo_slug,
+            "pr_number": target.pr_number,
+            "error": error.to_string(),
+        }),
+    ));
+    result
+}
+
+fn server_merge_execution_artifact(
+    target: Option<&GitHubPrSnapshotTarget>,
+    outcome: &str,
+    reason: Option<String>,
+    merge_call: Option<Value>,
+) -> ActivityArtifact {
+    ActivityArtifact::new(
+        SERVER_MERGE_EXECUTION_ARTIFACT,
+        json!({
+            "schema": SERVER_MERGE_EXECUTION_SCHEMA,
+            "executor": "server",
+            "repo": target.map(|target| target.repo_slug.as_str()),
+            "pr_number": target.map(|target| target.pr_number),
+            "outcome": outcome,
+            "reason": reason,
+            "merge_call": merge_call,
+        }),
+    )
+}
+
+fn server_merge_error_payload(error: &GitHubPrMergeError) -> Value {
+    json!({
+        "status": "error",
+        "error_kind": error.error_kind,
+        "message": error.message,
+        "status_code": error.status_code,
+        "response_body": error.response_body,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_workflow::runtime::{ActivityStatus, RuntimeKind, WorkflowSubject};
+
+    fn workflow() -> WorkflowInstance {
+        WorkflowInstance::new(
+            harness_workflow::runtime::GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "merging",
+            WorkflowSubject::new("issue", "issue:77"),
+        )
+        .with_data(json!({
+            "repo": "owner/repo",
+            "pr_number": 77,
+            "merge_method": "squash",
+            "merge_delete_branch": false,
+            "merge_require_review_threads_resolved": true,
+            "merge_require_clean_merge_state": true,
+            "merge_attempted_head_sha": "head-sha",
+        }))
+    }
+
+    fn job() -> RuntimeJob {
+        RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexExec,
+            "codex-default",
+            json!({
+                "activity": "merge_pr",
+                "expected_head_sha": "head-sha",
+            }),
+        )
+    }
+
+    fn server_merge_test_snapshot(
+        state: &str,
+        merged: bool,
+        head_sha: &str,
+    ) -> GitHubPrSnapshotArtifacts {
+        let normalized_snapshot = json!({
+            "schema": "harness.github.pr_snapshot.v1",
+            "repo": "owner/repo",
+            "pr_number": 77,
+            "state": state,
+            "merged": merged,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+            "base_ref": "main",
+            "head_ref": "feature",
+            "head_oid": head_sha,
+            "merge_commit_sha": if merged { json!("merge-sha") } else { Value::Null },
+            "is_draft": false,
+            "merge_state_status": "CLEAN",
+            "review_decision": "APPROVED",
+            "status_check_rollup_state": "SUCCESS",
+            "review_threads_complete": true,
+            "active_unresolved_review_threads_count": 0,
+        });
+        GitHubPrSnapshotArtifacts {
+            raw_pr: normalized_snapshot.clone(),
+            normalized_snapshot,
+        }
+    }
+
+    #[test]
+    fn server_merge_policy_uses_runtime_command_overrides() {
+        let workflow = workflow();
+        let policy =
+            server_merge_policy(&GitHubAutoMergeConfig::default(), &job(), Some(&workflow))
+                .expect("valid policy");
+
+        assert_eq!(policy.method, GitHubMergeMethod::Squash);
+        assert!(!policy.delete_branch);
+        assert!(policy.require_review_threads_resolved);
+        assert!(policy.require_clean_merge_state);
+        assert_eq!(policy.merge_execution, GitHubMergeExecution::Server);
+    }
+
+    #[test]
+    fn server_success_result_contains_verified_pull_request() {
+        let target = GitHubPrSnapshotTarget::new("owner/repo", 77).expect("target");
+        let result = server_merge_succeeded(
+            "merge_pr".to_string(),
+            &target,
+            server_merge_test_snapshot("MERGED", true, "head-sha"),
+            "merged",
+            Some(json!({ "status": "ok" })),
+        );
+
+        assert_eq!(result.status, ActivityStatus::Succeeded);
+        assert!(result.artifacts.iter().any(|artifact| {
+            artifact.artifact_type == "pull_request"
+                && artifact.artifact["merged"] == true
+                && artifact.artifact["server_verified"] == true
+        }));
+        assert!(result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_type == SERVER_MERGE_EXECUTION_ARTIFACT));
+    }
+
+    #[test]
+    fn stale_head_is_not_mergeable() {
+        assert!(snapshot_head_matches_expected(
+            &server_merge_test_snapshot("OPEN", false, "fresh-head").normalized_snapshot,
+            Some("fresh-head")
+        ));
+        assert!(!snapshot_head_matches_expected(
+            &server_merge_test_snapshot("OPEN", false, "fresh-head").normalized_snapshot,
+            Some("stale-head")
+        ));
+    }
+}

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -335,8 +335,8 @@ curl -X DELETE http://127.0.0.1:9800/projects/new-project
 |-------|---------|-------------|
 | `enabled` | `false` | Enables server-side auto-merge gating for configured GitHub issue workflows. |
 | `method` | `"squash"` | Merge method requested after the deterministic gate passes. |
-| `delete_branch` | `true` | Whether merge execution should delete the source branch after merge. |
-| `merge_execution` | `"agent"` | Selects the merge executor. `"agent"` keeps the current agent-executed merge path and requires server-side completion verification. `"server"` is reserved for the server-executed merge rollout and fails closed until that rollout lands. |
+| `delete_branch` | `true` | Whether merge execution should request source branch cleanup where the selected executor supports it. |
+| `merge_execution` | `"agent"` | Selects the merge executor. `"agent"` keeps the current agent-executed merge path and requires server-side completion verification. `"server"` runs the merge through the GitHub REST API, then re-reads the pull request before terminal success. |
 | `verify_merge_completion` | `true` | When true, an agent-reported `merge_pr` success is accepted only after Harness re-reads GitHub and observes the PR as merged. |
 
 Server-executed merge mode requires a GitHub token that can merge pull


### PR DESCRIPTION
## Summary

- Add a GitHub REST pull-request merge client for server-executed auto-merge mode.
- Route `merge_pr` runtime jobs to a server-owned activity when `merge_execution = "server"`.
- Re-check the auto-merge gate, enforce expected head SHA, call the merge API, and require a post-merge GitHub snapshot before terminal success.
- Preserve agent-mode completion verification and update auto-merge documentation for the server mode rollout.

Fixes #1415

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo test --package harness-server github_pr_merge -- --nocapture`
- `cargo test --package harness-server server_merge -- --nocapture`
- `cargo test --package harness-server merge_completion -- --nocapture`
- `git diff --check`

## Local test note

`cargo test --package harness-server` was attempted, but the local shared database pool blocked unrelated legacy tests. A representative isolated failure was `eval_store::tests::legacy_eval_store_migration_ignores_missing_legacy_schema`, which failed with `pool timed out while waiting for an open connection`. The merge-specific tests above passed after formatting and the workspace `-Dwarnings` check passed.
