### PR TITLE
fix(runtime): surface stalled terminal tasks

### DIFF
--- a/crates/harness-server/src/handlers/dashboard.rs
+++ b/crates/harness-server/src/handlers/dashboard.rs
@@ -35,6 +35,7 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
     let DashboardCounts {
         global_done,
         global_failed,
+        global_stalled,
         by_project: project_counts,
     } = state.task_svc.count_for_dashboard().await;
 
@@ -176,6 +177,7 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
                 let counts = project_counts.get(&key);
                 let done = counts.map_or(0, |c| c.done);
                 let failed = counts.map_or(0, |c| c.failed);
+                let stalled = counts.map_or(0, |c| c.stalled);
                 let latest_pr = project_pr_urls.get(&key);
                 entries.push(json!({
                     "id": p.id,
@@ -185,6 +187,7 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
                         "queued": active_project_counts.queued,
                         "done": done,
                         "failed": failed,
+                        "stalled": stalled,
                     },
                     "latest_pr": latest_pr,
                 }));
@@ -236,6 +239,7 @@ pub async fn dashboard(State(state): State<Arc<AppState>>) -> (StatusCode, Json<
             "uptime_secs": uptime_secs,
             "done": global_done,
             "failed": global_failed,
+            "stalled": global_stalled,
             "latest_pr": latest_pr,
             "grade": grade,
             "runtime_hosts_total": runtime_hosts_total,
@@ -376,6 +380,44 @@ mod tests {
         let project = project_entry(&body, &project_root)?;
         assert_eq!(project["tasks"]["running"], 0);
         assert_eq!(project["tasks"]["queued"], 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn status_stalled_terminal_dashboard_counts_budget_exhaustion() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let dir = crate::test_helpers::tempdir_in_home("harness-test-dashboard-stalled-")?;
+        let canonical_root = dir.path().canonicalize()?;
+        let project_root = canonical_root.to_string_lossy().into_owned();
+        let state = Arc::new(make_test_state(dir.path()).await?);
+        let mut task = TaskState::new(TaskId::from_str("dashboard-stalled-task"));
+        task.project_root = Some(canonical_root);
+        task.status = crate::task_runner::TaskStatus::Failed;
+        task.phase = crate::task_runner::TaskPhase::Terminal;
+        task.error = Some(
+            crate::task_runner::TaskTerminalFailure::round_budget_exhausted(
+                1,
+                crate::task_runner::TaskStatus::Reviewing,
+                Some("local_review_gate".to_string()),
+            )
+            .to_reason_string(),
+        );
+        task.scheduler
+            .mark_terminal(&crate::task_runner::TaskStatus::Failed);
+        state.core.tasks.insert(&task).await;
+
+        let body = dashboard_body(state).await?;
+
+        assert_eq!(body["global"]["failed"], 1);
+        assert_eq!(body["global"]["stalled"], 1);
+        let project = project_entry(&body, &project_root)?;
+        assert_eq!(project["tasks"]["running"], 0);
+        assert_eq!(project["tasks"]["queued"], 0);
+        assert_eq!(project["tasks"]["failed"], 1);
+        assert_eq!(project["tasks"]["stalled"], 1);
         Ok(())
     }
 

--- a/crates/harness-server/src/handlers/operator_snapshot.rs
+++ b/crates/harness-server/src/handlers/operator_snapshot.rs
@@ -39,6 +39,10 @@ fn stalled_task_json(t: &crate::task_runner::TaskState) -> Value {
 }
 
 fn recent_failure_json(t: &crate::task_runner::RecentFailureTask) -> Value {
+    let terminal = crate::task_runner::TaskTerminalInfo::from_status_error(
+        &crate::task_runner::TaskStatus::Failed,
+        t.error.as_deref(),
+    );
     let error = t
         .error
         .as_deref()
@@ -69,6 +73,7 @@ fn recent_failure_json(t: &crate::task_runner::RecentFailureTask) -> Value {
         "workspace_owner": t.workspace_owner.as_deref(),
         "run_generation": t.run_generation,
         "error":      error,
+        "terminal": terminal,
         "failed_at":  t.failed_at.as_deref(),
     })
 }

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -52,6 +52,7 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
     let dashboard_counts = state.task_svc.count_for_dashboard().await;
     let global_done = dashboard_counts.global_done;
     let global_failed = dashboard_counts.global_failed;
+    let global_stalled = dashboard_counts.global_stalled;
 
     let merged_24h = state.task_svc.count_done_since(since_dt).await;
 
@@ -111,6 +112,7 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
         let counts = dashboard_counts.by_project.get(&key);
         let done = counts.map_or(0, |c| c.done);
         let failed = counts.map_or(0, |c| c.failed);
+        let stalled = counts.map_or(0, |c| c.stalled);
         let buckets = per_project_buckets
             .remove(&key)
             .unwrap_or_else(|| vec![0; THROUGHPUT_BUCKETS]);
@@ -122,6 +124,7 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
             "queued": active_project_counts.queued,
             "done": done,
             "failed": failed,
+            "stalled": stalled,
             "merged_24h": merged_window,
             "trend": buckets,
             "avg_score": Value::Null,
@@ -271,6 +274,7 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
             "review": 0,
             "merged": global_done,
             "failed": global_failed,
+            "stalled": global_stalled,
         },
         "throughput": {
             "hours": hours,
@@ -291,6 +295,7 @@ pub async fn overview(State(state): State<Arc<AppState>>) -> (StatusCode, Json<V
             "queued": queued,
             "done": global_done,
             "failed": global_failed,
+            "stalled": global_stalled,
             "max_concurrent": max_concurrent,
         },
     });

