### PR TITLE
fix(workspace): guard reclaim of leased workspaces

### DIFF
--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -226,13 +226,21 @@ pub(crate) struct StartupReconciliation {
     pub(crate) released_leases: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SkippedLiveWorkspace {
+    pub(crate) path: PathBuf,
+    pub(crate) task_id: TaskId,
+    pub(crate) owner_session: String,
+}
+
 /// Summary produced by the periodic disk reconciliation scan.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct DiskReconciliationSummary {
     pub(crate) scanned: u32,
     pub(crate) removed: u32,
     pub(crate) skipped_uuid: u32,
     pub(crate) skipped_open: u32,
+    pub(crate) skipped_live: Vec<SkippedLiveWorkspace>,
     pub(crate) released_leases: u32,
 }
 

--- a/crates/harness-server/src/workspace_disk_reconcile_tests.rs
+++ b/crates/harness-server/src/workspace_disk_reconcile_tests.rs
@@ -131,6 +131,9 @@ async fn reconcile_disk_removes_closed_issue_pool_slot_workspace() {
 #[tokio::test]
 async fn reconcile_disk_skips_live_persisted_lease_from_other_manager() -> anyhow::Result<()> {
     let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
     let source = tempfile::tempdir()?;
     init_git_repo(source.path());
     let branch = current_branch(source.path());
@@ -176,6 +179,10 @@ async fn reconcile_disk_skips_live_persisted_lease_from_other_manager() -> anyho
 
     assert_eq!(summary.removed, 0);
     assert_eq!(summary.skipped_open, 1);
+    assert_eq!(summary.skipped_live.len(), 1);
+    assert_eq!(summary.skipped_live[0].path, lease.workspace_path);
+    assert_eq!(summary.skipped_live[0].task_id, task_id);
+    assert_eq!(summary.skipped_live[0].owner_session, lease.owner_session);
     assert!(
         lease.workspace_path.exists(),
         "disk GC must not remove a workspace with a persisted live lease from another manager"
@@ -261,6 +268,126 @@ async fn reconcile_disk_releases_dead_persisted_lease_before_cleanup() -> anyhow
         "dead persisted lease should be released before disk GC preservation checks"
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn reclaim_gate_skips_live_persisted_lease() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let source = tempfile::tempdir()?;
+    init_git_repo(source.path());
+    let branch = current_branch(source.path());
+
+    let workspaces = tempfile::tempdir()?;
+    let lease_db = tempfile::tempdir()?;
+    let store = std::sync::Arc::new(
+        WorkspaceLeaseStore::open(&lease_db.path().join("workspace-leases")).await?,
+    );
+    let config = WorkspaceConfig {
+        root: workspaces.path().to_path_buf(),
+        ..Default::default()
+    };
+    let mgr = WorkspaceManager::new_with_pool(
+        config,
+        WorkspacePoolConfig::default(),
+        Some(store.clone()),
+    )?;
+    let task_id = harness_core::types::TaskId("reclaim-gate-live-task".to_string());
+
+    let lease = mgr
+        .create_workspace(
+            &task_id,
+            source.path(),
+            "origin",
+            &branch,
+            1,
+            Some("issue:42"),
+            Some("myorg/my-repo"),
+        )
+        .await?;
+
+    let outcome =
+        try_reclaim_workspace(source.path(), &lease.workspace_path, Some(&store), None).await?;
+
+    assert_eq!(
+        outcome,
+        WorkspaceReclaimOutcome::SkippedLiveLease {
+            task_id: task_id.clone(),
+            owner_session: lease.owner_session.clone(),
+        }
+    );
+    assert!(
+        lease.workspace_path.exists(),
+        "reclaim gate must preserve live leased workspaces"
+    );
+
+    mgr.remove_workspace(&task_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn cleanup_orphan_worktrees_reclaim_gate_skips_live_persisted_lease() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let source = tempfile::tempdir()?;
+    init_git_repo(source.path());
+    let branch = current_branch(source.path());
+
+    let workspaces = tempfile::tempdir()?;
+    let lease_db = tempfile::tempdir()?;
+    let store = std::sync::Arc::new(
+        WorkspaceLeaseStore::open(&lease_db.path().join("workspace-leases")).await?,
+    );
+    let config = WorkspaceConfig {
+        root: workspaces.path().to_path_buf(),
+        ..Default::default()
+    };
+    let mgr_a = WorkspaceManager::new_with_pool(
+        config.clone(),
+        WorkspacePoolConfig::default(),
+        Some(store.clone()),
+    )?;
+    let mgr_b =
+        WorkspaceManager::new_with_pool(config, WorkspacePoolConfig::default(), Some(store))?;
+    let task_id = harness_core::types::TaskId("live-terminal-orphan-task".to_string());
+
+    let lease = mgr_a
+        .create_workspace(&task_id, source.path(), "origin", &branch, 1, None, None)
+        .await?;
+
+    mgr_b
+        .cleanup_orphan_worktrees(source.path(), std::slice::from_ref(&task_id))
+        .await;
+
+    assert!(
+        lease.workspace_path.exists(),
+        "orphan cleanup must not remove a workspace with a persisted live lease from another manager"
+    );
+
+    mgr_a.remove_workspace(&task_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn reclaim_gate_deletes_workspace_without_live_lease() -> anyhow::Result<()> {
+    let source = tempfile::tempdir()?;
+    init_git_repo(source.path());
+    let workspace = tempfile::tempdir()?;
+    let workspace_path = workspace.path().join("dead-workspace");
+    std::fs::create_dir_all(&workspace_path)?;
+
+    let outcome = try_reclaim_workspace(source.path(), &workspace_path, None, Some(false)).await?;
+
+    assert_eq!(outcome, WorkspaceReclaimOutcome::Deleted);
+    assert!(
+        !workspace_path.exists(),
+        "reclaim gate must delete unleased workspaces"
+    );
     Ok(())
 }
 

--- a/crates/harness-server/src/workspace_helpers.rs
+++ b/crates/harness-server/src/workspace_helpers.rs
@@ -236,6 +236,50 @@ pub(super) async fn cleanup_workspace_path(
     cleanup_workspace_path_with_registration(source_repo, workspace_path, None).await
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WorkspaceReclaimOutcome {
+    Deleted,
+    SkippedLiveLease {
+        task_id: TaskId,
+        owner_session: String,
+    },
+    SkippedLeaseLookupFailed {
+        error: String,
+    },
+}
+
+pub(super) async fn try_reclaim_workspace(
+    source_repo: &Path,
+    workspace_path: &Path,
+    lease_store: Option<&WorkspaceLeaseStore>,
+    known_worktree_registered: Option<bool>,
+) -> anyhow::Result<WorkspaceReclaimOutcome> {
+    if let Some(store) = lease_store {
+        match store.leased_workspace_path(workspace_path).await {
+            Ok(Some(record)) => {
+                return Ok(WorkspaceReclaimOutcome::SkippedLiveLease {
+                    task_id: record.task_id,
+                    owner_session: record.owner_session,
+                });
+            }
+            Ok(None) => {}
+            Err(error) => {
+                return Ok(WorkspaceReclaimOutcome::SkippedLeaseLookupFailed {
+                    error: error.to_string(),
+                });
+            }
+        }
+    }
+
+    cleanup_workspace_path_with_registration(
+        source_repo,
+        workspace_path,
+        known_worktree_registered,
+    )
+    .await?;
+    Ok(WorkspaceReclaimOutcome::Deleted)
+}
+
 pub(super) async fn cleanup_workspace_path_with_registration(
     source_repo: &Path,
     workspace_path: &Path,

--- a/crates/harness-server/src/workspace_reconcile.rs
+++ b/crates/harness-server/src/workspace_reconcile.rs
@@ -38,6 +38,20 @@ impl DiskRateLimiter {
     }
 }
 
+fn record_skipped_live_workspace(
+    summary: &mut DiskReconciliationSummary,
+    path: &Path,
+    task_id: TaskId,
+    owner_session: String,
+) {
+    summary.skipped_open += 1;
+    summary.skipped_live.push(SkippedLiveWorkspace {
+        path: path.to_path_buf(),
+        task_id,
+        owner_session,
+    });
+}
+
 impl WorkspaceManager {
     pub(crate) async fn reconcile_startup(
         &self,
@@ -276,7 +290,12 @@ impl WorkspaceManager {
                             task_id = %record.task_id.0,
                             "reconcile_disk_workspaces: skipping workspace with persisted live lease"
                         );
-                        summary.skipped_open += 1;
+                        record_skipped_live_workspace(
+                            &mut summary,
+                            &path,
+                            record.task_id,
+                            record.owner_session,
+                        );
                         continue;
                     }
                     Ok(None) => {}
@@ -338,8 +357,30 @@ impl WorkspaceManager {
             );
 
             if should_remove {
-                match self.cleanup_workspace_path_locked(source_repo, &path).await {
-                    Ok(()) => summary.removed += 1,
+                let _git_ops = self.git_ops.lock().await;
+                match try_reclaim_workspace(source_repo, &path, self.lease_store.as_deref(), None)
+                    .await
+                {
+                    Ok(WorkspaceReclaimOutcome::Deleted) => summary.removed += 1,
+                    Ok(WorkspaceReclaimOutcome::SkippedLiveLease {
+                        task_id,
+                        owner_session,
+                    }) => {
+                        tracing::debug!(
+                            workspace_path = ?path,
+                            task_id = %task_id.0,
+                            owner_session = %owner_session,
+                            "reconcile_disk_workspaces: reclaim gate skipped live workspace"
+                        );
+                        record_skipped_live_workspace(&mut summary, &path, task_id, owner_session);
+                    }
+                    Ok(WorkspaceReclaimOutcome::SkippedLeaseLookupFailed { error }) => {
+                        tracing::warn!(
+                            workspace_path = ?path,
+                            "reconcile_disk_workspaces: reclaim gate failed closed after lease lookup error: {error}"
+                        );
+                        summary.skipped_open += 1;
+                    }
                     Err(e) => tracing::warn!(
                         "reconcile_disk_workspaces: cleanup failed for {path:?}: {e}"
                     ),
@@ -354,6 +395,8 @@ impl WorkspaceManager {
             removed = summary.removed,
             skipped_uuid = summary.skipped_uuid,
             skipped_open = summary.skipped_open,
+            skipped_live = summary.skipped_live.len(),
+            skipped_live_workspaces = ?summary.skipped_live,
             released_leases = summary.released_leases,
             "reconcile_disk_workspaces: scan complete"
         );
@@ -431,12 +474,34 @@ impl WorkspaceManager {
             if self.active.iter().any(|e| e.workspace_path == path) {
                 continue;
             }
-            tracing::info!(
-                "cleanup_orphan_worktrees: removing orphan worktree {:?}",
-                path
-            );
-            if let Err(e) = remove_worktree(source_repo, &path).await {
-                tracing::warn!("cleanup_orphan_worktrees: failed to remove {:?}: {e}", path);
+            match try_reclaim_workspace(source_repo, &path, self.lease_store.as_deref(), None).await
+            {
+                Ok(WorkspaceReclaimOutcome::Deleted) => {
+                    tracing::info!(
+                        "cleanup_orphan_worktrees: removed orphan worktree {:?}",
+                        path
+                    );
+                }
+                Ok(WorkspaceReclaimOutcome::SkippedLiveLease {
+                    task_id,
+                    owner_session,
+                }) => {
+                    tracing::debug!(
+                        workspace_path = ?path,
+                        task_id = %task_id.0,
+                        owner_session = %owner_session,
+                        "cleanup_orphan_worktrees: reclaim gate skipped live workspace"
+                    );
+                }
+                Ok(WorkspaceReclaimOutcome::SkippedLeaseLookupFailed { error }) => {
+                    tracing::warn!(
+                        workspace_path = ?path,
+                        "cleanup_orphan_worktrees: reclaim gate failed closed after lease lookup error: {error}"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!("cleanup_orphan_worktrees: failed to remove {:?}: {e}", path);
+                }
             }
         }
 


### PR DESCRIPTION
Refs #1466

Linked work: #1466

## Summary

- add a workspace reclaim gate that skips persisted live leases and fails closed on lease lookup errors
- route closed-issue disk reconciliation and terminal orphan cleanup through the reclaim gate
- expose skipped-live workspace details in disk GC summaries so operators can see the path, task id, and owner session
- add focused tests for reclaim gate skip/delete behavior, disk GC skipped-live reporting, and orphan cleanup live-lease preservation

## Scope

Partial GH1466 implementation for `SP1466-T001`, `SP1466-T002`, and `SP1466-T005` only. This does not implement forced reclaim terminalization (`SP1466-T003`) or the explicit terminalize-vs-reclaim race/integration coverage (`SP1466-T006`). `SP1466-T004` was already covered by #1484.

## Verification

- `cargo test -p harness-server reclaim_gate`
- `cargo test -p harness-server reconcile_disk_skips_live_persisted_lease_from_other_manager`
- `cargo test -p harness-server disk_reconcile`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check -p harness-server --all-targets`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1466`
- `git diff --check`
