### PR TITLE
Add eval report and diff CLI commands

### DIFF
--- a/crates/harness-cli/src/commands.rs
+++ b/crates/harness-cli/src/commands.rs
@@ -7,9 +7,12 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tracing_subscriber::fmt::writer::MakeWriter;
 
+mod eval;
 mod exec;
 mod reconcile;
 mod runtime;
+#[cfg(test)]
+mod runtime_log_tests;
 mod serve;
 mod status;
 
@@ -122,6 +125,12 @@ pub enum Command {
     Pr {
         #[command(subcommand)]
         cmd: PrCommand,
+    },
+
+    /// Eval run reports and version-to-version diffs
+    Eval {
+        #[command(subcommand)]
+        cmd: eval::EvalCommand,
     },
 
     /// Display the current version
@@ -881,6 +890,10 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             }
         },
 
+        Command::Eval { cmd } => {
+            eval::run(cmd).await?;
+        }
+
         Command::Plan { cmd } => match cmd {
             PlanCommand::Init { spec } => {
                 let content = std::fs::read_to_string(&spec)?;
@@ -960,7 +973,6 @@ mod tests {
         enforce_exec_privilege_policy_with, normalize_allow_list, resolve_exec_output_path,
         ExecSandboxMode,
     };
-    use chrono::TimeZone;
     use std::path::Path;
 
     #[test]
@@ -1560,131 +1572,5 @@ mod tests {
             }
             _ => panic!("expected Serve command"),
         }
-    }
-
-    #[test]
-    fn prepare_logging_creates_runtime_log_for_serve() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let mut config = harness_core::config::HarnessConfig::default();
-        config.server.data_dir = tempdir.path().to_path_buf();
-
-        let bootstrap = prepare_logging(
-            &Command::Serve {
-                transport: None,
-                port: None,
-                project_root: None,
-                projects: vec![],
-                default_project: None,
-            },
-            &config,
-        );
-
-        assert_eq!(bootstrap.runtime_logs.state.as_str(), "enabled");
-        let active_path = bootstrap
-            .runtime_logs
-            .active_path
-            .as_ref()
-            .expect("active path");
-        assert!(active_path.starts_with(tempdir.path().join("logs")));
-        assert!(active_path.exists(), "runtime log file should be created");
-        assert_eq!(
-            bootstrap.runtime_logs.path_hint.as_deref(),
-            active_path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .map(|name| format!("logs/{name}"))
-                .as_deref()
-        );
-    }
-
-    #[test]
-    fn purge_stale_runtime_logs_keeps_current_and_non_matching_files() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let logs_dir = tempdir.path().join("logs");
-        fs::create_dir_all(&logs_dir).expect("create logs dir");
-        let now = Utc
-            .with_ymd_and_hms(2026, 4, 30, 12, 0, 0)
-            .single()
-            .expect("timestamp");
-        let stale = runtime_log_path(
-            tempdir.path(),
-            Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
-                .single()
-                .expect("stale timestamp"),
-            10,
-        );
-        let fresh = runtime_log_path(
-            tempdir.path(),
-            Utc.with_ymd_and_hms(2026, 4, 29, 12, 0, 0)
-                .single()
-                .expect("fresh timestamp"),
-            11,
-        );
-        let unrelated = logs_dir.join("notes.txt");
-        fs::write(&stale, "stale").expect("write stale");
-        fs::write(&fresh, "fresh").expect("write fresh");
-        fs::write(&unrelated, "keep").expect("write unrelated");
-
-        let warnings = purge_stale_runtime_logs(&logs_dir, 30, now);
-
-        assert!(warnings.is_empty(), "purge should not warn: {warnings:?}");
-        assert!(!stale.exists(), "stale runtime log should be deleted");
-        assert!(fresh.exists(), "fresh runtime log should be kept");
-        assert!(unrelated.exists(), "non-matching files should be kept");
-    }
-
-    #[test]
-    fn purge_stale_runtime_logs_reports_delete_errors_without_stopping() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let logs_dir = tempdir.path().join("logs");
-        fs::create_dir_all(&logs_dir).expect("create logs dir");
-        let now = Utc
-            .with_ymd_and_hms(2026, 4, 30, 12, 0, 0)
-            .single()
-            .expect("timestamp");
-        let stale = runtime_log_path(
-            tempdir.path(),
-            Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
-                .single()
-                .expect("stale timestamp"),
-            10,
-        );
-        let fresh = runtime_log_path(
-            tempdir.path(),
-            Utc.with_ymd_and_hms(2026, 4, 29, 12, 0, 0)
-                .single()
-                .expect("fresh timestamp"),
-            11,
-        );
-        fs::write(&stale, "stale").expect("write stale");
-        fs::write(&fresh, "fresh").expect("write fresh");
-
-        let warnings = purge_stale_runtime_logs_with(&logs_dir, 30, now, |path| {
-            if path == stale.as_path() {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    "simulated delete failure",
-                ));
-            }
-            fs::remove_file(path)
-        });
-
-        assert_eq!(warnings.len(), 1);
-        assert!(
-            warnings[0].contains("failed to delete stale runtime log"),
-            "warning should identify delete failure: {warnings:?}"
-        );
-        assert!(stale.exists(), "failed delete should leave stale file");
-        assert!(fresh.exists(), "fresh runtime log should be kept");
-    }
-
-    #[test]
-    fn prepare_logging_disables_file_persistence_for_non_serve_commands() {
-        let config = harness_core::config::HarnessConfig::default();
-        let bootstrap = prepare_logging(&Command::Version, &config);
-
-        assert_eq!(bootstrap.runtime_logs.state.as_str(), "disabled");
-        assert!(bootstrap.runtime_logs.active_path.is_none());
-        assert!(bootstrap.runtime_log_file.is_none());
     }
 }

