### PR TITLE
feat: add context composer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "harness-context"
+version = "0.6.34"
+dependencies = [
+ "anyhow",
+ "harness-core",
+ "harness-gc",
+ "harness-rules",
+ "harness-skills",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "harness-core"
 version = "0.6.34"
 dependencies = [
@@ -1368,6 +1383,7 @@ version = "0.6.34"
 dependencies = [
  "anyhow",
  "chrono",
+ "harness-context",
  "harness-core",
  "serde",
  "serde_json",
@@ -1417,6 +1433,7 @@ dependencies = [
  "dashmap",
  "futures",
  "harness-agents",
+ "harness-context",
  "harness-core",
  "harness-eval",
  "harness-exec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,11 +1284,13 @@ version = "0.6.34"
 dependencies = [
  "anyhow",
  "harness-core",
+ "harness-exec",
  "harness-gc",
  "harness-rules",
  "harness-skills",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/harness-rules",
     "crates/harness-skills",
     "crates/harness-exec",
+    "crates/harness-context",
     "crates/harness-eval",
     "crates/harness-observe",
     "crates/harness-cli",
@@ -36,6 +37,7 @@ harness-gc = { path = "crates/harness-gc", version = "0.6.34" }
 harness-rules = { path = "crates/harness-rules", version = "0.6.34" }
 harness-skills = { path = "crates/harness-skills", version = "0.6.34" }
 harness-exec = { path = "crates/harness-exec", version = "0.6.34" }
+harness-context = { path = "crates/harness-context", version = "0.6.34" }
 harness-eval = { path = "crates/harness-eval", version = "0.6.34" }
 harness-observe = { path = "crates/harness-observe", version = "0.6.34" }
 harness-workflow = { path = "crates/harness-workflow", version = "0.6.34" }

--- a/config/default.toml.example
+++ b/config/default.toml.example
@@ -117,6 +117,20 @@ discovery_paths = []
 session_renewal_secs = 1800
 log_retention_days = 90
 
+[context]
+# Shadow mode records composition manifests without changing injected context.
+mode = "shadow"
+budget_tokens = 24000
+reserved_headroom = 0.20
+provider_timeout_ms = 2000
+
+[context.quotas]
+rule = 0.30
+skill = 0.25
+contract = 0.25
+brief = 0.15
+draft = 0.05
+
 [otel]
 environment = "development"
 exporter = "disabled"

--- a/crates/harness-context/Cargo.toml
+++ b/crates/harness-context/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "harness-context"
+version.workspace = true
+edition.workspace = true
+description = "Deterministic context composition for the Harness agent orchestration layer"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+harness-core = { workspace = true }
+harness-rules = { workspace = true }
+harness-skills = { workspace = true }
+harness-gc = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }

--- a/crates/harness-context/Cargo.toml
+++ b/crates/harness-context/Cargo.toml
@@ -11,8 +11,12 @@ harness-core = { workspace = true }
 harness-rules = { workspace = true }
 harness-skills = { workspace = true }
 harness-gc = { workspace = true }
+harness-exec = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/harness-context/src/composer.rs
+++ b/crates/harness-context/src/composer.rs
@@ -1,0 +1,641 @@
+use crate::{
+    BudgetManifest, BytesDivFourEstimator, ComposeConfig, ComposeError, ComposeManifest,
+    ComposeMode, ComposeRequest, Composition, ContextItem, ContextProvider, ContextQuotas,
+    Degraded, Estimator, ItemClass, ManifestDecision, ManifestItem, Priority, ProviderError,
+    ProviderId, Tokens,
+};
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+#[derive(Clone)]
+struct Proposal {
+    provider_id: ProviderId,
+    item: ContextItem,
+    original_index: usize,
+}
+
+#[derive(Clone)]
+struct SelectedItem {
+    proposal: Proposal,
+    content: String,
+    tokens: Tokens,
+    level: Option<String>,
+    reason: Option<String>,
+    score: f32,
+}
+
+struct ManifestBuild {
+    total: Tokens,
+    effective: Tokens,
+    used: Tokens,
+    manifest_items: Vec<Option<ManifestItem>>,
+    provider_errors: Vec<ProviderError>,
+    warnings: Vec<String>,
+}
+
+pub struct ContextComposer {
+    config: ComposeConfig,
+    estimator: Box<dyn Estimator>,
+    providers: Vec<Arc<dyn ContextProvider>>,
+}
+
+impl ContextComposer {
+    pub fn new(config: ComposeConfig) -> Self {
+        Self {
+            config,
+            estimator: Box::new(BytesDivFourEstimator),
+            providers: Vec::new(),
+        }
+    }
+
+    pub fn with_estimator(mut self, estimator: Box<dyn Estimator>) -> Self {
+        self.estimator = estimator;
+        self
+    }
+
+    pub fn with_provider(mut self, provider: Box<dyn ContextProvider>) -> Self {
+        self.providers.push(Arc::from(provider));
+        self
+    }
+
+    pub fn compose(&self, req: &ComposeRequest) -> Result<Composition, ComposeError> {
+        self.compose_supplied(req, Vec::new())
+    }
+
+    pub fn compose_supplied(
+        &self,
+        req: &ComposeRequest,
+        supplied_items: Vec<ContextItem>,
+    ) -> Result<Composition, ComposeError> {
+        let mut proposals = Vec::new();
+        let mut provider_errors = Vec::new();
+        let mut original_index = 0usize;
+
+        for provider in &self.providers {
+            let provider_id = provider.id();
+            match self.propose_with_timeout(provider.clone(), provider_id.clone(), req) {
+                Ok(items) => {
+                    for item in items {
+                        proposals.push(self.normalize_proposal(
+                            provider_id.clone(),
+                            item,
+                            original_index,
+                        ));
+                        original_index += 1;
+                    }
+                }
+                Err(mut error) => {
+                    if error.provider_id.as_str().is_empty() {
+                        error.provider_id = provider_id;
+                    }
+                    tracing::error!(
+                        provider_id = %error.provider_id,
+                        error = %error.message,
+                        "context provider failed"
+                    );
+                    provider_errors.push(error);
+                }
+            }
+        }
+
+        if !supplied_items.is_empty() {
+            let provider_id = ProviderId::new("supplied");
+            for item in supplied_items {
+                proposals.push(self.normalize_proposal(provider_id.clone(), item, original_index));
+                original_index += 1;
+            }
+        }
+
+        self.compose_proposals(req, proposals, provider_errors)
+    }
+
+    fn propose_with_timeout(
+        &self,
+        provider: Arc<dyn ContextProvider>,
+        provider_id: ProviderId,
+        req: &ComposeRequest,
+    ) -> Result<Vec<ContextItem>, ProviderError> {
+        let timeout = Duration::from_millis(self.config.provider_timeout_ms);
+        if timeout.is_zero() {
+            return provider.propose(req);
+        }
+
+        let req = req.clone();
+        let (tx, rx) = mpsc::channel();
+        let send_provider_id = provider_id.clone();
+        std::thread::spawn(move || {
+            let result = provider.propose(&req);
+            if tx.send(result).is_err() {
+                tracing::debug!(
+                    provider_id = %send_provider_id,
+                    "context provider result arrived after timeout"
+                );
+            }
+        });
+
+        match rx.recv_timeout(timeout) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(ProviderError::new(
+                provider_id.as_str(),
+                format!(
+                    "provider timed out after {} ms",
+                    self.config.provider_timeout_ms
+                ),
+            )),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(ProviderError::new(
+                provider_id.as_str(),
+                "provider worker exited before returning context proposals",
+            )),
+        }
+    }
+
+    fn normalize_proposal(
+        &self,
+        provider_id: ProviderId,
+        mut item: ContextItem,
+        original_index: usize,
+    ) -> Proposal {
+        item.est_tokens = self.estimator.estimate(&item.content);
+        Proposal {
+            provider_id,
+            item,
+            original_index,
+        }
+    }
+
+    fn compose_proposals(
+        &self,
+        req: &ComposeRequest,
+        proposals: Vec<Proposal>,
+        provider_errors: Vec<ProviderError>,
+    ) -> Result<Composition, ComposeError> {
+        let total_budget = if req.budget_hint == 0 {
+            self.config.budget_tokens
+        } else {
+            req.budget_hint
+        };
+        let reserved_headroom = self.config.reserved_headroom.clamp(0.0, 0.95);
+        let effective_budget =
+            ((total_budget as f32) * (1.0 - reserved_headroom)).floor() as Tokens;
+        let mut manifest_items: Vec<Option<ManifestItem>> = vec![None; proposals.len()];
+
+        let mut warnings = Vec::new();
+        let proposed_instruction_count = proposals
+            .iter()
+            .filter(|proposal| proposal.item.instruction_bearing)
+            .count();
+        if proposed_instruction_count > 15 {
+            warnings.push(format!("constraint_overload:{proposed_instruction_count}"));
+        }
+
+        let survivor_indexes = dedupe(&proposals, &mut manifest_items, self.estimator.as_ref());
+        let mut survivors = survivor_indexes
+            .into_iter()
+            .map(|idx| proposals[idx].clone())
+            .collect::<Vec<_>>();
+        survivors.sort_by(compare_selection_order);
+
+        let mut selected = Vec::new();
+        let mut used: Tokens = 0;
+        let mut p0_total: Tokens = 0;
+        for proposal in survivors
+            .iter()
+            .filter(|proposal| proposal.item.priority == Priority::P0)
+        {
+            p0_total = p0_total.saturating_add(proposal.item.est_tokens);
+        }
+
+        if p0_total > effective_budget {
+            for proposal in survivors {
+                if proposal.item.priority == Priority::P0 {
+                    manifest_items[proposal.original_index] = Some(excluded_manifest_item(
+                        &proposal,
+                        proposal.item.est_tokens,
+                        "mandatory_overflow",
+                    ));
+                } else {
+                    manifest_items[proposal.original_index] = Some(excluded_manifest_item(
+                        &proposal,
+                        proposal.item.est_tokens,
+                        "blocked_by_mandatory_overflow",
+                    ));
+                }
+            }
+            let manifest = build_manifest(
+                req,
+                self.config.mode,
+                ManifestBuild {
+                    total: total_budget,
+                    effective: effective_budget,
+                    used: 0,
+                    manifest_items,
+                    provider_errors,
+                    warnings,
+                },
+            );
+            return Err(ComposeError::MandatoryOverflow {
+                mandatory: p0_total,
+                effective: effective_budget,
+                manifest: Box::new(manifest),
+            });
+        }
+
+        let mut remaining = Vec::new();
+        for proposal in survivors {
+            if proposal.item.priority == Priority::P0 {
+                used = used.saturating_add(proposal.item.est_tokens);
+                selected.push(SelectedItem {
+                    score: score(&proposal, &self.config.quotas),
+                    tokens: proposal.item.est_tokens,
+                    content: proposal.item.content.clone(),
+                    level: None,
+                    reason: None,
+                    proposal,
+                });
+            } else {
+                remaining.push(proposal);
+            }
+        }
+
+        let quota_budget = effective_budget.saturating_sub(used);
+        let mut class_remaining = BTreeMap::new();
+        for class in [
+            ItemClass::Rule,
+            ItemClass::Skill,
+            ItemClass::Contract,
+            ItemClass::Brief,
+            ItemClass::Draft,
+        ] {
+            let class_budget =
+                ((quota_budget as f32) * self.config.quotas.for_class(class)).floor() as Tokens;
+            class_remaining.insert(class, class_budget);
+        }
+
+        let mut deferred = Vec::new();
+        for class in [
+            ItemClass::Rule,
+            ItemClass::Skill,
+            ItemClass::Contract,
+            ItemClass::Brief,
+            ItemClass::Draft,
+        ] {
+            let mut class_items = remaining
+                .iter()
+                .filter(|proposal| proposal.item.class == class)
+                .cloned()
+                .collect::<Vec<_>>();
+            class_items.sort_by(|left, right| compare_scored(left, right, &self.config.quotas));
+            for proposal in class_items {
+                let class_budget = class_remaining.entry(class).or_insert(0);
+                if let Some(choice) = choose_fit(
+                    &proposal,
+                    *class_budget,
+                    self.estimator.as_ref(),
+                    &self.config.quotas,
+                    "quota",
+                ) {
+                    *class_budget = class_budget.saturating_sub(choice.tokens);
+                    used = used.saturating_add(choice.tokens);
+                    selected.push(choice);
+                } else {
+                    deferred.push(proposal);
+                }
+            }
+        }
+
+        let mut global_remaining = effective_budget.saturating_sub(used);
+        for unused in class_remaining.values() {
+            global_remaining = global_remaining.saturating_add(*unused);
+        }
+        global_remaining = global_remaining.min(effective_budget.saturating_sub(used));
+        deferred.sort_by(|left, right| compare_scored(left, right, &self.config.quotas));
+        let mut excluded = Vec::new();
+        for proposal in deferred {
+            if let Some(choice) = choose_fit(
+                &proposal,
+                global_remaining,
+                self.estimator.as_ref(),
+                &self.config.quotas,
+                "redistribute",
+            ) {
+                global_remaining = global_remaining.saturating_sub(choice.tokens);
+                used = used.saturating_add(choice.tokens);
+                selected.push(choice);
+            } else {
+                excluded.push(proposal);
+            }
+        }
+
+        apply_constraint_guard(
+            &mut selected,
+            &mut used,
+            self.estimator.as_ref(),
+            &mut warnings,
+        );
+        selected.sort_by(compare_selected_render_order);
+
+        for item in &selected {
+            manifest_items[item.proposal.original_index] = Some(ManifestItem {
+                id: item.proposal.item.id.clone(),
+                provider_id: item.proposal.provider_id.clone(),
+                class: item.proposal.item.class,
+                decision: if item.level.is_some() {
+                    ManifestDecision::Degraded
+                } else {
+                    ManifestDecision::Included
+                },
+                tokens: item.tokens,
+                level: item.level.clone(),
+                reason: item.reason.clone(),
+            });
+        }
+        for proposal in excluded {
+            manifest_items[proposal.original_index] = Some(excluded_manifest_item(
+                &proposal,
+                proposal.item.est_tokens,
+                "budget",
+            ));
+        }
+
+        let rendered = render_context(&selected);
+        let manifest = build_manifest(
+            req,
+            self.config.mode,
+            ManifestBuild {
+                total: total_budget,
+                effective: effective_budget,
+                used,
+                manifest_items,
+                provider_errors,
+                warnings,
+            },
+        );
+        Ok(Composition { rendered, manifest })
+    }
+}
+
+fn build_manifest(
+    req: &ComposeRequest,
+    mode: ComposeMode,
+    input: ManifestBuild,
+) -> ComposeManifest {
+    let mut items = input
+        .manifest_items
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    items.sort_by(|left, right| {
+        left.id
+            .cmp(&right.id)
+            .then_with(|| left.provider_id.cmp(&right.provider_id))
+    });
+    ComposeManifest {
+        v: 1,
+        thread_id: req.thread_id.clone(),
+        run_id: req.run_id.clone(),
+        mode,
+        budget: BudgetManifest {
+            total: input.total,
+            effective: input.effective,
+            used: input.used,
+        },
+        items,
+        provider_errors: input.provider_errors,
+        warnings: input.warnings,
+    }
+}
+
+fn dedupe(
+    proposals: &[Proposal],
+    manifest_items: &mut [Option<ManifestItem>],
+    estimator: &dyn Estimator,
+) -> Vec<usize> {
+    let mut survivors_by_key: HashMap<String, usize> = HashMap::new();
+    let mut survivor_indexes = Vec::new();
+
+    for (idx, proposal) in proposals.iter().enumerate() {
+        let Some(key) = proposal.item.dedupe_key.clone() else {
+            survivor_indexes.push(idx);
+            continue;
+        };
+        match survivors_by_key.get(&key).copied() {
+            Some(existing_idx) => {
+                let existing = &proposals[existing_idx];
+                let winner = if compare_dedupe_survivor(proposal, existing) == Ordering::Less {
+                    idx
+                } else {
+                    existing_idx
+                };
+                let loser = if winner == idx { existing_idx } else { idx };
+                manifest_items[proposals[loser].original_index] = Some(excluded_manifest_item(
+                    &proposals[loser],
+                    estimator.estimate(&proposals[loser].item.content),
+                    "dedupe",
+                ));
+                if winner == idx {
+                    survivors_by_key.insert(key, idx);
+                    survivor_indexes.retain(|existing| *existing != existing_idx);
+                    survivor_indexes.push(idx);
+                }
+            }
+            None => {
+                survivors_by_key.insert(key, idx);
+                survivor_indexes.push(idx);
+            }
+        }
+    }
+
+    survivor_indexes
+}
+
+fn compare_dedupe_survivor(left: &Proposal, right: &Proposal) -> Ordering {
+    left.item
+        .priority
+        .rank()
+        .cmp(&right.item.priority.rank())
+        .then_with(|| {
+            provider_precedence(&left.provider_id).cmp(&provider_precedence(&right.provider_id))
+        })
+        .then_with(|| left.item.id.cmp(&right.item.id))
+}
+
+fn compare_selection_order(left: &Proposal, right: &Proposal) -> Ordering {
+    left.item
+        .priority
+        .rank()
+        .cmp(&right.item.priority.rank())
+        .then_with(|| compare_scored(left, right, &ContextQuotas::default()))
+}
+
+fn compare_scored(left: &Proposal, right: &Proposal, quotas: &ContextQuotas) -> Ordering {
+    let left_score = score(left, quotas);
+    let right_score = score(right, quotas);
+    right_score
+        .partial_cmp(&left_score)
+        .unwrap_or(Ordering::Equal)
+        .then_with(|| left.item.id.cmp(&right.item.id))
+}
+
+fn score(proposal: &Proposal, quotas: &ContextQuotas) -> f32 {
+    proposal.item.relevance.clamp(0.0, 1.0) * quotas.for_class(proposal.item.class)
+}
+
+fn choose_fit(
+    proposal: &Proposal,
+    available: Tokens,
+    estimator: &dyn Estimator,
+    quotas: &ContextQuotas,
+    reason: &str,
+) -> Option<SelectedItem> {
+    if proposal.item.est_tokens <= available {
+        return Some(SelectedItem {
+            proposal: proposal.clone(),
+            content: proposal.item.content.clone(),
+            tokens: proposal.item.est_tokens,
+            level: None,
+            reason: None,
+            score: score(proposal, quotas),
+        });
+    }
+    for degraded in &proposal.item.degrade {
+        let tokens = estimator.estimate(degraded.content());
+        if tokens <= available {
+            return Some(SelectedItem {
+                proposal: proposal.clone(),
+                content: degraded.content().to_string(),
+                tokens,
+                level: Some(degraded.level_name().to_string()),
+                reason: Some(reason.to_string()),
+                score: score(proposal, quotas),
+            });
+        }
+    }
+    None
+}
+
+fn apply_constraint_guard(
+    selected: &mut [SelectedItem],
+    used: &mut Tokens,
+    estimator: &dyn Estimator,
+    warnings: &mut Vec<String>,
+) {
+    let mut instruction_count = selected
+        .iter()
+        .filter(|item| item.proposal.item.instruction_bearing)
+        .count();
+    if instruction_count <= 15 {
+        return;
+    }
+    if !warnings
+        .iter()
+        .any(|warning| warning.starts_with("constraint_overload:"))
+    {
+        warnings.push(format!("constraint_overload:{instruction_count}"));
+    }
+
+    let mut indexes = selected
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| {
+            item.proposal.item.instruction_bearing && item.proposal.item.priority == Priority::P2
+        })
+        .map(|(idx, item)| (idx, item.score, item.proposal.item.id.clone()))
+        .collect::<Vec<_>>();
+    indexes.sort_by(|left, right| {
+        left.1
+            .partial_cmp(&right.1)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| right.2.cmp(&left.2))
+    });
+
+    for (idx, _, _) in indexes {
+        if instruction_count <= 15 {
+            break;
+        }
+        let Some(pointer) = selected[idx]
+            .proposal
+            .item
+            .degrade
+            .iter()
+            .find(|degraded| matches!(degraded, Degraded::Pointer(_)))
+        else {
+            continue;
+        };
+        let pointer_tokens = estimator.estimate(pointer.content());
+        if selected[idx].level.as_deref() == Some("pointer") {
+            continue;
+        }
+        if pointer_tokens > selected[idx].tokens {
+            continue;
+        }
+        *used = used
+            .saturating_sub(selected[idx].tokens)
+            .saturating_add(pointer_tokens);
+        selected[idx].content = pointer.content().to_string();
+        selected[idx].tokens = pointer_tokens;
+        selected[idx].level = Some("pointer".to_string());
+        selected[idx].reason = Some("constraint_overload".to_string());
+        instruction_count -= 1;
+    }
+}
+
+fn compare_selected_render_order(left: &SelectedItem, right: &SelectedItem) -> Ordering {
+    left.proposal
+        .item
+        .class
+        .render_order()
+        .cmp(&right.proposal.item.class.render_order())
+        .then_with(|| left.proposal.item.id.cmp(&right.proposal.item.id))
+}
+
+fn render_context(selected: &[SelectedItem]) -> String {
+    let mut rendered = String::from("# Harness Context\n");
+    let mut by_class: BTreeMap<u8, (ItemClass, Vec<&SelectedItem>)> = BTreeMap::new();
+    for item in selected {
+        by_class
+            .entry(item.proposal.item.class.render_order())
+            .or_insert_with(|| (item.proposal.item.class, Vec::new()))
+            .1
+            .push(item);
+    }
+    for (_, (class, items)) in by_class {
+        rendered.push('\n');
+        rendered.push_str("## ");
+        rendered.push_str(class.section_title());
+        rendered.push('\n');
+        for item in items {
+            rendered.push_str("\n<!-- ");
+            rendered.push_str(item.proposal.item.id.as_str());
+            rendered.push_str(" -->\n");
+            rendered.push_str(&item.content);
+            rendered.push('\n');
+        }
+    }
+    rendered
+}
+
+fn excluded_manifest_item(proposal: &Proposal, tokens: Tokens, reason: &str) -> ManifestItem {
+    ManifestItem {
+        id: proposal.item.id.clone(),
+        provider_id: proposal.provider_id.clone(),
+        class: proposal.item.class,
+        decision: ManifestDecision::Excluded,
+        tokens,
+        level: None,
+        reason: Some(reason.to_string()),
+    }
+}
+
+fn provider_precedence(provider_id: &ProviderId) -> u8 {
+    match provider_id.as_str() {
+        "rules" => 0,
+        "contract" => 1,
+        "skills" => 2,
+        "brief" => 3,
+        "gc-drafts" => 4,
+        "supplied" => 5,
+        _ => 6,
+    }
+}

--- a/crates/harness-context/src/lib.rs
+++ b/crates/harness-context/src/lib.rs
@@ -1,0 +1,10 @@
+mod composer;
+mod types;
+
+pub mod providers;
+
+pub use composer::ContextComposer;
+pub use types::*;
+
+#[cfg(test)]
+mod tests;

--- a/crates/harness-context/src/providers.rs
+++ b/crates/harness-context/src/providers.rs
@@ -2,7 +2,7 @@ use crate::{
     ComposeRequest, ContextItem, ContextProvider, Degraded, ItemClass, ItemId, Priority,
     ProviderError, ProviderId,
 };
-use harness_core::types::DraftStatus;
+use harness_core::types::{DraftStatus, ExecPlanStatus, ProjectId};
 use harness_rules::engine::Rule;
 use harness_skills::store::Skill;
 
@@ -128,6 +128,58 @@ impl ContextProvider for ContractProvider {
             dedupe_key: Some("contract:task".to_string()),
             instruction_bearing: true,
         }])
