### PR TITLE
spec: add SpecRail packets for GH1436/GH1437/GH1442/GH1443

### DIFF
--- a/specs/GH1436/product.md
+++ b/specs/GH1436/product.md
@@ -1,0 +1,48 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1436
+
+## User Problem
+
+Operators running harness against Postgres accumulate tens of thousands of leaked per-workspace schemas (16,933 `h<hex>` schemas, 5.7 GB observed 2026-07-03). The automatic orphan reaper added in #1216/#1220 never touches them because they predate schema registration (#1213), so catalog bloat — the dominant live performance drag (sqlx slow-statement warnings on runtime queries) — keeps growing on any deployment older than the registry.
+
+## Goals
+
+- The running server automatically reclaims legacy (unregistered) orphaned path-derived schemas, not only registered ones.
+- Reaper progress and coverage are observable: each tick reports registered and legacy scan counts.
+- Reaping remains conservative: a schema whose owner cannot be proven dead is never dropped.
+
+## Non-Goals
+
+- Dropping non-path-derived schemas (workflow runtime tables, registry schema itself).
+- Changing the workspace-to-schema naming scheme.
+- Backfilling ownership metadata for schemas that will be dropped anyway.
+
+## Behavior Invariants
+
+1. A legacy `h<hex>` schema with no registry row and no owning workspace directory on the host is reaped within a bounded number of reaper ticks.
+2. A schema whose owning workspace directory exists is never dropped, registered or not.
+3. A schema that cannot be safely attributed (ambiguous owner, transient IO error during check) is kept and reported, never dropped.
+4. Each reaper tick logs scanned/reaped counts split by class (registered vs legacy) at info level; tick failures are logged at warn or higher.
+5. The reaper honors `storage.orphan_reaper_enabled` and `storage.orphan_reaper_interval_secs` for both classes; ticks recur at the configured interval for the lifetime of the server process.
+6. Legacy reaping is rate-limited per tick (bounded batch) so a first run against a 17k-schema backlog cannot starve the database.
+
+## Acceptance Criteria
+
+- [ ] On a database seeded with unregistered orphaned `h<hex>` schemas, the running server reduces their count to zero over successive ticks without operator action.
+- [ ] Live schemas (owner directory present) survive all ticks, registered or not.
+- [ ] Tick log line includes both class counts; production DB namespace count trends down after deploy.
+- [ ] `scripts/pg-orphan-cleanup.sh` documents the legacy class and matches server behavior.
+
+## Edge Cases
+
+- Registry table absent (fresh or partially migrated DB): legacy scan still works.
+- Schema name matches `h<hex>` but is not exactly the expected hash length — must not be dropped blindly; only names matching the canonical pattern are candidates.
+- Reaper running on a host that does not own the workspace paths (owner dirs unreachable but not deleted): invariant 3 applies — keep.
+- Interrupted reap mid-batch: next tick resumes without double-drop errors.
+
+## Rollout Notes
+
+First deploy against the production DB will reap ~17k schemas over multiple ticks; expect elevated catalog churn during the drain. Recommend snapshotting the DB (or running the CLI dry-run first) before enabling. No config migration: existing keys gate the new behavior.

