### PR TITLE
fix(db): reap legacy path schemas

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -56,6 +56,10 @@ runtime_retry_policy:
   activity_retries: {}
 storage:
   schema_namespace: workflow
+  orphan_reaper_enabled: true
+  orphan_reaper_interval_secs: 3600
+  orphan_reaper_legacy_enabled: true
+  orphan_reaper_legacy_batch: 200
   workflow_watchdog_enabled: false
   workflow_watchdog_age_minutes: 240
   workflow_watchdog_interval_secs: 300

--- a/config/default.toml.example
+++ b/config/default.toml.example
@@ -29,6 +29,13 @@ database_url = "postgres://harness:harness@localhost:5432/harness"
 data_dir = "/home/yourname/.local/share/harness"
 project_root = "."
 
+# Workflow storage sweepers are configured in WORKFLOW.md, not this TOML file.
+# The orphan schema reaper defaults are:
+#   orphan_reaper_enabled: true
+#   orphan_reaper_interval_secs: 3600
+#   orphan_reaper_legacy_enabled: true
+#   orphan_reaper_legacy_batch: 200
+
 [concurrency]
 # High-reasoning agent runs can stay silent for several minutes while thinking.
 # Increase this when using gpt-5.5/xhigh for background workflow runtime jobs.

--- a/crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs
+++ b/crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs
@@ -61,23 +61,27 @@ async fn main() -> anyhow::Result<()> {
             println!("{}", serde_json::to_string_pretty(&report)?);
         } else if report.orphans.is_empty() {
             println!(
-                "No orphaned path-derived schemas (scanned {})",
-                report.scanned
+                "No orphaned path-derived schemas (registered scanned {}, legacy scanned {})",
+                report.registered_scanned, report.legacy_scanned
             );
+            print_legacy_scan_errors(&report.legacy_scan_errors);
         } else {
             println!(
-                "{} {} orphaned schema(s) of {} scanned:",
+                "{} {} orphaned schema(s) of {} scanned (registered reaped {}, legacy reaped {}):",
                 if report.dropped {
                     "Reaped"
                 } else {
                     "Would reap"
                 },
                 report.orphans.len(),
-                report.scanned
+                report.scanned,
+                report.registered_reaped,
+                report.legacy_reaped
             );
             for schema in &report.orphans {
                 println!("  {schema}");
             }
+            print_legacy_scan_errors(&report.legacy_scan_errors);
             if !report.dropped {
                 println!("Re-run with --confirm-drop to drop them.");
             }
@@ -186,6 +190,12 @@ fn print_plan(plan: &PgSchemaCleanupPlan) {
             candidate.estimated_row_count,
             candidate.reason
         );
+    }
+}
+
+fn print_legacy_scan_errors(errors: &[String]) {
+    for error in errors {
+        println!("Legacy scan skipped: {error}");
     }
 }
 

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -262,6 +262,13 @@ pub struct WorkflowStoragePolicy {
     /// Interval, in seconds, between background orphan-schema reap passes.
     #[serde(default = "default_orphan_reaper_interval_secs")]
     pub orphan_reaper_interval_secs: u64,
+    /// Whether the orphan reaper also scans legacy unregistered path-derived
+    /// schemas by subtracting live workspace-derived schema hashes.
+    #[serde(default = "default_true")]
+    pub orphan_reaper_legacy_enabled: bool,
+    /// Maximum legacy unregistered path-derived schemas to drop per tick.
+    #[serde(default = "default_orphan_reaper_legacy_batch")]
+    pub orphan_reaper_legacy_batch: usize,
     /// Enable workflow-runtime stuck-instance reporting. Off by default so
     /// existing deployments keep their current background behavior on upgrade.
     #[serde(default)]
@@ -406,6 +413,8 @@ impl Default for WorkflowStoragePolicy {
             schema_namespace: default_workflow_schema_namespace(),
             orphan_reaper_enabled: true,
             orphan_reaper_interval_secs: default_orphan_reaper_interval_secs(),
+            orphan_reaper_legacy_enabled: true,
+            orphan_reaper_legacy_batch: default_orphan_reaper_legacy_batch(),
             workflow_watchdog_enabled: false,
             workflow_watchdog_age_minutes: default_workflow_watchdog_age_minutes(),
             workflow_watchdog_interval_secs: default_workflow_watchdog_interval_secs(),
@@ -560,6 +569,10 @@ fn default_workflow_schema_namespace() -> String {
 
 fn default_orphan_reaper_interval_secs() -> u64 {
     3600
+}
+
+fn default_orphan_reaper_legacy_batch() -> usize {
+    crate::db_pg_schema_registry::DEFAULT_ORPHAN_REAPER_LEGACY_BATCH
 }
 
 fn default_workflow_watchdog_age_minutes() -> u64 {

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -59,6 +59,8 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert_eq!(cfg.storage.schema_namespace, "workflow");
     assert!(cfg.storage.orphan_reaper_enabled);
     assert_eq!(cfg.storage.orphan_reaper_interval_secs, 3600);
+    assert!(cfg.storage.orphan_reaper_legacy_enabled);
+    assert_eq!(cfg.storage.orphan_reaper_legacy_batch, 200);
     assert!(!cfg.storage.workflow_watchdog_enabled);
     assert_eq!(cfg.storage.workflow_watchdog_age_minutes, 240);
     assert_eq!(cfg.storage.workflow_watchdog_interval_secs, 300);
@@ -196,6 +198,8 @@ storage:
   schema_namespace: orchestration
   orphan_reaper_enabled: false
   orphan_reaper_interval_secs: 44
+  orphan_reaper_legacy_enabled: false
+  orphan_reaper_legacy_batch: 55
   workflow_watchdog_enabled: true
   workflow_watchdog_age_minutes: 12
   workflow_watchdog_interval_secs: 13
@@ -352,6 +356,8 @@ Body
     assert_eq!(cfg.storage.schema_namespace, "orchestration");
     assert!(!cfg.storage.orphan_reaper_enabled);
     assert_eq!(cfg.storage.orphan_reaper_interval_secs, 44);
+    assert!(!cfg.storage.orphan_reaper_legacy_enabled);
+    assert_eq!(cfg.storage.orphan_reaper_legacy_batch, 55);
     assert!(cfg.storage.workflow_watchdog_enabled);
     assert_eq!(cfg.storage.workflow_watchdog_age_minutes, 12);
     assert_eq!(cfg.storage.workflow_watchdog_interval_secs, 13);

--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -11,9 +11,10 @@ pub use crate::db_pg::{
 };
 pub use crate::db_pg_schema_registry::{
     apply_pg_schema_cleanup, ensure_pg_schema_registry, pg_schema_cleanup_plan,
-    reap_orphaned_path_schemas, reap_orphaned_path_schemas_with_workspace_roots,
-    register_pg_schema_ownership, PgSchemaCleanupAction, PgSchemaCleanupCandidate,
-    PgSchemaCleanupPlan, PgSchemaDropResult, PgSchemaOwnership, PgSchemaReapReport,
+    reap_orphaned_path_schemas, reap_orphaned_path_schemas_with_legacy_options,
+    reap_orphaned_path_schemas_with_workspace_roots, register_pg_schema_ownership,
+    PgSchemaCleanupAction, PgSchemaCleanupCandidate, PgSchemaCleanupPlan, PgSchemaDropResult,
+    PgSchemaOwnership, PgSchemaReapReport, DEFAULT_ORPHAN_REAPER_LEGACY_BATCH,
     PG_SCHEMA_REGISTRY_SCHEMA, PG_SCHEMA_REGISTRY_TABLE,
 };
 

--- a/crates/harness-core/src/db_pg_schema_reaper.rs
+++ b/crates/harness-core/src/db_pg_schema_reaper.rs
@@ -1,0 +1,345 @@
+use serde::Serialize;
+use sqlx::postgres::PgPool;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use super::{
+    delete_schema_ownership, drop_schema_cascade_if_exists, ensure_pg_schema_registry,
+    is_legacy_workspace_directory_owner_path, normalize_path_for_comparison,
+    pg_schema_cleanup_plan, LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND,
+    PATH_DERIVED_DIRECTORY_OWNER_KIND, PATH_DERIVED_OWNER_KIND, PG_SCHEMA_REGISTRY_SCHEMA,
+    PG_SCHEMA_REGISTRY_TABLE,
+};
+
+pub const DEFAULT_ORPHAN_REAPER_LEGACY_BATCH: usize = 200;
+
+const LEGACY_WORKSPACE_STORE_PATHS: &[&str] = &[
+    "tasks.db",
+    "threads.db",
+    "projects.db",
+    "plans.db",
+    "issue_workflows.db",
+    "project_workflows.db",
+    "evals.db",
+    "reviews.db",
+    "q_values.db",
+    "runtime_state.db",
+    "events.db",
+    "workflow_runtime.db",
+    "workspace-leases",
+];
+
+/// Report from a reap pass over orphaned path-derived schemas.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct PgSchemaReapReport {
+    /// Total number of path-derived schemas examined.
+    pub scanned: usize,
+    /// Schemas whose owning workspace directory no longer exists.
+    pub orphans: Vec<String>,
+    /// `true` if the orphans were dropped, `false` for a dry run.
+    pub dropped: bool,
+    /// Number of registered path-derived schemas examined.
+    pub registered_scanned: usize,
+    /// Number of registered path-derived schemas selected for reaping.
+    pub registered_reaped: usize,
+    /// Number of unregistered legacy path-derived schemas examined.
+    pub legacy_scanned: usize,
+    /// Number of unregistered legacy path-derived schemas selected for reaping.
+    pub legacy_reaped: usize,
+    /// Non-fatal legacy scan errors. Any entry means legacy reaping was skipped
+    /// for this tick, but registered reaping may still have proceeded.
+    pub legacy_scan_errors: Vec<String>,
+}
+
+/// True if a path-derived schema's owner store path is orphaned.
+///
+/// File-style logical paths use the directory that contained the store (the owner
+/// path's parent) as the liveness signal. Directory owner paths are registered
+/// separately and use the owner path itself as the liveness signal, so deleting a
+/// workspace directory whose parent still exists is still detected as orphaned.
+/// Older registry rows did not distinguish directory owners, so generated
+/// workspace-key children of known workspace roots are treated as legacy
+/// directory owners.
+///
+/// Only a definitive `NotFound` counts as orphaned. Any other error reading the
+/// liveness path metadata (permissions, a transiently-unavailable mount, etc.) is
+/// treated as "keep", so a transient IO failure can never cause a destructive
+/// drop of a live schema. `metadata` (not `Path::exists`) is used precisely so
+/// these two cases can be distinguished.
+#[cfg(test)]
+pub(crate) fn owner_path_is_orphaned(owner_kind: &str, owner_path: &Path) -> bool {
+    owner_path_is_orphaned_with_workspace_roots(owner_kind, owner_path, &[])
+}
+
+pub(crate) fn owner_path_is_orphaned_with_workspace_roots(
+    owner_kind: &str,
+    owner_path: &Path,
+    workspace_roots: &[PathBuf],
+) -> bool {
+    let liveness_path = if owner_kind == PATH_DERIVED_DIRECTORY_OWNER_KIND
+        || ((owner_kind == PATH_DERIVED_OWNER_KIND
+            || owner_kind == LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND)
+            && is_legacy_workspace_directory_owner_path(owner_path, workspace_roots))
+    {
+        owner_path
+    } else {
+        let Some(parent) = owner_path.parent() else {
+            return false;
+        };
+        parent
+    };
+    match std::fs::metadata(liveness_path) {
+        Ok(_) => false,
+        Err(error) => error.kind() == std::io::ErrorKind::NotFound,
+    }
+}
+
+pub(crate) fn orphaned_path_schema_names(
+    rows: Vec<(String, String, Option<String>, Option<String>)>,
+    workspace_roots: Vec<PathBuf>,
+) -> Vec<String> {
+    let mut orphans = Vec::new();
+    for (schema_name, owner_kind, owner_key, owner_path) in rows {
+        // No recorded path: cannot prove the schema is orphaned, so keep it.
+        let Some(liveness_path) =
+            owner_liveness_path(&owner_kind, owner_key.as_deref(), owner_path.as_deref())
+        else {
+            continue;
+        };
+        if owner_path_is_orphaned_with_workspace_roots(
+            &owner_kind,
+            Path::new(liveness_path),
+            &workspace_roots,
+        ) {
+            orphans.push(schema_name);
+        }
+    }
+    orphans
+}
+
+fn owner_liveness_path<'a>(
+    owner_kind: &str,
+    owner_key: Option<&'a str>,
+    owner_path: Option<&'a str>,
+) -> Option<&'a str> {
+    owner_path.or_else(|| {
+        if owner_kind == LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND {
+            owner_key.filter(|key| Path::new(key).is_absolute())
+        } else {
+            None
+        }
+    })
+}
+
+/// Drop path-derived schemas whose owning workspace directory is gone.
+///
+/// This bounds Postgres catalog growth automatically: per-job / ephemeral stores
+/// create a schema under their workspace path, and once the workspace is removed
+/// the schema becomes a dead orphan that nothing can reopen. Reaping drops only
+/// those orphans (the owner directory or file owner parent is missing) and the
+/// matching registry rows — never a live store's schema.
+///
+/// With `apply = false` it reports what would be reaped (dry run) without
+/// dropping anything. Must run on the host that owns the workspace paths.
+pub async fn reap_orphaned_path_schemas(
+    pool: &PgPool,
+    apply: bool,
+) -> anyhow::Result<PgSchemaReapReport> {
+    reap_orphaned_path_schemas_with_workspace_roots(pool, apply, &[]).await
+}
+
+pub async fn reap_orphaned_path_schemas_with_workspace_roots(
+    pool: &PgPool,
+    apply: bool,
+    workspace_roots: &[PathBuf],
+) -> anyhow::Result<PgSchemaReapReport> {
+    reap_orphaned_path_schemas_with_legacy_options(
+        pool,
+        apply,
+        workspace_roots,
+        true,
+        DEFAULT_ORPHAN_REAPER_LEGACY_BATCH,
+    )
+    .await
+}
+
+pub async fn reap_orphaned_path_schemas_with_legacy_options(
+    pool: &PgPool,
+    apply: bool,
+    workspace_roots: &[PathBuf],
+    legacy_enabled: bool,
+    legacy_batch: usize,
+) -> anyhow::Result<PgSchemaReapReport> {
+    ensure_pg_schema_registry(pool).await?;
+    let rows: Vec<(String, String, Option<String>, Option<String>)> = sqlx::query_as(&format!(
+        "SELECT schema_name, owner_kind, owner_key, owner_path
+         FROM \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
+         WHERE owner_kind IN ($1, $2, $3)"
+    ))
+    .bind(PATH_DERIVED_OWNER_KIND)
+    .bind(PATH_DERIVED_DIRECTORY_OWNER_KIND)
+    .bind(LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND)
+    .fetch_all(pool)
+    .await?;
+
+    let registered_scanned = rows.len();
+    let registered_workspace_roots = workspace_roots.to_vec();
+    let registered_orphans = tokio::task::spawn_blocking(move || {
+        let workspace_roots: Vec<PathBuf> = registered_workspace_roots
+            .iter()
+            .map(|root| normalize_path_for_comparison(root))
+            .collect();
+        orphaned_path_schema_names(rows, workspace_roots)
+    })
+    .await?;
+    let registered_reaped = registered_orphans.len();
+
+    let legacy_scan = if legacy_enabled {
+        let legacy_workspace_roots = workspace_roots.to_vec();
+        let legacy_candidates = unregistered_legacy_path_schema_names(pool).await?;
+        tokio::task::spawn_blocking(move || {
+            legacy_orphaned_path_schema_names(
+                legacy_candidates,
+                &legacy_workspace_roots,
+                legacy_batch,
+            )
+        })
+        .await?
+    } else {
+        LegacyPathSchemaScan::disabled()
+    };
+    let legacy_scanned = legacy_scan.scanned;
+    let legacy_reaped = legacy_scan.orphans.len();
+    let legacy_scan_errors = legacy_scan.errors;
+    let legacy_orphans = legacy_scan.orphans;
+
+    if apply {
+        for schema_name in &registered_orphans {
+            // Reaping is registry-driven, so stale rows may point at schemas
+            // already removed by manual cleanup or an interrupted prior run.
+            // Delete those ownership rows and keep processing later orphans.
+            drop_schema_cascade_if_exists(pool, schema_name).await?;
+            delete_schema_ownership(pool, schema_name).await?;
+        }
+        for schema_name in &legacy_orphans {
+            drop_schema_cascade_if_exists(pool, schema_name).await?;
+        }
+    }
+
+    let scanned = registered_scanned + legacy_scanned;
+    let mut orphans = registered_orphans;
+    orphans.extend(legacy_orphans);
+
+    Ok(PgSchemaReapReport {
+        scanned,
+        orphans,
+        dropped: apply,
+        registered_scanned,
+        registered_reaped,
+        legacy_scanned,
+        legacy_reaped,
+        legacy_scan_errors,
+    })
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LegacyPathSchemaScan {
+    pub scanned: usize,
+    pub orphans: Vec<String>,
+    pub errors: Vec<String>,
+}
+
+impl LegacyPathSchemaScan {
+    fn disabled() -> Self {
+        Self::default()
+    }
+}
+
+async fn unregistered_legacy_path_schema_names(pool: &PgPool) -> anyhow::Result<Vec<String>> {
+    let plan = pg_schema_cleanup_plan(pool, true).await?;
+    Ok(plan
+        .candidates
+        .into_iter()
+        .filter(|candidate| !candidate.registered)
+        .map(|candidate| candidate.schema_name)
+        .collect())
+}
+
+pub(crate) fn legacy_orphaned_path_schema_names(
+    candidates: Vec<String>,
+    workspace_roots: &[PathBuf],
+    legacy_batch: usize,
+) -> LegacyPathSchemaScan {
+    let scanned = candidates.len();
+    if candidates.is_empty() || legacy_batch == 0 {
+        return LegacyPathSchemaScan {
+            scanned,
+            ..LegacyPathSchemaScan::default()
+        };
+    }
+
+    let live_schemas = match live_legacy_workspace_schema_names(workspace_roots) {
+        Ok(live_schemas) => live_schemas,
+        Err(error) => {
+            return LegacyPathSchemaScan {
+                scanned,
+                errors: vec![error.to_string()],
+                ..LegacyPathSchemaScan::default()
+            };
+        }
+    };
+
+    let orphans = candidates
+        .into_iter()
+        .filter(|schema| !live_schemas.contains(schema))
+        .take(legacy_batch)
+        .collect();
+
+    LegacyPathSchemaScan {
+        scanned,
+        orphans,
+        errors: Vec::new(),
+    }
+}
+
+pub(crate) fn live_legacy_workspace_schema_names(
+    workspace_roots: &[PathBuf],
+) -> anyhow::Result<HashSet<String>> {
+    if workspace_roots.is_empty() {
+        anyhow::bail!("no workspace roots configured for legacy path-schema reaping");
+    }
+
+    let mut schemas = HashSet::new();
+    for root in workspace_roots {
+        let entries = std::fs::read_dir(root).map_err(|error| {
+            anyhow::anyhow!("failed to read workspace root {:?}: {error}", root)
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                anyhow::anyhow!(
+                    "failed to read workspace root entry under {:?}: {error}",
+                    root
+                )
+            })?;
+            let file_type = entry.file_type().map_err(|error| {
+                anyhow::anyhow!(
+                    "failed to inspect workspace root entry {:?}: {error}",
+                    entry.path()
+                )
+            })?;
+            if !file_type.is_dir() {
+                continue;
+            }
+
+            let workspace_path = entry.path();
+            schemas.insert(crate::db_pg::pg_schema_for_path(&workspace_path)?);
+            for store_path in LEGACY_WORKSPACE_STORE_PATHS {
+                schemas.insert(crate::db_pg::pg_schema_for_path(
+                    &workspace_path.join(store_path),
+                )?);
+            }
+        }
+    }
+
+    Ok(schemas)
+}

--- a/crates/harness-core/src/db_pg_schema_reaper.rs
+++ b/crates/harness-core/src/db_pg_schema_reaper.rs
@@ -198,11 +198,11 @@ pub async fn reap_orphaned_path_schemas_with_legacy_options(
         let legacy_workspace_roots = workspace_roots.to_vec();
         let legacy_candidates = unregistered_legacy_path_schema_names(pool).await?;
         tokio::task::spawn_blocking(move || {
-            legacy_orphaned_path_schema_names(
-                legacy_candidates,
-                &legacy_workspace_roots,
-                legacy_batch,
-            )
+            let workspace_roots: Vec<PathBuf> = legacy_workspace_roots
+                .iter()
+                .map(|root| normalize_path_for_comparison(root))
+                .collect();
+            legacy_orphaned_path_schema_names(legacy_candidates, &workspace_roots, legacy_batch)
         })
         .await?
     } else {

--- a/crates/harness-core/src/db_pg_schema_registry.rs
+++ b/crates/harness-core/src/db_pg_schema_registry.rs
@@ -11,6 +11,21 @@ const PATH_DERIVED_DIRECTORY_OWNER_KIND: &str = "path_derived_directory_store";
 const LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND: &str = "path_derived_schema";
 const PATH_DERIVED_RETENTION_CLASS: &str = "path_derived";
 
+#[path = "db_pg_schema_reaper.rs"]
+mod db_pg_schema_reaper;
+pub use db_pg_schema_reaper::{
+    reap_orphaned_path_schemas, reap_orphaned_path_schemas_with_legacy_options,
+    reap_orphaned_path_schemas_with_workspace_roots, PgSchemaReapReport,
+    DEFAULT_ORPHAN_REAPER_LEGACY_BATCH,
+};
+
+#[cfg(test)]
+pub(crate) use db_pg_schema_reaper::{
+    legacy_orphaned_path_schema_names, live_legacy_workspace_schema_names,
+    orphaned_path_schema_names, owner_path_is_orphaned,
+    owner_path_is_orphaned_with_workspace_roots,
+};
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PgSchemaOwnership {
     pub schema_name: String,
@@ -520,159 +535,6 @@ async fn delete_schema_ownership(pool: &PgPool, schema: &str) -> anyhow::Result<
     .execute(pool)
     .await?;
     Ok(())
-}
-
-/// Report from a reap pass over orphaned path-derived schemas.
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct PgSchemaReapReport {
-    /// Number of registered path-derived schemas examined.
-    pub scanned: usize,
-    /// Schemas whose owning workspace directory no longer exists (orphans).
-    pub orphans: Vec<String>,
-    /// `true` if the orphans were dropped, `false` for a dry run.
-    pub dropped: bool,
-}
-
-/// True if a path-derived schema's owner store path is orphaned.
-///
-/// File-style logical paths use the directory that contained the store (the owner
-/// path's parent) as the liveness signal. Directory owner paths are registered
-/// separately and use the owner path itself as the liveness signal, so deleting a
-/// workspace directory whose parent still exists is still detected as orphaned.
-/// Older registry rows did not distinguish directory owners, so generated
-/// workspace-key children of known workspace roots are treated as legacy
-/// directory owners.
-///
-/// Only a definitive `NotFound` counts as orphaned. Any other error reading the
-/// liveness path metadata (permissions, a transiently-unavailable mount, etc.) is
-/// treated as "keep", so a transient IO failure can never cause a destructive
-/// drop of a live schema. `metadata` (not `Path::exists`) is used precisely so
-/// these two cases can be distinguished.
-#[cfg(test)]
-fn owner_path_is_orphaned(owner_kind: &str, owner_path: &Path) -> bool {
-    owner_path_is_orphaned_with_workspace_roots(owner_kind, owner_path, &[])
-}
-
-fn owner_path_is_orphaned_with_workspace_roots(
-    owner_kind: &str,
-    owner_path: &Path,
-    workspace_roots: &[PathBuf],
-) -> bool {
-    let liveness_path = if owner_kind == PATH_DERIVED_DIRECTORY_OWNER_KIND
-        || ((owner_kind == PATH_DERIVED_OWNER_KIND
-            || owner_kind == LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND)
-            && is_legacy_workspace_directory_owner_path(owner_path, workspace_roots))
-    {
-        owner_path
-    } else {
-        let Some(parent) = owner_path.parent() else {
-            return false;
-        };
-        parent
-    };
-    match std::fs::metadata(liveness_path) {
-        Ok(_) => false,
-        Err(error) => error.kind() == std::io::ErrorKind::NotFound,
-    }
-}
-
-fn orphaned_path_schema_names(
-    rows: Vec<(String, String, Option<String>, Option<String>)>,
-    workspace_roots: Vec<PathBuf>,
-) -> Vec<String> {
-    let mut orphans = Vec::new();
-    for (schema_name, owner_kind, owner_key, owner_path) in rows {
-        // No recorded path: cannot prove the schema is orphaned, so keep it.
-        let Some(liveness_path) =
-            owner_liveness_path(&owner_kind, owner_key.as_deref(), owner_path.as_deref())
-        else {
-            continue;
-        };
-        if owner_path_is_orphaned_with_workspace_roots(
-            &owner_kind,
-            Path::new(liveness_path),
-            &workspace_roots,
-        ) {
-            orphans.push(schema_name);
-        }
-    }
-    orphans
-}
-
-fn owner_liveness_path<'a>(
-    owner_kind: &str,
-    owner_key: Option<&'a str>,
-    owner_path: Option<&'a str>,
-) -> Option<&'a str> {
-    owner_path.or_else(|| {
-        if owner_kind == LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND {
-            owner_key.filter(|key| Path::new(key).is_absolute())
-        } else {
-            None
-        }
-    })
-}
-
-/// Drop registered path-derived schemas whose owning workspace directory is gone.
-///
-/// This bounds Postgres catalog growth automatically: per-job / ephemeral stores
-/// create a schema under their workspace path, and once the workspace is removed
-/// the schema becomes a dead orphan that nothing can reopen. Reaping drops only
-/// those orphans (the owner directory or file owner parent is missing) and the
-/// matching registry rows — never a live store's schema.
-///
-/// With `apply = false` it reports what would be reaped (dry run) without
-/// dropping anything. Must run on the host that owns the workspace paths.
-pub async fn reap_orphaned_path_schemas(
-    pool: &PgPool,
-    apply: bool,
-) -> anyhow::Result<PgSchemaReapReport> {
-    reap_orphaned_path_schemas_with_workspace_roots(pool, apply, &[]).await
-}
-
-pub async fn reap_orphaned_path_schemas_with_workspace_roots(
-    pool: &PgPool,
-    apply: bool,
-    workspace_roots: &[PathBuf],
-) -> anyhow::Result<PgSchemaReapReport> {
-    ensure_pg_schema_registry(pool).await?;
-    let rows: Vec<(String, String, Option<String>, Option<String>)> = sqlx::query_as(&format!(
-        "SELECT schema_name, owner_kind, owner_key, owner_path
-         FROM \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\"
-         WHERE owner_kind IN ($1, $2, $3)"
-    ))
-    .bind(PATH_DERIVED_OWNER_KIND)
-    .bind(PATH_DERIVED_DIRECTORY_OWNER_KIND)
-    .bind(LEGACY_PATH_DERIVED_SCHEMA_OWNER_KIND)
-    .fetch_all(pool)
-    .await?;
-
-    let scanned = rows.len();
-    let workspace_roots = workspace_roots.to_vec();
-    let orphans = tokio::task::spawn_blocking(move || {
-        let workspace_roots: Vec<PathBuf> = workspace_roots
-            .iter()
-            .map(|root| normalize_path_for_comparison(root))
-            .collect();
-        orphaned_path_schema_names(rows, workspace_roots)
-    })
-    .await?;
-
-    if apply {
-        for schema_name in &orphans {
-            // Reaping is registry-driven, so stale rows may point at schemas
-            // already removed by manual cleanup or an interrupted prior run.
-            // Delete those ownership rows and keep processing later orphans.
-            drop_schema_cascade_if_exists(pool, schema_name).await?;
-            delete_schema_ownership(pool, schema_name).await?;
-        }
-    }
-
-    Ok(PgSchemaReapReport {
-        scanned,
-        orphans,
-        dropped: apply,
-    })
 }
 
 #[cfg(test)]

