### PR TITLE
feat(observe): add OTel trajectory foundation

### DIFF
--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -519,6 +519,10 @@ pub struct OtelConfig {
     pub endpoint: Option<String>,
     #[serde(default)]
     pub log_user_prompt: bool,
+    #[serde(default)]
+    pub trajectory: bool,
+    #[serde(default)]
+    pub capture_content: bool,
 }
 
 impl Default for OtelConfig {
@@ -528,6 +532,8 @@ impl Default for OtelConfig {
             exporter: OtelExporter::default(),
             endpoint: None,
             log_user_prompt: false,
+            trajectory: false,
+            capture_content: false,
         }
     }
 }

--- a/crates/harness-core/tests/otel_config.rs
+++ b/crates/harness-core/tests/otel_config.rs
@@ -1,0 +1,19 @@
+use harness_core::config::misc::{OtelConfig, OtelExporter};
+
+#[test]
+fn otel_trajectory_flags_deserialize_and_default_off() -> anyhow::Result<()> {
+    let default_config = OtelConfig::default();
+    assert_eq!(default_config.exporter, OtelExporter::Disabled);
+    assert!(!default_config.trajectory);
+    assert!(!default_config.capture_content);
+
+    let config: OtelConfig = toml::from_str(
+        r#"
+        trajectory = true
+        capture_content = true
+        "#,
+    )?;
+    assert!(config.trajectory);
+    assert!(config.capture_content);
+    Ok(())
+}

--- a/crates/harness-observe/src/lib.rs
+++ b/crates/harness-observe/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod event_store;
 pub mod health;
+pub mod otel_attributes;
 mod otel_export;
 pub mod quality;
 pub mod session;

