### PR TITLE
fix(runtime): downgrade contradictory activity success

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
@@ -1,9 +1,9 @@
 use harness_core::types::{Item, ThreadId, TurnId, TurnStatus};
 use harness_workflow::runtime::{
-    ActivityArtifact, ActivityErrorKind, ActivityResult, ActivitySignal, RuntimeJob,
+    ActivityArtifact, ActivityErrorKind, ActivityResult, ActivitySignal, ActivityStatus, RuntimeJob,
 };
 use serde::Serialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::path::Path;
 
 use super::data_helpers::activity_name;
@@ -80,6 +80,18 @@ pub(super) fn activity_result_from_turn(
                 );
             }
         }
+        ActivityResultEnvelopeOutcome::StatusContractDowngraded => {
+            let blocker_signals = status_contract_blockers_from_result(&envelope.final_result);
+            tracing::error!(
+                runtime_job_id = %job.id,
+                activity = %activity,
+                agent = %agent_name,
+                claimed_status = "succeeded",
+                effective_status = "blocked",
+                blocker_signals = ?blocker_signals,
+                "activity result claimed succeeded while reporting blockers; downgraded to blocked"
+            );
+        }
         ActivityResultEnvelopeOutcome::Accepted | ActivityResultEnvelopeOutcome::TurnCancelled => {}
     }
     let envelope_artifact = envelope.to_artifact();
