### PR TITLE
spec: add SpecRail packets for GH1465 (terminal-event liveness) and GH1466 (lease-aware workspace GC)

### DIFF
--- a/specs/GH1465/product.md
+++ b/specs/GH1465/product.md
@@ -1,0 +1,74 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1465
+
+## User Problem
+
+Operators cannot tell stuck tasks from in-flight tasks. Execution records
+(2026-04-29..30, `harness-codex-runtime` data dir) show 21 created tasks
+producing 86 `reviewing` + 86 `waiting` transitions, hitting the turn cap of
+10, and then stopping silently: zero `completed`, zero `failed`. A task that
+exhausts its review-round budget looks identical to one that is still
+working, so stuck work is only discoverable by hand-diffing event logs.
+GH-1438 shows the same "silently stuck, no terminal signal" family is still
+alive on the current runtime via a different mechanism.
+
+## Goals
+
+- Guarantee a liveness invariant: every created task emits exactly one
+  terminal event (`completed`, `failed`, or `stalled`).
+- Make budget exhaustion an explicit, operator-visible terminal outcome with
+  a machine-readable reason.
+- Enforce the invariant with a regression eval so future runtime refactors
+  cannot silently reintroduce limbo states.
+
+## Non-Goals
+
+- Changing review-loop quality behavior (what counts as pass/fail per round).
+- Reworking the reconciler's illegal-transition handling (tracked in GH-1438).
+- Retroactively repairing historical April-era event logs.
+
+## Behavior Invariants
+
+1. Every task that emits `created` eventually emits exactly one terminal
+   event; no code path may abandon a task in `waiting`, `reviewing`, or any
+   other non-terminal status.
+2. When the round/turn budget is exhausted, the task transitions to an
+   explicit terminal state (`stalled` or `failed`) carrying reason
+   `round_budget_exhausted`, the rounds consumed, and the last status.
+3. The terminal event is emitted at error level to the operator surface
+   (events log + status API), never as a silent stop (U-29: no silent
+   degradation).
+4. Status surfaces (dashboard, status API, intake) count budget-exhausted
+   tasks as terminal, not in-flight.
+5. The invariant holds under crash/restart: recovery either resumes the task
+   or drives it to a terminal state — never back into indefinite limbo.
+
+## Acceptance Criteria
+
+- [ ] A task driven to its turn cap in a test emits a terminal event with
+      reason `round_budget_exhausted`.
+- [ ] An event-log audit check (test or eval) fails when any `created` task
+      lacks a terminal event after the run drains.
+- [ ] Status API reflects the terminal state; no task remains `waiting`
+      after budget exhaustion.
+- [ ] Restart mid-review resumes or terminates the task; a soak/recovery
+      test asserts no limbo survivors.
+
+## Edge Cases
+
+- Budget exhausted while an external review (bot/human) is genuinely
+  pending — terminal `stalled` must record what it was waiting on so the
+  operator can requeue.
+- Concurrent terminal proposals (budget exhaustion racing task completion) —
+  exactly-one-terminal-event must hold; first writer wins, second is a no-op.
+- Tasks created but never scheduled (queue drained/shutdown) — shutdown path
+  must also terminalize or persist-and-resume, not drop.
+
+## Rollout Notes
+
+Pure runtime-behavior fix plus an eval gate; no config surface. Announce the
+new `stalled` reason string in CHANGELOG so downstream log consumers can key
+on it.

