### PR TITLE
feat: add agent run identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -195,6 +195,7 @@ impl CodeAgent for ClaudeCodeAgent {
             "spawning claude agent"
         );
 
+        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
         let mut cmd = Command::new(&wrapped_command.program);
         cmd.args(&wrapped_command.args)
             .current_dir(&req.project_root)
@@ -206,6 +207,7 @@ impl CodeAgent for ClaudeCodeAgent {
         crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
         cmd.envs(&req.env_vars);
+        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         let _provider_permit = self
             .provider_gate
@@ -219,6 +221,14 @@ impl CodeAgent for ClaudeCodeAgent {
         let child = cmd.spawn().map_err(|e| {
             harness_core::error::HarnessError::AgentExecution(format!("failed to run claude: {e}"))
         })?;
+        if let Some(pid) = child.id() {
+            crate::write_provisional_agent_run_binding(
+                &run_identity,
+                "claude-code",
+                pid,
+                &req.project_root,
+            );
+        }
         let mut child = crate::ManagedChild::new(child, "claude execute");
 
         let output = child.wait_with_output().await.map_err(|e| {
@@ -315,6 +325,7 @@ impl CodeAgent for ClaudeCodeAgent {
             "claude execute_stream admitted by provider gate"
         );
 
+        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
         let mut cmd = Command::new(&wrapped_command.program);
         cmd.args(&wrapped_command.args)
             .current_dir(&req.project_root)
@@ -326,6 +337,7 @@ impl CodeAgent for ClaudeCodeAgent {
         crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
         cmd.envs(&req.env_vars);
+        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         // ETXTBSY (error 26) occurs on Linux when a security scanner or indexer
         // briefly opens the executable for writing after it is written. Retry once.
@@ -346,6 +358,14 @@ impl CodeAgent for ClaudeCodeAgent {
                 )));
             }
         };
+        if let Some(pid) = child.id() {
+            crate::write_provisional_agent_run_binding(
+                &run_identity,
+                "claude-code",
+                pid,
+                &req.project_root,
+            );
+        }
         let mut child = crate::ManagedChild::new(child, "claude execute_stream");
 
         let stderr_capture = Arc::new(Mutex::new(String::new()));

--- a/crates/harness-agents/src/claude_adapter.rs
+++ b/crates/harness-agents/src/claude_adapter.rs
@@ -8,6 +8,7 @@ use harness_observe::usage::parse_result_usage_metrics;
 use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::{collections::HashMap, process::Stdio};
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
 use tokio::sync::{mpsc, Mutex};
@@ -63,6 +64,7 @@ impl AgentAdapter for ClaudeAdapter {
         }
 
         let model = req.model.as_deref().unwrap_or(&self.default_model);
+        let run_identity = crate::resolve_agent_run_identity(&HashMap::new());
         let mut cmd = Command::new(&self.cli_path);
         // Prompt MUST follow -p immediately: Claude CLI parses `-p <VALUE>`.
         cmd.arg("-p")
@@ -74,13 +76,14 @@ impl AgentAdapter for ClaudeAdapter {
             .arg(model)
             .arg("--verbose")
             .current_dir(&req.project_root)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .kill_on_drop(true);
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
+        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         if !req.allowed_tools.is_empty() {
             cmd.arg("--allowedTools").arg(req.allowed_tools.join(","));
@@ -99,6 +102,14 @@ impl AgentAdapter for ClaudeAdapter {
                 "failed to spawn claude: {e}"
             ))
         })?;
