### PR TITLE
test: replace real sleeps with tokio virtual time in task_queue tests

### DIFF
--- a/crates/harness-workflow/Cargo.toml
+++ b/crates/harness-workflow/Cargo.toml
@@ -24,3 +24,6 @@ tokio-stream = { workspace = true }
 async-trait = { workspace = true }
 tempfile = { workspace = true }
 sha2 = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/harness-workflow/src/task_queue_tests.rs
+++ b/crates/harness-workflow/src/task_queue_tests.rs
@@ -22,7 +22,7 @@ async fn acquire_and_release_single_permit() {
     assert_eq!(q.running_count(), 0);
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn only_max_concurrent_tasks_run_simultaneously() {
     let q = Arc::new(TaskQueue::new(&config(2, 16)));
 
@@ -45,7 +45,7 @@ async fn only_max_concurrent_tasks_run_simultaneously() {
     assert_eq!(q.running_count(), 0);
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn queue_overflow_returns_error() {
     // 1 concurrent slot, queue capacity 2.
     let q = Arc::new(TaskQueue::new(&config(1, 2)));
@@ -68,7 +68,7 @@ async fn queue_overflow_returns_error() {
     assert!(result.unwrap_err().to_string().contains("max_queue_size=2"));
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn permit_drop_releases_slot_on_panic() {
     let q = Arc::new(TaskQueue::new(&config(1, 4)));
 
@@ -87,7 +87,7 @@ async fn permit_drop_releases_slot_on_panic() {
     assert!(result.is_ok(), "permit should be released after panic");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn queued_count_increments_while_waiting() {
     let q = Arc::new(TaskQueue::new(&config(1, 8)));
 
@@ -114,7 +114,7 @@ async fn running_count_and_queued_count_reset_after_completion() {
     assert_eq!(q.queued_count(), 0);
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn per_project_limit_enforced() {
     use std::collections::HashMap;
     let mut per_project = HashMap::new();
@@ -143,7 +143,7 @@ async fn per_project_limit_enforced() {
     drop(p_b);
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn project_cannot_starve_another() {
     use std::collections::HashMap;
     // global=2, proj_a=1 → proj_a can use at most 1 global slot,
@@ -175,7 +175,7 @@ async fn project_cannot_starve_another() {
     assert!(pb.is_ok(), "proj_b should get the remaining global slot");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn project_stats_reflect_running_and_queued() {
     let q = Arc::new(TaskQueue::new(&config(4, 16)));
 
@@ -206,7 +206,7 @@ async fn project_stats_reflect_running_and_queued() {
     assert_eq!(stats2.queued, 1);
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn set_project_limit_reconfigures_existing_project_queue() {
     let q = Arc::new(TaskQueue::new(&config(4, 16)));
 
@@ -225,7 +225,7 @@ async fn set_project_limit_reconfigures_existing_project_queue() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn reset_project_limit_restores_global_fallback() {
     let mut cfg = config(4, 16);
     cfg.per_project.insert("proj".to_string(), 2);
@@ -247,7 +247,7 @@ async fn reset_project_limit_restores_global_fallback() {
 
 // --- Priority tests ---
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn high_priority_acquired_before_low_when_slots_full() {
     // 1 slot: hold it, then enqueue priority=0 then priority=1.
     // When the slot is released, priority=1 should unblock first.
@@ -283,7 +283,7 @@ async fn high_priority_acquired_before_low_when_slots_full() {
     assert_eq!(first, 1, "priority=1 task should unblock before priority=0");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn same_priority_is_fifo() {
     // 1 slot: hold it, then enqueue three priority=1 waiters in order.
     // They should unblock in enqueue order (FIFO).
@@ -325,7 +325,7 @@ async fn priority_zero_default_compiles() {
 
 // --- running_count correctness ---
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn running_count_correct_with_global_waiters() {
     // limit=2; fill both slots, add a waiter in the global queue.
     // running_count must still report 2 — waiters do not reduce available_permits.
@@ -347,7 +347,7 @@ async fn running_count_correct_with_global_waiters() {
 
 // --- Cancellation-safety tests ---
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn cancelled_project_wait_does_not_leak_queued_count() {
     // 1 project slot; hold it so the next acquire blocks at project-wait.
     use std::collections::HashMap;
@@ -384,7 +384,7 @@ async fn cancelled_project_wait_does_not_leak_queued_count() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn cancelled_global_wait_releases_project_permit() {
     // project limit=2, global limit=1; hold global so the next acquire
     // passes project-wait then blocks at global-wait.
@@ -435,7 +435,7 @@ async fn cancelled_global_wait_releases_project_permit() {
 /// Regression: project permit must not be permanently lost when the future is
 /// cancelled *after* `release()` sends the signal but *before* `rx.await`
 /// completes (the "mid-send" race on the project queue).
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn project_permit_not_leaked_on_mid_send_cancellation() {
     use std::collections::HashMap;
     let mut per_project = HashMap::new();
@@ -475,7 +475,7 @@ async fn project_permit_not_leaked_on_mid_send_cancellation() {
 /// Regression: global permit must not be permanently lost when the future is
 /// cancelled *after* `release()` sends the global signal but *before*
 /// `rx.await` completes (the "mid-send" race on the global queue).
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn global_permit_not_leaked_on_mid_send_cancellation() {
     use std::collections::HashMap;
     let mut per_project = HashMap::new();
@@ -539,7 +539,7 @@ async fn task_admission_succeeds_no_pressure() {
 
 // ── saturation / cancellation stress tests ───────────────────────────────────
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn cancelled_acquire_releases_permit_for_next_waiter() {
     let q = Arc::new(TaskQueue::new(&config(1, 16)));
 
@@ -562,7 +562,7 @@ async fn cancelled_acquire_releases_permit_for_next_waiter() {
     assert!(result.is_ok(), "permit leaked after waiter cancellation");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn queue_recovers_after_repeated_cancellations() {
     let q = Arc::new(TaskQueue::new(&config(1, 64)));
 
@@ -593,7 +593,7 @@ async fn queue_recovers_after_repeated_cancellations() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn server_stays_responsive_after_saturation_and_abort() {
     let q = Arc::new(TaskQueue::new(&config(2, 32)));
 


### PR DESCRIPTION
Refs #1455

## What

Convert `harness-workflow` task_queue tests from wall-clock sleeps/timeouts to tokio virtual time via `#[tokio::test(start_paused = true)]`.

## Per-file changes

| File | Converted | Kept as-is |
|---|---|---|
| `crates/harness-workflow/src/task_queue_tests.rs` | 19 | 5 (no timers at all: `acquire_and_release_single_permit`, `running_count_and_queued_count_reset_after_completion`, `priority_zero_default_compiles`, `task_admission_blocked_under_pressure`, `task_admission_succeeds_no_pressure`) |
| `crates/harness-workflow/Cargo.toml` | +1 dev-dependency line | — |

No assertions weakened, no test removed, no intent changed — the only per-test change is the attribute. The `TaskQueue` under test uses pure tokio primitives (no `std::time::Instant`/`SystemTime`, no OS processes, no DB), so paused time is safe for every converted test; no test needed to stay real-time.

## Dependency note

`start_paused` requires tokio's `test-util` feature, added as a **dev-dependency only** of `harness-workflow` (`tokio = { workspace = true, features = ["test-util"] }`). With Cargo feature unification this affects test builds only; production builds are unaffected.

## Timing (test binary time, `cargo test -p harness-workflow task_queue`)

- Before: 24 passed, finished in **0.27s**
- After: 24 passed, finished in **0.01s**

## Verification

- `cargo test -p harness-workflow task_queue` — 24 passed, 0 failed
- `cargo fmt --all` — no diff outside the two changed files
- `RUSTFLAGS="-Dwarnings" cargo check -p harness-workflow --all-targets` — clean
- `cargo check -p harness-server` — clean (feature unification does not break the server crate)

## Follow-up

`crates/harness-server/src/task_queue_tests.rs` (the second file named by #1455) is **dead code**: it has no `mod`/`#[path]` reference anywhere in `harness-server` and is never compiled (`cargo test -p harness-server task_queue` matches 0 tests). It is a stale duplicate of the workflow copy — `harness-server` re-exports the queue via `pub use harness_workflow::task_queue` (`crates/harness-server/src/lib.rs:67`). It is intentionally left untouched here; recommend deleting it in a separate decision. Issue closure is withheld (`Refs`, not `Closes`) pending that call.