@@ -121,6 +133,7 @@ enum ActivityResultEnvelopeOutcome {
     InvalidStructuredOutput,
     TurnCancelled,
     TurnFailed,
+    StatusContractDowngraded,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -139,9 +152,11 @@ impl ActivityResultEnvelope {
         extraction_strategy: ActivityResultExtractionStrategy,
         result: ActivityResult,
     ) -> Self {
+        let (outcome, result) =
+            enforce_activity_status_contract(result, ActivityResultEnvelopeOutcome::Accepted);
         Self {
             extraction_strategy,
-            outcome: ActivityResultEnvelopeOutcome::Accepted,
+            outcome,
             raw_status,
             extracted_activity: Some(result.activity.clone()),
             extraction_error: None,
@@ -154,9 +169,13 @@ impl ActivityResultEnvelope {
         result: ActivityResult,
         warning: String,
     ) -> Self {
+        let (outcome, result) = enforce_activity_status_contract(
+            result,
+            ActivityResultEnvelopeOutcome::AcceptedWithTurnWarning,
+        );
         Self {
             extraction_strategy: ActivityResultExtractionStrategy::FencedActivityResult,
-            outcome: ActivityResultEnvelopeOutcome::AcceptedWithTurnWarning,
+            outcome,
             raw_status,
             extracted_activity: Some(result.activity.clone()),
             extraction_error: Some(warning),
@@ -251,6 +270,238 @@ impl ActivityResultEnvelope {
 
     fn into_final_result(self) -> ActivityResult {
         self.final_result
+    }
+}
+
+fn enforce_activity_status_contract(
+    mut result: ActivityResult,
+    default_outcome: ActivityResultEnvelopeOutcome,
+) -> (ActivityResultEnvelopeOutcome, ActivityResult) {
+    if result.status != ActivityStatus::Succeeded {
+        return (default_outcome, result);
+    }
+
+    let blockers = activity_status_contract_blockers(&result);
+    if blockers.is_empty() {
+        return (default_outcome, result);
+    }
+
+    let claimed_summary = result.summary.clone();
+    let reason = format!(
+        "activity result claimed succeeded while reporting blockers: {}",
+        blockers.join("; ")
+    );
+
+    result.status = ActivityStatus::Blocked;
+    result.summary = format!("Activity blocked by status contract. {reason}");
+    result.error = Some(reason);
+    result.artifacts.push(ActivityArtifact::new(
+        "activity_status_contract",
+        json!({
+            "schema": "harness.runtime.activity_status_contract.v1",
+            "claimed_status": "succeeded",
+            "effective_status": "blocked",
+            "claimed_summary": claimed_summary,
+            "blocker_signals": blockers,
+        }),
+    ));
+    result.signals.push(ActivitySignal::new(
+        "ActivityStatusContractDowngraded",
+        json!({
+            "claimed_status": "succeeded",
+            "effective_status": "blocked",
+        }),
+    ));
+
+    (
+        ActivityResultEnvelopeOutcome::StatusContractDowngraded,
+        result,
+    )
+}
+
+fn status_contract_blockers_from_result(result: &ActivityResult) -> Vec<String> {
+    result
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.artifact_type == "activity_status_contract")
+        .and_then(|artifact| artifact.artifact.get("blocker_signals"))
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn activity_status_contract_blockers(result: &ActivityResult) -> Vec<String> {
+    let mut blockers = Vec::new();
+
+    for signal in &result.signals {
+        match signal.signal_type.as_str() {
+            "ChangesRequested"
+            | "ChecksFailed"
+            | "LocalReviewChangesRequested"
+            | "LocalReviewBlocked"
+            | "QualityBlocked"
+            | "QualityFailed" => {
+                push_unique(&mut blockers, format!("signal:{}", signal.signal_type));
+            }
+            _ => {}
+        }
+    }
+
+    for artifact in &result.artifacts {
+        collect_structured_blockers(&artifact.artifact, &mut blockers);
+    }
+
+    collect_textual_blockers(&result.summary, &mut blockers);
+    if let Some(error) = result.error.as_deref() {
+        collect_textual_blockers(error, &mut blockers);
+    }
+
+    blockers
+}
+
+fn collect_structured_blockers(value: &Value, blockers: &mut Vec<String>) {
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                let normalized_key = key.to_ascii_lowercase();
+                match normalized_key.as_str() {
+                    "open_review_threads"
+                    | "unresolved_review_threads"
+                    | "pending_checks"
+                    | "failing_checks"
+                    | "failed_checks"
+                    | "requested_changes"
+                    | "blocking_reviews"
+                    | "mergeability_blockers"
+                    | "blockers"
+                        if json_value_reports_blocker(value) =>
+                    {
+                        push_unique(blockers, format!("field:{normalized_key}"));
+                    }
+                    "review_decision" if json_string_equals(value, "changes_requested") => {
+                        push_unique(blockers, "field:review_decision_changes_requested");
+                    }
+                    "merge_state_status"
+                        if json_string_is_one_of(
+                            value,
+                            &["blocked", "dirty", "unknown", "unstable", "behind"],
+                        ) =>
+                    {
+                        push_unique(blockers, "field:merge_state_status_blocked");
+                    }
+                    "mergeable" if value.as_bool() == Some(false) => {
+                        push_unique(blockers, "field:mergeable_false");
+                    }
+                    _ => {}
+                }
+                collect_structured_blockers(value, blockers);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_structured_blockers(value, blockers);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn json_value_reports_blocker(value: &Value) -> bool {
+    match value {
+        Value::Bool(value) => *value,
+        Value::Number(value) => value.as_u64().is_some_and(|count| count > 0),
+        Value::String(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            !matches!(
+                normalized.as_str(),
+                "" | "0" | "false" | "none" | "no" | "clean" | "[]"
+            )
+        }
+        Value::Array(values) => !values.is_empty(),
+        Value::Object(values) => !values.is_empty(),
+        Value::Null => false,
+    }
+}
+
+fn json_string_equals(value: &Value, expected: &str) -> bool {
+    value
+        .as_str()
+        .is_some_and(|value| value.eq_ignore_ascii_case(expected))
+}
+
+fn json_string_is_one_of(value: &Value, expected: &[&str]) -> bool {
+    value.as_str().is_some_and(|value| {
+        expected
+            .iter()
+            .any(|expected| value.eq_ignore_ascii_case(expected))
+    })
+}
+
+fn collect_textual_blockers(text: &str, blockers: &mut Vec<String>) {
+    let normalized = text.to_ascii_lowercase();
+    let patterns = [
+        (
+            "text:pending_ci",
+            &["pending ci", "pending check", "pending checks"][..],
+        ),
+        (
+            "text:failing_checks",
+            &[
+                "failing check",
+                "failing checks",
+                "failed check",
+                "failed checks",
+            ],
+        ),
+        (
+            "text:requested_changes",
+            &["requested changes", "changes requested"],
+        ),
+        (
+            "text:unresolved_review_threads",
+            &[
+                "open review thread",
+                "open review threads",
+                "unresolved review thread",
+                "unresolved review threads",
+            ],
+        ),
+        (
+            "text:not_merge_ready",
+            &["not merge-ready", "not merge ready", "not ready to merge"],
+        ),
+        (
+            "text:review_quota_blocker",
+            &["quota/credit-limit", "credit-limit notice", "quota notice"],
+        ),
+    ];
+
+    for (label, needles) in patterns {
+        if needles
+            .iter()
+            .any(|needle| contains_affirmative_blocker(&normalized, needle))
+        {
+            push_unique(blockers, label);
+        }
+    }
+}
+
+fn contains_affirmative_blocker(normalized_text: &str, needle: &str) -> bool {
+    normalized_text.contains(needle)
+        && !normalized_text.contains(&format!("no {needle}"))
+        && !normalized_text.contains(&format!("without {needle}"))
+}
+
+fn push_unique(blockers: &mut Vec<String>, blocker: impl Into<String>) {
+    let blocker = blocker.into();
+    if !blockers.contains(&blocker) {
+        blockers.push(blocker);
     }
 }
 

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
@@ -116,6 +116,153 @@ Final result:
 }
 
 #[test]
+fn activity_result_from_turn_downgrades_succeeded_with_textual_blockers() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![Item::AgentReasoning {
+        content: r#"Implementation report.
+
+```harness-activity-result
+{"activity":"implement_issue","status":"succeeded","summary":"PR is open with pending CI/review quota blockers. Gemini and Codex review bots both posted quota/credit-limit notices, so this is not merge-ready."}
+```"#
+            .to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Blocked);
+    assert!(result
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("claimed succeeded")));
+    assert!(result.signals.iter().any(|signal| {
+        signal.signal_type == "ActivityStatusContractDowngraded"
+            && signal.signal["effective_status"] == "blocked"
+    }));
+    let contract = artifact_by_type(&result, "activity_status_contract");
+    assert_eq!(contract.artifact["claimed_status"], "succeeded");
+    assert_eq!(contract.artifact["effective_status"], "blocked");
+    assert!(contract.artifact["blocker_signals"]
+        .as_array()
+        .is_some_and(|signals| signals.iter().any(|signal| signal == "text:pending_ci")));
+    assert!(contract.artifact["blocker_signals"]
+        .as_array()
+        .is_some_and(|signals| signals
+            .iter()
+            .any(|signal| signal == "text:review_quota_blocker")));
+    assert!(contract.artifact["blocker_signals"]
+        .as_array()
+        .is_some_and(|signals| signals
+            .iter()
+            .any(|signal| signal == "text:not_merge_ready")));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "status_contract_downgraded");
+    assert_eq!(envelope["final_result"]["status"], "blocked");
+}
+
+#[test]
+fn activity_result_from_turn_downgrades_succeeded_with_structured_blockers() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "inspect_pr_feedback"
+        }),
+    );
+    let items = vec![Item::AgentReasoning {
+        content: r#"Inspection report.
+
+```harness-activity-result
+{"activity":"inspect_pr_feedback","status":"succeeded","summary":"PR feedback inspection completed.","artifacts":[{"artifact_type":"pr_readiness","artifact":{"open_review_threads":2,"pending_checks":["Test"],"review_decision":"CHANGES_REQUESTED"}}]}
+```"#
+            .to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.status, ActivityStatus::Blocked);
+    let contract = artifact_by_type(&result, "activity_status_contract");
+    let Some(blockers) = contract.artifact["blocker_signals"].as_array() else {
+        panic!("blocker signals should be recorded");
+    };
+    assert!(blockers
+        .iter()
+        .any(|signal| signal == "field:open_review_threads"));
+    assert!(blockers
+        .iter()
+        .any(|signal| signal == "field:pending_checks"));
+    assert!(blockers
+        .iter()
+        .any(|signal| signal == "field:review_decision_changes_requested"));
+}
+
+#[test]
+fn activity_result_from_turn_leaves_blocked_status_unchanged() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![Item::AgentReasoning {
+        content: r#"Implementation report.
+
+```harness-activity-result
+{"activity":"implement_issue","status":"blocked","summary":"PR is open with pending CI."}
+```"#
+            .to_string(),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.status, ActivityStatus::Blocked);
+    assert!(!result
+        .signals
+        .iter()
+        .any(|signal| signal.signal_type == "ActivityStatusContractDowngraded"));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "accepted");
+    assert_eq!(envelope["final_result"]["status"], "blocked");
+}
+
+#[test]
 fn activity_result_from_turn_rejects_generic_json_activity_result_block() {
     let job = RuntimeJob::pending(
         "command-1",


### PR DESCRIPTION
Refs #1479

## Summary

- downgrade parsed `succeeded` activity results to `blocked` when the same payload reports explicit blocker signals
- detect conservative structured blockers such as open review threads, pending checks, requested changes, blocked merge state, and changes-requested review decisions
- detect high-precision textual blockers such as pending CI, requested changes, unresolved review threads, quota notices, and not-merge-ready reports
- emit an `activity_status_contract` artifact and `ActivityStatusContractDowngraded` signal, and log the downgrade at error level

## Scope

This is a partial #1479 implementation. It implements the default downgrade path. It does not add the optional rejection/re-reporting mode or config switches for textual extraction.

## Verification

- `cargo test -p harness-server workflow_runtime_worker::activity_result`
- `RUSTFLAGS="-Dwarnings" cargo check -p harness-server --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 checks/check_workflow.py --repo .`
