### PR TITLE
feat(observe): emit OTel runtime trajectory spans

### DIFF
--- a/crates/harness-agents/src/codex_adapter_tests.rs
+++ b/crates/harness-agents/src/codex_adapter_tests.rs
@@ -118,7 +118,7 @@ fn parse_error_notification() {
 }
 
 #[test]
-fn parse_token_usage_notification() {
+fn otel_turn_spans_parse_token_usage_notification() {
     let line = r#"{"method":"thread/tokenUsage/updated","params":{"threadId":"thread-1","turnId":"turn-1","tokenUsage":{"last":{"inputTokens":10,"cachedInputTokens":4,"outputTokens":3,"reasoningOutputTokens":2,"totalTokens":15},"total":{"inputTokens":10,"cachedInputTokens":4,"outputTokens":3,"reasoningOutputTokens":2,"totalTokens":15}}}}"#;
     let message = parse_codex_message(line).unwrap();
     assert_eq!(

--- a/crates/harness-observe/src/event_store/external_signals.rs
+++ b/crates/harness-observe/src/event_store/external_signals.rs
@@ -1,0 +1,48 @@
+use super::EventStore;
+use chrono::{DateTime, Utc};
+use harness_core::types::{ExternalSignal, ExternalSignalId};
+use std::io::{BufRead, Write};
+
+impl EventStore {
+    fn signals_file(&self) -> std::path::PathBuf {
+        self.data_dir.join("signals.jsonl")
+    }
+
+    pub fn log_external_signal(&self, signal: &ExternalSignal) -> anyhow::Result<ExternalSignalId> {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.signals_file())?;
+        let line = serde_json::to_string(signal)?;
+        writeln!(file, "{line}")?;
+        Ok(signal.id.clone())
+    }
+
+    pub fn query_external_signals(
+        &self,
+        since: Option<DateTime<Utc>>,
+    ) -> anyhow::Result<Vec<ExternalSignal>> {
+        let path = self.signals_file();
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = std::fs::File::open(&path)?;
+        let reader = std::io::BufReader::new(file);
+        let mut signals = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(sig) = serde_json::from_str::<ExternalSignal>(&line) {
+                if let Some(since) = since {
+                    if sig.received_at < since {
+                        continue;
+                    }
+                }
+                signals.push(sig);
+            }
+        }
+        Ok(signals)
+    }
+}

--- a/crates/harness-observe/src/event_store/mod.rs
+++ b/crates/harness-observe/src/event_store/mod.rs
@@ -2,17 +2,20 @@ use chrono::{DateTime, Utc};
 use harness_core::config::misc::OtelConfig;
 use harness_core::db::{pg_open_pool, PgStoreContext};
 use harness_core::run_id::RunId;
+#[cfg(test)]
+use harness_core::types::ExternalSignal;
 use harness_core::types::{
-    AutoFixReport, Decision, Event, EventFilters, EventId, ExternalSignal, ExternalSignalId, Grade,
-    SessionId, Severity, Violation,
+    AutoFixReport, Decision, Event, EventFilters, EventId, Grade, SessionId, Severity, Violation,
 };
 use sqlx::postgres::PgPool;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Mutex;
 
+mod external_signals;
 mod legacy;
 mod migrations;
+mod trajectory;
 
 pub use legacy::migrate_legacy_event_store_if_needed;
 use migrations::EVENT_MIGRATIONS;
@@ -747,50 +750,6 @@ impl EventStore {
             ..Default::default()
         })
         .await
-    }
-
-    fn signals_file(&self) -> std::path::PathBuf {
-        self.data_dir.join("signals.jsonl")
-    }
-
-    pub fn log_external_signal(&self, signal: &ExternalSignal) -> anyhow::Result<ExternalSignalId> {
-        use std::io::Write;
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(self.signals_file())?;
-        let line = serde_json::to_string(signal)?;
-        writeln!(file, "{line}")?;
-        Ok(signal.id.clone())
-    }
-
-    pub fn query_external_signals(
-        &self,
-        since: Option<DateTime<Utc>>,
-    ) -> anyhow::Result<Vec<ExternalSignal>> {
-        let path = self.signals_file();
-        if !path.exists() {
-            return Ok(Vec::new());
-        }
-        let file = std::fs::File::open(&path)?;
-        let reader = std::io::BufReader::new(file);
-        let mut signals = Vec::new();
-        use std::io::BufRead;
-        for line in reader.lines() {
-            let line = line?;
-            if line.trim().is_empty() {
-                continue;
-            }
-            if let Ok(sig) = serde_json::from_str::<ExternalSignal>(&line) {
-                if let Some(since) = since {
-                    if sig.received_at < since {
-                        continue;
-                    }
-                }
-                signals.push(sig);
-            }
-        }
-        Ok(signals)
     }
 
     #[cfg(test)]

--- a/crates/harness-observe/src/event_store/trajectory.rs
+++ b/crates/harness-observe/src/event_store/trajectory.rs
@@ -1,0 +1,25 @@
+use super::EventStore;
+use crate::otel_trajectory::{ActivitySpan, AgentTurnSpan, WorkflowRootSpan};
+
+impl EventStore {
+    pub fn record_trajectory_workflow_root(&self, span: WorkflowRootSpan) {
+        let slot = self.otel_pipeline.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(pipeline) = slot.as_ref() {
+            pipeline.record_workflow_root_span(span);
+        }
+    }
+
+    pub fn record_trajectory_activity(&self, span: ActivitySpan) {
+        let slot = self.otel_pipeline.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(pipeline) = slot.as_ref() {
+            pipeline.record_activity_span(span);
+        }
+    }
+
+    pub fn record_trajectory_agent_turn(&self, span: AgentTurnSpan) {
+        let slot = self.otel_pipeline.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(pipeline) = slot.as_ref() {
+            pipeline.record_agent_turn_span(span);
+        }
+    }
+}

--- a/crates/harness-observe/src/lib.rs
+++ b/crates/harness-observe/src/lib.rs
@@ -2,6 +2,7 @@ pub mod event_store;
 pub mod health;
 pub mod otel_attributes;
 mod otel_export;
+pub mod otel_trajectory;
 pub mod quality;
 pub mod session;
 pub mod stats;

--- a/crates/harness-observe/src/otel_attributes.rs
+++ b/crates/harness-observe/src/otel_attributes.rs
@@ -10,6 +10,10 @@ pub const HARNESS_WORKFLOW_ID: &str = "harness.workflow.id";
 pub const HARNESS_ACTIVITY_KIND: &str = "harness.activity.kind";
 pub const HARNESS_OUTCOME: &str = "harness.outcome";
 pub const HARNESS_COST_USD: &str = "harness.cost_usd";
