### PR TITLE
fix(runtime): cover recovery no-limbo exits

### DIFF
--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -734,9 +734,16 @@ where
                     .await;
             }
             Err(join_err) if join_err.is_cancelled() => {
-                // abort() was called by the cancel endpoint; status already set to
-                // Cancelled before abort() was called — do not overwrite with Failed.
+                // User cancellation persists Cancelled before abort(). Shutdown-style
+                // aborts do not, so the exit guard terminalizes any non-terminal row.
                 tracing::info!("task {id_watcher:?} cancelled via abort");
+                ensure_terminal_or_requeued_on_spawn_exit(
+                    &store_watcher,
+                    &events_watcher,
+                    &id_watcher,
+                    "spawn_task_aborted",
+                )
+                .await;
                 if let Some(wmgr) = workspace_mgr_watcher.as_ref() {
                     let final_state = store_watcher.get(&id_watcher);
                     if should_remove_workspace_after_task(

--- a/crates/harness-server/src/task_runner/spawn_tests/mod.rs
+++ b/crates/harness-server/src/task_runner/spawn_tests/mod.rs
@@ -270,6 +270,93 @@ async fn spawn_exit_paths_guard_terminalizes_running_waiting_state() -> anyhow::
 }
 
 #[tokio::test]
+async fn recovery_no_limbo_shutdown_abort_terminalizes_running_task() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let dir = crate::test_helpers::tempdir_in_home("harness-test-shutdown-abort-")?;
+    let database_url = crate::test_helpers::test_database_url()?;
+    let store = TaskStore::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(dir.path(), "tasks"),
+        Some(&database_url),
+    )
+    .await?;
+    let skills = Arc::new(RwLock::new(harness_skills::store::SkillStore::new()));
+    let events = Arc::new(
+        harness_observe::event_store::EventStore::new_with_database_url(
+            dir.path(),
+            Some(&database_url),
+        )
+        .await?,
+    );
+    let agent = helpers::BlockingAgent::new();
+    let req = CreateTaskRequest {
+        project: Some(dir.path().to_path_buf()),
+        prompt: Some("block until shutdown abort".to_string()),
+        wait_secs: 0,
+        max_rounds: Some(1),
+        turn_timeout_secs: 3600,
+        ..Default::default()
+    };
+
+    let queue = crate::task_queue::TaskQueue::unbounded();
+    let permit = queue.acquire("test", 0).await?;
+    let task_id = spawn_task(
+        store.clone(),
+        agent.clone(),
+        None,
+        Default::default(),
+        skills,
+        events,
+        vec![],
+        req,
+        None,
+        permit,
+        None,
+        None,
+        None,
+        vec![],
+    )
+    .await;
+
+    agent.wait_started(Duration::from_secs(15)).await?;
+    assert!(
+        store.abort_task(&task_id),
+        "running task should have an abort handle"
+    );
+    helpers::wait_until(Duration::from_secs(15), || {
+        store
+            .get(&task_id)
+            .is_some_and(|state| matches!(state.status, TaskStatus::Failed))
+    })
+    .await?;
+
+    let final_state = store
+        .get(&task_id)
+        .ok_or_else(|| anyhow::anyhow!("task should remain in store"))?;
+    assert_eq!(final_state.failure_kind, Some(TaskFailureKind::Task));
+    assert_eq!(
+        final_state.scheduler.authority_state,
+        SchedulerAuthorityState::Failed
+    );
+    assert!(
+        final_state
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("spawn exit invariant violated")),
+        "shutdown abort must terminalize instead of leaving a running task in limbo"
+    );
+    let guard_round = final_state
+        .rounds
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("shutdown abort should record a diagnostic round"))?;
+    assert_eq!(guard_round.action, "spawn_exit_guard");
+    assert_eq!(guard_round.result, "nonterminal_exit");
+    Ok(())
+}
+
+#[tokio::test]
 async fn cancelled_abort_releases_workspace_after_watcher_observes_join() -> anyhow::Result<()> {
     let _lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = crate::test_helpers::tempdir_in_home("harness-test-")?;

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -62,6 +62,26 @@ where
     Ok(store)
 }
 
