### PR TITLE
fix(workspace): force reclaim terminal task leases

### DIFF
--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -335,6 +335,27 @@ impl WorkspaceManager {
         cleanup_workspace_path(source_repo, workspace_path).await
     }
 
+    pub async fn force_reclaim_workspace(
+        &self,
+        task_store: &crate::task_runner::TaskStore,
+        source_repo: &Path,
+        workspace_path: &Path,
+    ) -> anyhow::Result<bool> {
+        let _git_ops = self.git_ops.lock().await;
+        let outcome = try_reclaim_workspace(
+            source_repo,
+            workspace_path,
+            self.lease_store.as_deref(),
+            None,
+            WorkspaceReclaimMode::Force { task_store },
+        )
+        .await?;
+        Ok(matches!(
+            outcome,
+            WorkspaceReclaimOutcome::Deleted | WorkspaceReclaimOutcome::ForcedDeleted { .. }
+        ))
+    }
+
     /// Remove the workspace for the given task. Runs `before_remove_hook` first (non-fatal).
     /// Idempotent: returns Ok if the task has no active workspace.
     pub async fn remove_workspace(&self, task_id: &TaskId) -> anyhow::Result<()> {
@@ -626,6 +647,10 @@ mod lease_store_tests;
 #[cfg(test)]
 #[path = "workspace_pool_tests.rs"]
 mod pool_tests;
+
+#[cfg(test)]
+#[path = "workspace_reclaim_tests.rs"]
+mod reclaim_tests;
 
 #[cfg(test)]
 #[path = "workspace_startup_reconcile_tests.rs"]

--- a/crates/harness-server/src/workspace_disk_reconcile_tests.rs
+++ b/crates/harness-server/src/workspace_disk_reconcile_tests.rs
@@ -309,8 +309,14 @@ async fn reclaim_gate_skips_live_persisted_lease() -> anyhow::Result<()> {
         )
         .await?;
 
-    let outcome =
-        try_reclaim_workspace(source.path(), &lease.workspace_path, Some(&store), None).await?;
+    let outcome = try_reclaim_workspace(
+        source.path(),
+        &lease.workspace_path,
+        Some(&store),
+        None,
+        WorkspaceReclaimMode::Guard,
+    )
+    .await?;
 
     assert_eq!(
         outcome,
@@ -381,7 +387,14 @@ async fn reclaim_gate_deletes_workspace_without_live_lease() -> anyhow::Result<(
     let workspace_path = workspace.path().join("dead-workspace");
     std::fs::create_dir_all(&workspace_path)?;
 
-    let outcome = try_reclaim_workspace(source.path(), &workspace_path, None, Some(false)).await?;
+    let outcome = try_reclaim_workspace(
+        source.path(),
+        &workspace_path,
+        None,
+        Some(false),
+        WorkspaceReclaimMode::Guard,
+    )
+    .await?;
 
     assert_eq!(outcome, WorkspaceReclaimOutcome::Deleted);
     assert!(

--- a/crates/harness-server/src/workspace_helpers.rs
+++ b/crates/harness-server/src/workspace_helpers.rs
@@ -239,7 +239,15 @@ pub(super) async fn cleanup_workspace_path(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum WorkspaceReclaimOutcome {
     Deleted,
+    ForcedDeleted {
+        task_id: TaskId,
+        owner_session: String,
+    },
     SkippedLiveLease {
+        task_id: TaskId,
+        owner_session: String,
+    },
+    SkippedMissingTask {
         task_id: TaskId,
         owner_session: String,
     },
@@ -248,19 +256,40 @@ pub(crate) enum WorkspaceReclaimOutcome {
     },
 }
 
+pub(crate) enum WorkspaceReclaimMode<'a> {
+    Guard,
+    Force {
+        task_store: &'a crate::task_runner::TaskStore,
+    },
+}
+
 pub(super) async fn try_reclaim_workspace(
     source_repo: &Path,
     workspace_path: &Path,
     lease_store: Option<&WorkspaceLeaseStore>,
     known_worktree_registered: Option<bool>,
+    mode: WorkspaceReclaimMode<'_>,
 ) -> anyhow::Result<WorkspaceReclaimOutcome> {
     if let Some(store) = lease_store {
         match store.leased_workspace_path(workspace_path).await {
             Ok(Some(record)) => {
-                return Ok(WorkspaceReclaimOutcome::SkippedLiveLease {
-                    task_id: record.task_id,
-                    owner_session: record.owner_session,
-                });
+                return match mode {
+                    WorkspaceReclaimMode::Guard => Ok(WorkspaceReclaimOutcome::SkippedLiveLease {
+                        task_id: record.task_id,
+                        owner_session: record.owner_session,
+                    }),
+                    WorkspaceReclaimMode::Force { task_store } => {
+                        force_reclaim_leased_workspace(
+                            source_repo,
+                            workspace_path,
+                            store,
+                            task_store,
+                            record,
+                            known_worktree_registered,
+                        )
+                        .await
+                    }
+                };
             }
             Ok(None) => {}
             Err(error) => {
@@ -278,6 +307,55 @@ pub(super) async fn try_reclaim_workspace(
     )
     .await?;
     Ok(WorkspaceReclaimOutcome::Deleted)
+}
+
+async fn force_reclaim_leased_workspace(
+    source_repo: &Path,
+    workspace_path: &Path,
+    lease_store: &WorkspaceLeaseStore,
+    task_store: &crate::task_runner::TaskStore,
+    record: WorkspaceLeaseRecord,
+    known_worktree_registered: Option<bool>,
+) -> anyhow::Result<WorkspaceReclaimOutcome> {
+    let task_id = record.task_id.clone();
+    let owner_session = record.owner_session.clone();
+    let Some(snapshot) = task_store.get(&task_id) else {
+        return Ok(WorkspaceReclaimOutcome::SkippedMissingTask {
+            task_id,
+            owner_session,
+        });
+    };
+
+    let outcome = crate::task_runner::TaskTerminalOutcome::Failed(
+        crate::task_runner::TaskTerminalFailure::new(
+            "workspace_reclaimed",
+            snapshot.turn,
+            snapshot.status,
+            None,
+        ),
+    );
+    match crate::task_runner::mark_terminal_once(task_store, &task_id, outcome).await? {
+        crate::task_runner::TerminalTransition::Applied
+        | crate::task_runner::TerminalTransition::AlreadyTerminal(_) => {}
+        crate::task_runner::TerminalTransition::MissingTask => {
+            return Ok(WorkspaceReclaimOutcome::SkippedMissingTask {
+                task_id,
+                owner_session,
+            });
+        }
+    }
+
+    cleanup_workspace_path_with_registration(
+        source_repo,
+        workspace_path,
+        known_worktree_registered,
+    )
+    .await?;
+    lease_store.release_task(&task_id).await?;
+    Ok(WorkspaceReclaimOutcome::ForcedDeleted {
+        task_id,
+        owner_session,
+    })
 }
 
 pub(super) async fn cleanup_workspace_path_with_registration(

--- a/crates/harness-server/src/workspace_reclaim_tests.rs
+++ b/crates/harness-server/src/workspace_reclaim_tests.rs
@@ -1,0 +1,160 @@
+use super::test_support::*;
+use super::*;
+use crate::task_runner::{
+    mark_terminal_once, TaskState, TaskStatus, TaskStore, TaskTerminalFailure, TaskTerminalOutcome,
+};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+struct ForceReclaimFixture {
+    _root: tempfile::TempDir,
+    source_repo: PathBuf,
+    lease_store: Arc<WorkspaceLeaseStore>,
+    manager: WorkspaceManager,
+    task_store: Arc<TaskStore>,
+    task_id: harness_core::types::TaskId,
+    workspace_path: PathBuf,
+}
+
+async fn force_reclaim_fixture(name: &str) -> anyhow::Result<ForceReclaimFixture> {
+    let root = crate::test_helpers::tempdir_in_home(&format!("harness-{name}-"))?;
+    let source_repo = root.path().join("repo");
+    std::fs::create_dir_all(&source_repo)?;
+    init_git_repo(&source_repo);
+    let branch = current_branch(&source_repo);
+
+    let database_url = crate::test_helpers::test_database_url()?;
+    let task_store = TaskStore::open_with_database_url(
+        &harness_core::config::dirs::default_db_path(root.path(), "tasks"),
+        Some(&database_url),
+    )
+    .await?;
+    let lease_store =
+        Arc::new(WorkspaceLeaseStore::open(&root.path().join("workspace-leases")).await?);
+    let manager = WorkspaceManager::new_with_pool(
+        WorkspaceConfig {
+            root: root.path().join("workspaces"),
+            ..Default::default()
+        },
+        WorkspacePoolConfig::default(),
+        Some(lease_store.clone()),
+    )?;
+    let task_id = harness_core::types::TaskId(format!("{name}-task"));
+    let lease = manager
+        .create_workspace(&task_id, &source_repo, "origin", &branch, 1, None, None)
+        .await?;
+
+    let mut state = TaskState::new(task_id.clone());
+    state.status = TaskStatus::Implementing;
+    state.turn = 3;
+    state.workspace_path = Some(lease.workspace_path.clone());
+    state.workspace_owner = Some(lease.owner_session);
+    state.run_generation = lease.run_generation;
+    task_store.insert(&state).await;
+
+    Ok(ForceReclaimFixture {
+        _root: root,
+        source_repo,
+        lease_store,
+        manager,
+        task_store,
+        task_id,
+        workspace_path: lease.workspace_path,
+    })
+}
+
+#[tokio::test]
+async fn forced_reclaim_terminalizes_owner_then_deletes_workspace() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let fixture = force_reclaim_fixture("forced-reclaim").await?;
+
+    let reclaimed = fixture
+        .manager
+        .force_reclaim_workspace(
+            &fixture.task_store,
+            &fixture.source_repo,
+            &fixture.workspace_path,
+        )
+        .await?;
+
+    assert!(reclaimed, "forced reclaim should delete the workspace");
+    assert!(
+        !fixture.workspace_path.exists(),
+        "forced reclaim should remove the workspace directory"
+    );
+    assert!(
+        fixture.lease_store.list_leased().await?.is_empty(),
+        "forced reclaim should release the persisted lease"
+    );
+
+    let state = fixture
+        .task_store
+        .get(&fixture.task_id)
+        .ok_or_else(|| anyhow::anyhow!("task should remain available"))?;
+    assert_eq!(state.status, TaskStatus::Failed);
+    let failure = serde_json::from_str::<TaskTerminalFailure>(
+        state
+            .error
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("forced reclaim should record a terminal reason"))?,
+    )
+    .map_err(|error| {
+        anyhow::anyhow!("terminal reason should parse as TaskTerminalFailure: {error}")
+    })?;
+    assert_eq!(failure.reason, "workspace_reclaimed");
+    assert_eq!(failure.last_status, TaskStatus::Implementing);
+    Ok(())
+}
+
+#[tokio::test]
+async fn reclaim_race_leaves_terminal_task_and_deleted_workspace() -> anyhow::Result<()> {
+    let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let fixture = force_reclaim_fixture("reclaim-race").await?;
+
+    let reclaim = fixture.manager.force_reclaim_workspace(
+        &fixture.task_store,
+        &fixture.source_repo,
+        &fixture.workspace_path,
+    );
+    let completing_store = fixture.task_store.clone();
+    let completing_task = fixture.task_id.clone();
+    let complete = async move {
+        mark_terminal_once(
+            &completing_store,
+            &completing_task,
+            TaskTerminalOutcome::Completed,
+        )
+        .await
+    };
+
+    let (reclaim_result, complete_result) = tokio::join!(reclaim, complete);
+    assert!(
+        reclaim_result?,
+        "reclaim should delete after a terminal transition wins the race"
+    );
+    complete_result?;
+
+    let state = fixture
+        .task_store
+        .get(&fixture.task_id)
+        .ok_or_else(|| anyhow::anyhow!("task should remain available"))?;
+    assert!(
+        state.status.is_terminal(),
+        "terminalize-vs-reclaim race must not leave a non-terminal task"
+    );
+    assert!(
+        !fixture.workspace_path.exists(),
+        "terminalize-vs-reclaim race should not preserve a reclaimed workspace"
+    );
+    assert!(
+        fixture.lease_store.list_leased().await?.is_empty(),
+        "terminalize-vs-reclaim race should release the persisted lease"
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/workspace_reconcile.rs
+++ b/crates/harness-server/src/workspace_reconcile.rs
@@ -358,10 +358,17 @@ impl WorkspaceManager {
 
             if should_remove {
                 let _git_ops = self.git_ops.lock().await;
-                match try_reclaim_workspace(source_repo, &path, self.lease_store.as_deref(), None)
-                    .await
+                match try_reclaim_workspace(
+                    source_repo,
+                    &path,
+                    self.lease_store.as_deref(),
+                    None,
+                    WorkspaceReclaimMode::Guard,
+                )
+                .await
                 {
                     Ok(WorkspaceReclaimOutcome::Deleted) => summary.removed += 1,
+                    Ok(WorkspaceReclaimOutcome::ForcedDeleted { .. }) => summary.removed += 1,
                     Ok(WorkspaceReclaimOutcome::SkippedLiveLease {
                         task_id,
                         owner_session,
@@ -378,6 +385,18 @@ impl WorkspaceManager {
                         tracing::warn!(
                             workspace_path = ?path,
                             "reconcile_disk_workspaces: reclaim gate failed closed after lease lookup error: {error}"
+                        );
+                        summary.skipped_open += 1;
+                    }
+                    Ok(WorkspaceReclaimOutcome::SkippedMissingTask {
+                        task_id,
+                        owner_session,
+                    }) => {
+                        tracing::warn!(
+                            workspace_path = ?path,
+                            task_id = %task_id.0,
+                            owner_session = %owner_session,
+                            "reconcile_disk_workspaces: reclaim gate skipped workspace because owning task was missing"
                         );
                         summary.skipped_open += 1;
                     }
@@ -474,11 +493,24 @@ impl WorkspaceManager {
             if self.active.iter().any(|e| e.workspace_path == path) {
                 continue;
             }
-            match try_reclaim_workspace(source_repo, &path, self.lease_store.as_deref(), None).await
+            match try_reclaim_workspace(
+                source_repo,
+                &path,
+                self.lease_store.as_deref(),
+                None,
+                WorkspaceReclaimMode::Guard,
+            )
+            .await
             {
                 Ok(WorkspaceReclaimOutcome::Deleted) => {
                     tracing::info!(
                         "cleanup_orphan_worktrees: removed orphan worktree {:?}",
+                        path
+                    );
+                }
+                Ok(WorkspaceReclaimOutcome::ForcedDeleted { .. }) => {
+                    tracing::info!(
+                        "cleanup_orphan_worktrees: force-removed orphan worktree {:?}",
                         path
                     );
                 }
@@ -497,6 +529,17 @@ impl WorkspaceManager {
                     tracing::warn!(
                         workspace_path = ?path,
                         "cleanup_orphan_worktrees: reclaim gate failed closed after lease lookup error: {error}"
+                    );
+                }
+                Ok(WorkspaceReclaimOutcome::SkippedMissingTask {
+                    task_id,
+                    owner_session,
+                }) => {
+                    tracing::warn!(
+                        workspace_path = ?path,
+                        task_id = %task_id.0,
+                        owner_session = %owner_session,
+                        "cleanup_orphan_worktrees: reclaim gate skipped workspace because owning task was missing"
                     );
                 }
                 Err(e) => {


### PR DESCRIPTION
Closes #1466

Linked work: #1466

## Summary

- add a forced workspace reclaim path that terminalizes a leased owner task with `workspace_reclaimed` before deleting the workspace
- release the persisted workspace lease after forced deletion succeeds
- preserve guarded GC behavior for normal disk reconciliation and orphan cleanup
- add focused tests for forced reclaim terminalization/deletion and terminalize-vs-reclaim race behavior

## Scope

Final GH1466 implementation slice for `SP1466-T003` and `SP1466-T006`. Earlier merged PRs covered `SP1466-T004` (#1484) and `SP1466-T001`/`SP1466-T002`/`SP1466-T005` (#1496).

## Verification

- `cargo test -p harness-server forced_reclaim`
- `cargo test -p harness-server reclaim_race`
- `cargo test -p harness-server disk_reconcile`
- `cargo test -p harness-server reclaim_gate`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check -p harness-server --all-targets`
- `python3 checks/route_gate.py --repo . --route implement --issue 1466 --state ready_to_implement --json`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1466`
- `git diff --cached --check`