--- a/specs/GH1436/tasks.md
+++ b/specs/GH1436/tasks.md
@@ -1,0 +1,28 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1436
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1436-T1` Owner: agent — Add legacy (unregistered) schema discovery to `reap_orphaned_path_schemas_with_workspace_roots` reusing the `pg_schema_cleanup_plan` scan, with hash-recompute subtraction of live workspaces and bounded batch drops. Done when: integration tests cover reaped/kept/ambiguous cases. Verify: `cargo test -p harness-core db_pg_schema_registry`
+- [ ] `SP1436-T2` Owner: agent — Extend `PgSchemaReapReport` with `legacy_scanned`/`legacy_reaped`, thread real workspace roots + new config keys (`orphan_reaper_legacy_enabled`, `orphan_reaper_legacy_batch`) from `WORKFLOW.md` config into `orphan_reaper.rs`, and log per-class counts each tick including idle-tick debug liveness. Done when: reaper log line shows both classes and config defaults documented in `config/default.toml.example`. Verify: `cargo test -p harness-server orphan_reaper`
+- [ ] `SP1436-T3` Owner: agent — Align `harness-pg-schema-cleanup` CLI and `scripts/pg-orphan-cleanup.sh` docs with the automatic legacy semantics. Done when: CLI dry-run output labels legacy candidates identically to server logs. Verify: `cargo test -p harness-cli`
+
+## Parallelization
+
+T1 (crates/harness-core) and T3 (crates/harness-cli, scripts/) touch disjoint files and can run in parallel; T2 depends on T1's report type change.
+
+## Verification
+
+- [ ] `SP1436-T4` Owner: agent — Full-tree verification and production dry-run. Done when: workspace check/test are green and the dry-run candidate count matches expectations before enabling apply. Verify: `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets && cargo test --workspace`
+
+## Handoff Notes
+
+Root cause evidence: prod scan 2026-07-03 — registry rows 1,133 vs 16,978 `h<hex>` namespaces; running reaper is registry-driven only (`db_pg_schema_registry.rs:619-627`). Only one reaper log line in 8.7 h uptime — verify tick loop recurrence while in there (`orphan_reaper.rs`). Decision: direct legacy scan chosen over registration backfill (see tech.md Alternatives).

--- a/specs/GH1436/tech.md
+++ b/specs/GH1436/tech.md
@@ -1,0 +1,68 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1436
+
+## Product Spec
+
+See `specs/GH1436/product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Server reaper loop | `crates/harness-server/src/http/orphan_reaper.rs` | Periodic task calls `reap_orphaned_path_schemas(pool, true)` per `storage.orphan_reaper_*` config | Entry point that must gain legacy coverage; also verify tick recurrence (only one run logged in 8.7 h) |
+| Reap implementation | `crates/harness-core/src/db_pg_schema_registry.rs:606-655` | `reap_orphaned_path_schemas_with_workspace_roots` selects **only registry rows** with `owner_kind IN (path_derived_store, path_derived_directory_store)`; `scanned` = registry row count (1,133 in prod) | Root cause: unregistered legacy schemas are invisible to this query |
+| Inventory/plan query | `crates/harness-core/src/db_pg_schema_registry.rs:262-349` | `pg_schema_cleanup_plan(pool, include_unregistered)` already scans `pg_namespace` for `^h[0-9a-f]{16}$` and LEFT JOINs the registry, classifying unregistered schemas | Reusable building block for legacy discovery |
+| Manual CLI | `crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs` | Plan/apply flow; unregistered schemas require explicit allowlist | Must stay consistent with new automatic semantics |
+| Ownership registration | `crates/harness-core/src/db_pg.rs:336` | New stores register `PgSchemaOwnership::path_derived` since #1213 | Explains why only post-#1213 schemas are registered |
+| Cleanup script | `scripts/pg-orphan-cleanup.sh` | Wraps the CLI | Docs/behavior must be updated together |
+
+## Proposed Design
+
+Extend the reap path with a legacy scan phase:
+
+1. In `reap_orphaned_path_schemas_with_workspace_roots`, after the registry-driven pass, run a second query based on the existing `pg_schema_cleanup_plan` SQL: all `pg_namespace` entries matching the canonical path-derived pattern with **no** registry row.
+2. For each unregistered candidate, apply the same orphan test used for registered directory-owned schemas: derive the candidate owner path set from the configured workspace roots (pass real roots from the server, not `&[]`); a schema is orphaned only when every plausible owner location is definitively absent (`try_exists() == Ok(false)` on the parent), mirroring the conservative rule in `orphaned_path_schema_names`. Since legacy schemas cannot be mapped back to a path from the hash alone, the practical test is: schema has no registry row AND no live workspace directory currently maps to it (recompute `h<hex>` hashes for all directories under the workspace roots and subtract). Anything unmatched and unregistered is a dead orphan.
+3. Drop in bounded batches (e.g. 200 per tick, configurable `storage.orphan_reaper_legacy_batch`) via existing `drop_schema_cascade_if_exists`.
+4. Extend `PgSchemaReapReport` with `legacy_scanned` / `legacy_reaped`; update the reaper log line.
+5. Fix/verify tick recurrence in `orphan_reaper.rs` (expected one log line per interval when work exists; add a debug line on idle ticks so liveness is observable).
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 legacy orphans reaped | `db_pg_schema_registry.rs` legacy phase | Integration test: seed unregistered `hXX` schema + no matching dir → reaped |
+| P2 live schemas kept | hash-recompute subtraction | Test: dir exists under workspace root → schema survives both passes |
+| P3 ambiguous kept | conservative orphan test | Test: unreadable root (permission) → schema kept, reported |
+| P4 observable counts | `PgSchemaReapReport`, reaper log | Unit test on report fields; log assertion in reaper test |
+| P5 config honored / recurring ticks | `orphan_reaper.rs` | Test with short interval: ≥2 ticks observed |
+| P6 bounded batch | batch limit | Test: seed batch+1 orphans → first tick reaps ≤ batch |
+
+## Data Flow
+
+Input: `pg_namespace` + `harness_pg_schema_registry` rows, workspace root listing (filesystem). Output: `DROP SCHEMA ... CASCADE` statements, registry row deletions, `PgSchemaReapReport`. No external network calls. Persistence: Postgres only.
+
+## Alternatives Considered
+
+- Backfill registration for all legacy schemas, then let the existing registry-driven reaper handle them — two-phase, more writes, and registration of dead schemas is churn for no benefit.
+- One-off manual cleanup via `scripts/pg-orphan-cleanup.sh` allowlist — does not fix the class for other deployments and requires exporting 17k names by hand.
+- Aggressive: drop every unregistered `h<hex>` schema unconditionally — violates invariant 2 for pre-#1213 deployments with live legacy stores.
+
+## Risks
+
+- Security: none new; DROP is already gated to the canonical name pattern with `validate_schema_name`.
+- Compatibility: pre-#1213 deployments with *live* unregistered stores rely on the hash-recompute subtraction being complete; missing a workspace root config would misclassify a live store as orphaned. Mitigation: default legacy phase to dry-run-log-only for one release, or gate behind `storage.orphan_reaper_legacy_enabled` (default true only after verification).
+- Performance: first drain drops ~17k schemas; bounded batches + `CASCADE` keep each tick short. Catalog locks are per-schema.
+- Maintenance: two scan paths; mitigated by sharing the plan query.
+
+## Test Plan
+
+- [ ] Unit tests: report fields, batch bounding, pattern gating (`h` + non-hex not a candidate).
+- [ ] Integration tests (existing pg test harness in `db_pg_schema_registry_tests.rs`): legacy orphan reaped, live legacy kept, registry-absent DB, interrupted-batch resume.
+- [ ] Manual verification: dry-run against production snapshot; compare candidate list with `pg_namespace` count (expect ≈16.9k − live workspaces).
+
+## Rollback Plan
+
+Config kill-switch: set `storage.orphan_reaper_enabled=false` (existing) or the new `storage.orphan_reaper_legacy_enabled=false` to stop the legacy phase; already-dropped schemas are recoverable only from DB backups, hence the pre-deploy snapshot recommendation in Rollout Notes.

