### PR TITLE
Add workflow runtime eval dispatch and evidence collection

### DIFF
--- a/crates/harness-workflow/src/runtime/eval/evidence.rs
+++ b/crates/harness-workflow/src/runtime/eval/evidence.rs
@@ -197,9 +197,13 @@ fn quality_gate_evidence(
         .and_then(|command_id| runtime_jobs.iter().find(|job| job.command_id == command_id))
         .or_else(|| {
             runtime_jobs.iter().find(|job| {
-                activity_result_from_job(job)
-                    .as_ref()
-                    .is_some_and(|result| result.activity == QUALITY_GATE_ACTIVITY)
+                job.input
+                    .get("activity")
+                    .and_then(Value::as_str)
+                    .is_some_and(|activity| activity == QUALITY_GATE_ACTIVITY)
+                    || activity_result_from_job(job)
+                        .as_ref()
+                        .is_some_and(|result| result.activity == QUALITY_GATE_ACTIVITY)
             })
         })?;
     let result = activity_result_from_job(job);
@@ -353,6 +357,7 @@ fn usage_snapshot_from_event(
                 .saturating_add(output_tokens.unwrap_or(0))
         })
     });
+    let cost_usd_micros = first_u64_field(payload, &["cost_usd_micros"]);
     UsageSnapshot {
         agent_invocation_id: payload
             .get("agent_invocation_id")
@@ -372,9 +377,9 @@ fn usage_snapshot_from_event(
         output_tokens,
         cached_input_tokens,
         total_tokens,
-        cost_usd_micros: first_u64_field(payload, &["cost_usd_micros"]),
+        cost_usd_micros,
         token_confidence: Confidence::Observed,
-        cost_confidence: if payload.get("cost_usd_micros").is_some() {
+        cost_confidence: if cost_usd_micros.is_some() {
             Confidence::Estimated
         } else {
             Confidence::Unknown
@@ -561,6 +566,23 @@ mod tests {
             evidence.runtime.as_ref().unwrap().terminal_state,
             Some("done".to_string())
         );
+    }
+
+    #[test]
+    fn eval_usage_invalid_cost_keeps_cost_confidence_unknown() {
+        let snapshot = usage_snapshot_from_event(
+            Some("workflow-1"),
+            "job-1",
+            &json!({
+                "usage": {
+                    "input_tokens": 10,
+                    "cost_usd_micros": "not-a-number"
+                }
+            }),
+        );
+
+        assert_eq!(snapshot.cost_usd_micros, None);
+        assert_eq!(snapshot.cost_confidence, Confidence::Unknown);
     }
 
     fn command_record(

--- a/crates/harness-workflow/src/runtime/eval/evidence.rs
+++ b/crates/harness-workflow/src/runtime/eval/evidence.rs
@@ -1,0 +1,584 @@
+use super::model::{
+    Confidence, RuntimeErrorKind, RuntimeJobSnapshot, RuntimeSnapshot, UsageSnapshot,
+};
+use crate::runtime::{
+    ActivityErrorKind, ActivityResult, RuntimeEvent, RuntimeJob, RuntimeJobStatus,
+    WorkflowCommandRecord, WorkflowInstance, WorkflowRuntimeStore, QUALITY_GATE_ACTIVITY,
+};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalEvidenceStatus {
+    Passed,
+    Failed,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvalCaseEvidence {
+    pub eval_run_id: String,
+    pub case_id: String,
+    pub workflow_id: Option<String>,
+    pub status: EvalEvidenceStatus,
+    pub runtime: Option<RuntimeSnapshot>,
+    pub usage: Vec<UsageSnapshot>,
+    pub submission: Option<EvalSubmissionEvidence>,
+    pub quality_gate: Option<EvalQualityGateEvidence>,
+    pub missing_evidence: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSubmissionEvidence {
+    pub repo: Option<String>,
+    pub issue_number: Option<u64>,
+    pub command_id: Option<String>,
+    pub command_status: Option<String>,
+    pub runtime_job_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalQualityGateEvidence {
+    pub command_id: Option<String>,
+    pub runtime_job_id: Option<String>,
+    pub status: String,
+    pub validation_passed: bool,
+    pub validation_commands: Vec<String>,
+}
+
+pub async fn collect_eval_case_evidence(
+    store: &WorkflowRuntimeStore,
+    eval_run_id: &str,
+    case_id: &str,
+    workflow_id: &str,
+) -> anyhow::Result<EvalCaseEvidence> {
+    let workflow = store.get_instance(workflow_id).await?;
+    let commands = store.commands_for(workflow_id).await?;
+    let command_ids = commands
+        .iter()
+        .map(|command| command.id.clone())
+        .collect::<Vec<_>>();
+    let jobs_by_command = store.runtime_jobs_for_commands(&command_ids).await?;
+    let runtime_jobs = command_ids
+        .iter()
+        .filter_map(|command_id| jobs_by_command.get(command_id))
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>();
+    let runtime_job_ids = runtime_jobs
+        .iter()
+        .map(|job| job.id.clone())
+        .collect::<Vec<_>>();
+    let events_by_job = store.runtime_events_for_jobs(&runtime_job_ids).await?;
+
+    Ok(collect_eval_case_evidence_from_records(
+        eval_run_id,
+        case_id,
+        workflow.as_ref(),
+        &commands,
+        &runtime_jobs,
+        &events_by_job,
+    ))
+}
+
+pub fn collect_eval_case_evidence_from_records(
+    eval_run_id: &str,
+    case_id: &str,
+    workflow: Option<&WorkflowInstance>,
+    commands: &[WorkflowCommandRecord],
+    runtime_jobs: &[RuntimeJob],
+    runtime_events: &BTreeMap<String, Vec<RuntimeEvent>>,
+) -> EvalCaseEvidence {
+    let mut missing_evidence = Vec::new();
+    let workflow_id = workflow.map(|workflow| workflow.id.clone());
+    if workflow.is_none() {
+        missing_evidence.push("workflow_instance".to_string());
+    }
+
+    let submission = submission_evidence(workflow, commands, runtime_jobs);
+    if submission.is_none() {
+        missing_evidence.push("submission".to_string());
+    } else if submission
+        .as_ref()
+        .is_some_and(|submission| submission.runtime_job_ids.is_empty())
+    {
+        missing_evidence.push("submission_runtime_job".to_string());
+    }
+    let quality_gate = quality_gate_evidence(commands, runtime_jobs);
+    if quality_gate.is_none() {
+        missing_evidence.push("quality_gate".to_string());
+    } else if quality_gate
+        .as_ref()
+        .is_some_and(|quality_gate| !quality_gate.validation_passed)
+    {
+        missing_evidence.push("quality_gate_pass".to_string());
+    }
+
+    let runtime = workflow.map(|workflow| runtime_snapshot(workflow, runtime_jobs));
+    if runtime.as_ref().is_none_or(|snapshot| {
+        snapshot.terminal_state.is_none()
+            && snapshot
+                .runtime_jobs
+                .iter()
+                .all(|job| job.terminal_state.is_none())
+    }) {
+        missing_evidence.push("terminal_runtime_state".to_string());
+    }
+    let usage = usage_snapshots(workflow_id.as_deref(), runtime_events);
+    if usage.is_empty() {
+        missing_evidence.push("usage".to_string());
+    }
+
+    let status = if missing_evidence.is_empty() {
+        EvalEvidenceStatus::Passed
+    } else {
+        EvalEvidenceStatus::Failed
+    };
+
+    EvalCaseEvidence {
+        eval_run_id: eval_run_id.to_string(),
+        case_id: case_id.to_string(),
+        workflow_id,
+        status,
+        runtime,
+        usage,
+        submission,
+        quality_gate,
+        missing_evidence,
+    }
+}
+
+fn submission_evidence(
+    workflow: Option<&WorkflowInstance>,
+    commands: &[WorkflowCommandRecord],
+    runtime_jobs: &[RuntimeJob],
+) -> Option<EvalSubmissionEvidence> {
+    let workflow = workflow?;
+    let implementation_command = commands
+        .iter()
+        .find(|command| command.command.runtime_activity_key() == "implement_issue")?;
+    let command_id = Some(implementation_command.id.clone());
+    let command_status = Some(implementation_command.status.as_str().to_string());
+    let runtime_job_ids = command_id
+        .as_deref()
+        .map(|command_id| {
+            runtime_jobs
+                .iter()
+                .filter(|job| job.command_id == command_id)
+                .map(|job| job.id.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+    Some(EvalSubmissionEvidence {
+        repo: workflow
+            .data
+            .get("repo")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        issue_number: workflow.data.get("issue_number").and_then(Value::as_u64),
+        command_id,
+        command_status,
+        runtime_job_ids,
+    })
+}
+
+fn quality_gate_evidence(
+    commands: &[WorkflowCommandRecord],
+    runtime_jobs: &[RuntimeJob],
+) -> Option<EvalQualityGateEvidence> {
+    let command = commands
+        .iter()
+        .find(|command| command.command.runtime_activity_key() == QUALITY_GATE_ACTIVITY);
+    let command_id = command.map(|command| command.id.clone());
+    let job = command_id
+        .as_deref()
+        .and_then(|command_id| runtime_jobs.iter().find(|job| job.command_id == command_id))
+        .or_else(|| {
+            runtime_jobs.iter().find(|job| {
+                activity_result_from_job(job)
+                    .as_ref()
+                    .is_some_and(|result| result.activity == QUALITY_GATE_ACTIVITY)
+            })
+        })?;
+    let result = activity_result_from_job(job);
+    let validation_commands = result
+        .as_ref()
+        .map(|result| {
+            result
+                .validation
+                .iter()
+                .map(|record| record.command.clone())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let validation_passed = result.as_ref().is_some_and(|result| {
+        result.status == crate::runtime::ActivityStatus::Succeeded
+            && !result.validation.is_empty()
+            && result
+                .validation
+                .iter()
+                .all(|record| record.status.eq_ignore_ascii_case("passed"))
+    });
+    Some(EvalQualityGateEvidence {
+        command_id,
+        runtime_job_id: Some(job.id.clone()),
+        status: eval_runtime_job_status(job.status).to_string(),
+        validation_passed,
+        validation_commands,
+    })
+}
+
+fn runtime_snapshot(workflow: &WorkflowInstance, runtime_jobs: &[RuntimeJob]) -> RuntimeSnapshot {
+    RuntimeSnapshot {
+        task_id: workflow
+            .data
+            .get("task_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        workflow_id: Some(workflow.id.clone()),
+        workflow_state: Some(workflow.state.clone()),
+        runtime_jobs: runtime_jobs.iter().map(runtime_job_snapshot).collect(),
+        latest_activity: runtime_jobs
+            .iter()
+            .rev()
+            .find_map(|job| job.input.get("activity").and_then(Value::as_str))
+            .map(ToOwned::to_owned),
+        terminal_state: workflow.is_terminal().then(|| workflow.state.clone()),
+        collected_at: Utc::now().to_rfc3339(),
+    }
+}
+
+fn runtime_job_snapshot(job: &RuntimeJob) -> RuntimeJobSnapshot {
+    let result = activity_result_from_job(job);
+    RuntimeJobSnapshot {
+        runtime_job_id: job.id.clone(),
+        state: eval_runtime_job_status(job.status).to_string(),
+        activity: job
+            .input
+            .get("activity")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .or_else(|| result.as_ref().map(|result| result.activity.clone())),
+        artifact_count: result
+            .as_ref()
+            .map(|result| result.artifacts.len() as u64)
+            .unwrap_or(0),
+        terminal_state: runtime_job_terminal_state(job),
+        error_kind: result
+            .as_ref()
+            .and_then(|result| result.error_kind.map(runtime_error_kind)),
+    }
+}
+
+fn activity_result_from_job(job: &RuntimeJob) -> Option<ActivityResult> {
+    job.output
+        .as_ref()
+        .and_then(|output| serde_json::from_value(output.clone()).ok())
+}
+
+fn runtime_job_terminal_state(job: &RuntimeJob) -> Option<String> {
+    match job.status {
+        RuntimeJobStatus::Succeeded | RuntimeJobStatus::Failed | RuntimeJobStatus::Cancelled => {
+            Some(eval_runtime_job_status(job.status).to_string())
+        }
+        RuntimeJobStatus::Pending | RuntimeJobStatus::Running => None,
+    }
+}
+
+fn eval_runtime_job_status(status: RuntimeJobStatus) -> &'static str {
+    match status {
+        RuntimeJobStatus::Pending => "pending",
+        RuntimeJobStatus::Running => "running",
+        RuntimeJobStatus::Succeeded => "succeeded",
+        RuntimeJobStatus::Failed => "failed",
+        RuntimeJobStatus::Cancelled => "cancelled",
+    }
+}
+
+fn runtime_error_kind(kind: ActivityErrorKind) -> RuntimeErrorKind {
+    match kind {
+        ActivityErrorKind::Retryable => RuntimeErrorKind::Retryable,
+        ActivityErrorKind::Timeout => RuntimeErrorKind::Timeout,
+        ActivityErrorKind::Fatal | ActivityErrorKind::SpawnFailure => RuntimeErrorKind::Fatal,
+        ActivityErrorKind::Configuration => RuntimeErrorKind::Configuration,
+        ActivityErrorKind::ExternalDependency => RuntimeErrorKind::ExternalDependency,
+        ActivityErrorKind::Unknown => RuntimeErrorKind::Unknown,
+    }
+}
+
+fn usage_snapshots(
+    workflow_id: Option<&str>,
+    runtime_events: &BTreeMap<String, Vec<RuntimeEvent>>,
+) -> Vec<UsageSnapshot> {
+    let mut usage = Vec::new();
+    for (runtime_job_id, events) in runtime_events {
+        for event in events {
+            if !matches!(
+                event.event_type.as_str(),
+                "UsageRecorded" | "TokenUsageRecorded"
+            ) {
+                continue;
+            }
+            let snapshot = usage_snapshot_from_event(workflow_id, runtime_job_id, &event.event);
+            if usage_snapshot_has_measurement(&snapshot) {
+                usage.push(snapshot);
+            }
+        }
+    }
+    usage
+}
+
+fn usage_snapshot_from_event(
+    workflow_id: Option<&str>,
+    runtime_job_id: &str,
+    event: &Value,
+) -> UsageSnapshot {
+    let payload = event.get("usage").unwrap_or(event);
+    let input_tokens = first_u64_field(payload, &["input_tokens", "input"]);
+    let output_tokens = first_u64_field(payload, &["output_tokens", "output"]);
+    let cached_input_tokens = first_u64_field(
+        payload,
+        &[
+            "cached_input_tokens",
+            "cache_read_input_tokens",
+            "cache_creation_input_tokens",
+        ],
+    );
+    let total_tokens = first_u64_field(payload, &["total_tokens"]).or_else(|| {
+        (input_tokens.is_some() || output_tokens.is_some()).then(|| {
+            input_tokens
+                .unwrap_or(0)
+                .saturating_add(output_tokens.unwrap_or(0))
+        })
+    });
+    UsageSnapshot {
+        agent_invocation_id: payload
+            .get("agent_invocation_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        runtime_job_id: Some(runtime_job_id.to_string()),
+        workflow_id: workflow_id.map(ToOwned::to_owned),
+        model: payload
+            .get("model")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        reasoning_effort: payload
+            .get("reasoning_effort")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        input_tokens,
+        output_tokens,
+        cached_input_tokens,
+        total_tokens,
+        cost_usd_micros: first_u64_field(payload, &["cost_usd_micros"]),
+        token_confidence: Confidence::Observed,
+        cost_confidence: if payload.get("cost_usd_micros").is_some() {
+            Confidence::Estimated
+        } else {
+            Confidence::Unknown
+        },
+    }
+}
+
+fn first_u64_field(value: &Value, keys: &[&str]) -> Option<u64> {
+    keys.iter().find_map(|key| value.get(*key)?.as_u64())
+}
+
+fn usage_snapshot_has_measurement(snapshot: &UsageSnapshot) -> bool {
+    snapshot.input_tokens.is_some()
+        || snapshot.output_tokens.is_some()
+        || snapshot.cached_input_tokens.is_some()
+        || snapshot.total_tokens.is_some()
+        || snapshot.cost_usd_micros.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{
+        ActivityResult, RuntimeKind, RuntimeProfile, ValidationRecord, WorkflowCommand,
+        WorkflowCommandStatus, WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn eval_evidence_missing_quality_gate_and_usage_fails_case() {
+        let workflow = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "pr_open",
+            WorkflowSubject::new("issue", "issue:42"),
+        )
+        .with_id("workflow-1")
+        .with_data(json!({
+            "repo": "owner/repo",
+            "issue_number": 42,
+            "task_id": "eval-task-1",
+            "eval": {"eval_run_id": "run-1", "case_id": "owner/repo#42"}
+        }));
+        let command = command_record(
+            "cmd-1",
+            "workflow-1",
+            WorkflowCommand::enqueue_activity("implement_issue", "impl-1"),
+            WorkflowCommandStatus::Completed,
+        );
+        let mut job = RuntimeJob::pending(
+            "cmd-1",
+            RuntimeKind::CodexExec,
+            RuntimeProfile::new("codex", RuntimeKind::CodexExec).name,
+            json!({"activity": "implement_issue"}),
+        );
+        job.id = "job-1".to_string();
+        job.complete(
+            &ActivityResult::succeeded("implement_issue", "opened PR").with_artifact(
+                crate::runtime::ActivityArtifact::new(
+                    "pull_request",
+                    json!({"pr_number": 5, "pr_url": "https://github.com/owner/repo/pull/5"}),
+                ),
+            ),
+        )
+        .expect("complete job");
+
+        let evidence = collect_eval_case_evidence_from_records(
+            "run-1",
+            "owner/repo#42",
+            Some(&workflow),
+            &[command],
+            &[job],
+            &BTreeMap::new(),
+        );
+
+        assert_eq!(evidence.status, EvalEvidenceStatus::Failed);
+        assert!(evidence
+            .missing_evidence
+            .contains(&"quality_gate".to_string()));
+        assert!(evidence.missing_evidence.contains(&"usage".to_string()));
+        assert_eq!(
+            evidence.submission.as_ref().unwrap().runtime_job_ids,
+            vec!["job-1".to_string()]
+        );
+    }
+
+    #[test]
+    fn eval_evidence_maps_quality_gate_and_usage_records() {
+        let workflow = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "done",
+            WorkflowSubject::new("issue", "issue:42"),
+        )
+        .with_id("workflow-1")
+        .with_data(json!({
+            "repo": "owner/repo",
+            "issue_number": 42,
+            "task_id": "eval-task-1",
+            "eval": {"eval_run_id": "run-1", "case_id": "owner/repo#42"}
+        }));
+        let implementation = command_record(
+            "cmd-impl",
+            "workflow-1",
+            WorkflowCommand::enqueue_activity("implement_issue", "impl-1"),
+            WorkflowCommandStatus::Completed,
+        );
+        let quality = command_record(
+            "cmd-quality",
+            "workflow-1",
+            WorkflowCommand::enqueue_activity(QUALITY_GATE_ACTIVITY, "quality-1"),
+            WorkflowCommandStatus::Completed,
+        );
+        let mut implementation_job = RuntimeJob::pending(
+            "cmd-impl",
+            RuntimeKind::CodexExec,
+            "codex",
+            json!({"activity": "implement_issue"}),
+        );
+        implementation_job.id = "job-impl".to_string();
+        implementation_job
+            .complete(
+                &ActivityResult::succeeded("implement_issue", "opened PR").with_artifact(
+                    crate::runtime::ActivityArtifact::new(
+                        "pull_request",
+                        json!({"pr_number": 5, "pr_url": "https://github.com/owner/repo/pull/5"}),
+                    ),
+                ),
+            )
+            .expect("complete implementation job");
+        let mut quality_job = RuntimeJob::pending(
+            "cmd-quality",
+            RuntimeKind::CodexExec,
+            "codex",
+            json!({"activity": QUALITY_GATE_ACTIVITY}),
+        );
+        quality_job.id = "job-quality".to_string();
+        quality_job
+            .complete(
+                &ActivityResult::succeeded(QUALITY_GATE_ACTIVITY, "validation passed")
+                    .with_validation(ValidationRecord::new(
+                        "cargo test -p harness-workflow eval_evidence",
+                        "passed",
+                    )),
+            )
+            .expect("complete quality job");
+        let mut events = BTreeMap::new();
+        events.insert(
+            "job-impl".to_string(),
+            vec![RuntimeEvent::new(
+                "job-impl",
+                1,
+                "UsageRecorded",
+                json!({
+                    "usage": {
+                        "agent_invocation_id": "agent-1",
+                        "model": "codex-test",
+                        "input_tokens": 100,
+                        "output_tokens": 20,
+                        "total_tokens": 120,
+                        "cost_usd_micros": 50
+                    }
+                }),
+            )],
+        );
+
+        let evidence = collect_eval_case_evidence_from_records(
+            "run-1",
+            "owner/repo#42",
+            Some(&workflow),
+            &[implementation, quality],
+            &[implementation_job, quality_job],
+            &events,
+        );
+
+        assert_eq!(evidence.status, EvalEvidenceStatus::Passed);
+        assert!(evidence.missing_evidence.is_empty());
+        assert_eq!(
+            evidence.quality_gate.as_ref().unwrap().validation_commands,
+            vec!["cargo test -p harness-workflow eval_evidence".to_string()]
+        );
+        assert_eq!(evidence.usage[0].total_tokens, Some(120));
+        assert_eq!(
+            evidence.runtime.as_ref().unwrap().terminal_state,
+            Some("done".to_string())
+        );
+    }
+
+    fn command_record(
+        id: &str,
+        workflow_id: &str,
+        command: WorkflowCommand,
+        status: WorkflowCommandStatus,
+    ) -> WorkflowCommandRecord {
+        WorkflowCommandRecord {
+            id: id.to_string(),
+            workflow_id: workflow_id.to_string(),
+            decision_id: None,
+            status,
+            dispatch_owner: None,
+            dispatch_lease_expires_at: None,
+            command,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+}

--- a/crates/harness-workflow/src/runtime/eval/mod.rs
+++ b/crates/harness-workflow/src/runtime/eval/mod.rs
@@ -2,14 +2,25 @@
 //!
 //! This module is additive groundwork for GH-1447. Eval execution will dispatch
 //! through the normal workflow runtime; this module only owns manifest parsing
-//! and deterministic scoring primitives.
+//! deterministic scoring primitives, and standard-path eval dispatch helpers.
 
+pub mod evidence;
 pub mod manifest;
 pub mod model;
+pub mod run;
 pub mod scoring;
 
+pub use evidence::{
+    collect_eval_case_evidence, collect_eval_case_evidence_from_records, EvalCaseEvidence,
+    EvalEvidenceStatus, EvalQualityGateEvidence, EvalSubmissionEvidence,
+};
 pub use manifest::{
     parse_benchmark_manifest_str, EvalBenchmarkCase, EvalBenchmarkManifest, ManifestError,
     DEFAULT_CASE_TIMEOUT_SECS,
+};
+pub use run::{
+    dispatch_eval_case_workflow, enqueue_eval_case_workflow, EvalCaseDispatchOutcome,
+    EvalCaseEnqueueOutcome, EvalCaseWorkflowInput, EvalCaseWorkflowPlan, EVAL_BRANCH_PREFIX,
+    EVAL_PR_DRAFT_MODE,
 };
 pub use scoring::{score_pr_repair_eval, ScoringError};

--- a/crates/harness-workflow/src/runtime/eval/run.rs
+++ b/crates/harness-workflow/src/runtime/eval/run.rs
@@ -1,0 +1,356 @@
+use super::manifest::EvalBenchmarkCase;
+use crate::runtime::{
+    build_issue_submission_decision, IssueSubmissionDecisionInput, RuntimeCommandDispatcher,
+    RuntimeProfile, ValidationContext, WorkflowCommandStatus, WorkflowDecisionTransition,
+    WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    GITHUB_ISSUE_PR_DEFINITION_ID,
+};
+use serde_json::{json, Value};
+
+pub const EVAL_BRANCH_PREFIX: &str = "harness-eval/";
+pub const EVAL_PR_DRAFT_MODE: &str = "draft";
+pub const EVAL_RUN_DEFINITION_SOURCE: &str = "runtime_eval";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvalCaseWorkflowPlan {
+    pub eval_run_id: String,
+    pub case_id: String,
+    pub workflow_id: String,
+    pub initial_instance: WorkflowInstance,
+    pub submitted_instance: WorkflowInstance,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvalCaseEnqueueOutcome {
+    pub plan: EvalCaseWorkflowPlan,
+    pub command_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvalCaseDispatchOutcome {
+    pub enqueue: EvalCaseEnqueueOutcome,
+    pub dispatched_jobs: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EvalCaseWorkflowInput<'a> {
+    pub eval_run_id: &'a str,
+    pub case: &'a EvalBenchmarkCase,
+    pub project_id: &'a str,
+    pub task_id: &'a str,
+    pub additional_prompt: Option<&'a str>,
+}
+
+pub async fn enqueue_eval_case_workflow(
+    store: &WorkflowRuntimeStore,
+    input: EvalCaseWorkflowInput<'_>,
+) -> anyhow::Result<EvalCaseEnqueueOutcome> {
+    store
+        .upsert_definition(
+            &WorkflowDefinition::new(GITHUB_ISSUE_PR_DEFINITION_ID, 1, "GitHub issue PR workflow")
+                .with_source_path(EVAL_RUN_DEFINITION_SOURCE),
+        )
+        .await?;
+
+    let initial_instance = eval_case_initial_instance(input);
+    let additional_prompt = eval_case_additional_prompt(input.additional_prompt);
+    let output = build_issue_submission_decision(
+        &initial_instance,
+        IssueSubmissionDecisionInput {
+            task_id: input.task_id,
+            repo: Some(&input.case.repo),
+            issue_number: input.case.issue,
+            labels: &[],
+            force_execute: true,
+            additional_prompt: Some(&additional_prompt),
+            depends_on: &[],
+            dependencies_blocked: false,
+            remote_fact_hash: None,
+        },
+    );
+    let decision = with_eval_command_metadata(output.decision, input);
+    let validator = crate::runtime::DecisionValidator::github_issue_pr();
+    validator.validate(
+        &initial_instance,
+        &decision,
+        &ValidationContext::new("eval-run", chrono::Utc::now()),
+    )?;
+
+    let mut submitted_instance = initial_instance.clone();
+    submitted_instance.state = decision.next_state.clone();
+    submitted_instance.version = submitted_instance.version.saturating_add(1);
+    submitted_instance.data = eval_case_submitted_data(input, &decision.decision);
+    let record = store
+        .apply_decision_transition(WorkflowDecisionTransition {
+            expected_state: &initial_instance.state,
+            create_if_missing: Some(&initial_instance),
+            event_type: "EvalCaseSubmitted",
+            source: "eval-run",
+            payload: json!({
+                "eval_run_id": input.eval_run_id,
+                "case_id": input.case.case_id,
+                "issue": input.case.issue,
+                "repo": input.case.repo,
+            }),
+            decision: &decision,
+            final_instance: &submitted_instance,
+            command_status: WorkflowCommandStatus::Pending,
+        })
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "eval case workflow {} was not in the expected `{}` state",
+                initial_instance.id,
+                initial_instance.state
+            )
+        })?;
+    let command_ids = store
+        .commands_for(&submitted_instance.id)
+        .await?
+        .into_iter()
+        .filter(|command| command.decision_id.as_deref() == Some(record.id.as_str()))
+        .map(|command| command.id)
+        .collect();
+
+    Ok(EvalCaseEnqueueOutcome {
+        plan: EvalCaseWorkflowPlan {
+            eval_run_id: input.eval_run_id.to_string(),
+            case_id: input.case.case_id.clone(),
+            workflow_id: submitted_instance.id.clone(),
+            initial_instance,
+            submitted_instance,
+        },
+        command_ids,
+    })
+}
+
+pub async fn dispatch_eval_case_workflow(
+    store: &WorkflowRuntimeStore,
+    runtime_profile: RuntimeProfile,
+    input: EvalCaseWorkflowInput<'_>,
+) -> anyhow::Result<EvalCaseDispatchOutcome> {
+    let enqueue = enqueue_eval_case_workflow(store, input).await?;
+    let outcomes = RuntimeCommandDispatcher::new(store, runtime_profile)
+        .dispatch_pending()
+        .await?;
+    let dispatched_jobs = outcomes
+        .into_iter()
+        .filter(|outcome| {
+            matches!(
+                outcome,
+                crate::runtime::CommandDispatchOutcome::Enqueued { .. }
+                    | crate::runtime::CommandDispatchOutcome::AlreadyDispatched { .. }
+            )
+        })
+        .count();
+    Ok(EvalCaseDispatchOutcome {
+        enqueue,
+        dispatched_jobs,
+    })
+}
+
+fn eval_case_initial_instance(input: EvalCaseWorkflowInput<'_>) -> WorkflowInstance {
+    WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "discovered",
+        WorkflowSubject::new("issue", format!("issue:{}", input.case.issue)),
+    )
+    .with_id(eval_case_workflow_id(
+        input.eval_run_id,
+        &input.case.case_id,
+    ))
+    .with_data(eval_case_submitted_data(input, "created"))
+}
+
+fn eval_case_submitted_data(input: EvalCaseWorkflowInput<'_>, last_decision: &str) -> Value {
+    json!({
+        "project_id": input.project_id,
+        "repo": input.case.repo,
+        "issue_number": input.case.issue,
+        "submission_id": input.task_id,
+        "task_id": input.task_id,
+        "task_ids": [input.task_id],
+        "force_execute": true,
+        "source": "eval_run",
+        "external_id": input.case.case_id,
+        "eval": {
+            "eval_run_id": input.eval_run_id,
+            "case_id": input.case.case_id,
+            "base_commit": input.case.base_commit,
+            "verify_commands": input.case.verify_commands,
+            "timeout_secs": input.case.timeout_secs,
+            "branch_prefix": EVAL_BRANCH_PREFIX,
+            "pull_request_mode": EVAL_PR_DRAFT_MODE,
+        },
+        "last_decision": last_decision,
+        "execution_path": "workflow_runtime",
+    })
+}
+
+fn with_eval_command_metadata(
+    mut decision: crate::runtime::WorkflowDecision,
+    input: EvalCaseWorkflowInput<'_>,
+) -> crate::runtime::WorkflowDecision {
+    for command in &mut decision.commands {
+        let Some(object) = command.command.as_object_mut() else {
+            continue;
+        };
+        object.insert(
+            "eval".to_string(),
+            json!({
+                "eval_run_id": input.eval_run_id,
+                "case_id": input.case.case_id,
+                "base_commit": input.case.base_commit,
+                "verify_commands": input.case.verify_commands,
+                "timeout_secs": input.case.timeout_secs,
+                "branch_prefix": EVAL_BRANCH_PREFIX,
+                "pull_request_mode": EVAL_PR_DRAFT_MODE,
+            }),
+        );
+        object.insert("branch_prefix".to_string(), json!(EVAL_BRANCH_PREFIX));
+        object.insert("pull_request_mode".to_string(), json!(EVAL_PR_DRAFT_MODE));
+        object.insert("base_commit".to_string(), json!(input.case.base_commit));
+        object.insert(
+            "validation_commands".to_string(),
+            json!(input.case.verify_commands),
+        );
+    }
+    decision
+}
+
+fn eval_case_workflow_id(eval_run_id: &str, case_id: &str) -> String {
+    format!("eval:{eval_run_id}:{case_id}")
+}
+
+const EVAL_CASE_DEFAULT_ADDITIONAL_PROMPT: &str = "\
+This is a Harness eval run. Execute through the normal workflow runtime path, \
+open only a draft pull request, use the harness-eval/ branch prefix, and do not \
+merge or close the eval-produced PR.";
+
+fn eval_case_additional_prompt(additional_prompt: Option<&str>) -> String {
+    match additional_prompt
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+    {
+        Some(prompt) => format!("{EVAL_CASE_DEFAULT_ADDITIONAL_PROMPT}\n\n{prompt}"),
+        None => EVAL_CASE_DEFAULT_ADDITIONAL_PROMPT.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{RuntimeKind, RuntimeProfile, WorkflowRuntimeStore};
+
+    #[test]
+    fn eval_run_plan_marks_issue_submission_for_draft_prs() {
+        let case = EvalBenchmarkCase {
+            case_id: "owner/repo#42".to_string(),
+            repo: "owner/repo".to_string(),
+            issue: 42,
+            base_commit: "abcdef1".to_string(),
+            verify_commands: vec!["cargo test -p harness-workflow eval_run".to_string()],
+            timeout_secs: 120,
+        };
+        let input = EvalCaseWorkflowInput {
+            eval_run_id: "run-1",
+            case: &case,
+            project_id: "/repo",
+            task_id: "eval-task-1",
+            additional_prompt: None,
+        };
+
+        let initial = eval_case_initial_instance(input);
+        assert_eq!(initial.id, "eval:run-1:owner/repo#42");
+        assert_eq!(initial.definition_id, GITHUB_ISSUE_PR_DEFINITION_ID);
+        assert_eq!(initial.data["eval"]["eval_run_id"], "run-1");
+        assert_eq!(initial.data["eval"]["branch_prefix"], EVAL_BRANCH_PREFIX);
+        assert_eq!(
+            initial.data["eval"]["pull_request_mode"],
+            EVAL_PR_DRAFT_MODE
+        );
+
+        let output = build_issue_submission_decision(
+            &initial,
+            IssueSubmissionDecisionInput {
+                task_id: "eval-task-1",
+                repo: Some("owner/repo"),
+                issue_number: 42,
+                labels: &[],
+                force_execute: true,
+                additional_prompt: Some(EVAL_CASE_DEFAULT_ADDITIONAL_PROMPT),
+                depends_on: &[],
+                dependencies_blocked: false,
+                remote_fact_hash: None,
+            },
+        );
+        let decision = with_eval_command_metadata(output.decision, input);
+        let command = &decision.commands[0].command;
+        assert_eq!(command["activity"], "implement_issue");
+        assert_eq!(command["eval"]["eval_run_id"], "run-1");
+        assert_eq!(command["branch_prefix"], EVAL_BRANCH_PREFIX);
+        assert_eq!(command["pull_request_mode"], EVAL_PR_DRAFT_MODE);
+        assert_eq!(
+            command["validation_commands"][0],
+            "cargo test -p harness-workflow eval_run"
+        );
+    }
+
+    #[test]
+    fn eval_run_prompt_preserves_required_draft_pr_constraints() {
+        let prompt = eval_case_additional_prompt(Some("Use the small implementation slice."));
+        assert!(prompt.contains("open only a draft pull request"));
+        assert!(prompt.contains("harness-eval/ branch prefix"));
+        assert!(prompt.contains("Use the small implementation slice."));
+    }
+
+    #[tokio::test]
+    async fn eval_run_dispatches_standard_runtime_job() -> anyhow::Result<()> {
+        if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
+            return Ok(());
+        }
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime_store")).await?;
+        let case = EvalBenchmarkCase {
+            case_id: "owner/repo#42".to_string(),
+            repo: "owner/repo".to_string(),
+            issue: 42,
+            base_commit: "abcdef1".to_string(),
+            verify_commands: vec!["cargo test -p harness-workflow eval_run".to_string()],
+            timeout_secs: 120,
+        };
+
+        let outcome = dispatch_eval_case_workflow(
+            &store,
+            RuntimeProfile::new("codex", RuntimeKind::CodexExec),
+            EvalCaseWorkflowInput {
+                eval_run_id: "run-1",
+                case: &case,
+                project_id: dir.path().to_string_lossy().as_ref(),
+                task_id: "eval-task-1",
+                additional_prompt: None,
+            },
+        )
+        .await?;
+
+        assert_eq!(outcome.dispatched_jobs, 1);
+        assert_eq!(outcome.enqueue.command_ids.len(), 1);
+        let jobs = store
+            .runtime_jobs_for_command(&outcome.enqueue.command_ids[0])
+            .await?;
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].input["activity"], "implement_issue");
+        assert_eq!(jobs[0].input["command"]["eval"]["eval_run_id"], "run-1");
+        assert_eq!(
+            jobs[0].input["command"]["branch_prefix"],
+            EVAL_BRANCH_PREFIX
+        );
+        assert_eq!(
+            jobs[0].input["command"]["pull_request_mode"],
+            EVAL_PR_DRAFT_MODE
+        );
+
+        Ok(())
+    }
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -37,8 +37,12 @@ pub use bus::InMemoryWorkflowBus;
 pub use dispatcher::{CommandDispatchOutcome, RuntimeCommandDispatcher, RuntimeProfileSelector};
 pub use errors::RuntimeJobNotFoundError;
 pub use eval::{
-    parse_benchmark_manifest_str, score_pr_repair_eval, EvalBenchmarkCase, EvalBenchmarkManifest,
-    ManifestError, ScoringError, DEFAULT_CASE_TIMEOUT_SECS,
+    collect_eval_case_evidence, collect_eval_case_evidence_from_records,
+    dispatch_eval_case_workflow, enqueue_eval_case_workflow, parse_benchmark_manifest_str,
+    score_pr_repair_eval, EvalBenchmarkCase, EvalBenchmarkManifest, EvalCaseDispatchOutcome,
+    EvalCaseEnqueueOutcome, EvalCaseEvidence, EvalCaseWorkflowInput, EvalCaseWorkflowPlan,
+    EvalEvidenceStatus, EvalQualityGateEvidence, EvalSubmissionEvidence, ManifestError,
+    ScoringError, DEFAULT_CASE_TIMEOUT_SECS, EVAL_BRANCH_PREFIX, EVAL_PR_DRAFT_MODE,
 };
 pub use lease_state::{runtime_job_running_lease_state_at, RuntimeJobRunningLeaseState};
 pub use model::{


### PR DESCRIPTION
Related: #1447.

## Summary
- Add `harness-workflow::runtime::eval::run` helpers that enqueue eval benchmark cases through the existing GitHub issue workflow submission and dispatcher path.
- Add eval metadata for `eval_run_id`, case IDs, pinned base commits, validation commands, the `harness-eval/` branch prefix, and draft PR mode.
- Add strict eval evidence collection from workflow instances, commands, runtime jobs, quality gate results, and explicit usage events; missing evidence marks the case failed.

## Scope
This covers `SP1447-T003` and `SP1447-T004`. GH-1447 remains open for CLI reports, cleanup behavior, and the curated 10+ case benchmark manifest.

## Verification
- `cargo test -p harness-workflow eval_run`
- `cargo test -p harness-workflow eval_evidence`
- `cargo check -p harness-workflow --all-targets`
- `cargo test -p harness-workflow`
- `cargo fmt --all -- --check`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1447`
- `git diff --check`
- `git diff --cached --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-run`