+    }
+}
+
+pub struct ExecPlanProvider {
+    plans: Vec<harness_exec::plan::ExecPlan>,
+}
+
+impl ExecPlanProvider {
+    pub fn new(plans: Vec<harness_exec::plan::ExecPlan>) -> Self {
+        Self { plans }
+    }
+}
+
+impl ContextProvider for ExecPlanProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("contract")
+    }
+
+    fn propose(&self, req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
+        let mut plans = self
+            .plans
+            .iter()
+            .filter(|plan| ProjectId::from_path(&plan.project_root) == req.project)
+            .filter(|plan| matches!(plan.status, ExecPlanStatus::Draft | ExecPlanStatus::Active))
+            .cloned()
+            .collect::<Vec<_>>();
+        plans.sort_by(|left, right| left.id.as_str().cmp(right.id.as_str()));
+
+        Ok(plans
+            .into_iter()
+            .map(|plan| {
+                let priority = if plan.status == ExecPlanStatus::Active {
+                    Priority::P0
+                } else {
+                    Priority::P1
+                };
+                ContextItem {
+                    id: ItemId::new(format!("contract:exec-plan:{}", plan.id)),
+                    class: ItemClass::Contract,
+                    content: plan.to_markdown(),
+                    est_tokens: 0,
+                    priority,
+                    relevance: if priority == Priority::P0 { 1.0 } else { 0.7 },
+                    degrade: vec![
+                        Degraded::Summary(format!("ExecPlan {}: {}", plan.id, plan.purpose)),
+                        Degraded::Pointer(format!("See ExecPlan {}", plan.id)),
+                    ],
+                    dedupe_key: Some(format!("contract:exec-plan:{}", plan.id)),
+                    instruction_bearing: true,
+                }
+            })
+            .collect())
     }
 }
 

