### PR TITLE
Add workflow runtime eval manifest and scorer foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,6 +1492,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "toml",
  "tracing",
  "uuid",
 ]

--- a/crates/harness-workflow/Cargo.toml
+++ b/crates/harness-workflow/Cargo.toml
@@ -12,6 +12,7 @@ harness-exec = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/harness-workflow/src/runtime/eval/manifest.rs
+++ b/crates/harness-workflow/src/runtime/eval/manifest.rs
@@ -1,0 +1,274 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::{error::Error, fmt};
+
+pub const DEFAULT_CASE_TIMEOUT_SECS: u64 = 3_600;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct EvalBenchmarkManifest {
+    pub suite: String,
+    pub cases: Vec<EvalBenchmarkCase>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct EvalBenchmarkCase {
+    pub case_id: String,
+    pub repo: String,
+    pub issue: u64,
+    pub base_commit: String,
+    pub verify_commands: Vec<String>,
+    pub timeout_secs: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ManifestError {
+    message: String,
+}
+
+impl ManifestError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ManifestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for ManifestError {}
+
+#[derive(Deserialize)]
+struct RawManifest {
+    suite: String,
+    #[serde(default)]
+    default_timeout_secs: Option<u64>,
+    cases: Vec<RawCase>,
+}
+
+#[derive(Deserialize)]
+struct RawCase {
+    #[serde(default)]
+    case_id: Option<String>,
+    repo: String,
+    issue: u64,
+    base_commit: String,
+    verify_commands: Vec<String>,
+    #[serde(default)]
+    timeout_secs: Option<u64>,
+}
+
+pub fn parse_benchmark_manifest_str(input: &str) -> Result<EvalBenchmarkManifest, ManifestError> {
+    let raw: RawManifest =
+        toml::from_str(input).map_err(|err| ManifestError::new(format!("invalid TOML: {err}")))?;
+    normalize_manifest(raw)
+}
+
+fn normalize_manifest(raw: RawManifest) -> Result<EvalBenchmarkManifest, ManifestError> {
+    let suite = non_empty(raw.suite, "suite")?;
+    if raw.cases.is_empty() {
+        return Err(ManifestError::new(
+            "manifest must contain at least one case",
+        ));
+    }
+
+    let default_timeout_secs = raw
+        .default_timeout_secs
+        .unwrap_or(DEFAULT_CASE_TIMEOUT_SECS);
+    validate_timeout(default_timeout_secs, "default_timeout_secs")?;
+
+    let mut seen_case_ids = BTreeSet::new();
+    let mut cases = Vec::with_capacity(raw.cases.len());
+    for (index, case) in raw.cases.into_iter().enumerate() {
+        let repo = non_empty(case.repo, "case repo")?;
+        validate_repo(&repo)?;
+        if case.issue == 0 {
+            return Err(ManifestError::new(format!(
+                "case {} issue must be greater than zero",
+                index + 1
+            )));
+        }
+        let base_commit = non_empty(case.base_commit, "base_commit")?;
+        validate_base_commit(&base_commit)?;
+        let verify_commands = normalize_verify_commands(case.verify_commands, index)?;
+        let timeout_secs = case.timeout_secs.unwrap_or(default_timeout_secs);
+        validate_timeout(timeout_secs, "timeout_secs")?;
+        let case_id = case
+            .case_id
+            .map(|id| non_empty(id, "case_id"))
+            .transpose()?
+            .unwrap_or_else(|| format!("{repo}#{}", case.issue));
+        if !seen_case_ids.insert(case_id.clone()) {
+            return Err(ManifestError::new(format!(
+                "duplicate benchmark case_id: {case_id}"
+            )));
+        }
+
+        cases.push(EvalBenchmarkCase {
+            case_id,
+            repo,
+            issue: case.issue,
+            base_commit,
+            verify_commands,
+            timeout_secs,
+        });
+    }
+
+    Ok(EvalBenchmarkManifest { suite, cases })
+}
+
+fn non_empty(value: String, field: &str) -> Result<String, ManifestError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(ManifestError::new(format!("{field} must not be empty")));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn validate_repo(repo: &str) -> Result<(), ManifestError> {
+    let Some((owner, name)) = repo.split_once('/') else {
+        return Err(ManifestError::new(format!(
+            "repo must use owner/name syntax: {repo}"
+        )));
+    };
+    if owner.is_empty()
+        || name.is_empty()
+        || repo.split('/').count() != 2
+        || repo.chars().any(char::is_whitespace)
+    {
+        return Err(ManifestError::new(format!(
+            "repo must use owner/name syntax: {repo}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_base_commit(base_commit: &str) -> Result<(), ManifestError> {
+    let len = base_commit.len();
+    if !(7..=40).contains(&len) || !base_commit.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return Err(ManifestError::new(format!(
+            "base_commit must be a 7 to 40 character hex commit: {base_commit}"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_verify_commands(
+    verify_commands: Vec<String>,
+    case_index: usize,
+) -> Result<Vec<String>, ManifestError> {
+    if verify_commands.is_empty() {
+        return Err(ManifestError::new(format!(
+            "case {} must include at least one verify command",
+            case_index + 1
+        )));
+    }
+    verify_commands
+        .into_iter()
+        .map(|command| non_empty(command, "verify command"))
+        .collect()
+}
+
+fn validate_timeout(timeout_secs: u64, field: &str) -> Result<(), ManifestError> {
+    if timeout_secs == 0 {
+        return Err(ManifestError::new(format!(
+            "{field} must be greater than zero"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_MANIFEST: &str = r#"
+suite = "harness-core"
+default_timeout_secs = 7200
+
+[[cases]]
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = ["cargo test -p harness-server lifecycle_"]
+
+[[cases]]
+case_id = "stall-timeout-control"
+repo = "majiayu000/harness"
+issue = 1443
+base_commit = "956076f02f546058960bf10d7a00157e5f0139dd"
+verify_commands = ["cargo test -p harness-server turn_lifecycle"]
+timeout_secs = 1800
+"#;
+
+    #[test]
+    fn eval_manifest_parses_cases_with_defaults() {
+        let manifest = parse_benchmark_manifest_str(VALID_MANIFEST).expect("manifest should parse");
+
+        assert_eq!(manifest.suite, "harness-core");
+        assert_eq!(manifest.cases.len(), 2);
+        assert_eq!(manifest.cases[0].case_id, "majiayu000/harness#1437");
+        assert_eq!(manifest.cases[0].timeout_secs, 7200);
+        assert_eq!(manifest.cases[1].case_id, "stall-timeout-control");
+        assert_eq!(manifest.cases[1].timeout_secs, 1800);
+    }
+
+    #[test]
+    fn eval_manifest_rejects_duplicate_case_ids() {
+        let input = r#"
+suite = "harness-core"
+
+[[cases]]
+case_id = "same"
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = ["cargo test"]
+
+[[cases]]
+case_id = "same"
+repo = "majiayu000/harness"
+issue = 1443
+base_commit = "956076f0"
+verify_commands = ["cargo test"]
+"#;
+
+        let err = parse_benchmark_manifest_str(input).expect_err("duplicate id should fail");
+        assert!(err.to_string().contains("duplicate benchmark case_id"));
+    }
+
+    #[test]
+    fn eval_manifest_rejects_missing_verify_commands() {
+        let input = r#"
+suite = "harness-core"
+
+[[cases]]
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = []
+"#;
+
+        let err = parse_benchmark_manifest_str(input).expect_err("empty verify list should fail");
+        assert!(err.to_string().contains("at least one verify command"));
+    }
+
+    #[test]
+    fn eval_manifest_rejects_non_hex_base_commit() {
+        let input = r#"
+suite = "harness-core"
+
+[[cases]]
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "main"
+verify_commands = ["cargo test"]
+"#;
+
+        let err = parse_benchmark_manifest_str(input).expect_err("non-hex commit should fail");
+        assert!(err.to_string().contains("base_commit"));
+    }
+}

--- a/crates/harness-workflow/src/runtime/eval/manifest.rs
+++ b/crates/harness-workflow/src/runtime/eval/manifest.rs
@@ -125,7 +125,11 @@ fn non_empty(value: String, field: &str) -> Result<String, ManifestError> {
     if trimmed.is_empty() {
         return Err(ManifestError::new(format!("{field} must not be empty")));
     }
-    Ok(trimmed.to_string())
+    if trimmed.len() == value.len() {
+        Ok(value)
+    } else {
+        Ok(trimmed.to_string())
+    }
 }
 
 fn validate_repo(repo: &str) -> Result<(), ManifestError> {
@@ -136,7 +140,7 @@ fn validate_repo(repo: &str) -> Result<(), ManifestError> {
     };
     if owner.is_empty()
         || name.is_empty()
-        || repo.split('/').count() != 2
+        || name.contains('/')
         || repo.chars().any(char::is_whitespace)
     {
         return Err(ManifestError::new(format!(

--- a/crates/harness-workflow/src/runtime/eval/mod.rs
+++ b/crates/harness-workflow/src/runtime/eval/mod.rs
@@ -1,0 +1,15 @@
+//! Runtime-owned eval primitives.
+//!
+//! This module is additive groundwork for GH-1447. Eval execution will dispatch
+//! through the normal workflow runtime; this module only owns manifest parsing
+//! and deterministic scoring primitives.
+
+pub mod manifest;
+pub mod model;
+pub mod scoring;
+
+pub use manifest::{
+    parse_benchmark_manifest_str, EvalBenchmarkCase, EvalBenchmarkManifest, ManifestError,
+    DEFAULT_CASE_TIMEOUT_SECS,
+};
+pub use scoring::{score_pr_repair_eval, ScoringError};

--- a/crates/harness-workflow/src/runtime/eval/model.rs
+++ b/crates/harness-workflow/src/runtime/eval/model.rs
@@ -1,0 +1,353 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalScenario {
+    PrRepair,
+    ReadyNoopControl,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalRunMode {
+    #[default]
+    LiveRun,
+    CollectOnly,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EvalTarget {
+    PullRequest {
+        repo: String,
+        pr_number: u64,
+        base_ref: Option<String>,
+        head_ref: Option<String>,
+    },
+    Issue {
+        repo: String,
+        issue_number: u64,
+    },
+    PromptTask {
+        task_id: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeState {
+    Unknown,
+    Clean,
+    Dirty,
+    Blocked,
+    Behind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckState {
+    Unknown,
+    Pending,
+    Passing,
+    Failing,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewDecision {
+    Approved,
+    ChangesRequested,
+    ReviewRequired,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewThreadSnapshot {
+    pub id: String,
+    pub path: Option<String>,
+    pub is_resolved: bool,
+    pub is_outdated: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangedFileSnapshot {
+    pub path: String,
+    pub additions: u64,
+    pub deletions: u64,
+    pub status: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestSnapshot {
+    pub repo: String,
+    pub pr_number: u64,
+    pub url: Option<String>,
+    pub title: Option<String>,
+    pub base_ref: String,
+    pub head_ref: String,
+    pub head_oid: String,
+    pub is_draft: bool,
+    pub merge_state: MergeState,
+    pub check_state: CheckState,
+    pub review_decision: Option<ReviewDecision>,
+    pub active_unresolved_review_threads: Vec<ReviewThreadSnapshot>,
+    #[serde(default)]
+    pub review_threads_complete: bool,
+    pub changed_files: Vec<ChangedFileSnapshot>,
+    #[serde(default)]
+    pub changed_files_complete: bool,
+    pub collected_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeJobSnapshot {
+    pub runtime_job_id: String,
+    pub state: String,
+    #[serde(default)]
+    pub activity: Option<String>,
+    pub artifact_count: u64,
+    pub terminal_state: Option<String>,
+    #[serde(default)]
+    pub error_kind: Option<RuntimeErrorKind>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeErrorKind {
+    Retryable,
+    Timeout,
+    Fatal,
+    Configuration,
+    ExternalDependency,
+    Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeSnapshot {
+    pub task_id: Option<String>,
+    pub workflow_id: Option<String>,
+    pub workflow_state: Option<String>,
+    pub runtime_jobs: Vec<RuntimeJobSnapshot>,
+    pub latest_activity: Option<String>,
+    pub terminal_state: Option<String>,
+    pub collected_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Confidence {
+    Exact,
+    Estimated,
+    Observed,
+    Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UsageSnapshot {
+    pub agent_invocation_id: Option<String>,
+    pub runtime_job_id: Option<String>,
+    pub workflow_id: Option<String>,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cached_input_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+    pub cost_usd_micros: Option<u64>,
+    pub token_confidence: Confidence,
+    pub cost_confidence: Confidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewerKind {
+    Human,
+    Llm,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingSeverity {
+    Info,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewerFinding {
+    pub path: Option<String>,
+    pub summary: String,
+    pub severity: FindingSeverity,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewerJudgment {
+    pub reviewer_kind: ReviewerKind,
+    pub judged_head_oid: String,
+    pub code_quality_score: u8,
+    pub trajectory_score: u8,
+    pub findings: Vec<ReviewerFinding>,
+    pub residual_risks: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PrRepairEvalInput {
+    pub scenario: EvalScenario,
+    pub run_mode: EvalRunMode,
+    pub target: EvalTarget,
+    pub baseline_pr: PullRequestSnapshot,
+    pub final_pr: PullRequestSnapshot,
+    pub final_evidence_head_oid: Option<String>,
+    pub runtime: Option<RuntimeSnapshot>,
+    pub usage: Vec<UsageSnapshot>,
+    pub reviewer_judgment: Option<ReviewerJudgment>,
+    pub created_unrelated_pr: bool,
+    pub scope_violations: Vec<String>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HardGateName {
+    TargetCorrectness,
+    BranchSafety,
+    NoUnrelatedPrCreation,
+    ScopeContainment,
+    HeadChange,
+    HeadFreshness,
+    RequiredChecks,
+    MergeabilityClean,
+    ReviewThreadClosure,
+    RuntimeArtifactCompleteness,
+    ReviewerJudgmentFreshness,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GateStatus {
+    Pass,
+    Fail,
+    NotApplicable,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EvalGrade {
+    F,
+    D,
+    C,
+    B,
+    A,
+}
+
+impl EvalGrade {
+    pub fn from_score(score: u8) -> Self {
+        match score {
+            90..=100 => Self::A,
+            80..=89 => Self::B,
+            65..=79 => Self::C,
+            50..=64 => Self::D,
+            _ => Self::F,
+        }
+    }
+
+    pub fn cap_at(self, cap: Self) -> Self {
+        if self.rank() > cap.rank() {
+            cap
+        } else {
+            self
+        }
+    }
+
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::F => 0,
+            Self::D => 1,
+            Self::C => 2,
+            Self::B => 3,
+            Self::A => 4,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardGateResult {
+    pub name: HardGateName,
+    pub status: GateStatus,
+    pub grade_cap: Option<EvalGrade>,
+    pub message: String,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScoreDimensionName {
+    TaskClassificationAndBaselineEvidence,
+    FeedbackDiscoveryAndPrioritization,
+    BranchAndPrSafety,
+    FixCorrectnessAndScope,
+    VerificationAndCurrentHeadGates,
+    RuntimeWorkflowBehaviorAndPersistence,
+    CostAndTimeEfficiency,
+    ReportingAndAttributionQuality,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScoreComponent {
+    pub name: ScoreDimensionName,
+    pub points: u8,
+    pub max_points: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScoreBreakdown {
+    pub task_classification_and_baseline_evidence: ScoreComponent,
+    pub feedback_discovery_and_prioritization: ScoreComponent,
+    pub branch_and_pr_safety: ScoreComponent,
+    pub fix_correctness_and_scope: ScoreComponent,
+    pub verification_and_current_head_gates: ScoreComponent,
+    pub runtime_workflow_behavior_and_persistence: ScoreComponent,
+    pub cost_and_time_efficiency: ScoreComponent,
+    pub reporting_and_attribution_quality: ScoreComponent,
+}
+
+impl ScoreBreakdown {
+    pub fn total(&self) -> u8 {
+        self.task_classification_and_baseline_evidence.points
+            + self.feedback_discovery_and_prioritization.points
+            + self.branch_and_pr_safety.points
+            + self.fix_correctness_and_scope.points
+            + self.verification_and_current_head_gates.points
+            + self.runtime_workflow_behavior_and_persistence.points
+            + self.cost_and_time_efficiency.points
+            + self.reporting_and_attribution_quality.points
+    }
+
+    pub fn max_total(&self) -> u8 {
+        self.task_classification_and_baseline_evidence.max_points
+            + self.feedback_discovery_and_prioritization.max_points
+            + self.branch_and_pr_safety.max_points
+            + self.fix_correctness_and_scope.max_points
+            + self.verification_and_current_head_gates.max_points
+            + self.runtime_workflow_behavior_and_persistence.max_points
+            + self.cost_and_time_efficiency.max_points
+            + self.reporting_and_attribution_quality.max_points
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct QualitySnapshot {
+    pub scenario: EvalScenario,
+    #[serde(default)]
+    pub run_mode: EvalRunMode,
+    pub target: EvalTarget,
+    pub baseline_pr: Option<PullRequestSnapshot>,
+    pub final_pr: Option<PullRequestSnapshot>,
+    pub runtime: Option<RuntimeSnapshot>,
+    pub usage: Vec<UsageSnapshot>,
+    pub hard_gates: Vec<HardGateResult>,
+    pub objective_score: ScoreBreakdown,
+    pub reviewer_judgment: Option<ReviewerJudgment>,
+    pub final_score: u8,
+    pub final_grade: EvalGrade,
+    pub grade_cap: Option<EvalGrade>,
+    pub blocker_summary: Vec<String>,
+}

--- a/crates/harness-workflow/src/runtime/eval/scoring.rs
+++ b/crates/harness-workflow/src/runtime/eval/scoring.rs
@@ -1,0 +1,451 @@
+use super::model::{
+    CheckState, Confidence, EvalGrade, EvalScenario, EvalTarget, GateStatus, HardGateName,
+    HardGateResult, MergeState, PrRepairEvalInput, QualitySnapshot, RuntimeErrorKind,
+    RuntimeJobSnapshot, RuntimeSnapshot, ScoreBreakdown, ScoreComponent, ScoreDimensionName,
+};
+use std::{error::Error, fmt};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ScoringError {
+    UnsupportedTarget,
+}
+
+impl fmt::Display for ScoringError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedTarget => {
+                f.write_str("PR repair scoring requires a pull request target")
+            }
+        }
+    }
+}
+
+impl Error for ScoringError {}
+
+pub fn score_pr_repair_eval(input: PrRepairEvalInput) -> Result<QualitySnapshot, ScoringError> {
+    let target_matches = target_matches_pr(&input)?;
+    let branch_safe = branch_safe(&input);
+    let no_unrelated_pr = !input.created_unrelated_pr;
+    let scope_contained = input.scope_violations.is_empty();
+    let head_changed = input.baseline_pr.head_oid != input.final_pr.head_oid;
+    let final_evidence_fresh = input
+        .final_evidence_head_oid
+        .as_deref()
+        .is_some_and(|head_oid| head_oid == input.final_pr.head_oid);
+    let checks_passing = input.final_pr.check_state == CheckState::Passing;
+    let mergeability_clean = input.final_pr.merge_state == MergeState::Clean;
+    let review_threads_closed = input.final_pr.active_unresolved_review_threads.is_empty()
+        && input.final_pr.review_threads_complete
+        && (input.scenario == EvalScenario::PrRepair || input.baseline_pr.review_threads_complete);
+    let final_remote_evidence_complete =
+        input.final_pr.review_threads_complete && input.final_pr.changed_files_complete;
+    let runtime_complete = input.runtime.as_ref().is_some_and(runtime_has_artifact);
+
+    let hard_gates = vec![
+        gate(
+            HardGateName::TargetCorrectness,
+            target_matches,
+            Some(EvalGrade::F),
+            "final PR matches the requested target",
+            "final PR does not match the requested target",
+        ),
+        gate(
+            HardGateName::BranchSafety,
+            branch_safe,
+            Some(EvalGrade::F),
+            "base and head refs stayed on the requested PR",
+            "base or head refs changed during evaluation",
+        ),
+        gate(
+            HardGateName::NoUnrelatedPrCreation,
+            no_unrelated_pr,
+            Some(EvalGrade::F),
+            "evaluation did not create an unrelated PR",
+            "evaluation created or reported an unrelated PR",
+        ),
+        gate(
+            HardGateName::ScopeContainment,
+            scope_contained,
+            Some(EvalGrade::F),
+            "final diff stayed within the repair scope",
+            "destructive or unrelated scope changes were detected",
+        ),
+        head_change_gate(&input.scenario, head_changed),
+        gate(
+            HardGateName::HeadFreshness,
+            final_evidence_fresh,
+            Some(EvalGrade::C),
+            "final evidence was collected for the final PR head",
+            "final evidence is missing or stale for the final PR head",
+        ),
+        gate(
+            HardGateName::RequiredChecks,
+            checks_passing,
+            Some(EvalGrade::C),
+            "required checks passed on the final PR head",
+            "required checks are not passing on the final PR head",
+        ),
+        gate(
+            HardGateName::MergeabilityClean,
+            mergeability_clean,
+            Some(EvalGrade::C),
+            "final PR mergeability is clean",
+            "final PR mergeability is not clean",
+        ),
+        gate(
+            HardGateName::ReviewThreadClosure,
+            review_threads_closed,
+            Some(EvalGrade::C),
+            "review threads were fully enumerated and no active unresolved review threads remain",
+            "active unresolved review threads remain or review thread enumeration is incomplete",
+        ),
+        gate(
+            HardGateName::RuntimeArtifactCompleteness,
+            runtime_complete,
+            Some(EvalGrade::B),
+            "usable runtime task, workflow, or job artifact is present",
+            "runtime artifact is missing, failed, or empty",
+        ),
+        reviewer_gate(&input),
+    ];
+    let gate_signals = GateSignals {
+        target_matches,
+        branch_safe,
+        no_unrelated_pr,
+        scope_contained,
+        final_evidence_fresh,
+        checks_passing,
+        mergeability_clean,
+        review_threads_closed,
+        final_remote_evidence_complete,
+        runtime_complete,
+    };
+    let objective_score = score_breakdown(&input, gate_signals);
+    let final_score = objective_score.total();
+    let raw_grade = EvalGrade::from_score(final_score);
+    let grade_cap = most_restrictive_cap(&hard_gates);
+    let final_grade = grade_cap.map_or(raw_grade, |cap| raw_grade.cap_at(cap));
+    let blocker_summary = hard_gates
+        .iter()
+        .filter(|gate| gate.status == GateStatus::Fail)
+        .map(|gate| gate.message.clone())
+        .collect();
+
+    Ok(QualitySnapshot {
+        scenario: input.scenario,
+        run_mode: input.run_mode,
+        target: input.target,
+        baseline_pr: Some(input.baseline_pr),
+        final_pr: Some(input.final_pr),
+        runtime: input.runtime,
+        usage: input.usage,
+        hard_gates,
+        objective_score,
+        reviewer_judgment: input.reviewer_judgment,
+        final_score,
+        final_grade,
+        grade_cap,
+        blocker_summary,
+    })
+}
+
+fn target_matches_pr(input: &PrRepairEvalInput) -> Result<bool, ScoringError> {
+    let EvalTarget::PullRequest {
+        repo,
+        pr_number,
+        base_ref,
+        head_ref,
+    } = &input.target
+    else {
+        return Err(ScoringError::UnsupportedTarget);
+    };
+
+    let target_matches = input.baseline_pr.repo == repo.as_str()
+        && input.final_pr.repo == repo.as_str()
+        && input.baseline_pr.pr_number == *pr_number
+        && input.final_pr.pr_number == *pr_number
+        && base_ref
+            .as_deref()
+            .is_none_or(|expected_base_ref| input.final_pr.base_ref == expected_base_ref)
+        && head_ref
+            .as_deref()
+            .is_none_or(|expected_head_ref| input.final_pr.head_ref == expected_head_ref);
+
+    Ok(target_matches)
+}
+
+fn branch_safe(input: &PrRepairEvalInput) -> bool {
+    input.baseline_pr.repo == input.final_pr.repo
+        && input.baseline_pr.pr_number == input.final_pr.pr_number
+        && input.baseline_pr.base_ref == input.final_pr.base_ref
+        && input.baseline_pr.head_ref == input.final_pr.head_ref
+}
+
+fn runtime_has_artifact(runtime: &RuntimeSnapshot) -> bool {
+    let has_runtime_identity = runtime.task_id.is_some() && runtime.workflow_id.is_some();
+    if !has_runtime_identity || runtime_has_failed_terminal_state(runtime) {
+        return false;
+    }
+
+    let has_terminal_or_job_evidence = runtime.terminal_state.is_some()
+        || runtime
+            .runtime_jobs
+            .iter()
+            .any(|job| job.artifact_count > 0 || job.terminal_state.is_some());
+
+    has_terminal_or_job_evidence
+}
+
+fn runtime_has_failed_terminal_state(runtime: &RuntimeSnapshot) -> bool {
+    runtime
+        .terminal_state
+        .as_deref()
+        .is_some_and(is_failed_runtime_terminal_state)
+        || runtime.runtime_jobs.iter().any(runtime_job_failed)
+}
+
+fn is_failed_runtime_terminal_state(state: &str) -> bool {
+    matches!(
+        state.trim().to_ascii_lowercase().as_str(),
+        "failed"
+            | "cancelled"
+            | "canceled"
+            | "timed_out"
+            | "timeout"
+            | "errored"
+            | "error"
+            | "expired"
+    )
+}
+
+fn gate(
+    name: HardGateName,
+    passed: bool,
+    grade_cap: Option<EvalGrade>,
+    pass_message: &str,
+    fail_message: &str,
+) -> HardGateResult {
+    HardGateResult {
+        name,
+        status: if passed {
+            GateStatus::Pass
+        } else {
+            GateStatus::Fail
+        },
+        grade_cap: if passed { None } else { grade_cap },
+        message: if passed { pass_message } else { fail_message }.to_string(),
+    }
+}
+
+fn head_change_gate(scenario: &EvalScenario, head_changed: bool) -> HardGateResult {
+    match scenario {
+        EvalScenario::ReadyNoopControl => gate(
+            HardGateName::HeadChange,
+            !head_changed,
+            Some(EvalGrade::C),
+            "ready/no-op control kept the PR head unchanged",
+            "ready/no-op control changed the PR head",
+        ),
+        EvalScenario::PrRepair => gate(
+            HardGateName::HeadChange,
+            head_changed,
+            Some(EvalGrade::C),
+            "PR repair changed the PR head",
+            "PR repair did not change the PR head",
+        ),
+    }
+}
+
+fn reviewer_gate(input: &PrRepairEvalInput) -> HardGateResult {
+    match &input.reviewer_judgment {
+        Some(judgment) if judgment.judged_head_oid == input.final_pr.head_oid => HardGateResult {
+            name: HardGateName::ReviewerJudgmentFreshness,
+            status: GateStatus::Pass,
+            grade_cap: None,
+            message: "reviewer judgment matches the final PR head".to_string(),
+        },
+        Some(_) => HardGateResult {
+            name: HardGateName::ReviewerJudgmentFreshness,
+            status: GateStatus::Fail,
+            grade_cap: Some(EvalGrade::C),
+            message: "reviewer judgment is stale for the final PR head".to_string(),
+        },
+        None => HardGateResult {
+            name: HardGateName::ReviewerJudgmentFreshness,
+            status: GateStatus::NotApplicable,
+            grade_cap: Some(EvalGrade::B),
+            message: "reviewer judgment was not provided; grade is capped at B".to_string(),
+        },
+    }
+}
+
+fn most_restrictive_cap(gates: &[HardGateResult]) -> Option<EvalGrade> {
+    gates
+        .iter()
+        .filter_map(|gate| gate.grade_cap)
+        .min_by_key(|grade| grade.rank())
+}
+
+#[derive(Copy, Clone)]
+struct GateSignals {
+    target_matches: bool,
+    branch_safe: bool,
+    no_unrelated_pr: bool,
+    scope_contained: bool,
+    final_evidence_fresh: bool,
+    checks_passing: bool,
+    mergeability_clean: bool,
+    review_threads_closed: bool,
+    final_remote_evidence_complete: bool,
+    runtime_complete: bool,
+}
+
+fn score_breakdown(input: &PrRepairEvalInput, gates: GateSignals) -> ScoreBreakdown {
+    let head_changed = input.baseline_pr.head_oid != input.final_pr.head_oid;
+    let scenario_head_behavior_ok = match input.scenario {
+        EvalScenario::PrRepair => head_changed,
+        EvalScenario::ReadyNoopControl => !head_changed,
+    };
+    let current_head_verified = gates.final_evidence_fresh
+        && gates.checks_passing
+        && gates.mergeability_clean
+        && gates.final_remote_evidence_complete;
+    let has_usage = input.usage.iter().any(|usage| usage.total_tokens.is_some());
+    let has_confident_usage = input.usage.iter().any(|usage| {
+        usage.token_confidence != Confidence::Unknown
+            || usage.cost_confidence != Confidence::Unknown
+    });
+
+    ScoreBreakdown {
+        task_classification_and_baseline_evidence: component(
+            ScoreDimensionName::TaskClassificationAndBaselineEvidence,
+            if gates.target_matches && !input.baseline_pr.collected_at.is_empty() {
+                12
+            } else {
+                4
+            },
+            12,
+        ),
+        feedback_discovery_and_prioritization: component(
+            ScoreDimensionName::FeedbackDiscoveryAndPrioritization,
+            if gates.review_threads_closed { 14 } else { 4 },
+            14,
+        ),
+        branch_and_pr_safety: component(
+            ScoreDimensionName::BranchAndPrSafety,
+            if gates.target_matches
+                && gates.branch_safe
+                && gates.no_unrelated_pr
+                && gates.scope_contained
+            {
+                10
+            } else {
+                0
+            },
+            10,
+        ),
+        fix_correctness_and_scope: component(
+            ScoreDimensionName::FixCorrectnessAndScope,
+            fix_correctness_points(input, scenario_head_behavior_ok),
+            22,
+        ),
+        verification_and_current_head_gates: component(
+            ScoreDimensionName::VerificationAndCurrentHeadGates,
+            if current_head_verified { 16 } else { 4 },
+            16,
+        ),
+        runtime_workflow_behavior_and_persistence: component(
+            ScoreDimensionName::RuntimeWorkflowBehaviorAndPersistence,
+            if gates.runtime_complete { 12 } else { 0 },
+            12,
+        ),
+        cost_and_time_efficiency: component(
+            ScoreDimensionName::CostAndTimeEfficiency,
+            cost_efficiency_points(input.runtime.as_ref(), has_usage),
+            8,
+        ),
+        reporting_and_attribution_quality: component(
+            ScoreDimensionName::ReportingAndAttributionQuality,
+            if gates.runtime_complete && gates.final_evidence_fresh && has_confident_usage {
+                6
+            } else {
+                2
+            },
+            6,
+        ),
+    }
+}
+
+fn cost_efficiency_points(runtime: Option<&RuntimeSnapshot>, has_usage: bool) -> u8 {
+    let Some(runtime) = runtime else {
+        return if has_usage { 6 } else { 4 };
+    };
+    let failed_jobs = runtime
+        .runtime_jobs
+        .iter()
+        .filter(|job| runtime_job_failed(job))
+        .count();
+    let repeated_non_retryable = runtime
+        .runtime_jobs
+        .iter()
+        .filter(|job| runtime_job_failed(job) && runtime_job_error_is_non_retryable(job))
+        .count()
+        > 1;
+
+    if repeated_non_retryable {
+        0
+    } else if failed_jobs > 1 {
+        3
+    } else if failed_jobs == 1 {
+        6
+    } else if has_usage {
+        8
+    } else {
+        4
+    }
+}
+
+fn runtime_job_failed(job: &RuntimeJobSnapshot) -> bool {
+    job.terminal_state
+        .as_deref()
+        .is_some_and(is_failed_runtime_terminal_state)
+        || is_failed_runtime_terminal_state(&job.state)
+}
+
+fn runtime_job_error_is_non_retryable(job: &RuntimeJobSnapshot) -> bool {
+    matches!(
+        job.error_kind,
+        Some(RuntimeErrorKind::Fatal | RuntimeErrorKind::Configuration)
+    )
+}
+
+fn fix_correctness_points(input: &PrRepairEvalInput, changed_or_noop: bool) -> u8 {
+    if input.created_unrelated_pr || !input.scope_violations.is_empty() {
+        return 4;
+    }
+
+    if let Some(judgment) = &input.reviewer_judgment {
+        let code_quality = judgment.code_quality_score.min(100) as u16;
+        let trajectory = judgment.trajectory_score.min(100) as u16;
+        let bounded = (code_quality * 3 + trajectory + 2) / 4;
+        return ((bounded * 22 + 50) / 100) as u8;
+    }
+
+    if changed_or_noop {
+        13
+    } else {
+        8
+    }
+}
+
+fn component(name: ScoreDimensionName, points: u8, max_points: u8) -> ScoreComponent {
+    ScoreComponent {
+        name,
+        points: points.min(max_points),
+        max_points,
+    }
+}
+
+#[cfg(test)]
+#[path = "scoring_tests.rs"]
+mod tests;

--- a/crates/harness-workflow/src/runtime/eval/scoring.rs
+++ b/crates/harness-workflow/src/runtime/eval/scoring.rs
@@ -205,17 +205,15 @@ fn runtime_has_failed_terminal_state(runtime: &RuntimeSnapshot) -> bool {
 }
 
 fn is_failed_runtime_terminal_state(state: &str) -> bool {
-    matches!(
-        state.trim().to_ascii_lowercase().as_str(),
-        "failed"
-            | "cancelled"
-            | "canceled"
-            | "timed_out"
-            | "timeout"
-            | "errored"
-            | "error"
-            | "expired"
-    )
+    let state = state.trim();
+    state.eq_ignore_ascii_case("failed")
+        || state.eq_ignore_ascii_case("cancelled")
+        || state.eq_ignore_ascii_case("canceled")
+        || state.eq_ignore_ascii_case("timed_out")
+        || state.eq_ignore_ascii_case("timeout")
+        || state.eq_ignore_ascii_case("errored")
+        || state.eq_ignore_ascii_case("error")
+        || state.eq_ignore_ascii_case("expired")
 }
 
 fn gate(
@@ -380,17 +378,17 @@ fn cost_efficiency_points(runtime: Option<&RuntimeSnapshot>, has_usage: bool) ->
     let Some(runtime) = runtime else {
         return if has_usage { 6 } else { 4 };
     };
-    let failed_jobs = runtime
-        .runtime_jobs
-        .iter()
-        .filter(|job| runtime_job_failed(job))
-        .count();
-    let repeated_non_retryable = runtime
-        .runtime_jobs
-        .iter()
-        .filter(|job| runtime_job_failed(job) && runtime_job_error_is_non_retryable(job))
-        .count()
-        > 1;
+    let mut failed_jobs = 0;
+    let mut non_retryable_failed_jobs = 0;
+    for job in &runtime.runtime_jobs {
+        if runtime_job_failed(job) {
+            failed_jobs += 1;
+            if runtime_job_error_is_non_retryable(job) {
+                non_retryable_failed_jobs += 1;
+            }
+        }
+    }
+    let repeated_non_retryable = non_retryable_failed_jobs > 1;
 
     if repeated_non_retryable {
         0

--- a/crates/harness-workflow/src/runtime/eval/scoring_tests.rs
+++ b/crates/harness-workflow/src/runtime/eval/scoring_tests.rs
@@ -1,0 +1,491 @@
+use super::super::model::{
+    ChangedFileSnapshot, MergeState, PullRequestSnapshot, ReviewerJudgment, ReviewerKind,
+    RuntimeErrorKind, RuntimeJobSnapshot, UsageSnapshot,
+};
+use super::*;
+
+#[test]
+fn ready_noop_control_accepts_unchanged_head() {
+    let mut input = perfect_input();
+    input.scenario = EvalScenario::ReadyNoopControl;
+    input.baseline_pr.head_oid = "same-head".to_string();
+    input.final_pr.head_oid = "same-head".to_string();
+    input.final_pr.changed_files.clear();
+    input.final_evidence_head_oid = Some("same-head".to_string());
+    input.reviewer_judgment = Some(reviewer_judgment("same-head"));
+
+    let snapshot = score_pr_repair_eval(input).expect("score ready/no-op input");
+    let gate = find_gate(&snapshot, HardGateName::HeadChange);
+
+    assert_eq!(gate.status, GateStatus::Pass);
+    assert_eq!(gate.grade_cap, None);
+    assert_eq!(snapshot.grade_cap, None);
+}
+
+#[test]
+fn ready_noop_control_changed_head_caps_and_penalizes() {
+    let mut input = perfect_input();
+    input.scenario = EvalScenario::ReadyNoopControl;
+    input.baseline_pr.head_oid = "base-head".to_string();
+    input.final_pr.head_oid = "changed-head".to_string();
+    input.final_evidence_head_oid = Some("changed-head".to_string());
+    input.reviewer_judgment = None;
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score changed ready/no-op input failed: {error}"),
+    };
+    let gate = find_gate(&snapshot, HardGateName::HeadChange);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.final_grade, EvalGrade::C);
+    assert_eq!(snapshot.objective_score.fix_correctness_and_scope.points, 8);
+}
+
+#[test]
+fn unresolved_active_review_threads_cap_and_fail() {
+    let mut input = perfect_input();
+    input.final_pr.active_unresolved_review_threads.push(
+        super::super::model::ReviewThreadSnapshot {
+            id: "thread-1".to_string(),
+            path: Some("src/lib.rs".to_string()),
+            is_resolved: false,
+            is_outdated: false,
+        },
+    );
+
+    let snapshot = score_pr_repair_eval(input).expect("score input with unresolved thread");
+    let gate = find_gate(&snapshot, HardGateName::ReviewThreadClosure);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.final_grade, EvalGrade::C);
+}
+
+#[test]
+fn non_clean_mergeability_caps_and_fails() {
+    let mut input = perfect_input();
+    input.final_pr.merge_state = MergeState::Blocked;
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score non-clean mergeability input failed: {error}"),
+    };
+    let gate = find_gate(&snapshot, HardGateName::MergeabilityClean);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.final_grade, EvalGrade::C);
+    assert!(snapshot
+        .blocker_summary
+        .contains(&"final PR mergeability is not clean".to_string()));
+}
+
+#[test]
+fn stale_final_evidence_caps_and_fails() {
+    let mut input = perfect_input();
+    input.final_evidence_head_oid = Some("old-head".to_string());
+
+    let snapshot = score_pr_repair_eval(input).expect("score stale final evidence");
+    let gate = find_gate(&snapshot, HardGateName::HeadFreshness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.final_grade, EvalGrade::C);
+}
+
+#[test]
+fn missing_runtime_artifact_caps_at_b() {
+    let mut input = perfect_input();
+    input.runtime = None;
+
+    let snapshot = score_pr_repair_eval(input).expect("score missing runtime input");
+    let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.final_grade, EvalGrade::B);
+}
+
+#[test]
+fn partial_runtime_artifact_without_workflow_identity_caps_at_b() {
+    let mut input = perfect_input();
+    input.runtime = Some(RuntimeSnapshot {
+        task_id: Some("task-1".to_string()),
+        workflow_id: None,
+        workflow_state: None,
+        runtime_jobs: Vec::new(),
+        latest_activity: None,
+        terminal_state: Some("succeeded".to_string()),
+        collected_at: "2026-06-05T00:10:00Z".to_string(),
+    });
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score partial runtime input failed: {error}"),
+    };
+    let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+}
+
+#[test]
+fn failed_runtime_terminal_states_cap_at_b() {
+    for state in [
+        "failed",
+        "cancelled",
+        "canceled",
+        "timed_out",
+        "timeout",
+        "errored",
+        "error",
+        "expired",
+    ] {
+        let mut input = perfect_input();
+        let Some(runtime) = input.runtime.as_mut() else {
+            panic!("runtime should exist");
+        };
+        runtime.terminal_state = Some(state.to_string());
+        runtime.runtime_jobs[0].artifact_count = 1;
+        runtime.runtime_jobs[0].terminal_state = Some("succeeded".to_string());
+
+        let snapshot = match score_pr_repair_eval(input) {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("score failed runtime input failed: {error}"),
+        };
+        let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+        assert_eq!(gate.status, GateStatus::Fail);
+        assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+        assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+        assert_eq!(snapshot.final_grade, EvalGrade::B);
+    }
+}
+
+#[test]
+fn failed_runtime_job_terminal_state_caps_at_b_even_with_artifacts() {
+    let mut input = perfect_input();
+    let Some(runtime) = input.runtime.as_mut() else {
+        panic!("runtime should exist");
+    };
+    runtime.terminal_state = Some("succeeded".to_string());
+    runtime.runtime_jobs[0].artifact_count = 1;
+    runtime.runtime_jobs[0].terminal_state = Some("failed".to_string());
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score failed job runtime input failed: {error}"),
+    };
+    let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+}
+
+#[test]
+fn expired_runtime_job_state_caps_at_b_when_terminal_state_is_missing() {
+    let mut input = perfect_input();
+    let Some(runtime) = input.runtime.as_mut() else {
+        panic!("runtime should exist");
+    };
+    runtime.terminal_state = Some("succeeded".to_string());
+    runtime.runtime_jobs[0].artifact_count = 1;
+    runtime.runtime_jobs[0].state = "expired".to_string();
+    runtime.runtime_jobs[0].terminal_state = None;
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score expired job runtime input failed: {error}"),
+    };
+    let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+}
+
+#[test]
+fn auditable_runtime_terminal_states_count_as_runtime_evidence() {
+    for state in ["ready_to_merge", "blocked"] {
+        let mut input = perfect_input();
+        let Some(runtime) = input.runtime.as_mut() else {
+            panic!("runtime should exist");
+        };
+        runtime.terminal_state = Some(state.to_string());
+        runtime.runtime_jobs.clear();
+
+        let snapshot = match score_pr_repair_eval(input) {
+            Ok(snapshot) => snapshot,
+            Err(error) => panic!("score auditable runtime input failed: {error}"),
+        };
+        let gate = find_gate(&snapshot, HardGateName::RuntimeArtifactCompleteness);
+
+        assert_eq!(gate.status, GateStatus::Pass);
+        assert_eq!(gate.grade_cap, None);
+        assert_eq!(snapshot.grade_cap, None);
+    }
+}
+
+#[test]
+fn repeated_non_retryable_runtime_failures_zero_cost_efficiency() {
+    let mut input = perfect_input();
+    let Some(runtime) = input.runtime.as_mut() else {
+        panic!("runtime should exist");
+    };
+    runtime.runtime_jobs = vec![
+        failed_job("job-1", RuntimeErrorKind::Configuration),
+        failed_job("job-2", RuntimeErrorKind::Configuration),
+    ];
+
+    let snapshot = score_pr_repair_eval(input).expect("score repeated configuration failures");
+
+    assert_eq!(snapshot.objective_score.cost_and_time_efficiency.points, 0);
+}
+
+#[test]
+fn single_failed_runtime_job_partially_penalizes_cost_efficiency() {
+    let mut input = perfect_input();
+    let Some(runtime) = input.runtime.as_mut() else {
+        panic!("runtime should exist");
+    };
+    runtime.runtime_jobs = vec![failed_job("job-1", RuntimeErrorKind::Timeout)];
+
+    let snapshot = score_pr_repair_eval(input).expect("score single failed runtime job");
+
+    assert_eq!(snapshot.objective_score.cost_and_time_efficiency.points, 6);
+}
+
+#[test]
+fn expired_runtime_job_state_partially_penalizes_cost_efficiency() {
+    let mut input = perfect_input();
+    let Some(runtime) = input.runtime.as_mut() else {
+        panic!("runtime should exist");
+    };
+    runtime.runtime_jobs[0].state = "expired".to_string();
+    runtime.runtime_jobs[0].terminal_state = None;
+
+    let snapshot = match score_pr_repair_eval(input) {
+        Ok(snapshot) => snapshot,
+        Err(error) => panic!("score expired runtime job failed: {error}"),
+    };
+
+    assert_eq!(snapshot.objective_score.cost_and_time_efficiency.points, 6);
+}
+
+#[test]
+fn stale_reviewer_judgment_caps_and_fails() {
+    let mut input = perfect_input();
+    input.reviewer_judgment = Some(reviewer_judgment("old-head"));
+
+    let snapshot = score_pr_repair_eval(input).expect("score stale reviewer input");
+    let gate = find_gate(&snapshot, HardGateName::ReviewerJudgmentFreshness);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::C));
+    assert_eq!(snapshot.final_grade, EvalGrade::C);
+    assert!(snapshot
+        .blocker_summary
+        .contains(&"reviewer judgment is stale for the final PR head".to_string()));
+}
+
+#[test]
+fn missing_reviewer_judgment_caps_at_b() {
+    let mut input = perfect_input();
+    input.reviewer_judgment = None;
+
+    let snapshot = score_pr_repair_eval(input).expect("score missing reviewer input");
+    let gate = find_gate(&snapshot, HardGateName::ReviewerJudgmentFreshness);
+
+    assert_eq!(gate.status, GateStatus::NotApplicable);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::B));
+    assert_eq!(snapshot.final_grade, EvalGrade::B);
+}
+
+#[test]
+fn unrelated_pr_creation_caps_at_f() {
+    let mut input = perfect_input();
+    input.created_unrelated_pr = true;
+
+    let snapshot = score_pr_repair_eval(input).expect("score unrelated PR input");
+    let gate = find_gate(&snapshot, HardGateName::NoUnrelatedPrCreation);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::F));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::F));
+    assert_eq!(snapshot.final_grade, EvalGrade::F);
+}
+
+#[test]
+fn destructive_or_unrelated_scope_changes_cap_at_f() {
+    let mut input = perfect_input();
+    input
+        .scope_violations
+        .push("changed unrelated dashboard files".to_string());
+
+    let snapshot = score_pr_repair_eval(input).expect("score scope violation input");
+    let gate = find_gate(&snapshot, HardGateName::ScopeContainment);
+
+    assert_eq!(gate.status, GateStatus::Fail);
+    assert_eq!(gate.grade_cap, Some(EvalGrade::F));
+    assert_eq!(snapshot.grade_cap, Some(EvalGrade::F));
+    assert_eq!(snapshot.final_grade, EvalGrade::F);
+}
+
+#[test]
+fn trajectory_score_contributes_to_fix_correctness() {
+    let mut input = perfect_input();
+    input.reviewer_judgment = Some(ReviewerJudgment {
+        code_quality_score: 100,
+        trajectory_score: 0,
+        ..reviewer_judgment("final-head")
+    });
+
+    let snapshot = score_pr_repair_eval(input).expect("score low trajectory input");
+
+    assert_eq!(
+        snapshot.objective_score.fix_correctness_and_scope.points,
+        17
+    );
+}
+
+#[test]
+fn basic_score_breakdown_returns_deterministic_total() {
+    let snapshot = score_pr_repair_eval(perfect_input()).expect("score perfect input");
+
+    assert_eq!(snapshot.objective_score.max_total(), 100);
+    assert_eq!(snapshot.objective_score.total(), 100);
+    assert_eq!(snapshot.final_score, 100);
+    assert_eq!(snapshot.final_grade, EvalGrade::A);
+    assert_eq!(snapshot.grade_cap, None);
+}
+
+#[test]
+fn eval_scoring_rescores_same_evidence_to_identical_json() {
+    let input = perfect_input();
+    let first = score_pr_repair_eval(input.clone()).expect("score first input");
+    let second = score_pr_repair_eval(input).expect("score second input");
+
+    let first_json = serde_json::to_vec(&first).expect("serialize first snapshot");
+    let second_json = serde_json::to_vec(&second).expect("serialize second snapshot");
+
+    assert_eq!(first_json, second_json);
+}
+
+fn find_gate(snapshot: &QualitySnapshot, name: HardGateName) -> &HardGateResult {
+    snapshot
+        .hard_gates
+        .iter()
+        .find(|gate| gate.name == name)
+        .expect("gate should exist")
+}
+
+fn perfect_input() -> PrRepairEvalInput {
+    PrRepairEvalInput {
+        scenario: EvalScenario::PrRepair,
+        run_mode: super::super::model::EvalRunMode::LiveRun,
+        target: EvalTarget::PullRequest {
+            repo: "owner/repo".to_string(),
+            pr_number: 42,
+            base_ref: Some("main".to_string()),
+            head_ref: Some("fix/pr-42".to_string()),
+        },
+        baseline_pr: pr_snapshot("base-head", Vec::new()),
+        final_pr: pr_snapshot(
+            "final-head",
+            vec![ChangedFileSnapshot {
+                path: "src/lib.rs".to_string(),
+                additions: 12,
+                deletions: 3,
+                status: "modified".to_string(),
+            }],
+        ),
+        final_evidence_head_oid: Some("final-head".to_string()),
+        runtime: Some(RuntimeSnapshot {
+            task_id: Some("task-1".to_string()),
+            workflow_id: Some("workflow-1".to_string()),
+            workflow_state: Some("completed".to_string()),
+            runtime_jobs: vec![RuntimeJobSnapshot {
+                runtime_job_id: "job-1".to_string(),
+                state: "completed".to_string(),
+                activity: Some("implement_issue".to_string()),
+                artifact_count: 1,
+                terminal_state: Some("succeeded".to_string()),
+                error_kind: None,
+            }],
+            latest_activity: Some("completed".to_string()),
+            terminal_state: Some("succeeded".to_string()),
+            collected_at: "2026-06-05T00:10:00Z".to_string(),
+        }),
+        usage: vec![UsageSnapshot {
+            agent_invocation_id: Some("invoke-1".to_string()),
+            runtime_job_id: Some("job-1".to_string()),
+            workflow_id: Some("workflow-1".to_string()),
+            model: Some("codex".to_string()),
+            reasoning_effort: Some("medium".to_string()),
+            input_tokens: Some(1000),
+            output_tokens: Some(200),
+            cached_input_tokens: Some(100),
+            total_tokens: Some(1200),
+            cost_usd_micros: Some(120_000),
+            token_confidence: Confidence::Exact,
+            cost_confidence: Confidence::Estimated,
+        }],
+        reviewer_judgment: Some(reviewer_judgment("final-head")),
+        created_unrelated_pr: false,
+        scope_violations: Vec::new(),
+    }
+}
+
+fn failed_job(id: &str, error_kind: RuntimeErrorKind) -> RuntimeJobSnapshot {
+    RuntimeJobSnapshot {
+        runtime_job_id: id.to_string(),
+        state: "failed".to_string(),
+        activity: Some("implement_issue".to_string()),
+        artifact_count: 1,
+        terminal_state: Some("failed".to_string()),
+        error_kind: Some(error_kind),
+    }
+}
+
+fn pr_snapshot(head_oid: &str, changed_files: Vec<ChangedFileSnapshot>) -> PullRequestSnapshot {
+    PullRequestSnapshot {
+        repo: "owner/repo".to_string(),
+        pr_number: 42,
+        url: Some("https://github.com/owner/repo/pull/42".to_string()),
+        title: Some("Fix issue".to_string()),
+        base_ref: "main".to_string(),
+        head_ref: "fix/pr-42".to_string(),
+        head_oid: head_oid.to_string(),
+        is_draft: false,
+        merge_state: MergeState::Clean,
+        check_state: CheckState::Passing,
+        review_decision: Some(super::super::model::ReviewDecision::Approved),
+        active_unresolved_review_threads: Vec::new(),
+        review_threads_complete: true,
+        changed_files,
+        changed_files_complete: true,
+        collected_at: "2026-06-05T00:00:00Z".to_string(),
+    }
+}
+
+fn reviewer_judgment(head_oid: &str) -> ReviewerJudgment {
+    ReviewerJudgment {
+        reviewer_kind: ReviewerKind::Human,
+        judged_head_oid: head_oid.to_string(),
+        code_quality_score: 100,
+        trajectory_score: 100,
+        findings: Vec::new(),
+        residual_risks: Vec::new(),
+    }
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -7,6 +7,7 @@
 pub mod bus;
 pub mod dispatcher;
 pub mod errors;
+pub mod eval;
 mod job_claim;
 pub mod lease_state;
 pub mod model;
@@ -35,6 +36,10 @@ mod tests;
 pub use bus::InMemoryWorkflowBus;
 pub use dispatcher::{CommandDispatchOutcome, RuntimeCommandDispatcher, RuntimeProfileSelector};
 pub use errors::RuntimeJobNotFoundError;
+pub use eval::{
+    parse_benchmark_manifest_str, score_pr_repair_eval, EvalBenchmarkCase, EvalBenchmarkManifest,
+    ManifestError, ScoringError, DEFAULT_CASE_TIMEOUT_SECS,
+};
 pub use lease_state::{runtime_job_running_lease_state_at, RuntimeJobRunningLeaseState};
 pub use model::{
     ActivityArtifact, ActivityErrorKind, ActivityResult, ActivitySignal, ActivityStatus,

--- a/evals/benchmarks/README.md
+++ b/evals/benchmarks/README.md
@@ -1,0 +1,20 @@
+# Runtime Eval Benchmark Manifests
+
+Benchmark manifests live in this directory as TOML files. Each manifest lists
+resolved issue cases that the eval driver can replay through the normal
+workflow runtime path.
+
+```toml
+suite = "harness-core"
+default_timeout_secs = 3600
+
+[[cases]]
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = ["cargo test -p harness-server lifecycle_"]
+```
+
+`case_id` is optional and defaults to `owner/repo#issue`. `base_commit` must be
+a 7- to 40-character hexadecimal commit prefix or SHA. Every case must include
+at least one verification command.


### PR DESCRIPTION
Related: #1447.

## Summary
- Add `harness-workflow::runtime::eval` as the runtime-owned eval foundation.
- Add the `evals/benchmarks/` TOML manifest convention with parser validation and reject tests.
- Port the deterministic PR-repair scoring model and scorer from `harness-eval` into `harness-workflow` without linking to the orphaned eval crate.

## Scope
This covers `SP1447-T001` and `SP1447-T002` only. GH-1447 remains open after this slice; the eval driver, evidence collection, CLI reports, cleanup, and curated 10+ case manifest remain for later PRs.

## Verification
- `cargo test -p harness-workflow eval_manifest`
- `cargo test -p harness-workflow eval_scoring`
- `cargo test -p harness-workflow runtime::eval`
- `cargo check -p harness-workflow --all-targets`
- `cargo test -p harness-workflow`
- `cargo fmt --all -- --check`
- `git diff --cached --check`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1447`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-run`

