### PR TITLE
Add eval run cleanup guard

### DIFF
--- a/crates/harness-workflow/src/runtime/eval/mod.rs
+++ b/crates/harness-workflow/src/runtime/eval/mod.rs
@@ -25,8 +25,8 @@ pub use report::{
     EvalReportMetricDelta, EvalReportMetrics, EvalRunReport, EvalRunReportDiff,
 };
 pub use run::{
-    dispatch_eval_case_workflow, enqueue_eval_case_workflow, EvalCaseDispatchOutcome,
-    EvalCaseEnqueueOutcome, EvalCaseWorkflowInput, EvalCaseWorkflowPlan, EVAL_BRANCH_PREFIX,
-    EVAL_PR_DRAFT_MODE,
+    cleanup_cancelled_eval_run, dispatch_eval_case_workflow, enqueue_eval_case_workflow,
+    EvalCaseDispatchOutcome, EvalCaseEnqueueOutcome, EvalCaseWorkflowInput, EvalCaseWorkflowPlan,
+    EvalRunCleanupInput, EvalRunCleanupSummary, EVAL_BRANCH_PREFIX, EVAL_PR_DRAFT_MODE,
 };
 pub use scoring::{score_pr_repair_eval, ScoringError};

--- a/crates/harness-workflow/src/runtime/eval/run.rs
+++ b/crates/harness-workflow/src/runtime/eval/run.rs
@@ -62,7 +62,17 @@ pub struct EvalRunCleanupSummary {
     pub active_runtime_jobs: usize,
     pub orphan_workspaces: usize,
     pub orphan_pull_requests: usize,
+    /// Eval runs reuse the workflow runtime schema and must not create per-run schemas.
     pub orphan_schemas: usize,
+    pub cleanup_failures: Vec<EvalRunCleanupFailure>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvalRunCleanupFailure {
+    pub case_id: String,
+    pub workflow_id: String,
+    pub step: String,
+    pub error: String,
 }
 
 impl EvalRunCleanupSummary {
@@ -79,6 +89,7 @@ impl EvalRunCleanupSummary {
             orphan_workspaces: 0,
             orphan_pull_requests: 0,
             orphan_schemas: 0,
+            cleanup_failures: Vec::new(),
         }
     }
 
@@ -89,6 +100,22 @@ impl EvalRunCleanupSummary {
             && self.orphan_workspaces == 0
             && self.orphan_pull_requests == 0
             && self.orphan_schemas == 0
+            && self.cleanup_failures.is_empty()
+    }
+
+    fn record_failure(
+        &mut self,
+        case_id: &str,
+        workflow_id: &str,
+        step: &str,
+        error: impl std::fmt::Display,
+    ) {
+        self.cleanup_failures.push(EvalRunCleanupFailure {
+            case_id: case_id.to_string(),
+            workflow_id: workflow_id.to_string(),
+            step: step.to_string(),
+            error: error.to_string(),
+        });
     }
 }
 
