### PR TITLE
Persist GitHub issue author trust class

### DIFF
--- a/crates/harness-core/src/config/isolation.rs
+++ b/crates/harness-core/src/config/isolation.rs
@@ -10,9 +10,10 @@ pub enum IsolationTier {
     Microvm,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IsolationTrustClass {
+    #[default]
     Trusted,
     NonCollaborator,
 }

--- a/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
+++ b/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
@@ -171,6 +171,7 @@ async fn intake_status_includes_runtime_github_issue_dispatches() -> anyhow::Res
             source: Some("github"),
             external_id: Some("issue:65"),
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -251,6 +252,7 @@ async fn intake_status_merges_runtime_dispatches_by_recency_before_limit() -> an
             source: Some("github"),
             external_id: Some("issue:165"),
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -174,6 +174,7 @@ async fn get_task_runtime_issue_exposes_tracker_identity() -> anyhow::Result<()>
             source: Some("github"),
             external_id: Some("issue:64"),
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -618,6 +619,7 @@ async fn workflow_runtime_cancel_endpoint_cancels_issue_workflow() -> anyhow::Re
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -702,6 +704,7 @@ async fn cancel_task_accepts_runtime_submission_handle_without_task_row() -> any
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/http/tests/runtime_worker_replay_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_worker_replay_tests.rs
@@ -113,6 +113,7 @@ async fn runtime_job_worker_replays_auto_submit_without_duplicate_child_side_eff
             source: Some("github"),
             external_id: Some("129"),
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/intake/direct_dispatch.rs
+++ b/crates/harness-server/src/intake/direct_dispatch.rs
@@ -170,6 +170,7 @@ pub(super) async fn run_direct_issue_dispatch(
                 source: Some(source.name()),
                 external_id: Some(ext_id.as_str()),
                 remote_fact_hash: fact_hash.as_deref(),
+                author_trust_class: Some(issue.author_trust_class),
             },
         )
         .await
@@ -230,6 +231,7 @@ mod tests {
             priority: None,
             labels: vec![],
             created_at: None,
+            author_trust_class: harness_core::config::isolation::IsolationTrustClass::Trusted,
             project_root: None,
         }
     }

--- a/crates/harness-server/src/intake/feishu.rs
+++ b/crates/harness-server/src/intake/feishu.rs
@@ -326,6 +326,7 @@ pub async fn feishu_webhook(
         priority: None,
         labels: vec!["feishu".to_string()],
         created_at: None,
+        author_trust_class: harness_core::config::isolation::IsolationTrustClass::Trusted,
         project_root: None,
     };
 
@@ -594,6 +595,7 @@ mod tests {
             priority: None,
             labels: vec!["feishu".to_string()],
             created_at: None,
+            author_trust_class: harness_core::config::isolation::IsolationTrustClass::Trusted,
             project_root: None,
         };
 

--- a/crates/harness-server/src/intake/github_coverage_gate.rs
+++ b/crates/harness-server/src/intake/github_coverage_gate.rs
@@ -178,6 +178,7 @@ mod tests {
             priority: None,
             labels: vec!["harness".to_string()],
             created_at: None,
+            author_trust_class: harness_core::config::isolation::IsolationTrustClass::Trusted,
             project_root: None,
         };
 

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
+use harness_core::config::isolation::IsolationTrustClass;
 use reqwest::header::{ACCEPT, LINK, USER_AGENT};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -324,6 +325,8 @@ struct GhIssue {
     pull_request: Option<serde_json::Value>,
     #[serde(default)]
     labels: Vec<GhLabel>,
+    #[serde(default)]
+    author_association: Option<String>,
     #[serde(alias = "createdAt")]
     created_at: Option<DateTime<Utc>>,
 }
@@ -372,6 +375,7 @@ fn parse_gh_output(
             priority: None,
             labels: issue.labels.into_iter().map(|l| l.name).collect(),
             created_at: issue.created_at,
+            author_trust_class: classify_author_association(issue.author_association.as_deref()),
             project_root: project_root.map(|p| p.to_path_buf()),
         })
         .collect();
@@ -395,6 +399,18 @@ fn github_issues_url(api_base_url: &str, repo: &str, label: &str) -> anyhow::Res
         }
     }
     Ok(url.to_string())