+pub const HARNESS_RUNTIME_JOB_ID: &str = "harness.runtime.job.id";
+pub const HARNESS_THREAD_ID: &str = "harness.thread.id";
+pub const HARNESS_TURN_ID: &str = "harness.turn.id";
+pub const HARNESS_RETRY_ATTEMPT: &str = "harness.retry.attempt";
 
 pub const ATTRIBUTE_ALLOWLIST: &[&str] = &[
     GEN_AI_SYSTEM,
@@ -20,6 +24,10 @@ pub const ATTRIBUTE_ALLOWLIST: &[&str] = &[
     HARNESS_WORKFLOW_ID,
     HARNESS_ACTIVITY_KIND,
     HARNESS_OUTCOME,
+    HARNESS_RUNTIME_JOB_ID,
+    HARNESS_THREAD_ID,
+    HARNESS_TURN_ID,
+    HARNESS_RETRY_ATTEMPT,
 ];
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -32,6 +40,10 @@ pub struct GenAiTurnAttributes {
     pub workflow_id: Option<String>,
     pub activity_kind: Option<String>,
     pub outcome: Option<String>,
+    pub runtime_job_id: Option<String>,
+    pub thread_id: Option<String>,
+    pub turn_id: Option<String>,
+    pub retry_attempt: Option<u64>,
 }
 
 pub fn is_allowed_attribute(key: &str) -> bool {
@@ -51,6 +63,10 @@ pub fn gen_ai_turn_attributes(input: GenAiTurnAttributes) -> Vec<KeyValue> {
     push_string(&mut attrs, HARNESS_WORKFLOW_ID, input.workflow_id);
     push_string(&mut attrs, HARNESS_ACTIVITY_KIND, input.activity_kind);
     push_string(&mut attrs, HARNESS_OUTCOME, input.outcome);
+    push_string(&mut attrs, HARNESS_RUNTIME_JOB_ID, input.runtime_job_id);
+    push_string(&mut attrs, HARNESS_THREAD_ID, input.thread_id);
+    push_string(&mut attrs, HARNESS_TURN_ID, input.turn_id);
+    push_u64(&mut attrs, HARNESS_RETRY_ATTEMPT, input.retry_attempt);
     attrs
 }
 
@@ -87,6 +103,10 @@ mod tests {
             workflow_id: Some("wf-1".to_string()),
             activity_kind: Some("implement".to_string()),
             outcome: Some("done".to_string()),
+            runtime_job_id: Some("job-1".to_string()),
+            thread_id: Some("thread-1".to_string()),
+            turn_id: Some("turn-1".to_string()),
+            retry_attempt: Some(2),
         });
 
         let keys: Vec<_> = attrs.iter().map(|attr| attr.key.as_str()).collect();
@@ -105,6 +125,10 @@ mod tests {
             workflow_id: None,
             activity_kind: None,
             outcome: None,
+            runtime_job_id: None,
+            thread_id: None,
+            turn_id: None,
+            retry_attempt: None,
         });
 
         assert_eq!(attrs.len(), 1);

--- a/crates/harness-observe/src/otel_export.rs
+++ b/crates/harness-observe/src/otel_export.rs
@@ -264,55 +264,30 @@ impl OtelPipeline {
             tracer_provider,
             logger_provider,
             meter_provider,
-            trajectory_export_errors_total,
             ..
         } = self;
         let shutdown_result = tokio::task::spawn_blocking(move || {
             for result in tracer_provider.force_flush() {
                 if let Err(err) = result {
-                    report_pipeline_error(
-                        &trajectory_export_errors_total,
-                        "failed to force flush tracer provider",
-                        err,
-                    );
+                    report_pipeline_error("failed to force flush tracer provider", err);
                 }
             }
             if let Err(err) = tracer_provider.shutdown() {
-                report_pipeline_error(
-                    &trajectory_export_errors_total,
-                    "failed to shut down tracer provider",
-                    err,
-                );
+                report_pipeline_error("failed to shut down tracer provider", err);
             }
             if let Err(err) = meter_provider.force_flush() {
-                report_pipeline_error(
-                    &trajectory_export_errors_total,
-                    "failed to force flush meter provider",
-                    err,
-                );
+                report_pipeline_error("failed to force flush meter provider", err);
             }
             if let Err(err) = meter_provider.shutdown() {
-                report_pipeline_error(
-                    &trajectory_export_errors_total,
-                    "failed to shut down meter provider",
-                    err,
-                );
+                report_pipeline_error("failed to shut down meter provider", err);
             }
             for result in logger_provider.force_flush() {
                 if let Err(err) = result {
-                    report_pipeline_error(
-                        &trajectory_export_errors_total,
-                        "failed to force flush logger provider",
-                        err,
-                    );
+                    report_pipeline_error("failed to force flush logger provider", err);
                 }
             }
             if let Err(err) = logger_provider.shutdown() {
-                report_pipeline_error(
-                    &trajectory_export_errors_total,
-                    "failed to shut down logger provider",
-                    err,
-                );
+                report_pipeline_error("failed to shut down logger provider", err);
             }
         })
         .await;
@@ -551,15 +526,7 @@ fn severity_for_decision(decision: Decision) -> Severity {
     }
 }
 
