### PR TITLE
Add isolation tier config schema

### DIFF
--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -1,6 +1,7 @@
 pub mod agents;
 pub mod dirs;
 pub mod intake;
+pub mod isolation;
 pub mod maintenance;
 pub mod misc;
 pub mod project;
@@ -13,6 +14,7 @@ pub mod workflow_circuit_breaker;
 
 use self::agents::*;
 use self::intake::*;
+use self::isolation::*;
 use self::maintenance::*;
 use self::misc::*;
 use self::server::*;
@@ -66,6 +68,8 @@ pub struct HarnessConfig {
     pub maintenance_window: MaintenanceWindowConfig,
     #[serde(default)]
     pub workflow: WorkflowRuntimeConfig,
+    #[serde(default)]
+    pub isolation: IsolationConfig,
     /// Projects declared in the config file. Registered on server startup.
     #[serde(default)]
     pub projects: Vec<ProjectEntry>,
@@ -159,6 +163,7 @@ impl Default for HarnessConfig {
             reconciliation: ReconciliationConfig::default(),
             maintenance_window: MaintenanceWindowConfig::default(),
             workflow: WorkflowRuntimeConfig::default(),
+            isolation: IsolationConfig::default(),
             projects: Vec::new(),
         };
         config.apply_derived_defaults();
@@ -200,6 +205,8 @@ impl<'de> Deserialize<'de> for HarnessConfig {
             #[serde(default)]
             workflow: WorkflowRuntimeConfig,
             #[serde(default)]
+            isolation: IsolationConfig,
+            #[serde(default)]
             projects: Vec<ProjectEntry>,
         }
 
@@ -221,6 +228,7 @@ impl<'de> Deserialize<'de> for HarnessConfig {
             reconciliation: input.reconciliation,
             maintenance_window: input.maintenance_window,
             workflow: input.workflow,
+            isolation: input.isolation,
             projects: input.projects,
         };
         config.apply_derived_defaults();

--- a/crates/harness-core/src/config/isolation.rs
+++ b/crates/harness-core/src/config/isolation.rs
@@ -1,0 +1,233 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IsolationTier {
+    #[default]
+    Host,
+    Container,
+    Microvm,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IsolationTrustClass {
+    Trusted,
+    NonCollaborator,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IsolationRule {
+    pub trust: IsolationTrustClass,
+    pub tier: IsolationTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IsolationConfig {
+    #[serde(default)]
+    pub default_tier: IsolationTier,
+    #[serde(default)]
+    pub rules: Vec<IsolationRule>,
+    #[serde(default)]
+    pub network_allowlist: Vec<String>,
+}
+
+impl Default for IsolationConfig {
+    fn default() -> Self {
+        Self {
+            default_tier: IsolationTier::Host,
+            rules: Vec::new(),
+            network_allowlist: Vec::new(),
+        }
+    }
+}
+
+impl IsolationConfig {
+    pub fn tier_for_trust_class(&self, trust: IsolationTrustClass) -> IsolationTier {
+        self.rules
+            .iter()
+            .find(|rule| rule.trust == trust)
+            .map(|rule| rule.tier)
+            .unwrap_or(self.default_tier)
+    }
+
+    pub fn required_tiers(&self) -> BTreeSet<IsolationTier> {
+        let mut tiers = BTreeSet::from([self.default_tier]);
+        tiers.extend(self.rules.iter().map(|rule| rule.tier));
+        tiers
+    }
+
+    pub fn validate_startup_support(&self) -> anyhow::Result<()> {
+        if self.required_tiers().contains(&IsolationTier::Microvm) {
+            anyhow::bail!(
+                "isolation tier `microvm` is reserved but not implemented; use `host` or `container`"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn isolation_config_defaults_to_host_without_rules() {
+        let config = IsolationConfig::default();
+
+        assert_eq!(config.default_tier, IsolationTier::Host);
+        assert_eq!(
+            config.tier_for_trust_class(IsolationTrustClass::NonCollaborator),
+            IsolationTier::Host
+        );
+        assert!(config.network_allowlist.is_empty());
+        assert!(config.validate_startup_support().is_ok());
+    }
+
+    #[test]
+    fn isolation_config_parses_rules_and_network_allowlist() {
+        let config: IsolationConfig = toml::from_str(
+            r#"
+default_tier = "host"
+network_allowlist = ["github.com", "api.anthropic.com"]
+
+[[rules]]
+trust = "non_collaborator"
+tier = "container"
+"#,
+        )
+        .expect("isolation config should parse");
+
+        assert_eq!(config.default_tier, IsolationTier::Host);
+        assert_eq!(
+            config.tier_for_trust_class(IsolationTrustClass::Trusted),
+            IsolationTier::Host
+        );
+        assert_eq!(
+            config.tier_for_trust_class(IsolationTrustClass::NonCollaborator),
+            IsolationTier::Container
+        );
+        assert_eq!(
+            config.network_allowlist,
+            vec!["github.com".to_string(), "api.anthropic.com".to_string()]
+        );
+        assert!(config.validate_startup_support().is_ok());
+    }
+
+    #[test]
+    fn isolation_config_accepts_microvm_in_parser_but_rejects_startup_support() {
+        let config: IsolationConfig = toml::from_str(
+            r#"
+default_tier = "microvm"
+"#,
+        )
+        .expect("reserved tier should parse");
+
+        assert_eq!(config.default_tier, IsolationTier::Microvm);
+        let err = config
+            .validate_startup_support()
+            .expect_err("microvm should fail startup validation");
+        assert!(
+            err.to_string().contains("microvm"),
+            "error should name reserved tier: {err}"
+        );
+    }
+
+    #[test]
+    fn isolation_config_rejects_microvm_rule_at_startup_support() {
+        let config: IsolationConfig = toml::from_str(
+            r#"
+default_tier = "host"
+
+[[rules]]
+trust = "non_collaborator"
+tier = "microvm"
+"#,
+        )
+        .expect("reserved rule tier should parse");
+
+        assert_eq!(
+            config.tier_for_trust_class(IsolationTrustClass::NonCollaborator),
+            IsolationTier::Microvm
+        );
+        let err = config
+            .validate_startup_support()
+            .expect_err("microvm rule should fail startup validation");
+        assert!(
+            err.to_string().contains("reserved"),
+            "error should explain reserved support: {err}"
+        );
+    }
+
+    #[test]
+    fn isolation_config_deserializes_from_harness_config() -> anyhow::Result<()> {
+        let input = r#"
+[server]
+transport = "http"
+http_addr = "127.0.0.1:9800"
+data_dir = "/tmp/harness-data"
+project_root = "/tmp/project"
+
+[agents]
+default_agent = "claude"
+
+[agents.claude]
+cli_path = "claude"
+default_model = "sonnet"
+
+[agents.codex]
+cli_path = "codex"
+
+[agents.anthropic_api]
+base_url = "https://api.anthropic.com"
+default_model = "claude-sonnet-4-6"
+
+[gc]
+max_drafts_per_run = 5
+budget_per_signal_usd = 0.5
+total_budget_usd = 5.0
+
+[gc.signal_thresholds]
+repeated_warn_min = 10
+chronic_block_min = 5
+hot_file_edits_min = 20
+slow_op_threshold_ms = 5000
+slow_op_count_min = 10
+escalation_ratio = 1.5
+violation_min = 5
+
+[rules]
+discovery_paths = []
+
+[observe]
+session_renewal_secs = 1800
+log_retention_days = 90
+
+[otel]
+
+[isolation]
+default_tier = "host"
+network_allowlist = ["github.com", "api.anthropic.com"]
+
+[[isolation.rules]]
+trust = "non_collaborator"
+tier = "container"
+"#;
+
+        let config: crate::config::HarnessConfig = toml::from_str(input)?;
+
+        assert_eq!(config.isolation.default_tier, IsolationTier::Host);
+        assert_eq!(
+            config
+                .isolation
+                .tier_for_trust_class(IsolationTrustClass::NonCollaborator),
+            IsolationTier::Container
+        );
+        assert_eq!(
+            config.isolation.network_allowlist,
+            vec!["github.com".to_string(), "api.anthropic.com".to_string()]
+        );
+        Ok(())
+    }
+}

--- a/crates/harness-core/src/config/project.rs
+++ b/crates/harness-core/src/config/project.rs
@@ -1,3 +1,4 @@
+use super::isolation::IsolationConfig;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -153,6 +154,9 @@ pub struct ProjectConfig {
     /// Per-project triage overrides. `None` inherits from defaults.
     #[serde(default)]
     pub triage: Option<ProjectTriageConfig>,
+    /// Per-project isolation overrides. `None` inherits from server defaults.
+    #[serde(default)]
+    pub isolation: Option<IsolationConfig>,
     /// Project type used to select review focus criteria. Default: mixed.
     #[serde(default)]
     pub review_type: ReviewType,
@@ -194,6 +198,7 @@ mod tests {
                 .and_then(|triage| triage.skip_on_review_label),
             None
         );
+        assert!(config.isolation.is_none());
         Ok(())
     }
 
@@ -229,6 +234,14 @@ branch_prefix = "featx/"
 [triage]
 skip_on_review_label = true
 
+[isolation]
+default_tier = "host"
+network_allowlist = ["github.com"]
+
+[[isolation.rules]]
+trust = "non_collaborator"
+tier = "container"
+
 review_type = "rust"
 "#,
         )?;
@@ -243,6 +256,13 @@ review_type = "rust"
                 .as_ref()
                 .and_then(|triage| triage.skip_on_review_label),
             Some(true)
+        );
+        let isolation = config.isolation.expect("isolation config should parse");
+        assert_eq!(
+            isolation.tier_for_trust_class(
+                super::super::isolation::IsolationTrustClass::NonCollaborator
+            ),
+            super::super::isolation::IsolationTier::Container
         );
         Ok(())
     }

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -163,6 +163,7 @@ async fn build_review_store(
 pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppState> {
     let dir = expand_tilde(&server.config.server.data_dir);
     let project_root = resolve_project_root(&server.config.server.project_root)?;
+    server.config.isolation.validate_startup_support()?;
     let api_auth_mode = super::auth::resolve_api_auth_mode(&server.config.server)?;
     super::auth::log_api_auth_mode(&api_auth_mode, &server.config.server);
     #[cfg(test)]

--- a/crates/harness-server/src/http/startup_tests.rs
+++ b/crates/harness-server/src/http/startup_tests.rs
@@ -6,8 +6,12 @@ use crate::{
 };
 use harness_agents::registry::AgentRegistry;
 use harness_core::{
-    config::HarnessConfig, types::EventFilters, types::RuleId, types::Severity,
-    types::SkillLocation, types::Violation,
+    config::{isolation::IsolationTier, HarnessConfig},
+    types::EventFilters,
+    types::RuleId,
+    types::Severity,
+    types::SkillLocation,
+    types::Violation,
 };
 use std::sync::Arc;
 
@@ -168,6 +172,33 @@ async fn build_app_state_refuses_tokenless_startup_without_opt_in() -> anyhow::R
     assert!(message.contains("api_token"));
     assert!(message.contains("HARNESS_API_TOKEN"));
     assert!(message.contains("allow_unauthenticated"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_app_state_rejects_reserved_microvm_isolation_tier() -> anyhow::Result<()> {
+    let sandbox = tempfile::tempdir()?;
+    let project_root = sandbox.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+
+    let mut config = unauthenticated_test_config();
+    config.server.project_root = project_root;
+    config.server.data_dir = sandbox.path().join("data");
+    config.isolation.default_tier = IsolationTier::Microvm;
+
+    let server = Arc::new(HarnessServer::new(
+        config,
+        ThreadManager::new(),
+        AgentRegistry::new("test"),
+    ));
+    let err = match build_app_state(server).await {
+        Ok(_) => anyhow::bail!("reserved microvm tier should fail startup"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+
+    assert!(message.contains("microvm"));
+    assert!(message.contains("not implemented"));
     Ok(())
 }
 


### PR DESCRIPTION
Issue: #1450

Refs #1450.

Covers SP1450-T001 only. GH-1450 remains open for intake classification, tier resolution, health reporting, container spawn wiring, scoped tokens, and docs.

Changes:
- Adds `[isolation]` config parsing for default tier, trust rules, and network allowlist.
- Accepts `microvm` as a reserved parser value while rejecting it at startup with an explicit error.
- Adds project-level isolation override parsing for future task routing work.

Verification:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p harness-core isolation_config`
- `cargo test -p harness-server build_app_state_rejects_reserved_microvm_isolation_tier`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1450`
- `cargo test --workspace --no-run`