+}
+
+fn classify_author_association(author_association: Option<&str>) -> IsolationTrustClass {
+    match author_association
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_uppercase)
+        .as_deref()
+    {
+        Some("COLLABORATOR" | "MEMBER" | "OWNER") => IsolationTrustClass::Trusted,
+        _ => IsolationTrustClass::NonCollaborator,
+    }
 }
 
 struct GitHubIssuePage {
@@ -518,3 +534,7 @@ impl IntakeSource for GitHubIssuesPoller {
 #[cfg(test)]
 #[path = "github_issues_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "github_issues_trust_tests.rs"]
+mod trust_tests;

--- a/crates/harness-server/src/intake/github_issues_tests.rs
+++ b/crates/harness-server/src/intake/github_issues_tests.rs
@@ -739,6 +739,7 @@ async fn runtime_aware_checker_preserves_runtime_issue_handles() -> anyhow::Resu
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/intake/github_issues_trust_tests.rs
+++ b/crates/harness-server/src/intake/github_issues_trust_tests.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[test]
+fn intake_trust_classifies_github_author_association() -> anyhow::Result<()> {
+    let parsed = parse_gh_output(
+        br##"[
+            {"number":1,"title":"Owner","body":null,"url":"u1","labels":[],"author_association":"OWNER","createdAt":null},
+            {"number":2,"title":"Member","body":null,"url":"u2","labels":[],"author_association":"MEMBER","createdAt":null},
+            {"number":3,"title":"Collaborator","body":null,"url":"u3","labels":[],"author_association":"COLLABORATOR","createdAt":null},
+            {"number":4,"title":"First timer","body":null,"url":"u4","labels":[],"author_association":"FIRST_TIME_CONTRIBUTOR","createdAt":null},
+            {"number":5,"title":"Missing association","body":null,"url":"u5","labels":[],"createdAt":null}
+        ]"##,
+        "owner/repo",
+        &DashMap::new(),
+        None,
+    )?;
+
+    let classes: Vec<_> = parsed
+        .new_issues
+        .into_iter()
+        .map(|issue| issue.author_trust_class)
+        .collect();
+
+    assert_eq!(
+        classes,
+        vec![
+            IsolationTrustClass::Trusted,
+            IsolationTrustClass::Trusted,
+            IsolationTrustClass::Trusted,
+            IsolationTrustClass::NonCollaborator,
+            IsolationTrustClass::NonCollaborator,
+        ]
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/intake/mod.rs
+++ b/crates/harness-server/src/intake/mod.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use harness_core::config::isolation::IsolationTrustClass;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
@@ -29,6 +30,9 @@ pub struct IncomingIssue {
     pub priority: Option<i32>,
     pub labels: Vec<String>,
     pub created_at: Option<DateTime<Utc>>,
+    /// Trust class derived from source metadata. Non-GitHub/internal sources default to trusted.
+    #[serde(default)]
+    pub author_trust_class: IsolationTrustClass,
     /// Project root override for this issue's repo.
     #[serde(default)]
     pub project_root: Option<std::path::PathBuf>,
@@ -467,6 +471,7 @@ mod tests {
             priority: Some(2),
             labels: vec!["inbox".to_string()],
             created_at: None,
+            author_trust_class: harness_core::config::isolation::IsolationTrustClass::Trusted,
             project_root: None,
         }
     }

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -697,6 +697,7 @@ impl DefaultExecutionService {
                 source: prepared.req.source.as_deref(),
                 external_id: prepared.req.external_id.as_deref(),
                 remote_fact_hash: None,
+                author_trust_class: None,
             },
         )
         .await

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -1,4 +1,5 @@
 use crate::task_runner::TaskId;
+use harness_core::config::isolation::IsolationTrustClass;
 use harness_workflow::runtime::{
     build_issue_submission_decision, build_prompt_submission_decision, DecisionValidator,
     IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, ValidationContext,
@@ -75,6 +76,7 @@ pub(crate) struct IssueSubmissionRuntimeContext<'a> {
     pub source: Option<&'a str>,
     pub external_id: Option<&'a str>,
     pub remote_fact_hash: Option<&'a str>,
+    pub author_trust_class: Option<IsolationTrustClass>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -348,27 +350,35 @@ fn issue_submission_data(
         .remote_fact_hash
         .map(ToOwned::to_owned)
         .or_else(|| optional_string_field(existing_data, "last_remote_fact_hash"));
-    crate::workflow_runtime_policy::merge_runtime_retry_policy(
-        ctx.project_root,
-        json!({
-            "project_id": project_id,
-            "repo": ctx.repo,
-            "issue_number": ctx.issue_number,
-            "submission_id": submission_id_for_data(existing_data, ctx.task_id),
-            "task_id": ctx.task_id.as_str(),
-            "task_ids": task_id_history(existing_data, ctx.task_id),
-            "labels": ctx.labels,
-            "force_execute": ctx.force_execute,
-            "additional_prompt": ctx.additional_prompt,
-            "depends_on": depends_on_strings(ctx.depends_on),
-            "dependencies_blocked": ctx.dependencies_blocked,
-            "source": ctx.source,
-            "external_id": ctx.external_id,
-            "last_remote_fact_hash": last_remote_fact_hash,
-            "tracker_source": issue_tracker_source(ctx),
-            "tracker_external_id": issue_tracker_external_id(ctx),
-        }),
-    )
+    let mut data = json!({
+        "project_id": project_id,
+        "repo": ctx.repo,
+        "issue_number": ctx.issue_number,
+        "submission_id": submission_id_for_data(existing_data, ctx.task_id),
+        "task_id": ctx.task_id.as_str(),
+        "task_ids": task_id_history(existing_data, ctx.task_id),
+        "labels": ctx.labels,
+        "force_execute": ctx.force_execute,
+        "additional_prompt": ctx.additional_prompt,
+        "depends_on": depends_on_strings(ctx.depends_on),
+        "dependencies_blocked": ctx.dependencies_blocked,
+        "source": ctx.source,
+        "external_id": ctx.external_id,
+        "last_remote_fact_hash": last_remote_fact_hash,
+        "tracker_source": issue_tracker_source(ctx),
+        "tracker_external_id": issue_tracker_external_id(ctx),
+    });
+    insert_author_trust_class(&mut data, ctx.author_trust_class);
+    crate::workflow_runtime_policy::merge_runtime_retry_policy(ctx.project_root, data)
+}
+
+fn insert_author_trust_class(
+    data: &mut serde_json::Value,
+    author_trust_class: Option<IsolationTrustClass>,
+) {
+    if let (Some(object), Some(author_trust_class)) = (data.as_object_mut(), author_trust_class) {
+        object.insert("author_trust_class".to_string(), json!(author_trust_class));
+    }
 }
 
 pub(super) fn issue_tracker_source(
@@ -452,6 +462,7 @@ struct IssueSubmissionFields {
     additional_prompt: Option<String>,
     tracker_source: Option<String>,
     tracker_external_id: Option<String>,
+    author_trust_class: Option<IsolationTrustClass>,
 }
 
 fn issue_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<IssueSubmissionFields> {
@@ -472,7 +483,24 @@ fn issue_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<IssueS
         additional_prompt: optional_string_field(&instance.data, "additional_prompt"),
         tracker_source: optional_string_field(&instance.data, "tracker_source"),
         tracker_external_id: optional_string_field(&instance.data, "tracker_external_id"),
+        author_trust_class: author_trust_class_field(&instance.data)?,
     })
+}
+
+fn author_trust_class_field(
+    data: &serde_json::Value,
+) -> anyhow::Result<Option<IsolationTrustClass>> {
+    let Some(value) = data.get("author_trust_class") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    serde_json::from_value(value.clone())
+        .map(Some)
+        .map_err(|error| {
+            anyhow::anyhow!("runtime issue workflow has invalid author_trust_class: {error}")
+        })
 }
 
 #[derive(Debug)]
@@ -602,6 +630,10 @@ mod dependency_tests;
 #[cfg(test)]
 #[path = "workflow_runtime_submission/replay_tests.rs"]
 mod replay_tests;
+
+#[cfg(test)]
+#[path = "workflow_runtime_submission/trust_tests.rs"]
+mod trust_tests;
 
 #[cfg(test)]
 #[path = "workflow_runtime_submission_tests.rs"]

--- a/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
@@ -41,6 +41,7 @@ async fn rejected_new_issue_submission_does_not_persist_live_instance_or_command
         source: Some("github"),
         external_id: Some("issue:409"),
         remote_fact_hash: None,
+        author_trust_class: None,
     };
     let decision = WorkflowDecision::new(
         &workflow_id,
@@ -98,6 +99,7 @@ async fn accepted_issue_replay_repairs_pending_command_without_advancing_instanc
             source: Some("github"),
             external_id: Some("issue:410"),
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -121,6 +123,7 @@ async fn accepted_issue_replay_repairs_pending_command_without_advancing_instanc
             source: Some("github"),
             external_id: Some("issue:410"),
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_submission/commit.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/commit.rs
@@ -1,7 +1,7 @@
 use super::{
-    depends_on_strings, merge_last_decision, optional_string_field, string_field,
-    IssueSubmissionRuntimeContext, PromptSubmissionRuntimeContext, WorkflowSubmissionRuntimeRecord,
-    EXECUTION_PATH_WORKFLOW_RUNTIME,
+    depends_on_strings, insert_author_trust_class, merge_last_decision, optional_string_field,
+    string_field, IssueSubmissionRuntimeContext, PromptSubmissionRuntimeContext,
+    WorkflowSubmissionRuntimeRecord, EXECUTION_PATH_WORKFLOW_RUNTIME,
 };
 use super::{
     prompt_memory::{cache_prompt_submission_prompt, remove_prompt_submission_prompt},
@@ -288,7 +288,7 @@ fn new_submission_event_id(event: &SubmissionEventSelection) -> Option<String> {
 }
 
 fn issue_submission_event_payload(ctx: &IssueSubmissionRuntimeContext<'_>) -> serde_json::Value {
-    json!({
+    let mut payload = json!({
         "task_id": ctx.task_id.as_str(),
         "repo": ctx.repo,
         "issue_number": ctx.issue_number,
@@ -303,7 +303,9 @@ fn issue_submission_event_payload(ctx: &IssueSubmissionRuntimeContext<'_>) -> se
         "tracker_source": super::issue_tracker_source(ctx),
         "tracker_external_id": super::issue_tracker_external_id(ctx),
         "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
-    })
+    });
+    insert_author_trust_class(&mut payload, ctx.author_trust_class);
+    payload
 }
 
 fn prompt_submission_event_payload(ctx: &PromptSubmissionRuntimeContext<'_>) -> serde_json::Value {

--- a/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
@@ -355,6 +355,7 @@ async fn release_issue_after_dependencies(
                 "depends_on": depends_on_strings(depends_on),
                 "tracker_source": fields.tracker_source,
                 "tracker_external_id": fields.tracker_external_id,
+                "author_trust_class": fields.author_trust_class,
                 "execution_path": super::EXECUTION_PATH_WORKFLOW_RUNTIME,
             }),
         )

--- a/crates/harness-server/src/workflow_runtime_submission/dependency_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependency_tests.rs
@@ -226,6 +226,7 @@ async fn issue_submission_releases_dependency_on_completed_runtime_handle() -> a
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -252,6 +253,7 @@ async fn issue_submission_releases_dependency_on_completed_runtime_handle() -> a
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -298,6 +300,7 @@ async fn issue_submission_releases_dependency_by_github_issue_handle_when_canoni
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -333,6 +336,7 @@ async fn issue_submission_releases_dependency_by_github_issue_handle_when_canoni
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -381,6 +385,7 @@ async fn issue_submission_keeps_blocked_runtime_dependency_without_closed_eviden
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -407,6 +412,7 @@ async fn issue_submission_keeps_blocked_runtime_dependency_without_closed_eviden
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -447,6 +453,7 @@ async fn issue_submission_releases_blocked_runtime_dependency_with_persisted_clo
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -480,6 +487,7 @@ async fn issue_submission_releases_blocked_runtime_dependency_with_persisted_clo
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -528,6 +536,7 @@ async fn issue_submission_releases_blocked_runtime_dependency_with_closed_issue_
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -583,6 +592,7 @@ async fn issue_submission_releases_blocked_runtime_dependency_with_closed_issue_
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -634,6 +644,7 @@ async fn dependency_release_rotates_waiting_rows_to_prevent_starvation() -> anyh
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -660,6 +671,7 @@ async fn dependency_release_rotates_waiting_rows_to_prevent_starvation() -> anyh
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_submission/identity_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/identity_tests.rs
@@ -32,6 +32,7 @@ async fn issue_submission_records_explicit_submission_id() -> anyhow::Result<()>
             source: Some("github"),
             external_id: Some("issue:1129"),
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_submission/replay_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/replay_tests.rs
@@ -35,6 +35,7 @@ async fn issue_resubmission_after_completed_command_creates_fresh_attempt() -> a
             source: Some("github"),
             external_id: Some("issue:501"),
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -65,6 +66,7 @@ async fn issue_resubmission_after_completed_command_creates_fresh_attempt() -> a
             source: Some("github"),
             external_id: Some("issue:501"),
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_submission/trust_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/trust_tests.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+#[test]
+fn intake_trust_issue_submission_data_records_author_trust_class() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("intake-trust");
+    let labels = vec!["harness".to_string()];
+    let ctx = IssueSubmissionRuntimeContext {
+        project_root: &project_root,
+        repo: Some("owner/repo"),
+        issue_number: 42,
+        task_id: &task_id,
+        labels: &labels,
+        force_execute: true,
+        additional_prompt: None,
+        depends_on: &[],
+        dependencies_blocked: false,
+        source: Some("github"),
+        external_id: Some("issue:42"),
+        remote_fact_hash: None,
+        author_trust_class: Some(IsolationTrustClass::NonCollaborator),
+    };
+
+    let data = issue_submission_data(&ctx, &project_root.to_string_lossy(), &json!({}));
+
+    assert_eq!(
+        data["author_trust_class"],
+        json!(IsolationTrustClass::NonCollaborator)
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/workflow_runtime_submission_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission_tests.rs
@@ -41,6 +41,7 @@ async fn issue_submission_records_pending_runtime_implementation_command() -> an
             source: Some("github"),
             external_id: Some("issue:42"),
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -300,6 +301,7 @@ async fn issue_submission_preserves_prior_task_handles_for_lookup() -> anyhow::R
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -318,6 +320,7 @@ async fn issue_submission_preserves_prior_task_handles_for_lookup() -> anyhow::R
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -380,6 +383,7 @@ async fn cancel_issue_submission_cancels_dispatched_runtime_jobs() -> anyhow::Re
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -454,6 +458,7 @@ async fn cancel_issue_submission_cancels_dispatching_runtime_command() -> anyhow
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -534,6 +539,7 @@ async fn cancel_issue_submission_by_workflow_id_uses_stable_runtime_handle() -> 
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -670,6 +676,7 @@ async fn rejected_issue_submission_keeps_existing_runtime_data() -> anyhow::Resu
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;
@@ -738,6 +745,7 @@ async fn issue_submission_waits_for_dependencies_then_releases_runtime_command(
             source: None,
             external_id: None,
             remote_fact_hash: None,
+            author_trust_class: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
@@ -147,6 +147,7 @@ pub(super) async fn execute_start_child_workflow(
                     source: Some(source.as_str()),
                     external_id: Some(external_id.as_str()),
                     remote_fact_hash: None,
+                    author_trust_class: None,
                 },
             )
             .await?;


### PR DESCRIPTION
Issue: #1450

Refs #1450.

Covers SP1450-T002 only. GH-1450 remains open for tier resolution, health reporting, container spawn wiring, scoped tokens, and docs.

Changes:
- Classifies GitHub issue `author_association` into `trusted` or `non_collaborator`.
- Carries the trust class through direct GitHub issue dispatch into runtime issue submission.
- Persists `author_trust_class` on workflow instance data and mirrors it in submission evidence payloads.
- Adds focused trust tests without growing existing oversized test files.

Verification:
- `cargo fmt --all -- --check`
- `cargo test -p harness-server intake_trust`
- `cargo check -p harness-server --all-targets`
- `cargo check -p harness-core --all-targets`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1450`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-run`