+        if let Some(pid) = child.id() {
+            crate::write_provisional_agent_run_binding(
+                &run_identity,
+                "claude-code",
+                pid,
+                &req.project_root,
+            );
+        }
 
         let stdout = child.stdout.take().ok_or_else(|| {
             harness_core::error::HarnessError::AgentExecution(

--- a/crates/harness-agents/src/claude_tests.rs
+++ b/crates/harness-agents/src/claude_tests.rs
@@ -6,6 +6,7 @@ use harness_core::{types::ExecutionPhase, types::Item, types::ReasoningBudget};
 use std::fs;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 use tokio::time::timeout;
 
@@ -347,6 +348,92 @@ fn write_executable_script(script_body: &str) -> (tempfile::TempDir, PathBuf) {
         fs::set_permissions(&path, perms).expect("set executable permissions");
     }
     (dir, path)
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct ScopedEnvVar {
+    entries: Vec<(String, Option<String>)>,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+impl ScopedEnvVar {
+    fn set_pairs(pairs: &[(&str, &str)]) -> Self {
+        let guard = env_lock().lock().expect("env lock should not be poisoned");
+        let entries = pairs
+            .iter()
+            .map(|(key, value)| {
+                let original = std::env::var(key).ok();
+                unsafe { std::env::set_var(key, value) };
+                (key.to_string(), original)
+            })
+            .collect();
+        Self {
+            entries,
+            _guard: guard,
+        }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        for (key, original) in &self.entries {
+            if let Some(value) = original {
+                unsafe { std::env::set_var(key, value) };
+            } else {
+                unsafe { std::env::remove_var(key) };
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn run_id_execute_exports_agent_run_id_after_claude_env_strip() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state_dir = dir.path().join("state");
+    let state_dir_str = state_dir.to_string_lossy().to_string();
+    let _guard = ScopedEnvVar::set_pairs(&[
+        ("CLAUDECODE", "1"),
+        ("CLAUDE_CODE_ENTRYPOINT", "claude-code"),
+        ("XDG_STATE_HOME", &state_dir_str),
+    ]);
+
+    let agent_capture = dir.path().join("agent-env.txt");
+    let (_script_dir, script) = write_executable_script(&format!(
+        r#"
+env > "{}"
+"#,
+        agent_capture.display()
+    ));
+    let expected_run_id = "ar-01j1qb3c9r7v5m2k8x4tznq6wd";
+    let agent = ClaudeCodeAgent::new(
+        script,
+        "test-model".to_string(),
+        SandboxMode::DangerFullAccess,
+    );
+    let mut request = AgentRequest {
+        prompt: "ping".to_string(),
+        project_root: dir.path().to_path_buf(),
+        ..AgentRequest::default()
+    };
+    request.env_vars.insert(
+        harness_core::run_id::AGENT_RUN_ID_ENV.to_string(),
+        expected_run_id.to_string(),
+    );
+
+    agent.execute(request).await?;
+
+    let agent_env = fs::read_to_string(agent_capture)?;
+    assert!(agent_env
+        .lines()
+        .any(|line| line == format!("AGENT_RUN_ID={expected_run_id}")));
+    assert!(!agent_env
+        .lines()
+        .any(|line| line.starts_with("CLAUDECODE=")));
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -187,6 +187,7 @@ impl CodexAgent {
                 ))
             })?;
 
+        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
         let mut cmd = Command::new(&wrapped_command.program);
         cmd.args(&wrapped_command.args)
             .current_dir(&req.project_root)
@@ -202,6 +203,7 @@ impl CodexAgent {
         crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
         cmd.envs(&req.env_vars);
+        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         if self.cloud.enabled {
             for key in &self.cloud.setup_secret_env {
@@ -230,6 +232,14 @@ impl CodexAgent {
             tracing::error!(agent = "codex", mode = "review", error_kind = ?error.kind(), "{message}");
             harness_core::error::HarnessError::AgentExecution(message)
         })?;
+        if let Some(pid) = child.id() {
+            crate::write_provisional_agent_run_binding(
+                &run_identity,
+                "codex",
+                pid,
+                &req.project_root,
+            );
+        }
 
         if use_stdin_prompt {
             let Some(instructions) = req.instructions.as_deref() else {
@@ -489,6 +499,7 @@ impl CodeAgent for CodexAgent {
                 ))
             })?;
 
+        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
         let mut cmd = Command::new(&wrapped_command.program);
         cmd.args(&wrapped_command.args)
             .current_dir(&req.project_root)
@@ -500,6 +511,7 @@ impl CodeAgent for CodexAgent {
         crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
         cmd.envs(&req.env_vars);
+        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         if self.cloud.enabled {
             for key in &self.cloud.setup_secret_env {
@@ -530,6 +542,14 @@ impl CodeAgent for CodexAgent {
             );
             harness_core::error::HarnessError::AgentExecution(message)
         })?;
+        if let Some(pid) = child.id() {
+            crate::write_provisional_agent_run_binding(
+                &run_identity,
+                "codex",
+                pid,
+                &req.project_root,
+            );
+        }
         let mut child = crate::ManagedChild::new(child, "codex execute");
         let output = child.wait_with_output().await.map_err(|err| {
             harness_core::error::HarnessError::AgentExecution(format!(
@@ -599,6 +619,7 @@ impl CodeAgent for CodexAgent {
                 ))
             })?;
 
+        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
         let mut cmd = Command::new(&wrapped_command.program);
         cmd.args(&wrapped_command.args)
             .current_dir(&req.project_root)
@@ -610,6 +631,7 @@ impl CodeAgent for CodexAgent {
         crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
         cmd.envs(&req.env_vars);
+        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         if self.cloud.enabled {
             for key in &self.cloud.setup_secret_env {
@@ -640,6 +662,14 @@ impl CodeAgent for CodexAgent {
             );
             harness_core::error::HarnessError::AgentExecution(message)
         })?;
+        if let Some(pid) = child.id() {
+            crate::write_provisional_agent_run_binding(
+                &run_identity,
+                "codex",
+                pid,
+                &req.project_root,
+            );
+        }
         let mut child = crate::ManagedChild::new(child, "codex execute_stream");
 
         let stderr_capture = Arc::new(Mutex::new(String::new()));

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use harness_core::agent::{AgentAdapter, AgentEvent, ApprovalDecision, TurnRequest};
 use harness_core::config::agents::SandboxMode;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
@@ -177,6 +178,7 @@ impl CodexAdapter {
             state.reset_child().await;
         }
 
+        let run_identity = crate::resolve_agent_run_identity(&HashMap::new());
         let mut cmd = tokio::process::Command::new(&self.cli_path);
         cmd.arg("app-server")
             .arg("--listen")
@@ -189,12 +191,21 @@ impl CodexAdapter {
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
+        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         let mut child = cmd.spawn().map_err(|error| {
             harness_core::error::HarnessError::AgentExecution(format!(
                 "failed to spawn codex app-server: {error}"
             ))
         })?;
+        if let Some(pid) = child.id() {
+            crate::write_provisional_agent_run_binding(
+                &run_identity,
+                "codex",
+                pid,
+                &req.project_root,
+            );
+        }
 
         if let Some(stderr) = child.stderr.take() {
             tokio::spawn(async move {

--- a/crates/harness-agents/src/codex_tests.rs
+++ b/crates/harness-agents/src/codex_tests.rs
@@ -717,6 +717,55 @@ async fn execute_stream_removes_claude_code_env_vars() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn run_id_execute_exports_agent_run_id_after_claude_env_strip() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let state_dir = dir.path().join("state");
+    let state_dir_str = state_dir.to_string_lossy().to_string();
+    let _guard = ScopedEnvVar::set_pairs(&[
+        ("CLAUDECODE", "1"),
+        ("CLAUDE_CODE_ENTRYPOINT", "claude-code"),
+        ("XDG_STATE_HOME", &state_dir_str),
+    ]);
+
+    let agent_capture = dir.path().join("agent-env.txt");
+    let cli_script = dir.path().join("capture-run-id-env.sh");
+    fs::write(
+        &cli_script,
+        format!("#!/bin/sh\nenv > \"{}\"\nexit 0\n", agent_capture.display()),
+    )?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&cli_script)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&cli_script, perms)?;
+    }
+
+    let expected_run_id = "ar-01j1qb3c9r7v5m2k8x4tznq6wd";
+    let agent = CodexAgent::new(cli_script, SandboxMode::DangerFullAccess);
+    let mut request = AgentRequest {
+        prompt: "ping".to_string(),
+        project_root: dir.path().to_path_buf(),
+        ..AgentRequest::default()
+    };
+    request.env_vars.insert(
+        harness_core::run_id::AGENT_RUN_ID_ENV.to_string(),
+        expected_run_id.to_string(),
+    );
+
+    agent.execute(request).await?;
+
+    let agent_env = fs::read_to_string(agent_capture)?;
+    assert!(agent_env
+        .lines()
+        .any(|line| line == format!("AGENT_RUN_ID={expected_run_id}")));
+    assert!(!agent_env
+        .lines()
+        .any(|line| line.starts_with("CLAUDECODE=")));
+    Ok(())
+}
+
 #[test]
 fn codex_sandbox_mode_maps_to_codex_cli_values() {
     assert_eq!(codex_sandbox_mode(SandboxMode::ReadOnly), "read-only");

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -88,84 +88,6 @@ pub(crate) fn set_process_group(cmd: &mut tokio::process::Command) {
     cmd.process_group(0);
 }
 
-#[cfg(test)]
-mod run_id_tests {
-    use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    #[test]
-    fn run_id_resolution_prefers_request_env() {
-        let mut env_vars = HashMap::new();
-        env_vars.insert(
-            AGENT_RUN_ID_ENV.to_string(),
-            "ar-01j1qb3c9r7v5m2k8x4tznq6wd".to_string(),
-        );
-        env_vars.insert(
-            AGENT_RUN_PARENT_ENV.to_string(),
-            "ar-01j1qb3c9r7v5m2k8x4tznq6we".to_string(),
-        );
-
-        let identity = resolve_agent_run_identity(&env_vars);
-
-        assert_eq!(identity.run_id.as_str(), "ar-01j1qb3c9r7v5m2k8x4tznq6wd");
-        assert_eq!(
-            identity.parent.as_ref().map(|id| id.as_str()),
-            Some("ar-01j1qb3c9r7v5m2k8x4tznq6we")
-        );
-    }
-
-    #[test]
-    fn run_id_resolution_mints_when_absent() {
-        let _guard = env_lock().lock().unwrap();
-        let original_id = std::env::var(AGENT_RUN_ID_ENV).ok();
-        let original_parent = std::env::var(AGENT_RUN_PARENT_ENV).ok();
-        unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) };
-        unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) };
-
-        let identity = resolve_agent_run_identity(&HashMap::new());
-
-        assert!(identity.run_id.as_str().starts_with("ar-"));
-        assert!(identity.parent.is_none());
-
-        match original_id {
-            Some(value) => unsafe { std::env::set_var(AGENT_RUN_ID_ENV, value) },
-            None => unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) },
-        }
-        match original_parent {
-            Some(value) => unsafe { std::env::set_var(AGENT_RUN_PARENT_ENV, value) },
-            None => unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) },
-        }
-    }
-
-    #[test]
-    fn run_id_provisional_binding_uses_harness_adapter_source() {
-        let identity = RunIdentity::from_env_values(
-            Some("ar-01j1qb3c9r7v5m2k8x4tznq6wd"),
-            Some("ar-01j1qb3c9r7v5m2k8x4tznq6we"),
-        )
-        .expect("valid identity")
-        .expect("identity");
-
-        let record =
-            provisional_agent_run_binding_record(&identity, "claude-code", 42, Path::new("/tmp/x"));
-
-        assert_eq!(record.run_id.as_str(), "ar-01j1qb3c9r7v5m2k8x4tznq6wd");
-        assert_eq!(
-            record.parent.as_ref().map(|id| id.as_str()),
-            Some("ar-01j1qb3c9r7v5m2k8x4tznq6we")
-        );
-        assert_eq!(record.native.kind, "claude-code");
-        assert!(record.native.id.is_empty());
-        assert_eq!(record.pid, 42);
-        assert_eq!(record.source, "harness-adapter");
-    }
-}
-
 #[cfg(unix)]
 fn kill_process_group_id(pid: u32) {
     // kill(-pgid, SIGKILL) kills the entire process group.
@@ -411,5 +333,83 @@ impl Drop for ManagedChild {
 
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
+    }
+}
+
+#[cfg(test)]
+mod run_id_tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn run_id_resolution_prefers_request_env() {
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            AGENT_RUN_ID_ENV.to_string(),
+            "ar-01j1qb3c9r7v5m2k8x4tznq6wd".to_string(),
+        );
+        env_vars.insert(
+            AGENT_RUN_PARENT_ENV.to_string(),
+            "ar-01j1qb3c9r7v5m2k8x4tznq6we".to_string(),
+        );
+
+        let identity = resolve_agent_run_identity(&env_vars);
+
+        assert_eq!(identity.run_id.as_str(), "ar-01j1qb3c9r7v5m2k8x4tznq6wd");
+        assert_eq!(
+            identity.parent.as_ref().map(|id| id.as_str()),
+            Some("ar-01j1qb3c9r7v5m2k8x4tznq6we")
+        );
+    }
+
+    #[test]
+    fn run_id_resolution_mints_when_absent() {
+        let _guard = env_lock().lock().unwrap();
+        let original_id = std::env::var(AGENT_RUN_ID_ENV).ok();
+        let original_parent = std::env::var(AGENT_RUN_PARENT_ENV).ok();
+        unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) };
+        unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) };
+
+        let identity = resolve_agent_run_identity(&HashMap::new());
+
+        assert!(identity.run_id.as_str().starts_with("ar-"));
+        assert!(identity.parent.is_none());
+
+        match original_id {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_ID_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) },
+        }
+        match original_parent {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_PARENT_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) },
+        }
+    }
+
+    #[test]
+    fn run_id_provisional_binding_uses_harness_adapter_source() {
+        let identity = RunIdentity::from_env_values(
+            Some("ar-01j1qb3c9r7v5m2k8x4tznq6wd"),
+            Some("ar-01j1qb3c9r7v5m2k8x4tznq6we"),
+        )
+        .expect("valid identity")
+        .expect("identity");
+
+        let record =
+            provisional_agent_run_binding_record(&identity, "claude-code", 42, Path::new("/tmp/x"));
+
+        assert_eq!(record.run_id.as_str(), "ar-01j1qb3c9r7v5m2k8x4tznq6wd");
+        assert_eq!(
+            record.parent.as_ref().map(|id| id.as_str()),
+            Some("ar-01j1qb3c9r7v5m2k8x4tznq6we")
+        );
+        assert_eq!(record.native.kind, "claude-code");
+        assert!(record.native.id.is_empty());
+        assert_eq!(record.pid, 42);
+        assert_eq!(record.source, "harness-adapter");
     }
 }

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -9,6 +9,11 @@ pub mod provider_backpressure;
 pub mod registry;
 mod streaming;
 
