### PR TITLE
fix(runtime): route spawn failures into breaker

### DIFF
--- a/crates/harness-server/src/runtime_circuit_breaker.rs
+++ b/crates/harness-server/src/runtime_circuit_breaker.rs
@@ -7,6 +7,7 @@ use std::sync::Mutex;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum FailureClass {
+    ZeroOutputSpawnFailure,
     QuotaInteractiveWait,
     CliMissingFile,
     WorktreeCollision,
@@ -18,6 +19,7 @@ pub(crate) enum FailureClass {
 impl FailureClass {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
+            Self::ZeroOutputSpawnFailure => "zero-output-spawn-failure",
             Self::QuotaInteractiveWait => "quota-interactive-wait",
             Self::CliMissingFile => "cli-missing-file",
             Self::WorktreeCollision => "worktree-collision",
@@ -30,6 +32,12 @@ impl FailureClass {
 
 pub(crate) fn classify_agent_failure(error: &str) -> FailureClass {
     let lower = error.to_ascii_lowercase();
+    if lower.contains("zero_output_spawn_failure")
+        || lower.contains("zero-output spawn failure")
+        || lower.contains("completed without assistant output")
+    {
+        return FailureClass::ZeroOutputSpawnFailure;
+    }
     if error.contains("Reading additional input")
         || lower.contains("hit your limit")
         || lower.contains("hit your usage limit")
@@ -424,6 +432,14 @@ mod tests {
 
     #[test]
     fn classify_agent_failure_maps_known_classes() {
+        assert_eq!(
+            classify_agent_failure("agent completed without assistant output"),
+            FailureClass::ZeroOutputSpawnFailure
+        );
+        assert_eq!(
+            classify_agent_failure("outcome=zero_output_spawn_failure"),
+            FailureClass::ZeroOutputSpawnFailure
+        );
         assert_eq!(
             classify_agent_failure(
                 "codex exited with exit status: 1: stderr=[Reading additional input"

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -132,7 +132,7 @@ pub(crate) async fn record_runtime_circuit_breaker_completion(
             chrono::Utc::now(),
         ),
         RuntimeJobStatus::Failed => {
-            let failure_class = classify_agent_failure(job.error.as_deref().unwrap_or_default());
+            let failure_class = runtime_job_failure_class(job);
             if let Some(updated) = store
                 .record_runtime_job_failure_class(&job.id, failure_class.as_str())
                 .await?
@@ -310,6 +310,15 @@ fn runtime_job_activity_result(job: &RuntimeJob) -> Option<ActivityResult> {
         .and_then(|output| serde_json::from_value(output.clone()).ok())
 }
 
+fn runtime_job_failure_class(job: &RuntimeJob) -> FailureClass {
+    if runtime_job_activity_result(job)
+        .is_some_and(|result| result.error_kind == Some(ActivityErrorKind::SpawnFailure))
+    {
+        return FailureClass::ZeroOutputSpawnFailure;
+    }
+    classify_agent_failure(job.error.as_deref().unwrap_or_default())
+}
+
 fn runtime_failure_kind(
     status: &TaskStatus,
     result: Option<&ActivityResult>,
@@ -465,6 +474,51 @@ mod tests {
             task.error.as_deref(),
             Some("provider temporarily unavailable")
         );
+    }
+
+    #[test]
+    fn runtime_job_failure_class_uses_structured_spawn_failure() -> anyhow::Result<()> {
+        let mut job = RuntimeJob::pending(
+            "command-1",
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "implement_issue" }),
+        );
+        let result = ActivityResult::failed(
+            "implement_issue",
+            "Agent completed without assistant output.",
+            "Agent completed without assistant output; treating as spawn failure.",
+        )
+        .with_error_kind(ActivityErrorKind::SpawnFailure);
+        job.complete(&result)?;
+
+        assert_eq!(
+            runtime_job_failure_class(&job),
+            FailureClass::ZeroOutputSpawnFailure
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_job_failure_class_falls_back_to_error_text() -> anyhow::Result<()> {
+        let mut job = RuntimeJob::pending(
+            "command-1",
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({ "activity": "implement_issue" }),
+        );
+        let result = ActivityResult::failed(
+            "implement_issue",
+            "Codex limit reached.",
+            "codex exited with exit status: 1: stderr=[Reading additional input]",
+        );
+        job.complete(&result)?;
+
+        assert_eq!(
+            runtime_job_failure_class(&job),
+            FailureClass::QuotaInteractiveWait
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Related: #1478

Partial GH1478 implementation.

## Summary
- Add a distinct runtime circuit-breaker failure class for zero-output spawn failures.
- Classify failed runtime jobs from structured `ActivityResult.error_kind == spawn_failure` before falling back to legacy error-text matching.
- Preserve text fallback for older zero-output evidence and existing quota/CLI/sandbox failure classes.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p harness-server runtime_job_failure_class`
- `cargo test -p harness-server classify_agent_failure_maps_known_classes`
- `cargo check -p harness-server --all-targets`
- `python3 checks/check_workflow.py --repo .`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`

## Notes
- This PR depends on #1487/#1477 landing first and consumes its `spawn_failure` classifier output.
- This is not the final GH1478 slice; distinct-task/window accounting, storm integration coverage, and health endpoint assertions remain follow-up work.