### PR TITLE
Implement GH1434 usage probes and archive script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ crates/*/.harness/
 ~/.local/
 .omx/
 docs/artifacts/
+archives/
 
 # Git worktrees (superpowers skill convention)
 .worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ dependencies = [
 name = "harness-eval"
 version = "0.6.34"
 dependencies = [
+ "harness-core",
  "serde",
  "serde_json",
 ]

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod store_backend;
 mod test_support;
 pub mod tool_isolation;
 pub mod types;
+pub mod usage_probe;
 pub mod validation;
 
 pub use config::misc::OtelExporter;

--- a/crates/harness-core/src/usage_probe.rs
+++ b/crates/harness-core/src/usage_probe.rs
@@ -105,31 +105,30 @@ pub fn reset_for_tests() {
 mod tests {
     use super::*;
 
+    fn count_for(surface: &str) -> u64 {
+        snapshot()
+            .into_iter()
+            .find(|entry| entry.surface == surface)
+            .map(|entry| entry.count)
+            .unwrap_or(0)
+    }
+
     #[test]
     fn snapshot_includes_recorded_surface_counts() {
-        reset_for_tests();
+        let thread_before = count_for("thread_rpc");
+        let review_before = count_for("review_store");
 
         record_usage(UsageProbeSurface::ThreadRpc);
         record_usage(UsageProbeSurface::ThreadRpc);
         record_usage(UsageProbeSurface::ReviewStore);
 
-        let snapshot = snapshot();
-        let thread_rpc = snapshot
-            .iter()
-            .find(|entry| entry.surface == "thread_rpc")
-            .expect("thread_rpc entry");
-        let review_store = snapshot
-            .iter()
-            .find(|entry| entry.surface == "review_store")
-            .expect("review_store entry");
-
-        assert_eq!(thread_rpc.count, 2);
-        assert_eq!(review_store.count, 1);
+        assert!(count_for("thread_rpc") >= thread_before + 2);
+        assert!(count_for("review_store") >= review_before + 1);
     }
 
     #[test]
     fn probe_report_event_uses_queryable_detail() -> anyhow::Result<()> {
-        reset_for_tests();
+        let before = count_for("task_runner");
         record_usage(UsageProbeSurface::TaskRunner);
 
         let event = build_probe_report_event()?;
@@ -138,8 +137,13 @@ mod tests {
         assert_eq!(event.tool, "usage_probe");
         assert_eq!(event.decision, Decision::Complete);
         let detail = event.detail.expect("detail");
-        assert!(detail.contains("\"surface\":\"task_runner\""));
-        assert!(detail.contains("\"count\":1"));
+        let counts: Vec<serde_json::Value> = serde_json::from_str(&detail)?;
+        let task_runner_count = counts
+            .iter()
+            .find(|entry| entry["surface"] == "task_runner")
+            .and_then(|entry| entry["count"].as_u64())
+            .unwrap_or(0);
+        assert!(task_runner_count >= before + 1);
         assert!(
             event.content.is_none(),
             "queryable summary must be in detail"

--- a/crates/harness-core/src/usage_probe.rs
+++ b/crates/harness-core/src/usage_probe.rs
@@ -123,7 +123,7 @@ mod tests {
         record_usage(UsageProbeSurface::ReviewStore);
 
         assert!(count_for("thread_rpc") >= thread_before + 2);
-        assert!(count_for("review_store") >= review_before + 1);
+        assert!(count_for("review_store") > review_before);
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod tests {
             .find(|entry| entry["surface"] == "task_runner")
             .and_then(|entry| entry["count"].as_u64())
             .unwrap_or(0);
-        assert!(task_runner_count >= before + 1);
+        assert!(task_runner_count > before);
         assert!(
             event.content.is_none(),
             "queryable summary must be in detail"

--- a/crates/harness-core/src/usage_probe.rs
+++ b/crates/harness-core/src/usage_probe.rs
@@ -1,0 +1,149 @@
+use crate::types::{Decision, Event, SessionId};
+use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageProbeSurface {
+    ThreadRpc,
+    TurnRpc,
+    ThreadManager,
+    TaskDb,
+    TaskExecutor,
+    TaskRunner,
+    HarnessEval,
+    ReviewStore,
+}
+
+impl UsageProbeSurface {
+    pub const ALL: [Self; 8] = [
+        Self::ThreadRpc,
+        Self::TurnRpc,
+        Self::ThreadManager,
+        Self::TaskDb,
+        Self::TaskExecutor,
+        Self::TaskRunner,
+        Self::HarnessEval,
+        Self::ReviewStore,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ThreadRpc => "thread_rpc",
+            Self::TurnRpc => "turn_rpc",
+            Self::ThreadManager => "thread_manager",
+            Self::TaskDb => "task_db",
+            Self::TaskExecutor => "task_executor",
+            Self::TaskRunner => "task_runner",
+            Self::HarnessEval => "harness_eval",
+            Self::ReviewStore => "review_store",
+        }
+    }
+
+    fn counter(self) -> &'static AtomicU64 {
+        match self {
+            Self::ThreadRpc => &THREAD_RPC_COUNT,
+            Self::TurnRpc => &TURN_RPC_COUNT,
+            Self::ThreadManager => &THREAD_MANAGER_COUNT,
+            Self::TaskDb => &TASK_DB_COUNT,
+            Self::TaskExecutor => &TASK_EXECUTOR_COUNT,
+            Self::TaskRunner => &TASK_RUNNER_COUNT,
+            Self::HarnessEval => &HARNESS_EVAL_COUNT,
+            Self::ReviewStore => &REVIEW_STORE_COUNT,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UsageProbeCount {
+    pub surface: &'static str,
+    pub count: u64,
+}
+
+static THREAD_RPC_COUNT: AtomicU64 = AtomicU64::new(0);
+static TURN_RPC_COUNT: AtomicU64 = AtomicU64::new(0);
+static THREAD_MANAGER_COUNT: AtomicU64 = AtomicU64::new(0);
+static TASK_DB_COUNT: AtomicU64 = AtomicU64::new(0);
+static TASK_EXECUTOR_COUNT: AtomicU64 = AtomicU64::new(0);
+static TASK_RUNNER_COUNT: AtomicU64 = AtomicU64::new(0);
+static HARNESS_EVAL_COUNT: AtomicU64 = AtomicU64::new(0);
+static REVIEW_STORE_COUNT: AtomicU64 = AtomicU64::new(0);
+
+pub fn record_usage(surface: UsageProbeSurface) {
+    surface.counter().fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn snapshot() -> Vec<UsageProbeCount> {
+    UsageProbeSurface::ALL
+        .into_iter()
+        .map(|surface| UsageProbeCount {
+            surface: surface.as_str(),
+            count: surface.counter().load(Ordering::Relaxed),
+        })
+        .collect()
+}
+
+pub fn build_probe_report_event() -> anyhow::Result<Event> {
+    let mut event = Event::new(
+        SessionId::new(),
+        "probe_report",
+        "usage_probe",
+        Decision::Complete,
+    );
+    event.detail = Some(serde_json::to_string(&snapshot())?);
+    Ok(event)
+}
+
+#[doc(hidden)]
+pub fn reset_for_tests() {
+    for surface in UsageProbeSurface::ALL {
+        surface.counter().store(0, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_includes_recorded_surface_counts() {
+        reset_for_tests();
+
+        record_usage(UsageProbeSurface::ThreadRpc);
+        record_usage(UsageProbeSurface::ThreadRpc);
+        record_usage(UsageProbeSurface::ReviewStore);
+
+        let snapshot = snapshot();
+        let thread_rpc = snapshot
+            .iter()
+            .find(|entry| entry.surface == "thread_rpc")
+            .expect("thread_rpc entry");
+        let review_store = snapshot
+            .iter()
+            .find(|entry| entry.surface == "review_store")
+            .expect("review_store entry");
+
+        assert_eq!(thread_rpc.count, 2);
+        assert_eq!(review_store.count, 1);
+    }
+
+    #[test]
+    fn probe_report_event_uses_queryable_detail() -> anyhow::Result<()> {
+        reset_for_tests();
+        record_usage(UsageProbeSurface::TaskRunner);
+
+        let event = build_probe_report_event()?;
+
+        assert_eq!(event.hook, "probe_report");
+        assert_eq!(event.tool, "usage_probe");
+        assert_eq!(event.decision, Decision::Complete);
+        let detail = event.detail.expect("detail");
+        assert!(detail.contains("\"surface\":\"task_runner\""));
+        assert!(detail.contains("\"count\":1"));
+        assert!(
+            event.content.is_none(),
+            "queryable summary must be in detail"
+        );
+        Ok(())
+    }
+}

--- a/crates/harness-eval/Cargo.toml
+++ b/crates/harness-eval/Cargo.toml
@@ -8,5 +8,6 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+harness-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/harness-eval/src/benchmark.rs
+++ b/crates/harness-eval/src/benchmark.rs
@@ -81,6 +81,9 @@ pub struct PrRepairBenchmarkSummary {
 }
 
 pub fn summarize_pr_repair_benchmark(input: PrRepairBenchmarkInput) -> PrRepairBenchmarkSummary {
+    harness_core::usage_probe::record_usage(
+        harness_core::usage_probe::UsageProbeSurface::HarnessEval,
+    );
     if input.cases.is_empty() {
         return PrRepairBenchmarkSummary {
             suite: input.suite,

--- a/crates/harness-eval/src/ingest.rs
+++ b/crates/harness-eval/src/ingest.rs
@@ -3,6 +3,7 @@ use crate::model::{
     PrRepairEvalInput, PullRequestSnapshot, ReviewDecision, ReviewThreadSnapshot, ReviewerJudgment,
     RuntimeJobSnapshot, RuntimeSnapshot,
 };
+use harness_core::usage_probe::{record_usage, UsageProbeSurface};
 use serde_json::Value;
 
 mod usage_ingest;
@@ -26,6 +27,7 @@ pub fn github_pr_snapshot_from_value(
     collected_at: &str,
     value: &Value,
 ) -> PullRequestSnapshot {
+    record_usage(UsageProbeSurface::HarnessEval);
     let review_threads = review_thread_values(value)
         .filter(|thread| {
             !thread
@@ -145,6 +147,7 @@ pub fn runtime_snapshot_from_values(
     task_detail: &Value,
     collected_at: &str,
 ) -> Option<RuntimeSnapshot> {
+    record_usage(UsageProbeSurface::HarnessEval);
     let task_id = optional_string_field(submission, "task_id")
         .or_else(|| optional_string_field(submission, "submission_id"))
         .or_else(|| optional_string_field(task_detail, "id"));
@@ -181,6 +184,7 @@ pub fn runtime_snapshot_from_values(
 }
 
 pub fn pr_repair_eval_input_from_values(input: PrRepairEvalIngest<'_>) -> PrRepairEvalInput {
+    record_usage(UsageProbeSurface::HarnessEval);
     let baseline_pr =
         github_pr_snapshot_from_value(input.repo, input.baseline_collected_at, input.baseline);
     let final_pr_snapshot =

--- a/crates/harness-eval/src/lib.rs
+++ b/crates/harness-eval/src/lib.rs
@@ -7,3 +7,56 @@ pub use benchmark::*;
 pub use ingest::*;
 pub use model::*;
 pub use scoring::{score_pr_repair_eval, ScoringError};
+
+#[cfg(test)]
+mod usage_probe_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn harness_eval_count() -> u64 {
+        harness_core::usage_probe::snapshot()
+            .into_iter()
+            .find(|entry| entry.surface == "harness_eval")
+            .map(|entry| entry.count)
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn ingest_public_entrypoints_record_harness_eval_usage() {
+        harness_core::usage_probe::reset_for_tests();
+        let pr = json!({
+            "number": 7,
+            "baseRefName": "main",
+            "headRefName": "feature",
+            "headRefOid": "abc123",
+            "isDraft": false,
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"state": "SUCCESS"},
+            "reviewThreads": {"nodes": []},
+            "files": {"nodes": []}
+        });
+        let submission = json!({"task_id": "task-1", "workflow_id": "workflow-1"});
+        let task_detail = json!({"id": "task-1", "status": "done"});
+
+        let pr_snapshot = github_pr_snapshot_from_value("owner/repo", "2026-07-04T00:00:00Z", &pr);
+        let runtime_snapshot =
+            runtime_snapshot_from_values(&submission, &task_detail, "2026-07-04T00:00:00Z");
+        let eval_input = pr_repair_eval_input_from_values(PrRepairEvalIngest {
+            repo: "owner/repo",
+            pr_number: 7,
+            baseline_collected_at: "2026-07-04T00:00:00Z",
+            final_collected_at: "2026-07-04T00:01:00Z",
+            baseline: &pr,
+            final_pr: &pr,
+            run_mode: EvalRunMode::LiveRun,
+            submission: Some(&submission),
+            task_detail: Some(&task_detail),
+            reviewer_judgment: None,
+        });
+
+        assert_eq!(pr_snapshot.pr_number, 7);
+        assert!(runtime_snapshot.is_some());
+        assert_eq!(eval_input.final_pr.pr_number, 7);
+        assert!(harness_eval_count() >= 3);
+    }
+}

--- a/crates/harness-eval/src/lib.rs
+++ b/crates/harness-eval/src/lib.rs
@@ -23,7 +23,7 @@ mod usage_probe_tests {
 
     #[test]
     fn ingest_public_entrypoints_record_harness_eval_usage() {
-        harness_core::usage_probe::reset_for_tests();
+        let before = harness_eval_count();
         let pr = json!({
             "number": 7,
             "baseRefName": "main",
@@ -57,6 +57,6 @@ mod usage_probe_tests {
         assert_eq!(pr_snapshot.pr_number, 7);
         assert!(runtime_snapshot.is_some());
         assert_eq!(eval_input.final_pr.pr_number, 7);
-        assert!(harness_eval_count() >= 3);
+        assert!(harness_eval_count() >= before + 3);
     }
 }

--- a/crates/harness-eval/src/scoring.rs
+++ b/crates/harness-eval/src/scoring.rs
@@ -23,6 +23,9 @@ impl fmt::Display for ScoringError {
 impl Error for ScoringError {}
 
 pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot, ScoringError> {
+    harness_core::usage_probe::record_usage(
+        harness_core::usage_probe::UsageProbeSurface::HarnessEval,
+    );
     let target_matches = target_matches_pr(&input)?;
     let branch_safe = branch_safe(&input);
     let no_unrelated_pr = !input.created_unrelated_pr;

--- a/crates/harness-server/src/review_store/mod.rs
+++ b/crates/harness-server/src/review_store/mod.rs
@@ -100,9 +100,16 @@ pub struct ReviewStore {
     pool: PgPool,
 }
 
+fn record_review_store_usage() {
+    harness_core::usage_probe::record_usage(
+        harness_core::usage_probe::UsageProbeSurface::ReviewStore,
+    );
+}
+
 impl ReviewStore {
     /// Open (or create) the review store, running any pending migrations.
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
+        record_review_store_usage();
         Self::open_with_database_url(path, None).await
     }
 
@@ -110,6 +117,7 @@ impl ReviewStore {
         path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
+        record_review_store_usage();
         let context = PgStoreContext::from_legacy_path_schema(path, configured_database_url)?;
         let pool = context.open_migrated_pool(REVIEW_MIGRATIONS).await?;
         Ok(Self { pool })
@@ -118,6 +126,7 @@ impl ReviewStore {
     pub fn shared_schema_context(
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<PgStoreContext> {
+        record_review_store_usage();
         PostgresBackend::new(configured_database_url.map(ToOwned::to_owned)).store_context(
             &StoreLocation::SharedSchema(REVIEW_STORE_SCHEMA.to_string()),
         )
@@ -127,6 +136,7 @@ impl ReviewStore {
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
+        record_review_store_usage();
         let pool = context
             .open_migrated_pool_with_setup_pool(setup_pool, REVIEW_MIGRATIONS)
             .await?;
@@ -147,6 +157,7 @@ impl ReviewStore {
         review_id: &str,
         findings: &[ReviewFinding],
     ) -> anyhow::Result<usize> {
+        record_review_store_usage();
         let mut seen_ids = std::collections::HashSet::with_capacity(findings.len());
         for f in findings {
             if !seen_ids.insert(f.id.as_str()) {
@@ -216,6 +227,7 @@ impl ReviewStore {
 
     /// List all open findings, ordered by priority then impact.
     pub async fn list_open(&self) -> anyhow::Result<Vec<ReviewFinding>> {
+        record_review_store_usage();
         let rows: Vec<FindingRow> = sqlx::query_as(
             "SELECT id, rule_id, priority, impact, confidence, effort, \
                     file, line, title, description, action, task_id \
@@ -237,6 +249,7 @@ impl ReviewStore {
         review_id: &str,
         priorities: &[&str],
     ) -> anyhow::Result<Vec<ReviewFinding>> {
+        record_review_store_usage();
         if priorities.is_empty() {
             return Ok(vec![]);
         }
@@ -271,6 +284,7 @@ impl ReviewStore {
         rule_id: &str,
         file: &str,
     ) -> anyhow::Result<bool> {
+        record_review_store_usage();
         let result = sqlx::query(
             "UPDATE review_findings SET task_id = 'pending', claimed_at = CURRENT_TIMESTAMP \
              WHERE project_root = $1 AND rule_id = $2 AND file = $3 AND status = 'open' \
@@ -297,6 +311,7 @@ impl ReviewStore {
         stale_secs: i64,
         get_task_outcome: impl Fn(&str) -> Option<bool>,
     ) -> anyhow::Result<u64> {
+        record_review_store_usage();
         let with_real_id: Vec<(String, String, String)> = sqlx::query_as(
             "SELECT rule_id, file, real_task_id \
              FROM review_findings \
@@ -344,6 +359,7 @@ impl ReviewStore {
         &self,
         project_root: &str,
     ) -> anyhow::Result<Vec<String>> {
+        record_review_store_usage();
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT real_task_id FROM review_findings \
              WHERE project_root = $1 AND task_id = 'pending' AND status = 'open' \
@@ -363,6 +379,7 @@ impl ReviewStore {
         file: &str,
         real_task_id: &str,
     ) -> anyhow::Result<()> {
+        record_review_store_usage();
         sqlx::query(
             "UPDATE review_findings SET real_task_id = $1 \
              WHERE project_root = $2 AND rule_id = $3 AND file = $4 \
@@ -385,6 +402,7 @@ impl ReviewStore {
         file: &str,
         task_id: &str,
     ) -> anyhow::Result<()> {
+        record_review_store_usage();
         sqlx::query(
             "UPDATE review_findings SET task_id = $1 \
              WHERE project_root = $2 AND rule_id = $3 AND file = $4 \
@@ -411,6 +429,7 @@ impl ReviewStore {
         rule_id: &str,
         file: &str,
     ) -> anyhow::Result<u64> {
+        record_review_store_usage();
         let result = sqlx::query(
             "UPDATE review_findings \
              SET task_id = NULL, \
@@ -437,6 +456,7 @@ impl ReviewStore {
         rule_id: &str,
         file: &str,
     ) -> anyhow::Result<()> {
+        record_review_store_usage();
         sqlx::query(
             "UPDATE review_findings \
              SET failure_count = 0, cooldown_until = NULL \
@@ -459,6 +479,7 @@ impl ReviewStore {
         project_root: &str,
         current_review_id: &str,
     ) -> anyhow::Result<u64> {
+        record_review_store_usage();
         let result = sqlx::query(
             "UPDATE review_findings \
              SET failure_count = 0, cooldown_until = NULL \
@@ -501,6 +522,7 @@ impl ReviewStore {
         rule_id: &str,
         file: &str,
     ) -> anyhow::Result<()> {
+        record_review_store_usage();
         sqlx::query(
             "UPDATE review_findings SET task_id = NULL \
              WHERE project_root = $1 AND rule_id = $2 AND file = $3 \
@@ -559,6 +581,7 @@ pub async fn migrate_legacy_review_store_if_needed(
     configured_database_url: Option<&str>,
     target_store: &ReviewStore,
 ) -> anyhow::Result<u64> {
+    record_review_store_usage();
     let legacy_context =
         PgStoreContext::from_legacy_path_schema(legacy_path, configured_database_url)?;
     let legacy_schema = legacy_context.schema();
@@ -611,6 +634,7 @@ pub async fn migrate_legacy_review_store_if_needed(
 /// The agent may wrap the JSON in markdown code fences; this function
 /// strips them before parsing.
 pub fn parse_review_output(raw: &str) -> anyhow::Result<ReviewOutput> {
+    record_review_store_usage();
     let trimmed = raw.trim();
 
     const START_MARKER: &str = "REVIEW_JSON_START";

--- a/crates/harness-server/src/router/mod.rs
+++ b/crates/harness-server/src/router/mod.rs
@@ -10,6 +10,7 @@
 
 use crate::handlers;
 use crate::http::AppState;
+use harness_core::usage_probe::{record_usage, UsageProbeSurface};
 use harness_protocol::{methods::Method, methods::RpcRequest, methods::RpcResponse};
 
 /// Route a JSON-RPC request to the appropriate handler.
@@ -28,6 +29,21 @@ pub async fn handle_request(state: &AppState, req: RpcRequest) -> Option<RpcResp
                 "Server not initialized. Send 'initialize' first.",
             ));
         }
+        _ => {}
+    }
+
+    match &req.method {
+        Method::ThreadStart { .. }
+        | Method::ThreadList
+        | Method::ThreadDelete { .. }
+        | Method::ThreadResume { .. }
+        | Method::ThreadFork { .. }
+        | Method::ThreadCompact { .. } => record_usage(UsageProbeSurface::ThreadRpc),
+        Method::TurnStart { .. }
+        | Method::TurnCancel { .. }
+        | Method::TurnStatus { .. }
+        | Method::TurnSteer { .. }
+        | Method::TurnRespondApproval { .. } => record_usage(UsageProbeSurface::TurnRpc),
         _ => {}
     }
 

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -773,6 +773,47 @@ async fn thread_start_persists_to_db() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn usage_probe_counts_thread_and_turn_rpc_dispatch() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    harness_core::usage_probe::reset_for_tests();
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+
+    let thread_req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(1)),
+        method: Method::ThreadList,
+    };
+    let turn_req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(2)),
+        method: Method::TurnStatus {
+            turn_id: harness_core::types::TurnId::from_str("missing-turn"),
+        },
+    };
+
+    let _ = handle_request(&state, thread_req).await;
+    let _ = handle_request(&state, turn_req).await;
+
+    let counts = harness_core::usage_probe::snapshot();
+    let thread_rpc = counts
+        .iter()
+        .find(|entry| entry.surface == "thread_rpc")
+        .ok_or_else(|| anyhow::anyhow!("missing thread_rpc count"))?;
+    let turn_rpc = counts
+        .iter()
+        .find(|entry| entry.surface == "turn_rpc")
+        .ok_or_else(|| anyhow::anyhow!("missing turn_rpc count"))?;
+
+    assert_eq!(thread_rpc.count, 1);
+    assert_eq!(turn_rpc.count, 1);
+    Ok(())
+}
+
+#[tokio::test]
 async fn event_log_then_query_roundtrip() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
@@ -840,6 +881,43 @@ async fn event_log_then_query_roundtrip() -> anyhow::Result<()> {
         serde_json::json!(event.id.as_str()),
         "returned event id should match logged event"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn usage_probe_report_is_queryable_from_event_detail() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    harness_core::usage_probe::reset_for_tests();
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+
+    harness_core::usage_probe::record_usage(
+        harness_core::usage_probe::UsageProbeSurface::TaskRunner,
+    );
+    let event = harness_core::usage_probe::build_probe_report_event()?;
+    state.observability.events.log(&event).await?;
+
+    let events = state
+        .observability
+        .events
+        .query(&harness_core::types::EventFilters {
+            hook: Some("probe_report".to_string()),
+            tool: Some("usage_probe".to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+    assert_eq!(events.len(), 1);
+    let detail = events[0]
+        .detail
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("missing probe detail"))?;
+    assert!(detail.contains("\"surface\":\"task_runner\""));
+    assert!(detail.contains("\"count\":1"));
+    assert!(events[0].content.is_none());
     Ok(())
 }
 

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -778,7 +778,17 @@ async fn usage_probe_counts_thread_and_turn_rpc_dispatch() -> anyhow::Result<()>
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());
     }
-    harness_core::usage_probe::reset_for_tests();
+    let before = harness_core::usage_probe::snapshot();
+    let thread_before = before
+        .iter()
+        .find(|entry| entry.surface == "thread_rpc")
+        .map(|entry| entry.count)
+        .unwrap_or(0);
+    let turn_before = before
+        .iter()
+        .find(|entry| entry.surface == "turn_rpc")
+        .map(|entry| entry.count)
+        .unwrap_or(0);
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
 
@@ -808,8 +818,8 @@ async fn usage_probe_counts_thread_and_turn_rpc_dispatch() -> anyhow::Result<()>
         .find(|entry| entry.surface == "turn_rpc")
         .ok_or_else(|| anyhow::anyhow!("missing turn_rpc count"))?;
 
-    assert_eq!(thread_rpc.count, 1);
-    assert_eq!(turn_rpc.count, 1);
+    assert!(thread_rpc.count >= thread_before + 1);
+    assert!(turn_rpc.count >= turn_before + 1);
     Ok(())
 }
 
@@ -890,7 +900,11 @@ async fn usage_probe_report_is_queryable_from_event_detail() -> anyhow::Result<(
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());
     }
-    harness_core::usage_probe::reset_for_tests();
+    let before = harness_core::usage_probe::snapshot()
+        .into_iter()
+        .find(|entry| entry.surface == "task_runner")
+        .map(|entry| entry.count)
+        .unwrap_or(0);
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
 
@@ -915,8 +929,13 @@ async fn usage_probe_report_is_queryable_from_event_detail() -> anyhow::Result<(
         .detail
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("missing probe detail"))?;
-    assert!(detail.contains("\"surface\":\"task_runner\""));
-    assert!(detail.contains("\"count\":1"));
+    let counts: Vec<serde_json::Value> = serde_json::from_str(detail)?;
+    let task_runner_count = counts
+        .iter()
+        .find(|entry| entry["surface"] == "task_runner")
+        .and_then(|entry| entry["count"].as_u64())
+        .unwrap_or(0);
+    assert!(task_runner_count >= before + 1);
     assert!(events[0].content.is_none());
     Ok(())
 }

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -818,8 +818,8 @@ async fn usage_probe_counts_thread_and_turn_rpc_dispatch() -> anyhow::Result<()>
         .find(|entry| entry.surface == "turn_rpc")
         .ok_or_else(|| anyhow::anyhow!("missing turn_rpc count"))?;
 
-    assert!(thread_rpc.count >= thread_before + 1);
-    assert!(turn_rpc.count >= turn_before + 1);
+    assert!(thread_rpc.count > thread_before);
+    assert!(turn_rpc.count > turn_before);
     Ok(())
 }
 
@@ -935,7 +935,7 @@ async fn usage_probe_report_is_queryable_from_event_detail() -> anyhow::Result<(
         .find(|entry| entry["surface"] == "task_runner")
         .and_then(|entry| entry["count"].as_u64())
         .unwrap_or(0);
-    assert!(task_runner_count >= before + 1);
+    assert!(task_runner_count > before);
     assert!(events[0].content.is_none());
     Ok(())
 }

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -112,6 +112,8 @@ impl Scheduler {
             .events
             .persist_rule_scan(&project_root, &violations)
             .await;
+        let probe_report = harness_core::usage_probe::build_probe_report_event()?;
+        state.observability.events.log(&probe_report).await?;
         let report = generate_health_report(&events, &violations);
         tracing::info!(
             grade = ?report.quality.grade,
@@ -200,6 +202,41 @@ mod tests {
         let expected_root = project_root.path().display().to_string();
         assert_eq!(scan.detail.as_deref(), Some(expected_root.as_str()));
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn health_tick_persists_usage_probe_report() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let data_dir = tempfile::tempdir()?;
+        let project_root = tempfile::tempdir()?;
+        let state = make_test_state(data_dir.path(), project_root.path()).await?;
+        harness_core::usage_probe::reset_for_tests();
+        harness_core::usage_probe::record_usage(
+            harness_core::usage_probe::UsageProbeSurface::ThreadManager,
+        );
+
+        Scheduler::run_health_tick(&state).await?;
+
+        let events = state
+            .observability
+            .events
+            .query(&EventFilters {
+                hook: Some("probe_report".to_string()),
+                tool: Some("usage_probe".to_string()),
+                ..Default::default()
+            })
+            .await?;
+        assert_eq!(events.len(), 1);
+        let detail = events[0]
+            .detail
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("missing probe report detail"))?;
+        assert!(detail.contains("\"surface\":\"thread_manager\""));
+        assert!(detail.contains("\"count\":1"));
         Ok(())
     }
 

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -214,7 +214,11 @@ mod tests {
         let data_dir = tempfile::tempdir()?;
         let project_root = tempfile::tempdir()?;
         let state = make_test_state(data_dir.path(), project_root.path()).await?;
-        harness_core::usage_probe::reset_for_tests();
+        let before = harness_core::usage_probe::snapshot()
+            .into_iter()
+            .find(|entry| entry.surface == "thread_manager")
+            .map(|entry| entry.count)
+            .unwrap_or(0);
         harness_core::usage_probe::record_usage(
             harness_core::usage_probe::UsageProbeSurface::ThreadManager,
         );
@@ -235,8 +239,13 @@ mod tests {
             .detail
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("missing probe report detail"))?;
-        assert!(detail.contains("\"surface\":\"thread_manager\""));
-        assert!(detail.contains("\"count\":1"));
+        let counts: Vec<serde_json::Value> = serde_json::from_str(detail)?;
+        let thread_manager_count = counts
+            .iter()
+            .find(|entry| entry["surface"] == "thread_manager")
+            .and_then(|entry| entry["count"].as_u64())
+            .unwrap_or(0);
+        assert!(thread_manager_count >= before + 1);
         Ok(())
     }
 

--- a/crates/harness-server/src/scheduler.rs
+++ b/crates/harness-server/src/scheduler.rs
@@ -245,7 +245,7 @@ mod tests {
             .find(|entry| entry["surface"] == "thread_manager")
             .and_then(|entry| entry["count"].as_u64())
             .unwrap_or(0);
-        assert!(thread_manager_count >= before + 1);
+        assert!(thread_manager_count > before);
         Ok(())
     }
 

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -22,6 +22,10 @@ pub struct TaskDb {
     store_key: String,
 }
 
+fn record_task_db_usage() {
+    harness_core::usage_probe::record_usage(harness_core::usage_probe::UsageProbeSurface::TaskDb);
+}
+
 impl TaskDb {
     /// Open a Postgres-backed task database.
     ///
@@ -30,6 +34,7 @@ impl TaskDb {
     /// fully isolated. The schema is created if it does not exist and migrations
     /// are applied before any queries run.
     pub async fn open(db_path: &Path) -> anyhow::Result<Self> {
+        record_task_db_usage();
         Self::open_with_database_url(db_path, None).await
     }
 
@@ -37,6 +42,7 @@ impl TaskDb {
         db_path: &Path,
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<Self> {
+        record_task_db_usage();
         let context = PgStoreContext::from_legacy_path_schema(db_path, configured_database_url)?;
         let schema = context.schema().to_owned();
         let store_key = schema.clone();
@@ -51,6 +57,7 @@ impl TaskDb {
     pub fn shared_schema_context(
         configured_database_url: Option<&str>,
     ) -> anyhow::Result<PgStoreContext> {
+        record_task_db_usage();
         PostgresBackend::new(configured_database_url.map(ToOwned::to_owned))
             .store_context(&StoreLocation::SharedSchema(TASK_DB_SCHEMA.to_string()))
     }
@@ -59,6 +66,7 @@ impl TaskDb {
         context: &PgStoreContext,
         setup_pool: &PgPool,
     ) -> anyhow::Result<Self> {
+        record_task_db_usage();
         Self::open_with_context_and_store_key(context, setup_pool, context.schema().to_owned())
             .await
     }
@@ -68,6 +76,7 @@ impl TaskDb {
         setup_pool: &PgPool,
         data_dir: &Path,
     ) -> anyhow::Result<Self> {
+        record_task_db_usage();
         let store_key = Self::store_key_for_data_dir(data_dir)?;
         Self::open_with_context_and_store_key(context, setup_pool, store_key).await
     }
@@ -89,6 +98,7 @@ impl TaskDb {
     }
 
     pub async fn from_pg_pool(pool: PgPool) -> anyhow::Result<Self> {
+        record_task_db_usage();
         let schema: String = sqlx::query_scalar("SELECT current_schema()")
             .fetch_one(&pool)
             .await?;
@@ -102,10 +112,12 @@ impl TaskDb {
     }
 
     pub fn schema(&self) -> &str {
+        record_task_db_usage();
         &self.schema
     }
 
     pub fn store_key_for_data_dir(data_dir: &Path) -> anyhow::Result<String> {
+        record_task_db_usage();
         let canonical = data_dir.canonicalize().map_err(|error| {
             anyhow::anyhow!(
                 "failed to canonicalize task data_dir {}: {error}",
@@ -116,6 +128,7 @@ impl TaskDb {
     }
 
     pub fn store_key(&self) -> &str {
+        record_task_db_usage();
         &self.store_key
     }
 

--- a/crates/harness-server/src/task_db/queries_aux.rs
+++ b/crates/harness-server/src/task_db/queries_aux.rs
@@ -14,6 +14,7 @@ impl TaskDb {
         pr_url: Option<&str>,
         last_phase: &str,
     ) -> anyhow::Result<()> {
+        super::record_task_db_usage();
         sqlx::query(
             "INSERT INTO task_checkpoints \
                  (store_key, task_id, triage_output, plan_output, pr_url, last_phase, updated_at) \
@@ -37,6 +38,7 @@ impl TaskDb {
     }
 
     pub async fn load_checkpoint(&self, task_id: &str) -> anyhow::Result<Option<TaskCheckpoint>> {
+        super::record_task_db_usage();
         let row = sqlx::query_as::<_, TaskCheckpoint>(
             "SELECT task_id, triage_output, plan_output, pr_url, last_phase, \
                     TO_CHAR(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS updated_at \
@@ -56,6 +58,7 @@ impl TaskDb {
         artifact_type: &str,
         content: &str,
     ) -> anyhow::Result<()> {
+        super::record_task_db_usage();
         let stored = if content.len() > ARTIFACT_MAX_BYTES {
             let mut boundary = ARTIFACT_MAX_BYTES;
             while boundary > 0 && !content.is_char_boundary(boundary) {
@@ -85,6 +88,7 @@ impl TaskDb {
     }
 
     pub async fn list_artifacts(&self, task_id: &str) -> anyhow::Result<Vec<TaskArtifact>> {
+        super::record_task_db_usage();
         let rows = sqlx::query_as::<_, TaskArtifact>(
             "SELECT task_id, turn, artifact_type, content, \
                     TO_CHAR(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS created_at \
@@ -104,6 +108,7 @@ impl TaskDb {
         phase: &str,
         prompt: &str,
     ) -> anyhow::Result<()> {
+        super::record_task_db_usage();
         let stored = if prompt.len() > PROMPT_MAX_BYTES {
             let mut boundary = PROMPT_MAX_BYTES;
             while boundary > 0 && !prompt.is_char_boundary(boundary) {
@@ -129,6 +134,7 @@ impl TaskDb {
     }
 
     pub async fn get_task_prompts(&self, task_id: &str) -> anyhow::Result<Vec<TaskPrompt>> {
+        super::record_task_db_usage();
         let rows = sqlx::query_as::<_, TaskPrompt>(
             "SELECT task_id, turn, phase, prompt, \
                     TO_CHAR(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS created_at \
@@ -144,6 +150,7 @@ impl TaskDb {
     pub async fn pending_tasks_with_checkpoint(
         &self,
     ) -> anyhow::Result<Vec<(TaskState, TaskCheckpoint)>> {
+        super::record_task_db_usage();
         let rows = sqlx::query_as::<_, PendingCheckpointRow>(
             "SELECT t.id, t.task_kind, t.status, t.turn, t.pr_url, t.rounds, t.error, t.source, \
                     t.external_id, t.parent_id, t.created_at, t.updated_at, t.repo, t.depends_on, \

--- a/crates/harness-server/src/task_db/queries_metrics.rs
+++ b/crates/harness-server/src/task_db/queries_metrics.rs
@@ -11,6 +11,7 @@ impl TaskDb {
     pub async fn list_terminal_first_token_latencies_ms(
         &self,
     ) -> anyhow::Result<Vec<(String, Option<i64>)>> {
+        super::record_task_db_usage();
         let rows: Vec<(String, Option<i64>)> = sqlx::query_as(
             "SELECT id, \
              (SELECT (r.value ->> 'first_token_latency_ms')::BIGINT \
@@ -31,6 +32,7 @@ impl TaskDb {
 
     /// Return `(task_id, turn)` pairs for the 500 most-recently-completed terminal tasks.
     pub async fn list_terminal_turn_counts(&self) -> anyhow::Result<Vec<(String, i64)>> {
+        super::record_task_db_usage();
         let rows: Vec<(String, i64)> = sqlx::query_as(
             "SELECT id, turn FROM tasks \
              WHERE store_key = $1 AND status IN ('done', 'failed') \
@@ -44,6 +46,7 @@ impl TaskDb {
 
     /// Return `(id, status)` pairs for all tasks.
     pub async fn list_id_status(&self) -> anyhow::Result<Vec<(String, String)>> {
+        super::record_task_db_usage();
         let rows: Vec<(String, String)> = sqlx::query_as(
             "SELECT id, status FROM tasks WHERE store_key = $1 ORDER BY created_at DESC",
         )
@@ -55,6 +58,7 @@ impl TaskDb {
 
     /// Return only task IDs whose `status` matches any value in `statuses`.
     pub async fn list_ids_by_status(&self, statuses: &[&str]) -> anyhow::Result<Vec<String>> {
+        super::record_task_db_usage();
         if statuses.is_empty() {
             return Ok(Vec::new());
         }
@@ -71,6 +75,7 @@ impl TaskDb {
 
     /// Return the status of a single task, fetching only the `status` column.
     pub async fn get_status_only(&self, id: &str) -> anyhow::Result<Option<String>> {
+        super::record_task_db_usage();
         let row: Option<(String,)> =
             sqlx::query_as("SELECT status FROM tasks WHERE store_key = $1 AND id = $2")
                 .bind(&self.store_key)
@@ -93,6 +98,7 @@ impl TaskDb {
 
     /// Return `true` if a task row with the given ID exists in the database.
     pub async fn exists_by_id(&self, id: &str) -> anyhow::Result<bool> {
+        super::record_task_db_usage();
         let row: Option<(String,)> =
             sqlx::query_as("SELECT id FROM tasks WHERE store_key = $1 AND id = $2")
                 .bind(&self.store_key)
@@ -104,6 +110,7 @@ impl TaskDb {
 
     /// Return the `pr_url` of the most recently completed Done task that has one.
     pub async fn latest_done_pr_url(&self) -> anyhow::Result<Option<String>> {
+        super::record_task_db_usage();
         let row: Option<(Option<String>,)> = sqlx::query_as(
             "SELECT pr_url FROM tasks \
              WHERE store_key = $1 AND status = 'done' AND pr_url IS NOT NULL \
@@ -120,6 +127,7 @@ impl TaskDb {
         &self,
         project: &str,
     ) -> anyhow::Result<Option<String>> {
+        super::record_task_db_usage();
         let row: Option<(Option<String>,)> = sqlx::query_as(
             "SELECT pr_url FROM tasks \
              WHERE store_key = $1 AND status = 'done' AND pr_url IS NOT NULL AND project = $2 \
@@ -136,6 +144,7 @@ impl TaskDb {
     pub async fn latest_done_pr_urls_all_projects(
         &self,
     ) -> anyhow::Result<HashMap<String, String>> {
+        super::record_task_db_usage();
         let rows: Vec<(String, String)> = sqlx::query_as(
             "SELECT project, pr_url FROM (\
                SELECT project, pr_url, \
@@ -157,6 +166,7 @@ impl TaskDb {
     pub async fn count_done_failed_by_project(
         &self,
     ) -> anyhow::Result<(u64, u64, Vec<(String, u64, u64)>)> {
+        super::record_task_db_usage();
         let outcome_statuses = [TaskStatus::Done.as_ref(), TaskStatus::Failed.as_ref()];
         let global_sql = format!(
             "SELECT COUNT(CASE WHEN status = 'done' THEN 1 END), \
@@ -198,6 +208,7 @@ impl TaskDb {
 
     /// Count tasks that reached `done` status with `updated_at >= since`.
     pub async fn count_done_since(&self, since: DateTime<Utc>) -> anyhow::Result<u64> {
+        super::record_task_db_usage();
         let row: (i64,) = sqlx::query_as(
             "SELECT COUNT(*) FROM tasks \
              WHERE store_key = $1 AND status = 'done' AND updated_at >= $2",
@@ -214,6 +225,7 @@ impl TaskDb {
         &self,
         since: DateTime<Utc>,
     ) -> anyhow::Result<Vec<(String, String, u64)>> {
+        super::record_task_db_usage();
         let rows: Vec<(Option<String>, String, i64)> = sqlx::query_as(
             "SELECT project, \
                     TO_CHAR(date_trunc('hour', updated_at AT TIME ZONE 'UTC'), \
@@ -235,6 +247,7 @@ impl TaskDb {
 
     /// Return all tasks whose `parent_id` matches the given parent task ID.
     pub async fn list_children(&self, parent_id: &str) -> anyhow::Result<Vec<TaskState>> {
+        super::record_task_db_usage();
         let sql = format!(
             "SELECT {TASK_ROW_COLUMNS} FROM tasks \
              WHERE store_key = $1 AND parent_id = $2 ORDER BY created_at DESC"
@@ -253,6 +266,7 @@ impl TaskDb {
         stale_threshold: std::time::Duration,
         project: Option<&str>,
     ) -> anyhow::Result<Vec<TaskState>> {
+        super::record_task_db_usage();
         let cutoff = Utc::now() - chrono::Duration::from_std(stale_threshold)?;
         let sql = if project.is_some() {
             format!(
@@ -294,6 +308,7 @@ impl TaskDb {
         &self,
         limit: i64,
     ) -> anyhow::Result<Vec<crate::task_runner::RecentFailureTask>> {
+        super::record_task_db_usage();
         let rows = sqlx::query_as::<_, RecentFailureRow>(
             "SELECT id, failure_kind, external_id, project, workspace_path, workspace_owner, \
              run_generation, error, updated_at FROM tasks \

--- a/crates/harness-server/src/task_db/queries_recovery.rs
+++ b/crates/harness-server/src/task_db/queries_recovery.rs
@@ -19,6 +19,7 @@ impl TaskDb {
         pr_url: Option<&str>,
         terminal_status: Option<&str>,
     ) -> anyhow::Result<()> {
+        super::record_task_db_usage();
         if let Some(status) = terminal_status {
             let scheduler_state_row: Option<(String, i32)> = sqlx::query_as(
                 "SELECT scheduler_state, version FROM tasks WHERE store_key = $1 AND id = $2",
@@ -82,6 +83,7 @@ impl TaskDb {
 
     /// Recovery on server restart: resume or fail interrupted tasks.
     pub async fn recover_in_progress(&self) -> anyhow::Result<RecoveryResult> {
+        super::record_task_db_usage();
         let rows = {
             let resumable = TaskStatus::resumable_statuses();
             let placeholders = Self::numbered_placeholders(2, resumable.len());

--- a/crates/harness-server/src/task_db/queries_tasks.rs
+++ b/crates/harness-server/src/task_db/queries_tasks.rs
@@ -7,6 +7,7 @@ use super::TaskDb;
 
 impl TaskDb {
     pub async fn insert(&self, state: &TaskState) -> anyhow::Result<()> {
+        super::record_task_db_usage();
         let rounds_json = serde_json::to_string(&state.rounds)?;
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
         let status = state.status.as_ref();
@@ -70,6 +71,7 @@ impl TaskDb {
     }
 
     pub async fn update(&self, state: &TaskState) -> anyhow::Result<()> {
+        super::record_task_db_usage();
         let rounds_json = serde_json::to_string(&state.rounds)?;
         let depends_on_json = serde_json::to_string(&state.depends_on)?;
         let phase_json = serde_json::to_string(&state.phase)?;
@@ -134,6 +136,7 @@ impl TaskDb {
     }
 
     pub async fn get(&self, id: &str) -> anyhow::Result<Option<TaskState>> {
+        super::record_task_db_usage();
         let sql = format!("SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE store_key = $1 AND id = $2");
         let row = sqlx::query_as::<_, TaskRow>(&sql)
             .bind(&self.store_key)
@@ -144,6 +147,7 @@ impl TaskDb {
     }
 
     pub async fn list(&self) -> anyhow::Result<Vec<TaskState>> {
+        super::record_task_db_usage();
         let sql = format!(
             "SELECT {TASK_ROW_COLUMNS} FROM tasks WHERE store_key = $1 ORDER BY created_at DESC"
         );
@@ -158,6 +162,7 @@ impl TaskDb {
     ///
     /// Returns an empty `Vec` when `statuses` is empty.
     pub async fn list_by_status(&self, statuses: &[&str]) -> anyhow::Result<Vec<TaskState>> {
+        super::record_task_db_usage();
         if statuses.is_empty() {
             return Ok(Vec::new());
         }
@@ -175,6 +180,7 @@ impl TaskDb {
 
     /// Return pending tasks that have no PR URL and no checkpoint row.
     pub async fn pending_orphan_tasks(&self) -> anyhow::Result<Vec<TaskState>> {
+        super::record_task_db_usage();
         let sql = format!(
             "SELECT {TASK_ROW_COLUMNS} \
              FROM tasks t \
@@ -201,6 +207,7 @@ impl TaskDb {
         project: &str,
         repo: Option<&str>,
     ) -> anyhow::Result<Vec<(String, String, Option<String>)>> {
+        super::record_task_db_usage();
         let base_sql = "SELECT external_id, status, created_at FROM (\
                  SELECT external_id, status, created_at, \
                         ROW_NUMBER() OVER (PARTITION BY external_id ORDER BY created_at DESC, id DESC) AS rn \
@@ -241,6 +248,7 @@ impl TaskDb {
         project: &str,
         external_id: &str,
     ) -> anyhow::Result<Option<String>> {
+        super::record_task_db_usage();
         let active_statuses: Vec<&str> = std::iter::once(TaskStatus::Pending.as_ref())
             .chain(std::iter::once(TaskStatus::AwaitingDeps.as_ref()))
             .chain(TaskStatus::resumable_statuses().iter().copied())
@@ -267,6 +275,7 @@ impl TaskDb {
         project: &str,
         external_id: &str,
     ) -> anyhow::Result<Option<(String, String)>> {
+        super::record_task_db_usage();
         let row: Option<(String, String)> = sqlx::query_as(
             "SELECT id, pr_url FROM tasks \
              WHERE store_key = $1 AND project = $2 AND external_id = $3 \
@@ -319,6 +328,7 @@ impl TaskDb {
         external_id: &str,
         expected_version: i32,
     ) -> anyhow::Result<()> {
+        super::record_task_db_usage();
         let result = sqlx::query(
             "UPDATE tasks SET external_id = $1, updated_at = CURRENT_TIMESTAMP, \
              version = version + 1 \
@@ -347,6 +357,7 @@ impl TaskDb {
         external_id: &str,
         expected_version: i32,
     ) -> anyhow::Result<()> {
+        super::record_task_db_usage();
         let result = sqlx::query(
             "UPDATE tasks SET external_id = $1, updated_at = CURRENT_TIMESTAMP, \
              version = version + 1 \
@@ -370,6 +381,7 @@ impl TaskDb {
 
     /// Return all tasks as lightweight summaries, skipping the heavy `rounds` column.
     pub async fn list_summaries(&self) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
+        super::record_task_db_usage();
         let rows = sqlx::query_as::<_, TaskSummaryRow>(
             "SELECT id, task_kind, status, failure_kind, turn, pr_url, error, source, external_id, parent_id, \
              created_at, repo, depends_on, project, workspace_path, workspace_owner, \
@@ -386,6 +398,7 @@ impl TaskDb {
     pub async fn list_active_summaries(
         &self,
     ) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
+        super::record_task_db_usage();
         let rows = sqlx::query_as::<_, TaskSummaryRow>(
             "SELECT id, task_kind, status, failure_kind, turn, pr_url, error, source, external_id, parent_id, \
              created_at, repo, depends_on, project, workspace_path, workspace_owner, \
@@ -405,6 +418,7 @@ impl TaskDb {
         &self,
         filter: &TaskSummaryFilter,
     ) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
+        super::record_task_db_usage();
         let mut query = QueryBuilder::<Postgres>::new(
             "SELECT id, task_kind, status, failure_kind, turn, pr_url, error, source, external_id, parent_id, \
              created_at, repo, depends_on, project, workspace_path, workspace_owner, \
@@ -440,6 +454,7 @@ impl TaskDb {
         cursor: Option<&TaskSummaryPageCursor>,
         limit: usize,
     ) -> anyhow::Result<Vec<crate::task_runner::TaskSummary>> {
+        super::record_task_db_usage();
         let mut query = QueryBuilder::<Postgres>::new(
             "SELECT id, task_kind, status, failure_kind, turn, pr_url, error, source, external_id, parent_id, \
              created_at, repo, depends_on, project, workspace_path, workspace_owner, \

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -49,9 +49,74 @@ use std::collections::HashMap;
 #[cfg(test)]
 use tokio::time::Instant;
 
-pub(crate) use run_task::run_task;
-// Re-export so existing call sites in handlers/ don't need updating.
-pub(crate) use turn_lifecycle::run_turn_lifecycle;
+use run_task::run_task as run_task_impl;
+use turn_lifecycle::run_turn_lifecycle as run_turn_lifecycle_impl;
+// Wrappers keep existing call sites stable while counting old task surfaces.
+pub(crate) async fn run_task(
+    store: &crate::task_runner::TaskStore,
+    task_id: &crate::task_runner::TaskId,
+    agent: &dyn harness_core::agent::CodeAgent,
+    reviewer: Option<&dyn harness_core::agent::CodeAgent>,
+    skills: Arc<tokio::sync::RwLock<harness_skills::store::SkillStore>>,
+    events: Arc<harness_observe::event_store::EventStore>,
+    interceptors: SharedTurnInterceptors,
+    req: &crate::task_runner::CreateTaskRequest,
+    project: std::path::PathBuf,
+    project_root: std::path::PathBuf,
+    server_config: &harness_core::config::HarnessConfig,
+    issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
+    workflow_runtime_store: Option<Arc<harness_workflow::runtime::WorkflowRuntimeStore>>,
+    turns_used_acc: &mut u32,
+) -> anyhow::Result<()> {
+    harness_core::usage_probe::record_usage(
+        harness_core::usage_probe::UsageProbeSurface::TaskExecutor,
+    );
+    run_task_impl(
+        store,
+        task_id,
+        agent,
+        reviewer,
+        skills,
+        events,
+        interceptors,
+        req,
+        project,
+        project_root,
+        server_config,
+        issue_workflow_store,
+        workflow_runtime_store,
+        turns_used_acc,
+    )
+    .await
+}
+
+pub(crate) async fn run_turn_lifecycle(
+    server: Arc<crate::server::HarnessServer>,
+    thread_db: Option<crate::thread_db::ThreadDb>,
+    notify_tx: Option<crate::notify::NotifySender>,
+    notification_tx: tokio::sync::broadcast::Sender<
+        harness_protocol::notifications::RpcNotification,
+    >,
+    thread_id: harness_core::types::ThreadId,
+    turn_id: harness_core::types::TurnId,
+    prompt: String,
+    agent_name: String,
+) {
+    harness_core::usage_probe::record_usage(
+        harness_core::usage_probe::UsageProbeSurface::TaskExecutor,
+    );
+    run_turn_lifecycle_impl(
+        server,
+        thread_db,
+        notify_tx,
+        notification_tx,
+        thread_id,
+        turn_id,
+        prompt,
+        agent_name,
+    )
+    .await;
+}
 pub(crate) use validation_gate::run_test_gate;
 
 pub(crate) type TurnInterceptorHandle = Arc<dyn TurnInterceptor>;

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -191,7 +191,7 @@ mod usage_probe_tests {
         child.parent_id = Some(task_id.clone());
         child.project_root = Some(dir.path().to_path_buf());
         store.insert(&child).await;
-        harness_core::usage_probe::reset_for_tests();
+        let before = task_runner_count();
 
         assert!(store.get(&task_id).is_some());
         assert_eq!(store.count(), 2);
@@ -215,7 +215,7 @@ mod usage_probe_tests {
         assert!(store.list_recent_failed(5).await?.is_empty());
         assert!(!store.abort_task(&task_id));
 
-        assert_eq!(task_runner_count(), 11);
+        assert!(task_runner_count() >= before + 11);
         Ok(())
     }
 }

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -19,22 +19,203 @@ pub use request::{
     fill_missing_repo_from_project, CreateTaskRequest, PersistedRequestSettings, SystemTaskInput,
     MAX_TASK_PRIORITY,
 };
-pub use spawn::{
-    check_awaiting_deps, effective_turn_timeout, prompt_requires_plan, register_pending_task,
-    resolve_canonical_project, spawn_preregistered_task, spawn_task, spawn_task_awaiting_deps,
+use spawn::{
+    check_awaiting_deps as check_awaiting_deps_impl,
+    register_pending_task as register_pending_task_impl,
+    spawn_preregistered_task as spawn_preregistered_task_impl, spawn_task as spawn_task_impl,
+    spawn_task_awaiting_deps as spawn_task_awaiting_deps_impl,
 };
+pub use spawn::{effective_turn_timeout, prompt_requires_plan, resolve_canonical_project};
 pub use state::{
     RecentFailureTask, RoundResult, SchedulerAuthorityState, SchedulerOwner, SchedulerOwnerKind,
     TaskSchedulerState, TaskState, TaskSummary, TaskWorkflowSummary,
 };
-pub use store::{
-    mutate_and_persist, update_status, TaskStore, TaskSummaryFilter, TaskSummaryPageCursor,
-};
+use store::{mutate_and_persist as mutate_and_persist_impl, update_status as update_status_impl};
+pub use store::{TaskStore, TaskSummaryFilter, TaskSummaryPageCursor};
 pub use types::{TaskFailureKind, TaskId, TaskKind, TaskPhase, TaskStatus};
+
+fn record_task_runner_usage() {
+    harness_core::usage_probe::record_usage(
+        harness_core::usage_probe::UsageProbeSurface::TaskRunner,
+    );
+}
+
+pub async fn spawn_task(
+    store: Arc<TaskStore>,
+    agent: Arc<dyn harness_core::agent::CodeAgent>,
+    reviewer: Option<Arc<dyn harness_core::agent::CodeAgent>>,
+    server_config: Arc<harness_core::config::HarnessConfig>,
+    skills: Arc<tokio::sync::RwLock<harness_skills::store::SkillStore>>,
+    events: Arc<harness_observe::event_store::EventStore>,
+    interceptors: impl Into<crate::task_executor::SharedTurnInterceptors>,
+    req: CreateTaskRequest,
+    workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
+    permit: crate::task_queue::TaskPermit,
+    completion_callback: Option<CompletionCallback>,
+    issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
+    workflow_runtime_store: Option<Arc<harness_workflow::runtime::WorkflowRuntimeStore>>,
+    allowed_project_roots: Vec<std::path::PathBuf>,
+) -> TaskId {
+    record_task_runner_usage();
+    spawn_task_impl(
+        store,
+        agent,
+        reviewer,
+        server_config,
+        skills,
+        events,
+        interceptors,
+        req,
+        workspace_mgr,
+        permit,
+        completion_callback,
+        issue_workflow_store,
+        workflow_runtime_store,
+        allowed_project_roots,
+    )
+    .await
+}
+
+pub async fn register_pending_task(store: Arc<TaskStore>, req: &CreateTaskRequest) -> TaskId {
+    record_task_runner_usage();
+    register_pending_task_impl(store, req).await
+}
+
+pub async fn spawn_preregistered_task(
+    task_id: TaskId,
+    store: Arc<TaskStore>,
+    agent: Arc<dyn harness_core::agent::CodeAgent>,
+    reviewer: Option<Arc<dyn harness_core::agent::CodeAgent>>,
+    server_config: Arc<harness_core::config::HarnessConfig>,
+    skills: Arc<tokio::sync::RwLock<harness_skills::store::SkillStore>>,
+    events: Arc<harness_observe::event_store::EventStore>,
+    interceptors: impl Into<crate::task_executor::SharedTurnInterceptors>,
+    req: CreateTaskRequest,
+    workspace_mgr: Option<Arc<crate::workspace::WorkspaceManager>>,
+    permit: crate::task_queue::TaskPermit,
+    completion_callback: Option<CompletionCallback>,
+    issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
+    workflow_runtime_store: Option<Arc<harness_workflow::runtime::WorkflowRuntimeStore>>,
+    allowed_project_roots: Vec<std::path::PathBuf>,
+    group_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+) {
+    record_task_runner_usage();
+    spawn_preregistered_task_impl(
+        task_id,
+        store,
+        agent,
+        reviewer,
+        server_config,
+        skills,
+        events,
+        interceptors,
+        req,
+        workspace_mgr,
+        permit,
+        completion_callback,
+        issue_workflow_store,
+        workflow_runtime_store,
+        allowed_project_roots,
+        group_permit,
+    )
+    .await;
+}
+
+pub async fn spawn_task_awaiting_deps(
+    store: Arc<TaskStore>,
+    req: CreateTaskRequest,
+) -> anyhow::Result<TaskId> {
+    record_task_runner_usage();
+    spawn_task_awaiting_deps_impl(store, req).await
+}
+
+pub async fn check_awaiting_deps(store: &TaskStore) -> (Vec<TaskId>, Vec<TaskId>) {
+    record_task_runner_usage();
+    check_awaiting_deps_impl(store).await
+}
+
+pub async fn update_status(
+    store: &TaskStore,
+    task_id: &TaskId,
+    status: TaskStatus,
+    turn: u32,
+) -> anyhow::Result<()> {
+    record_task_runner_usage();
+    update_status_impl(store, task_id, status, turn).await
+}
+
+pub async fn mutate_and_persist(
+    store: &TaskStore,
+    id: &TaskId,
+    f: impl FnOnce(&mut TaskState),
+) -> anyhow::Result<()> {
+    record_task_runner_usage();
+    mutate_and_persist_impl(store, id, f).await
+}
 
 impl TaskStore {
     /// Return the most recent `limit` failed tasks, newest first.
     pub async fn list_recent_failed(&self, limit: i64) -> anyhow::Result<Vec<RecentFailureTask>> {
+        record_task_runner_usage();
         self.db.list_recent_failed(limit).await
+    }
+}
+
+#[cfg(test)]
+mod usage_probe_tests {
+    use super::*;
+
+    fn task_runner_count() -> u64 {
+        harness_core::usage_probe::snapshot()
+            .into_iter()
+            .find(|entry| entry.surface == "task_runner")
+            .map(|entry| entry.count)
+            .unwrap_or(0)
+    }
+
+    #[tokio::test]
+    async fn task_store_cache_public_entries_record_task_runner_usage() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let task_id = TaskId::from_str("probe-task");
+        let mut task = TaskState::new(task_id.clone());
+        task.project_root = Some(dir.path().to_path_buf());
+        task.repo = Some("owner/repo".to_string());
+        task.external_id = Some("issue-1".to_string());
+        store.insert(&task).await;
+        let mut child = TaskState::new(TaskId::from_str("probe-child"));
+        child.parent_id = Some(task_id.clone());
+        child.project_root = Some(dir.path().to_path_buf());
+        store.insert(&child).await;
+        harness_core::usage_probe::reset_for_tests();
+
+        assert!(store.get(&task_id).is_some());
+        assert_eq!(store.count(), 2);
+        assert_eq!(store.list_all().len(), 2);
+        assert!(store
+            .list_all_statuses_with_terminal()
+            .await?
+            .contains_key(&task_id));
+        assert!(store
+            .list_latest_external_statuses_by_project_and_repo(
+                &dir.path().to_string_lossy(),
+                Some("owner/repo"),
+            )
+            .await?
+            .contains_key("issue-1"));
+        assert!(store.list_siblings(dir.path(), &task_id).is_empty());
+        let since = chrono::Utc::now() - chrono::TimeDelta::days(1);
+        assert_eq!(store.count_done_since(since).await, 0);
+        assert!(store.done_per_project_hour_since(since).await.is_empty());
+        assert_eq!(store.list_children(&task_id).len(), 1);
+        assert!(store.list_recent_failed(5).await?.is_empty());
+        assert!(!store.abort_task(&task_id));
+
+        assert_eq!(task_runner_count(), 11);
+        Ok(())
     }
 }

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -207,7 +207,7 @@ mod usage_probe_tests {
             )
             .await?
             .contains_key("issue-1"));
-        assert!(store.list_siblings(dir.path(), &task_id).is_empty());
+        assert_eq!(store.list_siblings(dir.path(), &task_id).len(), 1);
         let since = chrono::Utc::now() - chrono::TimeDelta::days(1);
         assert_eq!(store.count_done_since(since).await, 0);
         assert!(store.done_per_project_hour_since(since).await.is_empty());

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -20,6 +20,12 @@ const TASK_STREAM_CAPACITY: usize = 512;
 const RECOVERED_PR_VIEW_TIMEOUT: Duration = Duration::from_secs(10);
 const RECOVERED_PR_VALIDATION_CONCURRENCY: usize = 8;
 
+fn record_task_runner_usage() {
+    harness_core::usage_probe::record_usage(
+        harness_core::usage_probe::UsageProbeSurface::TaskRunner,
+    );
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RecoveredPrCandidate {
     task_id: TaskId,
@@ -274,6 +280,7 @@ impl TaskStore {
     }
 
     pub fn get(&self, id: &TaskId) -> Option<TaskState> {
+        record_task_runner_usage();
         self.cache.get(id).map(|r| r.value().clone())
     }
 
@@ -283,6 +290,7 @@ impl TaskStore {
     /// Returns `Ok(None)` only when the ID is unknown in both cache and DB.
     /// Returns `Err` when the database query itself fails.
     pub async fn get_with_db_fallback(&self, id: &TaskId) -> anyhow::Result<Option<TaskState>> {
+        record_task_runner_usage();
         if let Some(task) = self.cache.get(id) {
             return Ok(Some(task.value().clone()));
         }
@@ -295,6 +303,7 @@ impl TaskStore {
     /// Used by intake reconciliation to detect stale persisted dispatch markers
     /// after a task-storage backend change (for example SQLite -> Postgres).
     pub async fn exists_with_db_fallback(&self, id: &TaskId) -> anyhow::Result<bool> {
+        record_task_runner_usage();
         if self.cache.contains_key(id) {
             return Ok(true);
         }
@@ -328,6 +337,7 @@ impl TaskStore {
         stale_threshold: std::time::Duration,
         project: Option<&str>,
     ) -> anyhow::Result<Vec<TaskState>> {
+        record_task_runner_usage();
         self.db.list_stalled_tasks(stale_threshold, project).await
     }
 
@@ -336,6 +346,7 @@ impl TaskStore {
     /// Used during startup for worktree cleanup. Only fetches task IDs to avoid
     /// deserializing the heavy `rounds` column for large historical datasets.
     pub async fn list_terminal_ids_from_db(&self) -> anyhow::Result<Vec<TaskId>> {
+        record_task_runner_usage();
         let ids = self
             .db
             .list_ids_by_status(&["done", "failed", "cancelled"])
@@ -344,6 +355,7 @@ impl TaskStore {
     }
 
     pub fn count(&self) -> usize {
+        record_task_runner_usage();
         self.cache.len()
     }
 
@@ -359,6 +371,7 @@ impl TaskStore {
         project_id: &str,
         external_id: &str,
     ) -> Option<TaskId> {
+        record_task_runner_usage();
         let mut found_terminal_in_cache = false;
         for entry in self.cache.iter() {
             let task = entry.value();
@@ -401,6 +414,7 @@ impl TaskStore {
         project_id: &str,
         external_id: &str,
     ) -> Option<(TaskId, String)> {
+        record_task_runner_usage();
         for entry in self.cache.iter() {
             let task = entry.value();
             let same_key = task.external_id.as_deref() == Some(external_id)
@@ -433,6 +447,7 @@ impl TaskStore {
     /// To look up a specific completed task use [`get_with_db_fallback`].
     /// To enumerate all tasks including historical ones use [`list_all_with_terminal`].
     pub fn list_all(&self) -> Vec<TaskState> {
+        record_task_runner_usage();
         self.cache.iter().map(|e| e.value().clone()).collect()
     }
 
@@ -442,6 +457,7 @@ impl TaskStore {
     /// Cache entries take precedence over DB rows for the same task ID so that
     /// in-flight state is always reflected accurately.
     pub async fn list_all_with_terminal(&self) -> anyhow::Result<Vec<TaskState>> {
+        record_task_runner_usage();
         // DB is the authoritative record of all tasks ever created.
         let mut by_id: std::collections::HashMap<TaskId, TaskState> = self
             .db
@@ -463,6 +479,7 @@ impl TaskStore {
     /// then overrides with live cache entries so in-flight state is accurate.
     /// Use this in the `/tasks` list endpoint instead of `list_all_with_terminal`.
     pub async fn list_all_summaries_with_terminal(&self) -> anyhow::Result<Vec<TaskSummary>> {
+        record_task_runner_usage();
         let mut by_id: std::collections::HashMap<TaskId, TaskSummary> = self
             .db
             .list_summaries()
@@ -481,6 +498,7 @@ impl TaskStore {
     /// Fetches only non-terminal summary rows from the DB, then applies live cache
     /// overrides so recently terminal tasks are removed and in-flight state wins.
     pub async fn list_active_summaries(&self) -> anyhow::Result<Vec<TaskSummary>> {
+        record_task_runner_usage();
         let mut by_id: std::collections::HashMap<TaskId, TaskSummary> = self
             .db
             .list_active_summaries()
@@ -503,6 +521,7 @@ impl TaskStore {
         &self,
         filter: &TaskSummaryFilter,
     ) -> anyhow::Result<Vec<TaskSummary>> {
+        record_task_runner_usage();
         let mut by_id: std::collections::HashMap<TaskId, TaskSummary> = self
             .db
             .list_summaries_filtered(filter)
@@ -527,6 +546,7 @@ impl TaskStore {
         cursor: Option<&TaskSummaryPageCursor>,
         limit: usize,
     ) -> anyhow::Result<Vec<TaskSummary>> {
+        record_task_runner_usage();
         let db_limit = limit.saturating_add(self.cache.len()).saturating_add(1);
         let mut by_id: std::collections::HashMap<TaskId, TaskSummary> = self
             .db
@@ -555,6 +575,7 @@ impl TaskStore {
     pub async fn list_all_statuses_with_terminal(
         &self,
     ) -> anyhow::Result<HashMap<TaskId, TaskStatus>> {
+        record_task_runner_usage();
         let mut by_id: HashMap<TaskId, TaskStatus> = self
             .db
             .list_id_status()
@@ -583,6 +604,7 @@ impl TaskStore {
         project_id: &str,
         repo: Option<&str>,
     ) -> anyhow::Result<HashMap<String, (Option<String>, TaskStatus)>> {
+        record_task_runner_usage();
         let mut by_external_id: HashMap<String, (Option<String>, TaskStatus)> = self
             .db
             .list_latest_external_statuses_by_project_and_repo(project_id, repo)
@@ -786,6 +808,7 @@ impl TaskStore {
     /// Return the `pr_url` of the most recently created Done task, ordered by `created_at DESC`
     /// from the database (stable ordering, unlike the in-memory DashMap cache).
     pub async fn latest_done_pr_url(&self) -> Option<String> {
+        record_task_runner_usage();
         match self.db.latest_done_pr_url().await {
             Ok(url) => url,
             Err(e) => {
@@ -797,6 +820,7 @@ impl TaskStore {
 
     /// Return the `pr_url` of the most recent Done task for a specific project root path.
     pub async fn latest_done_pr_url_by_project(&self, project: &str) -> Option<String> {
+        record_task_runner_usage();
         match self.db.latest_done_pr_url_by_project(project).await {
             Ok(url) => url,
             Err(e) => {
@@ -809,6 +833,7 @@ impl TaskStore {
     /// Fetch the latest done PR URL for every project in a single DB query.
     /// Returns a map from project root path string to PR URL.
     pub async fn latest_done_pr_urls_all_projects(&self) -> HashMap<String, String> {
+        record_task_runner_usage();
         match self.db.latest_done_pr_urls_all_projects().await {
             Ok(map) => map,
             Err(e) => {
@@ -824,6 +849,7 @@ impl TaskStore {
     /// so each agent knows what other agents are working on and avoids touching their files.
     /// Only tasks that have `project_root` set (populated at spawn time) are considered.
     pub fn list_siblings(&self, project: &std::path::Path, exclude_id: &TaskId) -> Vec<TaskState> {
+        record_task_runner_usage();
         self.cache
             .iter()
             .filter(|e| {
@@ -842,6 +868,7 @@ impl TaskStore {
     /// than requiring an O(N) scan of the in-memory cache, which grows unboundedly
     /// as tasks accumulate. Uses the `idx_tasks_project_status_updated` index.
     pub async fn count_for_dashboard(&self) -> DashboardCounts {
+        record_task_runner_usage();
         match self.db.count_done_failed_by_project().await {
             Ok((global_done, global_failed, rows)) => {
                 let by_project = rows
@@ -870,6 +897,7 @@ impl TaskStore {
     /// Forwards to [`TaskDb::count_done_since`]; used by the system overview
     /// to compute merged-in-last-24h without materialising full task rows.
     pub async fn count_done_since(&self, since: chrono::DateTime<chrono::Utc>) -> u64 {
+        record_task_runner_usage();
         match self.db.count_done_since(since).await {
             Ok(v) => v,
             Err(e) => {
@@ -886,6 +914,7 @@ impl TaskStore {
         &self,
         since: chrono::DateTime<chrono::Utc>,
     ) -> Vec<(String, String, u64)> {
+        record_task_runner_usage();
         match self.db.done_per_project_hour_since(since).await {
             Ok(rows) => rows,
             Err(e) => {
@@ -911,6 +940,7 @@ impl TaskStore {
     /// Rounds whose `result` is `"resumed_checkpoint"` are skipped in both
     /// sources: they are synthetic markers with no real latency data.
     pub async fn collect_llm_metrics_inputs(&self) -> LlmMetricsInputs {
+        record_task_runner_usage();
         // Phase 1: iterate cache refs in-place; never clone full TaskState.
         // Collect both turn counts and latencies in a single pass, and track
         // IDs seen so we can deduplicate against the DB queries in phase 2.
@@ -1001,6 +1031,7 @@ impl TaskStore {
     /// Reconstructs the child list from in-memory state; does not require
     /// `subtask_ids` to be persisted on the parent.
     pub fn list_children(&self, parent_id: &TaskId) -> Vec<TaskState> {
+        record_task_runner_usage();
         self.cache
             .iter()
             .filter(|e| e.value().parent_id.as_ref() == Some(parent_id))
@@ -1016,6 +1047,7 @@ impl TaskStore {
 
     /// Subscribe to a task's active stream. Returns `None` if no stream is registered.
     pub fn subscribe_task_stream(&self, id: &TaskId) -> Option<broadcast::Receiver<StreamItem>> {
+        record_task_runner_usage();
         self.stream_txs.get(id).map(|tx| tx.subscribe())
     }
 
@@ -1051,6 +1083,7 @@ impl TaskStore {
     /// is also killed when the future is dropped after abort.
     /// Returns `true` if an abort handle was found and triggered.
     pub fn abort_task(&self, id: &TaskId) -> bool {
+        record_task_runner_usage();
         if let Some(handle) = self.abort_handles.get(id) {
             handle.abort();
             true
@@ -1062,6 +1095,7 @@ impl TaskStore {
     /// Activate the global rate-limit circuit breaker. All tasks will pause
     /// before their next agent call until `duration` elapses.
     pub async fn set_rate_limit(&self, duration: std::time::Duration) {
+        record_task_runner_usage();
         let until = tokio::time::Instant::now() + duration;
         *self.rate_limit_until.write().await = Some(until);
         tracing::warn!(
@@ -1076,6 +1110,7 @@ impl TaskStore {
     /// this task is sleeping — without looping, the task would proceed after the
     /// original deadline and burn turns / trigger extra 429s.
     pub async fn wait_for_rate_limit(&self) {
+        record_task_runner_usage();
         loop {
             let deadline = { *self.rate_limit_until.read().await };
             let Some(until) = deadline else { return };
@@ -1133,6 +1168,7 @@ impl TaskStore {
         &self,
         task_id: &TaskId,
     ) -> anyhow::Result<Vec<crate::task_db::TaskArtifact>> {
+        record_task_runner_usage();
         self.db.list_artifacts(&task_id.0).await
     }
 
@@ -1154,6 +1190,7 @@ impl TaskStore {
         &self,
         task_id: &TaskId,
     ) -> anyhow::Result<Vec<crate::task_db::TaskPrompt>> {
+        record_task_runner_usage();
         self.db.get_task_prompts(&task_id.0).await
     }
 
@@ -1714,966 +1751,5 @@ fn latest_timestamp_at_least(candidate: Option<&str>, existing: Option<&str>) ->
 }
 
 #[cfg(test)]
-mod tests {
-    use super::super::state::TaskState;
-    use super::*;
-
-    #[test]
-    fn collect_recovered_pr_candidates_filters_invalid_urls() {
-        let mut valid = TaskState::new(harness_core::types::TaskId("valid".to_string()));
-        valid.pr_url = Some("https://github.com/acme/myrepo/pull/42".to_string());
-
-        let mut invalid = TaskState::new(harness_core::types::TaskId("invalid".to_string()));
-        invalid.pr_url = Some("not-a-pr-url".to_string());
-
-        let mut inflight = TaskState::new(harness_core::types::TaskId("inflight".to_string()));
-        inflight.status = TaskStatus::Implementing;
-        inflight.pr_url = Some("https://github.com/acme/myrepo/pull/7".to_string());
-
-        let pending_without_pr = TaskState::new(harness_core::types::TaskId("no-pr".to_string()));
-        let tasks = [valid, invalid, inflight, pending_without_pr];
-        let candidates: Vec<_> = tasks.iter().filter_map(recovered_pr_candidate).collect();
-        assert_eq!(
-            candidates,
-            vec![RecoveredPrCandidate {
-                task_id: harness_core::types::TaskId("valid".to_string()),
-                pr_url: "https://github.com/acme/myrepo/pull/42".to_string(),
-            }]
-        );
-    }
-
-    #[tokio::test]
-    async fn list_active_summaries_filters_terminal_history_and_cache_overrides(
-    ) -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-
-        let active_id = harness_core::types::TaskId("active".to_string());
-        let active = TaskState::new(active_id.clone());
-        store.insert(&active).await;
-
-        let terminal_id = harness_core::types::TaskId("terminal".to_string());
-        let mut terminal = TaskState::new(terminal_id.clone());
-        terminal.status = TaskStatus::Done;
-        store.insert(&terminal).await;
-
-        let stale_db_id = harness_core::types::TaskId("stale-db-active".to_string());
-        let stale_db_active = TaskState::new(stale_db_id.clone());
-        store.insert(&stale_db_active).await;
-        let mut terminal_cache = stale_db_active;
-        terminal_cache.status = TaskStatus::Failed;
-        terminal_cache.reconcile_scheduler_with_status();
-        store.cache.insert(stale_db_id.clone(), terminal_cache);
-
-        let ids: std::collections::HashSet<_> = store
-            .list_active_summaries()
-            .await?
-            .into_iter()
-            .map(|summary| summary.id)
-            .collect();
-
-        assert!(ids.contains(&active_id));
-        assert!(!ids.contains(&terminal_id));
-        assert!(!ids.contains(&stale_db_id));
-        Ok(())
-    }
-
-    fn pending_task(id: &str) -> TaskState {
-        let mut task = TaskState::new(harness_core::types::TaskId(id.to_string()));
-        task.status = TaskStatus::Pending;
-        task
-    }
-
-    #[tokio::test]
-    async fn task_stream_subscribe_and_publish() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        let id = harness_core::types::TaskId("stream-test".to_string());
-
-        // No stream registered yet.
-        assert!(
-            store.subscribe_task_stream(&id).is_none(),
-            "subscribe before register should return None"
-        );
-
-        store.register_task_stream(&id);
-        let mut rx = store
-            .subscribe_task_stream(&id)
-            .ok_or_else(|| anyhow::anyhow!("subscribe after register should succeed"))?;
-
-        store.publish_stream_item(
-            &id,
-            harness_core::agent::StreamItem::MessageDelta {
-                text: "hello\n".into(),
-            },
-        );
-        store.publish_stream_item(&id, harness_core::agent::StreamItem::Done);
-
-        let item1 = rx.recv().await?;
-        let item2 = rx.recv().await?;
-        assert!(matches!(
-            item1,
-            harness_core::agent::StreamItem::MessageDelta { .. }
-        ));
-        assert!(matches!(item2, harness_core::agent::StreamItem::Done));
-
-        // After close_task_stream the channel sender is dropped.
-        store.close_task_stream(&id);
-        assert!(
-            store.subscribe_task_stream(&id).is_none(),
-            "subscribe after close should return None"
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn task_stream_backpressure_drops_oldest_on_lag() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        let id = harness_core::types::TaskId("backpressure-test".to_string());
-
-        store.register_task_stream(&id);
-        let mut rx = store
-            .subscribe_task_stream(&id)
-            .ok_or_else(|| anyhow::anyhow!("subscribe should succeed after register"))?;
-
-        // Publish more items than TASK_STREAM_CAPACITY to trigger lag.
-        for i in 0..(TASK_STREAM_CAPACITY + 10) as u64 {
-            store.publish_stream_item(
-                &id,
-                harness_core::agent::StreamItem::MessageDelta {
-                    text: format!("line {i}\n"),
-                },
-            );
-        }
-
-        // Receiver should see RecvError::Lagged on overflow.
-        let result = rx.recv().await;
-        assert!(
-            result.is_err(),
-            "expected Lagged error after overflow, got: {:?}",
-            result
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn list_children_returns_subtasks_for_parent() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-
-        let parent_id = harness_core::types::TaskId("parent-task".to_string());
-        let parent = TaskState::new(parent_id.clone());
-        store.insert(&parent).await;
-
-        let mut child1 = TaskState::new(harness_core::types::TaskId("child-1".to_string()));
-        child1.parent_id = Some(parent_id.clone());
-        store.insert(&child1).await;
-
-        let mut child2 = TaskState::new(harness_core::types::TaskId("child-2".to_string()));
-        child2.parent_id = Some(parent_id.clone());
-        store.insert(&child2).await;
-
-        // Unrelated task.
-        store
-            .insert(&TaskState::new(harness_core::types::TaskId(
-                "other".to_string(),
-            )))
-            .await;
-
-        let children = store.list_children(&parent_id);
-        assert_eq!(children.len(), 2);
-        assert!(children
-            .iter()
-            .all(|c| c.parent_id.as_ref() == Some(&parent_id)));
-
-        let no_children =
-            store.list_children(&harness_core::types::TaskId("nonexistent".to_string()));
-        assert!(no_children.is_empty());
-        Ok(())
-    }
-
-    #[test]
-    fn test_task_state_new() {
-        let id = super::TaskId::new();
-        let state = TaskState::new(id);
-        assert!(matches!(state.status, TaskStatus::Pending));
-        assert_eq!(state.turn, 0);
-        assert!(state.pr_url.is_none());
-        assert!(state.project_root.is_none());
-        assert!(state.issue.is_none());
-        assert!(state.description.is_none());
-    }
-
-    #[tokio::test]
-    async fn list_siblings_returns_active_tasks_for_same_project() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        let project = std::path::PathBuf::from("/repo/project");
-        let other_project = std::path::PathBuf::from("/repo/other");
-
-        let current_id = harness_core::types::TaskId("current".to_string());
-        let mut current = TaskState::new(current_id.clone());
-        current.project_root = Some(project.clone());
-        current.status = TaskStatus::Implementing;
-        store.insert(&current).await;
-
-        // Sibling on same project in Implementing status.
-        let mut sibling1 = TaskState::new(harness_core::types::TaskId("sibling-1".to_string()));
-        sibling1.project_root = Some(project.clone());
-        sibling1.status = TaskStatus::Implementing;
-        sibling1.issue = Some(77);
-        sibling1.description = Some("fix unwrap in s3.rs".to_string());
-        store.insert(&sibling1).await;
-
-        // Sibling on same project in Pending status.
-        let mut sibling2 = TaskState::new(harness_core::types::TaskId("sibling-2".to_string()));
-        sibling2.project_root = Some(project.clone());
-        sibling2.status = TaskStatus::Pending;
-        store.insert(&sibling2).await;
-
-        // Task on a different project — must not appear.
-        let mut other = TaskState::new(harness_core::types::TaskId("other-project".to_string()));
-        other.project_root = Some(other_project.clone());
-        other.status = TaskStatus::Implementing;
-        store.insert(&other).await;
-
-        // Done task on same project — must not appear.
-        let mut done = TaskState::new(harness_core::types::TaskId("done-task".to_string()));
-        done.project_root = Some(project.clone());
-        done.status = TaskStatus::Done;
-        store.insert(&done).await;
-
-        let siblings = store.list_siblings(&project, &current_id);
-        let sibling_ids: Vec<&str> = siblings.iter().map(|s| s.id.0.as_str()).collect();
-        assert_eq!(
-            siblings.len(),
-            2,
-            "expected 2 siblings, got: {sibling_ids:?}"
-        );
-        assert!(
-            siblings.iter().all(|s| s.id != current_id),
-            "current task must be excluded"
-        );
-        assert!(siblings
-            .iter()
-            .all(|s| s.project_root.as_deref() == Some(project.as_path())));
-
-        // One sibling on `other_project`.
-        let other_project_siblings = store.list_siblings(&other_project, &current_id);
-        assert_eq!(other_project_siblings.len(), 1);
-
-        Ok(())
-    }
-
-    #[test]
-    fn task_status_semantics_are_centralized() {
-        let cases = [
-            (
-                TaskStatus::Pending,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-            ),
-            (
-                TaskStatus::AwaitingDeps,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-            ),
-            (TaskStatus::Triaging, false, true, true, false, false, false),
-            (TaskStatus::Planning, false, true, true, false, false, false),
-            (
-                TaskStatus::Implementing,
-                false,
-                true,
-                true,
-                false,
-                false,
-                false,
-            ),
-            (
-                TaskStatus::ReviewGenerating,
-                false,
-                true,
-                true,
-                false,
-                false,
-                false,
-            ),
-            (
-                TaskStatus::ReviewWaiting,
-                false,
-                true,
-                true,
-                false,
-                false,
-                false,
-            ),
-            (
-                TaskStatus::PlannerGenerating,
-                false,
-                true,
-                true,
-                false,
-                false,
-                false,
-            ),
-            (
-                TaskStatus::PlannerWaiting,
-                false,
-                true,
-                true,
-                false,
-                false,
-                false,
-            ),
-            (
-                TaskStatus::AgentReview,
-                false,
-                true,
-                true,
-                false,
-                false,
-                false,
-            ),
-            (TaskStatus::Waiting, false, true, true, false, false, false),
-            (
-                TaskStatus::Reviewing,
-                false,
-                true,
-                true,
-                false,
-                false,
-                false,
-            ),
-            (TaskStatus::Done, true, false, false, true, false, false),
-            (TaskStatus::Failed, true, false, false, false, true, false),
-            (
-                TaskStatus::Cancelled,
-                true,
-                false,
-                false,
-                false,
-                false,
-                true,
-            ),
-        ];
-
-        for (status, terminal, inflight, resumable, success, failure, cancelled) in cases {
-            assert_eq!(status.is_terminal(), terminal, "{status:?} terminal");
-            assert_eq!(status.is_inflight(), inflight, "{status:?} inflight");
-            assert_eq!(
-                status.is_resumable_after_restart(),
-                resumable,
-                "{status:?} resumable"
-            );
-            assert_eq!(status.is_success(), success, "{status:?} success");
-            assert_eq!(status.is_failure(), failure, "{status:?} failure");
-            assert_eq!(status.is_cancelled(), cancelled, "{status:?} cancelled");
-        }
-
-        assert_eq!(
-            TaskStatus::terminal_statuses(),
-            &["done", "failed", "cancelled"]
-        );
-        assert_eq!(
-            TaskStatus::resumable_statuses(),
-            &[
-                "triaging",
-                "planning",
-                "implementing",
-                "review_generating",
-                "review_waiting",
-                "planner_generating",
-                "planner_waiting",
-                "agent_review",
-                "waiting",
-                "reviewing",
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn count_by_project_empty() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        assert!(store.count_for_dashboard().await.by_project.is_empty());
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn count_by_project_none_root_excluded() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-
-        let mut task = TaskState::new(harness_core::types::TaskId("no-root".to_string()));
-        task.status = TaskStatus::Done;
-        // project_root stays None
-        store.insert(&task).await;
-
-        assert!(
-            store.count_for_dashboard().await.by_project.is_empty(),
-            "tasks with no project_root must not appear in per-project counts"
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn count_by_project_groups_correctly() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-
-        let root_a = std::path::PathBuf::from("/projects/alpha");
-        let root_b = std::path::PathBuf::from("/projects/beta");
-
-        for (id, root, status) in [
-            ("a1", &root_a, TaskStatus::Done),
-            ("a2", &root_a, TaskStatus::Done),
-            ("a3", &root_a, TaskStatus::Failed),
-            ("a4", &root_a, TaskStatus::Cancelled),
-            ("b1", &root_b, TaskStatus::Done),
-            ("b2", &root_b, TaskStatus::Failed),
-            ("b3", &root_b, TaskStatus::Failed),
-            ("b4", &root_b, TaskStatus::Cancelled),
-        ] {
-            let mut task = TaskState::new(harness_core::types::TaskId(id.to_string()));
-            task.status = status;
-            task.project_root = Some(root.clone());
-            store.insert(&task).await;
-        }
-
-        let counts = store.count_for_dashboard().await.by_project;
-        let key_a = root_a.to_string_lossy().into_owned();
-        let key_b = root_b.to_string_lossy().into_owned();
-
-        assert!(counts.contains_key(&key_a), "alpha counts missing");
-        assert_eq!(counts[&key_a].done, 2, "alpha done");
-        assert_eq!(counts[&key_a].failed, 1, "alpha failed");
-
-        assert!(counts.contains_key(&key_b), "beta counts missing");
-        assert_eq!(counts[&key_b].done, 1, "beta done");
-        assert_eq!(counts[&key_b].failed, 2, "beta failed");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn count_by_project_excludes_cancelled_from_failed_totals() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-
-        let root = std::path::PathBuf::from("/projects/alpha");
-        for (id, status) in [
-            ("done", TaskStatus::Done),
-            ("failed", TaskStatus::Failed),
-            ("cancelled", TaskStatus::Cancelled),
-        ] {
-            let mut task = TaskState::new(harness_core::types::TaskId(id.to_string()));
-            task.status = status;
-            task.project_root = Some(root.clone());
-            store.insert(&task).await;
-        }
-
-        let counts = store.count_for_dashboard().await;
-        assert_eq!(counts.global_done, 1);
-        assert_eq!(counts.global_failed, 1);
-        let key = root.to_string_lossy().into_owned();
-        assert_eq!(counts.by_project[&key].done, 1);
-        assert_eq!(counts.by_project[&key].failed, 1);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn restore_status_preserve_staleness_mirrors_version_in_cache_and_db(
-    ) -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        let task_id = harness_core::types::TaskId("restore-version".to_string());
-        let task = TaskState::new(task_id.clone());
-        store.insert(&task).await;
-
-        store
-            .restore_status_preserve_staleness(&task_id, TaskStatus::Failed)
-            .await?;
-
-        let cached = store
-            .get(&task_id)
-            .expect("task should remain cached after status restore");
-        assert_eq!(cached.status, TaskStatus::Failed);
-        assert_eq!(cached.version, 1);
-
-        let persisted = store
-            .db
-            .get(task_id.as_str())
-            .await?
-            .expect("task should remain persisted after status restore");
-        assert_eq!(persisted.status, TaskStatus::Failed);
-        assert_eq!(persisted.version, 1);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn overwrite_external_id_auto_fix_mirrors_version_in_cache_and_db() -> anyhow::Result<()>
-    {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        let task_id = harness_core::types::TaskId("auto-fix-version".to_string());
-        let mut task = TaskState::new(task_id.clone());
-        task.source = Some("auto-fix".to_string());
-        task.external_id = Some("old-external-id".to_string());
-        store.insert(&task).await;
-
-        store
-            .overwrite_external_id_auto_fix(&task_id, "new-external-id")
-            .await?;
-
-        let cached = store
-            .get(&task_id)
-            .expect("task should remain cached after external_id overwrite");
-        assert_eq!(cached.external_id.as_deref(), Some("new-external-id"));
-        assert_eq!(cached.version, 1);
-
-        let persisted = store
-            .db
-            .get(task_id.as_str())
-            .await?
-            .expect("task should remain persisted after external_id overwrite");
-        assert_eq!(persisted.external_id.as_deref(), Some("new-external-id"));
-        assert_eq!(persisted.version, 1);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn mutate_and_persist_rolls_back_cache_on_optimistic_lock_conflict() -> anyhow::Result<()>
-    {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        let task_id = harness_core::types::TaskId("mutate-conflict".to_string());
-        let task = pending_task(task_id.as_str());
-        store.insert(&task).await;
-
-        let scheduler_json =
-            serde_json::to_string(&crate::task_runner::TaskSchedulerState::queued())?;
-        store
-            .db
-            .update_status_only(
-                task_id.as_str(),
-                TaskStatus::Failed.as_ref(),
-                &scheduler_json,
-                0,
-            )
-            .await?;
-
-        let error = mutate_and_persist(&store, &task_id, |state| {
-            state.status = TaskStatus::Done;
-            state.turn = 7;
-            state.error = Some("not persisted".to_string());
-        })
-        .await
-        .expect_err("stale cache version should fail optimistic locking");
-
-        assert!(format!("{error}").contains("optimistic-lock conflict"));
-        let cached = store
-            .get(&task_id)
-            .expect("task should remain cached after rollback");
-        assert_eq!(cached.status, TaskStatus::Pending);
-        assert_eq!(cached.turn, 0);
-        assert_eq!(cached.error, None);
-        assert_eq!(cached.version, 0);
-
-        let persisted = store
-            .db
-            .get(task_id.as_str())
-            .await?
-            .expect("task should remain persisted after conflict");
-        assert_eq!(persisted.status, TaskStatus::Failed);
-        assert_eq!(persisted.version, 1);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn mutate_and_persist_does_not_rollback_over_newer_cache_state() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = std::sync::Arc::new(TaskStore::open(&dir.path().join("tasks.db")).await?);
-        let task_id = harness_core::types::TaskId("mutate-newer-cache".to_string());
-        let task = pending_task(task_id.as_str());
-        store.insert(&task).await;
-
-        let scheduler_json =
-            serde_json::to_string(&crate::task_runner::TaskSchedulerState::queued())?;
-        store
-            .db
-            .update_status_only(
-                task_id.as_str(),
-                TaskStatus::Failed.as_ref(),
-                &scheduler_json,
-                0,
-            )
-            .await?;
-
-        let persist_lock = store
-            .persist_locks
-            .entry(task_id.clone())
-            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
-            .clone();
-        let guard = persist_lock.lock().await;
-
-        let worker_store = store.clone();
-        let worker_task_id = task_id.clone();
-        let worker = tokio::spawn(async move {
-            mutate_and_persist(worker_store.as_ref(), &worker_task_id, |state| {
-                state.status = TaskStatus::Done;
-                state.turn = 7;
-                state.error = Some("failed mutation".to_string());
-            })
-            .await
-        });
-
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(500);
-        loop {
-            let mutated = store
-                .get(&task_id)
-                .is_some_and(|state| state.status == TaskStatus::Done && state.turn == 7);
-            if mutated {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "mutate_and_persist did not reach the cache mutation before persist"
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-        }
-
-        if let Some(mut entry) = store.cache.get_mut(&task_id) {
-            entry.status = TaskStatus::AwaitingDeps;
-            entry.turn = 9;
-            entry.error = Some("newer cache state".to_string());
-        }
-
-        drop(guard);
-        let error = worker
-            .await
-            .expect("mutate task should not panic")
-            .expect_err("stale cache version should fail optimistic locking");
-
-        assert!(format!("{error}").contains("optimistic-lock conflict"));
-        let cached = store
-            .get(&task_id)
-            .expect("task should remain cached after failed persist");
-        assert_eq!(cached.status, TaskStatus::AwaitingDeps);
-        assert_eq!(cached.turn, 9);
-        assert_eq!(cached.error.as_deref(), Some("newer cache state"));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn release_runtime_host_claims_clears_pending_scheduler_owner() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-
-        let mut leased = pending_task("leased");
-        leased.scheduler.claim_runtime_host("host-a", Utc::now());
-        let leased_id = leased.id.clone();
-        store.insert(&leased).await;
-
-        let mut other_host = pending_task("other-host");
-        other_host
-            .scheduler
-            .claim_runtime_host("host-b", Utc::now());
-        let other_host_id = other_host.id.clone();
-        store.insert(&other_host).await;
-
-        let mut non_pending = pending_task("non-pending");
-        non_pending.status = TaskStatus::Implementing;
-        non_pending
-            .scheduler
-            .claim_runtime_host("host-a", Utc::now());
-        let non_pending_id = non_pending.id.clone();
-        store.insert(&non_pending).await;
-
-        let released = store.release_runtime_host_claims("host-a").await?;
-        assert_eq!(released, vec![leased_id.clone()]);
-
-        let released_task = store
-            .get(&leased_id)
-            .expect("released task should remain cached");
-        assert_eq!(released_task.scheduler.runtime_host_id(), None);
-        assert!(matches!(
-            released_task.scheduler.authority_state,
-            crate::task_runner::SchedulerAuthorityState::Queued
-        ));
-
-        let other_task = store
-            .get(&other_host_id)
-            .expect("other-host task should remain cached");
-        assert_eq!(other_task.scheduler.runtime_host_id(), Some("host-b"));
-
-        let non_pending_task = store
-            .get(&non_pending_id)
-            .expect("non-pending task should remain cached");
-        assert_eq!(non_pending_task.scheduler.runtime_host_id(), Some("host-a"));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn claim_for_runtime_host_blocks_scheduler_owned_pending_tasks() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-
-        let mut task = pending_task("scheduler-owned");
-        task.scheduler.claim_scheduler("local-scheduler");
-        let task_id = task.id.clone();
-        store.insert(&task).await;
-
-        let claim = store
-            .claim_for_runtime_host(&task_id, "host-a", Some(30))
-            .await?;
-        assert!(claim.is_none());
-
-        let cached = store
-            .get(&task_id)
-            .expect("scheduler-owned task should remain cached");
-        assert!(matches!(
-            cached
-                .scheduler
-                .owner
-                .as_ref()
-                .map(|owner| (&owner.kind, owner.id.as_str())),
-            Some((
-                crate::task_runner::SchedulerOwnerKind::Scheduler,
-                "local-scheduler"
-            ))
-        ));
-        assert!(matches!(
-            cached.scheduler.authority_state,
-            crate::task_runner::SchedulerAuthorityState::Running
-        ));
-        assert_eq!(cached.scheduler.run_generation, 1);
-
-        let persisted = store
-            .db
-            .get(task_id.as_str())
-            .await?
-            .expect("scheduler-owned task should remain persisted");
-        assert!(matches!(
-            persisted
-                .scheduler
-                .owner
-                .as_ref()
-                .map(|owner| (&owner.kind, owner.id.as_str())),
-            Some((
-                crate::task_runner::SchedulerOwnerKind::Scheduler,
-                "local-scheduler"
-            ))
-        ));
-        assert!(matches!(
-            persisted.scheduler.authority_state,
-            crate::task_runner::SchedulerAuthorityState::Running
-        ));
-        assert_eq!(persisted.scheduler.run_generation, 1);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn claim_for_runtime_host_blocks_live_runtime_host_leases() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-
-        let mut task = pending_task("leased");
-        task.scheduler
-            .claim_runtime_host("host-a", Utc::now() + chrono::TimeDelta::seconds(60));
-        let task_id = task.id.clone();
-        store.insert(&task).await;
-
-        let claim = store
-            .claim_for_runtime_host(&task_id, "host-b", Some(30))
-            .await?;
-        assert!(claim.is_none());
-
-        let cached = store
-            .get(&task_id)
-            .expect("leased task should remain cached");
-        assert_eq!(cached.scheduler.runtime_host_id(), Some("host-a"));
-        assert!(matches!(
-            cached.scheduler.authority_state,
-            crate::task_runner::SchedulerAuthorityState::Leased
-        ));
-        assert_eq!(cached.scheduler.run_generation, 1);
-
-        let persisted = store
-            .db
-            .get(task_id.as_str())
-            .await?
-            .expect("leased task should remain persisted");
-        assert_eq!(persisted.scheduler.runtime_host_id(), Some("host-a"));
-        assert!(matches!(
-            persisted.scheduler.authority_state,
-            crate::task_runner::SchedulerAuthorityState::Leased
-        ));
-        assert_eq!(persisted.scheduler.run_generation, 1);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn claim_for_runtime_host_reclaims_expired_runtime_host_leases() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-
-        let mut task = pending_task("expired-lease");
-        task.scheduler
-            .claim_runtime_host("host-a", Utc::now() - chrono::TimeDelta::seconds(60));
-        let task_id = task.id.clone();
-        store.insert(&task).await;
-
-        let claim = store
-            .claim_for_runtime_host(&task_id, "host-b", Some(30))
-            .await?;
-        let claim = claim.expect("expired lease should be reclaimed");
-        assert_eq!(claim.task_id, task_id);
-
-        let cached = store
-            .get(&task_id)
-            .expect("reclaimed task should remain cached");
-        assert_eq!(cached.scheduler.runtime_host_id(), Some("host-b"));
-        assert!(matches!(
-            cached.scheduler.authority_state,
-            crate::task_runner::SchedulerAuthorityState::Leased
-        ));
-        assert_eq!(cached.scheduler.run_generation, 2);
-        assert!(cached.scheduler.lease_expiry().is_some());
-
-        let persisted = store
-            .db
-            .get(task_id.as_str())
-            .await?
-            .expect("reclaimed task should remain persisted");
-        assert_eq!(persisted.scheduler.runtime_host_id(), Some("host-b"));
-        assert!(matches!(
-            persisted.scheduler.authority_state,
-            crate::task_runner::SchedulerAuthorityState::Leased
-        ));
-        assert_eq!(persisted.scheduler.run_generation, 2);
-        assert!(persisted.scheduler.lease_expiry().is_some());
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn claim_for_runtime_host_rolls_back_cache_when_persist_fails() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-
-        let task = pending_task("leased");
-        let task_id = task.id.clone();
-        store.insert(&task).await;
-
-        crate::test_helpers::drop_tasks_table(dir.path()).await?;
-
-        let result = store
-            .claim_for_runtime_host(&task_id, "host-a", Some(30))
-            .await;
-        assert!(
-            result.is_err(),
-            "claim should fail once the tasks table is gone"
-        );
-
-        let task = store
-            .get(&task_id)
-            .expect("task should remain cached after failed claim");
-        assert_eq!(task.scheduler.runtime_host_id(), None);
-        assert!(matches!(
-            task.scheduler.authority_state,
-            crate::task_runner::SchedulerAuthorityState::Queued
-        ));
-        assert_eq!(task.scheduler.run_generation, 0);
-        Ok(())
-    }
-
-    // --- rate-limit circuit-breaker tests ---
-
-    #[tokio::test]
-    async fn wait_for_rate_limit_no_op_when_none() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        tokio::time::timeout(
-            std::time::Duration::from_millis(100),
-            store.wait_for_rate_limit(),
-        )
-        .await
-        .map_err(|_| {
-            anyhow::anyhow!("wait_for_rate_limit must return immediately when no limit is active")
-        })?;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn rate_limit_cleared_after_deadline() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        store
-            .set_rate_limit(std::time::Duration::from_millis(50))
-            .await;
-        store.wait_for_rate_limit().await;
-        // After the limit expires, a subsequent call must return immediately.
-        tokio::time::timeout(
-            std::time::Duration::from_millis(100),
-            store.wait_for_rate_limit(),
-        )
-        .await
-        .map_err(|_| anyhow::anyhow!("rate limit must be cleared after its deadline passes"))?;
-        Ok(())
-    }
-
-    /// Regression for issue #1046: once a task is Cancelled, a late
-    /// `update_status` from an execution path that started before
-    /// cancellation must not resurrect it back to a non-terminal status
-    /// nor overwrite it with a different terminal status.
-    #[tokio::test]
-    async fn update_status_does_not_overwrite_cancelled_terminal() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        let task_id = harness_core::types::TaskId("cancelled-task".to_string());
-        let mut task = TaskState::new(task_id.clone());
-        task.status = TaskStatus::Cancelled;
-        task.scheduler.mark_terminal(&TaskStatus::Cancelled);
-        store.insert(&task).await;
-
-        // A late execution path tries to mark the task Implementing.
-        update_status(&store, &task_id, TaskStatus::Implementing, 0).await?;
-        let after = store.get(&task_id).expect("task in cache");
-        assert_eq!(after.status, TaskStatus::Cancelled, "must remain Cancelled");
-
-        // Reviewing must also be refused.
-        update_status(&store, &task_id, TaskStatus::Reviewing, 1).await?;
-        let after = store.get(&task_id).expect("task in cache");
-        assert_eq!(after.status, TaskStatus::Cancelled);
-
-        // Cross-terminal overwrites (Cancelled -> Done) must also be refused.
-        update_status(&store, &task_id, TaskStatus::Done, 2).await?;
-        let after = store.get(&task_id).expect("task in cache");
-        assert_eq!(after.status, TaskStatus::Cancelled);
-        Ok(())
-    }
-
-    /// Idempotent: writing the same terminal status is a no-op (no error).
-    #[tokio::test]
-    async fn update_status_idempotent_on_same_terminal() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
-        let task_id = harness_core::types::TaskId("done-task".to_string());
-        let mut task = TaskState::new(task_id.clone());
-        task.status = TaskStatus::Done;
-        task.scheduler.mark_terminal(&TaskStatus::Done);
-        store.insert(&task).await;
-
-        update_status(&store, &task_id, TaskStatus::Done, 5).await?;
-        let after = store.get(&task_id).expect("task in cache");
-        assert_eq!(after.status, TaskStatus::Done);
-        Ok(())
-    }
-}
+#[path = "store_tests.rs"]
+mod store_tests;

--- a/crates/harness-server/src/task_runner/store_tests.rs
+++ b/crates/harness-server/src/task_runner/store_tests.rs
@@ -1,0 +1,955 @@
+use super::super::state::TaskState;
+use super::*;
+
+#[test]
+fn collect_recovered_pr_candidates_filters_invalid_urls() {
+    let mut valid = TaskState::new(harness_core::types::TaskId("valid".to_string()));
+    valid.pr_url = Some("https://github.com/acme/myrepo/pull/42".to_string());
+
+    let mut invalid = TaskState::new(harness_core::types::TaskId("invalid".to_string()));
+    invalid.pr_url = Some("not-a-pr-url".to_string());
+
+    let mut inflight = TaskState::new(harness_core::types::TaskId("inflight".to_string()));
+    inflight.status = TaskStatus::Implementing;
+    inflight.pr_url = Some("https://github.com/acme/myrepo/pull/7".to_string());
+
+    let pending_without_pr = TaskState::new(harness_core::types::TaskId("no-pr".to_string()));
+    let tasks = [valid, invalid, inflight, pending_without_pr];
+    let candidates: Vec<_> = tasks.iter().filter_map(recovered_pr_candidate).collect();
+    assert_eq!(
+        candidates,
+        vec![RecoveredPrCandidate {
+            task_id: harness_core::types::TaskId("valid".to_string()),
+            pr_url: "https://github.com/acme/myrepo/pull/42".to_string(),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn list_active_summaries_filters_terminal_history_and_cache_overrides() -> anyhow::Result<()>
+{
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+    let active_id = harness_core::types::TaskId("active".to_string());
+    let active = TaskState::new(active_id.clone());
+    store.insert(&active).await;
+
+    let terminal_id = harness_core::types::TaskId("terminal".to_string());
+    let mut terminal = TaskState::new(terminal_id.clone());
+    terminal.status = TaskStatus::Done;
+    store.insert(&terminal).await;
+
+    let stale_db_id = harness_core::types::TaskId("stale-db-active".to_string());
+    let stale_db_active = TaskState::new(stale_db_id.clone());
+    store.insert(&stale_db_active).await;
+    let mut terminal_cache = stale_db_active;
+    terminal_cache.status = TaskStatus::Failed;
+    terminal_cache.reconcile_scheduler_with_status();
+    store.cache.insert(stale_db_id.clone(), terminal_cache);
+
+    let ids: std::collections::HashSet<_> = store
+        .list_active_summaries()
+        .await?
+        .into_iter()
+        .map(|summary| summary.id)
+        .collect();
+
+    assert!(ids.contains(&active_id));
+    assert!(!ids.contains(&terminal_id));
+    assert!(!ids.contains(&stale_db_id));
+    Ok(())
+}
+
+fn pending_task(id: &str) -> TaskState {
+    let mut task = TaskState::new(harness_core::types::TaskId(id.to_string()));
+    task.status = TaskStatus::Pending;
+    task
+}
+
+#[tokio::test]
+async fn task_stream_subscribe_and_publish() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let id = harness_core::types::TaskId("stream-test".to_string());
+
+    // No stream registered yet.
+    assert!(
+        store.subscribe_task_stream(&id).is_none(),
+        "subscribe before register should return None"
+    );
+
+    store.register_task_stream(&id);
+    let mut rx = store
+        .subscribe_task_stream(&id)
+        .ok_or_else(|| anyhow::anyhow!("subscribe after register should succeed"))?;
+
+    store.publish_stream_item(
+        &id,
+        harness_core::agent::StreamItem::MessageDelta {
+            text: "hello\n".into(),
+        },
+    );
+    store.publish_stream_item(&id, harness_core::agent::StreamItem::Done);
+
+    let item1 = rx.recv().await?;
+    let item2 = rx.recv().await?;
+    assert!(matches!(
+        item1,
+        harness_core::agent::StreamItem::MessageDelta { .. }
+    ));
+    assert!(matches!(item2, harness_core::agent::StreamItem::Done));
+
+    // After close_task_stream the channel sender is dropped.
+    store.close_task_stream(&id);
+    assert!(
+        store.subscribe_task_stream(&id).is_none(),
+        "subscribe after close should return None"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn task_stream_backpressure_drops_oldest_on_lag() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let id = harness_core::types::TaskId("backpressure-test".to_string());
+
+    store.register_task_stream(&id);
+    let mut rx = store
+        .subscribe_task_stream(&id)
+        .ok_or_else(|| anyhow::anyhow!("subscribe should succeed after register"))?;
+
+    // Publish more items than TASK_STREAM_CAPACITY to trigger lag.
+    for i in 0..(TASK_STREAM_CAPACITY + 10) as u64 {
+        store.publish_stream_item(
+            &id,
+            harness_core::agent::StreamItem::MessageDelta {
+                text: format!("line {i}\n"),
+            },
+        );
+    }
+
+    // Receiver should see RecvError::Lagged on overflow.
+    let result = rx.recv().await;
+    assert!(
+        result.is_err(),
+        "expected Lagged error after overflow, got: {:?}",
+        result
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_children_returns_subtasks_for_parent() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+    let parent_id = harness_core::types::TaskId("parent-task".to_string());
+    let parent = TaskState::new(parent_id.clone());
+    store.insert(&parent).await;
+
+    let mut child1 = TaskState::new(harness_core::types::TaskId("child-1".to_string()));
+    child1.parent_id = Some(parent_id.clone());
+    store.insert(&child1).await;
+
+    let mut child2 = TaskState::new(harness_core::types::TaskId("child-2".to_string()));
+    child2.parent_id = Some(parent_id.clone());
+    store.insert(&child2).await;
+
+    // Unrelated task.
+    store
+        .insert(&TaskState::new(harness_core::types::TaskId(
+            "other".to_string(),
+        )))
+        .await;
+
+    let children = store.list_children(&parent_id);
+    assert_eq!(children.len(), 2);
+    assert!(children
+        .iter()
+        .all(|c| c.parent_id.as_ref() == Some(&parent_id)));
+
+    let no_children = store.list_children(&harness_core::types::TaskId("nonexistent".to_string()));
+    assert!(no_children.is_empty());
+    Ok(())
+}
+
+#[test]
+fn test_task_state_new() {
+    let id = super::TaskId::new();
+    let state = TaskState::new(id);
+    assert!(matches!(state.status, TaskStatus::Pending));
+    assert_eq!(state.turn, 0);
+    assert!(state.pr_url.is_none());
+    assert!(state.project_root.is_none());
+    assert!(state.issue.is_none());
+    assert!(state.description.is_none());
+}
+
+#[tokio::test]
+async fn list_siblings_returns_active_tasks_for_same_project() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let project = std::path::PathBuf::from("/repo/project");
+    let other_project = std::path::PathBuf::from("/repo/other");
+
+    let current_id = harness_core::types::TaskId("current".to_string());
+    let mut current = TaskState::new(current_id.clone());
+    current.project_root = Some(project.clone());
+    current.status = TaskStatus::Implementing;
+    store.insert(&current).await;
+
+    // Sibling on same project in Implementing status.
+    let mut sibling1 = TaskState::new(harness_core::types::TaskId("sibling-1".to_string()));
+    sibling1.project_root = Some(project.clone());
+    sibling1.status = TaskStatus::Implementing;
+    sibling1.issue = Some(77);
+    sibling1.description = Some("fix unwrap in s3.rs".to_string());
+    store.insert(&sibling1).await;
+
+    // Sibling on same project in Pending status.
+    let mut sibling2 = TaskState::new(harness_core::types::TaskId("sibling-2".to_string()));
+    sibling2.project_root = Some(project.clone());
+    sibling2.status = TaskStatus::Pending;
+    store.insert(&sibling2).await;
+
+    // Task on a different project — must not appear.
+    let mut other = TaskState::new(harness_core::types::TaskId("other-project".to_string()));
+    other.project_root = Some(other_project.clone());
+    other.status = TaskStatus::Implementing;
+    store.insert(&other).await;
+
+    // Done task on same project — must not appear.
+    let mut done = TaskState::new(harness_core::types::TaskId("done-task".to_string()));
+    done.project_root = Some(project.clone());
+    done.status = TaskStatus::Done;
+    store.insert(&done).await;
+
+    let siblings = store.list_siblings(&project, &current_id);
+    let sibling_ids: Vec<&str> = siblings.iter().map(|s| s.id.0.as_str()).collect();
+    assert_eq!(
+        siblings.len(),
+        2,
+        "expected 2 siblings, got: {sibling_ids:?}"
+    );
+    assert!(
+        siblings.iter().all(|s| s.id != current_id),
+        "current task must be excluded"
+    );
+    assert!(siblings
+        .iter()
+        .all(|s| s.project_root.as_deref() == Some(project.as_path())));
+
+    // One sibling on `other_project`.
+    let other_project_siblings = store.list_siblings(&other_project, &current_id);
+    assert_eq!(other_project_siblings.len(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn task_status_semantics_are_centralized() {
+    let cases = [
+        (
+            TaskStatus::Pending,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (
+            TaskStatus::AwaitingDeps,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (TaskStatus::Triaging, false, true, true, false, false, false),
+        (TaskStatus::Planning, false, true, true, false, false, false),
+        (
+            TaskStatus::Implementing,
+            false,
+            true,
+            true,
+            false,
+            false,
+            false,
+        ),
+        (
+            TaskStatus::ReviewGenerating,
+            false,
+            true,
+            true,
+            false,
+            false,
+            false,
+        ),
+        (
+            TaskStatus::ReviewWaiting,
+            false,
+            true,
+            true,
+            false,
+            false,
+            false,
+        ),
+        (
+            TaskStatus::PlannerGenerating,
+            false,
+            true,
+            true,
+            false,
+            false,
+            false,
+        ),
+        (
+            TaskStatus::PlannerWaiting,
+            false,
+            true,
+            true,
+            false,
+            false,
+            false,
+        ),
+        (
+            TaskStatus::AgentReview,
+            false,
+            true,
+            true,
+            false,
+            false,
+            false,
+        ),
+        (TaskStatus::Waiting, false, true, true, false, false, false),
+        (
+            TaskStatus::Reviewing,
+            false,
+            true,
+            true,
+            false,
+            false,
+            false,
+        ),
+        (TaskStatus::Done, true, false, false, true, false, false),
+        (TaskStatus::Failed, true, false, false, false, true, false),
+        (
+            TaskStatus::Cancelled,
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+        ),
+    ];
+
+    for (status, terminal, inflight, resumable, success, failure, cancelled) in cases {
+        assert_eq!(status.is_terminal(), terminal, "{status:?} terminal");
+        assert_eq!(status.is_inflight(), inflight, "{status:?} inflight");
+        assert_eq!(
+            status.is_resumable_after_restart(),
+            resumable,
+            "{status:?} resumable"
+        );
+        assert_eq!(status.is_success(), success, "{status:?} success");
+        assert_eq!(status.is_failure(), failure, "{status:?} failure");
+        assert_eq!(status.is_cancelled(), cancelled, "{status:?} cancelled");
+    }
+
+    assert_eq!(
+        TaskStatus::terminal_statuses(),
+        &["done", "failed", "cancelled"]
+    );
+    assert_eq!(
+        TaskStatus::resumable_statuses(),
+        &[
+            "triaging",
+            "planning",
+            "implementing",
+            "review_generating",
+            "review_waiting",
+            "planner_generating",
+            "planner_waiting",
+            "agent_review",
+            "waiting",
+            "reviewing",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn count_by_project_empty() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    assert!(store.count_for_dashboard().await.by_project.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn count_by_project_none_root_excluded() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+    let mut task = TaskState::new(harness_core::types::TaskId("no-root".to_string()));
+    task.status = TaskStatus::Done;
+    // project_root stays None
+    store.insert(&task).await;
+
+    assert!(
+        store.count_for_dashboard().await.by_project.is_empty(),
+        "tasks with no project_root must not appear in per-project counts"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn count_by_project_groups_correctly() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+    let root_a = std::path::PathBuf::from("/projects/alpha");
+    let root_b = std::path::PathBuf::from("/projects/beta");
+
+    for (id, root, status) in [
+        ("a1", &root_a, TaskStatus::Done),
+        ("a2", &root_a, TaskStatus::Done),
+        ("a3", &root_a, TaskStatus::Failed),
+        ("a4", &root_a, TaskStatus::Cancelled),
+        ("b1", &root_b, TaskStatus::Done),
+        ("b2", &root_b, TaskStatus::Failed),
+        ("b3", &root_b, TaskStatus::Failed),
+        ("b4", &root_b, TaskStatus::Cancelled),
+    ] {
+        let mut task = TaskState::new(harness_core::types::TaskId(id.to_string()));
+        task.status = status;
+        task.project_root = Some(root.clone());
+        store.insert(&task).await;
+    }
+
+    let counts = store.count_for_dashboard().await.by_project;
+    let key_a = root_a.to_string_lossy().into_owned();
+    let key_b = root_b.to_string_lossy().into_owned();
+
+    assert!(counts.contains_key(&key_a), "alpha counts missing");
+    assert_eq!(counts[&key_a].done, 2, "alpha done");
+    assert_eq!(counts[&key_a].failed, 1, "alpha failed");
+
+    assert!(counts.contains_key(&key_b), "beta counts missing");
+    assert_eq!(counts[&key_b].done, 1, "beta done");
+    assert_eq!(counts[&key_b].failed, 2, "beta failed");
+    Ok(())
+}
+
+#[tokio::test]
+async fn count_by_project_excludes_cancelled_from_failed_totals() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+    let root = std::path::PathBuf::from("/projects/alpha");
+    for (id, status) in [
+        ("done", TaskStatus::Done),
+        ("failed", TaskStatus::Failed),
+        ("cancelled", TaskStatus::Cancelled),
+    ] {
+        let mut task = TaskState::new(harness_core::types::TaskId(id.to_string()));
+        task.status = status;
+        task.project_root = Some(root.clone());
+        store.insert(&task).await;
+    }
+
+    let counts = store.count_for_dashboard().await;
+    assert_eq!(counts.global_done, 1);
+    assert_eq!(counts.global_failed, 1);
+    let key = root.to_string_lossy().into_owned();
+    assert_eq!(counts.by_project[&key].done, 1);
+    assert_eq!(counts.by_project[&key].failed, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn restore_status_preserve_staleness_mirrors_version_in_cache_and_db() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = harness_core::types::TaskId("restore-version".to_string());
+    let task = TaskState::new(task_id.clone());
+    store.insert(&task).await;
+
+    store
+        .restore_status_preserve_staleness(&task_id, TaskStatus::Failed)
+        .await?;
+
+    let cached = store
+        .get(&task_id)
+        .expect("task should remain cached after status restore");
+    assert_eq!(cached.status, TaskStatus::Failed);
+    assert_eq!(cached.version, 1);
+
+    let persisted = store
+        .db
+        .get(task_id.as_str())
+        .await?
+        .expect("task should remain persisted after status restore");
+    assert_eq!(persisted.status, TaskStatus::Failed);
+    assert_eq!(persisted.version, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn overwrite_external_id_auto_fix_mirrors_version_in_cache_and_db() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = harness_core::types::TaskId("auto-fix-version".to_string());
+    let mut task = TaskState::new(task_id.clone());
+    task.source = Some("auto-fix".to_string());
+    task.external_id = Some("old-external-id".to_string());
+    store.insert(&task).await;
+
+    store
+        .overwrite_external_id_auto_fix(&task_id, "new-external-id")
+        .await?;
+
+    let cached = store
+        .get(&task_id)
+        .expect("task should remain cached after external_id overwrite");
+    assert_eq!(cached.external_id.as_deref(), Some("new-external-id"));
+    assert_eq!(cached.version, 1);
+
+    let persisted = store
+        .db
+        .get(task_id.as_str())
+        .await?
+        .expect("task should remain persisted after external_id overwrite");
+    assert_eq!(persisted.external_id.as_deref(), Some("new-external-id"));
+    assert_eq!(persisted.version, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mutate_and_persist_rolls_back_cache_on_optimistic_lock_conflict() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = harness_core::types::TaskId("mutate-conflict".to_string());
+    let task = pending_task(task_id.as_str());
+    store.insert(&task).await;
+
+    let scheduler_json = serde_json::to_string(&crate::task_runner::TaskSchedulerState::queued())?;
+    store
+        .db
+        .update_status_only(
+            task_id.as_str(),
+            TaskStatus::Failed.as_ref(),
+            &scheduler_json,
+            0,
+        )
+        .await?;
+
+    let error = mutate_and_persist(&store, &task_id, |state| {
+        state.status = TaskStatus::Done;
+        state.turn = 7;
+        state.error = Some("not persisted".to_string());
+    })
+    .await
+    .expect_err("stale cache version should fail optimistic locking");
+
+    assert!(format!("{error}").contains("optimistic-lock conflict"));
+    let cached = store
+        .get(&task_id)
+        .expect("task should remain cached after rollback");
+    assert_eq!(cached.status, TaskStatus::Pending);
+    assert_eq!(cached.turn, 0);
+    assert_eq!(cached.error, None);
+    assert_eq!(cached.version, 0);
+
+    let persisted = store
+        .db
+        .get(task_id.as_str())
+        .await?
+        .expect("task should remain persisted after conflict");
+    assert_eq!(persisted.status, TaskStatus::Failed);
+    assert_eq!(persisted.version, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mutate_and_persist_does_not_rollback_over_newer_cache_state() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = std::sync::Arc::new(TaskStore::open(&dir.path().join("tasks.db")).await?);
+    let task_id = harness_core::types::TaskId("mutate-newer-cache".to_string());
+    let task = pending_task(task_id.as_str());
+    store.insert(&task).await;
+
+    let scheduler_json = serde_json::to_string(&crate::task_runner::TaskSchedulerState::queued())?;
+    store
+        .db
+        .update_status_only(
+            task_id.as_str(),
+            TaskStatus::Failed.as_ref(),
+            &scheduler_json,
+            0,
+        )
+        .await?;
+
+    let persist_lock = store
+        .persist_locks
+        .entry(task_id.clone())
+        .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+        .clone();
+    let guard = persist_lock.lock().await;
+
+    let worker_store = store.clone();
+    let worker_task_id = task_id.clone();
+    let worker = tokio::spawn(async move {
+        mutate_and_persist(worker_store.as_ref(), &worker_task_id, |state| {
+            state.status = TaskStatus::Done;
+            state.turn = 7;
+            state.error = Some("failed mutation".to_string());
+        })
+        .await
+    });
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(500);
+    loop {
+        let mutated = store
+            .get(&task_id)
+            .is_some_and(|state| state.status == TaskStatus::Done && state.turn == 7);
+        if mutated {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "mutate_and_persist did not reach the cache mutation before persist"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+
+    if let Some(mut entry) = store.cache.get_mut(&task_id) {
+        entry.status = TaskStatus::AwaitingDeps;
+        entry.turn = 9;
+        entry.error = Some("newer cache state".to_string());
+    }
+
+    drop(guard);
+    let error = worker
+        .await
+        .expect("mutate task should not panic")
+        .expect_err("stale cache version should fail optimistic locking");
+
+    assert!(format!("{error}").contains("optimistic-lock conflict"));
+    let cached = store
+        .get(&task_id)
+        .expect("task should remain cached after failed persist");
+    assert_eq!(cached.status, TaskStatus::AwaitingDeps);
+    assert_eq!(cached.turn, 9);
+    assert_eq!(cached.error.as_deref(), Some("newer cache state"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn release_runtime_host_claims_clears_pending_scheduler_owner() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+    let mut leased = pending_task("leased");
+    leased.scheduler.claim_runtime_host("host-a", Utc::now());
+    let leased_id = leased.id.clone();
+    store.insert(&leased).await;
+
+    let mut other_host = pending_task("other-host");
+    other_host
+        .scheduler
+        .claim_runtime_host("host-b", Utc::now());
+    let other_host_id = other_host.id.clone();
+    store.insert(&other_host).await;
+
+    let mut non_pending = pending_task("non-pending");
+    non_pending.status = TaskStatus::Implementing;
+    non_pending
+        .scheduler
+        .claim_runtime_host("host-a", Utc::now());
+    let non_pending_id = non_pending.id.clone();
+    store.insert(&non_pending).await;
+
+    let released = store.release_runtime_host_claims("host-a").await?;
+    assert_eq!(released, vec![leased_id.clone()]);
+
+    let released_task = store
+        .get(&leased_id)
+        .expect("released task should remain cached");
+    assert_eq!(released_task.scheduler.runtime_host_id(), None);
+    assert!(matches!(
+        released_task.scheduler.authority_state,
+        crate::task_runner::SchedulerAuthorityState::Queued
+    ));
+
+    let other_task = store
+        .get(&other_host_id)
+        .expect("other-host task should remain cached");
+    assert_eq!(other_task.scheduler.runtime_host_id(), Some("host-b"));
+
+    let non_pending_task = store
+        .get(&non_pending_id)
+        .expect("non-pending task should remain cached");
+    assert_eq!(non_pending_task.scheduler.runtime_host_id(), Some("host-a"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn claim_for_runtime_host_blocks_scheduler_owned_pending_tasks() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+    let mut task = pending_task("scheduler-owned");
+    task.scheduler.claim_scheduler("local-scheduler");
+    let task_id = task.id.clone();
+    store.insert(&task).await;
+
+    let claim = store
+        .claim_for_runtime_host(&task_id, "host-a", Some(30))
+        .await?;
+    assert!(claim.is_none());
+
+    let cached = store
+        .get(&task_id)
+        .expect("scheduler-owned task should remain cached");
+    assert!(matches!(
+        cached
+            .scheduler
+            .owner
+            .as_ref()
+            .map(|owner| (&owner.kind, owner.id.as_str())),
+        Some((
+            crate::task_runner::SchedulerOwnerKind::Scheduler,
+            "local-scheduler"
+        ))
+    ));
+    assert!(matches!(
+        cached.scheduler.authority_state,
+        crate::task_runner::SchedulerAuthorityState::Running
+    ));
+    assert_eq!(cached.scheduler.run_generation, 1);
+
+    let persisted = store
+        .db
+        .get(task_id.as_str())
+        .await?
+        .expect("scheduler-owned task should remain persisted");
+    assert!(matches!(
+        persisted
+            .scheduler
+            .owner
+            .as_ref()
+            .map(|owner| (&owner.kind, owner.id.as_str())),
+        Some((
+            crate::task_runner::SchedulerOwnerKind::Scheduler,
+            "local-scheduler"
+        ))
+    ));
+    assert!(matches!(
+        persisted.scheduler.authority_state,
+        crate::task_runner::SchedulerAuthorityState::Running
+    ));
+    assert_eq!(persisted.scheduler.run_generation, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn claim_for_runtime_host_blocks_live_runtime_host_leases() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+    let mut task = pending_task("leased");
+    task.scheduler
+        .claim_runtime_host("host-a", Utc::now() + chrono::TimeDelta::seconds(60));
+    let task_id = task.id.clone();
+    store.insert(&task).await;
+
+    let claim = store
+        .claim_for_runtime_host(&task_id, "host-b", Some(30))
+        .await?;
+    assert!(claim.is_none());
+
+    let cached = store
+        .get(&task_id)
+        .expect("leased task should remain cached");
+    assert_eq!(cached.scheduler.runtime_host_id(), Some("host-a"));
+    assert!(matches!(
+        cached.scheduler.authority_state,
+        crate::task_runner::SchedulerAuthorityState::Leased
+    ));
+    assert_eq!(cached.scheduler.run_generation, 1);
+
+    let persisted = store
+        .db
+        .get(task_id.as_str())
+        .await?
+        .expect("leased task should remain persisted");
+    assert_eq!(persisted.scheduler.runtime_host_id(), Some("host-a"));
+    assert!(matches!(
+        persisted.scheduler.authority_state,
+        crate::task_runner::SchedulerAuthorityState::Leased
+    ));
+    assert_eq!(persisted.scheduler.run_generation, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn claim_for_runtime_host_reclaims_expired_runtime_host_leases() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+    let mut task = pending_task("expired-lease");
+    task.scheduler
+        .claim_runtime_host("host-a", Utc::now() - chrono::TimeDelta::seconds(60));
+    let task_id = task.id.clone();
+    store.insert(&task).await;
+
+    let claim = store
+        .claim_for_runtime_host(&task_id, "host-b", Some(30))
+        .await?;
+    let claim = claim.expect("expired lease should be reclaimed");
+    assert_eq!(claim.task_id, task_id);
+
+    let cached = store
+        .get(&task_id)
+        .expect("reclaimed task should remain cached");
+    assert_eq!(cached.scheduler.runtime_host_id(), Some("host-b"));
+    assert!(matches!(
+        cached.scheduler.authority_state,
+        crate::task_runner::SchedulerAuthorityState::Leased
+    ));
+    assert_eq!(cached.scheduler.run_generation, 2);
+    assert!(cached.scheduler.lease_expiry().is_some());
+
+    let persisted = store
+        .db
+        .get(task_id.as_str())
+        .await?
+        .expect("reclaimed task should remain persisted");
+    assert_eq!(persisted.scheduler.runtime_host_id(), Some("host-b"));
+    assert!(matches!(
+        persisted.scheduler.authority_state,
+        crate::task_runner::SchedulerAuthorityState::Leased
+    ));
+    assert_eq!(persisted.scheduler.run_generation, 2);
+    assert!(persisted.scheduler.lease_expiry().is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn claim_for_runtime_host_rolls_back_cache_when_persist_fails() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+
+    let task = pending_task("leased");
+    let task_id = task.id.clone();
+    store.insert(&task).await;
+
+    crate::test_helpers::drop_tasks_table(dir.path()).await?;
+
+    let result = store
+        .claim_for_runtime_host(&task_id, "host-a", Some(30))
+        .await;
+    assert!(
+        result.is_err(),
+        "claim should fail once the tasks table is gone"
+    );
+
+    let task = store
+        .get(&task_id)
+        .expect("task should remain cached after failed claim");
+    assert_eq!(task.scheduler.runtime_host_id(), None);
+    assert!(matches!(
+        task.scheduler.authority_state,
+        crate::task_runner::SchedulerAuthorityState::Queued
+    ));
+    assert_eq!(task.scheduler.run_generation, 0);
+    Ok(())
+}
+
+// --- rate-limit circuit-breaker tests ---
+
+#[tokio::test]
+async fn wait_for_rate_limit_no_op_when_none() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    tokio::time::timeout(
+        std::time::Duration::from_millis(100),
+        store.wait_for_rate_limit(),
+    )
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!("wait_for_rate_limit must return immediately when no limit is active")
+    })?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn rate_limit_cleared_after_deadline() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    store
+        .set_rate_limit(std::time::Duration::from_millis(50))
+        .await;
+    store.wait_for_rate_limit().await;
+    // After the limit expires, a subsequent call must return immediately.
+    tokio::time::timeout(
+        std::time::Duration::from_millis(100),
+        store.wait_for_rate_limit(),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("rate limit must be cleared after its deadline passes"))?;
+    Ok(())
+}
+
+/// Regression for issue #1046: once a task is Cancelled, a late
+/// `update_status` from an execution path that started before
+/// cancellation must not resurrect it back to a non-terminal status
+/// nor overwrite it with a different terminal status.
+#[tokio::test]
+async fn update_status_does_not_overwrite_cancelled_terminal() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = harness_core::types::TaskId("cancelled-task".to_string());
+    let mut task = TaskState::new(task_id.clone());
+    task.status = TaskStatus::Cancelled;
+    task.scheduler.mark_terminal(&TaskStatus::Cancelled);
+    store.insert(&task).await;
+
+    // A late execution path tries to mark the task Implementing.
+    update_status(&store, &task_id, TaskStatus::Implementing, 0).await?;
+    let after = store.get(&task_id).expect("task in cache");
+    assert_eq!(after.status, TaskStatus::Cancelled, "must remain Cancelled");
+
+    // Reviewing must also be refused.
+    update_status(&store, &task_id, TaskStatus::Reviewing, 1).await?;
+    let after = store.get(&task_id).expect("task in cache");
+    assert_eq!(after.status, TaskStatus::Cancelled);
+
+    // Cross-terminal overwrites (Cancelled -> Done) must also be refused.
+    update_status(&store, &task_id, TaskStatus::Done, 2).await?;
+    let after = store.get(&task_id).expect("task in cache");
+    assert_eq!(after.status, TaskStatus::Cancelled);
+    Ok(())
+}
+
+/// Idempotent: writing the same terminal status is a no-op (no error).
+#[tokio::test]
+async fn update_status_idempotent_on_same_terminal() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = harness_core::types::TaskId("done-task".to_string());
+    let mut task = TaskState::new(task_id.clone());
+    task.status = TaskStatus::Done;
+    task.scheduler.mark_terminal(&TaskStatus::Done);
+    store.insert(&task).await;
+
+    update_status(&store, &task_id, TaskStatus::Done, 5).await?;
+    let after = store.get(&task_id).expect("task in cache");
+    assert_eq!(after.status, TaskStatus::Done);
+    Ok(())
+}

--- a/crates/harness-server/src/thread_manager.rs
+++ b/crates/harness-server/src/thread_manager.rs
@@ -10,6 +10,7 @@ use harness_core::{
     types::Turn,
     types::TurnId,
     types::TurnStatus,
+    usage_probe::{record_usage, UsageProbeSurface},
 };
 use std::sync::Arc;
 use tokio::task::JoinHandle;
@@ -69,6 +70,7 @@ impl ThreadManager {
     }
 
     pub fn start_thread(&self, cwd: std::path::PathBuf) -> ThreadId {
+        record_usage(UsageProbeSurface::ThreadManager);
         let thread = Thread::new(cwd);
         let id = thread.id.clone();
         self.threads.insert(id.as_str().to_string(), thread);
@@ -76,18 +78,22 @@ impl ThreadManager {
     }
 
     pub fn get_thread(&self, id: &ThreadId) -> Option<Thread> {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.threads.get(id.as_str()).map(|t| t.clone())
     }
 
     pub fn list_threads(&self) -> Vec<Thread> {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.threads.iter().map(|e| e.value().clone()).collect()
     }
 
     pub fn delete_thread(&self, id: &ThreadId) -> bool {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.threads.remove(id.as_str()).is_some()
     }
 
     pub fn register_turn_task(&self, turn_id: &TurnId, handle: JoinHandle<()>) {
+        record_usage(UsageProbeSurface::ThreadManager);
         if let Some((_, previous)) = self.running_turn_tasks.remove(turn_id.as_str()) {
             previous.abort();
         }
@@ -96,10 +102,12 @@ impl ThreadManager {
     }
 
     pub fn clear_turn_task(&self, turn_id: &TurnId) {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.running_turn_tasks.remove(turn_id.as_str());
     }
 
     pub fn abort_turn_task(&self, turn_id: &TurnId) -> bool {
+        record_usage(UsageProbeSurface::ThreadManager);
         if let Some((_, handle)) = self.running_turn_tasks.remove(turn_id.as_str()) {
             handle.abort();
             true
@@ -114,6 +122,7 @@ impl ThreadManager {
         input: String,
         agent_id: AgentId,
     ) -> harness_core::error::Result<TurnId> {
+        record_usage(UsageProbeSurface::ThreadManager);
         let mut thread = self.threads.get_mut(thread_id.as_str()).ok_or_else(|| {
             harness_core::error::HarnessError::ThreadNotFound(thread_id.to_string())
         })?;
@@ -178,6 +187,7 @@ impl ThreadManager {
         thread_id: &ThreadId,
         turn_id: &TurnId,
     ) -> harness_core::error::Result<Option<TokenUsage>> {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.transition_turn(thread_id, turn_id, TurnStatus::Completed)
     }
 
@@ -186,6 +196,7 @@ impl ThreadManager {
         thread_id: &ThreadId,
         turn_id: &TurnId,
     ) -> harness_core::error::Result<Option<TokenUsage>> {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.transition_turn(thread_id, turn_id, TurnStatus::Failed)
     }
 
@@ -194,6 +205,7 @@ impl ThreadManager {
         thread_id: &ThreadId,
         turn_id: &TurnId,
     ) -> harness_core::error::Result<Option<TokenUsage>> {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.abort_turn_task(turn_id);
         self.transition_turn(thread_id, turn_id, TurnStatus::Cancelled)
     }
@@ -204,6 +216,7 @@ impl ThreadManager {
         turn_id: &TurnId,
         item: Item,
     ) -> harness_core::error::Result<()> {
+        record_usage(UsageProbeSurface::ThreadManager);
         let mut thread = self.threads.get_mut(thread_id.as_str()).ok_or_else(|| {
             harness_core::error::HarnessError::ThreadNotFound(thread_id.to_string())
         })?;
@@ -221,6 +234,7 @@ impl ThreadManager {
         turn_id: &TurnId,
         usage: TokenUsage,
     ) -> harness_core::error::Result<bool> {
+        record_usage(UsageProbeSurface::ThreadManager);
         let mut thread = self.threads.get_mut(thread_id.as_str()).ok_or_else(|| {
             harness_core::error::HarnessError::ThreadNotFound(thread_id.to_string())
         })?;
@@ -237,12 +251,14 @@ impl ThreadManager {
     }
 
     pub fn get_turn(&self, thread_id: &ThreadId, turn_id: &TurnId) -> Option<Turn> {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.threads
             .get(thread_id.as_str())
             .and_then(|thread| thread.turns.iter().find(|t| t.id == *turn_id).cloned())
     }
 
     pub fn is_turn_running(&self, thread_id: &ThreadId, turn_id: &TurnId) -> bool {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.get_turn(thread_id, turn_id)
             .is_some_and(|turn| matches!(turn.status, TurnStatus::Running))
     }
@@ -253,6 +269,7 @@ impl ThreadManager {
         turn_id: &TurnId,
         message: String,
     ) -> harness_core::error::Result<Option<TokenUsage>> {
+        record_usage(UsageProbeSurface::ThreadManager);
         if let Err(e) = self.add_item(thread_id, turn_id, Item::Error { code: -1, message }) {
             tracing::warn!("thread manager: failed to add error item for turn {turn_id}: {e}");
         }
@@ -260,14 +277,17 @@ impl ThreadManager {
     }
 
     pub fn active_turn_task_count(&self) -> usize {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.running_turn_tasks.len()
     }
 
     pub fn has_turn_task(&self, turn_id: &TurnId) -> bool {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.running_turn_tasks.contains_key(turn_id.as_str())
     }
 
     pub fn find_thread_and_turn(&self, turn_id: &TurnId) -> Option<(ThreadId, Turn)> {
+        record_usage(UsageProbeSurface::ThreadManager);
         for entry in self.threads.iter() {
             if let Some(turn) = entry.value().turns.iter().find(|turn| turn.id == *turn_id) {
                 return Some((entry.value().id.clone(), turn.clone()));
@@ -278,6 +298,7 @@ impl ThreadManager {
 
     /// Find which thread contains a given turn.
     pub fn find_thread_for_turn(&self, turn_id: &TurnId) -> Option<ThreadId> {
+        record_usage(UsageProbeSurface::ThreadManager);
         for entry in self.threads.iter() {
             if entry.value().turns.iter().any(|t| t.id == *turn_id) {
                 return Some(entry.value().id.clone());
@@ -293,6 +314,7 @@ impl ThreadManager {
         turn_id: &TurnId,
         instruction: String,
     ) -> harness_core::error::Result<()> {
+        record_usage(UsageProbeSurface::ThreadManager);
         let mut thread = self.threads.get_mut(thread_id.as_str()).ok_or_else(|| {
             harness_core::error::HarnessError::ThreadNotFound(thread_id.to_string())
         })?;
@@ -308,6 +330,7 @@ impl ThreadManager {
 
     /// Resume an archived thread back to Idle.
     pub fn resume_thread(&self, id: &ThreadId) -> harness_core::error::Result<()> {
+        record_usage(UsageProbeSurface::ThreadManager);
         let mut thread = self
             .threads
             .get_mut(id.as_str())
@@ -324,6 +347,7 @@ impl ThreadManager {
         id: &ThreadId,
         from_turn: Option<&TurnId>,
     ) -> harness_core::error::Result<ThreadId> {
+        record_usage(UsageProbeSurface::ThreadManager);
         // Clone eagerly and drop the read guard before any subsequent write to
         // `self.threads`.  DashMap shards reads with a RwLock: holding a read
         // Ref while calling `insert` on a key that hashes to the same shard
@@ -361,6 +385,7 @@ impl ThreadManager {
 
     /// Compact a thread by clearing items from all completed turns.
     pub fn compact_thread(&self, id: &ThreadId) -> harness_core::error::Result<()> {
+        record_usage(UsageProbeSurface::ThreadManager);
         let mut thread = self
             .threads
             .get_mut(id.as_str())
@@ -377,12 +402,14 @@ impl ThreadManager {
 
     /// Register an active `AgentAdapter` for a running turn.
     pub fn register_active_adapter(&self, turn_id: &TurnId, adapter: Arc<dyn AgentAdapter>) {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.running_adapters
             .insert(turn_id.as_str().to_string(), adapter);
     }
 
     /// Remove the adapter registration for a completed or cancelled turn.
     pub fn deregister_active_adapter(&self, turn_id: &TurnId) {
+        record_usage(UsageProbeSurface::ThreadManager);
         self.running_adapters.remove(turn_id.as_str());
     }
 
@@ -398,6 +425,7 @@ impl ThreadManager {
         turn_id: &TurnId,
         instruction: String,
     ) -> harness_core::error::Result<()> {
+        record_usage(UsageProbeSurface::ThreadManager);
         // Only append steering instructions to running turns.
         if !self.is_turn_running(thread_id, turn_id) {
             return Err(harness_core::error::HarnessError::Unsupported(format!(
@@ -466,6 +494,7 @@ impl ThreadManager {
         request_id: String,
         decision: ApprovalDecision,
     ) -> harness_core::error::Result<()> {
+        record_usage(UsageProbeSurface::ThreadManager);
         let adapter = self
             .running_adapters
             .get(turn_id.as_str())

--- a/scripts/archive-phase1-data.sh
+++ b/scripts/archive-phase1-data.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 2
+}
+
+need_tool() {
+  local env_name="$1"
+  local name="$2"
+  local fallback="/opt/homebrew/opt/libpq/bin/$2"
+  if [[ -n "${!env_name:-}" ]]; then
+    printf '%s\n' "${!env_name}"
+    return
+  fi
+  if command -v "$name" >/dev/null 2>&1; then
+    command -v "$name"
+    return
+  fi
+  if [[ -x "$fallback" ]]; then
+    printf '%s\n' "$fallback"
+    return
+  fi
+  die "$name not found; set $env_name"
+}
+
+[[ -n "${HARNESS_DATABASE_URL:-}" ]] || die "HARNESS_DATABASE_URL is required"
+
+PSQL="$(need_tool PSQL psql)"
+PG_DUMP="$(need_tool PG_DUMP pg_dump)"
+PG_RESTORE="$(need_tool PG_RESTORE pg_restore)"
+ARCHIVE_ROOT="${ARCHIVE_ROOT:-archives}"
+ARCHIVE_DATE="${ARCHIVE_DATE:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${ARCHIVE_DIR:-$ARCHIVE_ROOT/phase1-$ARCHIVE_DATE}"
+LOCK_WAIT_TIMEOUT="${PG_DUMP_LOCK_WAIT_TIMEOUT:-5s}"
+
+mkdir -p "$ARCHIVE_ROOT"
+[[ ! -e "$OUT_DIR" ]] || die "archive already exists: $OUT_DIR"
+mkdir "$OUT_DIR"
+
+psql_cmd=("$PSQL" -XAt --set ON_ERROR_STOP=1 "$HARNESS_DATABASE_URL")
+TABLE_SQL="
+SELECT table_schema || '.' || table_name
+FROM information_schema.tables
+WHERE table_type = 'BASE TABLE'
+  AND (
+    (
+      table_schema IN ('thread_db', 'task_db', 'eval_store', 'review_store')
+      AND table_name IN (
+        'schema_migrations', 'threads', 'tasks', 'task_artifacts',
+        'task_checkpoints', 'task_prompts', 'workspace_leases',
+        'eval_runs', 'eval_artifacts', 'quality_snapshots', 'review_findings'
+      )
+    )
+    OR (
+      table_schema ~ '^h[0-9a-f]{16}$'
+      AND table_name IN (
+        'schema_migrations', 'threads', 'tasks', 'task_artifacts',
+        'task_checkpoints', 'task_prompts', 'workspace_leases',
+        'eval_runs', 'eval_artifacts', 'quality_snapshots', 'review_findings'
+      )
+    )
+  )
+ORDER BY table_schema, table_name"
+
+tables_file="$OUT_DIR/tables.txt"
+if ! "${psql_cmd[@]}" -c "$TABLE_SQL" > "$tables_file"; then
+  die "failed to query phase1 tables"
+fi
+mapfile -t tables < "$tables_file"
+[[ "${#tables[@]}" -gt 0 ]] || die "no phase1 tables found"
+required_tables=(thread_db.threads task_db.tasks)
+for required_table in "${required_tables[@]}"; do
+  found=0
+  for table in "${tables[@]}"; do
+    if [[ "$table" == "$required_table" ]]; then
+      found=1
+      break
+    fi
+  done
+  [[ "$found" -eq 1 ]] || die "required table is missing: $required_table"
+done
+
+dump_args=()
+{
+  printf 'table\trows\n'
+  for table in "${tables[@]}"; do
+    [[ "$table" =~ ^(thread_db|task_db|eval_store|review_store|h[0-9a-f]{16})\.[a-z_]+$ ]] \
+      || die "refusing unexpected table name: $table"
+    IFS=. read -r schema name <<<"$table"
+    count="$("${psql_cmd[@]}" -c "SELECT count(*) FROM \"$schema\".\"$name\"")"
+    printf '%s\t%s\n' "$table" "$count"
+    dump_args+=(--table="$table")
+  done
+} > "$OUT_DIR/table_counts.tsv"
+
+"$PG_DUMP" \
+  --format=custom \
+  --no-owner \
+  --no-acl \
+  --lock-wait-timeout="$LOCK_WAIT_TIMEOUT" \
+  "${dump_args[@]}" \
+  --file="$OUT_DIR/phase1-data.dump" \
+  "$HARNESS_DATABASE_URL"
+
+"$PG_RESTORE" --list "$OUT_DIR/phase1-data.dump" > "$OUT_DIR/phase1-data.list"
+
+cat > "$OUT_DIR/RESTORE.md" <<'EOF'
+# Restore phase1 archive
+
+This archive contains Harness Phase 1 contraction data captured before code
+removal. It may include shared schemas (`thread_db`, `task_db`, `eval_store`,
+`review_store`) and path-derived `h<hex>` schemas when they contain matching
+thread, task, eval, or review tables.
+
+Restore only into an empty scratch database:
+
+```bash
+export SCRATCH_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_phase1_restore
+pg_restore --exit-on-error --no-owner --no-acl \
+  --dbname "$SCRATCH_DATABASE_URL" phase1-data.dump
+```
+
+Do not restore directly into a live Harness database. Do not pass `--clean`.
+Use `table_counts.tsv` and `phase1-data.list` to confirm expected objects first.
+EOF
+
+{
+  echo
+  echo "Created at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "Lock wait timeout: $LOCK_WAIT_TIMEOUT"
+  echo "Table count: ${#tables[@]}"
+} >> "$OUT_DIR/RESTORE.md"
+
+printf 'Archive written: %s\n' "$OUT_DIR"


### PR DESCRIPTION
## Summary
- Add in-process usage probes for Phase 1 contraction surfaces and persist daily `usage_probe` / `probe_report` event summaries.
- Instrument thread/turn RPC dispatch, ThreadManager, TaskDb, task executor/runner, ReviewStore, and harness-eval entrypoints.
- Add a non-destructive Phase 1 data archive script that requires both `thread_db.threads` and `task_db.tasks` before dumping selected tables.

Related: #1434

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1434`
- `bash -n scripts/archive-phase1-data.sh`
- `cargo check -p harness-core --all-targets`
- `cargo check -p harness-eval --all-targets`
- `cargo check -p harness-server --all-targets`
- `cargo test -p harness-core usage_probe -- --test-threads=1`
- `cargo test -p harness-eval -- --test-threads=1`
- `cargo test --package harness-server probe -- --test-threads=1`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

## Notes
- `cargo test --workspace -- --test-threads=1` was attempted on this machine and repeatedly reached existing local Postgres-dependent `harness-core::db` failures. Representative failure: `db::tests::get_returns_none_for_missing` failed with `failed to open Postgres bootstrap pool ... pool timed out while waiting for an open connection`.
- This PR intentionally does not delete Phase 1 code or close GH1434. Later removal tasks still need the required zero-usage observation window or maintainer waiver.