+use harness_core::run_id::{RunIdentity, AGENT_RUN_ID_ENV, AGENT_RUN_PARENT_ENV};
+use harness_core::run_registry::{append_binding_nonblocking, BindingRecord};
+use std::collections::HashMap;
+use std::path::Path;
+
 /// Remove all `CLAUDE`-prefixed environment variables from a command to prevent
 /// nested Claude Code detection (SIGTRAP).
 pub(crate) fn strip_claude_env(cmd: &mut tokio::process::Command) {
@@ -21,6 +26,57 @@ pub(crate) fn strip_claude_env(cmd: &mut tokio::process::Command) {
     }
 }
 
+pub(crate) fn resolve_agent_run_identity(env_vars: &HashMap<String, String>) -> RunIdentity {
+    match RunIdentity::from_env_vars(env_vars) {
+        Ok(Some(identity)) => identity,
+        Ok(None) => RunIdentity::mint(),
+        Err(error) => {
+            tracing::error!(
+                "invalid agent run identity environment; minting a new run id: {error}"
+            );
+            RunIdentity::mint()
+        }
+    }
+}
+
+pub(crate) fn apply_agent_run_identity_env(
+    cmd: &mut tokio::process::Command,
+    identity: &RunIdentity,
+) {
+    cmd.env(AGENT_RUN_ID_ENV, identity.run_id.as_str());
+    if let Some(parent) = &identity.parent {
+        cmd.env(AGENT_RUN_PARENT_ENV, parent.as_str());
+    } else {
+        cmd.env_remove(AGENT_RUN_PARENT_ENV);
+    }
+}
+
+pub(crate) fn write_provisional_agent_run_binding(
+    identity: &RunIdentity,
+    native_kind: &str,
+    pid: u32,
+    cwd: &Path,
+) {
+    let record = provisional_agent_run_binding_record(identity, native_kind, pid, cwd);
+    append_binding_nonblocking(&record);
+}
+
+pub(crate) fn provisional_agent_run_binding_record(
+    identity: &RunIdentity,
+    native_kind: &str,
+    pid: u32,
+    cwd: &Path,
+) -> BindingRecord {
+    BindingRecord::provisional(
+        identity.run_id.clone(),
+        identity.parent.clone(),
+        native_kind,
+        pid,
+        cwd.to_path_buf(),
+        "harness-adapter",
+    )
+}
+
 /// Place the child process into its own process group.
 ///
 /// Uses the stable `CommandExt::process_group(0)` API (Rust 1.64+).
@@ -30,6 +86,84 @@ pub(crate) fn strip_claude_env(cmd: &mut tokio::process::Command) {
 #[cfg(unix)]
 pub(crate) fn set_process_group(cmd: &mut tokio::process::Command) {
     cmd.process_group(0);
+}
+
+#[cfg(test)]
+mod run_id_tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn run_id_resolution_prefers_request_env() {
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            AGENT_RUN_ID_ENV.to_string(),
+            "ar-01j1qb3c9r7v5m2k8x4tznq6wd".to_string(),
+        );
+        env_vars.insert(
+            AGENT_RUN_PARENT_ENV.to_string(),
+            "ar-01j1qb3c9r7v5m2k8x4tznq6we".to_string(),
+        );
+
+        let identity = resolve_agent_run_identity(&env_vars);
+
+        assert_eq!(identity.run_id.as_str(), "ar-01j1qb3c9r7v5m2k8x4tznq6wd");
+        assert_eq!(
+            identity.parent.as_ref().map(|id| id.as_str()),
+            Some("ar-01j1qb3c9r7v5m2k8x4tznq6we")
+        );
+    }
+
+    #[test]
+    fn run_id_resolution_mints_when_absent() {
+        let _guard = env_lock().lock().unwrap();
+        let original_id = std::env::var(AGENT_RUN_ID_ENV).ok();
+        let original_parent = std::env::var(AGENT_RUN_PARENT_ENV).ok();
+        unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) };
+        unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) };
+
+        let identity = resolve_agent_run_identity(&HashMap::new());
+
+        assert!(identity.run_id.as_str().starts_with("ar-"));
+        assert!(identity.parent.is_none());
+
+        match original_id {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_ID_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) },
+        }
+        match original_parent {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_PARENT_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) },
+        }
+    }
+
+    #[test]
+    fn run_id_provisional_binding_uses_harness_adapter_source() {
+        let identity = RunIdentity::from_env_values(
+            Some("ar-01j1qb3c9r7v5m2k8x4tznq6wd"),
+            Some("ar-01j1qb3c9r7v5m2k8x4tznq6we"),
+        )
+        .expect("valid identity")
+        .expect("identity");
+
+        let record =
+            provisional_agent_run_binding_record(&identity, "claude-code", 42, Path::new("/tmp/x"));
+
+        assert_eq!(record.run_id.as_str(), "ar-01j1qb3c9r7v5m2k8x4tznq6wd");
+        assert_eq!(
+            record.parent.as_ref().map(|id| id.as_str()),
+            Some("ar-01j1qb3c9r7v5m2k8x4tznq6we")
+        );
+        assert_eq!(record.native.kind, "claude-code");
+        assert!(record.native.id.is_empty());
+        assert_eq!(record.pid, 42);
+        assert_eq!(record.source, "harness-adapter");
+    }
 }
 
 #[cfg(unix)]

--- a/crates/harness-core/Cargo.toml
+++ b/crates/harness-core/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { workspace = true, features = ["sync"] }
 anyhow = { workspace = true }
 sqlx = { workspace = true }
 sha2 = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -12,6 +12,8 @@ pub mod lang_detect;
 pub mod prompts;
 pub mod proof_of_work;
 pub mod review;
+pub mod run_id;
+pub mod run_registry;
 pub mod shell_safety;
 pub mod store_backend;
 #[cfg(test)]
@@ -21,6 +23,7 @@ pub mod types;
 pub mod validation;
 
 pub use config::misc::OtelExporter;
