### PR TITLE
spec: failure-storm circuit breaker for runtime dispatch (GH-1430)

### DIFF
--- a/specs/GH1430/product.md
+++ b/specs/GH1430/product.md
@@ -1,0 +1,68 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1430
+
+## 用户问题
+
+失败风暴复盘（66,971 runtime jobs，failed=37,694，2026-07-03 快照；数据底稿
+better/reports/harness-failure-taxonomy.md）：68% 的失败集中在 3 个风暴日
+（06-06 / 06-09 / 06-10，当日失败率 96–99%）；单一错误类
+`codex exited with exit status: 1: stderr=[Reading additional input` 独占
+20,170 条（53.5%），其中 95% 落在 4 个风暴日，07-02 又复发 320 条。
+
+根因模式：agent CLI 在配额耗尽或等待交互输入时立即 exit 1，而派发循环没有
+跨 tick 的失败记忆，把整个 backlog 持续派进同一个已死的 runtime——06-09 当天
+7,806 失败 vs 62 成功，token 照烧、产出接近零。
+
+## 目标
+
+1. 失败在源头分类：agent 退出类失败带稳定的 `failure_class` 落库，不再只有
+   一个不透明的 `agent execution failed` 字符串。
+2. 派发路径熔断：同一 runtime profile 连续 N 个同类失败 → 暂停该 profile 的
+   派发一个冷却期，发 error 级事件，`harness status` 可见熔断状态。
+3. 冷却后半开探测：探测成功关闸恢复，失败则带退避重新打开。
+
+## 非目标
+
+- 不重设计现有重试语义。
+- envelope/结构化输出强制化（另开 issue）。
+- WorktreeCollision 调度修复（另开 issue）。
+- 跨 profile / 跨 repo 的联动熔断（v1 只做 per-profile）。
+
+## Behavior Invariants
+
+1. 熔断只暂停"派发新 job"，不杀正在运行的 job，不改已落库 job 的状态。
+2. 熔断触发必须是 error 级事件（U-29：造成用户可见产出缺失的降级不允许
+   warning+继续）；事件里带 profile、触发类、连续失败数、冷却截止时间。
+3. 熔断器状态机：closed → (N 个连续同类失败) → open → (冷却到期) →
+   half-open → 探测成功 → closed；探测失败 → open（冷却时间×退避系数）。
+4. 计数按 (runtime_profile, failure_class) 维度；任一成功 job 将该 profile
+   的连续计数清零。
+5. 手动恢复入口存在（复位指定 profile 的熔断器），且复位动作本身留事件。
+6. 分类失败（无法识别的错误串）归入 `unclassified`，unclassified 也参与熔断
+   计数——不能因为"不认识这个错误"就放它刷穿队列。
+7. 默认阈值与冷却时间可配置且有文档；关闭熔断必须是显式配置项，默认开启。
+
+## 验收标准
+
+- [ ] runtime_jobs 上可见 failure_class；`harness status --json` 暴露熔断状态。
+- [ ] 默认阈值：同 profile 连续 5 个同类失败触发；冷却默认 10 分钟，退避×2，
+      上限 2 小时（数值允许 spec 评审时校准）。
+- [ ] 单测覆盖：触发、冷却、半开恢复、半开再失败退避、成功清零计数。
+- [ ] 风暴回放测试：以 06-09 的失败序列形状（同类失败连续到达）作 seed，
+      断言第 5 个失败后停止派发——历史上 7,806 次派发在此机制下应缩为个位数
+      加每冷却期一次探测。
+- [ ] config/default.toml.example 记录全部新配置键。
+- [ ] `cargo test --workspace` 绿（需要 DB 的测试按仓库现有惯例跑）。
+
+## 边界情况
+
+- 服务重启：熔断器状态可以丢（内存态可接受，v1 不要求持久化），但重启后
+  风暴若仍在，会在 N 个失败内重新触发——可接受。
+- 多 worker 并发 tick：计数器需要并发安全；v1 允许最坏情况下多派发少量 job
+  （计数近似即可），不追求严格一致。
+- 失败类交错（A,B,A,B…）：按类分别计数，都到不了 N 则不触发——这是设计内
+  行为；若真实风暴呈交错形态，靠"同 profile 总失败率"扩展再议（非目标）。
+- half-open 探测 job 的选取：取队首下一个自然 job，不构造合成 job。

