### PR TITLE
docs(specs): SpecRail spec packets for five capability gaps (#1447–#1451)

### DIFF
--- a/specs/GH1447/product.md
+++ b/specs/GH1447/product.md
@@ -1,0 +1,73 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1447
+
+## User Problem
+
+The maintainer changes prompts, retry policies, or workflow logic and cannot
+measure whether the change improved or regressed agent outcomes. The previous
+eval attempt (harness-eval crate, eval_store) recorded zero production runs and
+is scheduled for deletion in GH-1434 because it lived outside the real traffic
+path. Without a regression eval loop, every harness change ships on intuition.
+
+## Goals
+
+- Replay a curated set of real, already-resolved issues through the normal
+  workflow runtime dispatch path.
+- Report pass@1, pass^k, cost per task, and tokens per task for a harness
+  version, diffable against a previous version.
+- Score from durable evidence (validation commands, CI status, diff scope,
+  merge outcome), not from LLM judgment.
+
+## Non-Goals
+
+- Reviving the harness-eval crate, eval_store schema, or any standalone eval
+  layer (contradicts GH-1434).
+- LLM-as-judge as a primary scoring signal.
+- Public benchmark (SWE-bench) submission tooling.
+- Automatic merge of eval-produced PRs.
+
+## Behavior Invariants
+
+1. An eval run consumes a benchmark manifest listing issue references with
+   pinned base commits and expected verification commands.
+2. Each benchmark case dispatches through the same runtime path as production
+   issue work; no eval-only execution shortcut exists.
+3. Eval-produced branches and PRs are clearly marked and never auto-merged;
+   cleanup removes all eval workspaces at terminal state.
+4. Scoring uses only recorded evidence; two scorings of the same evidence
+   produce identical results.
+5. The report includes pass@1, pass^k (k configurable, default 3), total and
+   per-case cost, and tokens; missing evidence fails the case, it never
+   silently passes.
+6. Results persist as workflow runtime records queryable by harness version
+   tag; no new storage namespace is created.
+7. A comparison of two eval runs lists per-case status transitions
+   (pass→fail, fail→pass) and aggregate deltas.
+8. A cancelled or crashed eval run leaves no orphan workflows, workspaces, or
+   schemas (reuses existing reaper guarantees).
+
+## Acceptance Criteria
+
+- [ ] Benchmark manifest format documented; 10+ historical harness issues curated.
+- [ ] One command runs the set and emits the metric report.
+- [ ] Same-evidence rescoring is byte-identical (determinism test).
+- [ ] Version-to-version diff report implemented and demonstrated.
+- [ ] Zero new crates; zero new Postgres schemas outside the workflow namespace.
+
+## Edge Cases
+
+- Benchmark issue's pinned base commit no longer builds — case reports
+  `infra_failed`, excluded from pass-rate denominator with explicit count.
+- Agent opens no PR — case fails with `no_submission` evidence class.
+- Budget cap hit mid-case — case fails with `budget_exceeded`; run continues.
+- Two eval runs launched concurrently — second is rejected or queued; never
+  interleaved into the same report.
+
+## Rollout Notes
+
+Ships behind a CLI/API entry that operators invoke manually; no scheduled eval
+in this phase. Depends on GH-1434 Phase 1 landing first so scoring semantics
+are ported from, not linked against, the deleted crate.

--- a/specs/GH1447/tasks.md
+++ b/specs/GH1447/tasks.md
@@ -1,0 +1,37 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1447
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1447-T001` Owner: workflow | Done when: benchmark manifest schema + parser exist under an `evals/benchmarks/` convention with parse/reject unit tests | Verify: `cargo test -p harness-workflow eval_manifest`
+- [ ] `SP1447-T002` Owner: workflow | Done when: scoring pure functions are ported from `harness-eval/src/scoring.rs` into the runtime eval module with a determinism test (same evidence → byte-identical result), landed before the GH-1434 crate deletion PR | Verify: `cargo test -p harness-workflow eval_scoring`
+- [ ] `SP1447-T003` Owner: workflow | Done when: eval driver dispatches manifest cases through the standard runtime path with `eval_run_id` metadata, `harness-eval/` branch prefix, and draft-PR submission mode | Verify: `cargo test -p harness-workflow eval_run`
+- [ ] `SP1447-T004` Owner: workflow | Done when: evidence collector maps submission/quality_gate/usage records to per-case evidence, with missing evidence yielding case failure (never a silent pass) | Verify: `cargo test -p harness-workflow eval_evidence`
+- [ ] `SP1447-T005` Owner: server+cli | Done when: `harness eval run` and `harness eval diff` entries emit pass@1 / pass^k / cost / tokens and version-to-version transitions | Verify: `cargo test -p harness-cli eval_report`
+- [ ] `SP1447-T006` Owner: workflow | Done when: cancel-mid-run leaves zero orphan workflows, workspaces, PRs, or schemas | Verify: `cargo test -p harness-workflow eval_cleanup`
+- [ ] `SP1447-T007` Owner: docs+data | Done when: 10+ merged historical harness issues are curated into the initial manifest with pinned base commits | Verify: `harness eval run --manifest evals/benchmarks/harness-core.toml --dry-run` lists all cases
+
+## Parallelization
+
+- T001 and T002 are independent lanes (manifest module vs scorer module, disjoint files).
+- T003/T004 depend on T001; T005 depends on T002+T004; T006 follows T003.
+- T007 is data-only and parallel to every code lane.
+
+## Verification
+
+- `cargo test --workspace`
+- Determinism: rescore fixture evidence twice, byte-identical output.
+- Manual: full run of the curated manifest on the live harness, then `harness eval diff` across two runs.
+
+## Handoff Notes
+
+- Ordering constraint with GH-1434: port the scorer (T002) before the crate deletion lands; cross-link both PRs.
+- Do not create new Postgres schemas; stay inside the workflow namespace (GH-1436 orphan-schema history is the cautionary tale).

--- a/specs/GH1447/tech.md
+++ b/specs/GH1447/tech.md
@@ -1,0 +1,85 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1447
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Workflow runtime | `crates/harness-workflow/src/runtime/` (dispatcher, worker, reducer, submission, quality_gate) | Dispatches issue/PR activities, persists runtime_events/jobs/workflows | Eval cases must ride this exact path |
+| Scoring semantics | `crates/harness-eval/src/scoring.rs` (orphaned, deletion pending GH-1434) | Deterministic PR-repair scoring with hard gates | Port the pure functions; do not link the crate |
+| Quality gate | `crates/harness-workflow/src/runtime/quality_gate.rs` | Scores runtime submissions | Evidence source for case scoring |
+| Usage accounting | `crates/harness-server/src/handlers/usage_monitor*.rs`, `crates/harness-observe/src/usage.rs` | Token/cost attribution per process | Cost/tokens per case |
+| Manual eval artifacts | `docs/pr-repair-evals/`, `docs/pr-repair-capability-evaluation.md` | Hand-run eval records | Seed data for the benchmark manifest |
+
+## Proposed Design
+
+1. **Benchmark manifest** — `evals/benchmarks/<name>.toml`: list of cases
+   `{repo, issue, base_commit, verify_commands, timeout_secs}`. Checked into
+   the repo; the initial set curates 10–20 merged harness issues.
+2. **Eval driver** — a thin module in `harness-workflow` (`runtime/eval_run.rs`)
+   that, for each case, creates a standard workflow with an `eval_run_id`
+   marker in existing metadata columns, pinned to `base_commit`.
+3. **Evidence collection** — reuse runtime submission + quality_gate records;
+   an eval case is scored from: validation command exit codes, CI conclusion,
+   diff stats, and submission state at terminal.
+4. **Scorer** — pure functions ported from `harness-eval/src/scoring.rs`
+   (hard gates + breakdown) into the eval module, with a determinism unit test.
+5. **Report** — `harness eval run --manifest <path> --k 3` prints and persists
+   a JSON report (pass@1, pass^k, per-case evidence refs, cost, tokens);
+   `harness eval diff <run_a> <run_b>` renders transitions.
+6. **Safety** — eval workflows carry a distinct branch prefix
+   (`harness-eval/`), PR titles are prefixed `[eval]`, PRs are opened as
+   drafts and closed (not merged) at scoring time.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P2 same dispatch path | eval_run.rs uses existing dispatcher API | integration test asserting identical activity records |
+| P4 deterministic scoring | ported scorer pure fns | unit test: same evidence → identical bytes |
+| P5 metric completeness | report builder | unit test with missing-evidence fixture → case fails |
+| P8 no orphans | reuse workspace cleanup + reaper | integration test: cancel mid-run, assert zero leftovers |
+
+## Data Flow
+
+Manifest (TOML, repo) → eval driver → workflow runtime (Postgres, existing
+schemas, `eval_run_id` metadata) → GitHub (draft PRs, CI) → evidence rows →
+scorer → report JSON (persisted as runtime record + stdout).
+
+## Alternatives Considered
+
+- Keep harness-eval as a crate and wire it in — rejected: GH-1434 approved
+  deletion; a standalone layer already failed once with 0 runs.
+- LLM-judge scoring — rejected as primary signal (selector failure modes);
+  may be revisited as an annotator, never a gate.
+- External eval service (Langfuse/Braintrust datasets) — deferred; internal
+  loop must exist first, export later via GH-1451 spans.
+
+## Risks
+
+- Security: eval runs execute agent code on historical issues — same trust
+  model as production runs; draft PRs prevent accidental merges.
+- Compatibility: depends on GH-1434 ordering; port scorer before crate delete.
+- Performance: N cases × agent runs is expensive — per-case and per-run budget
+  caps mandatory; k>1 multiplies cost, default k applies only when requested.
+- Maintenance: benchmark rot as the repo evolves — pinned base commits plus an
+  `infra_failed` class keep reports honest; refresh cadence documented.
+
+## Test Plan
+
+- [ ] Unit tests: scorer determinism, report math (pass@1/pass^k), manifest parsing.
+- [ ] Integration tests: two-case manifest against fixture repo; cancel-mid-run cleanup.
+- [ ] Manual verification: full run of the curated set on the live harness; diff two runs.
+
+## Rollback Plan
+
+The eval driver is additive and invoked only by explicit command; disable by
+removing the CLI/API entry. Runtime records use existing schemas, so rollback
+requires no migration.

--- a/specs/GH1448/product.md
+++ b/specs/GH1448/product.md
@@ -1,0 +1,70 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1448
+
+## User Problem
+
+Every workflow run on a repo starts with zero knowledge of previous runs.
+Validation commands that mattered, recurring pitfalls, and reviewer feedback
+patterns are rediscovered (and re-billed) each time. Frontier agents ship
+repo-scoped memory; harness runs cold forever.
+
+## Goals
+
+- Persist a small structured memory record per terminal workflow run, keyed
+  by repo, covering both successes and failures.
+- Inject a bounded, relevance-ranked memory section into the activity prompt
+  packet at dispatch time.
+- Keep memory inspectable and prunable by the operator.
+
+## Non-Goals
+
+- Vector database or embedding retrieval.
+- Cross-repo or global memory sharing.
+- Mounting memory on the skills/rules layer (GH-1434 Phase 3 removes it).
+- Letting memory content act as instructions or override policy.
+
+## Behavior Invariants
+
+1. Every terminal run (done or failed) produces at most one memory record
+   with an explicit outcome flag; extraction failure never blocks run
+   completion but is logged at error level.
+2. Memory records contain only structured fields (validation commands,
+   failure class, feedback pattern, evidence refs) — never raw agent output
+   dumps.
+3. At dispatch, at most K records (default 5) within a hard token budget are
+   injected, ranked by recency and outcome relevance; fresh repos get an
+   empty section, not filler.
+4. Injected memory is delimited as untrusted background evidence; prompt text
+   states it must not override task instructions or policy.
+5. Failure lessons are retrievable: retrieval never filters to success-only
+   records when failures exist for the same activity class.
+6. Operator can list memories per repo and delete any record; deletion takes
+   effect on the next dispatch.
+7. Memory storage lives in existing workflow runtime storage; no new
+   storage namespace.
+
+## Acceptance Criteria
+
+- [ ] Done and failed runs both produce outcome-flagged records.
+- [ ] Prompt packets show a bounded memory section for repos with history.
+- [ ] Retrieval surfaces failure lessons alongside success patterns (test).
+- [ ] List + prune API works; pruned records stop appearing in packets.
+
+## Edge Cases
+
+- Run with no extractable signal — no record written (absence is valid, not
+  an empty record).
+- Memory store unavailable at dispatch — dispatch proceeds memory-less and
+  the degradation is surfaced in run evidence (no silent skip).
+- Record referencing a validation command that no longer exists in the repo —
+  ranked down by staleness; never blocks dispatch.
+- Token budget smaller than one record — section omitted with a recorded
+  reason.
+
+## Rollout Notes
+
+Feature-flagged per project (`memory.enabled`); default off for one release,
+then default on for projects with ≥10 terminal runs. No migration needed.

--- a/specs/GH1448/tasks.md
+++ b/specs/GH1448/tasks.md
@@ -1,0 +1,35 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1448
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1448-T001` Owner: workflow-store | Done when: `workflow_repo_memory` migration + store methods exist in the workflow namespace with CRUD tests | Verify: `cargo test -p harness-workflow repo_memory_store`
+- [ ] `SP1448-T002` Owner: workflow-reducer | Done when: deterministic extractors run on the terminal path for done and failed runs, produce outcome-flagged records, and extractor errors never block run completion (error-level logged) | Verify: `cargo test -p harness-workflow memory_extract`
+- [ ] `SP1448-T003` Owner: workflow-retrieval | Done when: retrieval ranks by activity match + recency with an outcome-mix guarantee (failure lessons surface), enforcing K=5 and the token budget by whole-record truncation | Verify: `cargo test -p harness-workflow memory_retrieval`
+- [ ] `SP1448-T004` Owner: workflow-dispatch | Done when: dispatcher appends the fenced `repo-memory` section with the untrusted-background-evidence preamble; fresh repos get no section | Verify: `cargo test -p harness-workflow memory_inject`
+- [ ] `SP1448-T005` Owner: server-api | Done when: list per repo and delete per record endpoints work and pruned records vanish from the next packet | Verify: `cargo test -p harness-server memory_api`
+- [ ] `SP1448-T006` Owner: config | Done when: `memory.enabled` project flag gates extraction+injection, and store unavailability at dispatch degrades visibly in run evidence instead of silently skipping | Verify: `cargo test -p harness-workflow memory_flag_degraded`
+
+## Parallelization
+
+- T001 first (schema owner). Then T002 (reducer files) ∥ T003 (retrieval module) ∥ T005 (handler files) with disjoint file ownership.
+- T004 after T003; T006 last.
+
+## Verification
+
+- `cargo test --workspace`
+- Integration: two sequential fixture runs — the second dispatch packet contains the first run's lesson, including a failed-run lesson.
+- Manual: list/prune via API, confirm pruned record absent from the next packet.
+
+## Handoff Notes
+
+- Do not depend on harness-skills or rules stores (GH-1434 Phase 3 removes them).
+- Memory content is untrusted background evidence by contract; keep the preamble text stable and covered by a test.

--- a/specs/GH1448/tech.md
+++ b/specs/GH1448/tech.md
@@ -1,0 +1,84 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1448
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Prompt packet assembly | `crates/harness-workflow/src/runtime/` (dispatcher, activity prompt construction), `WORKFLOW.md` activities | Static per-activity prompts + validation lists | Injection point for the memory section |
+| Terminal-state handling | `crates/harness-workflow/src/runtime/reducer/`, `submission.rs` | Reduces runs to terminal states with evidence | Extraction trigger point |
+| Runtime storage | `crates/harness-workflow/src/runtime/store.rs`, `store_migrations.rs` | Postgres-backed runtime records | Memory table lives here |
+| Prior art (failed) | `crates/harness-skills/` (deletion pending GH-1434 Phase 3), #957/#972 learn pipeline | Standalone learning layer with declaration-execution gap | Anti-pattern to avoid: memory must sit on the traffic path |
+| PR feedback | `crates/harness-server/src/workflow_runtime_pr_feedback.rs` | Structured PR feedback handling | Source of reviewer-pattern memory |
+
+## Proposed Design
+
+1. **Schema** — one table in the workflow namespace:
+   `workflow_repo_memory(id, repo, activity_class, outcome, kind, payload_json,
+   evidence_ref, created_at, last_used_at, use_count)`. `kind` ∈
+   {validation_command, failure_lesson, reviewer_pattern, environment_note}.
+2. **Extraction** — a post-terminal hook in the reducer path: deterministic
+   extractors first (validation commands actually run, failure class from
+   activity_result, feedback categories from pr_feedback records). No LLM
+   extraction in v1.
+3. **Retrieval** — SQL ranking: `activity_class` match, recency decay,
+   outcome mix guarantee (at least one failure lesson if any exist), cap K=5
+   and a token budget (estimate via chars/4, hard-truncate whole records only).
+4. **Injection** — dispatcher appends a fenced `repo-memory` section to the
+   prompt packet with a fixed preamble marking it untrusted background
+   evidence (SEC-18 posture).
+5. **API** — `GET /api/projects/{id}/memory`, `DELETE /api/memory/{id}`
+   on existing router surface.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 extraction never blocks | reducer hook error path | unit test: extractor error → run still terminal, error logged |
+| P3 bounded injection | retrieval + budget fn | unit test: K and token cap enforced |
+| P5 failure lessons surface | ranking SQL | unit test: success-heavy fixture still returns failure record |
+| P6 prune takes effect | DELETE handler + retrieval | integration test: delete → next packet excludes record |
+
+## Data Flow
+
+Terminal run evidence (Postgres) → deterministic extractors → memory table →
+dispatch-time retrieval → prompt packet section → agent (read-only context).
+No external calls; no new storage namespace.
+
+## Alternatives Considered
+
+- Embedding/vector retrieval — rejected for v1 (U-33: lexical + structural
+  first; corpus is tiny per repo).
+- Reusing harness-skills store — rejected: layer is scheduled for removal and
+  previously exhibited the declaration-execution gap.
+- Free-text memory notes written by the agent — rejected: injection surface
+  and drift risk; structured fields only.
+
+## Risks
+
+- Security: memory is model-influenced content re-entering prompts —
+  mitigate by structured fields, untrusted framing, and operator prune.
+- Compatibility: prompt packet growth could hit context limits — hard token
+  budget; measured in tests.
+- Performance: one extra SQL query per dispatch — indexed by (repo,
+  activity_class), negligible at current volume.
+- Maintenance: stale memories mislead agents — staleness decay + use_count
+  telemetry to inform future pruning policy.
+
+## Test Plan
+
+- [ ] Unit tests: extractors (done/failed fixtures), ranking guarantees, budget truncation.
+- [ ] Integration tests: end-to-end run → record → next dispatch packet contains section; prune flow.
+- [ ] Manual verification: run two sequential issues on one repo; inspect second packet's memory section.
+
+## Rollback Plan
+
+`memory.enabled = false` disables extraction and injection immediately; the
+table is additive and can remain in place. No data migration to revert.

--- a/specs/GH1449/product.md
+++ b/specs/GH1449/product.md
@@ -1,0 +1,74 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1449
+
+## User Problem
+
+One issue gets exactly one agent attempt. For high-value issues or issues that
+already failed once, a single attempt wastes wall-clock time on retry loops,
+while the frontier pattern fans out N independent candidates and keeps the
+best. Harness has parallel tasks across issues but no parallel candidates for
+one issue.
+
+## Goals
+
+- Opt-in fan-out: one issue → N (2–3) candidate runs in isolated workspaces.
+- Deterministic, evidence-driven selection of exactly one winner.
+- Full cost attribution per candidate.
+
+## Non-Goals
+
+- N > 3, tournaments, or iterative candidate breeding.
+- Merging diffs from multiple candidates.
+- Changing default single-candidate behavior or circuit-breaker semantics
+  (GH-1430/#1446).
+- LLM judgment as the primary selector.
+
+## Behavior Invariants
+
+1. Fan-out triggers only on explicit opt-in (issue label or per-project
+   config); default remains one candidate.
+2. Candidates run in disjoint worktrees/branches with per-candidate budget
+   caps; no shared writable files (W-14).
+3. The selection gate ranks candidates on hard evidence in fixed priority:
+   validation commands green > CI conclusion > quality gate score > diff
+   scope sanity; an LLM tiebreak, if ever added, applies only to exact ties
+   and is recorded as such.
+4. Exactly one PR results per issue: the winner's PR is opened (or the
+   existing PR updated); losing candidates leave no open PRs, remote
+   branches, or leaked workspaces.
+5. The selection decision persists with per-candidate evidence and is
+   reproducible from that evidence alone.
+6. Losing trajectories are retained as run evidence (and feed GH-1448 memory
+   when enabled), not discarded.
+7. If all candidates fail, the workflow fails with per-candidate failure
+   classes; it never silently falls back to picking a failing candidate.
+8. Candidate spend is attributed per candidate in usage monitoring; the
+   issue-level total equals the sum of candidates.
+
+## Acceptance Criteria
+
+- [ ] Label/config opt-in dispatches N candidates under one workflow.
+- [ ] Selection decision record contains ranked evidence and is replayable.
+- [ ] Exactly-one-PR invariant holds in success, partial-failure, and
+      all-fail scenarios (tests).
+- [ ] Usage monitor shows per-candidate token/cost rows.
+
+## Edge Cases
+
+- Two candidates produce identical evidence scores — deterministic tiebreak
+  (e.g. smallest diff, then earliest completion) documented and tested.
+- One candidate stalls (see GH-1437) — selection proceeds when remaining
+  candidates reach terminal state and the stalled one times out.
+- Winner's PR creation fails — runner-up is promoted; decision record shows
+  the promotion chain.
+- Concurrency limits reached — candidates queue like normal tasks; fan-out
+  never bypasses project `max_concurrent`.
+
+## Rollout Notes
+
+Builds on `docs/parallel-pr-repair-bakeoff-spec.md`. Ship behind
+`candidates.enabled` + `candidates.n` config; recommend first enabling on the
+harness repo itself with n=2.

--- a/specs/GH1449/tasks.md
+++ b/specs/GH1449/tasks.md
@@ -1,0 +1,35 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1449
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1449-T001` Owner: workflow-submission | Done when: `submission_mode` (immediate/deferred) is threaded through the submission path with exhaustive matches and unchanged single-candidate behavior | Verify: `cargo test -p harness-workflow submission_mode`
+- [ ] `SP1449-T002` Owner: workflow-reducer | Done when: opt-in fan-out creates N candidate jobs with `candidate_group_id`, per-candidate branches/worktrees, and budget split, gated by label + config | Verify: `cargo test -p harness-workflow candidate_fanout`
+- [ ] `SP1449-T003` Owner: workflow-selection | Done when: the selection gate is a pure function over persisted evidence with fixed priority ranking, deterministic tiebreaks, and a persisted `candidate_selection` record including any promotion chain | Verify: `cargo test -p harness-workflow candidate_selection`
+- [ ] `SP1449-T004` Owner: workflow-submission | Done when: the winner's branch produces exactly one PR, losing branches/worktrees are cleaned, and winner-PR-failure promotes the runner-up | Verify: `cargo test -p harness-workflow candidate_promotion`
+- [ ] `SP1449-T005` Owner: server-usage | Done when: usage monitor attributes tokens/cost per candidate and the group total equals the candidate sum | Verify: `cargo test -p harness-server candidate_usage`
+- [ ] `SP1449-T006` Owner: workflow-runtime | Done when: a stalled candidate's timeout feeds selection readiness so remaining terminal candidates are ranked without waiting forever (aligned with GH-1437) | Verify: `cargo test -p harness-workflow candidate_stall`
+
+## Parallelization
+
+- T001 ∥ T003 (disjoint: submission.rs vs new selection module).
+- T002 after T001; T004 after T002+T003; T005 ∥ T004 (handler files); T006 last.
+
+## Verification
+
+- `cargo test --workspace`
+- Integration: n=2 scenarios (success / winner-PR-fail / all-fail / one-stall) each preserve the exactly-one-PR invariant.
+- Manual: real harness issue with the `best-of-n` label at n=2; inspect the decision record, the single PR, and per-candidate usage rows.
+
+## Handoff Notes
+
+- Align terminology with `docs/parallel-pr-repair-bakeoff-spec.md` and update that doc to point at this packet.
+- Selection stays a pure function over persisted evidence; any future LLM tiebreak goes behind the same record contract and only on exact ties.

--- a/specs/GH1449/tech.md
+++ b/specs/GH1449/tech.md
@@ -1,0 +1,88 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1449
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Dispatch | `crates/harness-workflow/src/runtime/dispatcher.rs`, `worker.rs`, `job_claim.rs` | One job per issue activity | Fan-out point |
+| Workspace isolation | worktree strategy per `WORKFLOW.md` (`workspace.strategy: worktree`, branch_prefix) | One worktree per workflow | Per-candidate worktrees + branch suffixes |
+| Quality gate | `crates/harness-workflow/src/runtime/quality_gate.rs` | Scores a single submission | Reused as per-candidate evidence |
+| Submission | `crates/harness-workflow/src/runtime/submission.rs` | Opens/updates the PR | Must gate on selection decision |
+| Prior spec | `docs/parallel-pr-repair-bakeoff-spec.md` | Draft bakeoff design | Baseline to align with |
+| Usage attribution | `crates/harness-server/src/handlers/usage_monitor*.rs` | Per-process token attribution | Per-candidate rows |
+
+## Proposed Design
+
+1. **Fan-out** — when opt-in matches, the reducer expands the implement
+   activity into N candidate jobs sharing a `candidate_group_id`; each gets
+   branch `harness/<issue>-c<i>` and its own worktree.
+2. **Candidate contract** — candidates run the standard implement activity
+   but in `submission_mode = deferred`: they push their branch and record
+   evidence, without opening a PR.
+3. **Selection gate** — a new reducer step runs when all candidates are
+   terminal (or timed out per GH-1437 stall rules): rank by fixed evidence
+   priority (validation green > CI conclusion > quality score > diff scope;
+   deterministic tiebreak: smaller diff, then earlier completion). Decision
+   persisted as a `candidate_selection` runtime record with full ranking
+   input.
+4. **Promotion** — submission step opens the PR from the winner's branch; on
+   PR-creation failure, promote runner-up and append to the decision record.
+5. **Cleanup** — losing branches deleted remotely, worktrees reaped via
+   existing cleanup; trajectories kept as runtime evidence.
+6. **Config** — `candidates.enabled`, `candidates.n` (clamp 2–3),
+   `candidates.trigger_label` (default `best-of-n`), per-candidate budget cap
+   derived from existing budget config divided by n unless overridden.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P2 disjoint workspaces | fan-out worktree naming | integration test: n=2, distinct paths/branches |
+| P3/P5 deterministic selection | selection gate fn | unit test: fixture evidence → identical decision on rescore |
+| P4 exactly one PR | submission gating + cleanup | integration tests: success / winner-PR-fail / all-fail |
+| P8 cost attribution | usage rows keyed by candidate job | handler test: per-candidate rows sum to group total |
+
+## Data Flow
+
+Issue (opt-in) → reducer fan-out (N jobs, candidate_group_id) → agents in
+disjoint worktrees → evidence rows (validation, CI, quality, diff) →
+selection gate → decision record → submission (winner PR) → cleanup.
+
+## Alternatives Considered
+
+- Sequential retry with different agents (existing periodic_retry) — kept as
+  default; fan-out is for wall-clock-critical or previously-failed issues.
+- LLM-judge selection — rejected as primary (known best-of-N selector failure
+  modes); evidence gates first.
+- Cross-candidate diff merging — rejected: unreviewable provenance.
+
+## Risks
+
+- Security: N agents on one untrusted issue multiplies injected-content
+  exposure — same trust controls as single runs; pairs with GH-1450 tiers.
+- Compatibility: submission_mode=deferred must not disturb single-candidate
+  flow — mode defaults to immediate; exhaustive-match on the new enum.
+- Performance: n× token cost — per-candidate caps and opt-in only; usage
+  monitor makes spend visible.
+- Maintenance: reducer complexity — selection gate is a pure function with
+  its own test file.
+
+## Test Plan
+
+- [ ] Unit tests: selection ranking, tiebreaks, promotion chain, budget split.
+- [ ] Integration tests: n=2 fixture flow (success, winner-PR-failure, all-fail, one-stall).
+- [ ] Manual verification: `best-of-n` label on a real harness issue with n=2; inspect decision record and single resulting PR.
+
+## Rollback Plan
+
+Disable via `candidates.enabled=false` (fan-out never triggers). The
+candidate_selection record type is additive; deferred submission mode is
+unreachable when disabled.

--- a/specs/GH1450/product.md
+++ b/specs/GH1450/product.md
@@ -1,0 +1,74 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1450
+
+## User Problem
+
+Agents run on the operator's host under OS sandboxing (Seatbelt/Landlock)
+with host network and operator credentials. Issue bodies and PR comments are
+untrusted input; a prompt-injected agent can currently reach the network and
+act with the operator's GitHub token. There is no way to demand stronger
+isolation for untrusted work without moving off harness entirely.
+
+## Goals
+
+- Introduce an isolation tier axis: `host` (today) / `container` /
+  `microvm` (future), selectable per project and per intake trust class.
+- Route untrusted-origin tasks to the stricter tier automatically.
+- Scope credentials per tier (short-lived, repo-scoped tokens in container).
+
+## Non-Goals
+
+- Firecracker/microVM engine implementation (schema reserves the tier only).
+- Multi-tenant hosting of third-party users.
+- Changing defaults for existing trusted single-operator projects.
+- A cloud control plane.
+
+## Behavior Invariants
+
+1. Isolation tier is declared in config per project, with an optional
+   override map per intake trust class (e.g. non-collaborator issue author →
+   `container`).
+2. Startup validates that every configured tier is actually available on the
+   host; an unavailable required tier is surfaced as degraded health at
+   startup and the affected intake is refused, never silently downgraded.
+3. A `container` task runs with: ephemeral per-task workspace, network
+   egress allowlist, and a short-lived repo-scoped credential — never the
+   operator's full token.
+4. The chosen tier and the reason (trust-class rule that fired) are recorded
+   in run evidence for every task.
+5. Dispatch-time tier resolution is deterministic: same task metadata + same
+   config → same tier.
+6. Container teardown removes workspace and credentials at terminal state,
+   including on crash/cancel (reaper covers orphans).
+7. End-to-end issue→PR flow behaves identically across tiers from the
+   workflow runtime's perspective (same activities, same evidence classes).
+
+## Acceptance Criteria
+
+- [ ] Config schema with per-project tier + trust-class overrides; startup
+      availability validation with degraded-health surfacing.
+- [ ] Container tier completes a full issue→PR workflow with network
+      allowlist and scoped credential.
+- [ ] Untrusted-author fixture maps to container automatically; tier decision
+      visible in run evidence.
+- [ ] Unavailable-tier dispatch fails visibly (health/status), no fallback.
+
+## Edge Cases
+
+- Docker daemon dies mid-task — task fails with an infrastructure failure
+  class; retry policy applies; health reflects tier unavailability.
+- Repo requires host-only tooling (e.g. macOS codesigning) but rule says
+  container — task refused with an explicit conflict reason for the operator.
+- Credential minting fails — dispatch refused before any agent starts.
+- Author trust changes mid-flight (collaborator added) — tier decision is
+  fixed at dispatch; re-evaluated only on new dispatches.
+
+## Rollout Notes
+
+Additive config; absent config means `host` everywhere (today's behavior).
+Recommend first enabling container tier for one public repo's
+non-collaborator issues. Requires documenting the Docker image contract
+(agent CLI availability inside the image).

--- a/specs/GH1450/tasks.md
+++ b/specs/GH1450/tasks.md
@@ -1,0 +1,36 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1450
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1450-T001` Owner: core-config | Done when: `[isolation]` schema parses tiers, trust rules, and network allowlist, accepting `microvm` in the parser but rejecting it at startup with an explicit error | Verify: `cargo test -p harness-core isolation_config`
+- [ ] `SP1450-T002` Owner: server-intake | Done when: intake classifies author trust from `author_association` and persists the class on the workflow row | Verify: `cargo test -p harness-server intake_trust`
+- [ ] `SP1450-T003` Owner: workflow-dispatch | Done when: tier resolution is a pure function (task metadata + config → tier + reason) recorded in run evidence at dispatch | Verify: `cargo test -p harness-workflow tier_resolution`
+- [ ] `SP1450-T004` Owner: server-health | Done when: startup probes required tiers, unavailable tiers surface as degraded health, and matching intake is refused rather than silently downgraded (GH-1441 pattern) | Verify: `cargo test -p harness-server isolation_health`
+- [ ] `SP1450-T005` Owner: agents-spawn | Done when: a shared spawn contract trait has host and container implementations; container runs mount only the task workspace, apply the egress allowlist, and inherit no operator env secrets | Verify: `cargo test -p harness-agents container_spawn`
+- [ ] `SP1450-T006` Owner: agents-credentials | Done when: per-task repo-scoped GitHub App tokens are minted with TTL ≤ task timeout, injected into container env, and revoked at teardown | Verify: `cargo test -p harness-agents scoped_token`
+- [ ] `SP1450-T007` Owner: docs+image | Done when: a reference agent image (claude/codex CLIs) exists with digest pinning documented, plus the operator guide for enabling the container tier | Verify: container fixture flow passes against the pinned image
+
+## Parallelization
+
+- T001 first. Then T002 (intake files) ∥ T003 (resolution module) ∥ T007 (image/docs).
+- T004 after T001; T005 after T003; T006 ∥ T005 (credential module vs spawn module).
+
+## Verification
+
+- `cargo test --workspace`
+- Integration: container issue→PR fixture flow; refusal paths (docker absent, mint failure); cancel-mid-run teardown leaves no container or credential.
+- Manual: non-collaborator issue on a public repo runs in the container tier; container env shows the scoped token only.
+
+## Handoff Notes
+
+- Docker/OCI invocation lives in the agent-spawn layer; the crate-level gh/git ban concerns GitHub state mutations, which remain in agent prompts.
+- `microvm` is name-reserved only; do not scaffold an engine in this issue.

--- a/specs/GH1450/tech.md
+++ b/specs/GH1450/tech.md
@@ -1,0 +1,93 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1450
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Sandbox engines | `crates/harness-sandbox/src/lib.rs` | `SandboxEngine::{Seatbelt, Landlock, None}`, `wrap_command` | Extend with tier concept above OS-sandbox layer |
+| Agent spawn | `crates/harness-agents/src/{claude,codex}.rs` | Spawns CLIs as host processes | Container tier wraps the spawn |
+| Intake | `crates/harness-server/src/intake/github_issues.rs`, webhook path | Ingests issues without author-trust classification | Trust-class source |
+| Config | `crates/harness-core/src/config/` (agents.rs `sandbox_mode`, workflow.rs) | Per-agent sandbox_mode string | Tier schema home |
+| Workspace lifecycle | worktree admission per `WORKFLOW.md`; reaper (`scripts/pg-orphan-cleanup.sh`, runtime cleanup) | Host worktrees, cleanup on terminal | Container workspace lifecycle mirrors this |
+
+## Proposed Design
+
+1. **Config schema** — `[isolation]` per project: `default_tier = "host"`,
+   `[[isolation.rules]] trust = "non_collaborator", tier = "container"`,
+   `network_allowlist = ["github.com", "api.anthropic.com", ...]`.
+   `microvm` accepted by the parser but rejected at startup as unimplemented
+   (explicit error, reserving the name).
+2. **Trust classification** — at intake, classify author via existing GitHub
+   metadata (author_association on issue/PR payloads): collaborator/member/
+   owner → trusted; others → non_collaborator. Stored on the workflow row.
+3. **Tier resolution** — pure function (task metadata + config → tier +
+   reason), executed at dispatch, persisted in run evidence.
+4. **Container runner** — a `ContainerSpawn` wrapper in harness-agents: runs
+   the agent CLI inside a per-task ephemeral container (OCI via docker CLI
+   invocation from the runner layer, not from crates that ban subprocess
+   git/gh — spawning agents is already this layer's job): mounts the task
+   workspace only, applies network allowlist (docker network + proxy env),
+   injects scoped credential, no host home mount.
+5. **Scoped credentials** — mint GitHub installation/fine-grained token
+   scoped to the single repo with contents+pull_requests write; TTL ≤ task
+   timeout; revoke at teardown (best-effort + short TTL as backstop).
+6. **Availability probe** — startup checks docker availability when any rule
+   demands container; failure → degraded health entry + refusal of matching
+   intake (aligned with GH-1441's validate-at-startup pattern).
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P2 no silent downgrade | startup probe + dispatch guard | integration test: rule demands container, docker absent → dispatch refused, health degraded |
+| P3 scoped credential | credential minting | test: container env contains scoped token, not operator token |
+| P5 deterministic resolution | tier resolution fn | unit test: fixture matrix → stable tiers |
+| P6 teardown | container lifecycle + reaper | integration test: cancel mid-run → no container, no credential |
+
+## Data Flow
+
+Intake payload (author_association) → trust class on workflow row →
+dispatch-time tier resolution → container spawn (workspace mount, allowlist,
+scoped token) → normal activity evidence → teardown (container rm, token
+revoke).
+
+## Alternatives Considered
+
+- Jump straight to microVMs — rejected for v1: docker covers the credential
+  and filesystem blast radius on a single-operator deployment; microvm tier
+  name reserved.
+- Egress proxy only (no container) — rejected: does not scope filesystem or
+  credentials.
+- Per-task GitHub App installation tokens vs PAT — App tokens preferred;
+  fallback documented if the deployment uses a PAT (feature requires App).
+
+## Risks
+
+- Security: docker is not a hard security boundary vs kernel exploits —
+  documented; microvm tier is the escalation path. Allowlist bypass via DNS —
+  pin proxy + block direct egress.
+- Compatibility: agent CLIs must exist in the image — publish a reference
+  Dockerfile; image digest pinned in config.
+- Performance: container start adds seconds per task — acceptable for
+  untrusted tier only; host tier unchanged.
+- Maintenance: two spawn paths — shared spawn contract trait with
+  host/container implementations, both covered by the same contract tests.
+
+## Test Plan
+
+- [ ] Unit tests: tier resolution matrix, config parsing (including microvm rejection), allowlist construction.
+- [ ] Integration tests: container issue→PR fixture flow; refusal paths (docker absent, credential mint failure); teardown on cancel.
+- [ ] Manual verification: non-collaborator issue on a public repo runs in container; verify no operator token inside container env.
+
+## Rollback Plan
+
+Remove/disable `[isolation]` config → all dispatch resolves to host tier
+(exact current behavior). Container runner is unreachable without config.

--- a/specs/GH1451/product.md
+++ b/specs/GH1451/product.md
@@ -1,0 +1,67 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1451
+
+## User Problem
+
+Operators cannot inspect a run as a step-level trace in standard tooling.
+Harness exports custom OTLP counters only; trajectory data (which activity,
+which agent turn, how many tokens, what cost, what outcome) lives in bespoke
+Postgres records invisible to Grafana/Langfuse/Phoenix-class tools that teams
+already run.
+
+## Goals
+
+- Emit an OTel span tree per workflow run using GenAI semantic conventions.
+- Keep existing custom counters intact (additive change).
+- Make traces consumable by at least one mainstream backend out of the box.
+
+## Non-Goals
+
+- Replacing the internal event store or run evidence model.
+- A bundled tracing UI.
+- Attribute stability guarantees while upstream GenAI semconv is pre-stable.
+- Capturing prompt/response content by default.
+
+## Behavior Invariants
+
+1. With `otel.trajectory` enabled, each workflow run emits one root span with
+   child spans per activity and per agent turn, linked by trace context.
+2. Spans carry GenAI semconv attribute names for model id, input/output
+   tokens, and cost, plus harness identifiers (workflow id, activity kind,
+   outcome) under a harness namespace.
+3. Trajectory export defaults OFF; enabling it changes no other behavior and
+   existing counters keep their names and semantics.
+4. Prompt/response content is never exported unless a second, separate
+   content-capture flag is enabled; that flag's docs state the privacy
+   implications.
+5. Export failures degrade to dropped spans with an error-level log counter —
+   they never block or fail workflow execution.
+6. Span emission overhead is measured and documented; the feature is marked
+   experimental while upstream conventions are pre-stable.
+
+## Acceptance Criteria
+
+- [ ] One issue→PR run renders as a linked span tree in an OTLP backend with
+      model/token/cost/outcome attributes.
+- [ ] Off by default; counters unchanged in both states.
+- [ ] Content capture requires the explicit second flag.
+- [ ] Quickstart doc shows the trace in Grafana Tempo or Langfuse.
+
+## Edge Cases
+
+- Backend unreachable — spans drop with visible error counter; run unaffected.
+- Token/cost unknown for a turn (adapter gap) — attribute omitted, never
+  zero-filled (no fake data).
+- Very long runs — span batch limits respected; truncation surfaced as a
+  span event, not silent loss.
+- Trace context across retries — retried activities appear as sibling spans
+  with retry attributes, not overwritten.
+
+## Rollout Notes
+
+Experimental flag in config; document attribute names and their upstream
+semconv version (v1.41-era, "Development" stability) so consumers know
+renames may follow upstream.

--- a/specs/GH1451/tasks.md
+++ b/specs/GH1451/tasks.md
@@ -1,0 +1,35 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1451
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1451-T001` Owner: observe | Done when: `otel.trajectory` / `otel.capture_content` flags exist and `OtelPipeline` wires a TracerProvider alongside the existing MeterProvider, default off | Verify: `cargo test -p harness-observe otel_trajectory_config`
+- [ ] `SP1451-T002` Owner: observe | Done when: the attribute mapping module covers GenAI semconv names (model, input/output tokens) plus the harness namespace as a single allowlist, omitting unknown values instead of zero-filling | Verify: `cargo test -p harness-observe otel_attributes`
+- [ ] `SP1451-T003` Owner: workflow-runtime | Done when: workflow/activity lifecycle hooks emit the span tree, trace ids persist on workflow rows, and retries appear as sibling spans with retry attributes | Verify: `cargo test -p harness-workflow otel_spans`
+- [ ] `SP1451-T004` Owner: agents | Done when: agent-turn spans carry token/model/cost attributes fed from usage parsing | Verify: `cargo test -p harness-agents otel_turn_spans`
+- [ ] `SP1451-T005` Owner: observe | Done when: exporter failures drop spans, increment an error counter, and never affect run control flow | Verify: `cargo test -p harness-observe otel_failure_isolation`
+- [ ] `SP1451-T006` Owner: docs | Done when: `docs/otel-trajectory-quickstart.md` plus a compose snippet render a real run's trace in Tempo or Langfuse | Verify: manual quickstart walkthrough recorded in the PR
+
+## Parallelization
+
+- T001 ∥ T002 (disjoint: otel_export.rs vs new mapping module).
+- T003 after T001; T004 after T002; T005 with T003/T004 integration; T006 last.
+
+## Verification
+
+- `cargo test --workspace`
+- Integration: in-memory exporter asserts tree shape, retry siblings, content gating, and counter parity with the flag off.
+- Manual: quickstart renders a real issue→PR run's trace in the chosen backend.
+
+## Handoff Notes
+
+- Internal runtime records remain the source of truth; spans are derived and droppable.
+- Every exported attribute lives in the single allowlist module — that module is the leak-review surface.

--- a/specs/GH1451/tech.md
+++ b/specs/GH1451/tech.md
@@ -1,0 +1,87 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1451
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| OTel export | `crates/harness-observe/src/otel_export.rs` | `OtelPipeline`, metrics-only (counters/histograms) | Add a TracerProvider alongside the MeterProvider |
+| Run lifecycle | `crates/harness-workflow/src/runtime/{dispatcher,worker,reducer}` | State transitions persisted to Postgres | Span open/close hooks |
+| Turn telemetry | `crates/harness-agents/src/{claude,codex}.rs`, usage parsing (`harness-observe/src/usage.rs`) | Token usage parsed from agent output | Turn-span attributes |
+| Config | `crates/harness-core/src/config/` (otel section) | exporter/endpoint/environment | New `otel.trajectory`, `otel.capture_content` flags |
+| Activity results | `crates/harness-server/src/workflow_runtime_worker/activity_result.rs` | Structured outcome parsing | Outcome attributes |
+
+## Proposed Design
+
+1. **Tracer wiring** — extend `OtelPipeline` with an SDK `TracerProvider`
+   sharing the existing exporter config; gated by `otel.trajectory`.
+2. **Span model** —
+   - root: `harness.workflow` (workflow id, repo, trigger, terminal outcome);
+   - child: `harness.activity` per activity execution (kind, attempt, state);
+   - child: GenAI turn span per agent invocation with semconv attributes
+     (`gen_ai.system` (adapter), `gen_ai.request.model`,
+     `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`) plus
+     `harness.cost_usd` where computable.
+3. **Context propagation** — trace context stored on the workflow row when
+   the root span opens, so worker processes/retries attach spans to the same
+   trace; retries become sibling activity spans with `harness.retry` attrs.
+4. **Content capture** — off; when `otel.capture_content=true`, prompt/final
+   message are attached as span events following semconv content guidance.
+5. **Failure isolation** — span emission wrapped so exporter errors increment
+   an error counter and log at error level once per interval; never
+   propagate into run control flow.
+6. **Quickstart** — `docs/otel-trajectory-quickstart.md` + docker-compose
+   snippet (Tempo or Langfuse) with a screenshot-level walkthrough.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 span tree shape | lifecycle hooks | integration test with in-memory span exporter asserting hierarchy |
+| P3 additive default-off | config gating | tests: counters byte-identical with flag off/on |
+| P4 content gating | capture flag | test: content absent without second flag |
+| P5 failure isolation | wrapped emitter | test: failing exporter → run completes, error counter increments |
+
+## Data Flow
+
+Runtime state transitions + agent usage parsing → span builder → OTLP
+exporter (existing endpoint config) → external backend. Trace ids also
+persisted on workflow rows for cross-referencing with internal records.
+
+## Alternatives Considered
+
+- Log-based export (OTLP logs) — rejected: consumers want traces.
+- Exporting from Postgres via a sidecar ETL — rejected for v1: doubles the
+  data model; direct emission is simpler and real-time.
+- Waiting for semconv stability — rejected: mark experimental instead; the
+  consuming ecosystem already reads the Development-stability names.
+
+## Risks
+
+- Security: span attributes could leak repo-private strings — attribute set
+  is a fixed allowlist; content behind a second flag.
+- Compatibility: upstream semconv renames — attributes centralized in one
+  module; experimental labeling.
+- Performance: span overhead per turn is tiny vs agent runtime; measured in
+  the integration test and documented.
+- Maintenance: two telemetry surfaces (internal records + spans) — spans are
+  derived-only; internal records remain the source of truth.
+
+## Test Plan
+
+- [ ] Unit tests: attribute mapping (model/tokens/cost/outcome), config gating, allowlist.
+- [ ] Integration tests: in-memory exporter span-tree shape; retry siblings; failure isolation.
+- [ ] Manual verification: quickstart against Tempo or Langfuse with one real issue→PR run.
+
+## Rollback Plan
+
+Set `otel.trajectory=false` (default) — tracer never initializes; metrics
+pipeline untouched. No persisted-schema changes beyond a nullable trace-id
+column, which can remain.


### PR DESCRIPTION
# Summary

Adds five SpecRail spec packets (`specs/GH<issue>/{product,tech,tasks}.md`) for the capability gaps identified in the mid-2026 harness landscape research: runtime-native regression eval loop, repo-scoped cross-run memory, best-of-n candidate generation, per-task isolation tiers, and OTel GenAI trajectory telemetry. Docs-only change; no code.

## Linked Work

- Issue: #1447, #1448, #1449, #1450, #1451 (context: #1434 kernel contraction)
- Spec packet: `specs/GH1447/`, `specs/GH1448/`, `specs/GH1449/`, `specs/GH1450/`, `specs/GH1451/`

## Readiness Gate

- [ ] Linked issues need maintainer readiness labels (`ready_to_spec` → this PR is the spec; approve to reach `ready_to_implement`).
- [x] Product/tech spec is linked when required (this PR contains them).
- [x] Security-sensitive changes were routed privately or approved by maintainers (specs only; the isolation/credential design in GH1450 is itself the security review surface).

## Review Gate

- [x] Agent first-pass review completed (SpecRail deterministic checks, see Verification).
- [ ] Human final review requested — maintainer approval of the specs is the gate for implementation.
- [ ] Owner approval identified when ownership rules apply.

## Merge Gate

- [ ] PR head SHA recorded.
- [ ] CI/check rollup is complete and passing.
- [ ] Review threads were checked and unresolved actionable threads are addressed.
- [ ] Merge state is clean.
- [ ] Human merge authorization is recorded before merge.

## Verification

- [x] Tests: `python3 checks/check_workflow.py --repo <specrail> --spec-dir specs/GH<n>` passes for all five packets.
- [x] Manual proof: packets follow SpecRail templates (product invariants, product-to-test mapping, SP<issue>-T IDs with Owner/Done-when/Verify).
- [x] Not user-visible at runtime (docs only).

## Release Notes

- [x] Not user-visible.

## Agent Disclosure

- [x] Agent assisted; human author to review the full diff before merge.

## Notes for review

- All five designs deliberately avoid new crates and standalone layers, aligning with the #1434 kernel-contraction decision: eval (GH1447) replaces the deleted harness-eval with a runtime-native loop; memory (GH1448) rides prompt packets instead of the skills store slated for Phase-3 removal.
- GH1449 formalizes docs/parallel-pr-repair-bakeoff-spec.md; GH1450 follows the #1441 validate-at-startup/degraded-health pattern; GH1451 is additive behind default-off flags.