+pub use run_id::{RunId, RunIdentity};
 pub use types::{
     AutoFixAttempt, AutoFixReport, Decision, Event, EventFilters, ExternalSignal, RuleId,
     SessionId, Severity,

--- a/crates/harness-core/src/run_id.rs
+++ b/crates/harness-core/src/run_id.rs
@@ -1,0 +1,361 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+
+pub const AGENT_RUN_ID_ENV: &str = "AGENT_RUN_ID";
+pub const AGENT_RUN_PARENT_ENV: &str = "AGENT_RUN_PARENT";
+
+const RUN_ID_PREFIX: &str = "ar-";
+const ULID_LEN: usize = 26;
+const RUN_ID_LEN: usize = RUN_ID_PREFIX.len() + ULID_LEN;
+const CROCKFORD_LOWER: &[u8; 32] = b"0123456789abcdefghjkmnpqrstvwxyz";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct RunId(String);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunIdParseError {
+    Empty,
+    InvalidLength { actual: usize },
+    InvalidPrefix,
+    InvalidCharacter { index: usize, ch: char },
+    TimestampOverflow,
+}
+
+impl fmt::Display for RunIdParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "run id is empty"),
+            Self::InvalidLength { actual } => {
+                write!(f, "run id must be {RUN_ID_LEN} characters, got {actual}")
+            }
+            Self::InvalidPrefix => write!(f, "run id must start with {RUN_ID_PREFIX}"),
+            Self::InvalidCharacter { index, ch } => {
+                write!(f, "invalid run id character {ch:?} at byte {index}")
+            }
+            Self::TimestampOverflow => write!(f, "run id ULID timestamp prefix is out of range"),
+        }
+    }
+}
+
+impl std::error::Error for RunIdParseError {}
+
+impl RunId {
+    pub fn new() -> Self {
+        let millis = chrono::Utc::now().timestamp_millis().max(0) as u64;
+        let mut bytes = [0_u8; 16];
+        let timestamp = millis.to_be_bytes();
+        bytes[..6].copy_from_slice(&timestamp[2..]);
+        bytes[6..].copy_from_slice(&uuid::Uuid::new_v4().as_bytes()[..10]);
+        Self(format!("{RUN_ID_PREFIX}{}", encode_ulid_lower(bytes)))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn validate(value: &str) -> Result<(), RunIdParseError> {
+        parse_run_id(value).map(|_| ())
+    }
+}
+
+impl Default for RunId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for RunId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<RunId> for String {
+    fn from(value: RunId) -> Self {
+        value.0
+    }
+}
+
+impl TryFrom<String> for RunId {
+    type Error = RunIdParseError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        parse_run_id(&value)?;
+        Ok(Self(value))
+    }
+}
+
+impl FromStr for RunId {
+    type Err = RunIdParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        parse_run_id(value)?;
+        Ok(Self(value.to_string()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunIdentity {
+    pub run_id: RunId,
+    pub parent: Option<RunId>,
+}
+
+impl RunIdentity {
+    pub fn mint() -> Self {
+        Self {
+            run_id: RunId::new(),
+            parent: None,
+        }
+    }
+
+    pub fn from_env() -> Result<Option<Self>, RunIdParseError> {
+        let run_id = std::env::var(AGENT_RUN_ID_ENV).ok();
+        let parent = std::env::var(AGENT_RUN_PARENT_ENV).ok();
+        Self::from_env_values(run_id.as_deref(), parent.as_deref())
+    }
+
+    pub fn from_env_vars(
+        env_vars: &HashMap<String, String>,
+    ) -> Result<Option<Self>, RunIdParseError> {
+        let env_run_id = std::env::var(AGENT_RUN_ID_ENV).ok();
+        let env_parent = std::env::var(AGENT_RUN_PARENT_ENV).ok();
+        let run_id = env_vars
+            .get(AGENT_RUN_ID_ENV)
+            .map(String::as_str)
+            .filter(|value| !value.is_empty())
+            .or_else(|| env_run_id.as_deref().filter(|value| !value.is_empty()));
+        let parent = env_vars
+            .get(AGENT_RUN_PARENT_ENV)
+            .map(String::as_str)
+            .filter(|value| !value.is_empty())
+            .or_else(|| env_parent.as_deref().filter(|value| !value.is_empty()));
+        Self::from_env_values(run_id, parent)
+    }
+
+    pub fn from_env_values(
+        run_id: Option<&str>,
+        parent: Option<&str>,
+    ) -> Result<Option<Self>, RunIdParseError> {
+        let Some(run_id) = run_id.filter(|value| !value.is_empty()) else {
+            return Ok(None);
+        };
+        let run_id = RunId::from_str(run_id)?;
+        let parent = parent
+            .filter(|value| !value.is_empty())
+            .map(RunId::from_str)
+            .transpose()?;
+        Ok(Some(Self { run_id, parent }))
+    }
+
+    pub fn mint_if_absent() -> Result<Self, RunIdParseError> {
+        Ok(Self::from_env()?.unwrap_or_else(Self::mint))
+    }
+
+    pub fn ensure_env_vars(
+        env_vars: &mut HashMap<String, String>,
+    ) -> Result<Self, RunIdParseError> {
+        let identity = Self::from_env_vars(env_vars)?.unwrap_or_else(Self::mint);
+        identity.write_env_vars(env_vars);
+        Ok(identity)
+    }
+
+    pub fn mint_nested() -> Result<Self, RunIdParseError> {
+        let parent = Self::from_env()?.map(|identity| identity.run_id);
+        Ok(Self {
+            run_id: RunId::new(),
+            parent,
+        })
+    }
+
+    pub fn env_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut pairs = vec![(AGENT_RUN_ID_ENV, self.run_id.to_string())];
+        if let Some(parent) = &self.parent {
+            pairs.push((AGENT_RUN_PARENT_ENV, parent.to_string()));
+        }
+        pairs
+    }
+
+    pub fn write_env_vars(&self, env_vars: &mut HashMap<String, String>) {
+        env_vars.insert(AGENT_RUN_ID_ENV.to_string(), self.run_id.to_string());
+        if let Some(parent) = &self.parent {
+            env_vars.insert(AGENT_RUN_PARENT_ENV.to_string(), parent.to_string());
+        } else {
+            env_vars.remove(AGENT_RUN_PARENT_ENV);
+        }
+    }
+}
+
+fn parse_run_id(value: &str) -> Result<(), RunIdParseError> {
+    if value.is_empty() {
+        return Err(RunIdParseError::Empty);
+    }
+    if value.len() != RUN_ID_LEN {
+        return Err(RunIdParseError::InvalidLength {
+            actual: value.len(),
+        });
+    }
+    let Some(ulid) = value.strip_prefix(RUN_ID_PREFIX) else {
+        return Err(RunIdParseError::InvalidPrefix);
+    };
+    for (offset, ch) in ulid.char_indices() {
+        let index = RUN_ID_PREFIX.len() + offset;
+        if !CROCKFORD_LOWER.contains(&(ch as u8)) {
+            return Err(RunIdParseError::InvalidCharacter { index, ch });
+        }
+    }
+    if ulid.as_bytes()[0] > b'7' {
+        return Err(RunIdParseError::TimestampOverflow);
+    }
+    Ok(())
+}
+
+fn encode_ulid_lower(bytes: [u8; 16]) -> String {
+    let mut value = u128::from_be_bytes(bytes);
+    let mut encoded = [b'0'; ULID_LEN];
+    for slot in encoded.iter_mut().rev() {
+        *slot = CROCKFORD_LOWER[(value & 0b11111) as usize];
+        value >>= 5;
+    }
+    String::from_utf8(encoded.to_vec()).expect("ULID alphabet is valid UTF-8")
+}
+
+#[cfg(test)]
+mod run_id_tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn run_id_mints_lowercase_prefixed_ulid() {
+        let run_id = RunId::new();
+        assert!(run_id.as_str().starts_with("ar-"));
+        assert_eq!(run_id.as_str().len(), 29);
+        assert!(RunId::validate(run_id.as_str()).is_ok());
+        assert_eq!(run_id.as_str(), run_id.as_str().to_ascii_lowercase());
+    }
+
+    #[test]
+    fn run_id_rejects_invalid_values() {
+        assert!(RunId::from_str("").is_err());
+        assert!(RunId::from_str("01j1qb3c9r7v5m2k8x4tznq6wd").is_err());
+        assert!(RunId::from_str("ar-01J1QB3C9R7V5M2K8X4TZNQ6WD").is_err());
+        assert!(RunId::from_str("ar-81j1qb3c9r7v5m2k8x4tznq6wd").is_err());
+        assert!(RunId::from_str("ar-01j1qb3c9r7v5m2k8x4tznq6wu").is_err());
+    }
+
+    #[test]
+    fn run_id_env_resolution_honors_existing_value() {
+        let _guard = env_lock().lock().unwrap();
+        let original = std::env::var(AGENT_RUN_ID_ENV).ok();
+        let expected = "ar-01j1qb3c9r7v5m2k8x4tznq6wd";
+        unsafe { std::env::set_var(AGENT_RUN_ID_ENV, expected) };
+
+        let identity = RunIdentity::mint_if_absent().expect("valid env");
+        assert_eq!(identity.run_id.as_str(), expected);
+        assert!(identity.parent.is_none());
+
+        match original {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_ID_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) },
+        }
+    }
+
+    #[test]
+    fn run_id_nested_mint_hands_off_parent() {
+        let _guard = env_lock().lock().unwrap();
+        let original_id = std::env::var(AGENT_RUN_ID_ENV).ok();
+        let original_parent = std::env::var(AGENT_RUN_PARENT_ENV).ok();
+        let parent = "ar-01j1qb3c9r7v5m2k8x4tznq6wd";
+        unsafe { std::env::set_var(AGENT_RUN_ID_ENV, parent) };
+        unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) };
+
+        let identity = RunIdentity::mint_nested().expect("nested mint");
+        assert_ne!(identity.run_id.as_str(), parent);
+        assert_eq!(identity.parent.as_ref().map(RunId::as_str), Some(parent));
+        let env_pairs = identity.env_pairs();
+        assert!(env_pairs.iter().any(|(key, _)| *key == AGENT_RUN_ID_ENV));
+        assert!(env_pairs
+            .iter()
+            .any(|(key, value)| *key == AGENT_RUN_PARENT_ENV && value == parent));
+
+        match original_id {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_ID_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) },
+        }
+        match original_parent {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_PARENT_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) },
+        }
+    }
+
+    #[test]
+    fn run_id_from_env_vars_prefers_request_values() {
+        let _guard = env_lock().lock().unwrap();
+        let original_id = std::env::var(AGENT_RUN_ID_ENV).ok();
+        let original_parent = std::env::var(AGENT_RUN_PARENT_ENV).ok();
+        unsafe { std::env::set_var(AGENT_RUN_ID_ENV, "ar-01j1qb3c9r7v5m2k8x4tznq6wf") };
+        unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) };
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            AGENT_RUN_ID_ENV.to_string(),
+            "ar-01j1qb3c9r7v5m2k8x4tznq6wd".to_string(),
+        );
+        env_vars.insert(
+            AGENT_RUN_PARENT_ENV.to_string(),
+            "ar-01j1qb3c9r7v5m2k8x4tznq6we".to_string(),
+        );
+
+        let identity = RunIdentity::from_env_vars(&env_vars)
+            .expect("valid identity")
+            .expect("identity");
+
+        assert_eq!(identity.run_id.as_str(), "ar-01j1qb3c9r7v5m2k8x4tznq6wd");
+        assert_eq!(
+            identity.parent.as_ref().map(RunId::as_str),
+            Some("ar-01j1qb3c9r7v5m2k8x4tznq6we")
+        );
+
+        match original_id {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_ID_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) },
+        }
+        match original_parent {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_PARENT_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) },
+        }
+    }
+
+    #[test]
+    fn run_id_ensure_env_vars_mints_and_writes_request_env() {
+        let _guard = env_lock().lock().unwrap();
+        let original_id = std::env::var(AGENT_RUN_ID_ENV).ok();
+        let original_parent = std::env::var(AGENT_RUN_PARENT_ENV).ok();
+        unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) };
+        unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) };
+        let mut env_vars = HashMap::new();
+
+        let identity = RunIdentity::ensure_env_vars(&mut env_vars).expect("identity");
+
+        assert_eq!(
+            env_vars.get(AGENT_RUN_ID_ENV).map(String::as_str),
+            Some(identity.run_id.as_str())
+        );
+        assert!(!env_vars.contains_key(AGENT_RUN_PARENT_ENV));
+
+        match original_id {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_ID_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) },
+        }
+        match original_parent {
+            Some(value) => unsafe { std::env::set_var(AGENT_RUN_PARENT_ENV, value) },
+            None => unsafe { std::env::remove_var(AGENT_RUN_PARENT_ENV) },
+        }
+    }
+}

