### PR TITLE
Record isolation tier resolution at runtime dispatch

### DIFF
--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -636,10 +636,14 @@ async fn dispatch_runtime_command_with_project_policy(
         }
     };
 
+    let isolation_config = runtime_isolation_config_for_command(state, store, &command)
+        .await
+        .context("failed to load runtime isolation config")?;
     let repo = command_repo_hint(store, &command).await?;
     let activity = command.command.runtime_activity_key().to_string();
     let dispatch_gate_fact_hash = command_dispatch_gate_fact_hash(&command);
     let outcome = RuntimeCommandDispatcher::with_profile_selector(store, profile_selector)
+        .with_isolation_config(isolation_config)
         .with_dispatcher_id(dispatch_owner)
         .dispatch_command(command)
         .await?;
@@ -651,6 +655,26 @@ async fn dispatch_runtime_command_with_project_policy(
         dispatch_gate_fact_hash.as_deref(),
     );
     Ok(outcome)
+}
+
+async fn runtime_isolation_config_for_command(
+    state: &Arc<AppState>,
+    store: &WorkflowRuntimeStore,
+    command: &WorkflowCommandRecord,
+) -> anyhow::Result<harness_core::config::isolation::IsolationConfig> {
+    let project_root = runtime_command_project_root(store, command, &state.core.project_root)
+        .await
+        .context("failed to resolve command project root for isolation config")?;
+    let project_config = harness_core::config::project::load_project_config(&project_root)
+        .with_context(|| {
+            format!(
+                "failed to load project config for isolation at {}",
+                project_root.display()
+            )
+        })?;
+    Ok(project_config
+        .isolation
+        .unwrap_or_else(|| state.core.server.config.isolation.clone()))
 }
 
 async fn command_repo_hint(

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -1,8 +1,12 @@
 use super::model::{RuntimeJob, RuntimeProfile, WorkflowCommandRecord};
 use super::status::WorkflowCommandStatus;
 use super::store::{RuntimeJobEnqueueOutcome, WorkflowRuntimeStore};
+use super::tier_resolution::{
+    resolve_isolation_tier, IsolationTaskMetadata, IsolationTierResolution,
+};
 use anyhow::Context;
 use chrono::{DateTime, Duration, Utc};
+use harness_core::config::isolation::{IsolationConfig, IsolationTrustClass};
 use serde_json::json;
 use std::collections::BTreeMap;
 use uuid::Uuid;
@@ -105,6 +109,7 @@ impl From<RuntimeProfile> for RuntimeProfileSelector {
 pub struct RuntimeCommandDispatcher<'a> {
     store: &'a WorkflowRuntimeStore,
     profile_selector: RuntimeProfileSelector,
+    isolation_config: IsolationConfig,
     batch_limit: i64,
     dispatcher_id: String,
     lease_duration: Duration,
@@ -122,10 +127,16 @@ impl<'a> RuntimeCommandDispatcher<'a> {
         Self {
             store,
             profile_selector,
+            isolation_config: IsolationConfig::default(),
             batch_limit: 25,
             dispatcher_id: format!("dispatcher:{}", Uuid::new_v4()),
             lease_duration: Duration::seconds(30),
         }
+    }
+
+    pub fn with_isolation_config(mut self, isolation_config: IsolationConfig) -> Self {
+        self.isolation_config = isolation_config;
+        self
     }
 
     pub fn with_batch_limit(mut self, batch_limit: i64) -> Self {
@@ -186,7 +197,8 @@ impl<'a> RuntimeCommandDispatcher<'a> {
             });
         }
 
-        if let Some(instance) = self.store.get_instance(&command.workflow_id).await? {
+        let instance = self.store.get_instance(&command.workflow_id).await?;
+        if let Some(instance) = instance.as_ref() {
             if instance.is_terminal() {
                 let command_status = if instance.state == "cancelled" {
                     COMMAND_STATUS_CANCELLED
@@ -208,6 +220,14 @@ impl<'a> RuntimeCommandDispatcher<'a> {
 
         let activity = command.command.runtime_activity_key().to_string();
         let runtime_profile = self.profile_for_command(&command).await?;
+        let isolation =
+            isolation_resolution_for_instance(instance.as_ref(), &self.isolation_config)
+                .with_context(|| {
+                    format!(
+                        "failed to resolve isolation tier for workflow {}",
+                        command.workflow_id
+                    )
+                })?;
         let not_before = retry_not_before_for_command(&command)?;
         match self
             .store
@@ -224,6 +244,7 @@ impl<'a> RuntimeCommandDispatcher<'a> {
                     "activity": activity,
                     "command": command.command.command.clone(),
                     "runtime_profile": runtime_profile.clone(),
+                    "isolation": isolation,
                 }),
                 not_before,
             )
@@ -265,6 +286,33 @@ impl<'a> RuntimeCommandDispatcher<'a> {
             )
             .clone())
     }
+}
+
+fn isolation_resolution_for_instance(
+    instance: Option<&super::model::WorkflowInstance>,
+    config: &IsolationConfig,
+) -> anyhow::Result<IsolationTierResolution> {
+    let metadata = match instance {
+        Some(instance) => IsolationTaskMetadata {
+            author_trust_class: author_trust_class_from_data(&instance.data)?,
+        },
+        None => IsolationTaskMetadata::default(),
+    };
+    Ok(resolve_isolation_tier(metadata, config))
+}
+
+fn author_trust_class_from_data(
+    data: &serde_json::Value,
+) -> anyhow::Result<Option<IsolationTrustClass>> {
+    let Some(value) = data.get("author_trust_class") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    serde_json::from_value(value.clone())
+        .map(Some)
+        .with_context(|| format!("invalid author_trust_class in workflow metadata: {value}"))
 }
 
 fn retry_not_before_for_command(

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -25,6 +25,7 @@ mod store_migrations;
 mod store_summary;
 pub mod submission;
 pub mod terminal_state;
+pub mod tier_resolution;
 pub mod validator;
 pub mod worker;
 
@@ -32,6 +33,8 @@ pub mod worker;
 mod circuit_breaker_store_tests;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tier_resolution_dispatch_tests;
 
 pub use bus::InMemoryWorkflowBus;
 pub use dispatcher::{CommandDispatchOutcome, RuntimeCommandDispatcher, RuntimeProfileSelector};
@@ -107,6 +110,7 @@ pub use submission::{
     IssueSubmissionWorkflowAction,
 };
 pub use terminal_state::{workflow_terminal_state, WorkflowTerminalState};
+pub use tier_resolution::{resolve_isolation_tier, IsolationTaskMetadata, IsolationTierResolution};
 pub use validator::{
     DecisionValidator, TransitionAllowlist, TransitionRule, ValidationContext,
     WorkflowDecisionRejection, WorkflowDecisionRejectionKind,

--- a/crates/harness-workflow/src/runtime/tier_resolution.rs
+++ b/crates/harness-workflow/src/runtime/tier_resolution.rs
@@ -1,0 +1,89 @@
+use harness_core::config::isolation::{IsolationConfig, IsolationTier, IsolationTrustClass};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct IsolationTaskMetadata {
+    pub author_trust_class: Option<IsolationTrustClass>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IsolationTierResolution {
+    pub tier: IsolationTier,
+    pub reason: String,
+    pub trust_class: IsolationTrustClass,
+}
+
+pub fn resolve_isolation_tier(
+    metadata: IsolationTaskMetadata,
+    config: &IsolationConfig,
+) -> IsolationTierResolution {
+    let trust_class = metadata.author_trust_class.unwrap_or_default();
+    let tier = config.tier_for_trust_class(trust_class);
+    let reason = if config.rules.iter().any(|rule| rule.trust == trust_class) {
+        format!(
+            "trust_class:{} matched configured isolation rule",
+            trust_class_label(trust_class)
+        )
+    } else {
+        format!(
+            "trust_class:{} used default isolation tier",
+            trust_class_label(trust_class)
+        )
+    };
+
+    IsolationTierResolution {
+        tier,
+        reason,
+        trust_class,
+    }
+}
+
+fn trust_class_label(trust_class: IsolationTrustClass) -> &'static str {
+    match trust_class {
+        IsolationTrustClass::Trusted => "trusted",
+        IsolationTrustClass::NonCollaborator => "non_collaborator",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::config::isolation::IsolationRule;
+
+    #[test]
+    fn tier_resolution_defaults_to_host_for_missing_metadata() {
+        let resolution = resolve_isolation_tier(
+            IsolationTaskMetadata::default(),
+            &IsolationConfig::default(),
+        );
+
+        assert_eq!(resolution.tier, IsolationTier::Host);
+        assert_eq!(resolution.trust_class, IsolationTrustClass::Trusted);
+        assert!(resolution.reason.contains("default isolation tier"));
+    }
+
+    #[test]
+    fn tier_resolution_uses_trust_class_rule() {
+        let config = IsolationConfig {
+            default_tier: IsolationTier::Host,
+            rules: vec![IsolationRule {
+                trust: IsolationTrustClass::NonCollaborator,
+                tier: IsolationTier::Container,
+            }],
+            network_allowlist: Vec::new(),
+        };
+
+        let resolution = resolve_isolation_tier(
+            IsolationTaskMetadata {
+                author_trust_class: Some(IsolationTrustClass::NonCollaborator),
+            },
+            &config,
+        );
+
+        assert_eq!(resolution.tier, IsolationTier::Container);
+        assert_eq!(resolution.trust_class, IsolationTrustClass::NonCollaborator);
+        assert!(resolution
+            .reason
+            .contains("matched configured isolation rule"));
+    }
+}

--- a/crates/harness-workflow/src/runtime/tier_resolution_dispatch_tests.rs
+++ b/crates/harness-workflow/src/runtime/tier_resolution_dispatch_tests.rs
@@ -1,0 +1,70 @@
+use super::*;
+use harness_core::{
+    config::isolation::{IsolationConfig, IsolationRule, IsolationTier, IsolationTrustClass},
+    db::resolve_database_url,
+};
+use serde_json::json;
+
+#[tokio::test]
+async fn tier_resolution_runtime_dispatch_records_isolation_evidence() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "implementing",
+        WorkflowSubject::new("issue", "issue:42"),
+    )
+    .with_id("tier-resolution-workflow")
+    .with_data(json!({
+        "project_id": "/project",
+        "repo": "owner/repo",
+        "issue_number": 42,
+        "author_trust_class": "non_collaborator",
+    }));
+    store.upsert_instance(&instance).await?;
+
+    let command = WorkflowCommand::enqueue_activity("implement_issue", "tier-resolution-command");
+    let command_id = store.enqueue_command(&instance.id, None, &command).await?;
+    let dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc),
+    )
+    .with_isolation_config(IsolationConfig {
+        default_tier: IsolationTier::Host,
+        rules: vec![IsolationRule {
+            trust: IsolationTrustClass::NonCollaborator,
+            tier: IsolationTier::Container,
+        }],
+        network_allowlist: Vec::new(),
+    });
+
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+    let runtime_job = match outcome {
+        CommandDispatchOutcome::Enqueued {
+            command_id: dispatched_command_id,
+            runtime_job,
+        } => {
+            assert_eq!(dispatched_command_id, command_id);
+            runtime_job
+        }
+        other => panic!("unexpected dispatch outcome: {other:?}"),
+    };
+
+    assert_eq!(runtime_job.input["isolation"]["tier"], "container");
+    assert_eq!(
+        runtime_job.input["isolation"]["trust_class"],
+        "non_collaborator"
+    );
+    assert!(runtime_job.input["isolation"]["reason"]
+        .as_str()
+        .is_some_and(|reason| reason.contains("matched configured isolation rule")));
+    Ok(())
+}


### PR DESCRIPTION
Issue: #1450

Refs #1450.

Covers SP1450-T003 only. GH-1450 remains open for health reporting, container spawn wiring, scoped tokens, and docs.

Changes:
- Adds a pure isolation tier resolver in `harness-workflow`.
- Resolves tier from workflow metadata plus server/project isolation config at runtime dispatch.
- Records the resolved tier, reason, and trust class in runtime job input evidence.
- Adds focused resolver and dispatch evidence tests.

Verification:
- `cargo test -p harness-workflow tier_resolution`
- `cargo check -p harness-workflow --all-targets`
- `cargo check -p harness-server --all-targets`
- `cargo fmt --all -- --check`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1450`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-run`