### PR TITLE
ci: scope tests to changed crates, dedup compile jobs, build web bundle once

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,21 +6,84 @@ set -euo pipefail
 # tests that spawn their own git repos in temp directories.
 unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE 2>/dev/null || true
 
+# Derive the cargo package scope from staged files so clippy/test only cover
+# the crates touched by this commit. Falls back to the full workspace when:
+#   - workspace-level manifests (Cargo.toml / Cargo.lock) are staged
+#   - Rust files outside crates/ are staged
+#   - a staged path maps to a directory that is not a cargo package
+#   - no crate paths are staged at all (safe default)
+# harness-core is depended on by nearly every crate, so a core change expands
+# to its main dependents (mirrors the server/agents path filters in ci.yml).
+derive_scope() {
+    staged=$(git diff --cached --name-only)
+    full=0
+    pkgs=" "
+    for f in $staged; do
+        case "$f" in
+            Cargo.toml|Cargo.lock)
+                full=1
+                ;;
+            crates/*/*)
+                crate=${f#crates/}
+                crate=${crate%%/*}
+                if [ ! -f "crates/$crate/Cargo.toml" ]; then
+                    full=1
+                    continue
+                fi
+                case "$pkgs" in
+                    *" $crate "*) ;;
+                    *) pkgs="$pkgs$crate " ;;
+                esac
+                ;;
+            *.rs)
+                # Rust file outside crates/ — scope is unknown, be safe.
+                full=1
+                ;;
+        esac
+    done
+    if [ "$pkgs" != " " ]; then
+        case "$pkgs" in
+            *" harness-core "*)
+                for dep in harness-server harness-workflow harness-agents; do
+                    case "$pkgs" in
+                        *" $dep "*) ;;
+                        *) pkgs="$pkgs$dep " ;;
+                    esac
+                done
+                ;;
+        esac
+    fi
+    if [ "$full" -eq 1 ] || [ "$pkgs" = " " ]; then
+        echo "--workspace"
+    else
+        scope=""
+        for p in $pkgs; do
+            scope="$scope -p $p"
+        done
+        echo "$scope"
+    fi
+}
+
+scope=$(derive_scope)
+echo "=== pre-commit: cargo scope: $scope ==="
+
 echo "=== pre-commit: fmt ==="
 cargo fmt --all -- --check
 
 echo "=== pre-commit: clippy ==="
-cargo clippy --workspace --all-targets -- -D warnings
+# shellcheck disable=SC2086 # scope is an intentional word-split flag list
+cargo clippy $scope --all-targets -- -D warnings
 
 echo "=== pre-commit: test ==="
 # Live Postgres tests require a configured Harness database URL.
 # Run them when available; otherwise skip only the known live-Postgres lib tests
 # and let CI or a configured local database provide full DB coverage.
+# shellcheck disable=SC2086 # scope is an intentional word-split flag list
 if [ -n "${HARNESS_DATABASE_URL:-}" ]; then
-    cargo test --workspace --lib
+    cargo test $scope --lib
 else
     echo "HARNESS_DATABASE_URL not set — skipping live Postgres lib tests"
-    cargo test --workspace --lib -- --skip db::tests
+    cargo test $scope --lib -- --skip db::tests
 fi
 
 echo "=== pre-commit: all checks passed ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,12 @@ jobs:
             run_server=true
           fi
           if [ "$AGENTS_CHANGED" = "true" ]; then
+            # harness-server depends on harness-agents, so agent changes must
+            # also run the server test profiles: a behavioral regression in
+            # the agent adapters would otherwise ship untested (clippy only
+            # catches compile breakage).
             pkgs="$pkgs -p harness-agents"
+            run_server=true
             case "$pkgs" in
               *"-p harness-core"*) ;;
               *) pkgs="$pkgs -p harness-core" ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       server: ${{ steps.filter.outputs.server }}
       agents: ${{ steps.filter.outputs.agents }}
       ci: ${{ steps.filter.outputs.ci }}
+      workspace: ${{ steps.filter.outputs.workspace }}
+      other_crates: ${{ steps.filter.outputs.other_crates }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -43,6 +45,16 @@ jobs:
             ci:
               - '.github/workflows/**'
               - 'scripts/check_storage_legacy_openers.py'
+            workspace:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/**'
+            other_crates:
+              - 'crates/**'
+              - '!crates/harness-server/**'
+              - '!crates/harness-core/**'
+              - '!crates/harness-workflow/**'
+              - '!crates/harness-agents/**'
 
   storage-legacy-openers:
     name: Storage Legacy Openers
@@ -67,15 +79,14 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
-  check:
-    name: Check
+  # ── Step 3: Build web bundle once, share via artifact ─────────────────
+  web-build:
+    name: Web Build
     runs-on: ubuntu-latest
     needs: changed
     if: needs.changed.outputs.rust == 'true' || needs.changed.outputs.ci == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -84,36 +95,45 @@ jobs:
         run: |
           bun install --frozen-lockfile
           bun run build
-      - run: cargo check --workspace --all-targets
+      - uses: actions/upload-artifact@v4
+        with:
+          name: web-dist
+          path: web/dist
+          if-no-files-found: error
+          retention-days: 1
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    needs: check
+    needs: [changed, web-build]
     if: needs.changed.outputs.rust == 'true' || needs.changed.outputs.ci == 'true'
+    env:
+      # harness-server's build.rs reuses the prebuilt web/dist artifact
+      # instead of invoking bun again.
+      HARNESS_SKIP_WEB_BUILD: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/download-artifact@v4
         with:
-          bun-version: latest
-      - name: Build web bundle
-        working-directory: web
-        run: |
-          bun install --frozen-lockfile
-          bun run build
+          name: web-dist
+          path: web/dist
       - run: cargo clippy --workspace --all-targets
 
-  # ── Step 3: Tests (only when relevant crates change) ──────────────────
+  # ── Step 4: Tests (scoped to affected crates) ─────────────────────────
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: [check, changed]
+    needs: [changed, web-build]
     if: needs.changed.outputs.rust == 'true' || needs.changed.outputs.ci == 'true'
     timeout-minutes: 15
+    env:
+      # harness-server's build.rs reuses the prebuilt web/dist artifact
+      # instead of invoking bun again.
+      HARNESS_SKIP_WEB_BUILD: "1"
     services:
       postgres:
         image: postgres:16
@@ -132,22 +152,59 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/download-artifact@v4
         with:
-          bun-version: latest
-      - name: Build web bundle
-        working-directory: web
+          name: web-dist
+          path: web/dist
+      - name: Compute test scope
+        id: scope
+        env:
+          WORKSPACE_CHANGED: ${{ needs.changed.outputs.workspace }}
+          CI_CHANGED: ${{ needs.changed.outputs.ci }}
+          OTHER_CRATES_CHANGED: ${{ needs.changed.outputs.other_crates }}
+          SERVER_CHANGED: ${{ needs.changed.outputs.server }}
+          AGENTS_CHANGED: ${{ needs.changed.outputs.agents }}
         run: |
-          bun install --frozen-lockfile
-          bun run build
-      - run: cargo test --workspace --exclude harness-server
+          # Full workspace when workspace-level files or unclassified crates
+          # changed; otherwise scope cargo test to the affected package sets.
+          # harness-server is always excluded from `cargo test` because its
+          # tests run via the dedicated fast/db profile scripts below.
+          if [ "$WORKSPACE_CHANGED" = "true" ] || [ "$CI_CHANGED" = "true" ] || [ "$OTHER_CRATES_CHANGED" = "true" ]; then
+            echo "packages=--workspace --exclude harness-server" >> "$GITHUB_OUTPUT"
+            echo "run_server=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pkgs=""
+          run_server=false
+          if [ "$SERVER_CHANGED" = "true" ]; then
+            pkgs="-p harness-core -p harness-workflow"
+            run_server=true
+          fi
+          if [ "$AGENTS_CHANGED" = "true" ]; then
+            pkgs="$pkgs -p harness-agents"
+            case "$pkgs" in
+              *"-p harness-core"*) ;;
+              *) pkgs="$pkgs -p harness-core" ;;
+            esac
+          fi
+          if [ -z "$pkgs" ]; then
+            # Rust-adjacent change (e.g. helper scripts) with no crate match:
+            # fall back to the full workspace run to stay safe.
+            pkgs="--workspace --exclude harness-server"
+            run_server=true
+          fi
+          echo "packages=$pkgs" >> "$GITHUB_OUTPUT"
+          echo "run_server=$run_server" >> "$GITHUB_OUTPUT"
+      - run: cargo test ${{ steps.scope.outputs.packages }}
         env:
           HARNESS_DATABASE_URL: postgres://postgres:postgres@localhost:5432/harness_test
       - name: Harness-server fast profile
+        if: steps.scope.outputs.run_server == 'true'
         run: scripts/test-server-fast.sh
         env:
           HARNESS_DATABASE_URL: postgres://postgres:postgres@localhost:5432/harness_test
       - name: Harness-server full DB profile
+        if: steps.scope.outputs.run_server == 'true'
         run: scripts/test-server-db.sh
         env:
           HARNESS_DATABASE_URL: postgres://postgres:postgres@localhost:5432/harness_test
@@ -171,7 +228,7 @@ jobs:
     name: CI Result
     runs-on: ubuntu-latest
     if: always()
-    needs: [changed, storage-legacy-openers, fmt, check, clippy, test, audit]
+    needs: [changed, storage-legacy-openers, fmt, web-build, clippy, test, audit]
     steps:
       - name: Check all jobs
         run: |
@@ -179,7 +236,7 @@ jobs:
             "${{ needs.changed.result }}"
             "${{ needs.storage-legacy-openers.result }}"
             "${{ needs.fmt.result }}"
-            "${{ needs.check.result }}"
+            "${{ needs.web-build.result }}"
             "${{ needs.clippy.result }}"
             "${{ needs.test.result }}"
             "${{ needs.audit.result }}"


### PR DESCRIPTION
## Summary

Closes #1454

### 1. Scoped test job
The `changed` job gains `workspace` (Cargo.toml, Cargo.lock, `.github/workflows/**`) and `other_crates` (crates outside the server/agents filter sets) outputs. The test job computes its scope from them:

- workspace-level / workflow / unclassified-crate changes -> `cargo test --workspace --exclude harness-server` + server fast/db profile scripts (current full behavior)
- server changes -> `cargo test -p harness-core -p harness-workflow` + server profile scripts
- agents changes -> `cargo test -p harness-agents -p harness-core` + server profile scripts (harness-server depends on harness-agents, so agent adapter regressions must be exercised by the server test profiles, not just compiled)
- no crate match (e.g. helper scripts only) -> safe fallback to full workspace

harness-server stays excluded from plain `cargo test` because its tests run via `scripts/test-server-fast.sh` / `scripts/test-server-db.sh`, now gated on the same scope. Postgres service container and `HARNESS_DATABASE_URL` are unchanged.

**Scoping coverage note:** scoping currently benefits changes in the 4 filtered crates (harness-server, harness-core, harness-workflow, harness-agents). The remaining 11 workspace crates fall into `other_crates` and keep the full-suite run — a deliberate safe default until per-crate filters are worth adding.

### 2. Removed standalone `check` job
`cargo clippy --workspace --all-targets` with `RUSTFLAGS=-Dwarnings` subsumes `cargo check`. Clippy now depends only on `changed` + `web-build`, so clippy and test start in parallel instead of serializing behind check. `ci-result` needs/results updated (check removed, web-build added); it still fails on `failure`/`cancelled` and passes on `skipped`.

### 3. Web bundle built once
Previously `bun install + bun run build` ran in check, clippy, and test (3x). A new `web-build` job builds it once and uploads `web/dist` as an artifact. Clippy/test download it back to `web/dist` and set `HARNESS_SKIP_WEB_BUILD=1`; `crates/harness-server/build.rs` then reuses the existing `web/dist/index.html` instead of invoking bun.

### 4. Pre-commit hook scoping
`.githooks/pre-commit` derives a `-p` package list from `git diff --cached --name-only` (crate dir == package name, verified against `crates/*/Cargo.toml`). Falls back to `--workspace` when root Cargo.toml/Cargo.lock, Rust files outside `crates/`, or unknown crate dirs are staged, or when no crate paths are staged. `harness-core` expands to harness-server/workflow/agents, mirroring the ci.yml filters. fmt still runs `--all`; clippy/test use the derived scope.

## Expected time savings

- One full compile pipeline removed (`check` job: full `cargo check --workspace --all-targets` from scratch).
- Two redundant web bundle builds removed (bun install + vite build + SDK prebuild, previously 3x per run).
- Server/core/workflow/agents-scoped PRs drop from a full-workspace `cargo test` to the affected package set; the other 11 crates keep the full suite by design (see coverage note above).
- Local commits on a single crate no longer clippy+test the whole workspace.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — OK
- `sh -n .githooks/pre-commit` — OK; `shellcheck .githooks/pre-commit` — clean
- Dry-ran the hook's scope derivation against 10 fake staged-file lists (single crate, core-expansion, root manifests, non-crate rust, docs-only, unknown crate, multi-crate) — all produced the expected scope
- Simulated the CI compute-test-scope step across all 7 filter combinations — all produced the expected package set; every combination that can affect harness-server (including agents-only) now runs the server test profiles