### PR TITLE
test(runtime): add task event liveness audit

### DIFF
--- a/.github/workflows/workflow-check.yml
+++ b/.github/workflows/workflow-check.yml
@@ -37,7 +37,8 @@ jobs:
             tests/test_evaluate.py \
             tests/test_github_pr_evidence.py \
             tests/test_pr_gate.py \
-            tests/test_specrail_review_regressions.py
+            tests/test_specrail_review_regressions.py \
+            tests/test_task_event_liveness.py
       - name: Check committed whitespace
         run: |
           set -euo pipefail

--- a/checks/check_workflow.py
+++ b/checks/check_workflow.py
@@ -37,6 +37,7 @@ REQUIRED_FILES = [
     "checks/github_pr_evidence.py",
     "checks/pr_gate.py",
     "checks/route_gate.py",
+    "checks/task_event_liveness.py",
     "templates/issue_bug.md",
     "templates/issue_feature.md",
     "templates/product_spec.md",

--- a/checks/task_event_liveness.py
+++ b/checks/task_event_liveness.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Audit task-events.jsonl for created-task terminal liveness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+TERMINAL_EVENT_TYPES = {"completed", "failed", "cancelled"}
+
+
+@dataclass
+class TaskEventCounts:
+    created: int = 0
+    terminal: int = 0
+    terminal_types: list[str] = field(default_factory=list)
+
+
+def _issue_dict(task_id: str, counts: TaskEventCounts) -> dict[str, Any]:
+    return {
+        "task_id": task_id,
+        "created": counts.created,
+        "terminal": counts.terminal,
+        "terminal_types": counts.terminal_types,
+    }
+
+
+def audit_event_log(log_path: Path) -> dict[str, Any]:
+    tasks: dict[str, TaskEventCounts] = {}
+    invalid_lines: list[dict[str, Any]] = []
+    total_lines = 0
+
+    if not log_path.exists():
+        return {
+            "ok": True,
+            "log": str(log_path),
+            "missing_log": True,
+            "created_events": 0,
+            "terminal_events": 0,
+            "task_count": 0,
+            "missing_terminal": [],
+            "terminal_without_created": [],
+            "duplicate_created": [],
+            "duplicate_terminal": [],
+            "invalid_lines": [],
+        }
+
+    with log_path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            total_lines += 1
+            try:
+                event = json.loads(stripped)
+            except json.JSONDecodeError as error:
+                invalid_lines.append({"line": line_no, "error": str(error)})
+                continue
+
+            event_type = event.get("type")
+            task_id = event.get("task_id")
+            if not isinstance(event_type, str) or not isinstance(task_id, str) or not task_id:
+                invalid_lines.append(
+                    {
+                        "line": line_no,
+                        "error": "event must contain string fields type and task_id",
+                    }
+                )
+                continue
+
+            counts = tasks.setdefault(task_id, TaskEventCounts())
+            if event_type == "created":
+                counts.created += 1
+            elif event_type in TERMINAL_EVENT_TYPES:
+                counts.terminal += 1
+                counts.terminal_types.append(event_type)
+
+    missing_terminal = [
+        _issue_dict(task_id, counts)
+        for task_id, counts in sorted(tasks.items())
+        if counts.created > 0 and counts.terminal == 0
+    ]
+    terminal_without_created = [
+        _issue_dict(task_id, counts)
+        for task_id, counts in sorted(tasks.items())
+        if counts.created == 0 and counts.terminal > 0
+    ]
+    duplicate_created = [
+        _issue_dict(task_id, counts)
+        for task_id, counts in sorted(tasks.items())
+        if counts.created > 1
+    ]
+    duplicate_terminal = [
+        _issue_dict(task_id, counts)
+        for task_id, counts in sorted(tasks.items())
+        if counts.terminal > 1
+    ]
+    created_events = sum(counts.created for counts in tasks.values())
+    terminal_events = sum(counts.terminal for counts in tasks.values())
+    ok = not (
+        invalid_lines
+        or missing_terminal
+        or terminal_without_created
+        or duplicate_created
+        or duplicate_terminal
+    )
+
+    return {
+        "ok": ok,
+        "log": str(log_path),
+        "missing_log": False,
+        "total_lines": total_lines,
+        "created_events": created_events,
+        "terminal_events": terminal_events,
+        "task_count": len(tasks),
+        "missing_terminal": missing_terminal,
+        "terminal_without_created": terminal_without_created,
+        "duplicate_created": duplicate_created,
+        "duplicate_terminal": duplicate_terminal,
+        "invalid_lines": invalid_lines,
+    }
+
+
+def _format_failure(result: dict[str, Any]) -> str:
+    parts = [
+        f"task event liveness audit failed for {result['log']}",
+        f"created_events={result['created_events']}",
+        f"terminal_events={result['terminal_events']}",
+    ]
+    for key in [
+        "missing_terminal",
+        "terminal_without_created",
+        "duplicate_created",
+        "duplicate_terminal",
+        "invalid_lines",
+    ]:
+        values = result.get(key) or []
+        if values:
+            parts.append(f"{key}={values}")
+    return "; ".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Assert each created task in task-events.jsonl has exactly one terminal event."
+    )
+    parser.add_argument("log", nargs="?", default="task-events.jsonl")
+    parser.add_argument("--json", action="store_true", help="print machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    result = audit_event_log(Path(args.log))
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    elif result["ok"]:
+        print(
+            "task event liveness audit passed: "
+            f"created_events={result['created_events']} "
+            f"terminal_events={result['terminal_events']}"
+        )
+    else:
+        print(_format_failure(result), file=sys.stderr)
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_task_event_liveness.py
+++ b/tests/test_task_event_liveness.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKS = ROOT / "checks"
+sys.path.insert(0, str(CHECKS))
+
+from task_event_liveness import audit_event_log  # noqa: E402
+
+
+def write_events(path: Path, events: list[dict[str, object]]) -> None:
+    path.write_text(
+        "".join(json.dumps(event) + "\n" for event in events),
+        encoding="utf-8",
+    )
+
+
+def test_liveness_audit_passes_terminalized_stream(tmp_path: Path) -> None:
+    log = tmp_path / "task-events.jsonl"
+    write_events(
+        log,
+        [
+            {"type": "created", "task_id": "task-1", "ts": 1},
+            {"type": "status_changed", "task_id": "task-1", "ts": 2, "status": "waiting", "turn": 1},
+            {"type": "failed", "task_id": "task-1", "ts": 3, "reason": "round_budget_exhausted"},
+            {"type": "created", "task_id": "task-2", "ts": 4},
+            {"type": "completed", "task_id": "task-2", "ts": 5},
+            {"type": "created", "task_id": "task-3", "ts": 6},
+            {"type": "cancelled", "task_id": "task-3", "ts": 7, "reason": "operator"},
+        ],
+    )
+
+    result = audit_event_log(log)
+
+    assert result["ok"] is True
+    assert result["created_events"] == 3
+    assert result["terminal_events"] == 3
+
+
+def test_liveness_audit_fails_synthetic_limbo_fixture(tmp_path: Path) -> None:
+    log = tmp_path / "task-events.jsonl"
+    write_events(
+        log,
+        [
+            {"type": "created", "task_id": "limbo-task", "ts": 1},
+            {
+                "type": "status_changed",
+                "task_id": "limbo-task",
+                "ts": 2,
+                "status": "waiting",
+                "turn": 10,
+            },
+        ],
+    )
+
+    result = audit_event_log(log)
+
+    assert result["ok"] is False
+    assert result["missing_terminal"][0]["task_id"] == "limbo-task"
+
+
+def test_liveness_audit_fails_duplicate_terminal(tmp_path: Path) -> None:
+    log = tmp_path / "task-events.jsonl"
+    write_events(
+        log,
+        [
+            {"type": "created", "task_id": "double-terminal", "ts": 1},
+            {"type": "failed", "task_id": "double-terminal", "ts": 2, "reason": "first"},
+            {"type": "completed", "task_id": "double-terminal", "ts": 3},
+        ],
+    )
+
+    result = audit_event_log(log)
+
+    assert result["ok"] is False
+    assert result["duplicate_terminal"][0]["task_id"] == "double-terminal"
+
+
+def test_liveness_audit_cli_returns_nonzero_for_limbo(tmp_path: Path) -> None:
+    log = tmp_path / "task-events.jsonl"
+    write_events(log, [{"type": "created", "task_id": "limbo-task", "ts": 1}])
+
+    result = subprocess.run(
+        [sys.executable, "checks/task_event_liveness.py", str(log), "--json"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["missing_terminal"][0]["task_id"] == "limbo-task"


### PR DESCRIPTION
## Summary
- Add a deterministic `checks/task_event_liveness.py` audit over `task-events.jsonl` that requires every created task to have exactly one terminal event after drain.
- Add pytest coverage proving the audit is red on a synthetic limbo stream and duplicate terminal stream, and green on completed/failed/cancelled terminal streams.
- Wire the liveness audit tests into the workflow-check regression job and require the audit script in the workflow pack check.

Linked work: Closes #1465
SpecRail: GH1465 / SP1465-T006 only. This is the final GH1465 liveness audit tranche after the T001-T005 PRs.

## Verification
- `python3 -m pytest -q tests/test_task_event_liveness.py`
- `python3 -m pytest -q tests/test_evaluate.py tests/test_github_pr_evidence.py tests/test_pr_gate.py tests/test_specrail_review_regressions.py tests/test_task_event_liveness.py`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH5 --spec-dir specs/GH7 --spec-dir specs/GH9 --spec-dir specs/GH13 --spec-dir specs/GH1465`
- `python3 evaluate.py --repo . --spec-dir specs/GH13 --format json` (status `needs_human`, 0 errors, 2 existing adoption-matrix warnings)
- `python3 -m compileall checks evaluate.py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