--- a/specs/GH1430/tasks.md
+++ b/specs/GH1430/tasks.md
@@ -1,0 +1,24 @@
+# GH1430 Tasks
+
+Issue: `#1430`
+Product spec: `specs/GH1430/product.md`
+Tech spec: `specs/GH1430/tech.md`
+
+## Status
+
+- [ ] `SP1430-T001` Owner: `runtime-worker` | Done when: `classify_agent_failure` pure function exists with the regex table from tech.md,每类带取自生产数据的 fixture 串正例 + unclassified 兜底负例 | Verify: `cargo test --package harness-server classify`
+- [ ] `SP1430-T002` Owner: `runtime-worker` | Done when: executor 在失败落库时把 `failure_class` 写入 runtime_jobs 的 `data` jsonb，成功路径不写 | Verify: `cargo test --package harness-server workflow_runtime_worker`
+- [ ] `SP1430-T003` Owner: `runtime-worker` | Done when: `circuit_breaker.rs` 状态机（Closed/Open/HalfOpen）实现按 (profile, class) 连续计数、成功清零、冷却退避（×2 至上限），全部转移有单测 | Verify: `cargo test --package harness-server circuit_breaker`
+- [ ] `SP1430-T004` Owner: `runtime-worker` | Done when: worker tick 派发前调用 `allow(profile)`，Open 未到期跳过该 profile 并顺延 `not_before`；in-flight job 不受影响；结果落库后调用 record_success/record_failure | Verify: `cargo test --package harness-server workflow_runtime_worker`
+- [ ] `SP1430-T005` Owner: `observe` | Done when: 熔断触发/关闭/复位均发 error 级（触发）与 info 级（恢复）事件，字段含 profile、class、consecutive、cooldown_until | Verify: `cargo test --package harness-server`
+- [ ] `SP1430-T006` Owner: `config` | Done when: `[workflow.circuit_breaker]`（enabled/consecutive_failures/cooldown_secs/backoff_factor/max_cooldown_secs）解析、默认开启、default.toml.example 记录 | Verify: `cargo test --package harness-core config`
+- [ ] `SP1430-T007` Owner: `server-api` | Done when: status 聚合 JSON 增加 `circuit_breakers` 数组，CLI text 输出在存在非 Closed 熔断器时显示一行 | Verify: `cargo test --package harness-server && ./target/release/harness status --json`
+- [ ] `SP1430-T008` Owner: `server-api` | Done when: 手动复位入口（JSON-RPC method 或 `harness runtime breaker reset <profile>`）存在且复位留事件 | Verify: `cargo test --package harness-server`
+- [ ] `SP1430-T009` Owner: `tests` | Done when: 风暴回放集成测试以 06-09 序列形状（同类失败连续到达）seed，断言第 5 个失败后该 profile 停止派发，冷却期内仅 half-open 探测放行 | Verify: `cargo test --package harness-server storm_replay`
+- [ ] `SP1430-T010` Owner: `tests` | Done when: 全 workspace 测试通过 | Verify: `cargo test --workspace`
+
+## Parallelization
+
+- Lane A (T001, T002): 失败分类与落库。
+- Lane B (T003, T005, T006): 状态机、事件、配置（不依赖 Lane A）。
+- Lane C (T004, T007, T008, T009): 接入派发路径与暴露面（依赖 A+B）。