--- a/specs/GH1465/tasks.md
+++ b/specs/GH1465/tasks.md
@@ -1,0 +1,35 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1465
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1465-T001` Owner: runtime | Done when: terminal outcome `stalled` (or structured failed-reason) exists with `{reason, rounds_used, last_status, waiting_on}` payload and a single CAS-style terminal emission function enforces exactly-one terminal event per task | Verify: `cargo test -p harness-server terminal_exactly_once`
+- [ ] `SP1465-T002` Owner: runtime | Done when: budget exhaustion in the spawn/executor loop transitions the task to the terminal state via the CAS function before loop exit | Verify: `cargo test -p harness-server round_budget_exhausted`
+- [ ] `SP1465-T003` Owner: runtime | Done when: every early `break`/return in `task_runner/spawn.rs` (incl. workspace-lifecycle paths) records a terminal event or re-queues, with an on-exit guard asserting terminal-or-requeued | Verify: `cargo test -p harness-server spawn_exit_paths`
+- [ ] `SP1465-T004` Owner: server-http | Done when: status/overview endpoints and dashboard classify `stalled` as terminal with visible reason | Verify: `cargo test -p harness-server status_stalled_terminal`
+- [ ] `SP1465-T005` Owner: runtime | Done when: restart-mid-review and shutdown-drain tests prove tasks resume or terminalize, never stay in limbo | Verify: `cargo test -p harness-server recovery_no_limbo`
+- [ ] `SP1465-T006` Owner: eval | Done when: an event-stream liveness audit (created == terminal after drain) runs as a deterministic check and is wired into the regression eval loop | Verify: audit check red on a synthetic limbo fixture, green on suite
+
+## Parallelization
+
+- T001 first (shared foundation).
+- T002 ∥ T003 ∥ T004 after T001 (disjoint: executor loop vs spawn exits vs http).
+- T005 after T002/T003; T006 last.
+
+## Verification
+
+- `cargo test --workspace`
+- Synthetic fixture: turn cap 2 + always-failing review → exactly one `stalled` terminal event, status API terminal, audit green.
+
+## Handoff Notes
+
+- Do not reuse `completed` for exhausted budgets — downstream automation treats `completed` as success.
+- GH-1438 (reconciler illegal transition) stays separate; only the on-exit guard here may overlap — coordinate reason strings.

--- a/specs/GH1465/tech.md
+++ b/specs/GH1465/tech.md
@@ -1,0 +1,88 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1465
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Task spawn/retry loop | `crates/harness-server/src/task_runner/spawn.rs` | Retry loop tracks `total_turns_used` against the max_turns budget; several paths `break Ok(())` (e.g. workspace-lifecycle failures) | Budget exhaustion and early breaks are the paths that must terminalize |
+| Task execution | `crates/harness-server/src/task_executor.rs` (+ extracted modules per #1443) | Drives triage/plan/implement/review phases, emits `status_changed` events | Round accounting source |
+| Event emission | task events store (`task-events.jsonl` / events store) | Emits `created`, `status_changed`, `round_completed`, `completed`, `failed` | New terminal reason + audit surface |
+| Status surfaces | `crates/harness-server/src/http/` status/overview endpoints (see #1440) | Aggregate task states for dashboard/API | Must classify `stalled` as terminal |
+| Recovery/reconciliation | workflow runtime reconciler (see GH-1438), startup recovery | Re-proposes transitions on restart | Restart must not resurrect limbo |
+
+## Proposed Design
+
+1. **Terminal reason enum** — add `stalled` terminal outcome (or `failed`
+   with structured reason) carrying `{reason: round_budget_exhausted,
+   rounds_used, last_status, waiting_on}` in the event payload.
+2. **Budget-exhaustion transition** — in the spawn/executor loop, when
+   `total_turns_used >= max_turns` and the task is not `completed`, emit the
+   terminal event and persist the state in the same mutation
+   (`mutate_and_persist`), before breaking out of the loop.
+3. **Close the `break Ok(())` holes** — audit every early `break`/return in
+   `spawn.rs` (workspace-lifecycle failure paths included): each must either
+   have already recorded a terminal event or do so at the break site. A
+   debug assertion (`debug_assert_terminal_on_drop`-style guard) wraps the
+   spawn future: on exit, task state must be terminal or explicitly
+   re-queued.
+4. **Exactly-once terminal** — terminal emission goes through one function
+   that compare-and-swaps the persisted status; a second terminal proposal
+   becomes a logged no-op.
+5. **Liveness audit check** — a post-run audit (test helper + eval gate per
+   GH-1447 direction): given an event stream, assert `created` count ==
+   terminal count once the queue drains; wire into the workflow regression
+   eval and a `checks/`-style deterministic script over `task-events.jsonl`.
+6. **Status classification** — status/overview endpoints and the dashboard
+   map `stalled` into the terminal bucket with its reason visible.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 exactly-one terminal | terminal CAS function | unit test: double-terminal proposal → single event |
+| P2 budget exhaustion terminalizes | spawn/executor loop | integration test: turn cap 2, review never passes → `stalled(round_budget_exhausted)` |
+| P3 error-level visibility | event emission | test asserts error-level event + reason payload |
+| P4 status surfaces terminal | http status endpoints | endpoint test: stalled task counted terminal |
+| P5 crash safety | recovery path | restart-mid-review test: task resumes or terminalizes |
+
+## Data Flow
+
+Executor round accounting → budget check → terminal CAS → persisted task
+state + terminal event → status API/dashboard + audit check over the event
+stream.
+
+## Alternatives Considered
+
+- Timeout-based sweeper that marks old `waiting` tasks stalled — rejected as
+  primary fix: it papers over the missing transition and misfires on
+  legitimately long waits; acceptable later as a belt-and-braces reconciler
+  rule.
+- Treating budget exhaustion as `completed` with a warning — rejected:
+  silent degradation (U-29); the work is not done.
+- Only fixing the dashboard query — rejected: state must be truthful at the
+  source, not reinterpreted per consumer.
+
+## Risks
+
+- Behavior change: runs that previously "ended quietly" now produce failed/
+  stalled terminals — downstream automation keying on `failed` may retrigger;
+  mitigated by the distinct `stalled` reason.
+- Race between completion and exhaustion — covered by the CAS single-writer
+  design and a dedicated test.
+- The April-era records predate the current workflow runtime; the audit
+  check is the guard that proves the invariant on today's code rather than
+  assuming the old bug shape.
+
+## Test Plan
+
+- [ ] Unit: terminal CAS exactly-once; reason payload shape.
+- [ ] Integration: turn-cap exhaustion → stalled; restart-mid-review; shutdown drain.
+- [ ] Audit: event-stream liveness check green on full workspace test suite; wired into regression eval.

--- a/specs/GH1466/product.md
+++ b/specs/GH1466/product.md
@@ -1,0 +1,74 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1466
+
+## User Problem
+
+Workspace GC/cleanup can delete directories still referenced by non-terminal
+tasks. In the 2026-04-28..29 records (`harness2` data dir), 28 of 34 task
+failures (82%) carried `current_dir_exists=false`: the agent phase started in
+a workspace that no longer existed. The surfaced error — `failed to run
+codex: No such file or directory` — misdirected triage toward the codex
+binary. Current main detects the condition before a turn
+(`WorkspaceLifecycle: workspace path missing before task turn`), but
+detection is post-hoc: the task's in-flight work is already lost.
+
+## Goals
+
+- Prevent deletion of any workspace referenced by a non-terminal task
+  (lease/reference check at GC time), instead of only detecting the loss
+  afterwards.
+- When deletion is forced (operator override, corrupt workspace), atomically
+  terminalize the owning task with reason `workspace_reclaimed`.
+- Keep the existing detection path as defense-in-depth with accurate
+  diagnostics.
+
+## Non-Goals
+
+- Redesigning workspace layout, slots, or the lease data model.
+- Cross-process file locking between unrelated harness installations
+  (multiple data dirs sharing one workspace root is documented as
+  unsupported, not engineered around).
+- Orphaned Postgres schema reaping (GH-1436).
+
+## Behavior Invariants
+
+1. GC and every cleanup path (`cleanup_workspace_path`, orphan reaper, CLI
+   `gc`) consult the task/lease store and skip workspaces owned by
+   non-terminal tasks, logging the skip with the owning task id.
+2. Forced reclaim transitions the owning task to a terminal state with
+   reason `workspace_reclaimed` in the same operation as the deletion —
+   never delete first and let the task discover it later.
+3. A task failure caused by a missing workspace is reported as
+   `workspace missing` (with the path), never as an agent-binary error.
+4. GC reports what it skipped and why (no silent caps): operators can see
+   live-workspace pressure instead of wondering why GC freed nothing.
+
+## Acceptance Criteria
+
+- [ ] GC run against a store with a non-terminal task leaves that task's
+      workspace intact and logs the skip.
+- [ ] Forced reclaim produces a terminal task event `workspace_reclaimed`
+      and the deletion in one atomic step.
+- [ ] A missing-workspace failure surfaces `workspace missing: <path>` in
+      the task error, not a codex/claude binary error.
+- [ ] Existing spawn preflight detection stays green as the second layer.
+
+## Edge Cases
+
+- Task terminalizes between the lease check and the delete — delete path
+  re-checks under the lease/store lock (TOCTOU guard).
+- Stale leases from crashed runs — leases carry owner-session/generation;
+  reclaim allowed when the owning session is provably dead, still with the
+  terminalize-first rule.
+- Workspace root shared by a second harness instance — out of scope for
+  locking, but the lease check must fail closed (skip deletion) when the
+  owner cannot be resolved.
+
+## Rollout Notes
+
+Behavioral tightening of GC; may reduce space reclaimed per run (skipped
+live workspaces are now visible in GC output). Document the
+`workspace_reclaimed` reason string in CHANGELOG.

--- a/specs/GH1466/tasks.md
+++ b/specs/GH1466/tasks.md
@@ -1,0 +1,35 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1466
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1466-T001` Owner: server-workspace | Done when: `try_reclaim_workspace` exists with the decision table (non-terminal owner → skip+log, unresolvable owner → fail-closed skip with age override, terminal/absent → delete) and delete re-checks ownership under the store lock | Verify: `cargo test -p harness-server reclaim_gate`
+- [ ] `SP1466-T002` Owner: server-workspace | Done when: all three deletion paths (`cleanup_workspace_path`, orphan reaper, CLI/agent GC) route through the reclaim gate | Verify: `cargo test -p harness-server reclaim_gate_wiring` + grep shows no direct `remove_dir_all` on workspace roots outside the gate
+- [ ] `SP1466-T003` Owner: server-workspace | Done when: forced reclaim terminalizes the owning task with reason `workspace_reclaimed` and deletes atomically (depends on GH-1465 terminal CAS or a minimal helper) | Verify: `cargo test -p harness-server forced_reclaim`
+- [ ] `SP1466-T004` Owner: agents | Done when: ENOENT spawn failures with `current_dir_exists=false` surface `workspace missing: <path>` as the primary error in both codex and claude adapters, keeping the diagnostic tail | Verify: `cargo test -p harness-agents missing_cwd_classifier`
+- [ ] `SP1466-T005` Owner: server-workspace | Done when: GC output reports skipped-live workspaces (count + paths + owning tasks) | Verify: `cargo test -p harness-server gc_report_skips`
+- [ ] `SP1466-T006` Owner: tests | Done when: a concurrency test covers terminalize-racing-reclaim (TOCTOU) and an integration test runs GC over mixed live/dead workspaces | Verify: `cargo test -p harness-server reclaim_race gc_mixed`
+
+## Parallelization
+
+- T001 first; T004 ∥ T001 (disjoint crates: harness-agents vs harness-server).
+- T002 ∥ T005 after T001; T003 after T001 (and GH-1465 T001 if landed).
+- T006 last.
+
+## Verification
+
+- `cargo test --workspace`
+- Manual: run `harness gc` against a data dir with one in-flight task — its workspace survives and appears in the skip report.
+
+## Handoff Notes
+
+- Fail-closed is the default for unresolvable owners; do not "optimize" it to fail-open — the April incident class (28/34 failures) came from exactly that.
+- Multi-instance shared workspace roots remain unsupported; the gate must not be weakened to accommodate them.