--- a/crates/harness-core/src/run_registry.rs
+++ b/crates/harness-core/src/run_registry.rs
@@ -1,0 +1,258 @@
+use crate::run_id::{RunId, AGENT_RUN_PARENT_ENV};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub const REGISTRY_MAX_BYTES: u64 = 10 * 1024 * 1024;
+pub const REGISTRY_FILE_NAME: &str = "bindings.jsonl";
+pub const ROTATED_REGISTRY_FILE_NAME: &str = "bindings.1.jsonl";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeBinding {
+    pub kind: String,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BindingRecord {
+    pub v: u8,
+    pub run_id: RunId,
+    pub parent: Option<RunId>,
+    pub native: NativeBinding,
+    pub pid: u32,
+    pub cwd: PathBuf,
+    pub started_at: DateTime<Utc>,
+    pub source: String,
+}
+
+impl BindingRecord {
+    pub fn provisional(
+        run_id: RunId,
+        parent: Option<RunId>,
+        native_kind: impl Into<String>,
+        pid: u32,
+        cwd: PathBuf,
+        source: impl Into<String>,
+    ) -> Self {
+        Self {
+            v: 1,
+            run_id,
+            parent,
+            native: NativeBinding {
+                kind: native_kind.into(),
+                id: String::new(),
+            },
+            pid,
+            cwd,
+            started_at: Utc::now(),
+            source: source.into(),
+        }
+    }
+}
+
+pub fn default_registry_path() -> PathBuf {
+    let state_root = std::env::var_os("XDG_STATE_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|value| !value.is_empty())
+                .map(|home| PathBuf::from(home).join(".local/state"))
+        })
+        .unwrap_or_else(|| std::env::temp_dir().join("agent-run-state"));
+    state_root.join("agent-run").join(REGISTRY_FILE_NAME)
+}
+
+pub fn append_binding(record: &BindingRecord) -> anyhow::Result<()> {
+    append_binding_at(&default_registry_path(), record)
+}
+
+pub fn append_binding_at(path: &Path, record: &BindingRecord) -> anyhow::Result<()> {
+    rotate_if_needed(path, REGISTRY_MAX_BYTES)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("registry path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent)?;
+    let mut line = serde_json::to_vec(record)?;
+    if line.len() >= 4096 {
+        anyhow::bail!("binding record is too large: {} bytes", line.len());
+    }
+    line.push(b'\n');
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    file.write_all(&line)?;
+    Ok(())
+}
+
+pub fn append_binding_nonblocking(record: &BindingRecord) {
+    if let Err(error) = append_binding(record) {
+        tracing::error!(
+            run_id = record.run_id.as_str(),
+            native_kind = record.native.kind.as_str(),
+            source = record.source.as_str(),
+            parent_env = AGENT_RUN_PARENT_ENV,
+            "failed to write agent run binding: {error}"
+        );
+    }
+}
+
+pub fn read_latest_bindings() -> anyhow::Result<Vec<BindingRecord>> {
+    read_latest_bindings_at(&default_registry_path())
+}
+
+pub fn read_latest_bindings_at(path: &Path) -> anyhow::Result<Vec<BindingRecord>> {
+    let mut latest: HashMap<(String, String), BindingRecord> = HashMap::new();
+    for candidate in [rotated_path(path), path.to_path_buf()] {
+        for record in read_records_from_file(&candidate)? {
+            let key = (record.run_id.to_string(), record.native.id.clone());
+            match latest.get(&key) {
+                Some(existing) if existing.started_at >= record.started_at => {}
+                _ => {
+                    latest.insert(key, record);
+                }
+            }
+        }
+    }
+    Ok(latest.into_values().collect())
+}
+
+fn read_records_from_file(path: &Path) -> anyhow::Result<Vec<BindingRecord>> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(contents
+        .lines()
+        .filter_map(|line| serde_json::from_str::<BindingRecord>(line).ok())
+        .collect())
+}
+
+fn rotate_if_needed(path: &Path, max_bytes: u64) -> anyhow::Result<()> {
+    let Ok(metadata) = fs::metadata(path) else {
+        return Ok(());
+    };
+    if metadata.len() < max_bytes {
+        return Ok(());
+    }
+    let rotated = rotated_path(path);
+    if rotated.exists() {
+        fs::remove_file(&rotated)?;
+    }
+    fs::rename(path, rotated)?;
+    Ok(())
+}
+
+fn rotated_path(path: &Path) -> PathBuf {
+    path.with_file_name(ROTATED_REGISTRY_FILE_NAME)
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+    use crate::run_id::RunId;
+    use std::str::FromStr;
+
+    fn record(run_id: &str, native_id: &str, started_at: DateTime<Utc>) -> BindingRecord {
+        BindingRecord {
+            v: 1,
+            run_id: RunId::from_str(run_id).expect("valid run id"),
+            parent: None,
+            native: NativeBinding {
+                kind: "codex".to_string(),
+                id: native_id.to_string(),
+            },
+            pid: 123,
+            cwd: PathBuf::from("/tmp/project"),
+            started_at,
+            source: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn registry_appends_and_reads_latest_binding() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("agent-run").join(REGISTRY_FILE_NAME);
+        let old = record(
+            "ar-01j1qb3c9r7v5m2k8x4tznq6wd",
+            "native-1",
+            "2026-07-03T01:00:00Z".parse()?,
+        );
+        let mut new = old.clone();
+        new.pid = 456;
+        new.started_at = "2026-07-03T02:00:00Z".parse()?;
+
+        append_binding_at(&path, &old)?;
+        append_binding_at(&path, &new)?;
+
+        let bindings = read_latest_bindings_at(&path)?;
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0].pid, 456);
+        Ok(())
+    }
+
+    #[test]
+    fn registry_reader_skips_malformed_lines() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("agent-run").join(REGISTRY_FILE_NAME);
+        let valid = record(
+            "ar-01j1qb3c9r7v5m2k8x4tznq6wd",
+            "native-1",
+            "2026-07-03T01:00:00Z".parse()?,
+        );
+        fs::create_dir_all(path.parent().expect("parent"))?;
+        fs::write(
+            &path,
+            format!(
+                "not-json\n{}\n{{\"v\":1,\"run_id\":\"bad\"}}\n",
+                serde_json::to_string(&valid)?
+            ),
+        )?;
+
+        let bindings = read_latest_bindings_at(&path)?;
+        assert_eq!(bindings, vec![valid]);
+        Ok(())
+    }
+
+    #[test]
+    fn registry_rotates_at_ten_mb_and_keeps_one_file() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("agent-run").join(REGISTRY_FILE_NAME);
+        fs::create_dir_all(path.parent().expect("parent"))?;
+        fs::write(&path, vec![b'a'; REGISTRY_MAX_BYTES as usize])?;
+        let valid = record(
+            "ar-01j1qb3c9r7v5m2k8x4tznq6wd",
+            "native-1",
+            "2026-07-03T01:00:00Z".parse()?,
+        );
+
+        append_binding_at(&path, &valid)?;
+
+        assert!(path.exists());
+        assert!(path.with_file_name(ROTATED_REGISTRY_FILE_NAME).exists());
+        let current = fs::read_to_string(&path)?;
+        assert!(current.contains("native-1"));
+        Ok(())
+    }
+
+    #[test]
+    fn registry_write_failure_is_available_to_nonblocking_wrapper() {
+        let invalid_record = BindingRecord {
+            v: 1,
+            run_id: RunId::from_str("ar-01j1qb3c9r7v5m2k8x4tznq6wd").unwrap(),
+            parent: None,
+            native: NativeBinding {
+                kind: "codex".to_string(),
+                id: "x".repeat(5000),
+            },
+            pid: 1,
+            cwd: PathBuf::from("/tmp/project"),
+            started_at: Utc::now(),
+            source: "test".to_string(),
+        };
+
+        append_binding_nonblocking(&invalid_record);
+    }
+}