--- a/specs/GH1430/tech.md
+++ b/specs/GH1430/tech.md
@@ -1,0 +1,120 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1430
+
+## Product Spec
+
+`specs/GH1430/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| 派发 tick | `crates/harness-server/src/workflow_runtime_worker.rs` | `run_runtime_job_worker_tick` 每 tick 取 job 执行；`WorkerTickStats` 只统计当前 tick，无跨 tick 记忆 | 熔断检查点与计数更新点 |
+| job 执行 | `crates/harness-server/src/workflow_runtime_worker/executor.rs` | 运行 agent、落 job 状态 | 失败分类的采集点（拿到原始错误串的地方） |
+| 错误类型 | `crates/harness-core/src/error.rs:38` | `agent execution failed: {0}` 单一包装 | 需要附带 `failure_class` |
+| job 存储 | `workflow_runtime.runtime_jobs`（Postgres），`data` jsonb 已有 `error` 字段 | status + 不透明 error 串 | `failure_class` 写入 `data`，不加列、不迁移 schema |
+| 状态展示 | `harness status`（CLI）+ `/api/workflows/runtime/*` | 已聚合 job 状态计数 | 暴露熔断器状态 |
+| 配置 | `crates/harness-core/src/config/`、`config/default.toml.example` | workflow 配置已有先例（本地 feat 分支正在改 `config/workflow.rs`） | 新增 breaker 配置节 |
+| 事件 | `harness-observe`（events/OTLP） | 已有事件管线 | error 级熔断事件从这里发 |
+
+## Proposed Design
+
+新模块 `crates/harness-server/src/workflow_runtime_worker/circuit_breaker.rs`：
+
+```rust
+pub struct BreakerRegistry {                 // 服务级单例，Mutex<HashMap>
+    per_profile: HashMap<ProfileKey, BreakerState>,
+    config: BreakerConfig,
+}
+enum BreakerState {
+    Closed { consecutive: HashMap<FailureClass, u32> },
+    Open   { class: FailureClass, until: Instant, backoff_exp: u32 },
+    HalfOpen { class: FailureClass, backoff_exp: u32 },
+}
+```
+
+**失败分类（executor 侧）**：纯函数 `classify_agent_failure(&err_str) -> FailureClass`，
+regex 表映射（顺序匹配，首中即止）：
+
+| class | 匹配 |
+| --- | --- |
+| `quota-interactive-wait` | `Reading additional input`、`hit your (usage )?limit` |
+| `cli-missing-file` | `No such file or directory` |
+| `worktree-collision` | `WorktreeCollision` |
+| `structured-output-missing` | `no harness-activity-result` |
+| `sandbox-permission` | `sandbox|permission denied` |
+| `unclassified` | 其余 |
+
+class 写入 job `data.failure_class`（jsonb，无 schema 迁移）。
+
+**熔断检查（worker tick 侧）**：
+- 派发前：`registry.allow(profile)` — Open 且未到期 → 跳过该 profile 的 job
+  （保留在队列，`not_before` 顺延冷却期，避免空转热循环）；Open 到期 →
+  转 HalfOpen，放行恰好 1 个 job。
+- 落结果后：成功 → `record_success(profile)`（Closed 清零计数；HalfOpen →
+  Closed + 关闸事件）；失败 → `record_failure(profile, class)`（Closed 计数
+  +1，达阈值 → Open + error 事件；HalfOpen → Open，`backoff_exp+1`）。
+
+**配置**（`[workflow.circuit_breaker]`）：
+`enabled = true`、`consecutive_failures = 5`、`cooldown_secs = 600`、
+`backoff_factor = 2.0`、`max_cooldown_secs = 7200`。
+
+**状态暴露**：status 聚合响应加 `circuit_breakers: [{profile, state, class,
+consecutive, cooldown_until}]`；CLI text 输出加一行（仅在有非 Closed 时显示）。
+
+**并发**：registry 用 `parking_lot::Mutex`（或 tokio Mutex，按仓库惯例）；
+计数近似一致即可（product 边界情况 2）。内存态，不持久化（边界情况 1）。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 只停派发不杀运行中 job | worker tick 的 allow 检查位置 | 单测：open 状态下 in-flight job 正常落库 |
+| P2 error 级事件 | observe 事件发射 | 单测断言事件级别与字段 |
+| P3 状态机 | circuit_breaker.rs | 状态机单测（触发/冷却/半开/退避） |
+| P4 按 (profile, class) 计数、成功清零 | record_* | 单测：交错失败不触发；成功清零 |
+| P5 手动复位 + 事件 | JSON-RPC method 或 CLI 子命令 `harness runtime breaker reset <profile>` | 单测 + 手动验证 |
+| P6 unclassified 参与计数 | classify + record | 单测：未知错误串连续 5 个也触发 |
+| P7 默认开启、可配置 | config | 配置解析单测 |
+| 风暴回放 | 集成测试 | seed 06-09 序列形状，断言第 5 个失败后停止派发 |
+
+## Data Flow
+
+executor 失败 → classify → job.data.failure_class 落库 → registry.record_failure
+→ (达阈) Open + error 事件 → 下个 tick allow() 拦截该 profile → 冷却到期
+half-open 放行 1 个 → 结果决定 Closed/re-Open。无新外部依赖、无 schema 迁移。
+
+## Alternatives Considered
+
+- **持久化熔断状态到 DB**：拒绝（v1）——重启后风暴仍在会在 N 个失败内重新
+  触发，内存态足够；持久化增加迁移与一致性成本。
+- **全局（跨 profile）熔断**：拒绝——一个 profile 的配额风暴不应停掉其他
+  runtime 的正常工作。
+- **在 retry 层做（改重试策略）**：拒绝——风暴不是"该不该重试单个 job"的
+  问题，是"该不该继续向死 runtime 派发新 job"的问题，层级不同。
+- **失败率滑动窗口代替连续计数**：v1 用连续计数（更简单、可解释）；窗口版
+  作为后续演进，接口上 `record_*` 已可替换实现。
+
+## Risks
+
+- Security: 无新外部面；复位命令走既有 JSON-RPC 鉴权路径。
+- Compatibility: status JSON 加字段为 additive；jobs `data` 加 key 无迁移。
+- Performance: 每次派发一次 HashMap 查找 + Mutex，可忽略。
+- Maintenance: regex 分类表与真实错误串会漂移——每类必须带取自生产数据的
+  fixture 串做单测锚定；unclassified 兜底保证漂移不产生安全洞。
+
+## Test Plan
+
+- [ ] Unit tests: classify 表（每类正例 + unclassified）、状态机全转移、
+      并发 record 冒烟
+- [ ] Integration tests: 风暴回放（同类连续失败序列 → 第 5 个后派发停止）
+- [ ] Manual verification: 本地 serve，用假 profile 连发失败 job，观察
+      status 输出与事件
+
+## Rollback Plan
+
+`[workflow.circuit_breaker] enabled = false` 即完全旁路；代码回滚为 revert
+单 PR，无 schema 变更需要清理。


### PR DESCRIPTION
Spec packet (product/tech/tasks) for #1430.

Data basis: full runtime_jobs postmortem (66,971 jobs, failed=37,694) — 68% of failures on 3 storm days at 96–99% daily failure rate; one error class (codex exit 1, `Reading additional input`) = 53.5% of all failures, 95% of it inside 4 storm days, recurred 07-02.

Design: per-(runtime_profile, failure_class) consecutive-failure counter → Open with cooldown + error event → half-open probe → close/backoff. Failure classification persisted to runtime_jobs data jsonb, no schema migration. Config-gated, default on.

`python3 checks/check_workflow.py --repo . --spec-dir specs/GH1430` → SpecRail check passed.

Docs-only PR; implementation follows per tasks.md lanes.