--- a/crates/harness-observe/src/otel_attributes.rs
+++ b/crates/harness-observe/src/otel_attributes.rs
@@ -1,0 +1,114 @@
+use opentelemetry::KeyValue;
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+pub const GEN_AI_SYSTEM: &str = "gen_ai.system";
+pub const GEN_AI_REQUEST_MODEL: &str = "gen_ai.request.model";
+pub const GEN_AI_USAGE_INPUT_TOKENS: &str = "gen_ai.usage.input_tokens";
+pub const GEN_AI_USAGE_OUTPUT_TOKENS: &str = "gen_ai.usage.output_tokens";
+pub const HARNESS_WORKFLOW_ID: &str = "harness.workflow.id";
+pub const HARNESS_ACTIVITY_KIND: &str = "harness.activity.kind";
+pub const HARNESS_OUTCOME: &str = "harness.outcome";
+pub const HARNESS_COST_USD: &str = "harness.cost_usd";
+
+pub const ATTRIBUTE_ALLOWLIST: &[&str] = &[
+    GEN_AI_SYSTEM,
+    GEN_AI_REQUEST_MODEL,
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+    HARNESS_COST_USD,
+    HARNESS_WORKFLOW_ID,
+    HARNESS_ACTIVITY_KIND,
+    HARNESS_OUTCOME,
+];
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct GenAiTurnAttributes {
+    pub system: Option<String>,
+    pub model: Option<String>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cost_usd: Option<f64>,
+    pub workflow_id: Option<String>,
+    pub activity_kind: Option<String>,
+    pub outcome: Option<String>,
+}
+
+pub fn is_allowed_attribute(key: &str) -> bool {
+    static ALLOWLIST: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    ALLOWLIST
+        .get_or_init(|| ATTRIBUTE_ALLOWLIST.iter().copied().collect())
+        .contains(key)
+}
+
+pub fn gen_ai_turn_attributes(input: GenAiTurnAttributes) -> Vec<KeyValue> {
+    let mut attrs = Vec::new();
+    push_string(&mut attrs, GEN_AI_SYSTEM, input.system);
+    push_string(&mut attrs, GEN_AI_REQUEST_MODEL, input.model);
+    push_u64(&mut attrs, GEN_AI_USAGE_INPUT_TOKENS, input.input_tokens);
+    push_u64(&mut attrs, GEN_AI_USAGE_OUTPUT_TOKENS, input.output_tokens);
+    push_f64(&mut attrs, HARNESS_COST_USD, input.cost_usd);
+    push_string(&mut attrs, HARNESS_WORKFLOW_ID, input.workflow_id);
+    push_string(&mut attrs, HARNESS_ACTIVITY_KIND, input.activity_kind);
+    push_string(&mut attrs, HARNESS_OUTCOME, input.outcome);
+    attrs
+}
+
+fn push_string(attrs: &mut Vec<KeyValue>, key: &'static str, value: Option<String>) {
+    if let Some(value) = value.filter(|value| !value.trim().is_empty()) {
+        attrs.push(KeyValue::new(key, value));
+    }
+}
+
+fn push_u64(attrs: &mut Vec<KeyValue>, key: &'static str, value: Option<u64>) {
+    if let Some(value) = value.and_then(|value| i64::try_from(value).ok()) {
+        attrs.push(KeyValue::new(key, value));
+    }
+}
+
+fn push_f64(attrs: &mut Vec<KeyValue>, key: &'static str, value: Option<f64>) {
+    if let Some(value) = value.filter(|value| value.is_finite() && *value >= 0.0) {
+        attrs.push(KeyValue::new(key, value));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn otel_attributes_map_genai_and_harness_allowlist() {
+        let attrs = gen_ai_turn_attributes(GenAiTurnAttributes {
+            system: Some("codex".to_string()),
+            model: Some("gpt-5".to_string()),
+            input_tokens: Some(123),
+            output_tokens: Some(45),
+            cost_usd: Some(0.0123),
+            workflow_id: Some("wf-1".to_string()),
+            activity_kind: Some("implement".to_string()),
+            outcome: Some("done".to_string()),
+        });
+
+        let keys: Vec<_> = attrs.iter().map(|attr| attr.key.as_str()).collect();
+        assert_eq!(keys, ATTRIBUTE_ALLOWLIST);
+        assert!(keys.iter().all(|key| is_allowed_attribute(key)));
+    }
+
+    #[test]
+    fn otel_attributes_omit_unknown_values_instead_of_zero_filling() {
+        let attrs = gen_ai_turn_attributes(GenAiTurnAttributes {
+            system: Some(" ".to_string()),
+            model: None,
+            input_tokens: None,
+            output_tokens: Some(0),
+            cost_usd: Some(f64::NAN),
+            workflow_id: None,
+            activity_kind: None,
+            outcome: None,
+        });
+
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(attrs[0].key.as_str(), GEN_AI_USAGE_OUTPUT_TOKENS);
+        assert!(!is_allowed_attribute("gen_ai.prompt"));
+    }
+}

--- a/crates/harness-observe/src/otel_export.rs
+++ b/crates/harness-observe/src/otel_export.rs
@@ -53,6 +53,8 @@ impl SessionStartDeduper {
 
 pub struct OtelPipeline {
     log_user_prompt: bool,
+    _trajectory_enabled: bool,
+    _capture_content: bool,
     seen_sessions: Mutex<SessionStartDeduper>,
     tracer_provider: opentelemetry_sdk::trace::TracerProvider,
     tracer: opentelemetry_sdk::trace::Tracer,
@@ -106,6 +108,8 @@ impl OtelPipeline {
 
         Ok(Some(Self {
             log_user_prompt: config.log_user_prompt,
+            _trajectory_enabled: config.trajectory,
+            _capture_content: config.capture_content,
             seen_sessions: Mutex::new(SessionStartDeduper::new(MAX_TRACKED_CONVERSATION_SESSIONS)),
             tracer_provider,
             tracer,
@@ -117,6 +121,16 @@ impl OtelPipeline {
             tool_decision_total,
             tool_execution_duration_ms,
         }))
+    }
+
+    #[cfg(test)]
+    fn trajectory_enabled(&self) -> bool {
+        self._trajectory_enabled
+    }
+
+    #[cfg(test)]
+    fn capture_content_enabled(&self) -> bool {
+        self._capture_content
     }
 
     pub fn record_event(&self, event: &Event) {
@@ -530,5 +544,44 @@ mod tests {
         };
         let result = OtelPipeline::from_config(&config).await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn otel_trajectory_config_defaults_off_and_accepts_explicit_flags() {
+        let default_config = OtelConfig::default();
+        assert!(!default_config.trajectory);
+        assert!(!default_config.capture_content);
+
+        let config = OtelConfig {
+            trajectory: true,
+            capture_content: true,
+            ..OtelConfig::default()
+        };
+        assert!(config.trajectory);
+        assert!(config.capture_content);
+    }
+
+    #[tokio::test]
+    async fn otel_trajectory_config_reaches_pipeline_flags() -> anyhow::Result<()> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let endpoint = format!("http://{}", listener.local_addr()?);
+        let accept = tokio::spawn(async move { listener.accept().await.map(|_| ()) });
+        let config = OtelConfig {
+            exporter: OtelExporter::OtlpHttp,
+            endpoint: Some(endpoint),
+            trajectory: true,
+            capture_content: true,
+            ..OtelConfig::default()
+        };
+
+        let pipeline = OtelPipeline::from_config(&config)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("enabled exporter should initialize"))?;
+
+        assert!(pipeline.trajectory_enabled());
+        assert!(pipeline.capture_content_enabled());
+        pipeline.shutdown().await;
+        accept.await??;
+        Ok(())
     }
 }


### PR DESCRIPTION
Related: #1451

## Summary

- add off-by-default `otel.trajectory` and `otel.capture_content` config flags
- carry the trajectory/content flags through `OtelPipeline` for future workflow span hooks
- add a centralized GenAI + harness OTel attribute allowlist and turn-attribute builder that omits unknown values instead of zero-filling
- add focused tests for config defaults/deserialization, pipeline flag propagation, and attribute mapping

## Scope

Partial GH1451 implementation for `SP1451-T001` and `SP1451-T002` only. This does not emit workflow/activity/agent-turn spans yet (`SP1451-T003`/`SP1451-T004`), does not add exporter failure counters (`SP1451-T005`), and does not add the quickstart docs (`SP1451-T006`).

## Verification

- `cargo test -p harness-observe otel_trajectory_config`
- `cargo test -p harness-observe otel_attributes`
- `cargo test -p harness-core otel_trajectory_flags`
- `cargo fmt --all -- --check`
- `cargo check -p harness-core -p harness-observe --all-targets`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1451`
- `git diff --check`

