### PR TITLE
spec: agent run identity (cross-tool session correlation)

### DIFF
--- a/specs/session-identity/product.md
+++ b/specs/session-identity/product.md
@@ -42,7 +42,7 @@ Today the same agent run has a different identity in every tool: a harness task/
 - Two concurrent runs never share or overwrite each other's binding lines.
 - Reading tools tolerate a registry containing malformed lines (skip and continue).
 
-## Open Questions
+## Decisions
 
-- Should keepline also act as a minter when it *recovers* a session (new run id vs inheriting the lost run's id)? Leaning: recovery inherits, with a `recovered_from` marker.
-- Registry rotation policy: size-based cap vs age-based pruning.
+- keepline recovery **inherits** the lost run's id and records a `recovered_from` marker. A recovered session continues the same unit of work; the identity chain must not break at exactly the moment it is most useful.
+- Registry rotation is size-based (10 MB cap, one rotated file kept), as specified in the tech spec. Age-based pruning adds a clock dependency for no added value at this write volume.

--- a/specs/session-identity/product.md
+++ b/specs/session-identity/product.md
@@ -1,0 +1,48 @@
+# Agent Run Identity Product Spec
+
+## Summary
+
+One correlation ID (`run id`) for a single agent run, minted by whoever starts the run and propagated to every tool that observes it. harness tasks, keepline sessions, remem memories, and ccstats cost rows about the same run become joinable instead of living under four unrelated identities.
+
+## User Problem
+
+Today the same agent run has a different identity in every tool: a harness task/thread ID, a keepline session ID derived from the CLI's JSONL file, remem provenance keyed its own way, ccstats attribution keyed by native session. Nobody can answer basic operational questions across tools: "what did this harness task cost", "which memories came out of this run", "show me the keepline timeline for the task that produced this PR".
+
+## Product Behavior
+
+- Whoever starts a run mints a run id and exports it in the environment before spawning the agent CLI.
+- Tools that observe the run (hooks, scanners, adapters) record a **binding**: run id ↔ native session identity (Claude Code session UUID, Codex thread id), plus pid/cwd/timestamps.
+- Bindings live in a shared append-only local file. Any tool can join its own data to the run id by reading it. No daemon, no network service.
+- A run started outside any orchestrator (bare terminal) simply has no run id; every tool behaves exactly as it does today.
+
+## MVP Scope
+
+1. The identity spec itself (this document + tech spec): ID format, env contract, binding registry format.
+2. harness: mint and export the run id when spawning Claude Code / Codex CLI; stamp it on task/thread events in harness-observe.
+3. A reference hook snippet (Claude Code `SessionStart` / Codex equivalent) that appends the binding record.
+
+## Follow-Up Scope
+
+- keepline: read bindings (and `ps -Eww` fallback) to group sessions by run id and show harness task context.
+- ccstats: join cost rows to run ids via bindings.
+- remem: include the run id in memory provenance when present in the environment.
+- Nested runs (agent spawning agent) surfaced as parent/child chains in keepline.
+
+## Non-Goals
+
+- No central identity service or daemon. The registry is a local file.
+- No changes to the native CLIs' own session ID formats or JSONL layouts.
+- No cross-machine identity; scope is one machine, one user.
+- Does not decide *what* tools store — only how they key it.
+
+## Acceptance Criteria
+
+- A harness-spawned Claude Code run produces: env var set in the child process, one binding line in the registry, and harness events stamped with the run id.
+- A bare-terminal run (no run id) causes zero behavior change and zero errors in all tools.
+- Two concurrent runs never share or overwrite each other's binding lines.
+- Reading tools tolerate a registry containing malformed lines (skip and continue).
+
+## Open Questions
+
+- Should keepline also act as a minter when it *recovers* a session (new run id vs inheriting the lost run's id)? Leaning: recovery inherits, with a `recovered_from` marker.
+- Registry rotation policy: size-based cap vs age-based pruning.

--- a/specs/session-identity/tasks.md
+++ b/specs/session-identity/tasks.md
@@ -1,0 +1,115 @@
+# Agent Run Identity Task Plan
+
+Spec: `specs/session-identity/` (PR #1425)
+
+## Thread Lane Map
+
+- `SI-L1`: implementation worker. Owns `harness-core` run-id module, `harness-agents` spawn paths, `harness-observe` stamping, and their tests.
+- `SI-L2`: reviewer, read-only. Owns post-implementation diff review against this spec.
+
+No two writable lanes may edit the same file. `AGENTS.md`, `.claude/*`, hooks, settings, and global config are forbidden files unless explicitly requested.
+
+## Tasks
+
+### SI-T1: Run-id primitives in harness-core
+
+Owner: SI-L1
+
+Dependencies: spec merged
+
+Done when:
+
+- `RunId` type with `ar-<ulid>` (lowercase) formatting, parsing, and validation.
+- Mint-only-if-absent env resolution: reads `AGENT_RUN_ID`, honors existing value, nested-mint moves inherited value to `AGENT_RUN_PARENT`.
+
+Verify:
+
+```sh
+cargo test -p harness-core run_id
+```
+
+### SI-T2: Binding registry module
+
+Owner: SI-L1
+
+Dependencies: SI-T1
+
+Done when:
+
+- Append-only JSONL writer (`O_APPEND`, single line < 4 KB) at `${XDG_STATE_HOME:-~/.local/state}/agent-run/bindings.jsonl`.
+- Corruption-tolerant reader (skips malformed lines), latest-wins on duplicate `(run_id, native.id)`.
+- 10 MB size rotation keeping one rotated file.
+- Registry write failure logs at error level and never blocks execution.
+
+Verify:
+
+```sh
+cargo test -p harness-core registry
+```
+
+### SI-T3: Adapter env injection and provisional bindings
+
+Owner: SI-L1
+
+Dependencies: SI-T1, SI-T2
+
+Done when:
+
+- Claude Code and Codex spawn paths in `harness-agents` export `AGENT_RUN_ID` (minting when absent).
+- A provisional binding line (empty `native.id`, `source: harness-adapter`) is written at spawn.
+- Env survives the adapter's Claude-prefix sanitization (regression test).
+
+Verify:
+
+```sh
+cargo test -p harness-agents run_id
+```
+
+### SI-T4: Event stamping in harness-observe
+
+Owner: SI-L1
+
+Dependencies: SI-T3
+
+Done when:
+
+- Task/thread/turn events carry a nullable `run_id`; `event/query` exposes it.
+- Bare-terminal runs (no run id) produce unchanged behavior and no errors.
+
+Verify:
+
+```sh
+cargo test -p harness-observe run_id
+```
+
+### SI-T5: Reference hook snippet and docs
+
+Owner: SI-L1
+
+Dependencies: SI-T2
+
+Done when:
+
+- `docs/run-identity.md` documents the env contract and registry format, with a copy-paste Claude Code `SessionStart` hook snippet that writes the authoritative binding.
+
+Verify:
+
+```sh
+test -f docs/run-identity.md
+```
+
+### SI-T6: Cross-repo adoption issues
+
+Owner: coordinator
+
+Dependencies: SI-T5
+
+Done when:
+
+- One tracking issue each in keepline (join + `ps -Eww` fallback; recovery inherits run id with `recovered_from`), ccstats (`run_id` column at ingest), remem (provenance field from env).
+
+Verify:
+
+```sh
+gh issue list -R majiayu000/keepline --search "run identity" | grep -q .
+```

--- a/specs/session-identity/tech.md
+++ b/specs/session-identity/tech.md
@@ -1,0 +1,76 @@
+# Agent Run Identity Tech Spec
+
+## Context
+
+harness spawns agent CLIs through `harness-agents` adapters; keepline discovers sessions by scanning processes and parsing CLI JSONL files; remem and vibeguard ride inside the CLIs via hooks; ccstats parses usage after the fact. Each tool keys its data by whatever identity it can see locally. This spec defines the shared key and how it travels.
+
+## Design
+
+### ID format
+
+```
+ar-<ULID, lowercase>          e.g. ar-01j1qb3c9r7v5m2k8x4tznq6wd
+```
+
+ULID gives sortable, collision-safe, timestamp-embedded IDs with no coordination. The `ar-` prefix makes the value greppable and self-describing in logs.
+
+### Environment contract
+
+| Variable | Meaning |
+|---|---|
+| `AGENT_RUN_ID` | The run id for this agent process and its children |
+| `AGENT_RUN_PARENT` | Set by a nested minter to its inherited `AGENT_RUN_ID` before minting its own |
+
+Rules:
+
+1. **Mint only if absent.** If `AGENT_RUN_ID` is already set, do not overwrite it — the outermost owner wins. A tool that intentionally starts a *nested* run (agent spawning agent) moves the inherited value to `AGENT_RUN_PARENT` and mints a fresh `AGENT_RUN_ID`.
+2. The names deliberately avoid the `CLAUDE` prefix: harness strips Claude-prefixed variables before spawning child agents (per current adapter behavior), and this contract must survive that sanitization.
+3. Minters in MVP: `harness-agents` adapters at spawn time. Later: keepline recovery, an optional shell wrapper for manual terminals.
+
+### Binding registry
+
+Path: `${XDG_STATE_HOME:-~/.local/state}/agent-run/bindings.jsonl`, append-only JSONL, one binding per line:
+
+```json
+{"v":1,"run_id":"ar-01j1...","parent":null,"native":{"kind":"claude-code","id":"<session-uuid>"},
+ "pid":12345,"cwd":"/path/to/project","started_at":"2026-07-03T10:00:00+08:00","source":"claude-hook"}
+```
+
+- `native.kind`: `claude-code` | `codex` | other adapters later.
+- `source`: which component wrote the line (`claude-hook`, `codex-hook`, `harness-adapter`).
+- Writers open with `O_APPEND` and write a single line < 4 KB per record; readers must skip lines that fail to parse (corruption-tolerant, never fatal).
+- Duplicate bindings for the same `(run_id, native.id)` are allowed; readers take the latest by `started_at`.
+- Rotation: when the file exceeds 10 MB, the writer renames it to `bindings.1.jsonl` and starts fresh; readers consult at most the current + one rotated file.
+
+Who writes the binding: the CLI-side hook is the authoritative writer because only it reliably knows the native session id at start time (Claude Code `SessionStart` hooks receive the session id and inherit the environment). The harness adapter additionally writes a provisional line with `native.id` empty at spawn, so a crashed-before-hook run is still traceable.
+
+### Adoption per tool (follow-up scope)
+
+| Tool | Change |
+|---|---|
+| harness-observe | Stamp `run_id` on task/thread/turn events; expose in `event/query` |
+| keepline | Join scanner results to bindings by native session id; fallback `ps -Eww <pid>` (same-user) to read `AGENT_RUN_ID` when no binding exists |
+| ccstats | Add a `run_id` column resolved via bindings at ingest time |
+| remem | Read `AGENT_RUN_ID` from env inside its hook; store as provenance field when present |
+
+Each adoption is one small, independent PR in its own repo; none depends on another.
+
+## Data Model
+
+No shared database. Each tool adds one nullable `run_id` column/field to its own store. The registry file is the only shared artifact and it is reconstructible (worst case: lose joins for past runs, never lose tool-local data).
+
+## Privacy and Failure Behavior
+
+- The registry contains paths and pids but no prompt/response content.
+- Missing env var → no binding → all tools behave exactly as today. Absence is a supported state, not an error.
+- Registry unwritable (permissions, disk full): writers log at error level and continue the run — identity is an observability feature and must never block agent execution.
+
+## Verification Plan
+
+- Unit: mint-only-if-absent precedence; nested-run parent handoff; reader skips malformed lines.
+- Integration: `harness exec` spawns a real Claude Code run → assert child env contains `AGENT_RUN_ID`, registry gains a binding line with the CLI's session UUID, and harness events carry the same run id.
+- Negative: run Claude Code from a bare terminal → assert no binding written, keepline/ccstats output unchanged from baseline.
+
+## Rollback
+
+Remove env injection from the adapters; the registry file becomes inert data. No schema migrations to unwind (all adopted columns are nullable).


### PR DESCRIPTION
SpecRail-style product + tech spec for a run correlation ID minted at spawn, propagated via env, bound to native session IDs in a local append-only registry. Foundation for keepline / ccstats / remem joins. Design review only — no implementation yet.