### PR TITLE
Refuse unavailable isolation tiers

### DIFF
--- a/crates/harness-core/src/config/isolation.rs
+++ b/crates/harness-core/src/config/isolation.rs
@@ -10,6 +10,16 @@ pub enum IsolationTier {
     Microvm,
 }
 
+impl IsolationTier {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Host => "host",
+            Self::Container => "container",
+            Self::Microvm => "microvm",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IsolationTrustClass {
@@ -41,6 +51,99 @@ impl Default for IsolationConfig {
             rules: Vec::new(),
             network_allowlist: Vec::new(),
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IsolationTierStatus {
+    pub tier: IsolationTier,
+    pub available: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl IsolationTierStatus {
+    pub fn available(tier: IsolationTier) -> Self {
+        Self {
+            tier,
+            available: true,
+            reason: None,
+        }
+    }
+
+    pub fn unavailable(tier: IsolationTier, reason: impl Into<String>) -> Self {
+        Self {
+            tier,
+            available: false,
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IsolationAvailability {
+    #[serde(default)]
+    pub tiers: Vec<IsolationTierStatus>,
+}
+
+impl Default for IsolationAvailability {
+    fn default() -> Self {
+        Self {
+            tiers: vec![
+                IsolationTierStatus::available(IsolationTier::Host),
+                IsolationTierStatus::unavailable(
+                    IsolationTier::Container,
+                    "isolation tier `container` has not been probed",
+                ),
+                IsolationTierStatus::unavailable(
+                    IsolationTier::Microvm,
+                    "isolation tier `microvm` is reserved but not implemented",
+                ),
+            ],
+        }
+    }
+}
+
+impl IsolationAvailability {
+    pub fn new(tiers: Vec<IsolationTierStatus>) -> Self {
+        Self { tiers }
+    }
+
+    pub fn status_for(&self, tier: IsolationTier) -> IsolationTierStatus {
+        self.tiers
+            .iter()
+            .find(|status| status.tier == tier)
+            .cloned()
+            .unwrap_or_else(|| {
+                IsolationTierStatus::unavailable(
+                    tier,
+                    format!("isolation tier `{}` has not been probed", tier.as_str()),
+                )
+            })
+    }
+
+    pub fn unavailable_required_tiers(&self, config: &IsolationConfig) -> Vec<IsolationTierStatus> {
+        config
+            .required_tiers()
+            .into_iter()
+            .map(|tier| self.status_for(tier))
+            .filter(|status| !status.available)
+            .collect()
+    }
+
+    pub fn ensure_tier_available(&self, tier: IsolationTier) -> anyhow::Result<()> {
+        let status = self.status_for(tier);
+        if status.available {
+            return Ok(());
+        }
+        let reason = status
+            .reason
+            .as_deref()
+            .unwrap_or("tier availability probe failed");
+        anyhow::bail!(
+            "required isolation tier `{}` is unavailable: {reason}",
+            tier.as_str()
+        )
     }
 }
 
@@ -114,6 +217,32 @@ tier = "container"
             vec!["github.com".to_string(), "api.anthropic.com".to_string()]
         );
         assert!(config.validate_startup_support().is_ok());
+    }
+
+    #[test]
+    fn isolation_availability_reports_unavailable_required_tier() {
+        let config = IsolationConfig {
+            default_tier: IsolationTier::Host,
+            rules: vec![IsolationRule {
+                trust: IsolationTrustClass::NonCollaborator,
+                tier: IsolationTier::Container,
+            }],
+            network_allowlist: Vec::new(),
+        };
+        let availability = IsolationAvailability::new(vec![
+            IsolationTierStatus::available(IsolationTier::Host),
+            IsolationTierStatus::unavailable(IsolationTier::Container, "docker unavailable"),
+        ]);
+
+        let unavailable = availability.unavailable_required_tiers(&config);
+
+        assert_eq!(unavailable.len(), 1);
+        assert_eq!(unavailable[0].tier, IsolationTier::Container);
+        assert!(availability
+            .ensure_tier_available(IsolationTier::Container)
+            .expect_err("container should be unavailable")
+            .to_string()
+            .contains("docker unavailable"));
     }
 
     #[test]

--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -175,9 +175,14 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
     let runtime_log_state = state.core.server.runtime_logs.state.as_str();
     let degraded_subsystems = state.degraded_subsystems.clone();
     let runtime_state_dirty = state.is_runtime_state_dirty();
+    let isolation_degraded = !state
+        .isolation_availability
+        .unavailable_required_tiers(&state.core.server.config.isolation)
+        .is_empty();
     let health_status = if degraded_subsystems.is_empty()
         && runtime_log_state != "degraded"
         && !runtime_state_dirty
+        && !isolation_degraded
     {
         "ok"
     } else {

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -644,6 +644,7 @@ async fn dispatch_runtime_command_with_project_policy(
     let dispatch_gate_fact_hash = command_dispatch_gate_fact_hash(&command);
     let outcome = RuntimeCommandDispatcher::with_profile_selector(store, profile_selector)
         .with_isolation_config(isolation_config)
+        .with_isolation_availability(state.isolation_availability.clone())
         .with_dispatcher_id(dispatch_owner)
         .dispatch_command(command)
         .await?;

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -282,6 +282,10 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
             server.config.workflow.circuit_breaker.clone(),
         ),
     );
+    let isolation_availability = crate::isolation_health::probe_isolation_availability().await;
+    let isolation_required_unavailable = !isolation_availability
+        .unavailable_required_tiers(&server.config.isolation)
+        .is_empty();
 
     let (review_store, review_status) =
         build_review_store(&dir, server.config.server.database_url.as_deref()).await?;
@@ -297,6 +301,9 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         .collect();
     if services.snapshot_load_failed && !degraded_subsystems.contains(&"runtime_state_store") {
         degraded_subsystems.push("runtime_state_store");
+    }
+    if isolation_required_unavailable && !degraded_subsystems.contains(&"isolation") {
+        degraded_subsystems.push("isolation");
     }
 
     Ok(AppState {
@@ -353,6 +360,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         _db_state_guard: None,
         runtime_hosts: services.runtime_hosts,
         runtime_project_cache: services.runtime_project_cache,
+        isolation_availability,
         runtime_state_persist_lock: Mutex::new(()),
         runtime_state_dirty: AtomicBool::new(false),
         runtime_circuit_breakers,

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -53,6 +53,10 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
     let runtime_degraded = circuit_breakers
         .iter()
         .any(|breaker| breaker.state != "closed");
+    let unavailable_required_tiers = state
+        .isolation_availability
+        .unavailable_required_tiers(&state.core.server.config.isolation);
+    let isolation_degraded = !unavailable_required_tiers.is_empty();
     let startup_statuses: Vec<serde_json::Value> = state
         .startup_statuses
         .iter()
@@ -65,7 +69,7 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
             })
         })
         .collect();
-    let status = if degraded.is_empty() && !dirty && !runtime_degraded {
+    let status = if degraded.is_empty() && !dirty && !runtime_degraded && !isolation_degraded {
         "ok"
     } else {
         "degraded"
@@ -87,6 +91,10 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
         },
         "runtime": {
             "circuit_breakers": circuit_breakers,
+        },
+        "isolation": {
+            "tiers": state.isolation_availability.tiers.clone(),
+            "unavailable_required_tiers": unavailable_required_tiers,
         }
     }))
 }