--- a/specs/GH1466/tech.md
+++ b/specs/GH1466/tech.md
@@ -1,0 +1,84 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1466
+
+## Product Spec
+
+See `product.md`.
+
+## Codebase Context
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Workspace cleanup | `crates/harness-server/src/workspace_helpers.rs` (`cleanup_workspace_path`) | Removes worktrees, prunes stale metadata | Primary deletion path to gate |
+| Workspace create/reconcile | `crates/harness-server/src/workspace_create.rs`, `workspace_startup_reconcile_tests.rs` | Reconciles registered worktrees vs disk | Lease/registration source of truth |
+| Orphan reaper | `crates/harness-server/src/http/orphan_reaper.rs` | Reaps orphaned workspace resources | Second deletion path to gate |
+| CLI GC | `crates/harness-cli/src/gc.rs`, `crates/harness-gc/src/gc_agent.rs` | User/agent-initiated GC | Third deletion path to gate |
+| Spawn preflight | `crates/harness-server/src/task_runner/spawn.rs` (`workspace path missing before task turn`, `record_workspace_lifecycle_failure`) | Detects missing workspace before/after a turn | Existing detection layer; keep as defense-in-depth |
+| Workspace lease | spawn.rs lease admission (`workspace_owner`, `run_generation`, `slot_index`) | Task admission records owner/generation | The reference data the GC check reads |
+| Agent error surface | `crates/harness-agents/src/codex.rs:360-405` | Formats `failed to run codex: No such file or directory` with `current_dir_exists` diagnostics | Misattribution fix: classify missing-cwd before blaming the binary |
+
+## Proposed Design
+
+1. **Single reclaim gate** — one function `try_reclaim_workspace(path)`
+   used by all three deletion paths. It resolves the owning task via the
+   lease/registration store: non-terminal owner → skip (log task id +
+   path); no resolvable owner → configurable fail-closed default (skip)
+   with an explicit orphan-age override; terminal/absent owner → delete.
+2. **TOCTOU guard** — the delete happens under the same store lock as the
+   ownership re-check; lease admission and reclaim serialize on the store.
+3. **Forced reclaim** — an explicit `force` variant terminalizes the owning
+   task (`workspace_reclaimed` reason, reusing the GH-1465 terminal CAS)
+   and deletes in the same operation; used by operator CLI only.
+4. **Error classification** — in `codex.rs` (and the claude adapter), when
+   spawn fails with ENOENT and `current_dir_exists=false`, produce
+   `workspace missing: <path>` as the primary error string; keep the full
+   diagnostic tail. The spawn preflight already prevents most of these; the
+   classifier fixes the residual race window.
+5. **GC reporting** — GC output includes skipped-live counts and paths (no
+   silent caps), so shrinking reclaim volume is explainable.
+
+## Product-to-Test Mapping
+
+| Product invariant | Implementation area | Verification |
+| --- | --- | --- |
+| P1 skip live workspaces | `try_reclaim_workspace` | unit: non-terminal owner → skip + log |
+| P2 terminalize-then-delete | force path | integration: forced reclaim → terminal event + dir gone, atomically |
+| P3 accurate diagnostics | agent error classifier | unit: ENOENT + missing cwd → `workspace missing` |
+| P4 GC visibility | GC report | test asserts skipped items appear in report |
+| TOCTOU guard | store-lock re-check | concurrency test: terminalize racing reclaim |
+
+## Data Flow
+
+GC/reaper/CLI → `try_reclaim_workspace` → lease/task store lookup (under
+lock) → skip | delete | terminalize+delete → GC report + task events.
+
+## Alternatives Considered
+
+- Filesystem lock files inside each workspace — rejected: stale locks after
+  crashes recreate the same ambiguity; the task store already knows
+  ownership.
+- Only improving the error message — rejected: fixes triage, not the data
+  loss; detection without prevention keeps burning agent spend.
+- Refcounting workspaces across multiple harness data dirs — rejected:
+  multi-instance shared roots are declared unsupported; fail-closed skip is
+  the guard.
+
+## Risks
+
+- Fail-closed default may leave true orphans on disk — mitigated by the
+  age-based override and GC report visibility.
+- Coupling to GH-1465's terminal CAS — forced reclaim depends on it; land
+  GH-1465 T001 first or vendor a minimal terminal-emit helper.
+- April-era evidence predates current main — the spawn preflight has since
+  landed; this spec targets the prevention gap that remains (deletion paths
+  do not consult leases), which holds on today's tree (no reference check
+  found in `gc.rs` / `orphan_reaper.rs` / `cleanup_workspace_path`).
+
+## Test Plan
+
+- [ ] Unit: reclaim gate decision table (non-terminal / terminal / unresolvable owner / forced).
+- [ ] Concurrency: terminalize vs reclaim race under the store lock.
+- [ ] Integration: GC run over mixed live/dead workspaces; forced reclaim end-to-end; error classifier on ENOENT.