--- a/crates/harness-core/src/types.rs
+++ b/crates/harness-core/src/types.rs
@@ -1,4 +1,5 @@
 use crate::db::DbSerializable;
+use crate::run_id::{RunId, RunIdentity};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -400,6 +401,8 @@ pub struct Event {
     pub id: EventId,
     pub ts: DateTime<Utc>,
     pub session_id: SessionId,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub run_id: Option<RunId>,
     pub hook: String,
     pub tool: String,
     pub decision: Decision,
@@ -419,6 +422,10 @@ impl Event {
             id: EventId::new(),
             ts: Utc::now(),
             session_id,
+            run_id: RunIdentity::from_env()
+                .ok()
+                .flatten()
+                .map(|identity| identity.run_id),
             hook: hook.to_string(),
             tool: tool.to_string(),
             decision,
@@ -774,6 +781,7 @@ impl ReasoningBudget {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EventFilters {
     pub session_id: Option<SessionId>,
+    pub run_id: Option<RunId>,
     pub hook: Option<String>,
     /// Filter by `Event.tool` (e.g. rule id for `rule_check` events).
     pub tool: Option<String>,

--- a/crates/harness-observe/src/event_store/legacy.rs
+++ b/crates/harness-observe/src/event_store/legacy.rs
@@ -42,10 +42,10 @@ pub async fn migrate_legacy_event_store_if_needed(
     let mut tx = target_store.pool.begin().await?;
     let events_sql = format!(
         "INSERT INTO events (
-            store_key, id, ts, session_id, hook, tool, decision, reason, detail,
+            store_key, id, ts, session_id, run_id, hook, tool, decision, reason, detail,
             duration_ms, content, metadata
          )
-         SELECT $1, id, ts, session_id, hook, tool, decision, reason, detail,
+         SELECT $1, id, ts, session_id, run_id, hook, tool, decision, reason, detail,
                 duration_ms, content, metadata
          FROM {legacy_schema_sql}.events
          ON CONFLICT (store_key, id) DO NOTHING"

--- a/crates/harness-observe/src/event_store/migrations.rs
+++ b/crates/harness-observe/src/event_store/migrations.rs
@@ -86,4 +86,11 @@ pub(super) static EVENT_MIGRATIONS: &[Migration] = &[
             PRIMARY KEY (store_key, legacy_schema)
         )",
     },
+    Migration {
+        version: 7,
+        description: "add nullable agent run id to events",
+        sql: "ALTER TABLE events ADD COLUMN IF NOT EXISTS run_id TEXT;
+              CREATE INDEX IF NOT EXISTS idx_events_store_run_id
+              ON events (store_key, run_id)",
+    },
 ];

--- a/crates/harness-observe/src/event_store/mod.rs
+++ b/crates/harness-observe/src/event_store/mod.rs
@@ -1,12 +1,14 @@
 use chrono::{DateTime, Utc};
 use harness_core::config::misc::OtelConfig;
 use harness_core::db::{pg_open_pool, PgStoreContext};
+use harness_core::run_id::RunId;
 use harness_core::types::{
     AutoFixReport, Decision, Event, EventFilters, EventId, ExternalSignal, ExternalSignalId, Grade,
     SessionId, Severity, Violation,
 };
 use sqlx::postgres::PgPool;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Mutex;
 
 mod legacy;
@@ -386,14 +388,15 @@ impl EventStore {
         };
         sqlx::query(
             "INSERT INTO events
-                (store_key, id, ts, session_id, hook, tool, decision, reason, detail, duration_ms, content, metadata)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                (store_key, id, ts, session_id, run_id, hook, tool, decision, reason, detail, duration_ms, content, metadata)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
              ON CONFLICT (store_key, id) DO NOTHING",
         )
         .bind(&self.store_key)
         .bind(event.id.as_str())
         .bind(&ts)
         .bind(event.session_id.as_str())
+        .bind(event.run_id.as_ref().map(RunId::as_str))
         .bind(&event.hook)
         .bind(&event.tool)
         .bind(decision)
@@ -423,13 +426,17 @@ impl EventStore {
             "NULL as content"
         };
         let mut sql = format!(
-            "SELECT id, ts, session_id, hook, tool, decision, reason, detail, duration_ms, {content_col}, metadata
+            "SELECT id, ts, session_id, run_id, hook, tool, decision, reason, detail, duration_ms, {content_col}, metadata
              FROM events WHERE store_key = $1",
         );
         let mut param_count = 1usize;
         if filters.session_id.is_some() {
             param_count += 1;
             sql.push_str(&format!(" AND session_id = ${param_count}"));
+        }
+        if filters.run_id.is_some() {
+            param_count += 1;
+            sql.push_str(&format!(" AND run_id = ${param_count}"));
         }
         if filters.hook.is_some() {
             param_count += 1;
@@ -463,6 +470,9 @@ impl EventStore {
         if let Some(ref sid) = filters.session_id {
             q = q.bind(sid.as_str());
         }
+        if let Some(ref run_id) = filters.run_id {
+            q = q.bind(run_id.as_str());
+        }
         if let Some(ref hook) = filters.hook {
             q = q.bind(hook.as_str());
         }
@@ -495,6 +505,7 @@ impl EventStore {
         let id: String = row.try_get("id")?;
         let ts_str: String = row.try_get("ts")?;
         let session_id: String = row.try_get("session_id")?;
+        let run_id: Option<String> = row.try_get("run_id")?;
         let hook: String = row.try_get("hook")?;
         let tool: String = row.try_get("tool")?;
         let decision_str: String = row.try_get("decision")?;
@@ -515,6 +526,7 @@ impl EventStore {
             id: EventId::from_str(&id),
             ts,
             session_id: SessionId::from_str(&session_id),
+            run_id: run_id.as_deref().map(RunId::from_str).transpose()?,
             hook,
             tool,
             decision,

--- a/crates/harness-observe/src/event_store/store_tests.rs
+++ b/crates/harness-observe/src/event_store/store_tests.rs
@@ -2,11 +2,13 @@ use super::*;
 use harness_core::{
     config::misc::OtelExporter,
     db::{pg_open_pool, resolve_database_url},
+    run_id::{RunId, AGENT_RUN_ID_ENV},
     types::{
         AutoFixAttempt, EventMetadata, RuleId, TaskId, TurnFailure, TurnFailureKind, TurnTelemetry,
     },
 };
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::OnceCell;
@@ -16,6 +18,7 @@ use tokio::sync::OnceCell;
 // shared external session budget for the whole workspace.
 static DB_SEMAPHORE: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
 static DB_AVAILABLE: OnceCell<bool> = OnceCell::const_new();
+static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn db_semaphore() -> Arc<tokio::sync::Semaphore> {
     DB_SEMAPHORE
@@ -97,6 +100,37 @@ async fn open_test_store(data_dir: &Path) -> anyhow::Result<Option<TestStore>> {
 
 fn make_event(hook: &str, decision: Decision) -> Event {
     Event::new(SessionId::new(), hook, "Edit", decision)
+}
+
+#[test]
+fn run_id_event_new_stamps_valid_env_value() {
+    let _guard = ENV_MUTEX.lock().unwrap();
+    let original = std::env::var(AGENT_RUN_ID_ENV).ok();
+    let expected = "ar-01j1qb3c9r7v5m2k8x4tznq6wd";
+    unsafe { std::env::set_var(AGENT_RUN_ID_ENV, expected) };
+
+    let event = make_event("run_id_stamp", Decision::Pass);
+
+    assert_eq!(event.run_id.as_ref().map(RunId::as_str), Some(expected));
+    match original {
+        Some(value) => unsafe { std::env::set_var(AGENT_RUN_ID_ENV, value) },
+        None => unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) },
+    }
+}
+
+#[test]
+fn run_id_event_new_stays_none_when_env_absent() {
+    let _guard = ENV_MUTEX.lock().unwrap();
+    let original = std::env::var(AGENT_RUN_ID_ENV).ok();
+    unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) };
+
+    let event = make_event("run_id_absent", Decision::Pass);
+
+    assert!(event.run_id.is_none());
+    match original {
+        Some(value) => unsafe { std::env::set_var(AGENT_RUN_ID_ENV, value) },
+        None => unsafe { std::env::remove_var(AGENT_RUN_ID_ENV) },
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -331,6 +365,33 @@ async fn query_filters_by_session_id() -> anyhow::Result<()> {
         .await?;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].session_id, sid1);
+    store.close().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn run_id_query_filters_by_run_id() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some(store) = open_test_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let run_id = RunId::from_str("ar-01j1qb3c9r7v5m2k8x4tznq6wd")?;
+    let mut matching = make_event("run_id_query", Decision::Pass);
+    matching.run_id = Some(run_id.clone());
+    let mut other = make_event("run_id_query", Decision::Pass);
+    other.run_id = Some(RunId::from_str("ar-01j1qb3c9r7v5m2k8x4tznq6we")?);
+    store.log(&matching).await?;
+    store.log(&other).await?;
+
+    let results = store
+        .query(&EventFilters {
+            run_id: Some(run_id.clone()),
+            ..Default::default()
+        })
+        .await?;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].run_id, Some(run_id));
     store.close().await;
     Ok(())
 }

--- a/crates/harness-server/src/task_executor/helpers/streaming.rs
+++ b/crates/harness-server/src/task_executor/helpers/streaming.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, Utc};
 use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
 use harness_core::error::HarnessError;
 use harness_core::prompts;
+use harness_core::run_id::{RunId, RunIdentity};
 use harness_core::types::{
     Decision, Event, EventMetadata, ExecutionPhase, Item, SessionId, TokenUsage, TurnFailure,
     TurnTelemetry,
@@ -62,6 +63,7 @@ mod tests {
             Some("gpt-5"),
             "/repo",
             &usage,
+            None,
         )
         .ok_or_else(|| anyhow::anyhow!("missing llm_usage event"))?;
         assert_eq!(event.hook, "llm_usage");
@@ -96,6 +98,7 @@ mod tests {
             None,
             "/repo",
             &TokenUsage::default(),
+            None,
         );
         assert!(event.is_none());
     }
@@ -112,6 +115,7 @@ mod tests {
             "/repo",
             "hello world",
             2,
+            None,
         );
 
         assert_eq!(event.hook, "llm_prompt_input");
@@ -132,6 +136,44 @@ mod tests {
         assert_eq!(payload["prompt_bytes"], 11);
         assert_eq!(payload["context_items"], 2);
 
+        Ok(())
+    }
+
+    #[test]
+    fn telemetry_events_include_explicit_run_id() -> anyhow::Result<()> {
+        let task_id = TaskId::from_str("run-id-telemetry");
+        let run_id: RunId = "ar-01j1qb3c9r7v5m2k8x4tznq6wd".parse()?;
+
+        let prompt_event = build_prompt_input_event(
+            &task_id,
+            1,
+            "execution",
+            "codex",
+            None,
+            "/repo",
+            "prompt",
+            0,
+            Some(run_id.clone()),
+        );
+        let usage_event = build_llm_usage_event(
+            &task_id,
+            1,
+            "execution",
+            "codex",
+            None,
+            "/repo",
+            &TokenUsage {
+                input_tokens: 1,
+                output_tokens: 1,
+                total_tokens: 2,
+                cost_usd: 0.0,
+            },
+            Some(run_id.clone()),
+        )
+        .ok_or_else(|| anyhow::anyhow!("missing llm_usage event"))?;
+
+        assert_eq!(prompt_event.run_id, Some(run_id.clone()));
+        assert_eq!(usage_event.run_id, Some(run_id));
         Ok(())
     }
 
@@ -242,8 +284,10 @@ async fn log_llm_usage_event(
     model: Option<&str>,
     project: &str,
     usage: &TokenUsage,
+    run_id: Option<RunId>,
 ) {
-    let Some(event) = build_llm_usage_event(task_id, turn, phase, agent, model, project, usage)
+    let Some(event) =
+        build_llm_usage_event(task_id, turn, phase, agent, model, project, usage, run_id)
     else {
         return;
     };
@@ -268,6 +312,7 @@ async fn log_prompt_input_event(
     project: &str,
     prompt: &str,
     context_items: usize,
+    run_id: Option<RunId>,
 ) {
     let event = build_prompt_input_event(
         task_id,
@@ -278,6 +323,7 @@ async fn log_prompt_input_event(
         project,
         prompt,
         context_items,
+        run_id,
     );
     log_usage_event_with_timeout(
         task_id,
@@ -298,6 +344,7 @@ fn build_prompt_input_event(
     project: &str,
     prompt: &str,
     context_items: usize,
+    run_id: Option<RunId>,
 ) -> Event {
     let reported_at = Utc::now();
     let prompt_chars = prompt.chars().count();
@@ -320,6 +367,7 @@ fn build_prompt_input_event(
         agent,
         Decision::Complete,
     );
+    event.run_id = run_id;
     event.ts = reported_at;
     event.detail = Some(format!(
         "task_id={} project={} model={} prompt_chars={} prompt_bytes={}",
@@ -348,6 +396,7 @@ fn build_llm_usage_event(
     model: Option<&str>,
     project: &str,
     usage: &TokenUsage,
+    run_id: Option<RunId>,
 ) -> Option<Event> {
     if usage.input_tokens == 0 && usage.output_tokens == 0 && usage.total_tokens == 0 {
         return None;
@@ -367,6 +416,7 @@ fn build_llm_usage_event(
         "reported_total_tokens": usage_metrics.reported_total_tokens,
     });
     let mut event = Event::new(SessionId::new(), "llm_usage", agent, Decision::Complete);
+    event.run_id = run_id;
     event.ts = reported_at;
     event.detail = Some(format!(
         "task_id={} project={} model={} tokens={}",
@@ -453,7 +503,7 @@ pub(crate) async fn run_agent_streaming(
 
 pub(crate) async fn run_agent_streaming_with_options(
     agent: &dyn CodeAgent,
-    req: AgentRequest,
+    mut req: AgentRequest,
     task_id: &TaskId,
     store: &TaskStore,
     turn: u32,
@@ -469,6 +519,16 @@ pub(crate) async fn run_agent_streaming_with_options(
     let project = usage_project_label(task_project_root.as_deref(), &req.project_root);
     let is_prompt_only = is_prompt_only_task(store, task_id);
     let phase_str = execution_phase_label(req.execution_phase);
+    let run_id = match RunIdentity::ensure_env_vars(&mut req.env_vars) {
+        Ok(identity) => Some(identity.run_id),
+        Err(error) => {
+            tracing::error!(
+                task_id = %task_id,
+                "invalid agent run identity environment; telemetry events will not include run_id: {error}"
+            );
+            None
+        }
+    };
     if !is_prompt_only {
         let redacted_prompt = crate::redact::redact_secrets(&req.prompt, &req.env_vars);
         if let Err(e) = store
@@ -490,6 +550,7 @@ pub(crate) async fn run_agent_streaming_with_options(
                 &project,
                 &req.prompt,
                 req.context.len(),
+                run_id.clone(),
             )
             .await;
         }
@@ -618,6 +679,7 @@ pub(crate) async fn run_agent_streaming_with_options(
             requested_model.as_deref(),
             &project,
             &token_usage,
+            run_id,
         )
         .await;
     }

--- a/docs/run-identity.md
+++ b/docs/run-identity.md
@@ -1,0 +1,87 @@
+# Agent Run Identity
+
+Harness assigns one local run id to each agent process it starts so observability tools can join Harness events, native CLI sessions, cost rows, and memory provenance without a daemon or network service.
+
+## Environment Contract
+
+Harness exports these variables before spawning Claude Code or Codex:
+
+| Variable | Meaning |
+| --- | --- |
+| `AGENT_RUN_ID` | The run id for this agent process and its children. |
+| `AGENT_RUN_PARENT` | The inherited parent run id when a tool intentionally starts a nested run. |
+
+Run ids use this format:
+
+```text
+ar-<lowercase-ulid>
+```
+
+Example:
+
+```text
+ar-01j1qb3c9r7v5m2k8x4tznq6wd
+```
+
+Minters must only mint when `AGENT_RUN_ID` is absent. If a nested minter intentionally starts a new run, it moves the inherited `AGENT_RUN_ID` value to `AGENT_RUN_PARENT` and exports a freshly minted `AGENT_RUN_ID`.
+
+The variable names intentionally avoid the `CLAUDE` prefix so they survive Harness adapter sanitization for nested Claude Code detection.
+
+## Binding Registry
+
+Bindings are append-only JSONL records at:
+
+```text
+${XDG_STATE_HOME:-~/.local/state}/agent-run/bindings.jsonl
+```
+
+Each line maps a Harness run id to a native CLI session identity:
+
+```json
+{"v":1,"run_id":"ar-01j1qb3c9r7v5m2k8x4tznq6wd","parent":null,"native":{"kind":"claude-code","id":"<session-uuid>"},"pid":12345,"cwd":"/path/to/project","started_at":"2026-07-03T10:00:00Z","source":"claude-hook"}
+```
+
+Fields:
+
+| Field | Meaning |
+| --- | --- |
+| `v` | Registry record version. Current value is `1`. |
+| `run_id` | Harness agent run id. |
+| `parent` | Parent run id for nested runs, otherwise `null`. |
+| `native.kind` | Native adapter or CLI kind, such as `claude-code` or `codex`. |
+| `native.id` | Native session id. Harness adapter provisional records use an empty string until a CLI-side hook writes the authoritative binding. |
+| `pid` | Process id of the spawned CLI process. |
+| `cwd` | Working directory for the agent process. |
+| `started_at` | RFC 3339 timestamp. |
+| `source` | Writer name, such as `harness-adapter`, `claude-hook`, or `codex-hook`. |
+
+Writers open the file with append mode and write one JSON line per record. Readers skip malformed lines and take the latest record for each `(run_id, native.id)` pair by `started_at`.
+
+When `bindings.jsonl` reaches 10 MB, the writer rotates it to `bindings.1.jsonl` and starts a new current file. Readers consult the current file and one rotated file.
+
+Registry write failures are logged as errors and must not block agent execution.
+
+## Claude Code SessionStart Hook
+
+Claude Code `SessionStart` hooks inherit `AGENT_RUN_ID`, so they can write the authoritative binding with the native `session_id`.
+
+Reference hook:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 - <<'PY'\nimport json, os, pathlib, sys\nfrom datetime import datetime, timezone\n\nrun_id = os.environ.get('AGENT_RUN_ID')\nif not run_id:\n    sys.exit(0)\n\ntry:\n    payload = json.load(sys.stdin)\n    session_id = payload.get('session_id') or payload.get('sessionId') or ''\n    pid = payload.get('pid') or payload.get('process_id') or os.getppid()\n    state_home = pathlib.Path(os.environ.get('XDG_STATE_HOME') or pathlib.Path.home() / '.local' / 'state')\n    path = state_home / 'agent-run' / 'bindings.jsonl'\n    path.parent.mkdir(parents=True, exist_ok=True)\n    record = {\n        'v': 1,\n        'run_id': run_id,\n        'parent': os.environ.get('AGENT_RUN_PARENT'),\n        'native': {'kind': 'claude-code', 'id': session_id},\n        'pid': pid,\n        'cwd': os.getcwd(),\n        'started_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),\n        'source': 'claude-hook',\n    }\n    with path.open('a', encoding='utf-8') as fh:\n        fh.write(json.dumps(record, separators=(',', ':')) + '\\n')\nexcept Exception as exc:\n    print(f'agent run binding hook failed: {exc}', file=sys.stderr)\nPY"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Bare terminal runs that do not have `AGENT_RUN_ID` skip the hook body and keep current behavior.


### PR DESCRIPTION
Implements the merged `specs/session-identity/` packet from PR #1425.

Summary:
- Add `RunId` and run identity env helpers in `harness-core`.
- Add append-only agent-run binding registry with rotation and tolerant reads.
- Export `AGENT_RUN_ID` from Claude/Codex spawn paths and write provisional adapter bindings.
- Add nullable `run_id` to observe events/query and stamp task telemetry with the request run id.
- Document the env contract, registry format, and fail-open Claude Code SessionStart hook.

Verification:
- `cargo test -p harness-core run_id`
- `cargo test -p harness-core registry`
- `cargo test -p harness-agents run_id`
- `cargo test -p harness-observe run_id`
- `cargo test -p harness-server telemetry_events_include_explicit_run_id`
- `cargo check --workspace --all-targets`
- `git diff --check`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

Known local test environment blocker:
- Full `cargo test` was attempted. It failed only in 13 `harness-core::db` tests because the configured local Postgres bootstrap pool timed out while opening a connection; the same DB group also failed with `--test-threads=1`. No run-identity focused tests failed.

Refs #1425

Linked work: #1425 (merged spec PR)