--- a/crates/harness-cli/src/commands/eval.rs
+++ b/crates/harness-cli/src/commands/eval.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use clap::{Args, Subcommand};
 use harness_workflow::runtime::{
     diff_eval_run_reports, eval_report_dry_run, eval_report_from_evidence,
@@ -88,19 +89,36 @@ async fn run_eval_report(args: EvalRunArgs) -> anyhow::Result<()> {
 fn diff_eval_reports(args: EvalDiffArgs) -> anyhow::Result<()> {
     let baseline = read_run_report(&args.baseline)?;
     let candidate = read_run_report(&args.candidate)?;
+    if baseline.suite != candidate.suite {
+        anyhow::bail!(
+            "cannot diff reports from different suites: baseline={}, candidate={}",
+            baseline.suite,
+            candidate.suite
+        );
+    }
+    if baseline.k != candidate.k {
+        anyhow::bail!(
+            "cannot diff reports with different k values: baseline={}, candidate={}",
+            baseline.k,
+            candidate.k
+        );
+    }
     let diff = diff_eval_run_reports(&baseline, &candidate);
     emit_diff(&diff, args.json, args.output.as_deref())
 }
 
 fn read_eval_manifest(path: &Path) -> anyhow::Result<EvalBenchmarkManifest> {
-    let content = fs::read_to_string(path)?;
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read eval manifest at {}", path.display()))?;
     parse_benchmark_manifest_str(&content)
         .map_err(|error| anyhow::anyhow!("invalid eval manifest {}: {error}", path.display()))
 }
 
 fn read_evidence(path: &Path) -> anyhow::Result<Vec<EvalCaseEvidence>> {
-    let content = fs::read_to_string(path)?;
-    let input: EvidenceInput = serde_json::from_str(&content)?;
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read eval evidence at {}", path.display()))?;
+    let input: EvidenceInput = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse eval evidence at {}", path.display()))?;
     Ok(match input {
         EvidenceInput::Cases(cases) => cases,
         EvidenceInput::Wrapped { cases } => cases,
@@ -108,7 +126,8 @@ fn read_evidence(path: &Path) -> anyhow::Result<Vec<EvalCaseEvidence>> {
 }
 
 fn read_run_report(path: &Path) -> anyhow::Result<EvalRunReport> {
-    let content = fs::read_to_string(path)?;
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read eval report at {}", path.display()))?;
     serde_json::from_str(&content)
         .map_err(|error| anyhow::anyhow!("invalid eval report {}: {error}", path.display()))
 }
@@ -135,6 +154,14 @@ fn emit_diff(diff: &EvalRunReportDiff, json: bool, output: Option<&Path>) -> any
 
 fn write_json_output<T: serde::Serialize>(value: &T, output: Option<&Path>) -> anyhow::Result<()> {
     if let Some(output) = output {
+        if let Some(parent) = output
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create output directory {}", parent.display())
+            })?;
+        }
         fs::write(output, serde_json::to_string_pretty(value)?)?;
     }
     Ok(())
@@ -364,6 +391,25 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
     }
 
     #[test]
+    fn eval_report_rejects_invalid_k_values() {
+        let zero_error = match eval_report_dry_run(&sample_eval_manifest(), "run-zero", 0) {
+            Ok(_) => panic!("zero k should be rejected"),
+            Err(error) => error,
+        };
+        assert!(zero_error.to_string().contains("greater than zero"));
+
+        let excessive_k = i32::MAX as u32 + 1;
+        let excessive_error =
+            match eval_report_dry_run(&sample_eval_manifest(), "run-excessive", excessive_k) {
+                Ok(_) => panic!("k values above i32::MAX should be rejected"),
+                Err(error) => error,
+            };
+        assert!(excessive_error
+            .to_string()
+            .contains("less than or equal to i32::MAX"));
+    }
+
+    #[test]
     fn eval_report_evidence_text_includes_pass_cost_and_tokens() {
         let report = eval_report_from_evidence(
             &sample_eval_manifest(),
@@ -388,6 +434,38 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
         assert!(rendered.contains("pass@1: 0.5000"));
         assert!(rendered.contains("pass^3: 0.8750"));
         assert!(rendered.contains("missing_evidence: case_evidence"));
+    }
+
+    #[test]
+    fn eval_report_marks_missing_runtime_evidence_as_infra_failure() {
+        let report = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "run-1",
+            3,
+            vec![
+                case_evidence(
+                    "case-pass",
+                    EvalEvidenceStatus::Failed,
+                    vec![usage_snapshot(10, 5)],
+                    vec!["terminal_runtime_state".to_string()],
+                ),
+                case_evidence(
+                    "case-fail",
+                    EvalEvidenceStatus::Passed,
+                    vec![usage_snapshot(20, 10)],
+                    Vec::new(),
+                ),
+            ],
+        )
+        .unwrap_or_else(|error| panic!("evidence report should build: {error}"));
+        let rendered = render_run_report(&report);
+
+        assert_eq!(report.metrics.scored_cases, 1);
+        assert_eq!(report.metrics.passed_cases, 1);
+        assert_eq!(report.metrics.failed_cases, 0);
+        assert_eq!(report.metrics.infra_failed_cases, 1);
+        assert_eq!(report.metrics.pass_at_1, 1.0);
+        assert!(rendered.contains("status=infra_failed"));
     }
 
     #[test]
@@ -422,6 +500,77 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
         assert!(rendered.contains("pass_to_fail"));
         assert!(rendered.contains("tokens delta: -20"));
         assert!(rendered.contains("cost_usd_micros delta: -10"));
+    }
+
+    #[test]
+    fn eval_report_diff_rejects_suite_or_k_mismatch() {
+        let tempdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("tempdir should be creatable: {error}"));
+        let baseline_path = tempdir.path().join("baseline.json");
+        let candidate_path = tempdir.path().join("candidate.json");
+        let baseline = eval_report_dry_run(&sample_eval_manifest(), "baseline", 3)
+            .unwrap_or_else(|error| panic!("baseline report should build: {error}"));
+        let mut candidate = baseline.clone();
+        candidate.run_id = "candidate".to_string();
+        candidate.suite = "different-suite".to_string();
+        fs::write(
+            &baseline_path,
+            serde_json::to_string_pretty(&baseline)
+                .unwrap_or_else(|error| panic!("baseline should serialize: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("baseline should write: {error}"));
+        fs::write(
+            &candidate_path,
+            serde_json::to_string_pretty(&candidate)
+                .unwrap_or_else(|error| panic!("candidate should serialize: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("candidate should write: {error}"));
+
+        let error = match diff_eval_reports(EvalDiffArgs {
+            baseline: baseline_path.clone(),
+            candidate: candidate_path.clone(),
+            json: false,
+            output: None,
+        }) {
+            Ok(_) => panic!("different suites should be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("different suites"));
+
+        candidate.suite = baseline.suite.clone();
+        candidate.k = 5;
+        fs::write(
+            &candidate_path,
+            serde_json::to_string_pretty(&candidate)
+                .unwrap_or_else(|error| panic!("candidate should serialize: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("candidate should write: {error}"));
+        let error = match diff_eval_reports(EvalDiffArgs {
+            baseline: baseline_path,
+            candidate: candidate_path,
+            json: false,
+            output: None,
+        }) {
+            Ok(_) => panic!("different k values should be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("different k values"));
+    }
+
+    #[test]
+    fn eval_report_output_creates_parent_directory() {
+        let tempdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("tempdir should be creatable: {error}"));
+        let output = tempdir.path().join("nested").join("report.json");
+        let report = eval_report_dry_run(&sample_eval_manifest(), "run-dry", 3)
+            .unwrap_or_else(|error| panic!("dry run report should build: {error}"));
+
+        write_json_output(&report, Some(&output))
+            .unwrap_or_else(|error| panic!("nested output should write: {error}"));
+
+        assert!(output.exists());
     }
 
     fn case_evidence(

--- a/crates/harness-cli/src/commands/eval.rs
+++ b/crates/harness-cli/src/commands/eval.rs
@@ -1,0 +1,474 @@
+use clap::{Args, Subcommand};
+use harness_workflow::runtime::{
+    diff_eval_run_reports, eval_report_dry_run, eval_report_from_evidence,
+    parse_benchmark_manifest_str, EvalBenchmarkManifest, EvalCaseEvidence, EvalCaseTransitionKind,
+    EvalReportCaseStatus, EvalRunReport, EvalRunReportDiff,
+};
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Subcommand)]
+pub enum EvalCommand {
+    /// Emit an eval report from a manifest and collected case evidence
+    Run(EvalRunArgs),
+    /// Compare two saved eval run reports
+    Diff(EvalDiffArgs),
+}
+
+#[derive(Args)]
+pub struct EvalRunArgs {
+    /// Benchmark manifest path
+    #[arg(long)]
+    pub manifest: PathBuf,
+    /// Collected EvalCaseEvidence JSON path. Accepts either an array or {"cases": [...]}.
+    #[arg(long)]
+    pub evidence: Option<PathBuf>,
+    /// Stable run identifier. Defaults to suite plus current UTC timestamp.
+    #[arg(long)]
+    pub run_id: Option<String>,
+    /// pass^k retry count used for aggregate reporting
+    #[arg(long, default_value_t = 3)]
+    pub k: u32,
+    /// Validate the manifest and list cases without requiring collected evidence
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Print JSON instead of the compact text report
+    #[arg(long)]
+    pub json: bool,
+    /// Also write the JSON report to this path
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct EvalDiffArgs {
+    /// Baseline eval run report JSON
+    pub baseline: PathBuf,
+    /// Candidate eval run report JSON
+    pub candidate: PathBuf,
+    /// Print JSON instead of the compact text diff
+    #[arg(long)]
+    pub json: bool,
+    /// Also write the JSON diff to this path
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+}
+
+pub async fn run(cmd: EvalCommand) -> anyhow::Result<()> {
+    match cmd {
+        EvalCommand::Run(args) => run_eval_report(args).await,
+        EvalCommand::Diff(args) => diff_eval_reports(args),
+    }
+}
+
+async fn run_eval_report(args: EvalRunArgs) -> anyhow::Result<()> {
+    if args.dry_run && args.evidence.is_some() {
+        anyhow::bail!("use either --dry-run or --evidence, not both");
+    }
+
+    let manifest = read_eval_manifest(&args.manifest)?;
+    let run_id = args
+        .run_id
+        .unwrap_or_else(|| default_run_id(&manifest.suite));
+    let report = if args.dry_run {
+        eval_report_dry_run(&manifest, run_id, args.k)?
+    } else if let Some(evidence_path) = args.evidence.as_ref() {
+        let evidence = read_evidence(evidence_path)?;
+        eval_report_from_evidence(&manifest, run_id, args.k, evidence)?
+    } else {
+        anyhow::bail!(
+            "live eval execution is not wired to the CLI yet; pass --evidence to report collected evidence or --dry-run to validate the manifest"
+        );
+    };
+
+    emit_report(&report, args.json, args.output.as_deref())
+}
+
+fn diff_eval_reports(args: EvalDiffArgs) -> anyhow::Result<()> {
+    let baseline = read_run_report(&args.baseline)?;
+    let candidate = read_run_report(&args.candidate)?;
+    let diff = diff_eval_run_reports(&baseline, &candidate);
+    emit_diff(&diff, args.json, args.output.as_deref())
+}
+
+fn read_eval_manifest(path: &Path) -> anyhow::Result<EvalBenchmarkManifest> {
+    let content = fs::read_to_string(path)?;
+    parse_benchmark_manifest_str(&content)
+        .map_err(|error| anyhow::anyhow!("invalid eval manifest {}: {error}", path.display()))
+}
+
+fn read_evidence(path: &Path) -> anyhow::Result<Vec<EvalCaseEvidence>> {
+    let content = fs::read_to_string(path)?;
+    let input: EvidenceInput = serde_json::from_str(&content)?;
+    Ok(match input {
+        EvidenceInput::Cases(cases) => cases,
+        EvidenceInput::Wrapped { cases } => cases,
+    })
+}
+
+fn read_run_report(path: &Path) -> anyhow::Result<EvalRunReport> {
+    let content = fs::read_to_string(path)?;
+    serde_json::from_str(&content)
+        .map_err(|error| anyhow::anyhow!("invalid eval report {}: {error}", path.display()))
+}
+
+fn emit_report(report: &EvalRunReport, json: bool, output: Option<&Path>) -> anyhow::Result<()> {
+    write_json_output(report, output)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(report)?);
+    } else {
+        print!("{}", render_run_report(report));
+    }
+    Ok(())
+}
+
+fn emit_diff(diff: &EvalRunReportDiff, json: bool, output: Option<&Path>) -> anyhow::Result<()> {
+    write_json_output(diff, output)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(diff)?);
+    } else {
+        print!("{}", render_diff_report(diff));
+    }
+    Ok(())
+}
+
+fn write_json_output<T: serde::Serialize>(value: &T, output: Option<&Path>) -> anyhow::Result<()> {
+    if let Some(output) = output {
+        fs::write(output, serde_json::to_string_pretty(value)?)?;
+    }
+    Ok(())
+}
+
+fn default_run_id(suite: &str) -> String {
+    format!("{}-{}", suite, chrono::Utc::now().format("%Y%m%dT%H%M%SZ"))
+}
+
+pub(crate) fn render_run_report(report: &EvalRunReport) -> String {
+    let metrics = &report.metrics;
+    let mut output = String::new();
+    output.push_str(&format!(
+        "Eval report {} ({})\n",
+        report.run_id, report.suite
+    ));
+    output.push_str(&format!(
+        "cases: total={} scored={} passed={} failed={} pending={} infra_failed={}\n",
+        metrics.total_cases,
+        metrics.scored_cases,
+        metrics.passed_cases,
+        metrics.failed_cases,
+        metrics.pending_cases,
+        metrics.infra_failed_cases
+    ));
+    output.push_str(&format!(
+        "pass@1: {:.4}  pass^{}: {:.4}\n",
+        metrics.pass_at_1, report.k, metrics.pass_to_k
+    ));
+    output.push_str(&format!(
+        "tokens: total={} avg/scored={}\n",
+        metrics.total_tokens,
+        format_optional_float(metrics.avg_tokens_per_scored_case)
+    ));
+    output.push_str(&format!(
+        "cost_usd_micros: total={} avg/scored={}\n",
+        metrics.total_cost_usd_micros,
+        format_optional_float(metrics.avg_cost_usd_micros_per_scored_case)
+    ));
+    output.push_str("cases:\n");
+    for case in &report.cases {
+        output.push_str(&format!(
+            "- {} {}#{} status={} tokens={} cost_usd_micros={} base_commit={}\n",
+            case.case_id,
+            case.repo,
+            case.issue,
+            case_status_label(case.status),
+            case.total_tokens,
+            case.cost_usd_micros,
+            case.base_commit
+        ));
+        if !case.verify_commands.is_empty() {
+            output.push_str(&format!(
+                "  verify: {}\n",
+                case.verify_commands.join(" && ")
+            ));
+        }
+        if !case.missing_evidence.is_empty() {
+            output.push_str(&format!(
+                "  missing_evidence: {}\n",
+                case.missing_evidence.join(", ")
+            ));
+        }
+    }
+    output
+}
+
+pub(crate) fn render_diff_report(diff: &EvalRunReportDiff) -> String {
+    let mut output = String::new();
+    output.push_str(&format!(
+        "Eval diff {} -> {} ({})\n",
+        diff.baseline_run_id, diff.candidate_run_id, diff.suite
+    ));
+    output.push_str(&format!(
+        "pass@1 delta: {:+.4}  pass^{} delta: {:+.4}\n",
+        diff.delta.pass_at_1_delta, diff.k, diff.delta.pass_to_k_delta
+    ));
+    output.push_str(&format!(
+        "tokens delta: {:+}  cost_usd_micros delta: {:+}\n",
+        diff.delta.total_tokens_delta, diff.delta.total_cost_usd_micros_delta
+    ));
+    output.push_str("transitions:\n");
+    for transition in &diff.transitions {
+        output.push_str(&format!(
+            "- {} {}\n",
+            transition.case_id,
+            transition_kind_label(transition.transition)
+        ));
+    }
+    output
+}
+
+fn format_optional_float(value: Option<f64>) -> String {
+    value
+        .map(|value| format!("{value:.2}"))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn case_status_label(status: EvalReportCaseStatus) -> &'static str {
+    match status {
+        EvalReportCaseStatus::Pending => "pending",
+        EvalReportCaseStatus::Passed => "passed",
+        EvalReportCaseStatus::Failed => "failed",
+        EvalReportCaseStatus::InfraFailed => "infra_failed",
+    }
+}
+
+fn transition_kind_label(kind: EvalCaseTransitionKind) -> &'static str {
+    match kind {
+        EvalCaseTransitionKind::Added => "added",
+        EvalCaseTransitionKind::Removed => "removed",
+        EvalCaseTransitionKind::UnchangedPass => "unchanged_pass",
+        EvalCaseTransitionKind::UnchangedFail => "unchanged_fail",
+        EvalCaseTransitionKind::PassToFail => "pass_to_fail",
+        EvalCaseTransitionKind::FailToPass => "fail_to_pass",
+        EvalCaseTransitionKind::StatusChanged => "status_changed",
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum EvidenceInput {
+    Cases(Vec<EvalCaseEvidence>),
+    Wrapped { cases: Vec<EvalCaseEvidence> },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{Cli, Command};
+    use super::*;
+    use clap::Parser;
+    use harness_workflow::runtime::eval::model::{Confidence, UsageSnapshot};
+    use harness_workflow::runtime::{
+        EvalEvidenceStatus, EvalQualityGateEvidence, EvalSubmissionEvidence,
+    };
+
+    fn sample_eval_manifest() -> EvalBenchmarkManifest {
+        parse_benchmark_manifest_str(
+            r#"
+suite = "harness-core"
+
+[[cases]]
+case_id = "case-pass"
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = ["cargo test -p harness-workflow eval_report"]
+
+[[cases]]
+case_id = "case-fail"
+repo = "majiayu000/harness"
+issue = 1447
+base_commit = "69f5e113"
+verify_commands = ["cargo test -p harness-cli eval_report"]
+"#,
+        )
+        .unwrap_or_else(|error| panic!("manifest should parse: {error}"))
+    }
+
+    #[test]
+    fn eval_report_cli_parses_run_and_diff_commands() {
+        let cli = Cli::try_parse_from([
+            "harness",
+            "eval",
+            "run",
+            "--manifest",
+            "evals/benchmarks/harness-core.toml",
+            "--evidence",
+            "evidence.json",
+            "--run-id",
+            "run-1",
+            "--k",
+            "5",
+            "--json",
+            "--output",
+            "report.json",
+        ])
+        .unwrap_or_else(|error| panic!("eval run command should parse: {error}"));
+        match cli.command {
+            Command::Eval {
+                cmd: EvalCommand::Run(args),
+            } => {
+                assert_eq!(
+                    args.manifest,
+                    PathBuf::from("evals/benchmarks/harness-core.toml")
+                );
+                assert_eq!(args.evidence, Some(PathBuf::from("evidence.json")));
+                assert_eq!(args.run_id.as_deref(), Some("run-1"));
+                assert_eq!(args.k, 5);
+                assert!(args.json);
+                assert_eq!(args.output, Some(PathBuf::from("report.json")));
+            }
+            _ => panic!("expected eval run command"),
+        }
+
+        let cli = Cli::try_parse_from([
+            "harness",
+            "eval",
+            "diff",
+            "baseline.json",
+            "candidate.json",
+            "--json",
+        ])
+        .unwrap_or_else(|error| panic!("eval diff command should parse: {error}"));
+        match cli.command {
+            Command::Eval {
+                cmd: EvalCommand::Diff(args),
+            } => {
+                assert_eq!(args.baseline, PathBuf::from("baseline.json"));
+                assert_eq!(args.candidate, PathBuf::from("candidate.json"));
+                assert!(args.json);
+            }
+            _ => panic!("expected eval diff command"),
+        }
+    }
+
+    #[test]
+    fn eval_report_dry_run_text_lists_manifest_cases() {
+        let report = eval_report_dry_run(&sample_eval_manifest(), "run-dry", 3)
+            .unwrap_or_else(|error| panic!("dry run report should build: {error}"));
+        let rendered = render_run_report(&report);
+
+        assert!(rendered.contains("pass@1: 0.0000"));
+        assert!(rendered.contains("pass^3: 0.0000"));
+        assert!(rendered.contains("case-pass"));
+        assert!(rendered.contains("status=pending"));
+    }
+
+    #[test]
+    fn eval_report_evidence_text_includes_pass_cost_and_tokens() {
+        let report = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "run-1",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Passed,
+                vec![usage_snapshot(120, 50)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("evidence report should build: {error}"));
+        let rendered = render_run_report(&report);
+
+        assert_eq!(report.metrics.total_cases, 2);
+        assert_eq!(report.metrics.scored_cases, 2);
+        assert_eq!(report.metrics.passed_cases, 1);
+        assert_eq!(report.metrics.failed_cases, 1);
+        assert_eq!(report.metrics.total_tokens, 120);
+        assert_eq!(report.metrics.total_cost_usd_micros, 50);
+        assert!(rendered.contains("pass@1: 0.5000"));
+        assert!(rendered.contains("pass^3: 0.8750"));
+        assert!(rendered.contains("missing_evidence: case_evidence"));
+    }
+
+    #[test]
+    fn eval_report_diff_text_includes_status_transitions() {
+        let baseline = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "baseline",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Passed,
+                vec![usage_snapshot(100, 40)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("baseline report should build: {error}"));
+        let candidate = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "candidate",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Failed,
+                vec![usage_snapshot(80, 30)],
+                vec!["quality_gate_pass".to_string()],
+            )],
+        )
+        .unwrap_or_else(|error| panic!("candidate report should build: {error}"));
+        let diff = diff_eval_run_reports(&baseline, &candidate);
+        let rendered = render_diff_report(&diff);
+
+        assert!(rendered.contains("pass_to_fail"));
+        assert!(rendered.contains("tokens delta: -20"));
+        assert!(rendered.contains("cost_usd_micros delta: -10"));
+    }
+
+    fn case_evidence(
+        case_id: &str,
+        status: EvalEvidenceStatus,
+        usage: Vec<UsageSnapshot>,
+        missing_evidence: Vec<String>,
+    ) -> EvalCaseEvidence {
+        EvalCaseEvidence {
+            eval_run_id: "run-1".to_string(),
+            case_id: case_id.to_string(),
+            workflow_id: Some(format!("workflow-{case_id}")),
+            status,
+            runtime: None,
+            usage,
+            submission: Some(EvalSubmissionEvidence {
+                repo: Some("majiayu000/harness".to_string()),
+                issue_number: Some(1447),
+                command_id: Some("cmd-1".to_string()),
+                command_status: Some("completed".to_string()),
+                runtime_job_ids: vec!["job-1".to_string()],
+            }),
+            quality_gate: Some(EvalQualityGateEvidence {
+                command_id: Some("cmd-quality".to_string()),
+                runtime_job_id: Some("job-quality".to_string()),
+                status: "succeeded".to_string(),
+                validation_passed: true,
+                validation_commands: vec!["cargo test".to_string()],
+            }),
+            missing_evidence,
+        }
+    }
+
+    fn usage_snapshot(total_tokens: u64, cost_usd_micros: u64) -> UsageSnapshot {
+        UsageSnapshot {
+            agent_invocation_id: Some("agent-1".to_string()),
+            runtime_job_id: Some("job-1".to_string()),
+            workflow_id: Some("workflow-1".to_string()),
+            model: Some("codex-test".to_string()),
+            reasoning_effort: None,
+            input_tokens: None,
+            output_tokens: None,
+            cached_input_tokens: None,
+            total_tokens: Some(total_tokens),
+            cost_usd_micros: Some(cost_usd_micros),
+            token_confidence: Confidence::Observed,
+            cost_confidence: Confidence::Estimated,
+        }
+    }
+}

--- a/crates/harness-cli/src/commands/runtime_log_tests.rs
+++ b/crates/harness-cli/src/commands/runtime_log_tests.rs
@@ -1,0 +1,128 @@
+use super::*;
+use chrono::TimeZone;
+
+#[test]
+fn prepare_logging_creates_runtime_log_for_serve() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.data_dir = tempdir.path().to_path_buf();
+
+    let bootstrap = prepare_logging(
+        &Command::Serve {
+            transport: None,
+            port: None,
+            project_root: None,
+            projects: vec![],
+            default_project: None,
+        },
+        &config,
+    );
+
+    assert_eq!(bootstrap.runtime_logs.state.as_str(), "enabled");
+    let active_path = bootstrap
+        .runtime_logs
+        .active_path
+        .as_ref()
+        .expect("active path");
+    assert!(active_path.starts_with(tempdir.path().join("logs")));
+    assert!(active_path.exists(), "runtime log file should be created");
+    assert_eq!(
+        bootstrap.runtime_logs.path_hint.as_deref(),
+        active_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| format!("logs/{name}"))
+            .as_deref()
+    );
+}
+
+#[test]
+fn purge_stale_runtime_logs_keeps_current_and_non_matching_files() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let logs_dir = tempdir.path().join("logs");
+    fs::create_dir_all(&logs_dir).expect("create logs dir");
+    let now = Utc
+        .with_ymd_and_hms(2026, 4, 30, 12, 0, 0)
+        .single()
+        .expect("timestamp");
+    let stale = runtime_log_path(
+        tempdir.path(),
+        Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+            .single()
+            .expect("stale timestamp"),
+        10,
+    );
+    let fresh = runtime_log_path(
+        tempdir.path(),
+        Utc.with_ymd_and_hms(2026, 4, 29, 12, 0, 0)
+            .single()
+            .expect("fresh timestamp"),
+        11,
+    );
+    let unrelated = logs_dir.join("notes.txt");
+    fs::write(&stale, "stale").expect("write stale");
+    fs::write(&fresh, "fresh").expect("write fresh");
+    fs::write(&unrelated, "keep").expect("write unrelated");
+
+    let warnings = purge_stale_runtime_logs(&logs_dir, 30, now);
+
+    assert!(warnings.is_empty(), "purge should not warn: {warnings:?}");
+    assert!(!stale.exists(), "stale runtime log should be deleted");
+    assert!(fresh.exists(), "fresh runtime log should be kept");
+    assert!(unrelated.exists(), "non-matching files should be kept");
+}
+
+#[test]
+fn purge_stale_runtime_logs_reports_delete_errors_without_stopping() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let logs_dir = tempdir.path().join("logs");
+    fs::create_dir_all(&logs_dir).expect("create logs dir");
+    let now = Utc
+        .with_ymd_and_hms(2026, 4, 30, 12, 0, 0)
+        .single()
+        .expect("timestamp");
+    let stale = runtime_log_path(
+        tempdir.path(),
+        Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+            .single()
+            .expect("stale timestamp"),
+        10,
+    );
+    let fresh = runtime_log_path(
+        tempdir.path(),
+        Utc.with_ymd_and_hms(2026, 4, 29, 12, 0, 0)
+            .single()
+            .expect("fresh timestamp"),
+        11,
+    );
+    fs::write(&stale, "stale").expect("write stale");
+    fs::write(&fresh, "fresh").expect("write fresh");
+
+    let warnings = purge_stale_runtime_logs_with(&logs_dir, 30, now, |path| {
+        if path == stale.as_path() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "simulated delete failure",
+            ));
+        }
+        fs::remove_file(path)
+    });
+
+    assert_eq!(warnings.len(), 1);
+    assert!(
+        warnings[0].contains("failed to delete stale runtime log"),
+        "warning should identify delete failure: {warnings:?}"
+    );
+    assert!(stale.exists(), "failed delete should leave stale file");
+    assert!(fresh.exists(), "fresh runtime log should be kept");
+}
+
+#[test]
+fn prepare_logging_disables_file_persistence_for_non_serve_commands() {
+    let config = harness_core::config::HarnessConfig::default();
+    let bootstrap = prepare_logging(&Command::Version, &config);
+
+    assert_eq!(bootstrap.runtime_logs.state.as_str(), "disabled");
+    assert!(bootstrap.runtime_logs.active_path.is_none());
+    assert!(bootstrap.runtime_log_file.is_none());
+}

