### PR TITLE
fix(runtime): terminalize review budget exhaustion

### DIFF
--- a/crates/harness-server/src/task_executor/review_loop.rs
+++ b/crates/harness-server/src/task_executor/review_loop.rs
@@ -3,6 +3,7 @@ mod flow;
 mod pr_state;
 mod runtime_feedback;
 mod signals;
+mod terminal;
 mod wait_budget;
 
 pub(crate) use flow::run_review_loop;

--- a/crates/harness-server/src/task_executor/review_loop/flow.rs
+++ b/crates/harness-server/src/task_executor/review_loop/flow.rs
@@ -1,3 +1,4 @@
+use super::terminal::mark_round_budget_exhausted;
 use super::{
     decision::*, pr_state::*, runtime_feedback::*, signals::*, wait_budget::ReviewWaitBudget,
 };
@@ -327,16 +328,9 @@ pub(crate) async fn run_review_loop(
         let check_req = run_pre_execute(interceptors, check_req).await?;
         if let Some(max) = effective_max_turns {
             if *turns_used >= max {
-                let msg = format!(
-                    "Turn budget exhausted: used {} of {} allowed turns",
-                    turns_used, max
-                );
                 tracing::warn!(task_id = %task_id, turns_used, max, "turn budget exhausted in review loop");
-                mutate_and_persist(store, task_id, |s| {
-                    s.status = TaskStatus::Failed;
-                    s.error = Some(msg.clone());
-                })
-                .await?;
+                mark_round_budget_exhausted(store, task_id, *turns_used, TaskStatus::Reviewing)
+                    .await?;
                 return Ok(());
             }
         }
@@ -764,16 +758,7 @@ pub(crate) async fn run_review_loop(
         })
         .await?;
     } else {
-        mutate_and_persist(store, task_id, |s| {
-            s.status = TaskStatus::Failed;
-            s.turn = max_rounds.saturating_add(1);
-            s.error = Some(format!(
-                "Task did not receive LGTM after {} review rounds (last issues: {}).",
-                max_rounds,
-                last_issue_count.map_or("unknown".to_string(), |n| n.to_string()),
-            ));
-        })
-        .await?;
+        mark_round_budget_exhausted(store, task_id, max_rounds, TaskStatus::Reviewing).await?;
     }
     tracing::info!(
         task_id = %task_id,

--- a/crates/harness-server/src/task_executor/review_loop/terminal.rs
+++ b/crates/harness-server/src/task_executor/review_loop/terminal.rs
@@ -1,0 +1,32 @@
+use crate::task_runner::{
+    mark_terminal_once, TaskId, TaskStatus, TaskStore, TaskTerminalFailure, TaskTerminalOutcome,
+};
+
+pub(super) async fn mark_round_budget_exhausted(
+    store: &TaskStore,
+    task_id: &TaskId,
+    rounds_used: u32,
+    last_status: TaskStatus,
+) -> anyhow::Result<()> {
+    let outcome = TaskTerminalOutcome::Failed(TaskTerminalFailure::round_budget_exhausted(
+        rounds_used,
+        last_status.clone(),
+        Some("local_review_gate".to_string()),
+    ));
+    let transition = mark_terminal_once(store, task_id, outcome).await?;
+    if transition.applied() {
+        tracing::error!(
+            task_id = %task_id,
+            rounds_used,
+            last_status = last_status.as_ref(),
+            "task marked terminal after review round budget exhaustion"
+        );
+    } else {
+        tracing::debug!(
+            task_id = %task_id,
+            ?transition,
+            "round budget exhaustion skipped because task was already terminal or missing"
+        );
+    }
+    Ok(())
+}

--- a/crates/harness-server/src/task_executor/review_loop_wait_budget_tests.rs
+++ b/crates/harness-server/src/task_executor/review_loop_wait_budget_tests.rs
@@ -1,5 +1,8 @@
 use super::review_loop::run_review_loop;
-use crate::task_runner::{CreateTaskRequest, TaskId, TaskState, TaskStatus, TaskStore};
+use crate::event_replay::TaskEvent;
+use crate::task_runner::{
+    CreateTaskRequest, TaskId, TaskPhase, TaskState, TaskStatus, TaskStore, TaskTerminalFailure,
+};
 use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
 use harness_core::types::{Capability, TokenUsage};
 use std::collections::HashMap;
@@ -194,5 +197,94 @@ async fn review_loop_waiting_output_fails_when_wait_budget_exceeded() -> anyhow:
         "unexpected error: {:?}",
         final_state.error
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn review_loop_round_budget_exhausted_marks_terminal_once() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let dir = tempfile::tempdir()?;
+    let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+    let task_id = TaskId::new();
+    store.insert(&TaskState::new(task_id.clone())).await;
+    let agent =
+        StaticReviewAgent::new("Found 4 issues.\n1. Missing test\n2. Race\n3. Leak\n4. Panic");
+    let review_config = harness_core::config::agents::AgentReviewConfig {
+        review_wait_budget_secs: 60,
+        ..harness_core::config::agents::AgentReviewConfig::default()
+    };
+    let events = Arc::new(harness_observe::event_store::EventStore::new(dir.path()).await?);
+    let interceptors = Arc::new(Vec::new());
+    let mut turns_used = 0;
+    let mut turns_used_acc = 0;
+
+    run_review_loop(
+        store.as_ref(),
+        &task_id,
+        &agent,
+        &review_config,
+        &harness_core::config::project::ProjectConfig::default(),
+        None,
+        None,
+        dir.path(),
+        &CreateTaskRequest::default(),
+        &events,
+        &interceptors,
+        &[],
+        dir.path(),
+        &HashMap::new(),
+        Some("https://github.com/owner/repo/pull/1".to_string()),
+        1,
+        None,
+        1,
+        0,
+        1,
+        false,
+        false,
+        Duration::from_secs(5),
+        &mut turns_used,
+        &mut turns_used_acc,
+        Instant::now(),
+        Instant::now(),
+        "invalid-repo-slug".to_string(),
+        0.9,
+        None,
+    )
+    .await?;
+
+    let final_state = store
+        .get(&task_id)
+        .ok_or_else(|| anyhow::anyhow!("task state should exist"))?;
+    assert_eq!(final_state.status, TaskStatus::Failed);
+    assert_eq!(final_state.phase, TaskPhase::Terminal);
+    assert_eq!(final_state.turn, 2);
+    let failure: TaskTerminalFailure = serde_json::from_str(
+        final_state
+            .error
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("terminal failure should include a reason"))?,
+    )?;
+    assert_eq!(failure.reason, "round_budget_exhausted");
+    assert_eq!(failure.rounds_used, 1);
+    assert_eq!(failure.last_status, TaskStatus::Reviewing);
+    assert_eq!(failure.waiting_on.as_deref(), Some("local_review_gate"));
+    assert_eq!(agent.request_count().await, 1);
+
+    let event_log = std::fs::read_to_string(dir.path().join("task-events.jsonl"))?;
+    let failed_events = event_log
+        .lines()
+        .filter_map(|line| serde_json::from_str::<TaskEvent>(line).ok())
+        .filter(|event| {
+            matches!(
+                event,
+                TaskEvent::Failed { reason, .. }
+                    if reason.contains(r#""reason":"round_budget_exhausted""#)
+            )
+        })
+        .count();
+    assert_eq!(failed_events, 1);
     Ok(())
 }