+async fn recovered_task(store: &TaskStore, id: &str) -> anyhow::Result<TaskState> {
+    store
+        .get_with_db_fallback(&CoreTaskId(id.to_string()))
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("{id} should be fetchable after recovery"))
+}
+
+fn assert_not_limbo(task: &TaskState) {
+    assert!(
+        !task.status.is_inflight(),
+        "{} recovered into in-flight limbo status {:?}",
+        task.id.0,
+        task.status
+    );
+}
+
+fn database_tests_configured() -> bool {
+    std::env::var("HARNESS_DATABASE_URL").is_ok_and(|url| !url.trim().is_empty())
+}
+
 /// Restart with no checkpoints: all interrupted tasks (implementing, agent_review,
 /// reviewing, waiting) must become Failed; Pending/Done/Failed are left unchanged.
 #[tokio::test]
@@ -126,6 +146,111 @@ async fn restart_no_checkpoint_fails_interrupted_tasks() -> anyhow::Result<()> {
         .expect("DB query should not fail")
         .expect("t-failed must be fetchable from DB");
     assert!(matches!(failed.status, TaskStatus::Failed));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn recovery_no_limbo_restart_mid_review_states_resume_or_terminalize() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
+    let store = setup_store(|db| async move {
+        let mut review_with_pr = make_task("review-with-pr", TaskStatus::AgentReview);
+        review_with_pr.pr_url = Some("https://github.com/owner/repo/pull/1465".to_string());
+        db.insert(&review_with_pr).await?;
+
+        db.insert(&make_task("review-with-plan", TaskStatus::ReviewGenerating))
+            .await?;
+        db.write_checkpoint(
+            "review-with-plan",
+            None,
+            Some("persisted implementation plan"),
+            None,
+            "plan_done",
+        )
+        .await?;
+
+        db.insert(&make_task("reviewing-no-checkpoint", TaskStatus::Reviewing))
+            .await?;
+        db.insert(&make_task("waiting-no-checkpoint", TaskStatus::Waiting))
+            .await?;
+        Ok(())
+    })
+    .await?;
+
+    let review_with_pr = recovered_task(&store, "review-with-pr").await?;
+    assert_not_limbo(&review_with_pr);
+    assert_eq!(review_with_pr.status, TaskStatus::Pending);
+    assert!(matches!(
+        review_with_pr.scheduler.authority_state,
+        harness_server::task_runner::SchedulerAuthorityState::Recovering
+    ));
+
+    let review_with_plan = recovered_task(&store, "review-with-plan").await?;
+    assert_not_limbo(&review_with_plan);
+    assert_eq!(review_with_plan.status, TaskStatus::Pending);
+    assert!(matches!(
+        review_with_plan.scheduler.authority_state,
+        harness_server::task_runner::SchedulerAuthorityState::Recovering
+    ));
+
+    for id in ["reviewing-no-checkpoint", "waiting-no-checkpoint"] {
+        let task = recovered_task(&store, id).await?;
+        assert_not_limbo(&task);
+        assert_eq!(task.status, TaskStatus::Failed);
+        assert!(
+            task.error
+                .as_deref()
+                .is_some_and(|error| error.contains("recovered after restart")),
+            "{id} should carry a restart recovery failure reason"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn recovery_no_limbo_shutdown_drain_states_are_queued_or_terminal() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
+    let store = setup_store(|db| async move {
+        db.insert(&make_task("drained-pending", TaskStatus::Pending))
+            .await?;
+
+        let mut implementing = make_task("drained-implementing", TaskStatus::Implementing);
+        implementing.scheduler.claim_scheduler("shutdown-worker");
+        db.insert(&implementing).await?;
+
+        let mut review_waiting = make_task("drained-review-waiting", TaskStatus::ReviewWaiting);
+        review_waiting.scheduler.claim_scheduler("shutdown-worker");
+        db.insert(&review_waiting).await?;
+        Ok(())
+    })
+    .await?;
+
+    let pending = recovered_task(&store, "drained-pending").await?;
+    assert_not_limbo(&pending);
+    assert_eq!(pending.status, TaskStatus::Pending);
+    assert!(matches!(
+        pending.scheduler.authority_state,
+        harness_server::task_runner::SchedulerAuthorityState::Queued
+    ));
+
+    for id in ["drained-implementing", "drained-review-waiting"] {
+        let task = recovered_task(&store, id).await?;
+        assert_not_limbo(&task);
+        assert_eq!(task.status, TaskStatus::Failed);
+        assert!(
+            task.error
+                .as_deref()
+                .is_some_and(|error| error.contains("recovered after restart")),
+            "{id} should carry a restart recovery failure reason"
+        );
+    }
 
     Ok(())
 }

--- a/crates/harness-server/tests/checkpoint_recovery.rs
+++ b/crates/harness-server/tests/checkpoint_recovery.rs
@@ -86,6 +86,10 @@ fn database_tests_configured() -> bool {
 /// reviewing, waiting) must become Failed; Pending/Done/Failed are left unchanged.
 #[tokio::test]
 async fn restart_no_checkpoint_fails_interrupted_tasks() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
     let store = setup_store(|db| async move {
         db.insert(&make_task("t-impl", TaskStatus::Implementing))
             .await?;
@@ -259,6 +263,10 @@ async fn recovery_no_limbo_shutdown_drain_states_are_queued_or_terminal() -> any
 /// error message referencing the PR URL.
 #[tokio::test]
 async fn restart_with_pr_url_resumes_task() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
     let store = setup_store(|db| async move {
         let mut task = make_task("t-impl-pr", TaskStatus::Implementing);
         task.pr_url = Some("https://github.com/owner/repo/pull/42".to_string());
@@ -292,6 +300,10 @@ async fn restart_with_pr_url_resumes_task() -> anyhow::Result<()> {
 /// Restart with a checkpoint PR URL (checkpoint table, not tasks table): task resumes.
 #[tokio::test]
 async fn restart_with_checkpoint_pr_url_resumes_task() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
     let store = setup_store(|db| async move {
         db.insert(&make_task("t-ck-pr", TaskStatus::AgentReview))
             .await?;
@@ -327,6 +339,10 @@ async fn restart_with_checkpoint_pr_url_resumes_task() -> anyhow::Result<()> {
 /// Restart with a plan checkpoint: task resumes to Pending.
 #[tokio::test]
 async fn restart_with_plan_checkpoint_resumes_task() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
     let store = setup_store(|db| async move {
         db.insert(&make_task("t-plan", TaskStatus::Implementing))
             .await?;
@@ -362,6 +378,10 @@ async fn restart_with_plan_checkpoint_resumes_task() -> anyhow::Result<()> {
 /// Restart with a triage-only checkpoint: task resumes to Pending.
 #[tokio::test]
 async fn restart_with_triage_checkpoint_resumes_task() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
     let store = setup_store(|db| async move {
         db.insert(&make_task("t-triage", TaskStatus::Implementing))
             .await?;
@@ -396,6 +416,10 @@ async fn restart_with_triage_checkpoint_resumes_task() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn restart_review_task_without_system_input_fails() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
     let store = setup_store(|db| async move {
         let mut task = make_task("t-review-missing-input", TaskStatus::ReviewGenerating);
         task.task_kind = TaskKind::Review;
@@ -421,6 +445,10 @@ async fn restart_review_task_without_system_input_fails() -> anyhow::Result<()> 
 /// "retrying after transient failure") must become Failed on restart.
 #[tokio::test]
 async fn restart_transient_retry_task_fails() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
     let store = setup_store(|db| async move {
         let mut task = make_task("t-transient", TaskStatus::Pending);
         task.error = Some("retrying after transient failure (attempt 2)".to_string());
@@ -469,6 +497,10 @@ async fn restart_transient_retry_task_fails() -> anyhow::Result<()> {
 /// Mixed scenario: some tasks resume, some fail — recovery counts are correct.
 #[tokio::test]
 async fn restart_mixed_recovery_counts() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
     let store = setup_store(|db| async move {
         // Will be resumed: has plan checkpoint.
         db.insert(&make_task("t-resumable-plan", TaskStatus::Implementing))
@@ -523,6 +555,10 @@ async fn restart_mixed_recovery_counts() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn restart_marks_resumed_task_as_recovering_in_scheduler_state() -> anyhow::Result<()> {
+    if !database_tests_configured() {
+        return Ok(());
+    }
+
     let store = setup_store(|db| async move {
         db.insert(&make_task("t-recovering", TaskStatus::Implementing))
             .await?;


### PR DESCRIPTION
## Summary
- Route shutdown-style spawn aborts through the spawn exit guard so a running task cannot remain non-terminal after the spawned future exits.
- Add a shutdown-abort regression proving the guard terminalizes the task and records a diagnostic round.
- Add restart recovery no-limbo coverage for mid-review and shutdown-drain leftovers: recovered tasks are either pending/recovering or terminal, never still in an in-flight state.
- Keep DB-backed checkpoint recovery tests locally green when `HARNESS_DATABASE_URL` is not configured.

Linked work: #1465
SpecRail: GH1465 / SP1465-T005 only. Remaining GH1465 task: T006 liveness audit.

## Verification
- cargo fmt --all -- --check
- cargo test -p harness-server recovery_no_limbo
- cargo test -p harness-server --test checkpoint_recovery
- RUSTFLAGS="-Dwarnings" cargo check -p harness-server --all-targets
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1465