--- a/specs/GH1437/product.md
+++ b/specs/GH1437/product.md
@@ -1,0 +1,48 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1437
+
+## User Problem
+
+`Agent turn timed out after 3600s` is the dominant task-failure reason (14 of 28 failed tasks, 2026-07-03). When an upstream connection dies (observed with transient proxy/TUN drops), the turn produces no further output, yet the worker slot is held for a full hour before the task fails opaquely. During a network incident the whole worker pool degrades into hour-long zombies.
+
+## Goals
+
+- A silent (no-output) turn is aborted within a bounded inactivity window that is meaningfully shorter than the wall-clock ceiling.
+- Stall aborts are distinguishable from genuine long-turn wall-clock timeouts in task failure reasons and logs, so they can feed failure-class accounting (#1430).
+- Every agent execution path (task executor and workflow runtime jobs, all runtime kinds) has stall protection.
+
+## Non-Goals
+
+- Changing the wall-clock `timeout_secs` semantics or defaults.
+- Retry-policy or circuit-breaker behavior (#1430).
+- Detecting semantically-stuck turns that keep emitting output.
+
+## Behavior Invariants
+
+1. A turn that emits no stream items for the configured stall window is failed with a stall-specific reason naming the silence duration, before the wall-clock timeout fires.
+2. The default stall window is strictly smaller than the default wall-clock timeout (a stall default equal to the wall-clock default is a misconfiguration and must be impossible to ship silently).
+3. Any stream activity (output, tool events, errors) resets the stall clock; a turn steadily producing output can run up to the wall-clock limit.
+4. Stall failures and wall-clock failures produce distinct failure reasons, both visible in task status and logs.
+5. Stall protection applies uniformly across execution paths (task executor turns and workflow runtime jobs) and runtime kinds (claude, codex, codex_exec).
+6. Per-task/activity override of the stall window remains possible; an override larger than the wall-clock timeout is clamped or rejected with a warning.
+
+## Acceptance Criteria
+
+- [ ] With a simulated silent agent stream, the turn fails with a stall reason within the stall window (not after 3600 s).
+- [ ] Failure reason strings differ between stall and wall-clock timeout; both appear in `GET /tasks` failure output.
+- [ ] Default config ships a stall window ≤ 15 min while wall-clock stays 3600 s; `config/default.toml.example` documents both.
+- [ ] Workflow runtime (codex_exec) jobs demonstrate the same stall abort in a test.
+
+## Edge Cases
+
+- Agent emits only heartbeat/noise events but no substantive output — still counts as activity (v1 accepts this; semantic stalls are out of scope).
+- Stall fires exactly while the final result block is being flushed — result arriving after abort must not resurrect the turn.
+- Clock: stall window measured from last received item, not turn start.
+- Override set to 0 or absurdly small — enforce a sane floor (e.g. 60 s).
+
+## Rollout Notes
+
+Behavior change: previously-silent hour-long hangs now fail after the stall window. Deployments with legitimately silent long-running agents (none known) can raise `concurrency.stall_timeout_secs`. Announce the new default in the changelog; no data migration.

--- a/specs/GH1437/tasks.md
+++ b/specs/GH1437/tasks.md
@@ -1,0 +1,28 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1437
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1437-T1` Owner: agent — Lower `default_stall_timeout_secs` to 600, add config validation (clamp stall below wall-clock, floor 60 s, warn on clamp) and per-task override clamping. Done when: unit tests cover default, clamp, floor, and override cases and `config/default.toml.example` documents both windows. Verify: `cargo test -p harness-core config`
+- [ ] `SP1437-T2` Owner: agent — Audit workflow-runtime job execution for stall coverage and unify the stall `select!` arm into the shared stream driver so task-executor and codex_exec paths use one implementation with distinct stall vs wall-clock failure strings. Done when: a silent-stream runtime-job test fails with the stall reason within the window. Verify: `cargo test -p harness-server turn_lifecycle workflow_runtime_worker`
+- [ ] `SP1437-T3` Owner: agent — Surface stall window at turn start (debug log) and document the two failure strings as failure-class seeds for GH-1430. Done when: log assertions pass and docs updated. Verify: `cargo test -p harness-server`
+
+## Parallelization
+
+T1 (harness-core config) and T3 (logging/docs) touch disjoint files; T2 depends on T1's validated config type.
+
+## Verification
+
+- [ ] `SP1437-T4` Owner: agent — Full-tree verification. Done when: workspace check and tests are green. Verify: `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets && cargo test --workspace`
+
+## Handoff Notes
+
+Root cause: stall detection already exists (`turn_lifecycle.rs:280`) but its default window equals the wall-clock default (3600 s, `misc.rs:169`), making it vacuous — production evidence 2026-07-03: 14/28 task failures were 3600 s timeouts correlated with upstream tls-handshake drops. Open question for T2: confirm whether codex_exec runtime jobs flow through `turn_lifecycle.rs` at all; if not, stall coverage there is absent, not just misconfigured.

--- a/specs/GH1437/tech.md
+++ b/specs/GH1437/tech.md
@@ -1,0 +1,65 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1437
+
+## Product Spec
+
+See `specs/GH1437/product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Stall detection (exists) | `crates/harness-server/src/task_executor/turn_lifecycle.rs:280-310` | `select!` arm sleeps until `last_activity + stall_timeout`, fails turn with "Agent stream stalled: no output for {}s" | Mechanism already implemented for the task-executor path |
+| Stall default (root cause) | `crates/harness-core/src/config/misc.rs:118-120,169` | `concurrency.stall_timeout_secs` default is **3600** — identical to the wall-clock default, so the stall arm effectively never fires first | The observed 3600 s failures are the stall/wall race collapsing into one hour-long wait |
+| Wall-clock timeout | `turn_lifecycle.rs:297-310` | `execution_timeout` from `options.timeout_secs` → "Agent turn timed out after {timeout_secs}s" | Message that dominates production failures; must stay distinct from stall reason |
+| Per-task override | `crates/harness-server/src/task_runner/request.rs:56-58,152,191,229` | `stall_timeout_secs` override plumbed per task | Invariant 6 clamping goes here |
+| Workflow runtime jobs | `crates/harness-server/src/workflow_runtime_worker/` + `crates/harness-agents/src/codex_adapter.rs` | Runtime jobs run agent turns with activity-profile `timeout_secs` (3600 default in `harness-core/src/config/workflow.rs` activity profiles); stall coverage for the codex_exec path must be audited — `stall_timeout` plumbing is only visible in the task-executor path | Invariant 5: the dominant production traffic is workflow runtime, not task executor |
+| Failure classes | #1430 design (`workflow_runtime_worker.rs` WorkerTickStats) | No failure classification yet | Stall reason string should be a stable class seed |
+
+## Proposed Design
+
+1. Change `default_stall_timeout_secs()` to 600 (10 min) and add a validation step in config load: `stall_timeout_secs >= wall-clock timeout` logs a warning and clamps to `wall-clock - 1s`; floor at 60 s.
+2. Audit the workflow-runtime job execution path for stall coverage: if runtime jobs bypass `turn_lifecycle.rs` (e.g. codex_exec adapter drives the stream itself), lift the stall `select!` arm into the shared stream-consumption layer (`harness-agents` adapters or the worker's turn driver) so both paths share one implementation.
+3. Keep the two failure strings distinct and stable: `Agent stream stalled: no output for {n}s` vs `Agent turn timed out after {n}s`; document both as failure-class seeds for #1430 (`stall-silent` vs `wall-clock-timeout`).
+4. Surface the stall window in effect at turn start (debug log) so incident forensics can confirm configuration.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 stall aborts early | `turn_lifecycle.rs` + shared driver | Mock stream: no items → failure within window (test clock) |
+| P2 default ordering enforced | `config/misc.rs` validation | Unit test: equal/larger stall default clamps + warns |
+| P3 activity resets clock | stall arm reset on item | Test: item every window/2 → runs to wall-clock |
+| P4 distinct reasons | failure strings | Assert both strings; `GET /tasks` fixture |
+| P5 uniform coverage | workflow runtime path | Runtime-job test with silent codex_exec stream |
+| P6 override clamped | `task_runner/request.rs` | Unit test: override > wall-clock → clamped with warning |
+
+## Data Flow
+
+Input: agent stream items (stdout/events) per turn; config `concurrency.stall_timeout_secs`, per-task override, activity-profile `timeout_secs`. Output: turn failure with classified reason → task status, runtime job result, logs. No new persistence; failure strings flow into existing `runtime_jobs` error columns.
+
+## Alternatives Considered
+
+- Application-level heartbeat protocol (agent must emit keepalives) — requires CLI cooperation across three runtimes; stream-activity proxy achieves the goal without protocol changes.
+- Lowering wall-clock `timeout_secs` globally — kills legitimately long productive turns; rejected in the issue.
+- TCP keepalive tuning on upstream connections — helps some hangs but not silent-but-connected sessions; complementary, out of scope.
+
+## Risks
+
+- Security: none.
+- Compatibility: deployments that intentionally raised nothing but have slow-starting agents (e.g. cold container pulls > 10 min before first output) would now fail; mitigate with the pre-first-output grace equal to `max(stall, 600)` or document raising the key.
+- Performance: negligible (one timer per turn).
+- Maintenance: single shared stall implementation avoids the current risk of path-specific drift.
+
+## Test Plan
+
+- [ ] Unit tests: config validation/clamping, floor, override clamp.
+- [ ] Integration tests: silent stream stall abort (task executor and workflow runtime paths), activity-reset behavior, post-abort late-result rejection.
+- [ ] Manual verification: replay a proxy-drop window locally (kill upstream mid-turn) and confirm failure within the stall window with the stall reason in `GET /tasks`.
+
+## Rollback Plan
+
+Set `concurrency.stall_timeout_secs = 3600` (old effective behavior) in deployment config; no schema or data changes to revert.

--- a/specs/GH1442/product.md
+++ b/specs/GH1442/product.md
@@ -1,0 +1,45 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1442
+
+## User Problem
+
+Maintainers reading or contracting the harness codebase (#1434) encounter ~1,800 LOC of statically unreachable code that looks active: an interceptor whose registration is commented out (`rule_enforcer`), a workspace crate nothing depends on (`harness-api`), and a reward store whose read API has zero callers (`q_value_store`). Dead-but-plausible code misleads reviewers, inflates builds, and obscures the true deletion boundary for the kernel contraction.
+
+## Goals
+
+- The three unreachable surfaces are fully removed from the workspace.
+- Their empty Postgres tables are archived, never dropped, per the #1434 archive-first rule.
+- The removal is independently revertible (one focused PR).
+
+## Non-Goals
+
+- Removing `harness-rules` engine internals or any live consumer (Phase 3 of #1434).
+- Removing thread/turn/task layers (#1434 Phase 1 proper, boundary defined by GH-1443).
+- Any behavior change on the workflow-runtime hot path.
+
+## Behavior Invariants
+
+1. After removal, every existing server behavior observable via HTTP endpoints, webhook intake, workflow-runtime dispatch, and the dashboard is unchanged.
+2. No Postgres table is dropped; `q_value_store` schema tables are renamed to an archive name and their row counts (all 0) recorded in the PR.
+3. The workspace builds warning-free and all tests pass after removal.
+4. No dangling references remain: no commented-out registrations, no orphan config keys, no CLI or RPC surface that panics or 404s where it previously worked.
+
+## Acceptance Criteria
+
+- [ ] `rule_enforcer.rs`, `crates/harness-api/`, `q_value_store.rs` and all references deleted; workspace members updated.
+- [ ] Empty q_value tables archived with counts recorded.
+- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` and `cargo test --workspace` green.
+- [ ] Net LOC delta reported (expected ≈ -1,800).
+
+## Edge Cases
+
+- Config files in the wild may still contain q_value/rule-enforcer-related keys — unknown keys must be ignored (or warned about), not fail config load.
+- `builders/intake.rs` legacy completion callback must keep compiling after the q_value write hook is removed (the callback has other duties).
+- If any test exercises the removed modules, delete the test with the module (do not weaken shared test helpers).
+
+## Rollout Notes
+
+Pure code removal; no migration. Revert = revert the single PR. Archive rename is reversible with a single `ALTER SCHEMA`/`ALTER TABLE` statement recorded in the PR description.

--- a/specs/GH1442/tasks.md
+++ b/specs/GH1442/tasks.md
@@ -1,0 +1,28 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1442
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1442-T1` Owner: agent — Delete `rule_enforcer.rs` plus its commented registration in `services.rs`, mod declaration, and the stale reference comment in `periodic_reviewer.rs`. Done when: grep for rule_enforcer returns no code hits and workspace builds. Verify: `rg -i rule_enforcer crates && cargo check -p harness-server`
+- [ ] `SP1442-T2` Owner: agent — Remove `crates/harness-api/` and its workspace member entry. Done when: grep for harness-api/harness_api returns no code hits and workspace builds. Verify: `cargo check --workspace`
+- [ ] `SP1442-T3` Owner: agent — Delete `q_value_store.rs`, its construction, AppState field, health store-list entry, and the write calls inside `intake.rs` legacy callback; add archive SQL snippet under `scripts/`. Done when: `/health` no longer lists q_value_store and the legacy callback still compiles and passes its tests. Verify: `cargo test -p harness-server`
+
+## Parallelization
+
+T1, T2, T3 touch disjoint files (`rule_enforcer.rs`+`services.rs`+`periodic_reviewer.rs` / `crates/harness-api`+root `Cargo.toml` / `q_value_store.rs`+`storage.rs`+`intake.rs`+health) and can run in parallel.
+
+## Verification
+
+- [ ] `SP1442-T4` Owner: agent — Full-tree gate. Done when: warning-free check and full test suite green with net LOC delta recorded in the PR. Verify: `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets && cargo test --workspace`
+
+## Handoff Notes
+
+Evidence basis: static census 2026-07-04 (registration commented out at `services.rs:61`; zero dependents for harness-api; `q_value_for` zero callers; all q_value tables 0 rows). Decision: pulled forward from #1434 Phase 3 because static unreachability removes the need for the 7-day usage-probe gate. Do NOT touch `task_executor/` in this PR — that boundary belongs to GH-1443.

--- a/specs/GH1442/tech.md
+++ b/specs/GH1442/tech.md
@@ -1,0 +1,65 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1442
+
+## Product Spec
+
+See `specs/GH1442/product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Dead interceptor | `crates/harness-server/src/rule_enforcer.rs` | TurnInterceptor impl; registration commented out at `http/builders/services.rs:61`; only other reference is a comment in `periodic_reviewer.rs:778` | Deletion target 1 |
+| Dead crate | `crates/harness-api/` | Workspace member, zero dependents in any Cargo.toml | Deletion target 2 |
+| Write-only store | `crates/harness-server/src/q_value_store.rs` | Built at `http/builders/storage.rs:96`; written from legacy task completion callback `http/builders/intake.rs:172-213`; read API `q_value_for` (line 218) has zero callers; all tables 0 rows in prod | Deletion target 3 |
+| Health surface | `crates/harness-server/src/http/` health/startup store list | `q_value_store` appears in `/health` startup stores (`critical: false`) | Must remove from the store list without breaking health JSON consumers |
+| Root manifest | `Cargo.toml` | members list includes `crates/harness-api` | Workspace update |
+
+## Proposed Design
+
+Single PR, three mechanical removals:
+
+1. Delete `rule_enforcer.rs`, the commented registration lines in `services.rs`, its `mod` declaration, and the stale comment in `periodic_reviewer.rs:778`.
+2. Delete `crates/harness-api/` and its workspace member entry.
+3. Delete `q_value_store.rs`, its construction in `storage.rs:96`, the write calls in `intake.rs:172-213` (keep the surrounding callback intact), its `AppState` field, and its entry in the health startup-store list. Ship a small idempotent SQL snippet (in the PR description and `scripts/`, not auto-run) renaming `q_value_store` schema tables to `q_value_store_archived_*`.
+
+Grep gates before merge: `rg -i "rule_enforcer|harness-api|harness_api|q_value"` returns only changelog/docs history.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 behavior unchanged | hot path untouched | Existing workflow_runtime_worker + HTTP route test suites pass unmodified |
+| P2 archive not drop | SQL snippet | Manual: run snippet on dev DB; tables renamed, row counts logged |
+| P3 warning-free build | whole workspace | `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` |
+| P4 no dangling refs | grep gates | `rg` gates above return no code hits |
+
+## Data Flow
+
+No runtime data-flow change: the q_value write hook fired only on legacy task completion (62 tasks ever); removing it eliminates writes to already-empty tables. Health endpoint loses one non-critical store entry.
+
+## Alternatives Considered
+
+- Fold into #1434 Phase 1 PR — rejected: mixing zero-risk mechanical deletion with the risky task-layer split reduces revertibility (U-09).
+- Re-wire rule_enforcer instead of deleting — rejected: harness-rules per-turn enforcement is Phase 3 deletion scope; resurrecting it contradicts the approved contraction direction.
+- Keep q_value write path "for future data" — rejected: read end has never existed; writing unreadable data is waste.
+
+## Risks
+
+- Security: none (removal only).
+- Compatibility: external dashboards parsing `/health` `stores[]` by index would break — mitigation: consumers observed parse by `name`; note in PR.
+- Performance: negligible positive (less code, one fewer store init).
+- Maintenance: none; reduces surface.
+
+## Test Plan
+
+- [ ] Unit tests: existing suites pass unmodified (no assertion changes permitted).
+- [ ] Integration tests: `/health` returns without the q_value entry; startup succeeds with archived tables present and absent.
+- [ ] Manual verification: grep gates; archive SQL dry-run on dev DB.
+
+## Rollback Plan
+
+Revert the PR (single commit after squash). Restore archived tables by reversing the recorded renames. No config or data migration to undo.

--- a/specs/GH1443/product.md
+++ b/specs/GH1443/product.md
@@ -1,0 +1,46 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1443
+
+## User Problem
+
+The kernel contraction (#1434) plans to delete the legacy task layer, but the workflow runtime's live agent-turn engine currently lives *inside* that layer (`task_executor/turn_lifecycle.rs`, `task_executor/helpers.rs`). Deleting by module name would sever the hot path that executes every production runtime job. Maintainers need the module ownership to match the keep/delete boundary before any deletion PR lands.
+
+## Goals
+
+- The workflow runtime's turn engine lives under workflow-runtime ownership; `task_executor/` afterwards contains only legacy-path code.
+- The live command-safety check is separated from the legacy post-execution validator.
+- The move is purely mechanical (logic-preserving), so #1434 deletion PRs can subsequently remove whole directories.
+
+## Non-Goals
+
+- Deleting any code (GH-1442 and #1434 own deletions).
+- Behavior changes to turn execution, stall/timeout semantics (GH-1437), or token-usage handling (GH-1439).
+- Renaming config keys, RPC methods, or HTTP routes.
+
+## Behavior Invariants
+
+1. Every runtime job executes exactly as before: same prompts, same stream handling, same persistence, same failure strings.
+2. All existing tests pass without assertion changes; only import paths in tests may change.
+3. After the move, no file under `task_executor/` is referenced by `workflow_runtime_worker/` (the deletion boundary is clean).
+4. `validate_command_safety` remains invoked from workspace setup with identical semantics.
+5. The relocated modules carry a doc comment stating ownership and that `task_executor/` is legacy pending #1434.
+
+## Acceptance Criteria
+
+- [ ] `turn_lifecycle.rs` + `helpers.rs` (and direct-only private deps) moved under `workflow_runtime_worker/` (or a `turn_engine` module it owns); `git log --follow` shows pure moves.
+- [ ] `validate_command_safety` relocated out of `post_validator`; legacy interceptor shell untouched otherwise.
+- [ ] `rg "task_executor" crates/harness-server/src/workflow_runtime_worker/` returns nothing.
+- [ ] `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` and `cargo test --workspace` green.
+
+## Edge Cases
+
+- Shared private helpers used by BOTH the hot files and legacy files: duplicate into the legacy side rather than keeping a cross-boundary import (the legacy copy dies with #1434).
+- `thread_manager` calls from the moved code stay as-is (thread_manager survives contraction as in-memory state).
+- Re-exports may be needed temporarily if external crates (CLI) import moved types — prefer updating importers over leaving re-export shims.
+
+## Rollout Notes
+
+No runtime behavior change; ships as one refactor PR before any #1434 deletion PR. Coordinate with in-flight branches touching `task_executor/` (feat/usage-monitor-dashboard's `activity_result.rs` is in `workflow_runtime_worker/`, unaffected).

--- a/specs/GH1443/tasks.md
+++ b/specs/GH1443/tasks.md
@@ -1,0 +1,28 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1443
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1443-T1` Owner: agent — `git mv` `turn_lifecycle.rs` and `helpers.rs` into `workflow_runtime_worker/turn_engine/`, fix mod wiring and all importers, duplicating (not sharing) small private helpers still needed by legacy files. Done when: boundary grep `rg "task_executor" crates/harness-server/src/workflow_runtime_worker/` is empty and the workspace builds. Verify: `cargo check -p harness-server`
+- [ ] `SP1443-T2` Owner: agent — Move `validate_command_safety` (+ tests) into `command_safety.rs` owned by workspace setup; leave `post_validator.rs` legacy-only. Done when: relocated tests pass and both call sites compile. Verify: `cargo test -p harness-server command_safety`
+- [ ] `SP1443-T3` Owner: agent — Add ownership doc comments (turn_engine = workflow runtime; task_executor = legacy pending #1434) and update any CLI/builder import paths. Done when: docs present and no re-export shims remain. Verify: `rg "pub use.*task_executor" crates`
+
+## Parallelization
+
+T2 (post_validator/command_safety files) is disjoint from T1 (turn_lifecycle/helpers moves) and can run in parallel; T3 depends on T1.
+
+## Verification
+
+- [ ] `SP1443-T4` Owner: agent — Full-tree gate with move-integrity checks. Done when: warning-free check + full tests green, `git log --follow` shows pure renames for both files, and no assertion was modified. Verify: `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets && cargo test --workspace`
+
+## Handoff Notes
+
+This PR must land BEFORE any #1434 task-layer deletion PR — it defines the deletion boundary. Evidence: `executor.rs:129` calls `run_turn_lifecycle_with_options` per runtime job; `helpers.rs:259` is also the GH-1439 fix site (coordinate: if GH-1439 lands first, the move must carry its changes verbatim). Decision: module-under-worker chosen over new crate (crate count is shrinking per #1434). thread_manager is intentionally NOT moved — it survives contraction as in-memory state.

--- a/specs/GH1443/tech.md
+++ b/specs/GH1443/tech.md
@@ -1,0 +1,65 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1443
+
+## Product Spec
+
+See `specs/GH1443/product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Hot caller | `crates/harness-server/src/workflow_runtime_worker/executor.rs:113-155` | Per runtime job: thread_manager start_thread/start_turn → `run_turn_lifecycle_with_options` (line 129) | Defines what must keep working |
+| Move target 1 | `crates/harness-server/src/task_executor/turn_lifecycle.rs` | Turn execution loop: stream select, stall/wall-clock timeouts, failure strings | Live engine, wrongly homed |
+| Move target 2 | `crates/harness-server/src/task_executor/helpers.rs` | Stream-item processing incl. `StreamItem::TokenUsage` at :259 | Live; also the GH-1439 fix site |
+| Legacy siblings | `task_executor/{run_task,review_loop,agent_review,streaming}.rs` | Legacy POST /tasks pipeline (62 tasks ever); interceptors run only here | Stays behind; deleted by #1434 |
+| Split target | `crates/harness-server/src/post_validator.rs` | `validate_command_safety` live via `workspace_helpers.rs:139` + `task_executor/validation_gate.rs:29`; `PostExecutionValidator` interceptor legacy-only | Split-before-delete |
+| Consumers | `crates/harness-server/src/http/builders/*`, CLI | Construct services and import types from task_executor | Import-path updates |
+
+## Proposed Design
+
+1. Create `crates/harness-server/src/workflow_runtime_worker/turn_engine/` and `git mv` `turn_lifecycle.rs` and `helpers.rs` into it; update `mod` wiring and importers. Where a private helper is shared with legacy files, copy it into the legacy side and mark the copy `// legacy duplicate — dies with #1434`.
+2. Move `validate_command_safety` (+ its tests) into a new `command_safety.rs` owned by workspace setup (`workspace_helpers.rs` caller); leave `post_validator.rs` holding only the legacy interceptor.
+3. Add module doc comments: turn_engine = owned by workflow runtime; `task_executor/` = legacy task path pending #1434.
+4. Enforce the boundary in CI-greppable form: no `use crate::task_executor` inside `workflow_runtime_worker/` (checked in review; optionally a unit test asserting module paths).
+5. No logic edits: diffs limited to paths, imports, visibility (`pub(crate)` adjustments), and doc comments.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 identical execution | pure `git mv` + import fixes | Full existing test suite unmodified; `git log --follow` shows renames |
+| P2 tests unchanged | test imports only | Diff review: no assertion edits (test-weakening guard) |
+| P3 clean boundary | module wiring | `rg "task_executor" .../workflow_runtime_worker/` empty |
+| P4 command safety intact | `command_safety.rs` | Existing validate_command_safety tests pass relocated |
+| P5 ownership docs | doc comments | Review checklist |
+
+## Data Flow
+
+Unchanged: agent stream → turn_engine loop → thread_manager updates + notifications + persistence. Only the module path of the code changes.
+
+## Alternatives Considered
+
+- Do the split inside the #1434 deletion PR — rejected: mixes mechanical moves with deletions, making both harder to review and revert.
+- Extract into a new `harness-turn` crate — rejected: crate count is being reduced (#1434 merges small crates); a module under the worker suffices.
+- Leave permanent re-export shims in `task_executor` — rejected: shims are aliases (house rule U-24) and would keep the doomed directory referenced.
+
+## Risks
+
+- Security: none.
+- Compatibility: internal module paths only; JSON-RPC/HTTP surfaces unchanged.
+- Performance: none (no logic change).
+- Maintenance: temporary duplication of small shared helpers on the legacy side; bounded — that code is deleted by #1434.
+
+## Test Plan
+
+- [ ] Unit tests: full existing suite green with zero assertion changes.
+- [ ] Integration tests: workflow_runtime_worker job execution tests pass; one smoke run of a local runtime job (serve + dispatch) behaves identically.
+- [ ] Manual verification: `git log --follow` on both moved files; boundary grep empty.
+
+## Rollback Plan
+
+Revert the single refactor PR; no data, config, or schema involved.


### PR DESCRIPTION
## What/Why

Adds four SpecRail spec packets (product/tech/tasks each), authored from the 2026-07-03/04 runtime-health and dead-design analyses:

- `specs/GH1436/` — extend the orphan schema reaper to legacy unregistered `h<hex>` schemas (16,933 leaked schemas, DB 5.7 GB; running reaper is registry-driven and scans only 1,133 rows)
- `specs/GH1437/` — stall detection exists but its default window equals the wall-clock timeout (3600 s), making it vacuous; lower the default and unify coverage across execution paths
- `specs/GH1442/` — remove statically unreachable modules (rule_enforcer, harness-api, q_value_store)
- `specs/GH1443/` — extract turn_lifecycle/helpers out of task_executor to define the #1434 deletion boundary (must land before any task-layer deletion PR)

Docs-only change; no code touched.

## Test Plan

- `python3 checks/check_workflow.py --spec-dir specs/GH1436 --spec-dir specs/GH1437 --spec-dir specs/GH1442 --spec-dir specs/GH1443` (SpecRail pack): **SpecRail check passed**

Closes nothing.

Issues: #1436 #1437 #1442 #1443