-fn report_pipeline_error(
-    trajectory_export_errors_total: &Counter<u64>,
-    message: &str,
-    err: impl std::fmt::Display,
-) {
-    trajectory_export_errors_total.add(
-        1,
-        &[KeyValue::new("harness.otel.operation", "provider_shutdown")],
-    );
+fn report_pipeline_error(message: &str, err: impl std::fmt::Display) {
     tracing::warn!("{message}: {err}");
     eprintln!("harness-observe: {message}: {err}");
 }

--- a/crates/harness-observe/src/otel_export.rs
+++ b/crates/harness-observe/src/otel_export.rs
@@ -1,3 +1,7 @@
+use crate::otel_trajectory::{
+    record_activity_span, record_agent_turn_span, record_workflow_root_span, ActivitySpan,
+    AgentTurnSpan, WorkflowRootSpan,
+};
 use harness_core::config::misc::{OtelConfig, OtelExporter};
 use harness_core::types::{Decision, Event};
 use opentelemetry::logs::{AnyValue, LogRecord as _, Logger, LoggerProvider as _, Severity};
@@ -9,6 +13,7 @@ use opentelemetry_sdk::logs::LoggerProvider;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::Resource;
 use std::collections::{HashSet, VecDeque};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -53,7 +58,7 @@ impl SessionStartDeduper {
 
 pub struct OtelPipeline {
     log_user_prompt: bool,
-    _trajectory_enabled: bool,
+    trajectory_enabled: bool,
     _capture_content: bool,
     seen_sessions: Mutex<SessionStartDeduper>,
     tracer_provider: opentelemetry_sdk::trace::TracerProvider,
@@ -65,6 +70,7 @@ pub struct OtelPipeline {
     api_request_total: Counter<u64>,
     tool_decision_total: Counter<u64>,
     tool_execution_duration_ms: Histogram<u64>,
+    trajectory_export_errors_total: Counter<u64>,
 }
 
 impl OtelPipeline {
@@ -105,10 +111,14 @@ impl OtelPipeline {
             .u64_histogram("harness.tool_execution.duration_ms")
             .with_description("Tool execution duration in milliseconds.")
             .build();
+        let trajectory_export_errors_total = meter
+            .u64_counter("harness.otel.trajectory_export_errors.total")
+            .with_description("OpenTelemetry trajectory span recording/export isolation errors.")
+            .build();
 
         Ok(Some(Self {
             log_user_prompt: config.log_user_prompt,
-            _trajectory_enabled: config.trajectory,
+            trajectory_enabled: config.trajectory,
             _capture_content: config.capture_content,
             seen_sessions: Mutex::new(SessionStartDeduper::new(MAX_TRACKED_CONVERSATION_SESSIONS)),
             tracer_provider,
@@ -120,12 +130,13 @@ impl OtelPipeline {
             api_request_total,
             tool_decision_total,
             tool_execution_duration_ms,
+            trajectory_export_errors_total,
         }))
     }
 
     #[cfg(test)]
     fn trajectory_enabled(&self) -> bool {
-        self._trajectory_enabled
+        self.trajectory_enabled
     }
 
     #[cfg(test)]
@@ -216,35 +227,92 @@ impl OtelPipeline {
         self.logger.emit(record);
     }
 
+    pub(crate) fn record_workflow_root_span(&self, input: WorkflowRootSpan) {
+        self.record_trajectory_span("workflow_root", || {
+            record_workflow_root_span(&self.tracer, input);
+        });
+    }
+
+    pub(crate) fn record_activity_span(&self, input: ActivitySpan) {
+        self.record_trajectory_span("activity", || {
+            record_activity_span(&self.tracer, input);
+        });
+    }
+
+    pub(crate) fn record_agent_turn_span(&self, input: AgentTurnSpan) {
+        self.record_trajectory_span("agent_turn", || {
+            record_agent_turn_span(&self.tracer, input);
+        });
+    }
+
+    fn record_trajectory_span(&self, operation: &'static str, record: impl FnOnce()) {
+        if !self.trajectory_enabled {
+            return;
+        }
+        if catch_unwind(AssertUnwindSafe(record)).is_err() {
+            self.trajectory_export_errors_total
+                .add(1, &[KeyValue::new("harness.otel.operation", operation)]);
+            tracing::error!(
+                otel_operation = operation,
+                "OpenTelemetry trajectory span recording failed; dropping span"
+            );
+        }
+    }
+
     pub async fn shutdown(self) {
         let Self {
             tracer_provider,
             logger_provider,
             meter_provider,
+            trajectory_export_errors_total,
             ..
         } = self;
         let shutdown_result = tokio::task::spawn_blocking(move || {
             for result in tracer_provider.force_flush() {
                 if let Err(err) = result {
-                    report_pipeline_error("failed to force flush tracer provider", err);
+                    report_pipeline_error(
+                        &trajectory_export_errors_total,
+                        "failed to force flush tracer provider",
+                        err,
+                    );
                 }
             }
             if let Err(err) = tracer_provider.shutdown() {
-                report_pipeline_error("failed to shut down tracer provider", err);
+                report_pipeline_error(
+                    &trajectory_export_errors_total,
+                    "failed to shut down tracer provider",
+                    err,
+                );
             }
             if let Err(err) = meter_provider.force_flush() {
-                report_pipeline_error("failed to force flush meter provider", err);
+                report_pipeline_error(
+                    &trajectory_export_errors_total,
+                    "failed to force flush meter provider",
+                    err,
+                );
             }
             if let Err(err) = meter_provider.shutdown() {
-                report_pipeline_error("failed to shut down meter provider", err);
+                report_pipeline_error(
+                    &trajectory_export_errors_total,
+                    "failed to shut down meter provider",
+                    err,
+                );
             }
             for result in logger_provider.force_flush() {
                 if let Err(err) = result {
-                    report_pipeline_error("failed to force flush logger provider", err);
+                    report_pipeline_error(
+                        &trajectory_export_errors_total,
+                        "failed to force flush logger provider",
+                        err,
+                    );
                 }
             }
             if let Err(err) = logger_provider.shutdown() {
-                report_pipeline_error("failed to shut down logger provider", err);
+                report_pipeline_error(
+                    &trajectory_export_errors_total,
+                    "failed to shut down logger provider",
+                    err,
+                );
             }
         })
         .await;
@@ -483,7 +551,15 @@ fn severity_for_decision(decision: Decision) -> Severity {
     }
 }
 
-fn report_pipeline_error(message: &str, err: impl std::fmt::Display) {
+fn report_pipeline_error(
+    trajectory_export_errors_total: &Counter<u64>,
+    message: &str,
+    err: impl std::fmt::Display,
+) {
+    trajectory_export_errors_total.add(
+        1,
+        &[KeyValue::new("harness.otel.operation", "provider_shutdown")],
+    );
     tracing::warn!("{message}: {err}");
     eprintln!("harness-observe: {message}: {err}");
 }
@@ -580,6 +656,40 @@ mod tests {
 
         assert!(pipeline.trajectory_enabled());
         assert!(pipeline.capture_content_enabled());
+        pipeline.shutdown().await;
+        accept.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn otel_failure_isolation_drops_invalid_trajectory_context() -> anyhow::Result<()> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let endpoint = format!("http://{}", listener.local_addr()?);
+        let accept = tokio::spawn(async move { listener.accept().await.map(|_| ()) });
+        let config = OtelConfig {
+            exporter: OtelExporter::OtlpHttp,
+            endpoint: Some(endpoint),
+            trajectory: true,
+            ..OtelConfig::default()
+        };
+        let pipeline = OtelPipeline::from_config(&config)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("enabled exporter should initialize"))?;
+
+        pipeline.record_activity_span(crate::otel_trajectory::ActivitySpan {
+            trace_context: crate::otel_trajectory::TrajectoryTraceContext {
+                trace_id: "0".to_string(),
+                root_span_id: "0".to_string(),
+            },
+            workflow_id: "wf-1".to_string(),
+            runtime_job_id: "job-1".to_string(),
+            activity_kind: "implement".to_string(),
+            outcome: "succeeded".to_string(),
+            retry_attempt: None,
+            started_at: None,
+            ended_at: None,
+        });
+
         pipeline.shutdown().await;
         accept.await??;
         Ok(())

--- a/crates/harness-observe/src/otel_trajectory.rs
+++ b/crates/harness-observe/src/otel_trajectory.rs
@@ -1,0 +1,265 @@
+use crate::otel_attributes::{
+    gen_ai_turn_attributes, GenAiTurnAttributes, HARNESS_ACTIVITY_KIND, HARNESS_OUTCOME,
+    HARNESS_RETRY_ATTEMPT, HARNESS_RUNTIME_JOB_ID, HARNESS_WORKFLOW_ID,
+};
+use chrono::{DateTime, Utc};
+use opentelemetry::trace::{
+    Span, SpanBuilder, SpanContext, SpanId, SpanKind, Status, TraceContextExt, TraceFlags, TraceId,
+    TraceState, Tracer,
+};
+use opentelemetry::{Context, KeyValue};
+use sha2::{Digest, Sha256};
+use std::time::SystemTime;
+
+const WORKFLOW_SPAN_NAME: &str = "harness.workflow";
+const ACTIVITY_SPAN_NAME: &str = "harness.activity";
+const AGENT_TURN_SPAN_NAME: &str = "gen_ai.client.operation";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrajectoryTraceContext {
+    pub trace_id: String,
+    pub root_span_id: String,
+}
+
+impl TrajectoryTraceContext {
+    pub fn new(trace_id: impl Into<String>, root_span_id: impl Into<String>) -> Option<Self> {
+        let context = Self {
+            trace_id: trace_id.into(),
+            root_span_id: root_span_id.into(),
+        };
+        context.is_valid().then_some(context)
+    }
+
+    pub fn is_valid(&self) -> bool {
+        parse_trace_id(&self.trace_id).is_some() && parse_span_id(&self.root_span_id).is_some()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WorkflowRootSpan {
+    pub trace_context: TrajectoryTraceContext,
+    pub workflow_id: String,
+    pub definition_id: String,
+    pub subject_type: String,
+    pub subject_key: String,
+    pub outcome: String,
+    pub started_at: Option<DateTime<Utc>>,
+    pub ended_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ActivitySpan {
+    pub trace_context: TrajectoryTraceContext,
+    pub workflow_id: String,
+    pub runtime_job_id: String,
+    pub activity_kind: String,
+    pub outcome: String,
+    pub retry_attempt: Option<u64>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub ended_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentTurnSpan {
+    pub trace_context: TrajectoryTraceContext,
+    pub workflow_id: String,
+    pub runtime_job_id: String,
+    pub activity_kind: String,
+    pub outcome: String,
+    pub system: String,
+    pub model: Option<String>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cost_usd: Option<f64>,
+    pub thread_id: String,
+    pub turn_id: String,
+    pub retry_attempt: Option<u64>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub ended_at: Option<DateTime<Utc>>,
+}
+
+pub(crate) fn record_workflow_root_span<T>(tracer: &T, input: WorkflowRootSpan)
+where
+    T: Tracer,
+{
+    let Some(trace_id) = parse_trace_id(&input.trace_context.trace_id) else {
+        return;
+    };
+    let Some(root_span_id) = parse_span_id(&input.trace_context.root_span_id) else {
+        return;
+    };
+    let attrs = vec![
+        KeyValue::new(HARNESS_WORKFLOW_ID, input.workflow_id),
+        KeyValue::new("harness.workflow.definition_id", input.definition_id),
+        KeyValue::new("harness.workflow.subject_type", input.subject_type),
+        KeyValue::new("harness.workflow.subject_key", input.subject_key),
+        KeyValue::new(HARNESS_OUTCOME, input.outcome),
+    ];
+    let mut span = span_builder(WORKFLOW_SPAN_NAME, attrs, input.started_at, input.ended_at)
+        .with_trace_id(trace_id)
+        .with_span_id(root_span_id)
+        .start(tracer);
+    span.end();
+}
+
+pub(crate) fn record_activity_span<T>(tracer: &T, input: ActivitySpan)
+where
+    T: Tracer,
+{
+    let Some(activity_span_id) = activity_span_id(&input.runtime_job_id) else {
+        return;
+    };
+    let Some(parent) = root_parent_context(&input.trace_context) else {
+        return;
+    };
+    let mut attrs = vec![
+        KeyValue::new(HARNESS_WORKFLOW_ID, input.workflow_id),
+        KeyValue::new(HARNESS_RUNTIME_JOB_ID, input.runtime_job_id.clone()),
+        KeyValue::new(HARNESS_ACTIVITY_KIND, input.activity_kind),
+        KeyValue::new(HARNESS_OUTCOME, input.outcome),
+    ];
+    if let Some(retry_attempt) = input
+        .retry_attempt
+        .and_then(|value| i64::try_from(value).ok())
+    {
+        attrs.push(KeyValue::new(HARNESS_RETRY_ATTEMPT, retry_attempt));
+    }
+    let mut span = span_builder(ACTIVITY_SPAN_NAME, attrs, input.started_at, input.ended_at)
+        .with_span_id(activity_span_id)
+        .start_with_context(tracer, &parent);
+    span.end();
+}
+
+pub(crate) fn record_agent_turn_span<T>(tracer: &T, input: AgentTurnSpan)
+where
+    T: Tracer,
+{
+    let Some(parent) = activity_parent_context(&input.trace_context, &input.runtime_job_id) else {
+        return;
+    };
+    let attrs = gen_ai_turn_attributes(GenAiTurnAttributes {
+        system: Some(input.system),
+        model: input.model,
+        input_tokens: input.input_tokens,
+        output_tokens: input.output_tokens,
+        cost_usd: input.cost_usd,
+        workflow_id: Some(input.workflow_id),
+        activity_kind: Some(input.activity_kind),
+        outcome: Some(input.outcome),
+        runtime_job_id: Some(input.runtime_job_id),
+        thread_id: Some(input.thread_id.clone()),
+        turn_id: Some(input.turn_id.clone()),
+        retry_attempt: input.retry_attempt,
+    });
+    let Some(turn_span_id) = span_id_from_seed(format!("turn:{}", input.turn_id)) else {
+        return;
+    };
+    let mut span = span_builder(
+        AGENT_TURN_SPAN_NAME,
+        attrs,
+        input.started_at,
+        input.ended_at,
+    )
+    .with_span_id(turn_span_id)
+    .start_with_context(tracer, &parent);
+    span.end();
+}
+
+fn span_builder(
+    name: &'static str,
+    attrs: Vec<KeyValue>,
+    started_at: Option<DateTime<Utc>>,
+    ended_at: Option<DateTime<Utc>>,
+) -> SpanBuilder {
+    let mut builder = SpanBuilder::from_name(name)
+        .with_kind(SpanKind::Internal)
+        .with_attributes(attrs)
+        .with_status(Status::Unset);
+    if let Some(started_at) = started_at {
+        builder = builder.with_start_time(SystemTime::from(started_at));
+    }
+    if let Some(ended_at) = ended_at {
+        builder = builder.with_end_time(SystemTime::from(ended_at));
+    }
+    builder
+}
+
+fn root_parent_context(trace_context: &TrajectoryTraceContext) -> Option<Context> {
+    Some(remote_parent_context(
+        parse_trace_id(&trace_context.trace_id)?,
+        parse_span_id(&trace_context.root_span_id)?,
+    ))
+}
+
+fn activity_parent_context(
+    trace_context: &TrajectoryTraceContext,
+    runtime_job_id: &str,
+) -> Option<Context> {
+    Some(remote_parent_context(
+        parse_trace_id(&trace_context.trace_id)?,
+        activity_span_id(runtime_job_id)?,
+    ))
+}
+
+fn remote_parent_context(trace_id: TraceId, span_id: SpanId) -> Context {
+    Context::new().with_remote_span_context(SpanContext::new(
+        trace_id,
+        span_id,
+        TraceFlags::SAMPLED,
+        true,
+        TraceState::default(),
+    ))
+}
+
+fn activity_span_id(runtime_job_id: &str) -> Option<SpanId> {
+    span_id_from_seed(format!("activity:{runtime_job_id}"))
+}
+
+fn span_id_from_seed(seed: impl AsRef<[u8]>) -> Option<SpanId> {
+    let digest = Sha256::digest(seed.as_ref());
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    let mut value = u64::from_be_bytes(bytes);
+    if value == 0 {
+        value = 1;
+    }
+    parse_span_id(&format!("{value:016x}"))
+}
+
+fn parse_trace_id(value: &str) -> Option<TraceId> {
+    TraceId::from_hex(value)
+        .ok()
+        .filter(|trace_id| *trace_id != TraceId::INVALID)
+}
+
+fn parse_span_id(value: &str) -> Option<SpanId> {
+    SpanId::from_hex(value)
+        .ok()
+        .filter(|span_id| *span_id != SpanId::INVALID)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trajectory_trace_context_validates_w3c_ids() {
+        assert!(TrajectoryTraceContext::new(
+            "58406520a006649127e371903a2de979",
+            "5f467fe7bf42676c"
+        )
+        .is_some());
+        assert!(TrajectoryTraceContext::new("0", "5f467fe7bf42676c").is_none());
+        assert!(TrajectoryTraceContext::new("58406520a006649127e371903a2de979", "0").is_none());
+    }
+
+    #[test]
+    fn trajectory_activity_span_id_is_stable_per_runtime_job() {
+        let first = activity_span_id("job-1");
+        let second = activity_span_id("job-1");
+        let other = activity_span_id("job-2");
+
+        assert_eq!(first, second);
+        assert_ne!(first, other);
+    }
+}

--- a/crates/harness-observe/src/otel_trajectory.rs
+++ b/crates/harness-observe/src/otel_trajectory.rs
@@ -219,11 +219,10 @@ fn span_id_from_seed(seed: impl AsRef<[u8]>) -> Option<SpanId> {
     let digest = Sha256::digest(seed.as_ref());
     let mut bytes = [0u8; 8];
     bytes.copy_from_slice(&digest[..8]);
-    let mut value = u64::from_be_bytes(bytes);
-    if value == 0 {
-        value = 1;
+    if bytes.iter().all(|byte| *byte == 0) {
+        bytes[7] = 1;
     }
-    parse_span_id(&format!("{value:016x}"))
+    Some(SpanId::from_bytes(bytes))
 }
 
 fn parse_trace_id(value: &str) -> Option<TraceId> {

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -7,6 +7,7 @@ mod child_workflow_replay;
 mod data_helpers;
 mod executor;
 mod merge_completion;
+mod otel_trajectory;
 mod pr_feedback_inspection;
 mod prompt_input_telemetry;
 mod prompt_packet;
@@ -28,6 +29,7 @@ use harness_workflow::runtime::{
     ActivityErrorKind, ActivityResult, RuntimeJob, RuntimeJobStatus, RuntimeWorker,
     WorkflowInstance, GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID,
 };
+use otel_trajectory::emit_runtime_job_trajectory_completion;
 use serde_json::{json, Value};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -86,6 +88,13 @@ pub(crate) async fn run_runtime_job_worker_tick(
     let executor = ServerRuntimeJobExecutor::new(state);
     let mut completed = worker.run_once(&executor).await?;
     if let Some(job) = completed.as_mut() {
+        if let Err(error) = emit_runtime_job_trajectory_completion(state, store.as_ref(), job).await
+        {
+            tracing::warn!(
+                runtime_job_id = %job.id,
+                "workflow runtime OTel trajectory emission failed: {error}"
+            );
+        }
         record_runtime_circuit_breaker_completion(state, store.as_ref(), job).await?;
         if let Err(error) = notify_runtime_submission_terminal(state, job).await {
             tracing::warn!(

--- a/crates/harness-server/src/workflow_runtime_worker/otel_trajectory.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/otel_trajectory.rs
@@ -1,0 +1,197 @@
+use crate::http::AppState;
+use harness_core::types::{ThreadId, TurnId};
+use harness_observe::otel_trajectory::{
+    ActivitySpan, AgentTurnSpan, TrajectoryTraceContext, WorkflowRootSpan,
+};
+use harness_workflow::runtime::{
+    ActivityResult, ActivityStatus, RuntimeJob, RuntimeProfile, WorkflowInstance,
+    WorkflowRuntimeStore,
+};
+use serde_json::Value;
+use std::sync::Arc;
+
+pub(super) async fn emit_runtime_job_trajectory_completion(
+    state: &Arc<AppState>,
+    store: &WorkflowRuntimeStore,
+    job: &RuntimeJob,
+) -> anyhow::Result<()> {
+    if !state.core.server.config.otel.trajectory {
+        return Ok(());
+    }
+    let Some(workflow_id) = job.input.get("workflow_id").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let Some(workflow) = store.get_instance(workflow_id).await? else {
+        return Ok(());
+    };
+    let Some(trace_context) = store.ensure_otel_trace_context(workflow_id).await? else {
+        return Ok(());
+    };
+    let Some(trace_context) =
+        TrajectoryTraceContext::new(trace_context.trace_id, trace_context.root_span_id)
+    else {
+        anyhow::bail!("workflow {workflow_id} has invalid OTel trace context");
+    };
+    let Some(result) = job
+        .output
+        .as_ref()
+        .and_then(|output| serde_json::from_value::<ActivityResult>(output.clone()).ok())
+    else {
+        return Ok(());
+    };
+
+    let outcome = activity_status_label(result.status).to_string();
+    let retry_attempt = retry_attempt(job);
+    state
+        .observability
+        .events
+        .record_trajectory_activity(ActivitySpan {
+            trace_context: trace_context.clone(),
+            workflow_id: workflow_id.to_string(),
+            runtime_job_id: job.id.clone(),
+            activity_kind: result.activity.clone(),
+            outcome: outcome.clone(),
+            retry_attempt,
+            started_at: Some(job.created_at),
+            ended_at: Some(job.updated_at),
+        });
+
+    if let Some(turn_ref) = runtime_turn_artifact(&result) {
+        if let Some(turn) = state.core.server.thread_manager.get_turn(
+            &ThreadId::from_str(&turn_ref.thread_id),
+            &TurnId::from_str(&turn_ref.turn_id),
+        ) {
+            let runtime_profile = otel_runtime_profile_from_job(job);
+            state
+                .observability
+                .events
+                .record_trajectory_agent_turn(AgentTurnSpan {
+                    trace_context: trace_context.clone(),
+                    workflow_id: workflow_id.to_string(),
+                    runtime_job_id: job.id.clone(),
+                    activity_kind: result.activity.clone(),
+                    outcome,
+                    system: turn_ref.agent,
+                    model: runtime_profile.and_then(|profile| profile.model),
+                    input_tokens: Some(turn.token_usage.input_tokens),
+                    output_tokens: Some(turn.token_usage.output_tokens),
+                    cost_usd: Some(turn.token_usage.cost_usd),
+                    thread_id: turn_ref.thread_id,
+                    turn_id: turn_ref.turn_id,
+                    retry_attempt,
+                    started_at: Some(turn.started_at),
+                    ended_at: turn.completed_at,
+                });
+        }
+    }
+
+    if workflow.is_terminal() {
+        state
+            .observability
+            .events
+            .record_trajectory_workflow_root(workflow_root_span(trace_context, &workflow));
+    }
+    Ok(())
+}
+
+fn workflow_root_span(
+    trace_context: TrajectoryTraceContext,
+    workflow: &WorkflowInstance,
+) -> WorkflowRootSpan {
+    WorkflowRootSpan {
+        trace_context,
+        workflow_id: workflow.id.clone(),
+        definition_id: workflow.definition_id.clone(),
+        subject_type: workflow.subject.subject_type.clone(),
+        subject_key: workflow.subject.subject_key.clone(),
+        outcome: workflow.state.clone(),
+        started_at: Some(workflow.created_at),
+        ended_at: Some(workflow.updated_at),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeTurnRef {
+    thread_id: String,
+    turn_id: String,
+    agent: String,
+}
+
+fn runtime_turn_artifact(result: &ActivityResult) -> Option<RuntimeTurnRef> {
+    let artifact = result
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.artifact_type == "runtime_turn")?;
+    let thread_id = artifact.artifact.get("thread_id")?.as_str()?.trim();
+    let turn_id = artifact.artifact.get("turn_id")?.as_str()?.trim();
+    let agent = artifact.artifact.get("agent")?.as_str()?.trim();
+    if thread_id.is_empty() || turn_id.is_empty() || agent.is_empty() {
+        return None;
+    }
+    Some(RuntimeTurnRef {
+        thread_id: thread_id.to_string(),
+        turn_id: turn_id.to_string(),
+        agent: agent.to_string(),
+    })
+}
+
+fn otel_runtime_profile_from_job(job: &RuntimeJob) -> Option<RuntimeProfile> {
+    serde_json::from_value(job.input.get("runtime_profile")?.clone()).ok()
+}
+
+fn retry_attempt(job: &RuntimeJob) -> Option<u64> {
+    (job.lease_generation > 1).then_some(job.lease_generation - 1)
+}
+
+fn activity_status_label(status: ActivityStatus) -> &'static str {
+    match status {
+        ActivityStatus::Succeeded => "succeeded",
+        ActivityStatus::Failed => "failed",
+        ActivityStatus::Blocked => "blocked",
+        ActivityStatus::Cancelled => "cancelled",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_workflow::runtime::ActivityArtifact;
+    use serde_json::json;
+
+    #[test]
+    fn otel_turn_spans_extract_runtime_turn_artifact() {
+        let result =
+            ActivityResult::succeeded("implement", "done").with_artifact(ActivityArtifact::new(
+                "runtime_turn",
+                json!({
+                    "thread_id": "thread-1",
+                    "turn_id": "turn-1",
+                    "agent": "codex",
+                }),
+            ));
+
+        assert_eq!(
+            runtime_turn_artifact(&result),
+            Some(RuntimeTurnRef {
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                agent: "codex".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn otel_turn_spans_skip_incomplete_runtime_turn_artifact() {
+        let result =
+            ActivityResult::succeeded("implement", "done").with_artifact(ActivityArtifact::new(
+                "runtime_turn",
+                json!({
+                    "thread_id": "thread-1",
+                    "turn_id": "",
+                    "agent": "codex",
+                }),
+            ));
+
+        assert_eq!(runtime_turn_artifact(&result), None);
+    }
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -10,6 +10,7 @@ pub mod errors;
 mod job_claim;
 pub mod lease_state;
 pub mod model;
+mod otel_trace_context;
 pub mod plan_issue;
 pub mod pr_feedback;
 pub mod prompt_task;
@@ -42,6 +43,7 @@ pub use model::{
     WorkflowDecisionRecord, WorkflowDefinition, WorkflowEvent, WorkflowEvidence, WorkflowInstance,
     WorkflowLease, WorkflowSubject,
 };
+pub use otel_trace_context::WorkflowOtelTraceContext;
 pub use plan_issue::{
     build_plan_issue_decision, PlanIssueDecisionInput, PlanIssueDecisionOutput,
     PlanIssueWorkflowAction, ISSUE_PLAN_ACTIVITY, ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL,

--- a/crates/harness-workflow/src/runtime/otel_trace_context.rs
+++ b/crates/harness-workflow/src/runtime/otel_trace_context.rs
@@ -25,6 +25,12 @@ impl WorkflowOtelTraceContext {
     }
 }
 
+impl Default for WorkflowOtelTraceContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn is_lower_hex(value: &str, expected_len: usize) -> bool {
     value.len() == expected_len
         && value.as_bytes().iter().any(|byte| *byte != b'0')

--- a/crates/harness-workflow/src/runtime/otel_trace_context.rs
+++ b/crates/harness-workflow/src/runtime/otel_trace_context.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowOtelTraceContext {
+    pub trace_id: String,
+    pub root_span_id: String,
+}
+
+impl WorkflowOtelTraceContext {
+    pub fn new() -> Self {
+        Self {
+            trace_id: Uuid::new_v4().simple().to_string(),
+            root_span_id: Uuid::new_v4()
+                .simple()
+                .to_string()
+                .chars()
+                .take(16)
+                .collect(),
+        }
+    }
+
+    pub fn has_valid_trace_ids(&self) -> bool {
+        is_lower_hex(&self.trace_id, 32) && is_lower_hex(&self.root_span_id, 16)
+    }
+}
+
+fn is_lower_hex(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value.as_bytes().iter().any(|byte| *byte != b'0')
+        && value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn otel_trace_context_generates_valid_w3c_ids() {
+        let context = WorkflowOtelTraceContext::new();
+
+        assert!(context.has_valid_trace_ids());
+        assert_eq!(context.trace_id.len(), 32);
+        assert_eq!(context.root_span_id.len(), 16);
+    }
+
+    #[test]
+    fn otel_trace_context_rejects_invalid_ids() {
+        assert!(!WorkflowOtelTraceContext {
+            trace_id: "0".to_string(),
+            root_span_id: "5f467fe7bf42676c".to_string(),
+        }
+        .has_valid_trace_ids());
+        assert!(!WorkflowOtelTraceContext {
+            trace_id: "58406520a006649127e371903a2de979".to_string(),
+            root_span_id: "0000000000000000".to_string(),
+        }
+        .has_valid_trace_ids());
+    }
+}

--- a/crates/harness-workflow/src/runtime/store/instances.rs
+++ b/crates/harness-workflow/src/runtime/store/instances.rs
@@ -1,15 +1,24 @@
 use super::{
     command_store, insert_decision_record_tx, insert_event_tx, insert_instance_if_absent_tx,
-    load_or_insert_initial_instance_tx, to_jsonb_string, workflow_instance_from_row,
-    RuntimeHistoryPruneSummary, WorkflowDecisionTransition, WorkflowInstancePage,
-    WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
+    load_or_insert_initial_instance_tx, select_instance_for_update_tx, to_jsonb_string,
+    upsert_instance_tx, workflow_instance_from_row, RuntimeHistoryPruneSummary,
+    WorkflowDecisionTransition, WorkflowInstancePage, WorkflowRejectedDecisionTransition,
+    WorkflowRuntimeStore,
 };
 use crate::runtime::model::{WorkflowDecisionRecord, WorkflowInstance};
 use crate::runtime::state_registry::{
     known_workflow_definition_ids, workflow_terminal_state_names_for_definition,
 };
 use crate::runtime::status::WorkflowCommandStatus;
+use crate::runtime::WorkflowOtelTraceContext;
 use chrono::{DateTime, Utc};
+
+fn otel_trace_context_from_data(data: &serde_json::Value) -> Option<WorkflowOtelTraceContext> {
+    let context =
+        serde_json::from_value::<WorkflowOtelTraceContext>(data.get("otel_trace_context")?.clone())
+            .ok()?;
+    context.has_valid_trace_ids().then_some(context)
+}
 
 impl WorkflowRuntimeStore {
     pub async fn insert_instance_if_absent(
@@ -49,6 +58,38 @@ impl WorkflowRuntimeStore {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    pub async fn ensure_otel_trace_context(
+        &self,
+        workflow_id: &str,
+    ) -> anyhow::Result<Option<WorkflowOtelTraceContext>> {
+        let mut tx = self.pool.begin().await?;
+        let Some(mut instance) = select_instance_for_update_tx(&mut tx, workflow_id).await? else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+        if let Some(context) = otel_trace_context_from_data(&instance.data) {
+            tx.commit().await?;
+            return Ok(Some(context));
+        }
+
+        let context = WorkflowOtelTraceContext::new();
+        if !instance.data.is_object() {
+            instance.data = serde_json::json!({});
+        }
+        let data = instance
+            .data
+            .as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("workflow instance data is not an object"))?;
+        data.insert(
+            "otel_trace_context".to_string(),
+            serde_json::to_value(&context)?,
+        );
+        instance.version = instance.version.saturating_add(1);
+        upsert_instance_tx(&mut tx, &instance).await?;
+        tx.commit().await?;
+        Ok(Some(context))
     }
 
     pub async fn apply_decision_transition(

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -33,6 +33,7 @@ use std::sync::{
 
 mod issue_planning;
 mod local_review;
+mod otel_spans;
 mod p1_followups;
 mod pr_repair_evidence;
 mod replay_determinism;

--- a/crates/harness-workflow/src/runtime/tests/otel_spans.rs
+++ b/crates/harness-workflow/src/runtime/tests/otel_spans.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[tokio::test]
+async fn otel_spans_persist_trace_context_on_workflow_row() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&harness_core::config::dirs::default_db_path(
+        dir.path(),
+        "workflow_runtime",
+    ))
+    .await?;
+    let workflow = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "implementing",
+        WorkflowSubject::new("issue", "issue:1451"),
+    )
+    .with_id("otel-trace-workflow");
+    store.upsert_instance(&workflow).await?;
+
+    let first = store
+        .ensure_otel_trace_context(&workflow.id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("trace context should be created"))?;
+    let second = store
+        .ensure_otel_trace_context(&workflow.id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("trace context should be reused"))?;
+    let loaded = store
+        .get_instance(&workflow.id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("workflow should exist"))?;
+
+    assert_eq!(first, second);
+    assert!(first.has_valid_trace_ids());
+    assert_eq!(
+        loaded.data["otel_trace_context"]["trace_id"].as_str(),
+        Some(first.trace_id.as_str())
+    );
+    assert_eq!(
+        loaded.data["otel_trace_context"]["root_span_id"].as_str(),
+        Some(first.root_span_id.as_str())
+    );
+    Ok(())
+}

--- a/docs/otel-trajectory-compose.yml
+++ b/docs/otel-trajectory-compose.yml
@@ -1,0 +1,14 @@
+services:
+  otel-lgtm:
+    image: grafana/otel-lgtm:latest
+    container_name: harness-otel-lgtm
+    ports:
+      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
+    volumes:
+      - harness_otel_lgtm_data:/data
+
+volumes:
+  harness_otel_lgtm_data:
+    name: harness_otel_lgtm_data

--- a/docs/otel-trajectory-quickstart.md
+++ b/docs/otel-trajectory-quickstart.md
@@ -1,0 +1,118 @@
+# OTel Trajectory Quickstart
+
+This quickstart runs a local Grafana OTel LGTM stack and sends Harness workflow
+trajectory spans to Tempo. It is intended for development and demo use.
+
+## Start the Backend
+
+```bash
+docker compose -f docs/otel-trajectory-compose.yml up -d
+```
+
+The compose snippet exposes Grafana on `http://127.0.0.1:3000`, OTLP gRPC on
+`http://127.0.0.1:4317`, and OTLP HTTP on `http://127.0.0.1:4318`.
+
+## Configure Harness
+
+Build the server and create a local config file:
+
+```bash
+cargo build --release
+cat > /tmp/harness-otel-quickstart.toml <<'TOML'
+[server]
+transport = "http"
+http_addr = "127.0.0.1:9800"
+data_dir = ".harness/otel-quickstart"
+allow_unauthenticated = true
+
+[agents]
+default_agent = "auto"
+sandbox_mode = "danger-full-access"
+
+[agents.codex]
+cli_path = "codex"
+
+[otel]
+environment = "local"
+exporter = "otlp-http"
+endpoint = "http://127.0.0.1:4318"
+trajectory = true
+capture_content = false
+log_user_prompt = false
+
+[[projects]]
+name = "target-repo"
+root = "/absolute/path/to/target-repo"
+default = true
+TOML
+```
+
+Replace `root` with the repository that should receive the issue run. Keep
+`capture_content = false` unless the operator has explicitly approved exporting
+prompt or response content to the backend.
+
+Start Harness:
+
+```bash
+./target/release/harness --config /tmp/harness-otel-quickstart.toml serve \
+  --transport http \
+  --port 9800
+```
+
+## Submit an Issue Run
+
+Submit a real issue-backed task in a repository where the configured agent can
+open a PR:
+
+```bash
+curl -X POST http://127.0.0.1:9800/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "project": "/absolute/path/to/target-repo",
+    "issue": 123,
+    "description": "otel trajectory smoke run"
+  }'
+```
+
+Poll the task until it reaches a terminal state:
+
+```bash
+curl -s http://127.0.0.1:9800/tasks/{task_id} | python3 -m json.tool
+```
+
+## Inspect the Trace
+
+Open Grafana at `http://127.0.0.1:3000`, go to Explore, choose the Tempo data
+source, and search for Harness traces with:
+
+```traceql
+{ resource.service.name = "harness-observe" }
+```
+
+A complete issue-to-PR run should show one `harness.workflow` root span with
+`harness.activity` child spans and `gen_ai.client.operation` turn spans. The
+turn spans carry model, input token, output token, cost, workflow id, activity
+kind, runtime job id, thread id, turn id, outcome, and retry-attempt attributes
+when those values are known. Unknown token or cost values are omitted instead of
+zero-filled.
+
+## Manual Verification Record
+
+For a PR walkthrough, record:
+
+- `docker compose -f docs/otel-trajectory-compose.yml up -d`
+- the `[otel]` config values used for the run
+- the submitted task id, workflow id, issue number, and PR URL
+- the Tempo query result showing `harness.workflow`, `harness.activity`, and
+  `gen_ai.client.operation` spans in one trace
+- `docker compose -f docs/otel-trajectory-compose.yml down`
+
+## Troubleshooting
+
+- If Harness fails startup with an unreachable OTLP endpoint, make sure the
+  compose stack is running and that port `4318` is not blocked.
+- If Grafana has no trace, wait for the workflow-runtime job to complete and
+  then refresh Explore. Spans are emitted after committed runtime job
+  completion.
+- If only metrics or logs appear, confirm `exporter = "otlp-http"` and
+  `trajectory = true` in the config actually used by the server process.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -451,6 +451,11 @@ If no new commits have landed since the last review, the cycle is skipped.
 | `exporter` | `"disabled"` | OTLP exporter: `disabled`, `otlp-http`, `otlp-grpc` |
 | `endpoint` | — | OTLP collector endpoint URL |
 | `log_user_prompt` | `false` | Include user prompts in trace spans |
+| `trajectory` | `false` | Emit derived workflow, activity, and agent-turn spans when an OTLP exporter is enabled |
+| `capture_content` | `false` | Privacy gate for prompt or response content events; keep disabled unless content export has explicit operator approval |
+
+See [OTel Trajectory Quickstart](otel-trajectory-quickstart.md) for a local
+Tempo walkthrough.
 
 ### `[concurrency]`
 


### PR DESCRIPTION
Related: #1451

## Summary
- persist a stable workflow OTel trace context on runtime workflow rows
- emit committed runtime activity spans and agent-turn spans through the existing OTel pipeline when `otel.trajectory` is enabled
- carry GenAI and Harness allowlist attributes for model, token usage, cost, outcome, workflow id, runtime job id, thread id, turn id, and retry attempt
- isolate trajectory span recording and provider shutdown failures behind an error counter without affecting runtime completion
- add a Grafana OTel LGTM compose snippet and Tempo quickstart for inspecting an issue-to-PR trace
- split event-store external-signal helpers out of an oversized module to stay under the file-size guard

## Scope
Implements the GH1451 SpecRail task packet: `SP1451-T001` through `SP1451-T006`. The trajectory feature remains experimental and defaults off. Prompt/response content export remains behind the separate `otel.capture_content` privacy gate.

## Verification
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1451`
- `git diff --check`
- `docker compose -f docs/otel-trajectory-compose.yml config`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets`
- `cargo test -p harness-observe otel_trajectory`
- `cargo test -p harness-observe otel_failure_isolation`
- `cargo test -p harness-workflow otel_spans`
- `cargo test -p harness-server otel_turn_spans`
- `cargo test -p harness-observe otel_attributes`
- `cargo test -p harness-agents otel_turn_spans`
- `RUSTFLAGS="-Dwarnings" cargo check -p harness-observe -p harness-workflow -p harness-server --all-targets`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`