--- a/crates/harness-context/src/providers.rs
+++ b/crates/harness-context/src/providers.rs
@@ -1,0 +1,252 @@
+use crate::{
+    ComposeRequest, ContextItem, ContextProvider, Degraded, ItemClass, ItemId, Priority,
+    ProviderError, ProviderId,
+};
+use harness_core::types::DraftStatus;
+use harness_rules::engine::Rule;
+use harness_skills::store::Skill;
+
+pub struct RulesProvider {
+    rules: Vec<Rule>,
+}
+
+impl RulesProvider {
+    pub fn new(rules: Vec<Rule>) -> Self {
+        Self { rules }
+    }
+}
+
+impl ContextProvider for RulesProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("rules")
+    }
+
+    fn propose(&self, _req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
+        let mut rules = self.rules.clone();
+        rules.sort_by(|left, right| left.id.as_str().cmp(right.id.as_str()));
+        Ok(rules
+            .into_iter()
+            .map(|rule| {
+                let content = format!("{}: {}\n\n{}", rule.id, rule.title, rule.description);
+                ContextItem {
+                    id: ItemId::new(format!("rule:{}", rule.id)),
+                    class: ItemClass::Rule,
+                    est_tokens: 0,
+                    priority: Priority::P1,
+                    relevance: 0.8,
+                    degrade: vec![
+                        Degraded::Summary(format!("{}: {}", rule.id, rule.title)),
+                        Degraded::Pointer(format!("See rule {}", rule.id)),
+                    ],
+                    dedupe_key: Some(format!("rule:{}", rule.id)),
+                    instruction_bearing: true,
+                    content,
+                }
+            })
+            .collect())
+    }
+}
+
+pub struct SkillsProvider {
+    skills: Vec<Skill>,
+}
+
+impl SkillsProvider {
+    pub fn new(skills: Vec<Skill>) -> Self {
+        Self { skills }
+    }
+}
+
+impl ContextProvider for SkillsProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("skills")
+    }
+
+    fn propose(&self, req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
+        let prompt = req
+            .task_profile
+            .prompt
+            .as_deref()
+            .unwrap_or_default()
+            .to_lowercase();
+        let mut skills = self
+            .skills
+            .iter()
+            .filter(|skill| {
+                skill.trigger_patterns.is_empty()
+                    || skill
+                        .trigger_patterns
+                        .iter()
+                        .any(|pattern| prompt.contains(&pattern.to_lowercase()))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        skills.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(skills
+            .into_iter()
+            .map(|skill| ContextItem {
+                id: ItemId::new(format!("skill:{}", skill.name)),
+                class: ItemClass::Skill,
+                content: skill.content,
+                est_tokens: 0,
+                priority: Priority::P1,
+                relevance: if skill.trigger_patterns.is_empty() {
+                    0.4
+                } else {
+                    0.75
+                },
+                degrade: vec![
+                    Degraded::Summary(skill.description.clone()),
+                    Degraded::Pointer(format!("Use skill {}", skill.name)),
+                ],
+                dedupe_key: Some(format!("skill:{}", skill.name)),
+                instruction_bearing: true,
+            })
+            .collect())
+    }
+}
+
+pub struct ContractProvider;
+
+impl ContextProvider for ContractProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("contract")
+    }
+
+    fn propose(&self, req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
+        let Some(contract) = req.task_profile.contract.as_ref() else {
+            return Ok(Vec::new());
+        };
+        Ok(vec![ContextItem {
+            id: ItemId::new("contract:task"),
+            class: ItemClass::Contract,
+            content: contract.clone(),
+            est_tokens: 0,
+            priority: Priority::P0,
+            relevance: 1.0,
+            degrade: vec![Degraded::Pointer("See task contract".to_string())],
+            dedupe_key: Some("contract:task".to_string()),
+            instruction_bearing: true,
+        }])
+    }
+}
+
+pub struct TaskBriefProvider;
+
+impl ContextProvider for TaskBriefProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("brief")
+    }
+
+    fn propose(&self, req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
+        let Some(prompt) = req.task_profile.prompt.as_ref() else {
+            return Ok(Vec::new());
+        };
+        Ok(vec![ContextItem {
+            id: ItemId::new("brief:task"),
+            class: ItemClass::Brief,
+            content: prompt.clone(),
+            est_tokens: 0,
+            priority: Priority::P0,
+            relevance: 1.0,
+            degrade: vec![Degraded::Pointer("See task brief".to_string())],
+            dedupe_key: Some("brief:task".to_string()),
+            instruction_bearing: false,
+        }])
+    }
+}
+
+pub struct GcDraftsProvider {
+    drafts: Vec<harness_core::types::Draft>,
+}
+
+impl GcDraftsProvider {
+    pub fn new(drafts: Vec<harness_core::types::Draft>) -> Self {
+        Self { drafts }
+    }
+}
+
+impl ContextProvider for GcDraftsProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("gc-drafts")
+    }
+
+    fn propose(&self, _req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
+        let mut drafts = self
+            .drafts
+            .iter()
+            .filter(|draft| draft.status == DraftStatus::Pending)
+            .cloned()
+            .collect::<Vec<_>>();
+        drafts.sort_by(|left, right| left.id.as_str().cmp(right.id.as_str()));
+        Ok(drafts
+            .into_iter()
+            .map(|draft| ContextItem {
+                id: ItemId::new(format!("draft:{}", draft.id)),
+                class: ItemClass::Draft,
+                content: format!("{}\n\n{}", draft.rationale, draft.validation),
+                est_tokens: 0,
+                priority: Priority::P2,
+                relevance: 0.3,
+                degrade: vec![
+                    Degraded::Summary(draft.rationale.clone()),
+                    Degraded::Pointer(format!("See GC draft {}", draft.id)),
+                ],
+                dedupe_key: Some(format!("draft:{}", draft.id)),
+                instruction_bearing: false,
+            })
+            .collect())
+    }
+}
+
+pub struct ErrorProvider {
+    id: ProviderId,
+    message: String,
+}
+
+impl ErrorProvider {
+    pub fn new(id: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            id: ProviderId::new(id),
+            message: message.into(),
+        }
+    }
+}
+
+impl ContextProvider for ErrorProvider {
+    fn id(&self) -> ProviderId {
+        self.id.clone()
+    }
+
+    fn propose(&self, _req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
+        Err(ProviderError {
+            provider_id: self.id.clone(),
+            message: self.message.clone(),
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct StaticProvider {
+    id: ProviderId,
+    items: Vec<ContextItem>,
+}
+
+impl StaticProvider {
+    pub fn new(id: impl Into<String>, items: Vec<ContextItem>) -> Self {
+        Self {
+            id: ProviderId::new(id),
+            items,
+        }
+    }
+}
+
+impl ContextProvider for StaticProvider {
+    fn id(&self) -> ProviderId {
+        self.id.clone()
+    }
+
+    fn propose(&self, _req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
+        Ok(self.items.clone())
+    }
+}

--- a/crates/harness-context/src/tests.rs
+++ b/crates/harness-context/src/tests.rs
@@ -1,0 +1,209 @@
+use crate::providers::StaticProvider;
+use crate::*;
+use harness_core::types::{ProjectId, ThreadId};
+
+fn req() -> ComposeRequest {
+    ComposeRequest {
+        thread_id: ThreadId::from_str("thread-1"),
+        run_id: None,
+        project: ProjectId::from_str("project-1"),
+        task_profile: TaskProfile::default(),
+        budget_hint: 100,
+    }
+}
+
+fn item(id: &str, class: ItemClass, content_len: usize, priority: Priority) -> ContextItem {
+    ContextItem {
+        id: ItemId::new(id),
+        class,
+        content: "x".repeat(content_len),
+        est_tokens: 0,
+        priority,
+        relevance: 1.0,
+        degrade: vec![
+            Degraded::Summary(format!("summary {id}")),
+            Degraded::Pointer(format!("pointer {id}")),
+        ],
+        dedupe_key: None,
+        instruction_bearing: false,
+    }
+}
+
+#[test]
+fn types_bytes_div_four_estimator_documents_v1_behavior() {
+    let estimator = BytesDivFourEstimator;
+    assert_eq!(estimator.estimate(""), 0);
+    assert_eq!(estimator.estimate("abcd"), 1);
+    assert_eq!(estimator.estimate("abcde"), 1);
+}
+
+#[test]
+fn pipeline_is_deterministic_for_identical_inputs() {
+    let items = vec![
+        item("rule:b", ItemClass::Rule, 20, Priority::P1),
+        item("contract:a", ItemClass::Contract, 20, Priority::P0),
+    ];
+    let composer = ContextComposer::new(ComposeConfig::default())
+        .with_provider(Box::new(StaticProvider::new("rules", items)));
+    let first = composer.compose(&req()).expect("composition succeeds");
+    let second = composer.compose(&req()).expect("composition succeeds");
+    assert_eq!(first.rendered, second.rendered);
+    assert_eq!(first.manifest, second.manifest);
+}
+
+#[test]
+fn pipeline_enforces_budget_and_degrades_or_excludes() {
+    let config = ComposeConfig {
+        reserved_headroom: 0.0,
+        ..Default::default()
+    };
+    let composer = ContextComposer::new(config).with_provider(Box::new(StaticProvider::new(
+        "rules",
+        vec![
+            item("rule:a", ItemClass::Rule, 120, Priority::P1),
+            item("rule:b", ItemClass::Rule, 120, Priority::P1),
+        ],
+    )));
+    let mut request = req();
+    request.budget_hint = 20;
+    let result = composer.compose(&request).expect("composition succeeds");
+    assert!(result.manifest.budget.used <= result.manifest.budget.effective);
+    assert!(result.manifest.items.iter().any(|item| matches!(
+        item.decision,
+        ManifestDecision::Degraded | ManifestDecision::Excluded
+    )));
+}
+
+#[test]
+fn pipeline_mandatory_overflow_is_loud_error() {
+    let config = ComposeConfig {
+        reserved_headroom: 0.0,
+        ..Default::default()
+    };
+    let composer = ContextComposer::new(config).with_provider(Box::new(StaticProvider::new(
+        "contract",
+        vec![
+            item("contract:huge", ItemClass::Contract, 100, Priority::P0),
+            item("rule:blocked", ItemClass::Rule, 4, Priority::P1),
+        ],
+    )));
+    let mut request = req();
+    request.budget_hint = 10;
+    let error = composer.compose(&request).expect_err("P0 overflow fails");
+    assert!(matches!(error, ComposeError::MandatoryOverflow { .. }));
+    assert!(error
+        .manifest()
+        .items
+        .iter()
+        .any(|item| item.reason.as_deref() == Some("mandatory_overflow")));
+    assert!(error.manifest().items.iter().any(|item| {
+        item.id.as_str() == "rule:blocked"
+            && item.reason.as_deref() == Some("blocked_by_mandatory_overflow")
+    }));
+}
+
+#[test]
+fn manifest_records_dedupe_provider_errors_and_warnings() {
+    struct FailingProvider;
+    impl ContextProvider for FailingProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("broken")
+        }
+
+        fn propose(&self, _req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
+            Err(ProviderError::new("broken", "boom"))
+        }
+    }
+
+    let mut items = Vec::new();
+    for idx in 0..16 {
+        let mut proposal = item(&format!("rule:{idx:02}"), ItemClass::Rule, 4, Priority::P2);
+        proposal.instruction_bearing = true;
+        if idx == 1 {
+            proposal.dedupe_key = Some("same".to_string());
+        }
+        if idx == 2 {
+            proposal.dedupe_key = Some("same".to_string());
+        }
+        items.push(proposal);
+    }
+    let composer = ContextComposer::new(ComposeConfig::default())
+        .with_provider(Box::new(StaticProvider::new("rules", items)))
+        .with_provider(Box::new(FailingProvider));
+    let result = composer.compose(&req()).expect("composition succeeds");
+    assert_eq!(result.manifest.provider_errors.len(), 1);
+    assert!(result
+        .manifest
+        .warnings
+        .iter()
+        .any(|warning| warning.starts_with("constraint_overload:")));
+    assert!(result
+        .manifest
+        .items
+        .iter()
+        .any(|item| item.reason.as_deref() == Some("dedupe")));
+}
+
+#[test]
+fn collect_records_provider_timeout_and_continues() {
+    struct SlowProvider;
+    impl ContextProvider for SlowProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("slow")
+        }
+
+        fn propose(&self, _req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            Ok(vec![item("rule:late", ItemClass::Rule, 4, Priority::P1)])
+        }
+    }
+
+    let config = ComposeConfig {
+        provider_timeout_ms: 1,
+        ..Default::default()
+    };
+    let composer = ContextComposer::new(config)
+        .with_provider(Box::new(SlowProvider))
+        .with_provider(Box::new(StaticProvider::new(
+            "rules",
+            vec![item("rule:on-time", ItemClass::Rule, 4, Priority::P1)],
+        )));
+
+    let result = composer.compose(&req()).expect("composition succeeds");
+
+    assert!(result
+        .manifest
+        .provider_errors
+        .iter()
+        .any(|error| error.provider_id.as_str() == "slow" && error.message.contains("timed out")));
+    assert!(result
+        .manifest
+        .items
+        .iter()
+        .any(|item| item.id.as_str() == "rule:on-time"));
+    assert!(!result
+        .manifest
+        .items
+        .iter()
+        .any(|item| item.id.as_str() == "rule:late"));
+}
+
+#[test]
+fn manifest_serialization_omits_item_content() {
+    let secret_content = "secret instruction body must not be persisted";
+    let composer = ContextComposer::new(ComposeConfig::default()).with_provider(Box::new(
+        StaticProvider::new(
+            "rules",
+            vec![ContextItem {
+                content: secret_content.to_string(),
+                ..item("rule:secret", ItemClass::Rule, 4, Priority::P1)
+            }],
+        ),
+    ));
+
+    let result = composer.compose(&req()).expect("composition succeeds");
+    let manifest_json = serde_json::to_string(&result.manifest).expect("manifest serializes");
+
+    assert!(manifest_json.contains("rule:secret"));
+    assert!(!manifest_json.contains(secret_content));
+}

