### PR TITLE
spec: context composer (budgeted, auditable context injection)

### DIFF
--- a/specs/context-composer/product.md
+++ b/specs/context-composer/product.md
@@ -13,7 +13,7 @@ Two failure modes, both invisible today:
 
 ## Product Behavior
 
-- At `thread/start` (and on resume/steer), registered providers propose typed context items with a declared size, priority, and degrade ladder (full text → summary → one-line pointer).
+- At `thread/start` (and on resume), registered providers propose typed context items with a declared size, priority, and degrade ladder (full text → summary → one-line pointer).
 - The composer deduplicates, scores, and fits items into a configured token budget. Items that don't fit are degraded down their ladder before being excluded; every exclusion has a recorded reason.
 - Every composition emits a **manifest**: what was included, degraded, excluded, and why, with size accounting — stored as a harness-observe event, queryable later.
 - `context/preview` lets a human dry-run the composition for a task before running it.
@@ -47,8 +47,8 @@ Two failure modes, both invisible today:
 - Every excluded or degraded item appears in the manifest with a reason. No silent drops.
 - A count of instruction-bearing items > 15 raises a recorded warning in the manifest.
 
-## Open Questions
+## Decisions
 
-- Default class quotas (proposal in tech spec: rules 30 / skills 25 / contract 25 / brief 15 / drafts 5) — needs shadow-mode data to validate.
-- Token estimation: bytes/4 heuristic vs a real tokenizer; per-agent budget defaults for Claude Code vs Codex.
-- Should `turn/steer` recompose or only append? Leaning: recompose only on resume, never mid-turn.
+- Class quotas ship with the proposed defaults (rule 30 / skill 25 / contract 25 / brief 15 / draft 5). They are configuration, and shadow-mode manifests are the instrument for revising them — no further quota debate before that data exists.
+- v1 token estimation is `bytes / 4` behind the `Estimator` trait: deterministic, dependency-free, and shadow mode makes its error harmless. A real tokenizer is a drop-in replacement later.
+- Recomposition happens at `thread/start` and `thread/resume` only. `turn/steer` never recomposes mid-turn — steering text is user intent, not managed context.

--- a/specs/context-composer/product.md
+++ b/specs/context-composer/product.md
@@ -1,0 +1,54 @@
+# Context Composer Product Spec
+
+## Summary
+
+A single owner for the context harness injects when it starts an agent thread. Today rules, skills, ExecPlan contracts, task briefs, and GC drafts are injected by independent code paths with no shared token budget and no record of what the agent actually received. The Context Composer collects typed proposals from these sources, arbitrates them inside an explicit budget, and emits an auditable manifest for every composition. It ships in shadow mode first: observe and log what it *would* do before it changes anything.
+
+## User Problem
+
+Two failure modes, both invisible today:
+
+1. **Constraint overload.** Every injector adds "just one more" block. Research and our own VibeGuard U-32 experience agree that past ~15 active constraints agent compliance degrades — but nothing counts, so nobody notices until output quality drops.
+2. **No audit trail.** When a task goes wrong, there is no record of which rules, skills, and contract text were actually in the context at thread start. Debugging "why did the agent ignore rule X" is guesswork.
+
+## Product Behavior
+
+- At `thread/start` (and on resume/steer), registered providers propose typed context items with a declared size, priority, and degrade ladder (full text → summary → one-line pointer).
+- The composer deduplicates, scores, and fits items into a configured token budget. Items that don't fit are degraded down their ladder before being excluded; every exclusion has a recorded reason.
+- Every composition emits a **manifest**: what was included, degraded, excluded, and why, with size accounting — stored as a harness-observe event, queryable later.
+- `context/preview` lets a human dry-run the composition for a task before running it.
+- **Shadow mode (default at launch):** the composer runs and logs manifests, but injection continues through the existing code paths, byte-identical to today. **Enforce mode** switches injection over to the composed output.
+
+## MVP Scope
+
+- New `harness-context` crate with the provider trait and deterministic arbitration pipeline.
+- Five v1 providers, all sources harness already owns: rules (harness-rules), skills (harness-skills), ExecPlan/spec contract (harness-exec), task brief, GC remediation drafts (harness-gc).
+- Shadow mode + manifest logging + `context/preview` and `context/manifest/get` RPC methods.
+- Config: per-project budget, per-class quotas, mode flag.
+
+## Follow-Up Scope
+
+- Enforce mode rollout after shadow-mode manifests are reviewed against real tasks.
+- Measure **unmanaged injectors** (CLI-side hooks: remem, vibeguard, user hooks) by joining session JSONL to manifests via the run id (depends on the session-identity spec), so the reserved headroom becomes measured instead of guessed.
+- Outcome-driven tuning: correlate manifests with harness-observe quality grades; propose weight adjustments as adoptable drafts (same pattern as GC), never auto-applied.
+- Memory provider — explicitly deferred until the remem × harness integration question is decided; the design must not assume it.
+
+## Non-Goals
+
+- Not a RAG/retrieval system and not a prompt rewriter; v1 makes no model calls and is fully deterministic.
+- Does not touch CLI-side hook injections (remem, vibeguard hooks keep working exactly as today); it only governs what harness itself injects.
+- Does not manage the agent's in-conversation context window (compaction etc.) — only the initial/turn-start injection.
+
+## Acceptance Criteria
+
+- Shadow mode produces a manifest for 100% of thread starts; injection remains byte-identical to the pre-composer baseline (verified by integration test).
+- Determinism: identical inputs produce byte-identical composition and manifest.
+- The budget is never exceeded; mandatory items that cannot fit fail the composition loudly rather than being silently trimmed.
+- Every excluded or degraded item appears in the manifest with a reason. No silent drops.
+- A count of instruction-bearing items > 15 raises a recorded warning in the manifest.
+
+## Open Questions
+
+- Default class quotas (proposal in tech spec: rules 30 / skills 25 / contract 25 / brief 15 / drafts 5) — needs shadow-mode data to validate.
+- Token estimation: bytes/4 heuristic vs a real tokenizer; per-agent budget defaults for Claude Code vs Codex.
+- Should `turn/steer` recompose or only append? Leaning: recompose only on resume, never mid-turn.

