### PR TITLE
fix(runtime): classify zero-output turns as spawn failures

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -1,5 +1,6 @@
 mod activity_contract;
 mod activity_result;
+mod activity_status_contract;
 mod child_workflow;
 mod child_workflow_non_issue;
 mod child_workflow_replay;
@@ -319,6 +320,7 @@ fn runtime_failure_kind(
     match result.and_then(|result| result.error_kind) {
         Some(
             ActivityErrorKind::Retryable
+            | ActivityErrorKind::SpawnFailure
             | ActivityErrorKind::Timeout
             | ActivityErrorKind::ExternalDependency,
         ) => Some(TaskFailureKind::WorkspaceLifecycle),

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
@@ -1,11 +1,14 @@
 use harness_core::types::{Item, ThreadId, TurnId, TurnStatus};
 use harness_workflow::runtime::{
-    ActivityArtifact, ActivityErrorKind, ActivityResult, ActivitySignal, ActivityStatus, RuntimeJob,
+    ActivityArtifact, ActivityErrorKind, ActivityResult, ActivitySignal, RuntimeJob,
 };
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::json;
 use std::path::Path;
 
+use super::activity_status_contract::{
+    enforce_activity_status_contract, status_contract_blockers_from_result,
+};
 use super::data_helpers::activity_name;
 use super::prompt_packet::workflow_prompt_artifact;
 
@@ -44,6 +47,15 @@ pub(super) fn activity_result_from_turn(
                 agent = %agent_name,
                 "activity completed without harness-activity-result fenced block; \
                  marking failed to prevent silent state-machine no-progress loops"
+            );
+        }
+        ActivityResultEnvelopeOutcome::ZeroOutputSpawnFailure => {
+            tracing::error!(
+                runtime_job_id = %job.id,
+                activity = %activity,
+                agent = %agent_name,
+                items = items.len(),
+                "activity completed with no observable agent activity; classified as spawn failure"
             );
         }
         ActivityResultEnvelopeOutcome::InvalidStructuredOutput => {
@@ -131,6 +143,7 @@ enum ActivityResultEnvelopeOutcome {
     AcceptedWithTurnWarning,
     MissingStructuredOutput,
     InvalidStructuredOutput,
+    ZeroOutputSpawnFailure,
     TurnCancelled,
     TurnFailed,
     StatusContractDowngraded,
@@ -152,8 +165,12 @@ impl ActivityResultEnvelope {
         extraction_strategy: ActivityResultExtractionStrategy,
         result: ActivityResult,
     ) -> Self {
-        let (outcome, result) =
-            enforce_activity_status_contract(result, ActivityResultEnvelopeOutcome::Accepted);
+        let (downgraded, result) = enforce_activity_status_contract(result);
+        let outcome = if downgraded {
+            ActivityResultEnvelopeOutcome::StatusContractDowngraded
+        } else {
+            ActivityResultEnvelopeOutcome::Accepted
+        };
         Self {
             extraction_strategy,
             outcome,
@@ -169,10 +186,12 @@ impl ActivityResultEnvelope {
         result: ActivityResult,
         warning: String,
     ) -> Self {
-        let (outcome, result) = enforce_activity_status_contract(
-            result,
-            ActivityResultEnvelopeOutcome::AcceptedWithTurnWarning,
-        );
+        let (downgraded, result) = enforce_activity_status_contract(result);
+        let outcome = if downgraded {
+            ActivityResultEnvelopeOutcome::StatusContractDowngraded
+        } else {
+            ActivityResultEnvelopeOutcome::AcceptedWithTurnWarning
+        };
         Self {
             extraction_strategy: ActivityResultExtractionStrategy::FencedActivityResult,
             outcome,
@@ -197,6 +216,48 @@ impl ActivityResultEnvelope {
             extraction_error: Some(error.clone()),
             final_result: ActivityResult::failed(activity, summary, error)
                 .with_error_kind(ActivityErrorKind::Configuration),
+        }
+    }
+
+    fn zero_output_spawn_failure(
+        raw_status: TurnStatus,
+        activity: String,
+        activity_summary: AgentActivitySummary,
+    ) -> Self {
+        let error = "agent completed with no observable activity: zero assistant messages, zero tool invocations, and no structured activity result".to_string();
+        Self {
+            extraction_strategy: ActivityResultExtractionStrategy::FencedActivityResult,
+            outcome: ActivityResultEnvelopeOutcome::ZeroOutputSpawnFailure,
+            raw_status,
+            extracted_activity: None,
+            extraction_error: Some(error.clone()),
+            final_result: ActivityResult::failed(
+                activity,
+                "Agent turn completed without observable activity.",
+                error,
+            )
+            .with_error_kind(ActivityErrorKind::SpawnFailure)
+            .with_artifact(ActivityArtifact::new(
+                "agent_activity_gate",
+                json!({
+                    "schema": "harness.runtime.agent_activity_gate.v1",
+                    "classification": "spawn_failure",
+                    "assistant_messages": activity_summary.assistant_messages,
+                    "tool_invocations": activity_summary.tool_invocations,
+                    "structured_result_artifacts": activity_summary.structured_result_artifacts,
+                    "total_items": activity_summary.total_items,
+                }),
+            ))
+            .with_signal(ActivitySignal::new(
+                "AgentZeroOutputSpawnFailure",
+                json!({
+                    "classification": "spawn_failure",
+                    "assistant_messages": activity_summary.assistant_messages,
+                    "tool_invocations": activity_summary.tool_invocations,
+                    "structured_result_artifacts": activity_summary.structured_result_artifacts,
+                    "total_items": activity_summary.total_items,
+                }),
+            )),
         }
     }
 
@@ -273,238 +334,6 @@ impl ActivityResultEnvelope {
     }
 }
 
-fn enforce_activity_status_contract(
-    mut result: ActivityResult,
-    default_outcome: ActivityResultEnvelopeOutcome,
-) -> (ActivityResultEnvelopeOutcome, ActivityResult) {
-    if result.status != ActivityStatus::Succeeded {
-        return (default_outcome, result);
-    }
-
-    let blockers = activity_status_contract_blockers(&result);
-    if blockers.is_empty() {
-        return (default_outcome, result);
-    }
-
-    let claimed_summary = result.summary.clone();
-    let reason = format!(
-        "activity result claimed succeeded while reporting blockers: {}",
-        blockers.join("; ")
-    );
-
-    result.status = ActivityStatus::Blocked;
-    result.summary = format!("Activity blocked by status contract. {reason}");
-    result.error = Some(reason);
-    result.artifacts.push(ActivityArtifact::new(
-        "activity_status_contract",
-        json!({
-            "schema": "harness.runtime.activity_status_contract.v1",
-            "claimed_status": "succeeded",
-            "effective_status": "blocked",
-            "claimed_summary": claimed_summary,
-            "blocker_signals": blockers,
-        }),
-    ));
-    result.signals.push(ActivitySignal::new(
-        "ActivityStatusContractDowngraded",
-        json!({
-            "claimed_status": "succeeded",
-            "effective_status": "blocked",
-        }),
-    ));
-
-    (
-        ActivityResultEnvelopeOutcome::StatusContractDowngraded,
-        result,
-    )
-}
-
-fn status_contract_blockers_from_result(result: &ActivityResult) -> Vec<String> {
-    result
-        .artifacts
-        .iter()
-        .find(|artifact| artifact.artifact_type == "activity_status_contract")
-        .and_then(|artifact| artifact.artifact.get("blocker_signals"))
-        .and_then(Value::as_array)
-        .map(|values| {
-            values
-                .iter()
-                .filter_map(Value::as_str)
-                .map(ToString::to_string)
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn activity_status_contract_blockers(result: &ActivityResult) -> Vec<String> {
-    let mut blockers = Vec::new();
-
-    for signal in &result.signals {
-        match signal.signal_type.as_str() {
-            "ChangesRequested"
-            | "ChecksFailed"
-            | "LocalReviewChangesRequested"
-            | "LocalReviewBlocked"
-            | "QualityBlocked"
-            | "QualityFailed" => {
-                push_unique(&mut blockers, format!("signal:{}", signal.signal_type));
-            }
-            _ => {}
-        }
-    }
-
-    for artifact in &result.artifacts {
-        collect_structured_blockers(&artifact.artifact, &mut blockers);
-    }
-
-    collect_textual_blockers(&result.summary, &mut blockers);
-    if let Some(error) = result.error.as_deref() {
-        collect_textual_blockers(error, &mut blockers);
-    }
-
-    blockers
-}
-
-fn collect_structured_blockers(value: &Value, blockers: &mut Vec<String>) {
-    match value {
-        Value::Object(object) => {
-            for (key, value) in object {
-                let normalized_key = key.to_ascii_lowercase();
-                match normalized_key.as_str() {
-                    "open_review_threads"
-                    | "unresolved_review_threads"
-                    | "pending_checks"
-                    | "failing_checks"
-                    | "failed_checks"
-                    | "requested_changes"
-                    | "blocking_reviews"
-                    | "mergeability_blockers"
-                    | "blockers"
-                        if json_value_reports_blocker(value) =>
-                    {
-                        push_unique(blockers, format!("field:{normalized_key}"));
-                    }
-                    "review_decision" if json_string_equals(value, "changes_requested") => {
-                        push_unique(blockers, "field:review_decision_changes_requested");
-                    }
-                    "merge_state_status"
-                        if json_string_is_one_of(
-                            value,
-                            &["blocked", "dirty", "unknown", "unstable", "behind"],
-                        ) =>
-                    {
-                        push_unique(blockers, "field:merge_state_status_blocked");
-                    }
-                    "mergeable" if value.as_bool() == Some(false) => {
-                        push_unique(blockers, "field:mergeable_false");
-                    }
-                    _ => {}
-                }
-                collect_structured_blockers(value, blockers);
-            }
-        }
-        Value::Array(values) => {
-            for value in values {
-                collect_structured_blockers(value, blockers);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn json_value_reports_blocker(value: &Value) -> bool {
-    match value {
-        Value::Bool(value) => *value,
-        Value::Number(value) => value.as_u64().is_some_and(|count| count > 0),
-        Value::String(value) => {
-            let normalized = value.trim().to_ascii_lowercase();
-            !matches!(
-                normalized.as_str(),
-                "" | "0" | "false" | "none" | "no" | "clean" | "[]"
-            )
-        }
-        Value::Array(values) => !values.is_empty(),
-        Value::Object(values) => !values.is_empty(),
-        Value::Null => false,
-    }
-}
-
-fn json_string_equals(value: &Value, expected: &str) -> bool {
-    value
-        .as_str()
-        .is_some_and(|value| value.eq_ignore_ascii_case(expected))
-}
-
-fn json_string_is_one_of(value: &Value, expected: &[&str]) -> bool {
-    value.as_str().is_some_and(|value| {
-        expected
-            .iter()
-            .any(|expected| value.eq_ignore_ascii_case(expected))
-    })
-}
-
-fn collect_textual_blockers(text: &str, blockers: &mut Vec<String>) {
-    let normalized = text.to_ascii_lowercase();
-    let patterns = [
-        (
-            "text:pending_ci",
-            &["pending ci", "pending check", "pending checks"][..],
-        ),
-        (
-            "text:failing_checks",
-            &[
-                "failing check",
-                "failing checks",
-                "failed check",
-                "failed checks",
-            ],
-        ),
-        (
-            "text:requested_changes",
-            &["requested changes", "changes requested"],
-        ),
-        (
-            "text:unresolved_review_threads",
-            &[
-                "open review thread",
-                "open review threads",
-                "unresolved review thread",
-                "unresolved review threads",
-            ],
-        ),
-        (
-            "text:not_merge_ready",
-            &["not merge-ready", "not merge ready", "not ready to merge"],
-        ),
-        (
-            "text:review_quota_blocker",
-            &["quota/credit-limit", "credit-limit notice", "quota notice"],
-        ),
-    ];
-
-    for (label, needles) in patterns {
-        if needles
-            .iter()
-            .any(|needle| contains_affirmative_blocker(&normalized, needle))
-        {
-            push_unique(blockers, label);
-        }
-    }
-}
-
-fn contains_affirmative_blocker(normalized_text: &str, needle: &str) -> bool {
-    normalized_text.contains(needle)
-        && !normalized_text.contains(&format!("no {needle}"))
-        && !normalized_text.contains(&format!("without {needle}"))
-}
-
-fn push_unique(blockers: &mut Vec<String>, blocker: impl Into<String>) {
-    let blocker = blocker.into();
-    if !blockers.contains(&blocker) {
-        blockers.push(blocker);
-    }
-}
-
 fn activity_result_envelope_from_turn(
     status: &TurnStatus,
     items: &[Item],
@@ -518,11 +347,22 @@ fn activity_result_envelope_from_turn(
                 ActivityResultExtractionStrategy::FencedActivityResult,
                 result,
             ),
-            StructuredActivityResult::Missing => ActivityResultEnvelope::missing_structured_output(
-                *status,
-                activity.to_string(),
-                summary,
-            ),
+            StructuredActivityResult::Missing => {
+                let activity_summary = agent_activity_summary(items);
+                if activity_summary.is_zero_output() {
+                    ActivityResultEnvelope::zero_output_spawn_failure(
+                        *status,
+                        activity.to_string(),
+                        activity_summary,
+                    )
+                } else {
+                    ActivityResultEnvelope::missing_structured_output(
+                        *status,
+                        activity.to_string(),
+                        summary,
+                    )
+                }
+            }
             StructuredActivityResult::Invalid {
                 error,
                 extracted_activity,
@@ -566,6 +406,47 @@ fn activity_result_envelope_from_turn(
             ActivityResultEnvelope::failed(*status, activity.to_string(), summary, error)
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AgentActivitySummary {
+    assistant_messages: usize,
+    tool_invocations: usize,
+    structured_result_artifacts: usize,
+    total_items: usize,
+}
+
+impl AgentActivitySummary {
+    fn is_zero_output(&self) -> bool {
+        self.assistant_messages == 0
+            && self.tool_invocations == 0
+            && self.structured_result_artifacts == 0
+    }
+}
+
+fn agent_activity_summary(items: &[Item]) -> AgentActivitySummary {
+    AgentActivitySummary {
+        assistant_messages: items
+            .iter()
+            .filter(
+                |item| matches!(item, Item::AgentReasoning { content } if !content.trim().is_empty()),
+            )
+            .count(),
+        tool_invocations: items.iter().filter(|item| item_is_tool_activity(item)).count(),
+        structured_result_artifacts: usize::from(latest_activity_result_block(items).is_some()),
+        total_items: items.len(),
+    }
+}
+
+fn item_is_tool_activity(item: &Item) -> bool {
+    matches!(
+        item,
+        Item::ShellCommand { .. }
+            | Item::FileEdit { .. }
+            | Item::FileRead { .. }
+            | Item::ToolCall { .. }
+            | Item::ApprovalRequest { .. }
+    )
 }
 
 fn turn_error_is_timeout(error: &str) -> bool {

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
@@ -56,6 +56,82 @@ fn activity_result_from_turn_fails_when_no_fenced_block_present() {
 }
 
 #[test]
+fn activity_result_from_turn_classifies_zero_output_completion_as_spawn_failure() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &[],
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.activity, "implement_issue");
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(result.error_kind, Some(ActivityErrorKind::SpawnFailure));
+    assert!(result
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("no observable activity")));
+    assert!(result.signals.iter().any(|signal| {
+        signal.signal_type == "AgentZeroOutputSpawnFailure"
+            && signal.signal["classification"] == "spawn_failure"
+    }));
+    let gate = artifact_by_type(&result, "agent_activity_gate");
+    assert_eq!(gate.artifact["classification"], "spawn_failure");
+    assert_eq!(gate.artifact["assistant_messages"], 0);
+    assert_eq!(gate.artifact["tool_invocations"], 0);
+    assert_eq!(gate.artifact["structured_result_artifacts"], 0);
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "zero_output_spawn_failure");
+    assert_eq!(envelope["final_result"]["error_kind"], "spawn_failure");
+}
+
+#[test]
+fn activity_result_from_turn_does_not_classify_tool_only_completion_as_spawn_failure() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": "implement_issue"
+        }),
+    );
+    let items = vec![Item::ToolCall {
+        name: "read_file".to_string(),
+        input: json!({"path": "README.md"}),
+        output: Some(json!({"ok": true})),
+    }];
+
+    let result = activity_result_from_turn(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+    );
+
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(result.error_kind, Some(ActivityErrorKind::Configuration));
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "missing_structured_output");
+}
+
+#[test]
 fn activity_result_from_turn_parses_structured_activity_result_block() {
     let job = RuntimeJob::pending(
         "command-1",

--- a/crates/harness-server/src/workflow_runtime_worker/activity_status_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_status_contract.rs
@@ -1,0 +1,230 @@
+use harness_workflow::runtime::{ActivityArtifact, ActivityResult, ActivitySignal, ActivityStatus};
+use serde_json::{json, Value};
+
+pub(super) fn enforce_activity_status_contract(
+    mut result: ActivityResult,
+) -> (bool, ActivityResult) {
+    if result.status != ActivityStatus::Succeeded {
+        return (false, result);
+    }
+
+    let blockers = activity_status_contract_blockers(&result);
+    if blockers.is_empty() {
+        return (false, result);
+    }
+
+    let claimed_summary = result.summary.clone();
+    let reason = format!(
+        "activity result claimed succeeded while reporting blockers: {}",
+        blockers.join("; ")
+    );
+
+    result.status = ActivityStatus::Blocked;
+    result.summary = format!("Activity blocked by status contract. {reason}");
+    result.error = Some(reason);
+    result.artifacts.push(ActivityArtifact::new(
+        "activity_status_contract",
+        json!({
+            "schema": "harness.runtime.activity_status_contract.v1",
+            "claimed_status": "succeeded",
+            "effective_status": "blocked",
+            "claimed_summary": claimed_summary,
+            "blocker_signals": blockers,
+        }),
+    ));
+    result.signals.push(ActivitySignal::new(
+        "ActivityStatusContractDowngraded",
+        json!({
+            "claimed_status": "succeeded",
+            "effective_status": "blocked",
+        }),
+    ));
+
+    (true, result)
+}
+
+pub(super) fn status_contract_blockers_from_result(result: &ActivityResult) -> Vec<String> {
+    result
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.artifact_type == "activity_status_contract")
+        .and_then(|artifact| artifact.artifact.get("blocker_signals"))
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn activity_status_contract_blockers(result: &ActivityResult) -> Vec<String> {
+    let mut blockers = Vec::new();
+
+    for signal in &result.signals {
+        match signal.signal_type.as_str() {
+            "ChangesRequested"
+            | "ChecksFailed"
+            | "LocalReviewChangesRequested"
+            | "LocalReviewBlocked"
+            | "QualityBlocked"
+            | "QualityFailed" => {
+                push_unique(&mut blockers, format!("signal:{}", signal.signal_type));
+            }
+            _ => {}
+        }
+    }
+
+    for artifact in &result.artifacts {
+        collect_structured_blockers(&artifact.artifact, &mut blockers);
+    }
+
+    collect_textual_blockers(&result.summary, &mut blockers);
+    if let Some(error) = result.error.as_deref() {
+        collect_textual_blockers(error, &mut blockers);
+    }
+
+    blockers
+}
+
+fn collect_structured_blockers(value: &Value, blockers: &mut Vec<String>) {
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                let normalized_key = key.to_ascii_lowercase();
+                match normalized_key.as_str() {
+                    "open_review_threads"
+                    | "unresolved_review_threads"
+                    | "pending_checks"
+                    | "failing_checks"
+                    | "failed_checks"
+                    | "requested_changes"
+                    | "blocking_reviews"
+                    | "mergeability_blockers"
+                    | "blockers"
+                        if json_value_reports_blocker(value) =>
+                    {
+                        push_unique(blockers, format!("field:{normalized_key}"));
+                    }
+                    "review_decision" if json_string_equals(value, "changes_requested") => {
+                        push_unique(blockers, "field:review_decision_changes_requested");
+                    }
+                    "merge_state_status"
+                        if json_string_is_one_of(
+                            value,
+                            &["blocked", "dirty", "unknown", "unstable", "behind"],
+                        ) =>
+                    {
+                        push_unique(blockers, "field:merge_state_status_blocked");
+                    }
+                    "mergeable" if value.as_bool() == Some(false) => {
+                        push_unique(blockers, "field:mergeable_false");
+                    }
+                    _ => {}
+                }
+                collect_structured_blockers(value, blockers);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_structured_blockers(value, blockers);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn json_value_reports_blocker(value: &Value) -> bool {
+    match value {
+        Value::Bool(value) => *value,
+        Value::Number(value) => value.as_u64().is_some_and(|count| count > 0),
+        Value::String(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            !matches!(
+                normalized.as_str(),
+                "" | "0" | "false" | "none" | "no" | "clean" | "[]"
+            )
+        }
+        Value::Array(values) => !values.is_empty(),
+        Value::Object(values) => !values.is_empty(),
+        Value::Null => false,
+    }
+}
+
+fn json_string_equals(value: &Value, expected: &str) -> bool {
+    value
+        .as_str()
+        .is_some_and(|value| value.eq_ignore_ascii_case(expected))
+}
+
+fn json_string_is_one_of(value: &Value, expected: &[&str]) -> bool {
+    value.as_str().is_some_and(|value| {
+        expected
+            .iter()
+            .any(|expected| value.eq_ignore_ascii_case(expected))
+    })
+}
+
+fn collect_textual_blockers(text: &str, blockers: &mut Vec<String>) {
+    let normalized = text.to_ascii_lowercase();
+    let patterns = [
+        (
+            "text:pending_ci",
+            &["pending ci", "pending check", "pending checks"][..],
+        ),
+        (
+            "text:failing_checks",
+            &[
+                "failing check",
+                "failing checks",
+                "failed check",
+                "failed checks",
+            ],
+        ),
+        (
+            "text:requested_changes",
+            &["requested changes", "changes requested"],
+        ),
+        (
+            "text:unresolved_review_threads",
+            &[
+                "open review thread",
+                "open review threads",
+                "unresolved review thread",
+                "unresolved review threads",
+            ],
+        ),
+        (
+            "text:not_merge_ready",
+            &["not merge-ready", "not merge ready", "not ready to merge"],
+        ),
+        (
+            "text:review_quota_blocker",
+            &["quota/credit-limit", "credit-limit notice", "quota notice"],
+        ),
+    ];
+
+    for (label, needles) in patterns {
+        if needles
+            .iter()
+            .any(|needle| contains_affirmative_blocker(&normalized, needle))
+        {
+            push_unique(blockers, label);
+        }
+    }
+}
+
+fn contains_affirmative_blocker(normalized_text: &str, needle: &str) -> bool {
+    normalized_text.contains(needle)
+        && !normalized_text.contains(&format!("no {needle}"))
+        && !normalized_text.contains(&format!("without {needle}"))
+}
+
+fn push_unique(blockers: &mut Vec<String>, blocker: impl Into<String>) {
+    let blocker = blocker.into();
+    if !blockers.contains(&blocker) {
+        blockers.push(blocker);
+    }
+}

--- a/crates/harness-workflow/src/runtime/model.rs
+++ b/crates/harness-workflow/src/runtime/model.rs
@@ -639,6 +639,7 @@ pub enum ActivityStatus {
 #[serde(rename_all = "snake_case")]
 pub enum ActivityErrorKind {
     Retryable,
+    SpawnFailure,
     Timeout,
     Fatal,
     Configuration,

--- a/crates/harness-workflow/src/runtime/tests/retry.rs
+++ b/crates/harness-workflow/src/runtime/tests/retry.rs
@@ -155,6 +155,51 @@ fn runtime_completion_reducer_retries_timeout_activity_failure_when_policy_allow
 }
 
 #[test]
+fn runtime_completion_reducer_retries_spawn_failure_when_policy_allows() {
+    let instance = issue_instance("implementing").with_data(json!({
+        "runtime_retry_policy": {
+            "max_failed_activity_retries": 1
+        }
+    }));
+    let command = WorkflowCommand::enqueue_activity("implement_issue", "implement-spawn-1");
+    let result = ActivityResult::failed(
+        "implement_issue",
+        "Agent turn completed without observable activity.",
+        "agent completed with no observable activity",
+    )
+    .with_error_kind(ActivityErrorKind::SpawnFailure);
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::super::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "command-spawn-1",
+        "command": command,
+        "runtime_job_id": "job-spawn-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("spawn failure should produce a retry decision");
+
+    assert_eq!(decision.decision, "retry_failed_runtime_activity");
+    assert_eq!(
+        decision.commands[0].command["previous_error_kind"],
+        "spawn_failure"
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("spawn failure retry decision should validate");
+}
+
+#[test]
 fn runtime_completion_reducer_does_not_retry_fatal_activity_failure() {
     let instance = issue_instance("implementing").with_data(json!({
         "runtime_retry_policy": {


### PR DESCRIPTION
Refs #1477

## Summary
- Split activity-status contract enforcement out of `activity_result.rs` so the runtime result path stays under the file-size limit.
- Add `ActivityErrorKind::SpawnFailure` and classify completed turns with zero assistant messages, zero tool invocations, and no structured result as spawn failures.
- Attach activity-gate artifact/signal evidence and keep tool-only completions on the existing missing-structured-output path.
- Cover spawn-failure retry behavior in the workflow runtime reducer.

## Scope
- Implements the #1477 zero-output classification and retry-policy path.
- Does not implement the #1478 backoff/circuit-breaker policy.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p harness-server activity_result_from_turn`
- `cargo test -p harness-workflow runtime_completion_reducer_retries_spawn_failure_when_policy_allows`
- `cargo check -p harness-server --all-targets`
- `cargo check -p harness-workflow --all-targets`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`