--- a/crates/harness-core/src/db_pg_schema_registry_tests.rs
+++ b/crates/harness-core/src/db_pg_schema_registry_tests.rs
@@ -709,6 +709,32 @@ fn legacy_orphan_selection_keeps_live_workspace_schemas_and_bounds_batch() -> an
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn legacy_orphan_selection_normalizes_symlinked_workspace_root() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace_root = parent.path().join("workspaces");
+    let linked_root = parent.path().join("linked-workspaces");
+    let workspace = workspace_root.join("550e8400-e29b-41d4-a716-446655440000");
+    std::fs::create_dir_all(&workspace)?;
+    std::os::unix::fs::symlink(&workspace_root, &linked_root)?;
+    let live_schema = crate::db_pg::pg_schema_for_path(&crate::config::dirs::default_db_path(
+        &workspace, "tasks",
+    ))?;
+    let orphan = "h3333333333333333".to_string();
+
+    let scan = legacy_orphaned_path_schema_names(
+        vec![live_schema.clone(), orphan.clone()],
+        &[linked_root],
+        10,
+    );
+
+    assert_eq!(scan.orphans, vec![orphan]);
+    assert!(!scan.orphans.contains(&live_schema));
+    assert!(scan.errors.is_empty());
+    Ok(())
+}
+
 #[test]
 fn legacy_orphan_selection_keeps_all_candidates_when_workspace_root_is_ambiguous() {
     let scan = legacy_orphaned_path_schema_names(

--- a/crates/harness-core/src/db_pg_schema_registry_tests.rs
+++ b/crates/harness-core/src/db_pg_schema_registry_tests.rs
@@ -664,3 +664,61 @@ fn legacy_path_schema_name_detection_is_exact() {
     assert!(!is_legacy_path_schema_name("h0123456789abcdeg"));
     assert!(!is_legacy_path_schema_name("h0123456789abcde"));
 }
+
+#[test]
+fn live_legacy_workspace_schema_names_hashes_workspace_and_known_stores() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace_root = parent.path().join("workspaces");
+    let workspace = workspace_root.join("abcd1234__owner_repo__issue_42");
+    std::fs::create_dir_all(&workspace)?;
+
+    let live_schemas = live_legacy_workspace_schema_names(&[workspace_root])?;
+
+    assert!(live_schemas.contains(&crate::db_pg::pg_schema_for_path(&workspace)?));
+    assert!(live_schemas.contains(&crate::db_pg::pg_schema_for_path(
+        &crate::config::dirs::default_db_path(&workspace, "tasks")
+    )?));
+    assert!(live_schemas.contains(&crate::db_pg::pg_schema_for_path(
+        &crate::config::dirs::default_db_path(&workspace, "plans")
+    )?));
+    Ok(())
+}
+
+#[test]
+fn legacy_orphan_selection_keeps_live_workspace_schemas_and_bounds_batch() -> anyhow::Result<()> {
+    let parent = tempfile::tempdir()?;
+    let workspace_root = parent.path().join("workspaces");
+    let workspace = workspace_root.join("550e8400-e29b-41d4-a716-446655440000");
+    std::fs::create_dir_all(&workspace)?;
+    let live_schema = crate::db_pg::pg_schema_for_path(&crate::config::dirs::default_db_path(
+        &workspace, "tasks",
+    ))?;
+    let first_orphan = "h1111111111111111".to_string();
+    let second_orphan = "h2222222222222222".to_string();
+
+    let scan = legacy_orphaned_path_schema_names(
+        vec![live_schema.clone(), first_orphan.clone(), second_orphan],
+        &[workspace_root],
+        1,
+    );
+
+    assert_eq!(scan.scanned, 3);
+    assert_eq!(scan.orphans, vec![first_orphan]);
+    assert!(scan.errors.is_empty());
+    assert!(!scan.orphans.contains(&live_schema));
+    Ok(())
+}
+
+#[test]
+fn legacy_orphan_selection_keeps_all_candidates_when_workspace_root_is_ambiguous() {
+    let scan = legacy_orphaned_path_schema_names(
+        vec!["h1111111111111111".to_string()],
+        &[PathBuf::from("/definitely/missing/harness/workspaces")],
+        200,
+    );
+
+    assert_eq!(scan.scanned, 1);
+    assert!(scan.orphans.is_empty());
+    assert_eq!(scan.errors.len(), 1);
+    assert!(scan.errors[0].contains("failed to read workspace root"));
+}

--- a/crates/harness-server/src/http/orphan_reaper.rs
+++ b/crates/harness-server/src/http/orphan_reaper.rs
@@ -61,21 +61,46 @@ pub(super) fn spawn_orphan_schema_reaper(state: &Arc<AppState>) {
             } else if let Some(store) = state.core.workflow_runtime_store.as_ref() {
                 let workspace_roots =
                     workspace_roots_for_reaper(state.concurrency.workspace_mgr.as_deref());
-                match harness_core::db::reap_orphaned_path_schemas_with_workspace_roots(
+                match harness_core::db::reap_orphaned_path_schemas_with_legacy_options(
                     store.pool(),
                     true,
                     &workspace_roots,
+                    workflow_cfg.storage.orphan_reaper_legacy_enabled,
+                    workflow_cfg.storage.orphan_reaper_legacy_batch,
                 )
                 .await
                 {
-                    Ok(report) if !report.orphans.is_empty() => {
-                        tracing::info!(
-                            scanned = report.scanned,
-                            reaped = report.orphans.len(),
-                            "orphan schema reaper dropped orphaned path-derived schemas"
-                        );
+                    Ok(report) => {
+                        if !report.legacy_scan_errors.is_empty() {
+                            tracing::warn!(
+                                registered_scanned = report.registered_scanned,
+                                registered_reaped = report.registered_reaped,
+                                legacy_scanned = report.legacy_scanned,
+                                legacy_reaped = report.legacy_reaped,
+                                legacy_scan_errors = ?report.legacy_scan_errors,
+                                "orphan schema reaper skipped legacy path-derived schema reaping"
+                            );
+                        }
+                        if report.orphans.is_empty() {
+                            tracing::debug!(
+                                registered_scanned = report.registered_scanned,
+                                registered_reaped = report.registered_reaped,
+                                legacy_scanned = report.legacy_scanned,
+                                legacy_reaped = report.legacy_reaped,
+                                "orphan schema reaper tick found no orphaned path-derived schemas"
+                            );
+                        } else {
+                            tracing::info!(
+                                scanned = report.scanned,
+                                reaped = report.orphans.len(),
+                                registered_scanned = report.registered_scanned,
+                                registered_reaped = report.registered_reaped,
+                                legacy_scanned = report.legacy_scanned,
+                                legacy_reaped = report.legacy_reaped,
+                                "orphan schema reaper dropped orphaned path-derived schemas"
+                            );
+                        }
                     }
-                    Ok(_) => {}
                     Err(error) => {
                         tracing::warn!("orphan schema reaper tick failed: {error}");
                     }

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -532,6 +532,10 @@ Workflow-runtime watchdog and retention sweepers are configured in
 
 ```yaml
 storage:
+  orphan_reaper_enabled: true
+  orphan_reaper_interval_secs: 3600
+  orphan_reaper_legacy_enabled: true
+  orphan_reaper_legacy_batch: 200
   workflow_watchdog_enabled: false
   workflow_watchdog_age_minutes: 240
   workflow_watchdog_interval_secs: 300
@@ -541,6 +545,11 @@ storage:
   runtime_retention_batch_size: 1000
   runtime_retention_interval_secs: 3600
 ```
+
+The orphan schema reaper is enabled by default. It drops registered
+path-derived schemas with dead owner paths and, in bounded batches, legacy
+unregistered `h<16-hex>` schemas that cannot be matched to a live workspace
+directory or known store path under the configured workspace root.
 
 Enable `workflow_watchdog_enabled` first. It is read-only: aged `blocked` and
 `awaiting_feedback` workflow instances appear in `/api/operator-monitor` under

--- a/scripts/check_storage_legacy_openers.py
+++ b/scripts/check_storage_legacy_openers.py
@@ -285,6 +285,18 @@ def is_allowed_legacy_context(
     return False
 
 
+def is_allowed_legacy_hash_discovery(
+    path: Path,
+    current_function: str | None,
+    pattern: str,
+) -> bool:
+    return (
+        path.name == "db_pg_schema_reaper.rs"
+        and current_function == "live_legacy_workspace_schema_names"
+        and pattern == "pg_schema_for_path("
+    )
+
+
 def scan_file(path: Path) -> list[Violation]:
     if is_test_source(path):
         return []
@@ -363,7 +375,7 @@ def scan_file(path: Path) -> list[Violation]:
         for pattern in LEGACY_PATTERNS:
             if pattern not in line:
                 continue
-            if is_allowed:
+            if is_allowed or is_allowed_legacy_hash_discovery(path, current_function, pattern):
                 continue
             violations.append(Violation(path, index + 1, pattern, line))
         for alias, function_name in function_aliases.items():
@@ -607,6 +619,14 @@ def run_self_test() -> int:
                 pub fn allowed_cfg_nested_all_test(path: &std::path::Path) {
                     let _ = PgStoreContext::from_legacy_path_schema(path, None);
                 }
+            }
+            """,
+        )
+        write(
+            root / "crates/demo/src/db_pg_schema_reaper.rs",
+            """
+            pub fn live_legacy_workspace_schema_names(path: &std::path::Path) {
+                let _ = pg_schema_for_path(path);
             }
             """,
         )

--- a/scripts/pg-orphan-cleanup.sh
+++ b/scripts/pg-orphan-cleanup.sh
@@ -1,99 +1,55 @@
 #!/usr/bin/env bash
-# One-off P1 cleanup: drop dead path-derived Postgres schemas (storage RFC).
+# Dry-run or apply the same path-derived Postgres schema reaper used by the
+# running server.
 #
-# SAFETY MODEL (dual-signal keep-list, recomputed at apply time — never trusts a
-# stale list):
-#   KEEP a schema iff EITHER it had write activity in a fresh observation window
-#   OR its registry owner_path still exists on disk; plus `workflow_runtime` and
-#   all non-`h*` schemas. Everything else matching ^h[0-9a-f]{16}$ is dropped.
+# The server and this wrapper both handle two classes:
+#   1. registered path-derived schemas with dead owner paths
+#   2. legacy unregistered h<16-hex> schemas whose hash does not match any live
+#      workspace directory or known logical store path under the configured
+#      workspace root
 #
-# Defaults to DRY-RUN. Pass --confirm to apply. Dumps schema-only first.
-# Recommended: run with the harness server paused for maximum safety.
+# Safety model:
+#   - Defaults to dry-run.
+#   - Pass --confirm to drop selected schemas via DROP SCHEMA IF EXISTS ... CASCADE.
+#   - Legacy reaping fails closed if the configured workspace root cannot be
+#     listed, because live ownership cannot be proven.
+#   - The legacy class is bounded by storage.orphan_reaper_legacy_batch in server
+#     config and by the CLI default when run here.
 set -euo pipefail
 
-PSQL="${PSQL:-/opt/homebrew/opt/libpq/bin/psql}"
-PGHOST="${PGHOST:-localhost}"; PGPORT="${PGPORT:-5432}"
-PGUSER="${PGUSER:-harness}"; PGDB="${PGDB:-harness}"
-export PGPASSWORD="${PGPASSWORD:-harness}"
-WINDOW="${WINDOW:-70}"
-CONFIRM=0
-[ "${1:-}" = "--confirm" ] && CONFIRM=1
+HARNESS_PG_SCHEMA_CLEANUP="${HARNESS_PG_SCHEMA_CLEANUP:-harness-pg-schema-cleanup}"
 
-q() { "$PSQL" -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" -t -A -F'|' -c "$1"; }
+CONFIRM_ARGS=()
+CONFIG_ARGS=()
 
-echo "== observing write activity for ${WINDOW}s to identify live schemas =="
-q "SELECT schemaname, sum(n_tup_ins+n_tup_upd+n_tup_del) FROM pg_stat_user_tables GROUP BY schemaname" > /tmp/_wt0.txt
-sleep "$WINDOW"
-q "SELECT schemaname, sum(n_tup_ins+n_tup_upd+n_tup_del) FROM pg_stat_user_tables GROUP BY schemaname" > /tmp/_wt1.txt
-q "SELECT schema_name, coalesce(owner_path,'') FROM harness_admin.schema_ownership" > /tmp/_own.txt
-q "SELECT schema_name FROM information_schema.schemata WHERE schema_name ~ '^h[0-9a-f]{16}\$'" > /tmp/_allh.txt
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --confirm)
+      CONFIRM_ARGS=(--confirm-drop)
+      shift
+      ;;
+    --config)
+      if [ "$#" -lt 2 ]; then
+        echo "--config requires a path" >&2
+        exit 2
+      fi
+      CONFIG_ARGS=(--config "$2")
+      shift 2
+      ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: scripts/pg-orphan-cleanup.sh [--config PATH] [--confirm]
 
-python3 - "$CONFIRM" << 'PY'
-import os, sys, re
-confirm = sys.argv[1] == "1"
-def lw(p):
-    d={}
-    for ln in open(p):
-        ln=ln.strip()
-        if '|' in ln:
-            s,w=ln.rsplit('|',1)
-            try: d[s]=int(w)
-            except: d[s]=0
-    return d
-t0,t1=lw('/tmp/_wt0.txt'),lw('/tmp/_wt1.txt')
-owner={}
-for ln in open('/tmp/_own.txt'):
-    ln=ln.rstrip('\n')
-    if '|' in ln:
-        a,b=ln.rsplit('|',1); owner[a]=b
-allh={ln.strip() for ln in open('/tmp/_allh.txt') if ln.strip()}
-live={s for s in t1 if t1.get(s,0)>t0.get(s,0)}
-# Match the runtime reaper's orphan oracle (db_pg_schema_registry::owner_path_is_orphaned):
-# a path-derived store is alive while its owner_path's PARENT directory exists.
-# owner_path is an identity like `<workspace>/events.db` and the .db file may not
-# exist on disk for a Postgres-backed store, so checking the file (not its parent)
-# could drop a live schema whose workspace dir is still present.
-def owner_parent_alive(p):
-    return bool(p) and os.path.isdir(os.path.dirname(p.rstrip('/')))
-keep={s for s in allh if (s in live) or owner_parent_alive(owner.get(s))} | {'workflow_runtime'}
-drop=sorted(allh-keep)
-open('/tmp/_drop.txt','w').write('\n'.join(drop)+('\n' if drop else ''))
-# keep-list for the targeted backup (only live data needs preserving)
-open('/tmp/_keep.txt','w').write('\n'.join(sorted(allh & keep))+('\n' if (allh & keep) else ''))
-print(f"KEEP {len(allh & keep)} h* schemas, DROP {len(drop)}")
-print("KEEP:", ", ".join(sorted(allh & keep)) or "(none)")
-if not confirm:
-    print("\nDRY-RUN. Re-run with --confirm to drop the listed schemas.")
-PY
+Runs harness-pg-schema-cleanup --reap-orphans with the same registered and
+legacy path-derived schema semantics as the background server reaper.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
 
-[ "$CONFIRM" = 1 ] || exit 0
-
-echo "== backing up ONLY the live keep-list schemas (full data) before dropping =="
-# A whole-catalog dump locks every table in one txn and blows max_locks_per_transaction
-# with 13k schemas. The schemas being dropped are dead by definition and need no
-# backup; only the live keep-list holds data worth preserving — dump just those.
-DUMP="/tmp/harness-keepset-predrop-$(q "SELECT to_char(now(),'YYYYMMDDHH24MISS')").sql"
-NARGS=(-n harness_admin -n workflow_runtime)
-while IFS= read -r s; do [ -n "$s" ] && NARGS+=(-n "$s"); done < /tmp/_keep.txt
-/opt/homebrew/opt/libpq/bin/pg_dump -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" \
-  "${NARGS[@]}" -f "$DUMP"
-echo "keep-set backup written: $DUMP ($(wc -c < "$DUMP") bytes)"
-
-echo "== dropping $(wc -l < /tmp/_drop.txt) schemas =="
-n=0
-while IFS= read -r s; do
-  [ -z "$s" ] && continue
-  # Re-validate the schema name immediately before interpolating it into SQL.
-  # Only the hashed path-derived form is ever a drop target; anything else is a bug.
-  if ! printf '%s' "$s" | grep -Eq '^h[0-9a-f]{16}$'; then
-    echo "  REFUSING to drop non-conforming schema name: '$s'" >&2
-    continue
-  fi
-  "$PSQL" -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" -c "DROP SCHEMA IF EXISTS \"$s\" CASCADE" >/dev/null
-  if ! q "DELETE FROM harness_admin.schema_ownership WHERE schema_name = '$s'" >/dev/null; then
-    echo "  WARN: dropped schema $s but failed to delete its ownership row" >&2
-  fi
-  n=$((n+1))
-  [ $((n % 500)) -eq 0 ] && echo "  dropped $n ..."
-done < /tmp/_drop.txt
-echo "done: dropped $n schemas. Run VACUUM/ANALYZE and check pg_database_size."
+exec "$HARNESS_PG_SCHEMA_CLEANUP" "${CONFIG_ARGS[@]}" --reap-orphans "${CONFIRM_ARGS[@]}"


### PR DESCRIPTION
## Summary

- Closes #1436
- Linked work: #1436
- Implements GH1436 legacy unregistered path-derived schema discovery for the server orphan reaper.
- Splits the reaper out of `db_pg_schema_registry.rs`, keeps registered reaping behavior, and adds fail-closed legacy live-workspace subtraction plus bounded batch drops.
- Adds workflow config keys for `orphan_reaper_legacy_enabled` and `orphan_reaper_legacy_batch`, updates per-class server logs, and aligns the CLI/script/docs with server behavior.

## SpecRail

- Spec packet: `specs/GH1436/product.md`, `specs/GH1436/tech.md`, `specs/GH1436/tasks.md`
- Tasks covered: SP1436-T1, SP1436-T2, SP1436-T3
- SP1436-T4 local verification covered below; production dry-run was not run from this checkout because no local database URL is configured.

## Verification

- `cargo test -p harness-core db_pg_schema_registry`
- `cargo test -p harness-server orphan_reaper`
- `cargo test -p harness-cli`
- `cargo test -p harness-core load_workflow_config`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check -p harness-core -p harness-server -p harness-cli --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 scripts/check_storage_legacy_openers.py --self-test && python3 scripts/check_storage_legacy_openers.py`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1436`
- `python3 checks/route_gate.py --repo . --route implement --issue 1436 --state ready_to_implement --json`

## CI diagnosis

- Initial PR head `45d3fd7c` failed `Storage Legacy Openers` because the guard flagged the intentional `pg_schema_for_path` calls in `db_pg_schema_reaper.rs`.
- Reproduced locally with `python3 scripts/check_storage_legacy_openers.py --self-test && python3 scripts/check_storage_legacy_openers.py`.
- Fixed with a path- and function-specific allowlist for `db_pg_schema_reaper.rs::live_legacy_workspace_schema_names` and extended the guard self-test.

## Verification gap

- `cargo run -p harness-cli --bin harness-pg-schema-cleanup -- --reap-orphans --json` built the binary but could not run the dry-run because this shell has no `server.database_url` or `HARNESS_DATABASE_URL` configured.