@@ -216,33 +243,70 @@ pub async fn cleanup_cancelled_eval_run(
     let mut summary = EvalRunCleanupSummary::new(eval_run_id);
     for case in input.cases {
         let workflow_id = eval_case_workflow_id(eval_run_id, &case.case_id);
-        let Some(instance) = store.get_instance(&workflow_id).await? else {
-            continue;
+        let instance = match store.get_instance(&workflow_id).await {
+            Ok(Some(instance)) => instance,
+            Ok(None) => continue,
+            Err(error) => {
+                summary.record_failure(&case.case_id, &workflow_id, "load_workflow", error);
+                continue;
+            }
         };
         summary.workflows_seen += 1;
 
-        let commands = store.commands_for(&workflow_id).await?;
+        let commands = match store.commands_for(&workflow_id).await {
+            Ok(commands) => commands,
+            Err(error) => {
+                summary.record_failure(&case.case_id, &workflow_id, "load_commands", error);
+                continue;
+            }
+        };
         for command in commands {
             if !active_command_status(command.status) {
                 continue;
             }
-            summary.commands_cancelled += 1;
-            summary.runtime_jobs_cancelled += store
+            match store
                 .cancel_command_and_unfinished_runtime_jobs(
                     &command.id,
                     command.command.runtime_activity_key(),
                     reason,
                 )
-                .await?;
+                .await
+            {
+                Ok(cancelled_jobs) => {
+                    summary.commands_cancelled += 1;
+                    summary.runtime_jobs_cancelled += cancelled_jobs;
+                }
+                Err(error) => {
+                    summary.record_failure(&case.case_id, &workflow_id, "cancel_command", error);
+                }
+            }
         }
 
-        if !instance.is_terminal()
-            && cancel_eval_workflow_instance(store, instance, eval_run_id, case, reason).await?
+        let mut final_instance = instance.clone();
+        if !instance.is_terminal() {
+            match cancel_eval_workflow_instance(store, &instance, eval_run_id, case, reason).await {
+                Ok(Some(cancelled_instance)) => {
+                    summary.workflows_cancelled += 1;
+                    final_instance = cancelled_instance;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    summary.record_failure(&case.case_id, &workflow_id, "cancel_workflow", error);
+                }
+            }
+        };
+
+        if let Err(error) =
+            collect_remaining_eval_resources(store, &workflow_id, &final_instance, &mut summary)
+                .await
         {
-            summary.workflows_cancelled += 1;
+            summary.record_failure(
+                &case.case_id,
+                &workflow_id,
+                "collect_remaining_resources",
+                error,
+            );
         }
-
-        collect_remaining_eval_resources(store, &workflow_id, &mut summary).await?;
     }
 
     Ok(summary)
@@ -250,11 +314,11 @@ pub async fn cleanup_cancelled_eval_run(
 
 async fn cancel_eval_workflow_instance(
     store: &WorkflowRuntimeStore,
-    instance: WorkflowInstance,
+    instance: &WorkflowInstance,
     eval_run_id: &str,
     case: &EvalBenchmarkCase,
     reason: &str,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<Option<WorkflowInstance>> {
     let observed_state = instance.state.clone();
     let mut final_instance = instance.clone();
     final_instance.state = "cancelled".to_string();
@@ -285,7 +349,7 @@ async fn cancel_eval_workflow_instance(
     .high_confidence();
 
     crate::runtime::DecisionValidator::github_issue_pr().validate(
-        &instance,
+        instance,
         &decision,
         &ValidationContext::new("eval-cleanup", Utc::now()),
     )?;
@@ -306,26 +370,35 @@ async fn cancel_eval_workflow_instance(
             command_status: WorkflowCommandStatus::Pending,
         })
         .await?;
-    Ok(record.is_some())
+    Ok(record.map(|_| final_instance))
 }
 
 async fn collect_remaining_eval_resources(
     store: &WorkflowRuntimeStore,
     workflow_id: &str,
+    instance: &WorkflowInstance,
     summary: &mut EvalRunCleanupSummary,
 ) -> anyhow::Result<()> {
-    if let Some(instance) = store.get_instance(workflow_id).await? {
-        if !instance.is_terminal() {
-            summary.active_workflows += 1;
-        }
-        if instance.data.pointer("/eval/workspace_path").is_some() {
-            summary.orphan_workspaces += 1;
-        }
-        if instance.data.pointer("/pr_number").is_some()
-            || instance.data.pointer("/eval/pr_number").is_some()
-        {
-            summary.orphan_pull_requests += 1;
-        }
+    if !instance.is_terminal() {
+        summary.active_workflows += 1;
+    }
+    if instance
+        .data
+        .pointer("/eval/workspace_path")
+        .is_some_and(|value| !value.is_null())
+    {
+        summary.orphan_workspaces += 1;
+    }
+    if instance
+        .data
+        .pointer("/pr_number")
+        .is_some_and(|value| !value.is_null())
+        || instance
+            .data
+            .pointer("/eval/pr_number")
+            .is_some_and(|value| !value.is_null())
+    {
+        summary.orphan_pull_requests += 1;
     }
 
     for command in store.commands_for(workflow_id).await? {

--- a/crates/harness-workflow/src/runtime/eval/run.rs
+++ b/crates/harness-workflow/src/runtime/eval/run.rs
@@ -1,10 +1,12 @@
 use super::manifest::EvalBenchmarkCase;
 use crate::runtime::{
     build_issue_submission_decision, IssueSubmissionDecisionInput, RuntimeCommandDispatcher,
-    RuntimeProfile, ValidationContext, WorkflowCommandStatus, WorkflowDecisionTransition,
-    WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    RuntimeJobStatus, RuntimeProfile, ValidationContext, WorkflowCommand, WorkflowCommandStatus,
+    WorkflowCommandType, WorkflowDecision, WorkflowDecisionTransition, WorkflowDefinition,
+    WorkflowEvidence, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
     GITHUB_ISSUE_PR_DEFINITION_ID,
 };
+use chrono::Utc;
 use serde_json::{json, Value};
 
 pub const EVAL_BRANCH_PREFIX: &str = "harness-eval/";
@@ -39,6 +41,55 @@ pub struct EvalCaseWorkflowInput<'a> {
     pub project_id: &'a str,
     pub task_id: &'a str,
     pub additional_prompt: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EvalRunCleanupInput<'a> {
+    pub eval_run_id: &'a str,
+    pub cases: &'a [EvalBenchmarkCase],
+    pub reason: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvalRunCleanupSummary {
+    pub eval_run_id: String,
+    pub workflows_seen: usize,
+    pub workflows_cancelled: usize,
+    pub commands_cancelled: usize,
+    pub runtime_jobs_cancelled: usize,
+    pub active_workflows: usize,
+    pub active_commands: usize,
+    pub active_runtime_jobs: usize,
+    pub orphan_workspaces: usize,
+    pub orphan_pull_requests: usize,
+    pub orphan_schemas: usize,
+}
+
+impl EvalRunCleanupSummary {
+    fn new(eval_run_id: impl Into<String>) -> Self {
+        Self {
+            eval_run_id: eval_run_id.into(),
+            workflows_seen: 0,
+            workflows_cancelled: 0,
+            commands_cancelled: 0,
+            runtime_jobs_cancelled: 0,
+            active_workflows: 0,
+            active_commands: 0,
+            active_runtime_jobs: 0,
+            orphan_workspaces: 0,
+            orphan_pull_requests: 0,
+            orphan_schemas: 0,
+        }
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.active_workflows == 0
+            && self.active_commands == 0
+            && self.active_runtime_jobs == 0
+            && self.orphan_workspaces == 0
+            && self.orphan_pull_requests == 0
+            && self.orphan_schemas == 0
+    }
 }
 
 pub async fn enqueue_eval_case_workflow(
@@ -147,6 +198,191 @@ pub async fn dispatch_eval_case_workflow(
         enqueue,
         dispatched_jobs,
     })
+}
+
+pub async fn cleanup_cancelled_eval_run(
+    store: &WorkflowRuntimeStore,
+    input: EvalRunCleanupInput<'_>,
+) -> anyhow::Result<EvalRunCleanupSummary> {
+    let eval_run_id = input.eval_run_id.trim();
+    if eval_run_id.is_empty() {
+        anyhow::bail!("eval_run_id must not be empty");
+    }
+    let reason = input.reason.trim();
+    if reason.is_empty() {
+        anyhow::bail!("eval cleanup reason must not be empty");
+    }
+
+    let mut summary = EvalRunCleanupSummary::new(eval_run_id);
+    for case in input.cases {
+        let workflow_id = eval_case_workflow_id(eval_run_id, &case.case_id);
+        let Some(instance) = store.get_instance(&workflow_id).await? else {
+            continue;
+        };
+        summary.workflows_seen += 1;
+
+        let commands = store.commands_for(&workflow_id).await?;
+        for command in commands {
+            if !active_command_status(command.status) {
+                continue;
+            }
+            summary.commands_cancelled += 1;
+            summary.runtime_jobs_cancelled += store
+                .cancel_command_and_unfinished_runtime_jobs(
+                    &command.id,
+                    command.command.runtime_activity_key(),
+                    reason,
+                )
+                .await?;
+        }
+
+        if !instance.is_terminal()
+            && cancel_eval_workflow_instance(store, instance, eval_run_id, case, reason).await?
+        {
+            summary.workflows_cancelled += 1;
+        }
+
+        collect_remaining_eval_resources(store, &workflow_id, &mut summary).await?;
+    }
+
+    Ok(summary)
+}
+
+async fn cancel_eval_workflow_instance(
+    store: &WorkflowRuntimeStore,
+    instance: WorkflowInstance,
+    eval_run_id: &str,
+    case: &EvalBenchmarkCase,
+    reason: &str,
+) -> anyhow::Result<bool> {
+    let observed_state = instance.state.clone();
+    let mut final_instance = instance.clone();
+    final_instance.state = "cancelled".to_string();
+    final_instance.version = final_instance.version.saturating_add(1);
+    final_instance.data =
+        eval_cleanup_data(final_instance.data, eval_run_id, &case.case_id, reason);
+
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &observed_state,
+        "cancel_eval_run",
+        "cancelled",
+        reason,
+    )
+    .with_evidence(WorkflowEvidence::new(
+        "eval_cleanup",
+        format!("Eval run {eval_run_id} was cancelled before completion."),
+    ))
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkCancelled,
+        format!("eval-cleanup:{eval_run_id}:{}", case.case_id),
+        json!({
+            "reason": reason,
+            "eval_run_id": eval_run_id,
+            "case_id": case.case_id,
+        }),
+    ))
+    .high_confidence();
+
+    crate::runtime::DecisionValidator::github_issue_pr().validate(
+        &instance,
+        &decision,
+        &ValidationContext::new("eval-cleanup", Utc::now()),
+    )?;
+
+    let record = store
+        .apply_decision_transition(WorkflowDecisionTransition {
+            expected_state: &observed_state,
+            create_if_missing: None,
+            event_type: "EvalRunCancelled",
+            source: "eval-cleanup",
+            payload: json!({
+                "eval_run_id": eval_run_id,
+                "case_id": case.case_id,
+                "reason": reason,
+            }),
+            decision: &decision,
+            final_instance: &final_instance,
+            command_status: WorkflowCommandStatus::Pending,
+        })
+        .await?;
+    Ok(record.is_some())
+}
+
+async fn collect_remaining_eval_resources(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    summary: &mut EvalRunCleanupSummary,
+) -> anyhow::Result<()> {
+    if let Some(instance) = store.get_instance(workflow_id).await? {
+        if !instance.is_terminal() {
+            summary.active_workflows += 1;
+        }
+        if instance.data.pointer("/eval/workspace_path").is_some() {
+            summary.orphan_workspaces += 1;
+        }
+        if instance.data.pointer("/pr_number").is_some()
+            || instance.data.pointer("/eval/pr_number").is_some()
+        {
+            summary.orphan_pull_requests += 1;
+        }
+    }
+
+    for command in store.commands_for(workflow_id).await? {
+        if active_command_status(command.status) {
+            summary.active_commands += 1;
+        }
+        for job in store.runtime_jobs_for_command(&command.id).await? {
+            if active_runtime_job_status(job.status) {
+                summary.active_runtime_jobs += 1;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn eval_cleanup_data(mut data: Value, eval_run_id: &str, case_id: &str, reason: &str) -> Value {
+    if !data.is_object() {
+        data = json!({});
+    }
+    let Some(object) = data.as_object_mut() else {
+        return data;
+    };
+    let eval = object
+        .entry("eval".to_string())
+        .or_insert_with(|| json!({}));
+    if !eval.is_object() {
+        *eval = json!({});
+    }
+    if let Some(eval_object) = eval.as_object_mut() {
+        eval_object.insert(
+            "cleanup".to_string(),
+            json!({
+                "status": "cancelled",
+                "eval_run_id": eval_run_id,
+                "case_id": case_id,
+                "reason": reason,
+            }),
+        );
+    }
+    data
+}
+
+fn active_command_status(status: WorkflowCommandStatus) -> bool {
+    matches!(
+        status,
+        WorkflowCommandStatus::Pending
+            | WorkflowCommandStatus::Dispatching
+            | WorkflowCommandStatus::Dispatched
+    )
+}
+
+fn active_runtime_job_status(status: RuntimeJobStatus) -> bool {
+    matches!(
+        status,
+        RuntimeJobStatus::Pending | RuntimeJobStatus::Running
+    )
 }
 
 fn eval_case_initial_instance(input: EvalCaseWorkflowInput<'_>) -> WorkflowInstance {
@@ -303,6 +539,104 @@ mod tests {
         assert!(prompt.contains("open only a draft pull request"));
         assert!(prompt.contains("harness-eval/ branch prefix"));
         assert!(prompt.contains("Use the small implementation slice."));
+    }
+
+    #[test]
+    fn eval_cleanup_summary_requires_zero_remaining_resources() {
+        let mut summary = EvalRunCleanupSummary::new("run-1");
+        assert!(summary.is_clean());
+
+        summary.active_runtime_jobs = 1;
+        assert!(!summary.is_clean());
+
+        summary.active_runtime_jobs = 0;
+        summary.orphan_pull_requests = 1;
+        assert!(!summary.is_clean());
+    }
+
+    #[tokio::test]
+    async fn eval_cleanup_cancels_mid_run_workflow_without_runtime_orphans() -> anyhow::Result<()> {
+        if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
+            return Ok(());
+        }
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime_store")).await?;
+        let case = EvalBenchmarkCase {
+            case_id: "owner/repo#42".to_string(),
+            repo: "owner/repo".to_string(),
+            issue: 42,
+            base_commit: "abcdef1".to_string(),
+            verify_commands: vec!["cargo test -p harness-workflow eval_cleanup".to_string()],
+            timeout_secs: 120,
+        };
+        let outcome = enqueue_eval_case_workflow(
+            &store,
+            EvalCaseWorkflowInput {
+                eval_run_id: "run-cleanup",
+                case: &case,
+                project_id: dir.path().to_string_lossy().as_ref(),
+                task_id: "eval-task-1",
+                additional_prompt: None,
+            },
+        )
+        .await?;
+        assert_eq!(outcome.command_ids.len(), 1);
+        let _job = store
+            .enqueue_runtime_job_for_pending_command(
+                &outcome.command_ids[0],
+                RuntimeKind::CodexExec,
+                "codex",
+                json!({
+                    "activity": "implement_issue",
+                    "eval": {
+                        "eval_run_id": "run-cleanup",
+                        "case_id": case.case_id.clone(),
+                    }
+                }),
+                None,
+            )
+            .await?;
+
+        let summary = cleanup_cancelled_eval_run(
+            &store,
+            EvalRunCleanupInput {
+                eval_run_id: "run-cleanup",
+                cases: std::slice::from_ref(&case),
+                reason: "operator cancelled eval run",
+            },
+        )
+        .await?;
+
+        assert_eq!(summary.workflows_seen, 1);
+        assert_eq!(summary.workflows_cancelled, 1);
+        assert_eq!(summary.commands_cancelled, 1);
+        assert_eq!(summary.runtime_jobs_cancelled, 1);
+        assert!(summary.is_clean());
+
+        let workflow = match store.get_instance(&outcome.plan.workflow_id).await? {
+            Some(workflow) => workflow,
+            None => panic!("eval workflow should remain as terminal history"),
+        };
+        assert_eq!(workflow.state, "cancelled");
+        assert_eq!(
+            workflow.data["eval"]["cleanup"]["reason"],
+            "operator cancelled eval run"
+        );
+
+        let commands = store.commands_for(&outcome.plan.workflow_id).await?;
+        assert!(commands.iter().all(|command| {
+            matches!(
+                command.status,
+                WorkflowCommandStatus::Cancelled | WorkflowCommandStatus::HandledInline
+            )
+        }));
+        let jobs = store
+            .runtime_jobs_for_command(&outcome.command_ids[0])
+            .await?;
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].status, RuntimeJobStatus::Cancelled);
+
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
Related: #1447.

Covers SP1447-T006 by adding a workflow-runtime cleanup API for cancelled eval runs. The cleanup path cancels unfinished eval commands and runtime jobs, marks eval case workflows terminal, and reports remaining active/orphaned runtime resources.

GH-1447 remains open for the curated benchmark manifest.

Verification:
- cargo test -p harness-workflow eval_cleanup
- cargo test -p harness-workflow eval_run
- cargo test -p harness-workflow
- cargo check -p harness-workflow --all-targets
- cargo fmt --all -- --check
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1447
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-run
