### PR TITLE
fix(runtime): add terminal outcome transition helper

### DIFF
--- a/crates/harness-server/src/event_replay.rs
+++ b/crates/harness-server/src/event_replay.rs
@@ -47,6 +47,12 @@ pub enum TaskEvent {
     },
     /// Task reached terminal `Done` state.
     Completed { task_id: String, ts: u64 },
+    /// Task reached terminal `Cancelled` state.
+    Cancelled {
+        task_id: String,
+        ts: u64,
+        reason: Option<String>,
+    },
     /// A pull-request URL was extracted from the agent's output.
     PrDetected {
         task_id: String,
@@ -70,6 +76,7 @@ impl TaskEvent {
             | TaskEvent::StatusChanged { task_id, .. }
             | TaskEvent::Failed { task_id, .. }
             | TaskEvent::Completed { task_id, .. }
+            | TaskEvent::Cancelled { task_id, .. }
             | TaskEvent::PrDetected { task_id, .. }
             | TaskEvent::RoundCompleted { task_id, .. } => task_id,
         }
@@ -248,6 +255,10 @@ pub fn apply_event(states: &mut HashMap<String, ReplayedState>, event: TaskEvent
         }
         TaskEvent::Completed { .. } => {
             state.status = Some(TaskStatus::Done);
+            state.terminal = true;
+        }
+        TaskEvent::Cancelled { .. } => {
+            state.status = Some(TaskStatus::Cancelled);
             state.terminal = true;
         }
         TaskEvent::PrDetected { pr_url, .. } => {

--- a/crates/harness-server/src/event_replay_tests.rs
+++ b/crates/harness-server/src/event_replay_tests.rs
@@ -75,6 +75,22 @@ fn apply_completed_sets_terminal() {
 }
 
 #[test]
+fn apply_cancelled_sets_terminal() {
+    let mut states = HashMap::new();
+    apply_event(
+        &mut states,
+        TaskEvent::Cancelled {
+            task_id: "t1".into(),
+            ts: ts(),
+            reason: Some("operator_cancelled".into()),
+        },
+    );
+    let s = &states["t1"];
+    assert!(matches!(s.status, Some(TaskStatus::Cancelled)));
+    assert!(s.terminal);
+}
+
+#[test]
 fn apply_event_ignores_status_changed_after_terminal_failed() {
     let mut states = HashMap::new();
     apply_event(

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -30,9 +30,15 @@ pub use state::{
     RecentFailureTask, RoundResult, SchedulerAuthorityState, SchedulerOwner, SchedulerOwnerKind,
     TaskSchedulerState, TaskState, TaskSummary, TaskWorkflowSummary,
 };
-use store::{mutate_and_persist as mutate_and_persist_impl, update_status as update_status_impl};
-pub use store::{TaskStore, TaskSummaryFilter, TaskSummaryPageCursor};
-pub use types::{TaskFailureKind, TaskId, TaskKind, TaskPhase, TaskStatus};
+use store::{
+    mark_terminal_once as mark_terminal_once_impl, mutate_and_persist as mutate_and_persist_impl,
+    update_status as update_status_impl,
+};
+pub use store::{TaskStore, TaskSummaryFilter, TaskSummaryPageCursor, TerminalTransition};
+pub use types::{
+    TaskFailureKind, TaskId, TaskKind, TaskPhase, TaskStatus, TaskTerminalFailure,
+    TaskTerminalOutcome,
+};
 
 fn record_task_runner_usage() {
     harness_core::usage_probe::record_usage(
@@ -151,6 +157,15 @@ pub async fn mutate_and_persist(
 ) -> anyhow::Result<()> {
     record_task_runner_usage();
     mutate_and_persist_impl(store, id, f).await
+}
+
+pub async fn mark_terminal_once(
+    store: &TaskStore,
+    id: &TaskId,
+    outcome: TaskTerminalOutcome,
+) -> anyhow::Result<TerminalTransition> {
+    record_task_runner_usage();
+    mark_terminal_once_impl(store, id, outcome).await
 }
 
 impl TaskStore {

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 use super::request::PersistedRequestSettings;
-use super::types::{TaskFailureKind, TaskId, TaskKind, TaskPhase, TaskStatus};
+use super::types::{TaskFailureKind, TaskId, TaskKind, TaskPhase, TaskStatus, TaskTerminalOutcome};
 use chrono::{DateTime, Utc};
 use harness_core::types::{TurnFailure, TurnTelemetry};
 
@@ -594,5 +594,60 @@ impl TaskState {
                 }
             }
         }
+    }
+
+    pub(crate) fn apply_terminal_outcome_once(&mut self, outcome: TaskTerminalOutcome) -> bool {
+        if self.status.is_terminal() {
+            return false;
+        }
+
+        let status = outcome.status();
+        self.status = status.clone();
+        self.phase = TaskPhase::Terminal;
+        self.error = outcome.reason_string();
+        self.scheduler.mark_terminal(&status);
+        true
+    }
+}
+
+#[cfg(test)]
+mod terminal_tests {
+    use super::*;
+    use crate::task_runner::TaskTerminalFailure;
+
+    #[test]
+    fn terminal_exactly_once_round_budget_exhausted() {
+        let mut state = TaskState::new(TaskId::from_str("terminal-once"));
+        state.status = TaskStatus::Reviewing;
+
+        let outcome = TaskTerminalOutcome::Failed(TaskTerminalFailure::round_budget_exhausted(
+            3,
+            state.status.clone(),
+            Some("local_review_gate".to_string()),
+        ));
+        assert!(state.apply_terminal_outcome_once(outcome));
+
+        assert_eq!(state.status, TaskStatus::Failed);
+        assert_eq!(state.phase, TaskPhase::Terminal);
+        assert_eq!(
+            state.error.as_deref(),
+            Some(
+                r#"{"reason":"round_budget_exhausted","rounds_used":3,"last_status":"reviewing","waiting_on":"local_review_gate"}"#
+            )
+        );
+        assert_eq!(
+            state.scheduler.authority_state,
+            SchedulerAuthorityState::Failed
+        );
+
+        let second = TaskTerminalOutcome::Completed;
+        assert!(!state.apply_terminal_outcome_once(second));
+        assert_eq!(state.status, TaskStatus::Failed);
+        assert_eq!(
+            state.error.as_deref(),
+            Some(
+                r#"{"reason":"round_budget_exhausted","rounds_used":3,"last_status":"reviewing","waiting_on":"local_review_gate"}"#
+            )
+        );
     }
 }

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -11,7 +11,7 @@ use tokio::sync::{broadcast, Mutex, RwLock};
 
 use super::metrics::{DashboardCounts, LlmMetricsInputs, ProjectCounts};
 use super::state::{SchedulerAuthorityState, SchedulerOwnerKind, TaskState, TaskSummary};
-use super::types::{TaskId, TaskKind, TaskStatus};
+use super::types::{TaskId, TaskKind, TaskStatus, TaskTerminalOutcome};
 use super::CompletionCallback;
 
 /// Broadcast channel capacity for per-task stream events.
@@ -1694,6 +1694,98 @@ pub async fn update_status(
         );
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TerminalTransition {
+    Applied,
+    AlreadyTerminal(TaskStatus),
+    MissingTask,
+}
+
+impl TerminalTransition {
+    pub fn applied(&self) -> bool {
+        matches!(self, Self::Applied)
+    }
+}
+
+pub async fn mark_terminal_once(
+    store: &TaskStore,
+    id: &TaskId,
+    outcome: TaskTerminalOutcome,
+) -> anyhow::Result<TerminalTransition> {
+    let lock = store
+        .persist_locks
+        .entry(id.clone())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone();
+    let _guard = lock.lock().await;
+
+    let mut rollback_state = None;
+    let mut state_to_persist = None;
+    let mut event = None;
+    let transition = if let Some(mut entry) = store.cache.get_mut(id) {
+        if entry.status.is_terminal() {
+            TerminalTransition::AlreadyTerminal(entry.status.clone())
+        } else {
+            let original = entry.value().clone();
+            let status = outcome.status();
+            let reason = outcome.reason_string();
+            entry.apply_terminal_outcome_once(outcome);
+            let attempted = entry.value().clone();
+            state_to_persist = Some(attempted.clone());
+            rollback_state = Some((original, attempted));
+            event = Some(match status {
+                TaskStatus::Done => crate::event_replay::TaskEvent::Completed {
+                    task_id: id.0.clone(),
+                    ts: crate::event_replay::now_ts(),
+                },
+                TaskStatus::Failed => crate::event_replay::TaskEvent::Failed {
+                    task_id: id.0.clone(),
+                    ts: crate::event_replay::now_ts(),
+                    reason: reason.unwrap_or_else(|| "failed".to_string()),
+                },
+                TaskStatus::Cancelled => crate::event_replay::TaskEvent::Cancelled {
+                    task_id: id.0.clone(),
+                    ts: crate::event_replay::now_ts(),
+                    reason,
+                },
+                _ => unreachable!("terminal outcome produced non-terminal status"),
+            });
+            TerminalTransition::Applied
+        }
+    } else {
+        TerminalTransition::MissingTask
+    };
+
+    if transition.applied() {
+        let Some(state) = state_to_persist else {
+            anyhow::bail!("terminal transition was applied without a persisted task snapshot");
+        };
+        if let Err(error) = store.db.update(&state).await {
+            if let Some((original, attempted)) = rollback_state {
+                if let Some(mut entry) = store.cache.get_mut(id) {
+                    if task_states_match_for_rollback(entry.value(), &attempted) {
+                        *entry.value_mut() = original;
+                    } else {
+                        tracing::warn!(
+                            task_id = %id.0,
+                            "mark_terminal_once rollback skipped because cache changed after failed persist"
+                        );
+                    }
+                }
+            }
+            return Err(error);
+        }
+        if let Some(mut entry) = store.cache.get_mut(id) {
+            entry.value_mut().version = entry.value().version.saturating_add(1);
+        }
+        if let Some(event) = event {
+            store.log_event(event);
+        }
+    }
+
+    Ok(transition)
 }
 
 /// Mutate a task in the cache then persist to SQLite.

--- a/crates/harness-server/src/task_runner/types.rs
+++ b/crates/harness-server/src/task_runner/types.rs
@@ -156,7 +156,7 @@ pub enum TaskPhase {
     Terminal,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatus {
     Pending,
@@ -176,6 +176,73 @@ pub enum TaskStatus {
     Done,
     Failed,
     Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskTerminalFailure {
+    pub reason: String,
+    pub rounds_used: u32,
+    pub last_status: TaskStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub waiting_on: Option<String>,
+}
+
+impl TaskTerminalFailure {
+    pub fn new(
+        reason: impl Into<String>,
+        rounds_used: u32,
+        last_status: TaskStatus,
+        waiting_on: Option<String>,
+    ) -> Self {
+        Self {
+            reason: reason.into(),
+            rounds_used,
+            last_status,
+            waiting_on,
+        }
+    }
+
+    pub fn round_budget_exhausted(
+        rounds_used: u32,
+        last_status: TaskStatus,
+        waiting_on: Option<String>,
+    ) -> Self {
+        Self::new(
+            "round_budget_exhausted",
+            rounds_used,
+            last_status,
+            waiting_on,
+        )
+    }
+
+    pub fn to_reason_string(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| self.reason.clone())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskTerminalOutcome {
+    Completed,
+    Failed(TaskTerminalFailure),
+    Cancelled(Option<String>),
+}
+
+impl TaskTerminalOutcome {
+    pub fn status(&self) -> TaskStatus {
+        match self {
+            Self::Completed => TaskStatus::Done,
+            Self::Failed(_) => TaskStatus::Failed,
+            Self::Cancelled(_) => TaskStatus::Cancelled,
+        }
+    }
+
+    pub fn reason_string(&self) -> Option<String> {
+        match self {
+            Self::Completed => None,
+            Self::Failed(reason) => Some(reason.to_reason_string()),
+            Self::Cancelled(reason) => reason.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Refs #1465

## Summary
- Add structured terminal failure payloads for budget-exhaustion style outcomes.
- Add a single `mark_terminal_once` helper that applies terminal outcomes under the task persist lock and emits exactly one terminal event.
- Teach event replay about explicit cancelled terminal events and cover the new paths with focused unit tests.

## Scope
- Implements the SP1465-T001 foundation only.
- Does not close #1465; budget-exhaustion wiring and exit-path migration remain follow-up tasks.

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p harness-server --all-targets`
- `cargo test -p harness-server terminal_exactly_once`
- `cargo test -p harness-server apply_cancelled_sets_terminal`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

## Local Limitation
- `cargo test -p harness-server event_replay` ran the no-DB replay unit tests successfully but the Postgres-backed replay tests failed locally because `HARNESS_DATABASE_URL` is not configured.