--- a/specs/context-composer/tasks.md
+++ b/specs/context-composer/tasks.md
@@ -1,0 +1,135 @@
+# Context Composer Task Plan
+
+Spec: `specs/context-composer/` (PR #1426)
+
+## Thread Lane Map
+
+- `CC-L1`: implementation worker. Owns the new `harness-context` crate, provider adapters, server wiring, and their tests.
+- `CC-L2`: reviewer, read-only. Owns post-implementation diff review against this spec, with special attention to determinism and no-silent-drop guarantees.
+
+No two writable lanes may edit the same file. `AGENTS.md`, `.claude/*`, hooks, settings, and global config are forbidden files unless explicitly requested.
+
+## Tasks
+
+### CC-T1: harness-context crate skeleton
+
+Owner: CC-L1
+
+Dependencies: spec merged
+
+Done when:
+
+- New workspace crate `harness-context` with `ContextItem`, `ComposeRequest`, `ContextProvider`, `Priority`, `Degraded`, `ProviderError` types.
+- `Estimator` trait with the `bytes / 4` v1 implementation and its error margin documented.
+
+Verify:
+
+```sh
+cargo test -p harness-context types
+```
+
+### CC-T2: Arbitration pipeline
+
+Owner: CC-L1
+
+Dependencies: CC-T1
+
+Done when:
+
+- Deterministic pipeline: collect (per-provider timeout) → dedupe (priority, provider precedence, item-id tiebreak) → mandatory P0 (overflow = hard `compose_error`) → quota fill with degrade ladders → global redistribution → constraint-count guard (> 15 instruction-bearing items degrades lowest-score P2 to pointers and records a warning).
+- Golden tests: fixture proposals → byte-exact snapshot of composition + manifest.
+- Property tests: budget never exceeded; every input item appears in the manifest exactly once with a decision.
+
+Verify:
+
+```sh
+cargo test -p harness-context pipeline
+```
+
+### CC-T3: Manifest emission
+
+Owner: CC-L1
+
+Dependencies: CC-T2
+
+Done when:
+
+- Manifest schema (v1) rendered per composition and logged through harness-observe as event kind `context_manifest`.
+- Manifests record item ids, sizes, and decisions — never full item content.
+
+Verify:
+
+```sh
+cargo test -p harness-context manifest
+```
+
+### CC-T4: Five v1 providers
+
+Owner: CC-L1
+
+Dependencies: CC-T1
+
+Done when:
+
+- Providers wrapping existing crates: rules (harness-rules), skills (harness-skills), contract (harness-exec ExecPlan), task brief, GC drafts (harness-gc).
+- Providers reuse existing selection logic; they add only sizing, relevance, degrade ladders, and dedupe keys.
+
+Verify:
+
+```sh
+cargo test -p harness-context providers
+```
+
+### CC-T5: Shadow-mode server wiring
+
+Owner: CC-L1
+
+Dependencies: CC-T2, CC-T3, CC-T4
+
+Done when:
+
+- `harness-server` invokes the composer at `thread/start` and `thread/resume` when `context.mode = "shadow"` (default); `turn/steer` never recomposes.
+- Injection remains byte-identical to the pre-composer baseline (integration test against a captured baseline).
+- Composer failure in shadow mode produces an error event only and never affects thread start.
+- Config surface: `budget_tokens` (per agent kind), `reserved_headroom` (default 0.20), `provider_timeout_ms`, `quotas` (defaults: rule 0.30 / skill 0.25 / contract 0.25 / brief 0.15 / draft 0.05).
+
+Verify:
+
+```sh
+cargo test -p harness-server context_shadow
+```
+
+### CC-T6: RPC methods
+
+Owner: CC-L1
+
+Dependencies: CC-T5
+
+Done when:
+
+- `context/preview` dry-runs a composition for a hypothetical request; `context/manifest/get` returns a thread's manifest.
+- Both registered in the JSON-RPC router with protocol tests.
+
+Verify:
+
+```sh
+cargo test -p harness-server context_rpc
+```
+
+### CC-T7: Enforce mode (gated)
+
+Owner: CC-L1
+
+Dependencies: CC-T5 plus a shadow-mode review period on real tasks
+
+Done when:
+
+- Per-project `context.mode = "enforce"` disables the five legacy injection paths behind the same flag and makes the composed block the single harness-side injection.
+- Integration test asserts the legacy paths inject nothing under enforce.
+- Rollback documented: flip the flag back to `shadow`; legacy paths are disabled, not deleted, until enforce has run stably.
+
+Verify:
+
+```sh
+cargo test -p harness-server context_enforce
+```

--- a/specs/context-composer/tech.md
+++ b/specs/context-composer/tech.md
@@ -1,0 +1,121 @@
+# Context Composer Tech Spec
+
+## Context
+
+harness injects context into agent threads from at least five code paths: harness-rules (loaded rule text), harness-skills (skill projection), harness-exec (ExecPlan/spec contract), the task brief itself, and harness-gc (remediation drafts). Each path decides independently what to include. This spec centralizes those decisions in a new `harness-context` crate, invoked by `harness-server` at `thread/start` and `thread/resume`.
+
+CLI-side hook injections (remem, vibeguard, user hooks) are outside the composer's control by design; they are accounted for with reserved headroom (see Budget).
+
+## Design
+
+### Provider trait
+
+```rust
+pub trait ContextProvider: Send + Sync {
+    fn id(&self) -> ProviderId;                       // "rules", "skills", "contract", "brief", "gc-drafts"
+    fn propose(&self, req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError>;
+}
+
+pub struct ComposeRequest {
+    pub thread_id: ThreadId,
+    pub run_id: Option<RunId>,          // from the session-identity spec, when present
+    pub project: ProjectId,
+    pub task_profile: TaskProfile,      // task kind, target paths, agent kind (claude|codex)
+    pub budget_hint: Tokens,
+}
+
+pub struct ContextItem {
+    pub id: ItemId,
+    pub class: ItemClass,               // Rule | Skill | Contract | Brief | Draft
+    pub content: String,
+    pub est_tokens: Tokens,             // provider's estimate; composer re-estimates
+    pub priority: Priority,             // P0 (mandatory) | P1 | P2
+    pub relevance: f32,                 // 0.0..=1.0, provider-scored for this task
+    pub degrade: Vec<Degraded>,         // ordered ladder: e.g. [Summary(String), Pointer(String)]
+    pub dedupe_key: Option<String>,     // same key across providers → single survivor
+    pub instruction_bearing: bool,      // counts toward the constraint-count guard
+}
+```
+
+Providers adapt existing crates; they do not reimplement selection logic they already have — e.g. the skills provider wraps harness-skills' existing discovery/dedup and only adds sizing, relevance, and a degrade ladder.
+
+### Arbitration pipeline (deterministic, no model calls)
+
+```
+collect → dedupe → mandatory → quota fill → redistribute → guards → render
+```
+
+1. **Collect.** Run providers with a per-provider timeout (config, default 2s). A provider error or timeout contributes nothing, is logged at error level, and is recorded in the manifest as `provider_error` — the composition is marked degraded, never silently complete.
+2. **Dedupe.** Items sharing a `dedupe_key` collapse to one survivor: highest priority wins, ties broken by configured provider precedence (`rules > contract > skills > brief > gc-drafts`), then lexicographic item id (for determinism).
+3. **Mandatory.** All P0 items are placed first. If P0 alone exceeds the budget, composition **fails loudly** (`compose_error`), failing the thread start in enforce mode — mandatory context must never be silently trimmed.
+4. **Quota fill.** Remaining budget splits into class quotas (default: Rule 30%, Skill 25%, Contract 25%, Brief 15%, Draft 5%). Within each class, items sort by `score = relevance × class_weight`, ties by item id. Each item is placed at the highest degrade level that fits its class's remaining quota: full content, else ladder steps in order, else deferred to step 5.
+5. **Redistribute.** Unused quota pools globally; deferred items compete in global score order, same degrade-to-fit rule.
+6. **Guards.**
+   - Items still unplaced → `excluded` with reason `budget`.
+   - Count items with `instruction_bearing = true`; if > 15, degrade the lowest-scoring instruction-bearing P2 items to `Pointer` until ≤ 15 or none remain to degrade, and record a `constraint_overload` warning either way.
+7. **Render.** Emit the composed block (stable section order: contract, rules, skills, brief, drafts) plus the manifest.
+
+### Budget model
+
+```toml
+[context]
+mode = "shadow"                  # shadow | enforce
+budget_tokens = 24000            # per agent kind overridable: [context.claude-code] / [context.codex]
+reserved_headroom = 0.20         # fraction left free for CLI-hook injections the composer cannot see
+provider_timeout_ms = 2000
+quotas = { rule = 0.30, skill = 0.25, contract = 0.25, brief = 0.15, draft = 0.05 }
+```
+
+Effective budget = `budget_tokens × (1 − reserved_headroom)`. Token estimation is a pluggable `Estimator`; v1 ships `bytes / 4` with its error margin documented. The interface admits a real tokenizer later without touching the pipeline.
+
+### Manifest
+
+Logged through harness-observe as event kind `context_manifest`:
+
+```json
+{"v":1,"thread_id":"...","run_id":"ar-01j1...","mode":"shadow","ts":"...",
+ "budget":{"total":24000,"effective":19200,"used":14730},
+ "items":[
+   {"id":"rule:U-29","class":"rule","decision":"included","tokens":410},
+   {"id":"skill:tdd-guide","class":"skill","decision":"degraded","level":"pointer","tokens":28,"reason":"quota"},
+   {"id":"draft:gc-114","class":"draft","decision":"excluded","reason":"budget"}
+ ],
+ "provider_errors":[],"warnings":["constraint_overload:17"]}
+```
+
+`context/manifest/get` returns the manifest for a thread; `context/preview` runs steps 1–7 for a hypothetical `ComposeRequest` without starting a thread.
+
+### Modes
+
+- **Shadow (default):** pipeline runs, manifest is logged, existing injection paths remain the sole writers of agent context. Zero behavioral risk; produces the data needed to validate quotas and headroom.
+- **Enforce:** the five v1 providers' legacy direct-injection paths are disabled behind the same config flag and the composed block becomes the single injection. The flag flips per project, not globally.
+
+### Interaction with unmanaged injectors
+
+remem, vibeguard, and user hooks inject inside the CLI where harness cannot (and should not) intercept. v1 accounts for them only via `reserved_headroom`. Follow-up (requires session-identity): join the run's JSONL to its manifest by run id, measure actual hook-injected volume, and report headroom accuracy per project — turning the 20% guess into a measured value.
+
+### Outcome feedback (follow-up, design constraint only)
+
+harness-observe already grades task quality. Manifests give every graded task a record of its context decisions, so quota/weight tuning becomes an offline analysis producing **adoptable drafts** (the existing GC draft-adopt pattern). Auto-application is explicitly out; the pipeline stays deterministic and human-governed.
+
+## Data Model
+
+No new store. Manifests are harness-observe events; config lives in the existing TOML. The crate is stateless between compositions.
+
+## Privacy and Failure Behavior
+
+- Manifests record item ids, sizes, and decisions — not full item content (content is recoverable from providers by id).
+- Provider failure: error-level log + degraded manifest, never a silent partial composition (U-29).
+- In shadow mode, composer panics/errors must never affect thread start: the composer call is isolated and its failure only produces an error event.
+
+## Verification Plan
+
+- Golden tests: fixture proposals → snapshot of composition + manifest (byte-exact, guards determinism).
+- Property tests: `used ≤ effective budget` for arbitrary item sets; every input item appears in the manifest exactly once with a decision.
+- Pipeline unit tests: dedupe precedence, P0-overflow hard failure, degrade-ladder fitting, redistribution order, constraint-count guard.
+- Integration (shadow): run a real task; assert manifest event exists and the injected context is byte-identical to a pre-composer baseline capture.
+- Integration (enforce, gated): same task with enforce on; assert the five legacy paths injected nothing and the composed block is present.
+
+## Rollback
+
+Shadow mode is inert by construction. Enforce mode rolls back by flipping `context.mode` back to `shadow` per project — legacy injection paths are disabled behind the flag, not deleted, until enforce has run stably for an agreed period.


### PR DESCRIPTION
SpecRail-style product + tech spec for a single owner of harness-side context injection: provider trait, deterministic arbitration pipeline, degrade ladders, constraint-count guard, per-composition manifest, shadow mode first. CLI-hook injections (remem/vibeguard) stay untouched by design. Design review only — no implementation yet.