### PR DESCRIPTION
## Summary

Adds SpecRail spec packets (product / tech / tasks) for two runtime-reliability issues found by auditing April–July execution records across the local harness data dirs:

- `specs/GH1465` — terminal-event liveness invariant: review-round exhaustion left 21/21 tasks with zero terminal events (86 reviewing + 86 waiting transitions, turn cap 10, then silence). Spec defines an exactly-one-terminal-event invariant, a `round_budget_exhausted` stalled reason, exit-path audits in `task_runner/spawn.rs`, and an event-stream liveness check wired toward the GH-1447 eval loop.
- `specs/GH1466` — lease-aware workspace GC: 28/34 failures (82%) in the observed window were `current_dir_exists=false` (workspace deleted under a non-terminal task), misreported as a codex binary error. Spec defines a single `try_reclaim_workspace` gate (fail-closed on unresolvable owners), terminalize-then-delete forced reclaim, and ENOENT error classification.

## Evidence

- `~/Library/Application Support/harness-codex-runtime/task-events.jsonl` (2026-04-29..30) and `harness2/task-events.jsonl` (2026-04-28..29); current-main code check confirms the spawn preflight detection exists but no reference check on the GC deletion paths.

## Verification

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1465` — passed
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1466` — passed

Closes nothing; implementation PRs will reference GH-1465 / GH-1466.