--- a/crates/harness-workflow/src/runtime/eval/mod.rs
+++ b/crates/harness-workflow/src/runtime/eval/mod.rs
@@ -7,6 +7,7 @@
 pub mod evidence;
 pub mod manifest;
 pub mod model;
+pub mod report;
 pub mod run;
 pub mod scoring;
 
@@ -17,6 +18,11 @@ pub use evidence::{
 pub use manifest::{
     parse_benchmark_manifest_str, EvalBenchmarkCase, EvalBenchmarkManifest, ManifestError,
     DEFAULT_CASE_TIMEOUT_SECS,
+};
+pub use report::{
+    diff_eval_run_reports, eval_report_dry_run, eval_report_from_evidence, EvalCaseTransition,
+    EvalCaseTransitionKind, EvalReportCase, EvalReportCaseStatus, EvalReportError,
+    EvalReportMetricDelta, EvalReportMetrics, EvalRunReport, EvalRunReportDiff,
 };
 pub use run::{
     dispatch_eval_case_workflow, enqueue_eval_case_workflow, EvalCaseDispatchOutcome,

--- a/crates/harness-workflow/src/runtime/eval/report.rs
+++ b/crates/harness-workflow/src/runtime/eval/report.rs
@@ -244,23 +244,35 @@ fn report_case_from_evidence(
 ) -> EvalReportCase {
     let (total_tokens, cost_usd_micros) = evidence_usage_totals(&evidence);
     let passed = evidence.status == EvalEvidenceStatus::Passed;
+    let status = evidence_case_status(&evidence, passed);
     EvalReportCase {
         case_id: case.case_id.clone(),
         repo: case.repo.clone(),
         issue: case.issue,
         base_commit: case.base_commit.clone(),
         verify_commands: case.verify_commands.clone(),
-        status: if passed {
-            EvalReportCaseStatus::Passed
-        } else {
-            EvalReportCaseStatus::Failed
-        },
+        status,
         passed,
         workflow_id: evidence.workflow_id,
         total_tokens,
         cost_usd_micros,
         missing_evidence: evidence.missing_evidence,
     }
+}
+
+fn evidence_case_status(evidence: &EvalCaseEvidence, passed: bool) -> EvalReportCaseStatus {
+    if passed {
+        return EvalReportCaseStatus::Passed;
+    }
+    if evidence.missing_evidence.iter().any(|missing| {
+        matches!(
+            missing.as_str(),
+            "workflow_instance" | "terminal_runtime_state"
+        )
+    }) {
+        return EvalReportCaseStatus::InfraFailed;
+    }
+    EvalReportCaseStatus::Failed
 }
 
 fn evidence_usage_totals(evidence: &EvalCaseEvidence) -> (u64, u64) {
@@ -377,6 +389,11 @@ fn transition_kind(
 fn validate_k(k: u32) -> Result<(), EvalReportError> {
     if k == 0 {
         return Err(EvalReportError::new("k must be greater than zero"));
+    }
+    if k > i32::MAX as u32 {
+        return Err(EvalReportError::new(
+            "k must be less than or equal to i32::MAX",
+        ));
     }
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/eval/report.rs
+++ b/crates/harness-workflow/src/runtime/eval/report.rs
@@ -1,0 +1,382 @@
+use super::evidence::{EvalCaseEvidence, EvalEvidenceStatus};
+use super::manifest::EvalBenchmarkManifest;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::{error::Error, fmt};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvalRunReport {
+    pub run_id: String,
+    pub suite: String,
+    pub k: u32,
+    pub metrics: EvalReportMetrics,
+    pub cases: Vec<EvalReportCase>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvalReportMetrics {
+    pub total_cases: u64,
+    pub scored_cases: u64,
+    pub passed_cases: u64,
+    pub failed_cases: u64,
+    pub pending_cases: u64,
+    pub infra_failed_cases: u64,
+    pub pass_at_1: f64,
+    pub pass_to_k: f64,
+    pub total_tokens: u64,
+    pub avg_tokens_per_scored_case: Option<f64>,
+    pub total_cost_usd_micros: u64,
+    pub avg_cost_usd_micros_per_scored_case: Option<f64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalReportCase {
+    pub case_id: String,
+    pub repo: String,
+    pub issue: u64,
+    pub base_commit: String,
+    pub verify_commands: Vec<String>,
+    pub status: EvalReportCaseStatus,
+    pub passed: bool,
+    pub workflow_id: Option<String>,
+    pub total_tokens: u64,
+    pub cost_usd_micros: u64,
+    pub missing_evidence: Vec<String>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalReportCaseStatus {
+    Pending,
+    Passed,
+    Failed,
+    InfraFailed,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvalRunReportDiff {
+    pub baseline_run_id: String,
+    pub candidate_run_id: String,
+    pub suite: String,
+    pub k: u32,
+    pub delta: EvalReportMetricDelta,
+    pub transitions: Vec<EvalCaseTransition>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvalReportMetricDelta {
+    pub pass_at_1_delta: f64,
+    pub pass_to_k_delta: f64,
+    pub total_tokens_delta: i128,
+    pub total_cost_usd_micros_delta: i128,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalCaseTransition {
+    pub case_id: String,
+    pub transition: EvalCaseTransitionKind,
+    pub baseline_status: Option<EvalReportCaseStatus>,
+    pub candidate_status: Option<EvalReportCaseStatus>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalCaseTransitionKind {
+    Added,
+    Removed,
+    UnchangedPass,
+    UnchangedFail,
+    PassToFail,
+    FailToPass,
+    StatusChanged,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvalReportError {
+    message: String,
+}
+
+impl EvalReportError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for EvalReportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for EvalReportError {}
+
+pub fn eval_report_dry_run(
+    manifest: &EvalBenchmarkManifest,
+    run_id: impl Into<String>,
+    k: u32,
+) -> Result<EvalRunReport, EvalReportError> {
+    validate_k(k)?;
+    let cases = manifest
+        .cases
+        .iter()
+        .map(|case| EvalReportCase {
+            case_id: case.case_id.clone(),
+            repo: case.repo.clone(),
+            issue: case.issue,
+            base_commit: case.base_commit.clone(),
+            verify_commands: case.verify_commands.clone(),
+            status: EvalReportCaseStatus::Pending,
+            passed: false,
+            workflow_id: None,
+            total_tokens: 0,
+            cost_usd_micros: 0,
+            missing_evidence: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+    Ok(report_from_cases(manifest, run_id, k, cases))
+}
+
+pub fn eval_report_from_evidence(
+    manifest: &EvalBenchmarkManifest,
+    run_id: impl Into<String>,
+    k: u32,
+    evidence: Vec<EvalCaseEvidence>,
+) -> Result<EvalRunReport, EvalReportError> {
+    validate_k(k)?;
+    let mut known_case_ids = BTreeSet::new();
+    for case in &manifest.cases {
+        known_case_ids.insert(case.case_id.as_str());
+    }
+
+    let mut evidence_by_case = BTreeMap::new();
+    for case_evidence in evidence {
+        if !known_case_ids.contains(case_evidence.case_id.as_str()) {
+            return Err(EvalReportError::new(format!(
+                "evidence references unknown case_id `{}`",
+                case_evidence.case_id
+            )));
+        }
+        if evidence_by_case
+            .insert(case_evidence.case_id.clone(), case_evidence)
+            .is_some()
+        {
+            return Err(EvalReportError::new("duplicate evidence case_id"));
+        }
+    }
+
+    let cases = manifest
+        .cases
+        .iter()
+        .map(|case| match evidence_by_case.remove(&case.case_id) {
+            Some(evidence) => report_case_from_evidence(case, evidence),
+            None => EvalReportCase {
+                case_id: case.case_id.clone(),
+                repo: case.repo.clone(),
+                issue: case.issue,
+                base_commit: case.base_commit.clone(),
+                verify_commands: case.verify_commands.clone(),
+                status: EvalReportCaseStatus::Failed,
+                passed: false,
+                workflow_id: None,
+                total_tokens: 0,
+                cost_usd_micros: 0,
+                missing_evidence: vec!["case_evidence".to_string()],
+            },
+        })
+        .collect::<Vec<_>>();
+    Ok(report_from_cases(manifest, run_id, k, cases))
+}
+
+pub fn diff_eval_run_reports(
+    baseline: &EvalRunReport,
+    candidate: &EvalRunReport,
+) -> EvalRunReportDiff {
+    let baseline_cases = baseline
+        .cases
+        .iter()
+        .map(|case| (case.case_id.as_str(), case))
+        .collect::<BTreeMap<_, _>>();
+    let candidate_cases = candidate
+        .cases
+        .iter()
+        .map(|case| (case.case_id.as_str(), case))
+        .collect::<BTreeMap<_, _>>();
+    let mut case_ids = BTreeSet::new();
+    case_ids.extend(baseline_cases.keys().copied());
+    case_ids.extend(candidate_cases.keys().copied());
+
+    let transitions = case_ids
+        .into_iter()
+        .map(|case_id| {
+            let baseline_case = baseline_cases.get(case_id).copied();
+            let candidate_case = candidate_cases.get(case_id).copied();
+            EvalCaseTransition {
+                case_id: case_id.to_string(),
+                transition: transition_kind(baseline_case, candidate_case),
+                baseline_status: baseline_case.map(|case| case.status),
+                candidate_status: candidate_case.map(|case| case.status),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    EvalRunReportDiff {
+        baseline_run_id: baseline.run_id.clone(),
+        candidate_run_id: candidate.run_id.clone(),
+        suite: candidate.suite.clone(),
+        k: candidate.k,
+        delta: EvalReportMetricDelta {
+            pass_at_1_delta: candidate.metrics.pass_at_1 - baseline.metrics.pass_at_1,
+            pass_to_k_delta: candidate.metrics.pass_to_k - baseline.metrics.pass_to_k,
+            total_tokens_delta: i128::from(candidate.metrics.total_tokens)
+                - i128::from(baseline.metrics.total_tokens),
+            total_cost_usd_micros_delta: i128::from(candidate.metrics.total_cost_usd_micros)
+                - i128::from(baseline.metrics.total_cost_usd_micros),
+        },
+        transitions,
+    }
+}
+
+fn report_case_from_evidence(
+    case: &super::manifest::EvalBenchmarkCase,
+    evidence: EvalCaseEvidence,
+) -> EvalReportCase {
+    let (total_tokens, cost_usd_micros) = evidence_usage_totals(&evidence);
+    let passed = evidence.status == EvalEvidenceStatus::Passed;
+    EvalReportCase {
+        case_id: case.case_id.clone(),
+        repo: case.repo.clone(),
+        issue: case.issue,
+        base_commit: case.base_commit.clone(),
+        verify_commands: case.verify_commands.clone(),
+        status: if passed {
+            EvalReportCaseStatus::Passed
+        } else {
+            EvalReportCaseStatus::Failed
+        },
+        passed,
+        workflow_id: evidence.workflow_id,
+        total_tokens,
+        cost_usd_micros,
+        missing_evidence: evidence.missing_evidence,
+    }
+}
+
+fn evidence_usage_totals(evidence: &EvalCaseEvidence) -> (u64, u64) {
+    evidence.usage.iter().fold((0_u64, 0_u64), |acc, usage| {
+        let tokens = usage.total_tokens.unwrap_or_else(|| {
+            usage
+                .input_tokens
+                .unwrap_or(0)
+                .saturating_add(usage.output_tokens.unwrap_or(0))
+                .saturating_add(usage.cached_input_tokens.unwrap_or(0))
+        });
+        (
+            acc.0.saturating_add(tokens),
+            acc.1.saturating_add(usage.cost_usd_micros.unwrap_or(0)),
+        )
+    })
+}
+
+fn report_from_cases(
+    manifest: &EvalBenchmarkManifest,
+    run_id: impl Into<String>,
+    k: u32,
+    cases: Vec<EvalReportCase>,
+) -> EvalRunReport {
+    EvalRunReport {
+        run_id: run_id.into(),
+        suite: manifest.suite.clone(),
+        k,
+        metrics: metrics_for_cases(k, &cases),
+        cases,
+    }
+}
+
+fn metrics_for_cases(k: u32, cases: &[EvalReportCase]) -> EvalReportMetrics {
+    let total_cases = cases.len() as u64;
+    let scored_cases = cases
+        .iter()
+        .filter(|case| {
+            matches!(
+                case.status,
+                EvalReportCaseStatus::Passed | EvalReportCaseStatus::Failed
+            )
+        })
+        .count() as u64;
+    let passed_cases = cases.iter().filter(|case| case.passed).count() as u64;
+    let failed_cases = cases
+        .iter()
+        .filter(|case| case.status == EvalReportCaseStatus::Failed)
+        .count() as u64;
+    let pending_cases = cases
+        .iter()
+        .filter(|case| case.status == EvalReportCaseStatus::Pending)
+        .count() as u64;
+    let infra_failed_cases = cases
+        .iter()
+        .filter(|case| case.status == EvalReportCaseStatus::InfraFailed)
+        .count() as u64;
+    let pass_at_1 = if scored_cases == 0 {
+        0.0
+    } else {
+        passed_cases as f64 / scored_cases as f64
+    };
+    let total_tokens = cases
+        .iter()
+        .fold(0_u64, |sum, case| sum.saturating_add(case.total_tokens));
+    let total_cost_usd_micros = cases
+        .iter()
+        .fold(0_u64, |sum, case| sum.saturating_add(case.cost_usd_micros));
+
+    EvalReportMetrics {
+        total_cases,
+        scored_cases,
+        passed_cases,
+        failed_cases,
+        pending_cases,
+        infra_failed_cases,
+        pass_at_1,
+        pass_to_k: pass_to_k(pass_at_1, k),
+        total_tokens,
+        avg_tokens_per_scored_case: average_u64(total_tokens, scored_cases),
+        total_cost_usd_micros,
+        avg_cost_usd_micros_per_scored_case: average_u64(total_cost_usd_micros, scored_cases),
+    }
+}
+
+fn pass_to_k(pass_at_1: f64, k: u32) -> f64 {
+    1.0 - (1.0 - pass_at_1).powi(k as i32)
+}
+
+fn average_u64(value: u64, count: u64) -> Option<f64> {
+    (count > 0).then(|| value as f64 / count as f64)
+}
+
+fn transition_kind(
+    baseline: Option<&EvalReportCase>,
+    candidate: Option<&EvalReportCase>,
+) -> EvalCaseTransitionKind {
+    match (baseline, candidate) {
+        (None, Some(_)) => EvalCaseTransitionKind::Added,
+        (Some(_), None) => EvalCaseTransitionKind::Removed,
+        (None, None) => EvalCaseTransitionKind::StatusChanged,
+        (Some(baseline), Some(candidate)) => match (baseline.passed, candidate.passed) {
+            (true, true) => EvalCaseTransitionKind::UnchangedPass,
+            (false, false) if baseline.status == candidate.status => {
+                EvalCaseTransitionKind::UnchangedFail
+            }
+            (true, false) => EvalCaseTransitionKind::PassToFail,
+            (false, true) => EvalCaseTransitionKind::FailToPass,
+            (false, false) => EvalCaseTransitionKind::StatusChanged,
+        },
+    }
+}
+
+fn validate_k(k: u32) -> Result<(), EvalReportError> {
+    if k == 0 {
+        return Err(EvalReportError::new("k must be greater than zero"));
+    }
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -37,12 +37,15 @@ pub use bus::InMemoryWorkflowBus;
 pub use dispatcher::{CommandDispatchOutcome, RuntimeCommandDispatcher, RuntimeProfileSelector};
 pub use errors::RuntimeJobNotFoundError;
 pub use eval::{
-    collect_eval_case_evidence, collect_eval_case_evidence_from_records,
-    dispatch_eval_case_workflow, enqueue_eval_case_workflow, parse_benchmark_manifest_str,
-    score_pr_repair_eval, EvalBenchmarkCase, EvalBenchmarkManifest, EvalCaseDispatchOutcome,
-    EvalCaseEnqueueOutcome, EvalCaseEvidence, EvalCaseWorkflowInput, EvalCaseWorkflowPlan,
-    EvalEvidenceStatus, EvalQualityGateEvidence, EvalSubmissionEvidence, ManifestError,
-    ScoringError, DEFAULT_CASE_TIMEOUT_SECS, EVAL_BRANCH_PREFIX, EVAL_PR_DRAFT_MODE,
+    collect_eval_case_evidence, collect_eval_case_evidence_from_records, diff_eval_run_reports,
+    dispatch_eval_case_workflow, enqueue_eval_case_workflow, eval_report_dry_run,
+    eval_report_from_evidence, parse_benchmark_manifest_str, score_pr_repair_eval,
+    EvalBenchmarkCase, EvalBenchmarkManifest, EvalCaseDispatchOutcome, EvalCaseEnqueueOutcome,
+    EvalCaseEvidence, EvalCaseTransition, EvalCaseTransitionKind, EvalCaseWorkflowInput,
+    EvalCaseWorkflowPlan, EvalEvidenceStatus, EvalQualityGateEvidence, EvalReportCase,
+    EvalReportCaseStatus, EvalReportError, EvalReportMetricDelta, EvalReportMetrics, EvalRunReport,
+    EvalRunReportDiff, EvalSubmissionEvidence, ManifestError, ScoringError,
+    DEFAULT_CASE_TIMEOUT_SECS, EVAL_BRANCH_PREFIX, EVAL_PR_DRAFT_MODE,
 };
 pub use lease_state::{runtime_job_running_lease_state_at, RuntimeJobRunningLeaseState};
 pub use model::{


### PR DESCRIPTION
Related: #1447.

Summary:
- Adds workflow-runtime eval report and diff models for pass@1, pass^k, cost, token, and case transition reporting.
- Adds `harness eval run` for dry-run manifest listing or evidence-backed reports.
- Adds `harness eval diff` for version-to-version report transitions.
- Moves runtime-log CLI tests into a focused test module to keep `commands.rs` below the local size gate.

Scope:
- Covers `SP1447-T005`.
- GH-1447 remains open for cleanup behavior and the curated benchmark manifest.

Verification:
- `cargo test -p harness-cli eval_report`
- `cargo test -p harness-cli runtime_log`
- `cargo test -p harness-cli`
- `cargo check -p harness-cli --all-targets`
- `cargo check -p harness-workflow --all-targets`
- `cargo fmt --all -- --check`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1447`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-run`
