### PR TITLE
fix(runtime): surface circuit breaker health

### DIFF
--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -49,6 +49,10 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
     let dirty = state.is_runtime_state_dirty();
     let degraded = &state.degraded_subsystems;
     let runtime_logs = &state.core.server.runtime_logs;
+    let circuit_breakers = state.runtime_circuit_breakers.snapshots(chrono::Utc::now());
+    let runtime_degraded = circuit_breakers
+        .iter()
+        .any(|breaker| breaker.state != "closed");
     let startup_statuses: Vec<serde_json::Value> = state
         .startup_statuses
         .iter()
@@ -61,7 +65,7 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
             })
         })
         .collect();
-    let status = if degraded.is_empty() && !dirty {
+    let status = if degraded.is_empty() && !dirty && !runtime_degraded {
         "ok"
     } else {
         "degraded"
@@ -80,6 +84,9 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
             "state": runtime_logs.state.as_str(),
             "path_hint": runtime_logs.path_hint.clone(),
             "retention_days": runtime_logs.retention_days,
+        },
+        "runtime": {
+            "circuit_breakers": circuit_breakers,
         }
     }))
 }

--- a/crates/harness-server/src/http/tests/health_route_tests.rs
+++ b/crates/harness-server/src/http/tests/health_route_tests.rs
@@ -62,6 +62,39 @@ async fn health_runtime_logs_can_report_degraded_without_raw_error_text() -> any
 }
 
 #[tokio::test]
+async fn health_degraded_when_runtime_circuit_breaker_open() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_read_only_route_test_state(dir.path()).await?;
+    let now = Utc::now();
+    for index in 0..5 {
+        state.runtime_circuit_breakers.record_failure(
+            "codex-high",
+            &format!("job-{index}"),
+            crate::runtime_circuit_breaker::FailureClass::ZeroOutputSpawnFailure,
+            now,
+        );
+    }
+
+    let health = call_health(state).await?;
+
+    assert_eq!(health.status, "degraded");
+    let breakers = health.runtime["circuit_breakers"]
+        .as_array()
+        .expect("runtime circuit breakers should be an array");
+    assert_eq!(breakers.len(), 1);
+    assert_eq!(breakers[0]["profile"], "codex-high");
+    assert_eq!(breakers[0]["state"], "open");
+    assert_eq!(breakers[0]["class"], "zero-output-spawn-failure");
+    assert_eq!(breakers[0]["consecutive"], 5);
+    assert!(breakers[0]["cooldown_until"].is_string());
+    Ok(())
+}
+
+#[tokio::test]
 async fn health_startup_errors_are_redacted() -> anyhow::Result<()> {
     let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = tempfile::tempdir()?;

--- a/crates/harness-server/src/http/tests/route_helpers.rs
+++ b/crates/harness-server/src/http/tests/route_helpers.rs
@@ -496,6 +496,7 @@ pub(super) struct HealthResponse {
     pub(super) tasks: u64,
     pub(super) persistence: PersistenceBlock,
     pub(super) runtime_logs: RuntimeLogsBlock,
+    pub(super) runtime: serde_json::Value,
 }
 
 #[derive(serde::Deserialize, Debug)]


### PR DESCRIPTION
## Summary
- Mark /health as degraded when a runtime circuit breaker is open or half-open.
- Expose runtime circuit breaker snapshots under runtime.circuit_breakers using the existing snapshot shape.
- Add a health-route regression for zero-output spawn failure breaker state.

Related: #1478

## Verification
- cargo fmt --all -- --check
- cargo test -p harness-server health_degraded_when_runtime_circuit_breaker_open
- cargo check -p harness-server --all-targets
- python3 checks/check_workflow.py --repo .
- RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets