### PR TITLE
spec: kernel contraction Phase 1 — remove zero-traffic layers (GH-1434)

### DIFF
--- a/specs/GH1434/product.md
+++ b/specs/GH1434/product.md
@@ -1,0 +1,78 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1434
+
+## 用户问题
+
+内核化收缩 Phase 1（架构分析与决策见 better/reports/harness-kernel-design.md，
+2026-07-03 拍板：直接删、不拆插件仓）。生产数据显示体量与价值严重倒挂：
+
+- workflow runtime：216,161 runtime_events / 67,436 jobs / 1,877 workflows——全部真实流量
+- thread/turn 生命周期层（16 个 JSON-RPC 方法 + thread_manager/thread_db）：历史共 **9 个 thread**
+- task 层（task_db/task_executor/task_runner）：历史共 **62 个 task**
+- harness-eval（848 LOC）：**0** 次 eval_runs
+- review_store：**0** 条 review_findings（评审实际走 GitHub bot）
+
+三代状态机叠加，第三代（workflow runtime）已事实性取代前两代。死代码不仅是
+维护成本：它撑大了对外面（30 个 RPC 方法）、拖慢构建、并让新贡献者无法分辨
+哪条路径是活的。
+
+## 目标
+
+1. 删除零流量层：thread/turn RPC 面、task 层、harness-eval、review_store。
+2. 删除前有安全探针：每个待删面先落使用计数器，7 天零计数（或维护者显式
+   豁免并留档）后方可删除。
+3. 数据先归档后删码：9 threads + 62 tasks 及关联表 pg_dump 存档；本阶段
+   只归档不 drop 任何表。
+4. workflow runtime 主路径行为完全不变。
+
+## 非目标
+
+- Phase 2（GitHub 事实核验替代 activity envelope）、Phase 3（智能层删除：
+  rules 非 execpolicy 部分/skills/GC/learn/self_evolution/q_value/
+  complexity_router）——各自另立 issue。
+- 不 drop 任何 Postgres 表或 schema。
+- 不改 workflow runtime 派发语义；不与 #1430 熔断工作冲突。
+- 不重构保留模块的代码风格（U-07）。
+
+## Behavior Invariants
+
+1. 删除动作仅在探针证据（7 天零计数）或书面豁免存在后发生；removal PR
+   必须引用计数结果。
+2. 归档先于删除：threads/tasks 相关表的 pg_dump 产物存在且可恢复
+   （文档记录恢复命令）后，代码删除才可合并。
+3. 每层删除是独立 PR（thread/turn、task、eval、review_store 至少四个），
+   任一可单独 revert（U-09）。
+4. 保留面的行为不变：`harness serve/status/pr fix/execpolicy/reconcile`、
+   webhook intake、dashboard 的 workflow 视图，删除前后输出一致。
+5. 删除后 workspace 无悬挂引用：protocol 定义、router 注册、CLI 子命令、
+   dashboard 面板同步清理；`cargo test --workspace` 与 clippy `-D warnings` 绿。
+6. 对外面收缩可见：RPC 方法数从 ~30 降到 ~14（thread×8 + turn×8 移除），
+   在 CHANGELOG 记录 breaking change 清单。
+
+## 验收标准
+
+- [ ] 探针 PR 先行合并，计数器对 thread/*、turn/*、task 执行路径、eval、
+      review_store 生效并可在日志/事件中查询。
+- [ ] 归档产物：threads(9)、tasks(62) 及关联表的 dump 文件 + 恢复文档。
+- [ ] 四个删除 PR 合并后：harness-eval crate 不在 workspace；review_store、
+      thread_manager/thread_db、task_db/task_executor/task_runner 模块不存在；
+      protocol 中 thread/turn 方法定义移除。
+- [ ] 净删除 LOC > 10k，在最终 PR 汇总。
+- [ ] `cargo test --workspace` 退出码 0；smoke：serve 启动 + status +
+      `pr fix --help` + dashboard 首屏加载。
+
+## 边界情况
+
+- **暗流量**：event_store 只记 hook 类事件，可能存在不经它的调用路径——
+  这正是探针存在的原因；探针必须覆盖 RPC 入口和模块公开函数两层。
+- **CLI 兼容**：若 CLI 存在 thread 相关子命令，删除属 breaking change，
+  版本号按 SemVer MINOR（0.x 阶段）+ CHANGELOG 记录。
+- **dashboard 依赖**：若面板查询 thread/task 端点，先改面板后删端点，
+  避免中间态白屏。
+- **进行中分支**：feat/usage-monitor-dashboard 改的 usage_monitor 属保留面，
+  无冲突；若其触碰 task_db，删除 PR 需先 rebase 协调。
+- **workflow runtime 对 task 层的残余依赖**：task 层"合并进 runtime 或删除"
+  以依赖扫描结果为准——有真实依赖的部分并入，无依赖的删除。

--- a/specs/GH1434/tasks.md
+++ b/specs/GH1434/tasks.md
@@ -1,0 +1,25 @@
+# GH1434 Tasks
+
+Issue: `#1434`
+Product spec: `specs/GH1434/product.md`
+Tech spec: `specs/GH1434/tech.md`
+
+## Status
+
+- [ ] `SP1434-T001` Owner: `observe` | Done when: UsageProbe 计数器覆盖 thread/*、turn/* 路由分发点与 thread_manager/task_db/task_executor/task_runner/harness-eval/review_store 公开入口，每日 probe_report 事件可查询，单测覆盖计数与日报 | Verify: `cargo test --package harness-server probe`
+- [ ] `SP1434-T002` Owner: `ops` | Done when: `scripts/archive-phase1-data.sh` 对 thread_db.threads、task_db.tasks 及关联表产出 pg_dump 存档 + RESTORE.md，恢复演练到临时库行数一致（threads=9, tasks=62 为当前值，以执行时实际行数为准） | Verify: `bash scripts/archive-phase1-data.sh && test -s archives/phase1-*/RESTORE.md`
+- [ ] `SP1434-T003` Owner: `gate` | Done when: 探针运行 ≥7 天且待删面计数为 0，或维护者在 issue #1434 留言豁免并说明理由；结论记录在各 removal PR 描述中 | Verify: probe_report 事件查询输出附在 PR
+- [ ] `SP1434-T004` Owner: `workspace` | Done when: harness-eval 移出 workspace members，相关引用清理，eval_store schema 数据原地留档 | Verify: `cargo test --workspace && ! grep -r harness-eval crates/*/Cargo.toml Cargo.toml`
+- [ ] `SP1434-T005` Owner: `server` | Done when: review_store 模块及 router/handlers 引用删除 | Verify: `cargo test --workspace && rg -l review_store crates | wc -l 输出 0`
+- [ ] `SP1434-T006` Owner: `consumers` | Done when: CLI 子命令、dashboard 面板、websocket 中对 thread/turn/task 端点的引用先行移除或改指 workflow runtime 等价物，dashboard 首屏无回归 | Verify: `cargo test --workspace` + dashboard 手动加载
+- [ ] `SP1434-T007` Owner: `server` | Done when: thread/* 与 turn/* 共 16 个 RPC 方法从 protocol 定义、router 注册、handlers 移除，thread_manager/thread_db 模块删除 | Verify: `cargo test --workspace && rg -l 'thread_manager|thread/start|turn/start' crates | wc -l 输出 0`
+- [ ] `SP1434-T008` Owner: `server` | Done when: 依赖扫描列出 workflow runtime 对 task_* 的真实引用；被引用部分仅搬运（diff 对照证明无语义改动）并入 runtime 邻近模块，其余 task_db/task_executor/task_runner 删除 | Verify: `cargo test --workspace` + PR 附搬运对照表
+- [ ] `SP1434-T009` Owner: `docs` | Done when: CHANGELOG 记录 16 个移除方法的 breaking 清单与归档/恢复指引；净删除 LOC 统计写入汇总 PR（预期 >10k） | Verify: 评审核对 + `git diff --shortstat` 汇总
+- [ ] `SP1434-T010` Owner: `tests` | Done when: 全 workspace 测试与 clippy -D warnings 通过，smoke 清单（serve 启动/status/pr fix --help/webhook 健康/dashboard 首屏）逐项通过并附输出 | Verify: `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings`
+
+## Parallelization
+
+- Lane A (T001, T002): 探针与归档，立即可做，互不依赖。
+- Lane B (T004, T005): eval 与 review_store 删除，各自独立 PR，等 T003 门通过。
+- Lane C (T006 → T007 → T008): 消费方先行，再删 thread/turn，最后 task 层（依赖最多，压轴）。
+- T009/T010 收尾，依赖全部删除 PR 合并。

--- a/specs/GH1434/tech.md
+++ b/specs/GH1434/tech.md
@@ -1,0 +1,96 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1434
+
+## Product Spec
+
+`specs/GH1434/product.md`
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| thread/turn RPC | `crates/harness-protocol/src`（thread/* ×8、turn/* ×8 方法定义）、`crates/harness-server/src/router/mod.rs`（注册）、`handlers/thread.rs` | 完整生命周期 RPC，历史仅 9 threads | 删除主体 1 |
+| thread 状态 | `crates/harness-server/src/thread_manager.rs`、`thread_db.rs`、`thread_manager_tests.rs` | 自有 thread 状态机 + Postgres（thread_db.threads） | 删除主体 1 |
+| task 层 | `crates/harness-server/src/task_db{,.rs}`、`task_executor/`、`task_runner/`、`task_queue_tests.rs` | 第二代任务状态机（task_db.tasks，62 行数据） | 删除主体 2；先做依赖扫描，runtime 仍引用的部分并入 |
+| eval | `crates/harness-eval`（848 LOC）、`eval_store` schema、workspace Cargo.toml | 0 eval_runs | 删除主体 3 |
+| review_store | `crates/harness-server/src/review_store/`、`review_store` schema | 0 findings | 删除主体 4 |
+| 消费方 | `crates/harness-cli/src/main.rs`、`crates/harness-server/src/dashboard.rs`、`websocket.rs`、`web/` | 可能引用 thread/task 端点 | 先改消费方后删端点（product 边界情况） |
+| 探针落点 | router 分发处 + 各模块公开入口 | 无使用计数 | T001 |
+| 事实来源 | workflow runtime（`workflow_runtime_*`、`crates/harness-workflow`） | 全部真实流量 | 保留面，行为不变的基准 |
+
+## Proposed Design
+
+**探针（先行 PR）**：轻量计数器 `UsageProbe`——`static AtomicU64` per surface +
+每日一条 info 事件汇总（`probe_report` 事件：surface → count）。覆盖两层：
+(a) router 里 thread/*、turn/* 方法分发点；(b) `thread_manager`、`task_db`、
+`task_executor`、`task_runner`、`harness-eval`、`review_store` 的公开函数入口
+（宏或手工，取实现简单者）。探针本身无配置、无持久化，7 天后读事件即可。
+
+**归档**：`scripts/archive-phase1-data.sh`——对 `thread_db.threads`、
+`task_db.tasks` 及外键关联表、各 hash schema 中同名表执行
+`pg_dump --table` 到 `archives/phase1-<date>/`，附 `RESTORE.md`（恢复命令）。
+表保留原地不动（本阶段不 drop、不 rename，避免运行中代码踩空）。
+
+**删除顺序**（每步独立 PR，依赖从少到多）：
+1. `harness-eval`：从 workspace members 移除 crate；删 `evaluate.py` 中的
+   引用（如有）；eval_store schema 留档不动。
+2. `review_store`：删模块目录 + router/handlers 引用。
+3. thread/turn：先删 CLI/dashboard/websocket 消费方 → 删 handlers/thread.rs、
+   router 注册 → 删 protocol 方法定义 → 删 thread_manager/thread_db。
+4. task 层：`cargo tree`/`rg` 依赖扫描出 workflow runtime 对 task_* 的真实
+   引用清单；被引用的类型/函数移入 `workflow_runtime_*` 邻近模块（仅搬运，
+   不改语义），其余删除。
+
+**RPC 面收缩后**：protocol 保留 skill/*（Phase 3 处理）、gc/*（Phase 3）、
+rule/*、metrics/*、event/*、stats、task/classify（归属 runtime，改名或保留）、
+health。thread/turn 16 个方法移除进 CHANGELOG breaking 清单。
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 探针先行 + removal PR 引用计数 | UsageProbe + PR 模板纪律 | 探针单测 + PR 描述人工核对 |
+| P2 归档先于删除 | archive 脚本 + RESTORE.md | 脚本跑通、dump 文件存在、恢复演练一次 |
+| P3 每层独立 PR 可 revert | PR 切分 | git 历史 |
+| P4 保留面行为不变 | — | 删除前后 `harness status --json` diff 为空；smoke 清单 |
+| P5 无悬挂引用 | 全 workspace | `cargo test --workspace` + clippy `-D warnings` + `rg 'thread_manager|task_db|review_store|harness-eval'` 零命中（除 CHANGELOG/specs） |
+| P6 CHANGELOG breaking 清单 | CHANGELOG.md | 评审核对 16 个方法名 |
+
+## Data Flow
+
+探针：AtomicU64 → 每日 probe_report 事件 → 人读。归档：Postgres → pg_dump
+文件（本地 archives/，不进 git——加 .gitignore）。删除不触碰任何运行时数据流。
+
+## Alternatives Considered
+
+- **拆插件仓**：拒绝（用户拍板）——为"未来可能有人要"维护插件仓贵于
+  真需要时从 git 历史恢复。
+- **rename 表代替 pg_dump**：拒绝——运行中的旧二进制可能仍在写，rename
+  会制造运行时错误；dump + 原表不动最稳。
+- **一个大 PR 删完**：拒绝——不可局部 revert，review 不可读（U-09）。
+- **跳过探针直接删**：拒绝——event_store 只见 hook 类事件，暗流量风险
+  真实存在；探针成本一天，误删成本一周。
+
+## Risks
+
+- Security: 无新对外面；删除减少攻击面。
+- Compatibility: thread/turn RPC 移除是 breaking——0.x 阶段 + CHANGELOG +
+  16 方法清单；已知消费方仅 CLI/dashboard（同仓同 PR 修）。
+- Performance: 探针为原子自增，可忽略。
+- Maintenance: task 层并入 runtime 的"仅搬运"边界要在 PR 里明示 diff 对照，
+  防止顺手重构（U-04/U-07）。
+
+## Test Plan
+
+- [ ] Unit tests: UsageProbe 计数与日报事件
+- [ ] Integration tests: 删除后全量 `cargo test --workspace`
+- [ ] Manual verification: smoke 清单——serve 启动、`status`、`pr fix --help`、
+      webhook 健康、dashboard 首屏；归档恢复演练（restore 到临时库数一致）
+
+## Rollback Plan
+
+每层一个 PR，revert 即回滚该层；数据未动（表原地、dump 在手）。探针 PR
+可长期保留（保留面上的计数器对 Phase 2/3 同样有用）。


### PR DESCRIPTION
Spec packet (product/tech/tasks) for #1434.

Data basis (2026-07-03 production DB census): workflow runtime carries 216,161 runtime_events / 67,436 jobs, while the layers slated for removal served 9 threads, 62 tasks, 0 eval_runs, and 0 review_findings in total. Full analysis: better repo, reports/harness-kernel-design.md (approved: direct delete, no plugin repo).

Protocol: usage probe first (7-day zero-count gate or written waiver) → pg_dump archive with restore rehearsal → four independent removal PRs (eval, review_store, thread/turn, task layer) → CHANGELOG breaking list (16 RPC methods) + LOC accounting (expected >10k net negative).

`python3 checks/check_workflow.py --repo . --spec-dir specs/GH1434` → SpecRail check passed.

Docs-only PR; implementation follows per tasks.md lanes.