### PR TITLE
feat(agents): add container spawn contract

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -15,7 +15,7 @@ use harness_core::{
     agent::AgentRequest, agent::AgentResponse, agent::CodeAgent, agent::StreamItem,
     types::Capability, types::ReasoningBudget,
 };
-use harness_sandbox::{wrap_command, SandboxSpec};
+use harness_sandbox::SandboxSpec;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -181,33 +181,36 @@ impl CodeAgent for ClaudeCodeAgent {
         } else {
             SandboxSpec::new(sandbox_mode, &req.project_root)
         };
-        let wrapped_command =
-            wrap_command(&self.cli_path, &base_args, &sandbox_spec).map_err(|error| {
-                harness_core::error::HarnessError::AgentExecution(format!(
-                    "sandbox setup failed for claude: {error}"
-                ))
+        let mut spawn_env_vars = req.env_vars.clone();
+        let run_identity = crate::resolve_agent_run_identity(&spawn_env_vars);
+        run_identity.write_env_vars(&mut spawn_env_vars);
+        let prepared_spawn =
+            crate::spawn_contract::prepare_agent_spawn(crate::spawn_contract::AgentSpawnInput {
+                program: &self.cli_path,
+                args: &base_args,
+                project_root: &req.project_root,
+                sandbox_spec: &sandbox_spec,
+                env_vars: &spawn_env_vars,
             })?;
 
         tracing::debug!(
-            cli = %wrapped_command.program.display(),
-            project_root = %req.project_root.display(),
+            cli = %prepared_spawn.program.display(),
+            project_root = %prepared_spawn.current_dir.display(),
             model = %self.resolve_model(&req),
             "spawning claude agent"
         );
 
-        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
-        let mut cmd = Command::new(&wrapped_command.program);
-        cmd.args(&wrapped_command.args)
-            .current_dir(&req.project_root)
+        let mut cmd = Command::new(&prepared_spawn.program);
+        cmd.args(&prepared_spawn.args)
+            .current_dir(&prepared_spawn.current_dir)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
+        crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
         crate::strip_claude_env(&mut cmd);
-        cmd.envs(&req.env_vars);
-        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         let _provider_permit = self
             .provider_gate
@@ -231,7 +234,7 @@ impl CodeAgent for ClaudeCodeAgent {
                 &run_identity,
                 "claude-code",
                 pid,
-                &req.project_root,
+                &prepared_spawn.current_dir,
             );
         }
         let mut child = crate::ManagedChild::new(child, "claude execute");
@@ -292,16 +295,21 @@ impl CodeAgent for ClaudeCodeAgent {
         } else {
             SandboxSpec::new(sandbox_mode, &req.project_root)
         };
-        let wrapped_command =
-            wrap_command(&self.cli_path, &base_args, &sandbox_spec).map_err(|error| {
-                harness_core::error::HarnessError::AgentExecution(format!(
-                    "sandbox setup failed for claude: {error}"
-                ))
+        let mut spawn_env_vars = req.env_vars.clone();
+        let run_identity = crate::resolve_agent_run_identity(&spawn_env_vars);
+        run_identity.write_env_vars(&mut spawn_env_vars);
+        let prepared_spawn =
+            crate::spawn_contract::prepare_agent_spawn(crate::spawn_contract::AgentSpawnInput {
+                program: &self.cli_path,
+                args: &base_args,
+                project_root: &req.project_root,
+                sandbox_spec: &sandbox_spec,
+                env_vars: &spawn_env_vars,
             })?;
 
         // Dump full args (truncate each to 120 chars) so we can diagnose
         // exactly what is being passed to the Claude CLI process.
-        let args_debug: Vec<String> = wrapped_command
+        let args_debug: Vec<String> = prepared_spawn
             .args
             .iter()
             .enumerate()
@@ -315,8 +323,8 @@ impl CodeAgent for ClaudeCodeAgent {
             })
             .collect();
         tracing::info!(
-            program = %wrapped_command.program.display(),
-            arg_count = wrapped_command.args.len(),
+            program = %prepared_spawn.program.display(),
+            arg_count = prepared_spawn.args.len(),
             prompt_len = req.prompt.len(),
             args = %args_debug.join(" | "),
             "claude execute_stream: full command args"
@@ -330,19 +338,17 @@ impl CodeAgent for ClaudeCodeAgent {
             "claude execute_stream admitted by provider gate"
         );
 
-        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
-        let mut cmd = Command::new(&wrapped_command.program);
-        cmd.args(&wrapped_command.args)
-            .current_dir(&req.project_root)
+        let mut cmd = Command::new(&prepared_spawn.program);
+        cmd.args(&prepared_spawn.args)
+            .current_dir(&prepared_spawn.current_dir)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
+        crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
         crate::strip_claude_env(&mut cmd);
-        cmd.envs(&req.env_vars);
-        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         // ETXTBSY (error 26) occurs on Linux when a security scanner or indexer
         // briefly opens the executable for writing after it is written. Retry once.
@@ -374,7 +380,7 @@ impl CodeAgent for ClaudeCodeAgent {
                 &run_identity,
                 "claude-code",
                 pid,
-                &req.project_root,
+                &prepared_spawn.current_dir,
             );
         }
         let mut child = crate::ManagedChild::new(child, "claude execute_stream");

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -389,26 +389,34 @@ impl CodeAgent for CodexAgent {
         } else {
             SandboxSpec::new(sandbox_mode, &req.project_root)
         };
-        let wrapped_command =
-            wrap_command(&self.cli_path, &base_args, &sandbox_spec).map_err(|error| {
-                harness_core::error::HarnessError::AgentExecution(format!(
-                    "sandbox setup failed for codex: {error}"
-                ))
+        let mut spawn_env_vars = req.env_vars.clone();
+        let run_identity = crate::resolve_agent_run_identity(&spawn_env_vars);
+        run_identity.write_env_vars(&mut spawn_env_vars);
+        if self.cloud.enabled {
+            for key in &self.cloud.setup_secret_env {
+                spawn_env_vars.remove(key);
+            }
+        }
+        let prepared_spawn =
+            crate::spawn_contract::prepare_agent_spawn(crate::spawn_contract::AgentSpawnInput {
+                program: &self.cli_path,
+                args: &base_args,
+                project_root: &req.project_root,
+                sandbox_spec: &sandbox_spec,
+                env_vars: &spawn_env_vars,
             })?;
 
-        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
-        let mut cmd = Command::new(&wrapped_command.program);
-        cmd.args(&wrapped_command.args)
-            .current_dir(&req.project_root)
+        let mut cmd = Command::new(&prepared_spawn.program);
+        cmd.args(&prepared_spawn.args)
+            .current_dir(&prepared_spawn.current_dir)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
+        crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
         crate::strip_claude_env(&mut cmd);
-        cmd.envs(&req.env_vars);
-        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         if self.cloud.enabled {
             for key in &self.cloud.setup_secret_env {
@@ -417,18 +425,18 @@ impl CodeAgent for CodexAgent {
         }
 
         log_codex_spawn_attempt(
-            &wrapped_command.program,
-            wrapped_command.args.len(),
+            &prepared_spawn.program,
+            prepared_spawn.args.len(),
             &req,
-            wrapped_command.engine,
+            prepared_spawn.sandbox_engine,
             "execute",
         );
         let child = cmd.spawn().map_err(|err| {
             let message = codex_spawn_failure_message(
                 &err,
-                &wrapped_command.program,
+                &prepared_spawn.program,
                 &req,
-                wrapped_command.engine,
+                prepared_spawn.sandbox_engine,
                 "execute",
             );
             tracing::error!(
@@ -444,7 +452,7 @@ impl CodeAgent for CodexAgent {
                 &run_identity,
                 "codex",
                 pid,
-                &req.project_root,
+                &prepared_spawn.current_dir,
             );
         }
         let mut child = crate::ManagedChild::new(child, "codex execute");
@@ -509,26 +517,34 @@ impl CodeAgent for CodexAgent {
         } else {
             SandboxSpec::new(sandbox_mode, &req.project_root)
         };
-        let wrapped_command =
-            wrap_command(&self.cli_path, &base_args, &sandbox_spec).map_err(|error| {
-                harness_core::error::HarnessError::AgentExecution(format!(
-                    "sandbox setup failed for codex: {error}"
-                ))
+        let mut spawn_env_vars = req.env_vars.clone();
+        let run_identity = crate::resolve_agent_run_identity(&spawn_env_vars);
+        run_identity.write_env_vars(&mut spawn_env_vars);
+        if self.cloud.enabled {
+            for key in &self.cloud.setup_secret_env {
+                spawn_env_vars.remove(key);
+            }
+        }
+        let prepared_spawn =
+            crate::spawn_contract::prepare_agent_spawn(crate::spawn_contract::AgentSpawnInput {
+                program: &self.cli_path,
+                args: &base_args,
+                project_root: &req.project_root,
+                sandbox_spec: &sandbox_spec,
+                env_vars: &spawn_env_vars,
             })?;
 
-        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
-        let mut cmd = Command::new(&wrapped_command.program);
-        cmd.args(&wrapped_command.args)
-            .current_dir(&req.project_root)
+        let mut cmd = Command::new(&prepared_spawn.program);
+        cmd.args(&prepared_spawn.args)
+            .current_dir(&prepared_spawn.current_dir)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
+        crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
         crate::strip_claude_env(&mut cmd);
-        cmd.envs(&req.env_vars);
-        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
 
         if self.cloud.enabled {
             for key in &self.cloud.setup_secret_env {
@@ -537,18 +553,18 @@ impl CodeAgent for CodexAgent {
         }
 
         log_codex_spawn_attempt(
-            &wrapped_command.program,
-            wrapped_command.args.len(),
+            &prepared_spawn.program,
+            prepared_spawn.args.len(),
             &req,
-            wrapped_command.engine,
+            prepared_spawn.sandbox_engine,
             "execute_stream",
         );
         let child = cmd.spawn().map_err(|error| {
             let message = codex_spawn_failure_message(
                 &error,
-                &wrapped_command.program,
+                &prepared_spawn.program,
                 &req,
-                wrapped_command.engine,
+                prepared_spawn.sandbox_engine,
                 "execute_stream",
             );
             tracing::error!(
@@ -564,7 +580,7 @@ impl CodeAgent for CodexAgent {
                 &run_identity,
                 "codex",
                 pid,
-                &req.project_root,
+                &prepared_spawn.current_dir,
             );
         }
         let mut child = crate::ManagedChild::new(child, "codex execute_stream");

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -7,6 +7,7 @@ pub mod codex;
 pub mod codex_adapter;
 pub mod provider_backpressure;
 pub mod registry;
+mod spawn_contract;
 mod streaming;
 
 use harness_core::run_id::{RunIdentity, AGENT_RUN_ID_ENV, AGENT_RUN_PARENT_ENV};

--- a/crates/harness-agents/src/spawn_contract.rs
+++ b/crates/harness-agents/src/spawn_contract.rs
@@ -1,0 +1,464 @@
+use harness_core::agent::{AGENT_ISOLATION_TIER_ENV, AGENT_NETWORK_ALLOWLIST_ENV};
+use harness_core::config::isolation::IsolationTier;
+use harness_core::error::HarnessError;
+use harness_core::run_id::{AGENT_RUN_ID_ENV, AGENT_RUN_PARENT_ENV};
+use harness_sandbox::{wrap_command, SandboxEngine, SandboxSpec};
+use std::collections::{BTreeMap, HashMap};
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+const DEFAULT_AGENT_CONTAINER_IMAGE: &str = "harness-agent:latest";
+const AGENT_CONTAINER_IMAGE_ENV: &str = "HARNESS_AGENT_CONTAINER_IMAGE";
+const AGENT_EGRESS_PROXY_ENV: &str = "HARNESS_AGENT_EGRESS_PROXY";
+const CONTAINER_EGRESS_ALLOWLIST_ENV: &str = "HARNESS_AGENT_EGRESS_ALLOWLIST";
+const CONTAINER_WORKSPACE: &str = "/workspace";
+
+pub(crate) struct AgentSpawnInput<'a> {
+    pub(crate) program: &'a Path,
+    pub(crate) args: &'a [OsString],
+    pub(crate) project_root: &'a Path,
+    pub(crate) sandbox_spec: &'a SandboxSpec,
+    pub(crate) env_vars: &'a HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedAgentSpawn {
+    pub(crate) program: PathBuf,
+    pub(crate) args: Vec<OsString>,
+    pub(crate) current_dir: PathBuf,
+    pub(crate) process_env: BTreeMap<String, String>,
+    pub(crate) clear_inherited_env: bool,
+    pub(crate) sandbox_engine: SandboxEngine,
+}
+
+pub(crate) trait AgentSpawnContract {
+    fn prepare(&self, input: AgentSpawnInput<'_>) -> Result<PreparedAgentSpawn, HarnessError>;
+}
+
+pub(crate) struct HostSpawn;
+
+impl AgentSpawnContract for HostSpawn {
+    fn prepare(&self, input: AgentSpawnInput<'_>) -> Result<PreparedAgentSpawn, HarnessError> {
+        let wrapped_command =
+            wrap_command(input.program, input.args, input.sandbox_spec).map_err(|error| {
+                HarnessError::AgentExecution(format!("sandbox setup failed for agent: {error}"))
+            })?;
+        Ok(PreparedAgentSpawn {
+            program: wrapped_command.program,
+            args: wrapped_command.args,
+            current_dir: input.project_root.to_path_buf(),
+            process_env: host_process_env(input.env_vars),
+            clear_inherited_env: false,
+            sandbox_engine: wrapped_command.engine,
+        })
+    }
+}
+
+pub(crate) struct ContainerSpawn;
+
+impl AgentSpawnContract for ContainerSpawn {
+    fn prepare(&self, input: AgentSpawnInput<'_>) -> Result<PreparedAgentSpawn, HarnessError> {
+        let workspace = canonical_workspace(input.project_root)?;
+        let tier = isolation_tier(input.env_vars)?;
+        if tier != IsolationTier::Container {
+            return Err(HarnessError::AgentExecution(format!(
+                "container spawn received non-container isolation tier `{}`",
+                tier.as_str()
+            )));
+        }
+
+        let allowlist = network_allowlist(input.env_vars);
+        let image = container_image(input.env_vars);
+        let mut args = vec![OsString::from("run"), OsString::from("--rm")];
+        args.push(OsString::from("--workdir"));
+        args.push(OsString::from(CONTAINER_WORKSPACE));
+        args.push(OsString::from("--mount"));
+        args.push(OsString::from(format!(
+            "type=bind,src={},dst={CONTAINER_WORKSPACE}",
+            workspace.display()
+        )));
+        args.push(OsString::from("--network"));
+        args.push(OsString::from(container_network_mode(
+            input.env_vars,
+            &allowlist,
+        )));
+        for (key, value) in container_env_vars(input.env_vars) {
+            args.push(OsString::from("--env"));
+            args.push(OsString::from(format!("{key}={value}")));
+        }
+        if !allowlist.is_empty() {
+            args.push(OsString::from("--env"));
+            args.push(OsString::from(format!(
+                "{CONTAINER_EGRESS_ALLOWLIST_ENV}={}",
+                allowlist.join(",")
+            )));
+        }
+        if let Some(proxy) = egress_proxy(input.env_vars) {
+            for key in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"] {
+                args.push(OsString::from("--env"));
+                args.push(OsString::from(format!("{key}={proxy}")));
+            }
+            args.push(OsString::from("--env"));
+            args.push(OsString::from("NO_PROXY=localhost,127.0.0.1"));
+        }
+        args.push(OsString::from(image));
+        args.push(container_program(input.program));
+        args.extend(input.args.iter().cloned());
+
+        Ok(PreparedAgentSpawn {
+            program: PathBuf::from("docker"),
+            args,
+            current_dir: workspace,
+            process_env: docker_process_env(),
+            clear_inherited_env: true,
+            sandbox_engine: SandboxEngine::None,
+        })
+    }
+}
+
+pub(crate) fn prepare_agent_spawn(
+    input: AgentSpawnInput<'_>,
+) -> Result<PreparedAgentSpawn, HarnessError> {
+    match isolation_tier(input.env_vars)? {
+        IsolationTier::Host => HostSpawn.prepare(input),
+        IsolationTier::Container => ContainerSpawn.prepare(input),
+        IsolationTier::Microvm => Err(HarnessError::AgentExecution(
+            "isolation tier `microvm` is reserved but not implemented".to_string(),
+        )),
+    }
+}
+
+pub(crate) fn apply_process_env(cmd: &mut tokio::process::Command, spawn: &PreparedAgentSpawn) {
+    if spawn.clear_inherited_env {
+        cmd.env_clear();
+    }
+    cmd.envs(spawn.process_env.iter());
+}
+
+fn isolation_tier(env_vars: &HashMap<String, String>) -> Result<IsolationTier, HarnessError> {
+    match env_vars.get(AGENT_ISOLATION_TIER_ENV).map(String::as_str) {
+        None | Some("") | Some("host") => Ok(IsolationTier::Host),
+        Some("container") => Ok(IsolationTier::Container),
+        Some("microvm") => Ok(IsolationTier::Microvm),
+        Some(other) => Err(HarnessError::AgentExecution(format!(
+            "unknown isolation tier `{other}`"
+        ))),
+    }
+}
+
+fn network_allowlist(env_vars: &HashMap<String, String>) -> Vec<String> {
+    env_vars
+        .get(AGENT_NETWORK_ALLOWLIST_ENV)
+        .map(String::as_str)
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn host_process_env(env_vars: &HashMap<String, String>) -> BTreeMap<String, String> {
+    env_vars
+        .iter()
+        .filter(|(key, _)| !is_spawn_control_env(key))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+fn container_env_vars(env_vars: &HashMap<String, String>) -> BTreeMap<String, String> {
+    env_vars
+        .iter()
+        .filter(|(key, _)| !is_spawn_control_env(key))
+        .filter(|(key, _)| !is_operator_secret_env(key))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+fn docker_process_env() -> BTreeMap<String, String> {
+    std::env::var("PATH")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(|path| BTreeMap::from([("PATH".to_string(), path)]))
+        .unwrap_or_default()
+}
+
+fn is_spawn_control_env(key: &str) -> bool {
+    matches!(
+        key,
+        AGENT_ISOLATION_TIER_ENV
+            | AGENT_NETWORK_ALLOWLIST_ENV
+            | AGENT_CONTAINER_IMAGE_ENV
+            | AGENT_EGRESS_PROXY_ENV
+    )
+}
+
+fn is_operator_secret_env(key: &str) -> bool {
+    if key == AGENT_RUN_ID_ENV || key == AGENT_RUN_PARENT_ENV || key.starts_with("HARNESS_SCOPED_")
+    {
+        return false;
+    }
+    let key = key.to_ascii_uppercase();
+    key == "GITHUB_TOKEN"
+        || key == "GH_TOKEN"
+        || key.ends_with("_TOKEN")
+        || key.contains("API_KEY")
+        || key.contains("SECRET")
+        || key.contains("PASSWORD")
+}
+
+fn container_image(env_vars: &HashMap<String, String>) -> String {
+    env_vars
+        .get(AGENT_CONTAINER_IMAGE_ENV)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_AGENT_CONTAINER_IMAGE)
+        .to_string()
+}
+
+fn egress_proxy(env_vars: &HashMap<String, String>) -> Option<String> {
+    env_vars
+        .get(AGENT_EGRESS_PROXY_ENV)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn container_network_mode(
+    env_vars: &HashMap<String, String>,
+    allowlist: &[String],
+) -> &'static str {
+    if allowlist.is_empty() || egress_proxy(env_vars).is_none() {
+        "none"
+    } else {
+        "bridge"
+    }
+}
+
+fn canonical_workspace(project_root: &Path) -> Result<PathBuf, HarnessError> {
+    std::fs::canonicalize(project_root).map_err(|error| {
+        HarnessError::AgentExecution(format!(
+            "failed to resolve container workspace {}: {error}",
+            project_root.display()
+        ))
+    })
+}
+
+fn container_program(program: &Path) -> OsString {
+    if program.is_absolute() {
+        program
+            .file_name()
+            .map(OsStr::to_os_string)
+            .unwrap_or_else(|| program.as_os_str().to_os_string())
+    } else {
+        program.as_os_str().to_os_string()
+    }
+}
+
+#[cfg(test)]
+mod container_spawn_tests {
+    use super::*;
+    use harness_core::config::agents::SandboxMode;
+
+    fn input<'a>(
+        program: &'a Path,
+        args: &'a [OsString],
+        project_root: &'a Path,
+        sandbox_spec: &'a SandboxSpec,
+        env_vars: &'a HashMap<String, String>,
+    ) -> AgentSpawnInput<'a> {
+        AgentSpawnInput {
+            program,
+            args,
+            project_root,
+            sandbox_spec,
+            env_vars,
+        }
+    }
+
+    fn string_args(spawn: &PreparedAgentSpawn) -> Vec<String> {
+        spawn
+            .args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn container_spawn_mounts_only_task_workspace() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            AGENT_ISOLATION_TIER_ENV.to_string(),
+            "container".to_string(),
+        );
+        env_vars.insert(
+            AGENT_CONTAINER_IMAGE_ENV.to_string(),
+            "example/agent:sha256-test".to_string(),
+        );
+        let args = vec![OsString::from("exec"), OsString::from("prompt")];
+        let sandbox_spec = SandboxSpec::new(SandboxMode::WorkspaceWrite, root.path());
+
+        let spawn = ContainerSpawn.prepare(input(
+            Path::new("/opt/harness/bin/codex"),
+            &args,
+            root.path(),
+            &sandbox_spec,
+            &env_vars,
+        ))?;
+
+        let args = string_args(&spawn);
+        assert_eq!(spawn.program, PathBuf::from("docker"));
+        assert!(spawn.clear_inherited_env);
+        assert_eq!(spawn.current_dir, std::fs::canonicalize(root.path())?);
+        assert!(args.contains(&"--mount".to_string()));
+        assert!(args.contains(&format!(
+            "type=bind,src={},dst={CONTAINER_WORKSPACE}",
+            std::fs::canonicalize(root.path())?.display()
+        )));
+        assert!(!args
+            .iter()
+            .any(|arg| arg.contains("/Users/") && arg.contains("home")));
+        assert!(args.contains(&"--network".to_string()));
+        assert!(args.contains(&"none".to_string()));
+        assert!(args.contains(&"example/agent:sha256-test".to_string()));
+        assert!(args.contains(&"codex".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn container_spawn_applies_allowlist_proxy_contract() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            AGENT_ISOLATION_TIER_ENV.to_string(),
+            "container".to_string(),
+        );
+        env_vars.insert(
+            AGENT_NETWORK_ALLOWLIST_ENV.to_string(),
+            "github.com, api.anthropic.com".to_string(),
+        );
+        env_vars.insert(
+            AGENT_EGRESS_PROXY_ENV.to_string(),
+            "http://egress-proxy.local:8080".to_string(),
+        );
+        let sandbox_spec = SandboxSpec::new(SandboxMode::WorkspaceWrite, root.path());
+
+        let spawn = ContainerSpawn.prepare(input(
+            Path::new("claude"),
+            &[],
+            root.path(),
+            &sandbox_spec,
+            &env_vars,
+        ))?;
+
+        let args = string_args(&spawn);
+        assert!(args.contains(&"bridge".to_string()));
+        assert!(args.contains(&format!(
+            "{CONTAINER_EGRESS_ALLOWLIST_ENV}=github.com,api.anthropic.com"
+        )));
+        assert!(args.contains(&"HTTPS_PROXY=http://egress-proxy.local:8080".to_string()));
+        assert!(args.contains(&"ALL_PROXY=http://egress-proxy.local:8080".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn container_spawn_keeps_network_closed_without_proxy_for_allowlist() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            AGENT_ISOLATION_TIER_ENV.to_string(),
+            "container".to_string(),
+        );
+        env_vars.insert(
+            AGENT_NETWORK_ALLOWLIST_ENV.to_string(),
+            "github.com".to_string(),
+        );
+        let sandbox_spec = SandboxSpec::new(SandboxMode::WorkspaceWrite, root.path());
+
+        let spawn = ContainerSpawn.prepare(input(
+            Path::new("codex"),
+            &[],
+            root.path(),
+            &sandbox_spec,
+            &env_vars,
+        ))?;
+
+        let args = string_args(&spawn);
+        assert!(args.contains(&"none".to_string()));
+        assert!(args.contains(&format!("{CONTAINER_EGRESS_ALLOWLIST_ENV}=github.com")));
+        assert!(!args.iter().any(|arg| arg.starts_with("HTTPS_PROXY=")));
+        Ok(())
+    }
+
+    #[test]
+    fn container_spawn_filters_operator_env_secrets() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            AGENT_ISOLATION_TIER_ENV.to_string(),
+            "container".to_string(),
+        );
+        env_vars.insert(
+            AGENT_RUN_ID_ENV.to_string(),
+            "ar-01j00000000000000000000000".to_string(),
+        );
+        env_vars.insert("GITHUB_TOKEN".to_string(), "operator-token".to_string());
+        env_vars.insert("ANTHROPIC_API_KEY".to_string(), "operator-key".to_string());
+        env_vars.insert(
+            "HARNESS_SCOPED_GITHUB_TOKEN".to_string(),
+            "scoped-token".to_string(),
+        );
+        env_vars.insert(
+            "CARGO_TARGET_DIR".to_string(),
+            "/workspace/target".to_string(),
+        );
+        let sandbox_spec = SandboxSpec::new(SandboxMode::WorkspaceWrite, root.path());
+
+        let spawn = ContainerSpawn.prepare(input(
+            Path::new("codex"),
+            &[],
+            root.path(),
+            &sandbox_spec,
+            &env_vars,
+        ))?;
+
+        let args = string_args(&spawn);
+        assert!(args.contains(&format!("{AGENT_RUN_ID_ENV}=ar-01j00000000000000000000000")));
+        assert!(args.contains(&"HARNESS_SCOPED_GITHUB_TOKEN=scoped-token".to_string()));
+        assert!(args.contains(&"CARGO_TARGET_DIR=/workspace/target".to_string()));
+        assert!(!args.iter().any(|arg| arg.contains("operator-token")));
+        assert!(!args.iter().any(|arg| arg.contains("operator-key")));
+        assert!(!spawn.process_env.contains_key("GITHUB_TOKEN"));
+        Ok(())
+    }
+
+    #[test]
+    fn host_spawn_filters_spawn_control_env() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut env_vars = HashMap::new();
+        env_vars.insert(AGENT_ISOLATION_TIER_ENV.to_string(), "host".to_string());
+        env_vars.insert("CARGO_TARGET_DIR".to_string(), "/tmp/target".to_string());
+        let args = vec![OsString::from("exec")];
+        let sandbox_spec = SandboxSpec::new(SandboxMode::DangerFullAccess, root.path());
+
+        let spawn = prepare_agent_spawn(input(
+            Path::new("codex"),
+            &args,
+            root.path(),
+            &sandbox_spec,
+            &env_vars,
+        ))?;
+
+        assert!(!spawn.clear_inherited_env);
+        assert_eq!(
+            spawn.process_env.get("CARGO_TARGET_DIR"),
+            Some(&"/tmp/target".to_string())
+        );
+        assert!(!spawn.process_env.contains_key(AGENT_ISOLATION_TIER_ENV));
+        assert_eq!(spawn.program, PathBuf::from("codex"));
+        Ok(())
+    }
+}

--- a/crates/harness-core/src/agent.rs
+++ b/crates/harness-core/src/agent.rs
@@ -6,6 +6,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+pub const AGENT_ISOLATION_TIER_ENV: &str = "HARNESS_AGENT_ISOLATION_TIER";
+pub const AGENT_NETWORK_ALLOWLIST_ENV: &str = "HARNESS_AGENT_NETWORK_ALLOWLIST";
+
 /// Core trait for all code agents (Claude Code, Codex, Anthropic API, etc.)
 #[async_trait]
 pub trait CodeAgent: Send + Sync {

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -1,5 +1,6 @@
 use crate::http::AppState;
 use async_trait::async_trait;
+use harness_core::agent::{AGENT_ISOLATION_TIER_ENV, AGENT_NETWORK_ALLOWLIST_ENV};
 use harness_core::config::workflow::{RuntimeDispatchProfileOverride, WorkflowConfig};
 use harness_core::types::{AgentId, ThreadId};
 use harness_workflow::runtime::{
@@ -7,6 +8,7 @@ use harness_workflow::runtime::{
     WorkflowInstance,
 };
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -162,6 +164,7 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                     approval_policy,
                     timeout_secs: runtime_profile.timeout_secs,
                     stall_timeout_secs: None,
+                    env_vars: isolation_spawn_env_vars(&job),
                     // Always drive Codex turns through the `codex exec` CLI rather
                     // than the persistent `codex app-server` JSON-RPC adapter. The
                     // app-server holds one long-lived connection per turn, which is
@@ -346,6 +349,37 @@ fn is_internal_non_agent_activity(job: &RuntimeJob) -> bool {
     is_builtin_lifecycle_activity(job) || is_server_owned_pr_feedback_inspection(job)
 }
 
+fn isolation_spawn_env_vars(job: &RuntimeJob) -> HashMap<String, String> {
+    let mut env_vars = HashMap::new();
+    let Some(isolation) = job.input.get("isolation").and_then(Value::as_object) else {
+        return env_vars;
+    };
+    if let Some(tier) = isolation
+        .get("tier")
+        .and_then(Value::as_str)
+        .filter(|tier| !tier.trim().is_empty())
+    {
+        env_vars.insert(AGENT_ISOLATION_TIER_ENV.to_string(), tier.to_string());
+    }
+    let allowlist = isolation
+        .get("network_allowlist")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .unwrap_or_default();
+    if !allowlist.is_empty() {
+        env_vars.insert(AGENT_NETWORK_ALLOWLIST_ENV.to_string(), allowlist);
+    }
+    env_vars
+}
+
 async fn persist_created_thread(state: &AppState, thread_id: &ThreadId) {
     let Some(db) = state.core.thread_db.as_ref() else {
         return;
@@ -487,6 +521,30 @@ mod tests {
             "codex-default",
             json!({ "activity": activity }),
         )
+    }
+
+    #[test]
+    fn isolation_spawn_env_vars_extracts_tier_and_allowlist() {
+        let mut job = runtime_job("implement_issue");
+        job.input = json!({
+            "activity": "implement_issue",
+            "isolation": {
+                "tier": "container",
+                "trust_class": "non_collaborator",
+                "network_allowlist": ["github.com", " api.anthropic.com ", ""],
+            }
+        });
+
+        let env_vars = isolation_spawn_env_vars(&job);
+
+        assert_eq!(
+            env_vars.get(AGENT_ISOLATION_TIER_ENV),
+            Some(&"container".to_string())
+        );
+        assert_eq!(
+            env_vars.get(AGENT_NETWORK_ALLOWLIST_ENV),
+            Some(&"github.com,api.anthropic.com".to_string())
+        );
     }
 
     fn workflow(definition_id: &str) -> WorkflowInstance {

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
@@ -7,6 +7,7 @@ use harness_core::config::stall_timeout::normalize_stall_timeout_secs;
 use harness_core::error::HarnessError;
 use harness_core::types::{ExecutionPhase, TurnId};
 use harness_protocol::notifications::{Notification, RpcNotification};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::time::{Duration, Instant};
@@ -91,6 +92,7 @@ pub(crate) struct TurnLifecycleOptions {
     pub timeout_secs: Option<u64>,
     pub stall_timeout_secs: Option<u64>,
     pub force_code_agent: bool,
+    pub env_vars: HashMap<String, String>,
 }
 
 pub(crate) async fn run_turn_lifecycle_with_options(
@@ -263,6 +265,7 @@ pub(crate) async fn run_turn_lifecycle_with_options(
             execution_phase: options.execution_phase,
             sandbox_mode: options.sandbox_mode,
             approval_policy: options.approval_policy.clone(),
+            env_vars: options.env_vars.clone(),
             ..Default::default()
         };
         Box::pin(agent.execute_stream(req, stream_tx))

--- a/crates/harness-workflow/src/runtime/tier_resolution.rs
+++ b/crates/harness-workflow/src/runtime/tier_resolution.rs
@@ -11,6 +11,8 @@ pub struct IsolationTierResolution {
     pub tier: IsolationTier,
     pub reason: String,
     pub trust_class: IsolationTrustClass,
+    #[serde(default)]
+    pub network_allowlist: Vec<String>,
 }
 
 pub fn resolve_isolation_tier(
@@ -35,6 +37,7 @@ pub fn resolve_isolation_tier(
         tier,
         reason,
         trust_class,
+        network_allowlist: config.network_allowlist.clone(),
     }
 }
 
@@ -59,6 +62,7 @@ mod tests {
 
         assert_eq!(resolution.tier, IsolationTier::Host);
         assert_eq!(resolution.trust_class, IsolationTrustClass::Trusted);
+        assert!(resolution.network_allowlist.is_empty());
         assert!(resolution.reason.contains("default isolation tier"));
     }
 
@@ -70,7 +74,7 @@ mod tests {
                 trust: IsolationTrustClass::NonCollaborator,
                 tier: IsolationTier::Container,
             }],
-            network_allowlist: Vec::new(),
+            network_allowlist: vec!["github.com".to_string(), "api.anthropic.com".to_string()],
         };
 
         let resolution = resolve_isolation_tier(
@@ -82,6 +86,10 @@ mod tests {
 
         assert_eq!(resolution.tier, IsolationTier::Container);
         assert_eq!(resolution.trust_class, IsolationTrustClass::NonCollaborator);
+        assert_eq!(
+            resolution.network_allowlist,
+            vec!["github.com".to_string(), "api.anthropic.com".to_string()]
+        );
         assert!(resolution
             .reason
             .contains("matched configured isolation rule"));


### PR DESCRIPTION
## Summary
- Add a shared host/container spawn contract for legacy agent CLI execution.
- Route GH1450 isolation evidence into runtime turn env controls, including network allowlist.
- Wrap Codex/Claude legacy spawn paths through the contract while preserving host sandbox behavior.
- Build container invocation with only the task workspace mounted, sanitized Docker process env, container secret filtering, and explicit allowlist/proxy metadata.

Refs #1450

## Verification
- cargo fmt --all -- --check
- cargo test -p harness-agents container_spawn
- cargo test -p harness-agents
- cargo test -p harness-server isolation_spawn_env_vars_extracts_tier_and_allowlist
- cargo test -p harness-workflow tier_resolution
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1450
- cargo test --workspace --no-run