--- a/crates/harness-server/src/task_runner/state.rs
+++ b/crates/harness-server/src/task_runner/state.rs
@@ -602,6 +602,9 @@ impl TaskState {
         }
 
         let status = outcome.status();
+        if let TaskTerminalOutcome::Failed(failure) = &outcome {
+            self.turn = failure.rounds_used.saturating_add(1);
+        }
         self.status = status.clone();
         self.phase = TaskPhase::Terminal;
         self.error = outcome.reason_string();
@@ -628,6 +631,7 @@ mod terminal_tests {
         assert!(state.apply_terminal_outcome_once(outcome));
 
         assert_eq!(state.status, TaskStatus::Failed);
+        assert_eq!(state.turn, 4);
         assert_eq!(state.phase, TaskPhase::Terminal);
         assert_eq!(
             state.error.as_deref(),


### PR DESCRIPTION
Related: #1465

Partial GH1465 implementation for SP1465-T002.

## Summary
- Route hosted review-loop turn-budget and max-review-round exhaustion through the terminal CAS helper instead of direct Failed mutations.
- Persist structured `round_budget_exhausted` failure metadata with `rounds_used`, `last_status`, and `waiting_on`.
- Add a focused regression for the review-loop exhaustion path and assert exactly one terminal failed event when DB tests are enabled.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p harness-server round_budget_exhausted`
- `RUSTFLAGS="-Dwarnings" cargo check -p harness-server --all-targets`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1465`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Notes
- Local `HARNESS_DATABASE_URL` is not configured on this machine, so the new store-backed regression follows the repo DB-gated test pattern locally and exercises the DB-backed path when DB tests are enabled.
- This is not the final GH1465 slice; spawn exit paths, status/API surfacing, recovery, and liveness audit tasks remain.