--- a/crates/harness-server/src/http/state.rs
+++ b/crates/harness-server/src/http/state.rs
@@ -254,6 +254,7 @@ pub struct AppState {
     pub _db_state_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
     pub runtime_hosts: Arc<crate::runtime_hosts::RuntimeHostManager>,
     pub runtime_project_cache: Arc<crate::runtime_project_cache::RuntimeProjectCacheManager>,
+    pub isolation_availability: harness_core::config::isolation::IsolationAvailability,
     /// Serializes runtime snapshot writes to avoid out-of-order persistence.
     pub runtime_state_persist_lock: Mutex<()>,
     /// Set when a runtime-state persist fails; the next successful

--- a/crates/harness-server/src/http/test_fixtures.rs
+++ b/crates/harness-server/src/http/test_fixtures.rs
@@ -227,6 +227,7 @@ async fn make_read_only_route_test_state_with_project_root(
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: AtomicBool::new(false),
         runtime_circuit_breakers: Arc::new(

--- a/crates/harness-server/src/http/tests/health_route_tests.rs
+++ b/crates/harness-server/src/http/tests/health_route_tests.rs
@@ -95,6 +95,46 @@ async fn health_degraded_when_runtime_circuit_breaker_open() -> anyhow::Result<(
 }
 
 #[tokio::test]
+async fn health_degraded_when_required_isolation_tier_unavailable() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let mut state = make_read_only_route_test_state(dir.path()).await?;
+    let state_mut = Arc::get_mut(&mut state).expect("unique state");
+    let server = Arc::get_mut(&mut state_mut.core.server).expect("unique server");
+    server.config.isolation.rules = vec![harness_core::config::isolation::IsolationRule {
+        trust: harness_core::config::isolation::IsolationTrustClass::NonCollaborator,
+        tier: harness_core::config::isolation::IsolationTier::Container,
+    }];
+    state_mut.isolation_availability =
+        harness_core::config::isolation::IsolationAvailability::new(vec![
+            harness_core::config::isolation::IsolationTierStatus::available(
+                harness_core::config::isolation::IsolationTier::Host,
+            ),
+            harness_core::config::isolation::IsolationTierStatus::unavailable(
+                harness_core::config::isolation::IsolationTier::Container,
+                "docker missing",
+            ),
+        ]);
+
+    let health = call_health(state).await?;
+
+    assert_eq!(health.status, "degraded");
+    assert!(health.persistence.degraded_subsystems.is_empty());
+    assert_eq!(
+        health.isolation["unavailable_required_tiers"][0]["tier"],
+        "container"
+    );
+    assert_eq!(
+        health.isolation["unavailable_required_tiers"][0]["reason"],
+        "docker missing"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn health_startup_errors_are_redacted() -> anyhow::Result<()> {
     let _home_lock = crate::test_helpers::HOME_LOCK.lock().await;
     let dir = tempfile::tempdir()?;

--- a/crates/harness-server/src/http/tests/route_helpers.rs
+++ b/crates/harness-server/src/http/tests/route_helpers.rs
@@ -497,6 +497,7 @@ pub(super) struct HealthResponse {
     pub(super) persistence: PersistenceBlock,
     pub(super) runtime_logs: RuntimeLogsBlock,
     pub(super) runtime: serde_json::Value,
+    pub(super) isolation: serde_json::Value,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/crates/harness-server/src/http/tests/runtime_dispatch_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_dispatch_tests.rs
@@ -92,6 +92,98 @@ async fn runtime_command_dispatch_tick_enqueues_runtime_jobs() -> anyhow::Result
 }
 
 #[tokio::test]
+async fn runtime_command_dispatch_tick_refuses_unavailable_isolation_tier() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project-isolation-unavailable");
+    std::fs::create_dir(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nruntime_dispatch:\n  enabled: true\nruntime_worker:\n  enabled: true\n---\n",
+    )?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.isolation.rules = vec![harness_core::config::isolation::IsolationRule {
+        trust: harness_core::config::isolation::IsolationTrustClass::NonCollaborator,
+        tier: harness_core::config::isolation::IsolationTier::Container,
+    }];
+    let mut state = make_test_state_with_workflow_runtime_config_and_registry(
+        dir.path(),
+        dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    Arc::get_mut(&mut state)
+        .expect("unique state")
+        .isolation_availability =
+        harness_core::config::isolation::IsolationAvailability::new(vec![
+            harness_core::config::isolation::IsolationTierStatus::available(
+                harness_core::config::isolation::IsolationTier::Host,
+            ),
+            harness_core::config::isolation::IsolationTierStatus::unavailable(
+                harness_core::config::isolation::IsolationTier::Container,
+                "docker missing",
+            ),
+        ]);
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "replanning",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:126"),
+    )
+    .with_id("issue-126")
+    .with_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 126,
+        "author_trust_class": "non_collaborator",
+    }));
+    store.upsert_instance(&workflow).await?;
+    let command =
+        harness_workflow::runtime::WorkflowCommand::enqueue_activity("replan_issue", "replan-126");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+
+    let tick = super::background::run_runtime_command_dispatch_tick(
+        &state,
+        harness_workflow::runtime::RuntimeProfile::new(
+            "server-fallback",
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+        ),
+        10,
+    )
+    .await?;
+
+    assert_eq!(tick.enqueued, 0);
+    assert_eq!(tick.already_dispatched, 0);
+    assert_eq!(tick.skipped, 1);
+    assert!(store
+        .runtime_jobs_for_command(&command_id)
+        .await?
+        .is_empty());
+    assert_eq!(store.commands_for(&workflow.id).await?[0].status, "failed");
+    let events = store.events_for(&workflow.id).await?;
+    let event = events
+        .iter()
+        .find(|event| event.event_type == "WorkflowRuntimeIsolationUnavailable")
+        .expect("isolation refusal event should be recorded");
+    assert_eq!(event.event["command_id"], command_id);
+    assert_eq!(event.event["tier"], "container");
+    assert!(event.event["reason"]
+        .as_str()
+        .expect("reason should be a string")
+        .contains("docker missing"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_command_dispatch_tick_fails_command_when_workflow_config_is_malformed(
 ) -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {

--- a/crates/harness-server/src/http/tests/state_support.rs
+++ b/crates/harness-server/src/http/tests/state_support.rs
@@ -370,6 +370,7 @@ pub(super) async fn make_test_state_with_project_root(
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         runtime_circuit_breakers: Arc::new(
@@ -455,6 +456,7 @@ pub(super) async fn make_test_state_with_issue_workflows(
         _db_state_guard: None,
         runtime_hosts: state.runtime_hosts.clone(),
         runtime_project_cache: state.runtime_project_cache.clone(),
+        isolation_availability: state.isolation_availability.clone(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         runtime_circuit_breakers: state.runtime_circuit_breakers.clone(),
@@ -575,6 +577,7 @@ pub(super) async fn make_test_state_with_workflow_runtime_config_and_registry(
         _db_state_guard: None,
         runtime_hosts: state.runtime_hosts.clone(),
         runtime_project_cache: state.runtime_project_cache.clone(),
+        isolation_availability: state.isolation_availability.clone(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         runtime_circuit_breakers: state.runtime_circuit_breakers.clone(),

--- a/crates/harness-server/src/isolation_health.rs
+++ b/crates/harness-server/src/isolation_health.rs
@@ -1,0 +1,77 @@
+use harness_core::config::isolation::{IsolationAvailability, IsolationTier, IsolationTierStatus};
+use tokio::{process::Command, time::Duration};
+
+const DOCKER_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub(crate) async fn probe_isolation_availability() -> IsolationAvailability {
+    availability_from_container_status(probe_container_tier().await)
+}
+
+pub(crate) fn availability_from_container_status(
+    container_status: IsolationTierStatus,
+) -> IsolationAvailability {
+    IsolationAvailability::new(vec![
+        IsolationTierStatus::available(IsolationTier::Host),
+        container_status,
+        IsolationTierStatus::unavailable(
+            IsolationTier::Microvm,
+            "isolation tier `microvm` is reserved but not implemented",
+        ),
+    ])
+}
+
+async fn probe_container_tier() -> IsolationTierStatus {
+    let probe = Command::new("docker")
+        .arg("info")
+        .arg("--format")
+        .arg("{{.ServerVersion}}")
+        .output();
+    match tokio::time::timeout(DOCKER_PROBE_TIMEOUT, probe).await {
+        Ok(Ok(output)) if output.status.success() => {
+            IsolationTierStatus::available(IsolationTier::Container)
+        }
+        Ok(Ok(output)) => IsolationTierStatus::unavailable(
+            IsolationTier::Container,
+            docker_probe_failure_reason(&output),
+        ),
+        Ok(Err(error)) => IsolationTierStatus::unavailable(
+            IsolationTier::Container,
+            format!("docker CLI probe failed: {error}"),
+        ),
+        Err(_) => {
+            IsolationTierStatus::unavailable(IsolationTier::Container, "docker CLI probe timed out")
+        }
+    }
+}
+
+fn docker_probe_failure_reason(output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail = stderr
+        .lines()
+        .chain(stdout.lines())
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("docker info failed");
+    format!("docker CLI probe failed: {detail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn availability_marks_container_unavailable_from_probe_status() {
+        let availability = availability_from_container_status(IsolationTierStatus::unavailable(
+            IsolationTier::Container,
+            "docker missing",
+        ));
+
+        let container = availability.status_for(IsolationTier::Container);
+        let host = availability.status_for(IsolationTier::Host);
+
+        assert!(host.available);
+        assert!(!container.available);
+        assert_eq!(container.reason.as_deref(), Some("docker missing"));
+    }
+}

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -29,6 +29,7 @@ pub mod handlers;
 pub mod hook_enforcer;
 pub mod http;
 pub mod intake;
+pub(crate) mod isolation_health;
 pub mod memory_monitor;
 pub mod notify;
 pub mod overview;

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -115,6 +115,7 @@ async fn make_test_state_with_config_and_registry(
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         runtime_circuit_breakers: std::sync::Arc::new(
@@ -1875,6 +1876,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         runtime_circuit_breakers: std::sync::Arc::new(

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -273,6 +273,7 @@ mod tests {
             runtime_project_cache: Arc::new(
                 crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
             ),
+            isolation_availability: Default::default(),
             runtime_state_persist_lock: tokio::sync::Mutex::new(()),
             runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
             runtime_circuit_breakers: std::sync::Arc::new(

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -305,6 +305,7 @@ async fn make_state_inner(
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
         runtime_circuit_breakers: std::sync::Arc::new(

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -377,6 +377,7 @@ mod tests {
             runtime_project_cache: Arc::new(
                 crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
             ),
+            isolation_availability: Default::default(),
             runtime_state_persist_lock: tokio::sync::Mutex::new(()),
             runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
             runtime_circuit_breakers: std::sync::Arc::new(

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -6,13 +6,16 @@ use super::tier_resolution::{
 };
 use anyhow::Context;
 use chrono::{DateTime, Duration, Utc};
-use harness_core::config::isolation::{IsolationConfig, IsolationTrustClass};
+use harness_core::config::isolation::{
+    IsolationAvailability, IsolationConfig, IsolationTrustClass,
+};
 use serde_json::json;
 use std::collections::BTreeMap;
 use uuid::Uuid;
 
 const COMMAND_STATUS_SKIPPED: WorkflowCommandStatus = WorkflowCommandStatus::Skipped;
 const COMMAND_STATUS_CANCELLED: WorkflowCommandStatus = WorkflowCommandStatus::Cancelled;
+const COMMAND_STATUS_FAILED: WorkflowCommandStatus = WorkflowCommandStatus::Failed;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CommandDispatchOutcome {
@@ -110,6 +113,7 @@ pub struct RuntimeCommandDispatcher<'a> {
     store: &'a WorkflowRuntimeStore,
     profile_selector: RuntimeProfileSelector,
     isolation_config: IsolationConfig,
+    isolation_availability: IsolationAvailability,
     batch_limit: i64,
     dispatcher_id: String,
     lease_duration: Duration,
@@ -128,6 +132,7 @@ impl<'a> RuntimeCommandDispatcher<'a> {
             store,
             profile_selector,
             isolation_config: IsolationConfig::default(),
+            isolation_availability: IsolationAvailability::default(),
             batch_limit: 25,
             dispatcher_id: format!("dispatcher:{}", Uuid::new_v4()),
             lease_duration: Duration::seconds(30),
@@ -136,6 +141,14 @@ impl<'a> RuntimeCommandDispatcher<'a> {
 
     pub fn with_isolation_config(mut self, isolation_config: IsolationConfig) -> Self {
         self.isolation_config = isolation_config;
+        self
+    }
+
+    pub fn with_isolation_availability(
+        mut self,
+        isolation_availability: IsolationAvailability,
+    ) -> Self {
+        self.isolation_availability = isolation_availability;
         self
     }
 
@@ -228,6 +241,32 @@ impl<'a> RuntimeCommandDispatcher<'a> {
                         command.workflow_id
                     )
                 })?;
+        if let Err(error) = self
+            .isolation_availability
+            .ensure_tier_available(isolation.tier)
+        {
+            let reason = error.to_string();
+            self.store
+                .mark_command_status(&command.id, COMMAND_STATUS_FAILED)
+                .await?;
+            self.store
+                .append_event(
+                    &command.workflow_id,
+                    "WorkflowRuntimeIsolationUnavailable",
+                    "workflow_runtime_command_dispatcher",
+                    json!({
+                        "command_id": command.id.clone(),
+                        "tier": isolation.tier,
+                        "trust_class": isolation.trust_class,
+                        "reason": reason.clone(),
+                    }),
+                )
+                .await?;
+            return Ok(CommandDispatchOutcome::Skipped {
+                command_id: command.id,
+                reason,
+            });
+        }
         let not_before = retry_not_before_for_command(&command)?;
         match self
             .store

--- a/crates/harness-workflow/src/runtime/tier_resolution_dispatch_tests.rs
+++ b/crates/harness-workflow/src/runtime/tier_resolution_dispatch_tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use harness_core::{
-    config::isolation::{IsolationConfig, IsolationRule, IsolationTier, IsolationTrustClass},
+    config::isolation::{
+        IsolationAvailability, IsolationConfig, IsolationRule, IsolationTier, IsolationTierStatus,
+        IsolationTrustClass,
+    },
     db::resolve_database_url,
 };
 use serde_json::json;
@@ -41,7 +44,11 @@ async fn tier_resolution_runtime_dispatch_records_isolation_evidence() -> anyhow
             tier: IsolationTier::Container,
         }],
         network_allowlist: Vec::new(),
-    });
+    })
+    .with_isolation_availability(IsolationAvailability::new(vec![
+        IsolationTierStatus::available(IsolationTier::Host),
+        IsolationTierStatus::available(IsolationTier::Container),
+    ]));
 
     let outcome = dispatcher
         .dispatch_once()


### PR DESCRIPTION
## Summary
- add isolation tier availability status and Docker-based container tier probing at server startup
- surface unavailable required tiers in health/operator status
- refuse runtime dispatch when the resolved tier is unavailable, recording WorkflowRuntimeIsolationUnavailable instead of enqueueing a weaker run

Issue: #1450
Refs #1450
Covers SP1450-T004; GH-1450 remains open for container spawn wiring, scoped tokens, and docs.

## Verification
- cargo fmt --all -- --check
- cargo test -p harness-core isolation_availability
- cargo test -p harness-core isolation_config
- cargo test -p harness-workflow tier_resolution
- cargo test -p harness-server availability_marks_container_unavailable_from_probe_status
- cargo test -p harness-server health_degraded_when_required_isolation_tier_unavailable
- cargo test -p harness-server runtime_command_dispatch_tick_refuses_unavailable_isolation_tier
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-run
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1450