--- a/crates/harness-server/src/handlers/overview_tests.rs
+++ b/crates/harness-server/src/handlers/overview_tests.rs
@@ -404,6 +404,74 @@ async fn overview_returns_expected_shape() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn status_stalled_terminal_overview_counts_budget_exhaustion() -> anyhow::Result<()> {
+    let _lock = test_helpers::HOME_LOCK.lock().await;
+    if !test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let dir = test_helpers::tempdir_in_home("harness-test-overview-stalled-")?;
+    let canonical_root = dir.path().canonicalize()?;
+    let project_root = canonical_root.to_string_lossy().into_owned();
+    let state = Arc::new(test_helpers::make_test_state(dir.path()).await?);
+    state
+        .project_svc
+        .register(crate::project_registry::Project {
+            id: project_root.clone(),
+            root: canonical_root.clone(),
+            name: None,
+            max_concurrent: None,
+            default_agent: None,
+            active: true,
+            created_at: Utc::now().to_rfc3339(),
+        })
+        .await?;
+    let mut task = crate::task_runner::TaskState::new(harness_core::types::TaskId(
+        "overview-stalled-task".to_string(),
+    ));
+    task.project_root = Some(canonical_root.clone());
+    task.status = crate::task_runner::TaskStatus::Failed;
+    task.phase = crate::task_runner::TaskPhase::Terminal;
+    task.error = Some(
+        crate::task_runner::TaskTerminalFailure::round_budget_exhausted(
+            1,
+            crate::task_runner::TaskStatus::Reviewing,
+            Some("local_review_gate".to_string()),
+        )
+        .to_reason_string(),
+    );
+    task.scheduler
+        .mark_terminal(&crate::task_runner::TaskStatus::Failed);
+    state.core.tasks.insert(&task).await;
+
+    let app = Router::new()
+        .route("/api/overview", get(overview))
+        .with_state(state);
+    let req = axum::http::Request::builder()
+        .uri("/api/overview")
+        .body(axum::body::Body::empty())?;
+    let resp = tower::ServiceExt::oneshot(app, req).await?;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+    let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+
+    assert_eq!(body["distribution"]["failed"], 1);
+    assert_eq!(body["distribution"]["stalled"], 1);
+    assert_eq!(body["global"]["failed"], 1);
+    assert_eq!(body["global"]["stalled"], 1);
+    let project = body["projects"]
+        .as_array()
+        .and_then(|projects| {
+            projects
+                .iter()
+                .find(|project| project["root"].as_str() == Some(project_root.as_str()))
+        })
+        .ok_or_else(|| anyhow::anyhow!("overview project should be present"))?;
+    assert_eq!(project["failed"], 1);
+    assert_eq!(project["stalled"], 1);
+    Ok(())
+}
+
+#[tokio::test]
 async fn worktrees_used_includes_local_workspace_manager() -> anyhow::Result<()> {
     let _lock = test_helpers::HOME_LOCK.lock().await;
     if !test_helpers::db_tests_enabled().await {

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -15,7 +15,7 @@ use super::state::AppState;
 use crate::runtime_projection::{runtime_string_field, RuntimeWorkflowProjection};
 use crate::task_runner::{
     SchedulerAuthorityState, TaskId, TaskKind, TaskState, TaskStatus, TaskSummary,
-    TaskSummaryFilter, TaskSummaryPageCursor, TaskWorkflowSummary,
+    TaskSummaryFilter, TaskSummaryPageCursor, TaskTerminalInfo, TaskWorkflowSummary,
 };
 use harness_core::proof_of_work::{CiStatus, ProofOfWork, QualitySignal, ReviewOutcome};
 
@@ -54,11 +54,30 @@ struct TaskListCursor {
 
 #[derive(Serialize)]
 struct TaskListResponse {
-    data: Vec<TaskSummary>,
+    data: Vec<TaskSummaryResponse>,
     page: TaskListPage,
     counts: TaskListCounts,
     #[serde(skip_serializing_if = "Option::is_none")]
     degraded: Option<TaskListDegradation>,
+}
+
+#[derive(Serialize)]
+struct TaskSummaryResponse {
+    #[serde(flatten)]
+    inner: TaskSummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    terminal: Option<TaskTerminalInfo>,
+}
+
+impl From<TaskSummary> for TaskSummaryResponse {
+    fn from(summary: TaskSummary) -> Self {
+        let terminal =
+            TaskTerminalInfo::from_status_error(&summary.status, summary.error.as_deref());
+        Self {
+            inner: summary,
+            terminal,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -233,7 +252,7 @@ pub(crate) async fn list_tasks(
             let (data, page) = paginate_task_summaries(&summaries, &query);
             let counts = task_list_counts(&data);
             Json(TaskListResponse {
-                data,
+                data: data.into_iter().map(TaskSummaryResponse::from).collect(),
                 page,
                 counts,
                 degraded,

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -7,6 +7,8 @@ struct FullTaskResponse {
     #[serde(flatten)]
     inner: crate::task_runner::TaskState,
     #[serde(skip_serializing_if = "Option::is_none")]
+    terminal: Option<TaskTerminalInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     workflow: Option<TaskWorkflowSummary>,
 }
 
@@ -40,6 +42,8 @@ struct RuntimeTaskResponse {
     issue: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    terminal: Option<TaskTerminalInfo>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     depends_on: Vec<TaskId>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -62,8 +66,10 @@ pub(crate) async fn get_task(
     match state.core.tasks.get_with_db_fallback(&task_id).await {
         Ok(Some(task)) => {
             let workflow = enrich_task_workflow(&state, &task).await;
+            let terminal = TaskTerminalInfo::from_status_error(&task.status, task.error.as_deref());
             Json(FullTaskResponse {
                 inner: task,
+                terminal,
                 workflow,
             })
             .into_response()
@@ -137,6 +143,8 @@ async fn runtime_task_response_by_handle(
     let submission_id = submission_handle
         .map(|handle| handle.0)
         .unwrap_or_else(|| task_id.0.clone());
+    let error = runtime_string_field(&workflow.data, "failure_reason");
+    let terminal = TaskTerminalInfo::from_status_error(&task_status, error.as_deref());
     Ok(Some(RuntimeTaskResponse {
         id: submission_id.clone(),
         task_id: submission_id.clone(),
@@ -161,7 +169,8 @@ async fn runtime_task_response_by_handle(
             .map(ToOwned::to_owned),
         project: project_id,
         issue,
-        error: runtime_string_field(&workflow.data, "failure_reason"),
+        error,
+        terminal,
         depends_on: runtime_task_id_array(&workflow.data, "depends_on"),
         subtask_ids: Vec::new(),
         workflow: Some(TaskWorkflowSummary::from_runtime(&workflow)),

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -824,6 +824,72 @@ async fn get_task_runtime_issue_surfaces_failure_reason() -> anyhow::Result<()> 
 }
 
 #[tokio::test]
+async fn status_stalled_terminal_list_and_detail_surface_terminal_reason() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_read_only_route_test_state(dir.path()).await?;
+    let task_id = task_runner::TaskId::from_str("stalled-budget-task");
+    let mut task = task_runner::TaskState::new(task_id.clone());
+    task.status = task_runner::TaskStatus::Failed;
+    task.phase = task_runner::TaskPhase::Terminal;
+    task.turn = 2;
+    task.error = Some(
+        task_runner::TaskTerminalFailure::round_budget_exhausted(
+            1,
+            task_runner::TaskStatus::Reviewing,
+            Some("local_review_gate".to_string()),
+        )
+        .to_reason_string(),
+    );
+    task.scheduler
+        .mark_terminal(&task_runner::TaskStatus::Failed);
+    state.core.tasks.insert(&task).await;
+
+    let app = Router::new()
+        .route("/tasks", get(list_tasks))
+        .route("/tasks/{id}", get(get_task))
+        .with_state(state);
+
+    let list_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/tasks?status=failed")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let listed = response_json(list_response).await?;
+    let listed_task = listed["data"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["id"] == task_id.as_str()))
+        .ok_or_else(|| anyhow::anyhow!("stalled task should be listed"))?;
+    assert_eq!(listed_task["status"], "failed");
+    assert_eq!(listed_task["phase"], "terminal");
+    assert_eq!(listed_task["terminal"]["classification"], "stalled");
+    assert_eq!(listed_task["terminal"]["reason"], "round_budget_exhausted");
+    assert_eq!(listed_task["terminal"]["rounds_used"], 1);
+    assert_eq!(listed_task["terminal"]["last_status"], "reviewing");
+    assert_eq!(listed_task["terminal"]["waiting_on"], "local_review_gate");
+
+    let detail_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/tasks/{}", task_id.as_str()))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(detail_response.status(), StatusCode::OK);
+    let detail = response_json(detail_response).await?;
+    assert_eq!(detail["terminal"]["classification"], "stalled");
+    assert_eq!(detail["terminal"]["reason"], "round_budget_exhausted");
+    Ok(())
+}
+
+#[tokio::test]
 async fn list_tasks_includes_runtime_prompt_submissions() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/task_db/queries_metrics.rs
+++ b/crates/harness-server/src/task_db/queries_metrics.rs
@@ -1,4 +1,4 @@
-use crate::task_runner::{TaskState, TaskStatus};
+use crate::task_runner::{TaskState, TaskStatus, ROUND_BUDGET_EXHAUSTED_REASON};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
@@ -162,48 +162,59 @@ impl TaskDb {
         Ok(rows.into_iter().collect())
     }
 
-    /// Count done/failed tasks globally and per project.
+    /// Count done, failed, and round-budget-stalled tasks globally and per project.
     pub async fn count_done_failed_by_project(
         &self,
-    ) -> anyhow::Result<(u64, u64, Vec<(String, u64, u64)>)> {
+    ) -> anyhow::Result<(u64, u64, u64, Vec<(String, u64, u64, u64)>)> {
         super::record_task_db_usage();
         let outcome_statuses = [TaskStatus::Done.as_ref(), TaskStatus::Failed.as_ref()];
+        let stalled_pattern = format!("%\"reason\":\"{ROUND_BUDGET_EXHAUSTED_REASON}\"%");
+        let stalled_param = outcome_statuses.len() + 2;
         let global_sql = format!(
             "SELECT COUNT(CASE WHEN status = 'done' THEN 1 END), \
-                    COUNT(CASE WHEN status = 'failed' THEN 1 END) \
+                    COUNT(CASE WHEN status = 'failed' THEN 1 END), \
+                    COUNT(CASE WHEN status = 'failed' AND error LIKE ${stalled_param} THEN 1 END) \
              FROM tasks WHERE store_key = $1 AND status IN ({})",
             Self::numbered_placeholders(2, outcome_statuses.len())
         );
-        let global: (i64, i64) = outcome_statuses
+        let global: (i64, i64, i64) = outcome_statuses
             .iter()
             .fold(
                 sqlx::query_as(&global_sql).bind(&self.store_key),
                 |q, status| q.bind(*status),
             )
+            .bind(&stalled_pattern)
             .fetch_one(&self.pool)
             .await?;
         let rows_sql = format!(
             "SELECT project, \
                     COUNT(CASE WHEN status = 'done' THEN 1 END), \
-                    COUNT(CASE WHEN status = 'failed' THEN 1 END) \
+                    COUNT(CASE WHEN status = 'failed' THEN 1 END), \
+                    COUNT(CASE WHEN status = 'failed' AND error LIKE ${stalled_param} THEN 1 END) \
              FROM tasks \
              WHERE store_key = $1 AND status IN ({}) AND project IS NOT NULL \
              GROUP BY project",
             Self::numbered_placeholders(2, outcome_statuses.len())
         );
-        let rows: Vec<(String, i64, i64)> = outcome_statuses
+        let rows: Vec<(String, i64, i64, i64)> = outcome_statuses
             .iter()
             .fold(
                 sqlx::query_as(&rows_sql).bind(&self.store_key),
                 |q, status| q.bind(*status),
             )
+            .bind(&stalled_pattern)
             .fetch_all(&self.pool)
             .await?;
         let by_project = rows
             .into_iter()
-            .map(|(p, d, f)| (p, d as u64, f as u64))
+            .map(|(p, d, f, s)| (p, d as u64, f as u64, s as u64))
             .collect();
-        Ok((global.0 as u64, global.1 as u64, by_project))
+        Ok((
+            global.0 as u64,
+            global.1 as u64,
+            global.2 as u64,
+            by_project,
+        ))
     }
 
     /// Count tasks that reached `done` status with `updated_at >= since`.

--- a/crates/harness-server/src/task_runner/metrics.rs
+++ b/crates/harness-server/src/task_runner/metrics.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 pub struct ProjectCounts {
     pub done: u64,
     pub failed: u64,
+    pub stalled: u64,
 }
 
 /// Combined global and per-project done/failed counts produced by a single
@@ -14,6 +15,7 @@ pub struct ProjectCounts {
 pub struct DashboardCounts {
     pub global_done: u64,
     pub global_failed: u64,
+    pub global_stalled: u64,
     pub by_project: HashMap<String, ProjectCounts>,
 }
 

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -36,8 +36,8 @@ use store::{
 };
 pub use store::{TaskStore, TaskSummaryFilter, TaskSummaryPageCursor, TerminalTransition};
 pub use types::{
-    TaskFailureKind, TaskId, TaskKind, TaskPhase, TaskStatus, TaskTerminalFailure,
-    TaskTerminalOutcome,
+    TaskFailureKind, TaskId, TaskKind, TaskPhase, TaskStatus, TaskTerminalClassification,
+    TaskTerminalFailure, TaskTerminalInfo, TaskTerminalOutcome, ROUND_BUDGET_EXHAUSTED_REASON,
 };
 
 fn record_task_runner_usage() {

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -870,14 +870,24 @@ impl TaskStore {
     pub async fn count_for_dashboard(&self) -> DashboardCounts {
         record_task_runner_usage();
         match self.db.count_done_failed_by_project().await {
-            Ok((global_done, global_failed, rows)) => {
+            Ok((global_done, global_failed, global_stalled, rows)) => {
                 let by_project = rows
                     .into_iter()
-                    .map(|(project, done, failed)| (project, ProjectCounts { done, failed }))
+                    .map(|(project, done, failed, stalled)| {
+                        (
+                            project,
+                            ProjectCounts {
+                                done,
+                                failed,
+                                stalled,
+                            },
+                        )
+                    })
                     .collect();
                 DashboardCounts {
                     global_done,
                     global_failed,
+                    global_stalled,
                     by_project,
                 }
             }
@@ -886,6 +896,7 @@ impl TaskStore {
                 DashboardCounts {
                     global_done: 0,
                     global_failed: 0,
+                    global_stalled: 0,
                     by_project: HashMap::new(),
                 }
             }

--- a/crates/harness-server/src/task_runner/types.rs
+++ b/crates/harness-server/src/task_runner/types.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 pub type TaskId = CoreTaskId;
 
+pub const ROUND_BUDGET_EXHAUSTED_REASON: &str = "round_budget_exhausted";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskKind {
@@ -208,7 +210,7 @@ impl TaskTerminalFailure {
         waiting_on: Option<String>,
     ) -> Self {
         Self::new(
-            "round_budget_exhausted",
+            ROUND_BUDGET_EXHAUSTED_REASON,
             rounds_used,
             last_status,
             waiting_on,
@@ -218,6 +220,71 @@ impl TaskTerminalFailure {
     pub fn to_reason_string(&self) -> String {
         serde_json::to_string(self).unwrap_or_else(|_| self.reason.clone())
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskTerminalClassification {
+    Done,
+    Failed,
+    Stalled,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskTerminalInfo {
+    pub status: TaskStatus,
+    pub classification: TaskTerminalClassification,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rounds_used: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_status: Option<TaskStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub waiting_on: Option<String>,
+}
+
+impl TaskTerminalInfo {
+    pub fn from_status_error(status: &TaskStatus, error: Option<&str>) -> Option<Self> {
+        if !status.is_terminal() {
+            return None;
+        }
+        let failure = error.and_then(parse_terminal_failure);
+        let classification = match status {
+            TaskStatus::Done => TaskTerminalClassification::Done,
+            TaskStatus::Cancelled => TaskTerminalClassification::Cancelled,
+            TaskStatus::Failed
+                if failure
+                    .as_ref()
+                    .is_some_and(|failure| failure.reason == ROUND_BUDGET_EXHAUSTED_REASON) =>
+            {
+                TaskTerminalClassification::Stalled
+            }
+            TaskStatus::Failed => TaskTerminalClassification::Failed,
+            _ => return None,
+        };
+        let reason = failure
+            .as_ref()
+            .map(|failure| failure.reason.clone())
+            .or_else(|| error.map(ToOwned::to_owned));
+        Some(Self {
+            status: status.clone(),
+            classification,
+            reason,
+            rounds_used: failure.as_ref().map(|failure| failure.rounds_used),
+            last_status: failure.as_ref().map(|failure| failure.last_status.clone()),
+            waiting_on: failure.and_then(|failure| failure.waiting_on),
+        })
+    }
+
+    pub fn is_stalled(&self) -> bool {
+        self.classification == TaskTerminalClassification::Stalled
+    }
+}
+
+pub fn parse_terminal_failure(error: &str) -> Option<TaskTerminalFailure> {
+    serde_json::from_str::<TaskTerminalFailure>(error).ok()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/web/src/components/ProjectsTable.test.tsx
+++ b/web/src/components/ProjectsTable.test.tsx
@@ -23,6 +23,7 @@ const p: OverviewProject = {
   queued: 4,
   done: 28,
   failed: 1,
+  stalled: 0,
   merged_24h: 28,
   trend: [1, 2, 3, 4],
   avg_score: 92,

--- a/web/src/routes/Overview.test.tsx
+++ b/web/src/routes/Overview.test.tsx
@@ -56,6 +56,7 @@ function makeOverview(): OverviewPayload {
       review: 0,
       merged: 0,
       failed: 0,
+      stalled: 0,
     },
     throughput: {
       hours: [],
@@ -76,6 +77,7 @@ function makeOverview(): OverviewPayload {
       queued: 0,
       done: 0,
       failed: 0,
+      stalled: 0,
       max_concurrent: 1,
     },
   };

--- a/web/src/routes/Overview.tsx
+++ b/web/src/routes/Overview.tsx
@@ -38,6 +38,13 @@ export function Overview() {
   const isSystemHealthy = !isError && !isOperatorSnapshotError;
   const agentTokens = [...(data?.agent_tokens ?? [])].sort((a, b) => b.tokens_24h - a.tokens_24h);
   const maxAgentTokens = Math.max(...agentTokens.map((a) => a.tokens_24h), 0);
+  const distribution = data?.distribution;
+  const distributionTotal =
+    (distribution?.queued ?? 0) +
+    (distribution?.running ?? 0) +
+    (distribution?.review ?? 0) +
+    (distribution?.merged ?? 0) +
+    (distribution?.failed ?? 0);
 
   const sections: SidebarSection[] = [
     {
@@ -125,13 +132,13 @@ export function Overview() {
             </Panel>
             <Panel
               title="Task distribution"
-              sub={`${fmtInt(Object.values(data?.distribution ?? {}).reduce((a, b) => a + b, 0))} tasks`}
+              sub={`${fmtInt(distributionTotal)} tasks`}
             >
               <div className="p-5">
                 <div className="font-mono text-[11px] text-ink-3">
                   queued {fmtInt(data?.distribution.queued)} · running {fmtInt(data?.distribution.running)} · review{" "}
                   {fmtInt(data?.distribution.review)} · merged {fmtInt(data?.distribution.merged)} · failed{" "}
-                  {fmtInt(data?.distribution.failed)}
+                  {fmtInt(data?.distribution.failed)} · stalled {fmtInt(data?.distribution.stalled)}
                 </div>
                 <div className="mt-5 border-t border-line pt-4">
                   <div className="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3">Agent usage</div>

--- a/web/src/routes/dashboard/Channels.test.tsx
+++ b/web/src/routes/dashboard/Channels.test.tsx
@@ -31,8 +31,8 @@ const hosts = [
 ];
 
 const projects = [
-  { id: "harness", root: "/srv/repos/harness", tasks: { running: 0, queued: 0, done: 0, failed: 0 }, latest_pr: null },
-  { id: "other", root: "/srv/repos/other", tasks: { running: 0, queued: 0, done: 0, failed: 0 }, latest_pr: null },
+  { id: "harness", root: "/srv/repos/harness", tasks: { running: 0, queued: 0, done: 0, failed: 0, stalled: 0 }, latest_pr: null },
+  { id: "other", root: "/srv/repos/other", tasks: { running: 0, queued: 0, done: 0, failed: 0, stalled: 0 }, latest_pr: null },
 ];
 
 beforeEach(() => {

--- a/web/src/routes/dashboard/History.test.tsx
+++ b/web/src/routes/dashboard/History.test.tsx
@@ -147,4 +147,41 @@ describe("<History>", () => {
       "/dashboard?tab=submit&project=harness",
     );
   });
+
+  it("renders budget-exhausted terminal failures as stalled with reason", () => {
+    mockUseAllTasks.mockReturnValue({
+      data: historyTaskList([
+        makeHistoryTask("stalled-budget", {
+          status: "failed",
+          description: "Review budget stopped",
+          error:
+            '{"reason":"round_budget_exhausted","rounds_used":1,"last_status":"reviewing","waiting_on":"local_review_gate"}',
+          terminal: {
+            status: "failed",
+            classification: "stalled",
+            reason: "round_budget_exhausted",
+            rounds_used: 1,
+            last_status: "reviewing",
+            waiting_on: "local_review_gate",
+          },
+        }),
+        makeHistoryTask("plain-failed", {
+          status: "failed",
+          description: "Plain failure",
+          error: "agent crashed",
+        }),
+      ]),
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<History />);
+
+    expect(screen.getAllByText("Stalled").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("round budget exhausted · waiting on local review gate")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "stalled" } });
+    expect(screen.getByText("Review budget stopped")).toBeInTheDocument();
+    expect(screen.queryByText("Plain failure")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/routes/dashboard/History.tsx
+++ b/web/src/routes/dashboard/History.tsx
@@ -9,6 +9,7 @@ interface Props {
 
 const PAGE_SIZE = 20;
 const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled"]);
+type HistoryFilter = "all" | "done" | "failed" | "stalled";
 
 function timestampValue(value: string | null | undefined): number {
   if (!value) return 0;
@@ -23,6 +24,11 @@ function statusLabel(status: string): string {
   return status;
 }
 
+function taskStatusLabel(task: Task): string {
+  if (task.terminal?.classification === "stalled") return "Stalled";
+  return statusLabel(task.status);
+}
+
 function statusClass(status: string): string {
   if (status === "done") return "border-mint/40 bg-mint/10 text-mint";
   if (status === "failed") return "border-rust/40 bg-rust/10 text-rust";
@@ -30,11 +36,29 @@ function statusClass(status: string): string {
   return "border-line bg-bg text-ink-2";
 }
 
+function taskStatusClass(task: Task): string {
+  if (task.terminal?.classification === "stalled") return "border-warn/40 bg-warn/10 text-warn";
+  return statusClass(task.status);
+}
+
 function taskTitle(task: Task): string {
   const title = task.description?.trim();
   if (title) return title;
   if (task.repo) return task.repo;
   return task.id.slice(0, 8);
+}
+
+function formatReason(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+function terminalReason(task: Task): string | null {
+  if (task.terminal?.classification !== "stalled") return null;
+  const parts = [
+    task.terminal.reason ? formatReason(task.terminal.reason) : null,
+    task.terminal.waiting_on ? `waiting on ${formatReason(task.terminal.waiting_on)}` : null,
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(" · ") : "stalled";
 }
 
 function prLabel(prUrl: string): string {
@@ -45,7 +69,9 @@ function prLabel(prUrl: string): string {
 function matchesQuery(task: Task, query: string): boolean {
   const q = query.trim().toLowerCase();
   if (!q) return true;
-  return [task.description, task.repo, task.pr_url].some((value) => value?.toLowerCase().includes(q));
+  return [task.description, task.repo, task.pr_url, task.terminal?.reason, task.terminal?.waiting_on].some((value) =>
+    value?.toLowerCase().includes(q),
+  );
 }
 
 function sortHistoryTasks(tasks: Task[]): Task[] {
@@ -57,7 +83,7 @@ function sortHistoryTasks(tasks: Task[]): Task[] {
 }
 
 export function History({ projectFilter }: Props) {
-  const [filter, setFilter] = useState<"all" | "done" | "failed">("all");
+  const [filter, setFilter] = useState<HistoryFilter>("all");
   const [query, setQuery] = useState("");
   const [page, setPage] = useState(1);
   const { data: dashboard } = useDashboard();
@@ -77,6 +103,7 @@ export function History({ projectFilter }: Props) {
     const statusFiltered =
       data?.data.filter((task) => {
         if (!TERMINAL_STATUSES.has(task.status)) return false;
+        if (filter === "stalled") return task.terminal?.classification === "stalled" && matchesQuery(task, query);
         if (filter !== "all" && task.status !== filter) return false;
         return matchesQuery(task, query);
       }) ?? [];
@@ -102,12 +129,13 @@ export function History({ projectFilter }: Props) {
         />
         <select
           value={filter}
-          onChange={(e) => setFilter(e.target.value as "all" | "done" | "failed")}
+          onChange={(e) => setFilter(e.target.value as HistoryFilter)}
           className="h-[30px] bg-bg-1 border border-line-2 text-ink font-mono text-[12px] px-2 rounded-[3px]"
         >
           <option value="all">All</option>
           <option value="done">Done</option>
           <option value="failed">Failed</option>
+          <option value="stalled">Stalled</option>
         </select>
       </div>
 
@@ -153,8 +181,8 @@ export function History({ projectFilter }: Props) {
                       {task.created_at ? relativeAgo(task.created_at) : "—"}
                     </td>
                     <td className="px-3 py-2">
-                      <span className={`inline-block border px-1.5 py-[1px] font-mono text-[10px] ${statusClass(task.status)}`}>
-                        {statusLabel(task.status)}
+                      <span className={`inline-block border px-1.5 py-[1px] font-mono text-[10px] ${taskStatusClass(task)}`}>
+                        {taskStatusLabel(task)}
                       </span>
                     </td>
                     <td className="px-3 py-2">
@@ -162,6 +190,11 @@ export function History({ projectFilter }: Props) {
                         {taskTitle(task)}
                       </div>
                       <div className="mt-1 font-mono text-[10px] text-ink-4">{task.id.slice(0, 8)}</div>
+                      {terminalReason(task) && (
+                        <div className="mt-1 line-clamp-1 font-mono text-[10px] text-warn" title={terminalReason(task) ?? undefined}>
+                          {terminalReason(task)}
+                        </div>
+                      )}
                     </td>
                     <td className="px-3 py-2 font-mono text-[11px] text-ink-3">
                       <span className="block truncate" title={task.repo ?? undefined}>

--- a/web/src/routes/dashboard/Submit.test.tsx
+++ b/web/src/routes/dashboard/Submit.test.tsx
@@ -46,8 +46,8 @@ function wrap(ui: React.ReactElement) {
 }
 
 const PROJECTS = [
-  { id: "alpha", root: "/alpha", agents: ["claude", "codex"], running: 0, queued: 0, done: 0, failed: 0, merged_24h: 0, trend: [], avg_score: null, worktrees: null, tokens_24h: null, latest_pr: null },
-  { id: "beta", root: "/beta", agents: ["gemini"], running: 0, queued: 0, done: 0, failed: 0, merged_24h: 0, trend: [], avg_score: null, worktrees: null, tokens_24h: null, latest_pr: null },
+  { id: "alpha", root: "/alpha", agents: ["claude", "codex"], running: 0, queued: 0, done: 0, failed: 0, stalled: 0, merged_24h: 0, trend: [], avg_score: null, worktrees: null, tokens_24h: null, latest_pr: null },
+  { id: "beta", root: "/beta", agents: ["gemini"], running: 0, queued: 0, done: 0, failed: 0, stalled: 0, merged_24h: 0, trend: [], avg_score: null, worktrees: null, tokens_24h: null, latest_pr: null },
 ];
 
 beforeEach(() => {

--- a/web/src/routes/overview/OperatorPanel.test.tsx
+++ b/web/src/routes/overview/OperatorPanel.test.tsx
@@ -110,4 +110,34 @@ describe("<OperatorPanel>", () => {
 
     expect(screen.getByText("Runtime log path unavailable.")).toBeInTheDocument();
   });
+
+  it("renders stalled terminal failures with a readable reason", () => {
+    const snapshot = makeSnapshot();
+    snapshot.recent_failures = [
+      {
+        task_id: "failed-1",
+        external_id: "issue:2",
+        project: "proj",
+        error:
+          '{"reason":"round_budget_exhausted","rounds_used":1,"last_status":"reviewing","waiting_on":"local_review_gate"}',
+        terminal: {
+          status: "failed",
+          classification: "stalled",
+          reason: "round_budget_exhausted",
+          rounds_used: 1,
+          last_status: "reviewing",
+          waiting_on: "local_review_gate",
+        },
+        failed_at: null,
+      },
+    ];
+    mockUseOperatorSnapshot.mockReturnValue({
+      data: snapshot,
+      isError: false,
+    });
+
+    wrap(<OperatorPanel />);
+
+    expect(screen.getByText("Stalled: round budget exhausted · waiting on local review gate")).toBeInTheDocument();
+  });
 });

--- a/web/src/routes/overview/OperatorPanel.tsx
+++ b/web/src/routes/overview/OperatorPanel.tsx
@@ -13,6 +13,17 @@ function timeAgo(iso: string | null | undefined): string {
   return `${Math.floor(secs / 86400)}d`;
 }
 
+function formatReason(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+function failureMessage(failure: RecentFailure): string {
+  if (failure.terminal?.classification !== "stalled") return failure.error;
+  const reason = failure.terminal.reason ? formatReason(failure.terminal.reason) : "stalled";
+  const waitingOn = failure.terminal.waiting_on ? ` · waiting on ${formatReason(failure.terminal.waiting_on)}` : "";
+  return `Stalled: ${reason}${waitingOn}`;
+}
+
 function Counter({ label, value }: { label: string; value: number }) {
   return (
     <div className="flex flex-col items-center gap-0.5 px-4 py-2 border-r border-line last:border-r-0">
@@ -37,7 +48,7 @@ function FailureRow({ failure }: { failure: RecentFailure }) {
   return (
     <div className="flex items-center gap-3 px-4 py-1.5 border-b border-line last:border-b-0 font-mono text-[11px]">
       <span className="text-ink-2 truncate w-32">{failure.external_id}</span>
-      <span className="text-rust truncate flex-1">{failure.error}</span>
+      <span className="text-rust truncate flex-1">{failureMessage(failure)}</span>
       <span className="text-ink-4 shrink-0">{timeAgo(failure.failed_at)}</span>
     </div>
   );

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -3,6 +3,7 @@ export interface DashboardProjectTasks {
   queued: number;
   done: number;
   failed: number;
+  stalled: number;
 }
 
 export interface DashboardProject {
@@ -38,6 +39,7 @@ export interface DashboardGlobal {
   uptime_secs: number;
   done: number;
   failed: number;
+  stalled: number;
   latest_pr: string | null;
   grade: string | null;
   runtime_hosts_total: number;

--- a/web/src/types/operator_snapshot.ts
+++ b/web/src/types/operator_snapshot.ts
@@ -19,6 +19,7 @@ export interface RecentFailure {
   external_id: string;
   project: string;
   error: string;
+  terminal?: import("./task").TaskTerminalInfo | null;
   failed_at: string | null;
 }
 

--- a/web/src/types/overview.ts
+++ b/web/src/types/overview.ts
@@ -25,6 +25,7 @@ export interface OverviewDistribution {
   review: number;
   merged: number;
   failed: number;
+  stalled: number;
 }
 
 export interface OverviewThroughputSeries {
@@ -49,6 +50,7 @@ export interface OverviewProject {
   queued: number;
   done: number;
   failed: number;
+  stalled: number;
   merged_24h: number;
   trend: number[];
   avg_score: number | null;
@@ -104,6 +106,7 @@ export interface OverviewGlobal {
   queued: number;
   done: number;
   failed: number;
+  stalled: number;
   max_concurrent: number;
 }
 

--- a/web/src/types/task.ts
+++ b/web/src/types/task.ts
@@ -15,6 +15,7 @@ export interface Task {
   turn: number;
   pr_url: string | null;
   error: string | null;
+  terminal?: TaskTerminalInfo | null;
   source: string | null;
   parent_id: string | null;
   external_id: string | null;
@@ -28,6 +29,15 @@ export interface Task {
   project: string | null;
   workflow?: WorkflowSummary | null;
   scheduler: TaskSchedulerState;
+}
+
+export interface TaskTerminalInfo {
+  status: string;
+  classification: "done" | "failed" | "stalled" | "cancelled" | string;
+  reason?: string | null;
+  rounds_used?: number | null;
+  last_status?: string | null;
+  waiting_on?: string | null;
 }
 
 export interface TaskSchedulerOwner {


### PR DESCRIPTION
## Summary

- Add structured `terminal` metadata to task list/detail responses so round-budget exhaustion is classified as `stalled` while preserving `status: failed` compatibility.
- Add stalled subset counts to `/api/dashboard` and `/api/overview` without double-counting stalled tasks as a separate terminal status.
- Render stalled terminal rows and readable reasons in the React History and overview operator failure surfaces.

Linked work: #1465
SpecRail: GH1465 / SP1465-T004 only. Remaining GH1465 tasks include T003 spawn exit guard, T005 recovery/no-limbo coverage, and T006 liveness audit.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p harness-server status_stalled_terminal`
- `RUSTFLAGS="-Dwarnings" cargo check -p harness-server --all-targets`
- `cd web && bun run typecheck`
- `cd web && bun run test src/routes/dashboard/History.test.tsx src/routes/overview/OperatorPanel.test.tsx`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1465`