--- a/crates/harness-context/src/tests.rs
+++ b/crates/harness-context/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::providers::StaticProvider;
+use crate::providers::{ExecPlanProvider, StaticProvider};
 use crate::*;
 use harness_core::types::{ProjectId, ThreadId};
 
@@ -206,4 +206,26 @@ fn manifest_serialization_omits_item_content() {
 
     assert!(manifest_json.contains("rule:secret"));
     assert!(!manifest_json.contains(secret_content));
+}
+
+#[test]
+fn providers_include_active_exec_plans_for_matching_project() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut plan = harness_exec::plan::ExecPlan::from_spec("# Ship context composer", dir.path())
+        .expect("plan");
+    plan.activate();
+    let provider = ExecPlanProvider::new(vec![plan.clone()]);
+    let mut request = req();
+    request.project = ProjectId::from_path(dir.path());
+
+    let items = provider.propose(&request).expect("provider succeeds");
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(
+        items[0].id.as_str(),
+        format!("contract:exec-plan:{}", plan.id)
+    );
+    assert_eq!(items[0].class, ItemClass::Contract);
+    assert_eq!(items[0].priority, Priority::P0);
+    assert!(items[0].content.contains("Ship context composer"));
 }

--- a/crates/harness-context/src/types.rs
+++ b/crates/harness-context/src/types.rs
@@ -1,0 +1,359 @@
+use harness_core::run_id::RunId;
+use harness_core::types::{ProjectId, ThreadId};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use thiserror::Error;
+
+pub type Tokens = u32;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ProviderId(pub String);
+
+impl ProviderId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ProviderId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ItemId(pub String);
+
+impl ItemId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ItemId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComposeRequest {
+    pub thread_id: ThreadId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<RunId>,
+    pub project: ProjectId,
+    pub task_profile: TaskProfile,
+    pub budget_hint: Tokens,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TaskProfile {
+    #[serde(default)]
+    pub task_kind: Option<String>,
+    #[serde(default)]
+    pub target_paths: Vec<PathBuf>,
+    #[serde(default)]
+    pub agent_kind: Option<String>,
+    #[serde(default)]
+    pub prompt: Option<String>,
+    #[serde(default)]
+    pub contract: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ItemClass {
+    Rule,
+    Skill,
+    Contract,
+    Brief,
+    Draft,
+}
+
+impl ItemClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rule => "rule",
+            Self::Skill => "skill",
+            Self::Contract => "contract",
+            Self::Brief => "brief",
+            Self::Draft => "draft",
+        }
+    }
+
+    pub(crate) fn section_title(self) -> &'static str {
+        match self {
+            Self::Contract => "Contract",
+            Self::Rule => "Rules",
+            Self::Skill => "Skills",
+            Self::Brief => "Brief",
+            Self::Draft => "Drafts",
+        }
+    }
+
+    pub(crate) fn render_order(self) -> u8 {
+        match self {
+            Self::Contract => 0,
+            Self::Rule => 1,
+            Self::Skill => 2,
+            Self::Brief => 3,
+            Self::Draft => 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Priority {
+    P0,
+    P1,
+    P2,
+}
+
+impl Priority {
+    pub(crate) fn rank(self) -> u8 {
+        match self {
+            Self::P0 => 0,
+            Self::P1 => 1,
+            Self::P2 => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "level", content = "content", rename_all = "snake_case")]
+pub enum Degraded {
+    Summary(String),
+    Pointer(String),
+}
+
+impl Degraded {
+    pub(crate) fn level_name(&self) -> &'static str {
+        match self {
+            Self::Summary(_) => "summary",
+            Self::Pointer(_) => "pointer",
+        }
+    }
+
+    pub(crate) fn content(&self) -> &str {
+        match self {
+            Self::Summary(content) | Self::Pointer(content) => content,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContextItem {
+    pub id: ItemId,
+    pub class: ItemClass,
+    pub content: String,
+    pub est_tokens: Tokens,
+    pub priority: Priority,
+    pub relevance: f32,
+    #[serde(default)]
+    pub degrade: Vec<Degraded>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dedupe_key: Option<String>,
+    pub instruction_bearing: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderError {
+    pub provider_id: ProviderId,
+    pub message: String,
+}
+
+impl ProviderError {
+    pub fn new(provider_id: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            provider_id: ProviderId::new(provider_id),
+            message: message.into(),
+        }
+    }
+}
+
+pub trait ContextProvider: Send + Sync {
+    fn id(&self) -> ProviderId;
+    fn propose(&self, req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError>;
+}
+
+pub trait Estimator: Send + Sync {
+    fn estimate(&self, content: &str) -> Tokens;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BytesDivFourEstimator;
+
+impl Estimator for BytesDivFourEstimator {
+    fn estimate(&self, content: &str) -> Tokens {
+        if content.is_empty() {
+            0
+        } else {
+            ((content.len() as Tokens) / 4).max(1)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComposeMode {
+    Shadow,
+    Enforce,
+    Preview,
+}
+
+impl From<harness_core::config::misc::ContextMode> for ComposeMode {
+    fn from(value: harness_core::config::misc::ContextMode) -> Self {
+        match value {
+            harness_core::config::misc::ContextMode::Shadow => Self::Shadow,
+            harness_core::config::misc::ContextMode::Enforce => Self::Enforce,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContextQuotas {
+    pub rule: f32,
+    pub skill: f32,
+    pub contract: f32,
+    pub brief: f32,
+    pub draft: f32,
+}
+
+impl Default for ContextQuotas {
+    fn default() -> Self {
+        Self {
+            rule: 0.30,
+            skill: 0.25,
+            contract: 0.25,
+            brief: 0.15,
+            draft: 0.05,
+        }
+    }
+}
+
+impl ContextQuotas {
+    pub(crate) fn for_class(&self, class: ItemClass) -> f32 {
+        match class {
+            ItemClass::Rule => self.rule,
+            ItemClass::Skill => self.skill,
+            ItemClass::Contract => self.contract,
+            ItemClass::Brief => self.brief,
+            ItemClass::Draft => self.draft,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComposeConfig {
+    pub mode: ComposeMode,
+    pub budget_tokens: Tokens,
+    pub reserved_headroom: f32,
+    pub provider_timeout_ms: u64,
+    pub quotas: ContextQuotas,
+}
+
+impl Default for ComposeConfig {
+    fn default() -> Self {
+        Self {
+            mode: ComposeMode::Shadow,
+            budget_tokens: 24_000,
+            reserved_headroom: 0.20,
+            provider_timeout_ms: 2_000,
+            quotas: ContextQuotas::default(),
+        }
+    }
+}
+
+impl From<&harness_core::config::misc::ContextConfig> for ComposeConfig {
+    fn from(value: &harness_core::config::misc::ContextConfig) -> Self {
+        Self {
+            mode: value.mode.into(),
+            budget_tokens: value.budget_tokens,
+            reserved_headroom: value.reserved_headroom,
+            provider_timeout_ms: value.provider_timeout_ms,
+            quotas: ContextQuotas {
+                rule: value.quotas.rule,
+                skill: value.quotas.skill,
+                contract: value.quotas.contract,
+                brief: value.quotas.brief,
+                draft: value.quotas.draft,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BudgetManifest {
+    pub total: Tokens,
+    pub effective: Tokens,
+    pub used: Tokens,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManifestDecision {
+    Included,
+    Degraded,
+    Excluded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestItem {
+    pub id: ItemId,
+    pub provider_id: ProviderId,
+    pub class: ItemClass,
+    pub decision: ManifestDecision,
+    pub tokens: Tokens,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub level: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComposeManifest {
+    pub v: u8,
+    pub thread_id: ThreadId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<RunId>,
+    pub mode: ComposeMode,
+    pub budget: BudgetManifest,
+    pub items: Vec<ManifestItem>,
+    pub provider_errors: Vec<ProviderError>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Composition {
+    pub rendered: String,
+    pub manifest: ComposeManifest,
+}
+
+#[derive(Debug, Error)]
+pub enum ComposeError {
+    #[error(
+        "mandatory context exceeds effective budget: mandatory={mandatory}, effective={effective}"
+    )]
+    MandatoryOverflow {
+        mandatory: Tokens,
+        effective: Tokens,
+        manifest: Box<ComposeManifest>,
+    },
+}
+
+impl ComposeError {
+    pub fn manifest(&self) -> &ComposeManifest {
+        match self {
+            Self::MandatoryOverflow { manifest, .. } => manifest,
+        }
+    }
+}

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -42,6 +42,8 @@ pub struct HarnessConfig {
     pub gc: GcConfig,
     pub rules: RulesConfig,
     pub observe: ObserveConfig,
+    #[serde(default)]
+    pub context: ContextConfig,
     pub otel: OtelConfig,
     #[serde(default)]
     pub validation: ValidationConfig,
@@ -141,6 +143,7 @@ impl Default for HarnessConfig {
             gc: GcConfig::default(),
             rules: RulesConfig::default(),
             observe: ObserveConfig::default(),
+            context: ContextConfig::default(),
             otel: OtelConfig::default(),
             validation: ValidationConfig::default(),
             workspace: WorkspaceConfig::default(),
@@ -169,6 +172,8 @@ impl<'de> Deserialize<'de> for HarnessConfig {
             gc: GcConfig,
             rules: RulesConfig,
             observe: ObserveConfig,
+            #[serde(default)]
+            context: ContextConfig,
             otel: OtelConfig,
             #[serde(default)]
             validation: ValidationConfig,
@@ -197,6 +202,7 @@ impl<'de> Deserialize<'de> for HarnessConfig {
             gc: input.gc,
             rules: input.rules,
             observe: input.observe,
+            context: input.context,
             otel: input.otel,
             validation: input.validation,
             workspace: input.workspace,
@@ -216,3 +222,7 @@ impl<'de> Deserialize<'de> for HarnessConfig {
 #[cfg(test)]
 #[path = "config_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "config_context_tests.rs"]
+mod context_tests;

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -417,6 +417,98 @@ impl Default for ObserveConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextMode {
+    #[default]
+    Shadow,
+    Enforce,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextQuotasConfig {
+    #[serde(default = "default_context_rule_quota")]
+    pub rule: f32,
+    #[serde(default = "default_context_skill_quota")]
+    pub skill: f32,
+    #[serde(default = "default_context_contract_quota")]
+    pub contract: f32,
+    #[serde(default = "default_context_brief_quota")]
+    pub brief: f32,
+    #[serde(default = "default_context_draft_quota")]
+    pub draft: f32,
+}
+
+fn default_context_rule_quota() -> f32 {
+    0.30
+}
+
+fn default_context_skill_quota() -> f32 {
+    0.25
+}
+
+fn default_context_contract_quota() -> f32 {
+    0.25
+}
+
+fn default_context_brief_quota() -> f32 {
+    0.15
+}
+
+fn default_context_draft_quota() -> f32 {
+    0.05
+}
+
+impl Default for ContextQuotasConfig {
+    fn default() -> Self {
+        Self {
+            rule: default_context_rule_quota(),
+            skill: default_context_skill_quota(),
+            contract: default_context_contract_quota(),
+            brief: default_context_brief_quota(),
+            draft: default_context_draft_quota(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextConfig {
+    #[serde(default)]
+    pub mode: ContextMode,
+    #[serde(default = "default_context_budget_tokens")]
+    pub budget_tokens: u32,
+    #[serde(default = "default_context_reserved_headroom")]
+    pub reserved_headroom: f32,
+    #[serde(default = "default_context_provider_timeout_ms")]
+    pub provider_timeout_ms: u64,
+    #[serde(default)]
+    pub quotas: ContextQuotasConfig,
+}
+
+fn default_context_budget_tokens() -> u32 {
+    24_000
+}
+
+fn default_context_reserved_headroom() -> f32 {
+    0.20
+}
+
+fn default_context_provider_timeout_ms() -> u64 {
+    2_000
+}
+
+impl Default for ContextConfig {
+    fn default() -> Self {
+        Self {
+            mode: ContextMode::Shadow,
+            budget_tokens: default_context_budget_tokens(),
+            reserved_headroom: default_context_reserved_headroom(),
+            provider_timeout_ms: default_context_provider_timeout_ms(),
+            quotas: ContextQuotasConfig::default(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OtelConfig {
     #[serde(default = "default_otel_environment")]

--- a/crates/harness-core/src/config_context_tests.rs
+++ b/crates/harness-core/src/config_context_tests.rs
@@ -1,0 +1,46 @@
+use super::misc::{ContextConfig, ContextMode};
+use super::HarnessConfig;
+
+#[test]
+fn harness_config_defaults_include_context_shadow_mode() {
+    let config = HarnessConfig::default();
+
+    assert_eq!(config.context.mode, ContextMode::Shadow);
+    assert_eq!(config.context.budget_tokens, 24_000);
+    assert_eq!(config.context.reserved_headroom, 0.20);
+    assert_eq!(config.context.provider_timeout_ms, 2_000);
+    assert_eq!(config.context.quotas.rule, 0.30);
+    assert_eq!(config.context.quotas.skill, 0.25);
+    assert_eq!(config.context.quotas.contract, 0.25);
+    assert_eq!(config.context.quotas.brief, 0.15);
+    assert_eq!(config.context.quotas.draft, 0.05);
+}
+
+#[test]
+fn context_config_deserializes_from_toml() {
+    let toml_str = r#"
+        mode = "enforce"
+        budget_tokens = 12000
+        reserved_headroom = 0.10
+        provider_timeout_ms = 500
+
+        [quotas]
+        rule = 0.40
+        skill = 0.20
+        contract = 0.20
+        brief = 0.15
+        draft = 0.05
+    "#;
+
+    let config: ContextConfig = toml::from_str(toml_str).expect("context config should parse");
+
+    assert_eq!(config.mode, ContextMode::Enforce);
+    assert_eq!(config.budget_tokens, 12_000);
+    assert_eq!(config.reserved_headroom, 0.10);
+    assert_eq!(config.provider_timeout_ms, 500);
+    assert_eq!(config.quotas.rule, 0.40);
+    assert_eq!(config.quotas.skill, 0.20);
+    assert_eq!(config.quotas.contract, 0.20);
+    assert_eq!(config.quotas.brief, 0.15);
+    assert_eq!(config.quotas.draft, 0.05);
+}

--- a/crates/harness-protocol/Cargo.toml
+++ b/crates/harness-protocol/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 harness-core = { workspace = true }
+harness-context = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/harness-protocol/src/methods.rs
+++ b/crates/harness-protocol/src/methods.rs
@@ -188,6 +188,16 @@ pub enum Method {
         target: String,
         max_rounds: Option<u32>,
     },
+
+    // === Context composer ===
+    ContextPreview {
+        request: harness_context::ComposeRequest,
+        #[serde(default)]
+        supplied_items: Vec<harness_context::ContextItem>,
+    },
+    ContextManifestGet {
+        thread_id: ThreadId,
+    },
 }
 
 /// JSON-RPC 2.0 request envelope.
@@ -353,6 +363,8 @@ impl Method {
             Self::AgentList => "agent/list",
             Self::Preflight { .. } => "preflight",
             Self::CrossReview { .. } => "cross_review",
+            Self::ContextPreview { .. } => "context/preview",
+            Self::ContextManifestGet { .. } => "context/manifest/get",
             Self::SkillGovernanceView { .. } => "skill/governance/view",
             Self::SkillGovernanceHistory { .. } => "skill/governance/history",
             Self::SkillStale => "skill/stale",
@@ -374,3 +386,69 @@ pub const NOT_INITIALIZED: i32 = -32003;
 pub const STORAGE_ERROR: i32 = -32004;
 pub const AGENT_ERROR: i32 = -32005;
 pub const VALIDATION_ERROR: i32 = -32006;
+
+#[cfg(test)]
+mod context_tests {
+    use super::*;
+
+    #[test]
+    fn context_rpc_preview_slash_method_deserializes() -> anyhow::Result<()> {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "context/preview",
+            "params": {
+                "request": {
+                    "thread_id": "thread-1",
+                    "project": "project-1",
+                    "task_profile": {"prompt": "implement context composer"},
+                    "budget_hint": 100
+                },
+                "supplied_items": [{
+                    "id": "rule:test",
+                    "class": "rule",
+                    "content": "Follow the test rule.",
+                    "est_tokens": 0,
+                    "priority": "p1",
+                    "relevance": 1.0,
+                    "degrade": [{"level": "pointer", "content": "See test rule"}],
+                    "instruction_bearing": true
+                }]
+            }
+        });
+
+        let parsed: RpcRequest = serde_json::from_value(request)?;
+        assert_eq!(parsed.method.method_name(), "context/preview");
+        match parsed.method {
+            Method::ContextPreview {
+                request,
+                supplied_items,
+            } => {
+                assert_eq!(request.thread_id.as_str(), "thread-1");
+                assert_eq!(supplied_items.len(), 1);
+            }
+            other => panic!("unexpected method: {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn context_rpc_manifest_get_slash_method_deserializes() -> anyhow::Result<()> {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "context/manifest/get",
+            "params": {"thread_id": "thread-1"}
+        });
+
+        let parsed: RpcRequest = serde_json::from_value(request)?;
+        assert_eq!(parsed.method.method_name(), "context/manifest/get");
+        match parsed.method {
+            Method::ContextManifestGet { thread_id } => {
+                assert_eq!(thread_id.as_str(), "thread-1");
+            }
+            other => panic!("unexpected method: {other:?}"),
+        }
+        Ok(())
+    }
+}

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -14,6 +14,7 @@ harness-workflow = { workspace = true }
 harness-gc = { workspace = true }
 harness-rules = { workspace = true }
 harness-skills = { workspace = true }
+harness-context = { workspace = true }
 harness-observe = { workspace = true }
 harness-exec = { workspace = true }
 harness-eval = { workspace = true }

--- a/crates/harness-server/src/handlers/context.rs
+++ b/crates/harness-server/src/handlers/context.rs
@@ -1,8 +1,8 @@
 use crate::http::AppState;
 use harness_context::{
     providers::{
-        ContractProvider, ErrorProvider, GcDraftsProvider, RulesProvider, SkillsProvider,
-        TaskBriefProvider,
+        ContractProvider, ErrorProvider, ExecPlanProvider, GcDraftsProvider, RulesProvider,
+        SkillsProvider, TaskBriefProvider,
     },
     ComposeConfig, ComposeManifest, ComposeMode, ComposeRequest, Composition, ContextComposer,
     ContextItem,
@@ -69,7 +69,7 @@ pub(crate) async fn record_context_composition(
     thread_id: &ThreadId,
     project: ProjectId,
     task_profile: harness_context::TaskProfile,
-) {
+) -> Result<(), String> {
     let mode = state.core.server.config.context.mode.into();
     let request = ComposeRequest {
         thread_id: thread_id.clone(),
@@ -80,23 +80,43 @@ pub(crate) async fn record_context_composition(
     };
     let composer = build_composer(state, mode).await;
     let outcome = composer.compose(&request);
-    let (manifest, decision, reason) = match outcome {
+    let (manifest, decision, reason, fatal_error) = match outcome {
         Ok(composition) => {
-            let decision = if composition.manifest.provider_errors.is_empty()
-                && composition.manifest.warnings.is_empty()
-            {
-                Decision::Pass
+            let mut manifest = composition.manifest;
+            if mode == ComposeMode::Enforce {
+                let message = "context enforce mode is not available until composed injection replaces legacy injection paths";
+                manifest
+                    .warnings
+                    .push("context_enforce_not_wired".to_string());
+                tracing::error!(thread_id = %thread_id, "context enforce mode requested before injection wiring is available");
+                (
+                    manifest,
+                    Decision::Block,
+                    Some("context_enforce_not_wired".to_string()),
+                    Some(message.to_string()),
+                )
             } else {
-                Decision::Warn
-            };
-            (composition.manifest, decision, None)
+                let decision =
+                    if manifest.provider_errors.is_empty() && manifest.warnings.is_empty() {
+                        Decision::Pass
+                    } else {
+                        Decision::Warn
+                    };
+                (manifest, decision, None, None)
+            }
         }
         Err(error) => {
             tracing::error!(thread_id = %thread_id, error = %error, "context composition failed");
+            let fatal_error = if mode == ComposeMode::Enforce {
+                Some(error.to_string())
+            } else {
+                None
+            };
             (
                 error.manifest().clone(),
                 Decision::Block,
                 Some("compose_error".to_string()),
+                fatal_error,
             )
         }
     };
@@ -104,6 +124,10 @@ pub(crate) async fn record_context_composition(
     if let Err(error) = log_manifest_event(state, thread_id, manifest, decision, reason).await {
         tracing::warn!(thread_id = %thread_id, error = %error, "context manifest logging failed");
     }
+    if let Some(error) = fatal_error {
+        return Err(error);
+    }
+    Ok(())
 }
 
 async fn build_composer(state: &AppState, mode: ComposeMode) -> ContextComposer {
@@ -118,8 +142,15 @@ async fn build_composer(state: &AppState, mode: ComposeMode) -> ContextComposer 
         let skills = state.engines.skills.read().await;
         skills.list().to_vec()
     };
+    let plans = state
+        .core
+        .plan_cache
+        .iter()
+        .map(|entry| entry.value().clone())
+        .collect::<Vec<_>>();
     let composer = ContextComposer::new(config)
         .with_provider(Box::new(ContractProvider))
+        .with_provider(Box::new(ExecPlanProvider::new(plans)))
         .with_provider(Box::new(RulesProvider::new(rules)))
         .with_provider(Box::new(SkillsProvider::new(skills)))
         .with_provider(Box::new(TaskBriefProvider));

--- a/crates/harness-server/src/handlers/context.rs
+++ b/crates/harness-server/src/handlers/context.rs
@@ -1,0 +1,172 @@
+use crate::http::AppState;
+use harness_context::{
+    providers::{
+        ContractProvider, ErrorProvider, GcDraftsProvider, RulesProvider, SkillsProvider,
+        TaskBriefProvider,
+    },
+    ComposeConfig, ComposeManifest, ComposeMode, ComposeRequest, Composition, ContextComposer,
+    ContextItem,
+};
+use harness_core::run_id::RunIdentity;
+use harness_core::types::{Decision, Event, EventFilters, ProjectId, SessionId, ThreadId};
+use harness_protocol::methods::{RpcResponse, INTERNAL_ERROR, NOT_FOUND};
+
+const CONTEXT_MANIFEST_HOOK: &str = "context_manifest";
+
+pub async fn context_preview(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    mut request: ComposeRequest,
+    supplied_items: Vec<ContextItem>,
+) -> RpcResponse {
+    request.run_id = request.run_id.or_else(current_run_id);
+    let composer = build_composer(state, ComposeMode::Preview).await;
+    match composer.compose_supplied(&request, supplied_items) {
+        Ok(composition) => RpcResponse::success(id, composition_response(composition)),
+        Err(error) => RpcResponse::error(id, INTERNAL_ERROR, error.to_string()),
+    }
+}
+
+pub async fn context_manifest_get(
+    state: &AppState,
+    id: Option<serde_json::Value>,
+    thread_id: ThreadId,
+) -> RpcResponse {
+    let filters = EventFilters {
+        hook: Some(CONTEXT_MANIFEST_HOOK.to_string()),
+        tool: Some(thread_id.to_string()),
+        ..Default::default()
+    };
+    match state.observability.events.query(&filters).await {
+        Ok(events) => {
+            let Some(event) = events.into_iter().last() else {
+                return RpcResponse::error(id, NOT_FOUND, "context manifest not found");
+            };
+            let Some(detail) = event.detail else {
+                return RpcResponse::error(
+                    id,
+                    INTERNAL_ERROR,
+                    "context manifest event missing detail",
+                );
+            };
+            match serde_json::from_str::<ComposeManifest>(&detail) {
+                Ok(manifest) => {
+                    RpcResponse::success(id, serde_json::json!({ "manifest": manifest }))
+                }
+                Err(error) => RpcResponse::error(
+                    id,
+                    INTERNAL_ERROR,
+                    format!("failed to decode context manifest: {error}"),
+                ),
+            }
+        }
+        Err(error) => RpcResponse::error(id, INTERNAL_ERROR, error.to_string()),
+    }
+}
+
+pub(crate) async fn record_context_composition(
+    state: &AppState,
+    thread_id: &ThreadId,
+    project: ProjectId,
+    task_profile: harness_context::TaskProfile,
+) {
+    let mode = state.core.server.config.context.mode.into();
+    let request = ComposeRequest {
+        thread_id: thread_id.clone(),
+        run_id: current_run_id(),
+        project,
+        task_profile,
+        budget_hint: state.core.server.config.context.budget_tokens,
+    };
+    let composer = build_composer(state, mode).await;
+    let outcome = composer.compose(&request);
+    let (manifest, decision, reason) = match outcome {
+        Ok(composition) => {
+            let decision = if composition.manifest.provider_errors.is_empty()
+                && composition.manifest.warnings.is_empty()
+            {
+                Decision::Pass
+            } else {
+                Decision::Warn
+            };
+            (composition.manifest, decision, None)
+        }
+        Err(error) => {
+            tracing::error!(thread_id = %thread_id, error = %error, "context composition failed");
+            (
+                error.manifest().clone(),
+                Decision::Block,
+                Some("compose_error".to_string()),
+            )
+        }
+    };
+
+    if let Err(error) = log_manifest_event(state, thread_id, manifest, decision, reason).await {
+        tracing::warn!(thread_id = %thread_id, error = %error, "context manifest logging failed");
+    }
+}
+
+async fn build_composer(state: &AppState, mode: ComposeMode) -> ContextComposer {
+    let mut config = ComposeConfig::from(&state.core.server.config.context);
+    config.mode = mode;
+
+    let rules = {
+        let rules = state.engines.rules.read().await;
+        rules.rules().to_vec()
+    };
+    let skills = {
+        let skills = state.engines.skills.read().await;
+        skills.list().to_vec()
+    };
+    let composer = ContextComposer::new(config)
+        .with_provider(Box::new(ContractProvider))
+        .with_provider(Box::new(RulesProvider::new(rules)))
+        .with_provider(Box::new(SkillsProvider::new(skills)))
+        .with_provider(Box::new(TaskBriefProvider));
+
+    match state.engines.gc_agent.drafts() {
+        Ok(drafts) => composer.with_provider(Box::new(GcDraftsProvider::new(drafts))),
+        Err(error) => {
+            tracing::error!(error = %error, "context gc-drafts provider snapshot failed");
+            composer.with_provider(Box::new(ErrorProvider::new(
+                "gc-drafts",
+                format!("snapshot failed: {error}"),
+            )))
+        }
+    }
+}
+
+async fn log_manifest_event(
+    state: &AppState,
+    thread_id: &ThreadId,
+    manifest: ComposeManifest,
+    decision: Decision,
+    reason: Option<String>,
+) -> anyhow::Result<()> {
+    let detail = serde_json::to_string(&manifest)?;
+    let mut event = Event::new(
+        SessionId::new(),
+        CONTEXT_MANIFEST_HOOK,
+        &thread_id.to_string(),
+        decision,
+    );
+    event.run_id = manifest.run_id.clone();
+    event.reason = reason;
+    event.detail = Some(detail);
+    state.observability.events.log(&event).await?;
+    Ok(())
+}
+
+fn composition_response(composition: Composition) -> serde_json::Value {
+    serde_json::json!({
+        "rendered": composition.rendered,
+        "manifest": composition.manifest,
+    })
+}
+
+fn current_run_id() -> Option<harness_core::run_id::RunId> {
+    RunIdentity::from_env()
+        .ok()
+        .flatten()
+        .map(|identity| identity.run_id)
+}

--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod classify;
+pub mod context;
 pub mod cross_review;
 pub mod dashboard;
 mod dashboard_active_counts;

--- a/crates/harness-server/src/handlers/thread.rs
+++ b/crates/harness-server/src/handlers/thread.rs
@@ -59,6 +59,25 @@ pub async fn thread_start(
 ) -> RpcResponse {
     let cwd = validate_root!(&cwd, id, &state.core.home_dir);
     let thread_id = state.core.server.thread_manager.start_thread(cwd);
+    if let Some(thread) = state.core.server.thread_manager.get_thread(&thread_id) {
+        crate::handlers::context::record_context_composition(
+            state,
+            &thread_id,
+            harness_core::types::ProjectId::from_path(&thread.project_root),
+            harness_context::TaskProfile {
+                task_kind: Some("thread_start".to_string()),
+                target_paths: vec![thread.project_root],
+                agent_kind: state
+                    .core
+                    .server
+                    .agent_registry
+                    .resolved_default_agent_name()
+                    .map(str::to_string),
+                ..Default::default()
+            },
+        )
+        .await;
+    }
     persist_thread_insert(state, &thread_id).await;
     crate::notify::emit(
         &state.notifications.notify_tx,
@@ -315,6 +334,25 @@ pub async fn thread_resume(
 ) -> RpcResponse {
     match state.core.server.thread_manager.resume_thread(&thread_id) {
         Ok(()) => {
+            if let Some(thread) = state.core.server.thread_manager.get_thread(&thread_id) {
+                crate::handlers::context::record_context_composition(
+                    state,
+                    &thread_id,
+                    harness_core::types::ProjectId::from_path(&thread.project_root),
+                    harness_context::TaskProfile {
+                        task_kind: Some("thread_resume".to_string()),
+                        target_paths: vec![thread.project_root],
+                        agent_kind: state
+                            .core
+                            .server
+                            .agent_registry
+                            .resolved_default_agent_name()
+                            .map(str::to_string),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            }
             persist_thread(state, &thread_id).await;
             RpcResponse::success(id, serde_json::json!({ "resumed": true }))
         }

--- a/crates/harness-server/src/handlers/thread.rs
+++ b/crates/harness-server/src/handlers/thread.rs
@@ -1,5 +1,8 @@
 use crate::{http::AppState, validate_root};
-use harness_core::{types::ThreadId, types::ThreadStatus, types::TurnStatus};
+use harness_core::{
+    config::workflow::load_workflow_document,
+    types::{Item, Thread, ThreadId, ThreadStatus, TurnStatus},
+};
 use harness_protocol::{
     methods::RpcResponse, methods::INTERNAL_ERROR, methods::NOT_FOUND, notifications::Notification,
 };
@@ -60,23 +63,18 @@ pub async fn thread_start(
     let cwd = validate_root!(&cwd, id, &state.core.home_dir);
     let thread_id = state.core.server.thread_manager.start_thread(cwd);
     if let Some(thread) = state.core.server.thread_manager.get_thread(&thread_id) {
-        crate::handlers::context::record_context_composition(
+        let profile = task_profile_for_thread(state, &thread, "thread_start", None);
+        if let Err(error) = crate::handlers::context::record_context_composition(
             state,
             &thread_id,
             harness_core::types::ProjectId::from_path(&thread.project_root),
-            harness_context::TaskProfile {
-                task_kind: Some("thread_start".to_string()),
-                target_paths: vec![thread.project_root],
-                agent_kind: state
-                    .core
-                    .server
-                    .agent_registry
-                    .resolved_default_agent_name()
-                    .map(str::to_string),
-                ..Default::default()
-            },
+            profile,
         )
-        .await;
+        .await
+        {
+            state.core.server.thread_manager.delete_thread(&thread_id);
+            return RpcResponse::error(id, INTERNAL_ERROR, error);
+        }
     }
     persist_thread_insert(state, &thread_id).await;
     crate::notify::emit(
@@ -139,6 +137,20 @@ pub async fn turn_start(
         .unwrap_or("claude")
         .to_string();
     let agent_id = harness_core::types::AgentId::from_str(&agent_name);
+    let Some(thread) = state.core.server.thread_manager.get_thread(&thread_id) else {
+        return RpcResponse::error(id, NOT_FOUND, "thread not found");
+    };
+    let profile = task_profile_for_thread(state, &thread, "turn_start", Some(input.clone()));
+    if let Err(error) = crate::handlers::context::record_context_composition(
+        state,
+        &thread_id,
+        harness_core::types::ProjectId::from_path(&thread.project_root),
+        profile,
+    )
+    .await
+    {
+        return RpcResponse::error(id, INTERNAL_ERROR, error);
+    }
     match state
         .core
         .server
@@ -335,28 +347,97 @@ pub async fn thread_resume(
     match state.core.server.thread_manager.resume_thread(&thread_id) {
         Ok(()) => {
             if let Some(thread) = state.core.server.thread_manager.get_thread(&thread_id) {
-                crate::handlers::context::record_context_composition(
+                let profile = task_profile_for_thread(
+                    state,
+                    &thread,
+                    "thread_resume",
+                    latest_user_message(&thread),
+                );
+                if let Err(error) = crate::handlers::context::record_context_composition(
                     state,
                     &thread_id,
                     harness_core::types::ProjectId::from_path(&thread.project_root),
-                    harness_context::TaskProfile {
-                        task_kind: Some("thread_resume".to_string()),
-                        target_paths: vec![thread.project_root],
-                        agent_kind: state
-                            .core
-                            .server
-                            .agent_registry
-                            .resolved_default_agent_name()
-                            .map(str::to_string),
-                        ..Default::default()
-                    },
+                    profile,
                 )
-                .await;
+                .await
+                {
+                    return RpcResponse::error(id, INTERNAL_ERROR, error);
+                }
             }
             persist_thread(state, &thread_id).await;
             RpcResponse::success(id, serde_json::json!({ "resumed": true }))
         }
         Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+    }
+}
+
+fn task_profile_for_thread(
+    state: &AppState,
+    thread: &Thread,
+    task_kind: &str,
+    prompt: Option<String>,
+) -> harness_context::TaskProfile {
+    harness_context::TaskProfile {
+        task_kind: Some(task_kind.to_string()),
+        target_paths: vec![thread.project_root.clone()],
+        agent_kind: state
+            .core
+            .server
+            .agent_registry
+            .resolved_default_agent_name()
+            .map(str::to_string),
+        prompt: Some(prompt.unwrap_or_else(|| default_thread_brief(thread, task_kind))),
+        contract: context_contract_for_project(&thread.project_root),
+    }
+}
+
+fn default_thread_brief(thread: &Thread, task_kind: &str) -> String {
+    format!("{task_kind} for project {}", thread.project_root.display())
+}
+
+fn latest_user_message(thread: &Thread) -> Option<String> {
+    thread
+        .turns
+        .iter()
+        .rev()
+        .flat_map(|turn| turn.items.iter().rev())
+        .find_map(|item| match item {
+            Item::UserMessage { content } => Some(content.clone()),
+            _ => None,
+        })
+}
+
+fn context_contract_for_project(project_root: &std::path::Path) -> Option<String> {
+    let mut sections = Vec::new();
+    let project_instructions = harness_core::agents_md::load_agents_md(project_root);
+    if !project_instructions.trim().is_empty() {
+        sections.push(format!(
+            "Project instructions:\n{}",
+            project_instructions.trim()
+        ));
+    }
+
+    match load_workflow_document(project_root) {
+        Ok(document) => {
+            if !document.prompt_template.trim().is_empty() {
+                let source = document
+                    .source_path
+                    .as_deref()
+                    .map(|path| format!(" from {path}"))
+                    .unwrap_or_default();
+                sections.push(format!(
+                    "Workflow prompt template{source}:\n{}",
+                    document.prompt_template.trim()
+                ));
+            }
+        }
+        Err(error) => sections.push(format!("Workflow contract load error: {error}")),
+    }
+
+    if sections.is_empty() {
+        None
+    } else {
+        Some(sections.join("\n\n"))
     }
 }
 

--- a/crates/harness-server/src/handlers/thread.rs
+++ b/crates/harness-server/src/handlers/thread.rs
@@ -289,6 +289,21 @@ pub async fn turn_steer(
         .find_thread_for_turn(&turn_id)
     {
         Some(thread_id) => {
+            let Some(thread) = state.core.server.thread_manager.get_thread(&thread_id) else {
+                return RpcResponse::error(id, NOT_FOUND, "thread not found");
+            };
+            let profile =
+                task_profile_for_thread(state, &thread, "turn_steer", Some(instruction.clone()));
+            if let Err(error) = crate::handlers::context::record_context_composition(
+                state,
+                &thread_id,
+                harness_core::types::ProjectId::from_path(&thread.project_root),
+                profile,
+            )
+            .await
+            {
+                return RpcResponse::error(id, INTERNAL_ERROR, error);
+            }
             match state
                 .core
                 .server
@@ -344,26 +359,27 @@ pub async fn thread_resume(
     id: Option<serde_json::Value>,
     thread_id: ThreadId,
 ) -> RpcResponse {
+    let Some(thread) = state.core.server.thread_manager.get_thread(&thread_id) else {
+        return RpcResponse::error(id, INTERNAL_ERROR, format!("thread not found: {thread_id}"));
+    };
+    let profile = task_profile_for_thread(
+        state,
+        &thread,
+        "thread_resume",
+        latest_user_message(&thread),
+    );
+    if let Err(error) = crate::handlers::context::record_context_composition(
+        state,
+        &thread_id,
+        harness_core::types::ProjectId::from_path(&thread.project_root),
+        profile,
+    )
+    .await
+    {
+        return RpcResponse::error(id, INTERNAL_ERROR, error);
+    }
     match state.core.server.thread_manager.resume_thread(&thread_id) {
         Ok(()) => {
-            if let Some(thread) = state.core.server.thread_manager.get_thread(&thread_id) {
-                let profile = task_profile_for_thread(
-                    state,
-                    &thread,
-                    "thread_resume",
-                    latest_user_message(&thread),
-                );
-                if let Err(error) = crate::handlers::context::record_context_composition(
-                    state,
-                    &thread_id,
-                    harness_core::types::ProjectId::from_path(&thread.project_root),
-                    profile,
-                )
-                .await
-                {
-                    return RpcResponse::error(id, INTERNAL_ERROR, error);
-                }
-            }
             persist_thread(state, &thread_id).await;
             RpcResponse::success(id, serde_json::json!({ "resumed": true }))
         }

--- a/crates/harness-server/src/router/mod.rs
+++ b/crates/harness-server/src/router/mod.rs
@@ -212,6 +212,15 @@ pub async fn handle_request(state: &AppState, req: RpcRequest) -> Option<RpcResp
         } => Some(
             handlers::cross_review::cross_review(state, id, project_root, target, max_rounds).await,
         ),
+
+        // === Context composer ===
+        Method::ContextPreview {
+            request,
+            supplied_items,
+        } => Some(handlers::context::context_preview(state, id, request, supplied_items).await),
+        Method::ContextManifestGet { thread_id } => {
+            Some(handlers::context::context_manifest_get(state, id, thread_id).await)
+        }
     }
 }
 

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -1154,6 +1154,123 @@ async fn skill_delete_removes_skill() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn context_rpc_preview_with_supplied_items_returns_manifest() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    let request = harness_context::ComposeRequest {
+        thread_id: harness_core::types::ThreadId::from_str("thread-preview"),
+        run_id: None,
+        project: harness_core::types::ProjectId::from_str("project-preview"),
+        task_profile: harness_context::TaskProfile {
+            prompt: Some("preview supplied context".to_string()),
+            ..Default::default()
+        },
+        budget_hint: 100,
+    };
+    let supplied = vec![harness_context::ContextItem {
+        id: harness_context::ItemId::new("rule:supplied"),
+        class: harness_context::ItemClass::Rule,
+        content: "Follow the supplied rule.".to_string(),
+        est_tokens: 0,
+        priority: harness_context::Priority::P1,
+        relevance: 1.0,
+        degrade: vec![harness_context::Degraded::Pointer(
+            "See supplied rule.".to_string(),
+        )],
+        dedupe_key: None,
+        instruction_bearing: true,
+    }];
+
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(1)),
+        method: Method::ContextPreview {
+            request,
+            supplied_items: supplied,
+        },
+    };
+    let resp = handle_request(&state, req).await.expect("response");
+    assert!(
+        resp.error.is_none(),
+        "context preview should succeed: {:?}",
+        resp.error
+    );
+    let result = resp
+        .result
+        .ok_or_else(|| anyhow::anyhow!("missing result"))?;
+    assert!(result["rendered"]
+        .as_str()
+        .unwrap_or("")
+        .contains("supplied rule"));
+    assert_eq!(result["manifest"]["mode"], serde_json::json!("preview"));
+    let manifest_items = result["manifest"]["items"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("manifest items should be an array"))?;
+    assert!(manifest_items
+        .iter()
+        .any(|item| item["id"] == serde_json::json!("rule:supplied")));
+    Ok(())
+}
+
+#[tokio::test]
+async fn context_shadow_thread_start_logs_manifest_without_response_shape_change(
+) -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    let proj_dir = crate::test_helpers::tempdir_in_home("harness-context-shadow-")?;
+
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(1)),
+        method: Method::ThreadStart {
+            cwd: proj_dir.path().to_path_buf(),
+        },
+    };
+    let resp = handle_request(&state, req).await.expect("response");
+    assert!(
+        resp.error.is_none(),
+        "thread_start should preserve success: {:?}",
+        resp.error
+    );
+    let result = resp
+        .result
+        .ok_or_else(|| anyhow::anyhow!("missing result"))?;
+    let thread_id = result["thread_id"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("missing thread_id"))?
+        .to_string();
+    assert_eq!(
+        result.as_object().map(|object| object.len()),
+        Some(1),
+        "shadow mode must not add response fields"
+    );
+
+    let get_req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(2)),
+        method: Method::ContextManifestGet {
+            thread_id: harness_core::types::ThreadId::from_str(&thread_id),
+        },
+    };
+    let get_resp = handle_request(&state, get_req).await.expect("response");
+    assert!(
+        get_resp.error.is_none(),
+        "manifest get should succeed: {:?}",
+        get_resp.error
+    );
+    let manifest = get_resp
+        .result
+        .ok_or_else(|| anyhow::anyhow!("missing manifest result"))?;
+    assert_eq!(manifest["manifest"]["mode"], serde_json::json!("shadow"));
+    assert_eq!(
+        manifest["manifest"]["thread_id"],
+        serde_json::json!(thread_id)
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn thread_resume_errors_for_unknown_thread() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -6,9 +6,15 @@ use crate::{
     thread_manager::ThreadManager,
 };
 use harness_agents::registry::AgentRegistry;
-use harness_core::config::HarnessConfig;
+use harness_core::{
+    agent::{AgentAdapter, AgentEvent, TurnRequest},
+    config::HarnessConfig,
+};
 use harness_protocol::{methods::Method, methods::RpcRequest, methods::VALIDATION_ERROR};
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use tokio::sync::RwLock;
 
 async fn make_test_state_with_config_and_registry(
@@ -1323,6 +1329,149 @@ async fn context_enforce_thread_start_fails_closed_until_injection_is_wired() ->
         error.message
     );
     assert!(resp.result.is_none());
+    Ok(())
+}
+
+struct SteerTrackingAdapter {
+    steer_called: Arc<AtomicBool>,
+}
+
+#[async_trait::async_trait]
+impl AgentAdapter for SteerTrackingAdapter {
+    fn name(&self) -> &str {
+        "tracking"
+    }
+
+    async fn start_turn(
+        &self,
+        _req: TurnRequest,
+        _tx: tokio::sync::mpsc::Sender<AgentEvent>,
+    ) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn interrupt(&self) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn steer(&self, _text: String) -> harness_core::error::Result<()> {
+        self.steer_called.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn context_enforce_thread_resume_does_not_mutate_thread_status() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut config = HarnessConfig::default();
+    config.context.mode = harness_core::config::misc::ContextMode::Enforce;
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), config, AgentRegistry::new("claude"))
+            .await?;
+    let proj_dir = tempfile::tempdir()?;
+    let thread_id = state
+        .core
+        .server
+        .thread_manager
+        .start_thread(proj_dir.path().to_path_buf());
+    {
+        let mut thread = state
+            .core
+            .server
+            .thread_manager
+            .threads_cache()
+            .get_mut(thread_id.as_str())
+            .ok_or_else(|| anyhow::anyhow!("thread should exist"))?;
+        thread.status = harness_core::types::ThreadStatus::Archived;
+    }
+
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(1)),
+        method: Method::ThreadResume {
+            thread_id: thread_id.clone(),
+        },
+    };
+    let resp = handle_request(&state, req).await.expect("response");
+    let error = resp
+        .error
+        .ok_or_else(|| anyhow::anyhow!("enforce mode should fail closed"))?;
+
+    assert!(
+        error.message.contains("context enforce mode"),
+        "unexpected error: {}",
+        error.message
+    );
+    let thread = state
+        .core
+        .server
+        .thread_manager
+        .get_thread(&thread_id)
+        .ok_or_else(|| anyhow::anyhow!("thread should remain present"))?;
+    assert_eq!(thread.status, harness_core::types::ThreadStatus::Archived);
+    Ok(())
+}
+
+#[tokio::test]
+async fn context_enforce_turn_steer_does_not_call_adapter_or_append_item() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let mut config = HarnessConfig::default();
+    config.context.mode = harness_core::config::misc::ContextMode::Enforce;
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), config, AgentRegistry::new("claude"))
+            .await?;
+    let proj_dir = tempfile::tempdir()?;
+    let thread_id = state
+        .core
+        .server
+        .thread_manager
+        .start_thread(proj_dir.path().to_path_buf());
+    let turn_id = state.core.server.thread_manager.start_turn(
+        &thread_id,
+        "initial task".to_string(),
+        harness_core::types::AgentId::new(),
+    )?;
+    let steer_called = Arc::new(AtomicBool::new(false));
+    state.core.server.thread_manager.register_active_adapter(
+        &turn_id,
+        Arc::new(SteerTrackingAdapter {
+            steer_called: steer_called.clone(),
+        }),
+    );
+
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(1)),
+        method: Method::TurnSteer {
+            turn_id: turn_id.clone(),
+            instruction: "redirect here".to_string(),
+        },
+    };
+    let resp = handle_request(&state, req).await.expect("response");
+    let error = resp
+        .error
+        .ok_or_else(|| anyhow::anyhow!("enforce mode should fail closed"))?;
+
+    assert!(
+        error.message.contains("context enforce mode"),
+        "unexpected error: {}",
+        error.message
+    );
+    assert!(
+        !steer_called.load(Ordering::SeqCst),
+        "adapter steer must not run when context enforce fails"
+    );
+    let turn = state
+        .core
+        .server
+        .thread_manager
+        .get_turn(&thread_id, &turn_id)
+        .ok_or_else(|| anyhow::anyhow!("turn should remain present"))?;
+    assert_eq!(
+        turn.items.len(),
+        1,
+        "failed enforce steer must not append a user message"
+    );
     Ok(())
 }
 

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -1219,6 +1219,14 @@ async fn context_shadow_thread_start_logs_manifest_without_response_shape_change
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
     let proj_dir = crate::test_helpers::tempdir_in_home("harness-context-shadow-")?;
+    std::fs::write(
+        proj_dir.path().join("AGENTS.md"),
+        "Project instruction body",
+    )?;
+    std::fs::write(
+        proj_dir.path().join("WORKFLOW.md"),
+        "---\nworkflow:\n  id: context-shadow-test\n---\nWorkflow prompt body\n",
+    )?;
 
     let req = RpcRequest {
         jsonrpc: "2.0".to_string(),
@@ -1267,6 +1275,54 @@ async fn context_shadow_thread_start_logs_manifest_without_response_shape_change
         manifest["manifest"]["thread_id"],
         serde_json::json!(thread_id)
     );
+    let items = manifest["manifest"]["items"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("manifest items should be an array"))?;
+    assert!(
+        items
+            .iter()
+            .any(|item| item["id"] == serde_json::json!("brief:task")),
+        "thread_start should record a task brief item"
+    );
+    assert!(
+        items
+            .iter()
+            .any(|item| item["id"] == serde_json::json!("contract:task")),
+        "thread_start should record a project/workflow contract item"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn context_enforce_thread_start_fails_closed_until_injection_is_wired() -> anyhow::Result<()>
+{
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    let dir = tempfile::tempdir()?;
+    let mut config = HarnessConfig::default();
+    config.context.mode = harness_core::config::misc::ContextMode::Enforce;
+    let state =
+        make_test_state_with_config_and_registry(dir.path(), config, AgentRegistry::new("claude"))
+            .await?;
+    let proj_dir = crate::test_helpers::tempdir_in_home("harness-context-enforce-")?;
+
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(1)),
+        method: Method::ThreadStart {
+            cwd: proj_dir.path().to_path_buf(),
+        },
+    };
+    let resp = handle_request(&state, req).await.expect("response");
+    let error = resp
+        .error
+        .ok_or_else(|| anyhow::anyhow!("enforce mode should fail closed"))?;
+
+    assert!(
+        error.message.contains("context enforce mode"),
+        "unexpected error: {}",
+        error.message
+    );
+    assert!(resp.result.is_none());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Add the deterministic context composition pipeline for preview, shadow, and enforce modes.
- Register task brief, project/workflow contract, rules, skills, GC draft, and active exec-plan providers.
- Log context composition manifests for thread start, turn start, turn steer, and thread resume.
- Fail closed in enforce mode before legacy injection is wired, including turn steer and thread resume mutation paths.

Supersedes #1428. Builds on merged #1427.

Linked work: #1426 (merged spec PR).

## Verification
- cargo fmt --all -- --check && git diff --check
- cargo test -p harness-context
- cargo test -p harness-core context
- cargo test -p harness-protocol context_rpc
- HARNESS_DATABASE_URL=postgres://harness:harness@127.0.0.1:55433/harness_context_enforce_1783066524_72158 cargo test -p harness-server context_enforce_ -- --test-threads=1
- HARNESS_DATABASE_URL=postgres://harness:harness@127.0.0.1:55433/harness_context_suite_1783066592_92974 cargo test -p harness-server context_ -- --test-threads=1
- cargo check --workspace --all-targets
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
- RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets

Note: temporary Postgres databases used for the focused server suites were dropped after the tests completed.
