### PR TITLE
docs: add container tier agent image guide

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+ARG NODE_BASE_IMAGE=docker.io/library/node:22-bookworm-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4
+FROM ${NODE_BASE_IMAGE}
+
+ARG CODEX_CLI_PACKAGE=@openai/codex@0.142.5
+ARG CLAUDE_CODE_PACKAGE=@anthropic-ai/claude-code@2.1.201
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        openssh-client \
+        python3 \
+        ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g "${CODEX_CLI_PACKAGE}" "${CLAUDE_CODE_PACKAGE}" \
+    && npm cache clean --force \
+    && command -v codex \
+    && command -v claude
+
+RUN useradd --create-home --home-dir /home/harness --shell /bin/bash harness \
+    && mkdir -p /workspace \
+    && chown -R harness:harness /workspace /home/harness
+
+ENV HOME=/home/harness
+WORKDIR /workspace
+USER harness
+ENTRYPOINT []

--- a/docker/agent/README.md
+++ b/docker/agent/README.md
@@ -1,0 +1,31 @@
+# Harness Agent Image
+
+This is the reference container-tier image for Harness agent spawns. It includes
+the Codex and Claude CLIs plus basic repository tools.
+
+Current pinned inputs:
+
+- Base image: `docker.io/library/node:22-bookworm-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4`
+- Codex CLI package: `@openai/codex@0.142.5`
+- Claude Code package: `@anthropic-ai/claude-code@2.1.201`
+
+Build and verify locally:
+
+```bash
+scripts/verify-agent-container-image.sh
+```
+
+Publish and pin an operator image:
+
+```bash
+docker build -f docker/agent/Dockerfile -t ghcr.io/OWNER/harness-agent:2026-07-04 docker/agent
+docker push ghcr.io/OWNER/harness-agent:2026-07-04
+docker buildx imagetools inspect ghcr.io/OWNER/harness-agent:2026-07-04
+```
+
+Use the reported `Digest:` value in runtime config:
+
+```bash
+export HARNESS_AGENT_CONTAINER_IMAGE=ghcr.io/OWNER/harness-agent@sha256:...
+scripts/verify-agent-container-image.sh
+```

--- a/docs/container-tier-operator-guide.md
+++ b/docs/container-tier-operator-guide.md
@@ -1,0 +1,95 @@
+# Container Tier Operator Guide
+
+Harness can route untrusted GitHub issue intake to the `container` isolation
+tier. The container tier runs the agent CLI through Docker with only the task
+workspace mounted, no inherited operator secrets, and the scoped GitHub token
+mapped to `GITHUB_TOKEN` and `GH_TOKEN` inside the container.
+
+## Build The Agent Image
+
+Use the reference image in `docker/agent/Dockerfile`. The Dockerfile pins the
+Node base image by digest and pins the default Codex and Claude CLI packages.
+
+```bash
+scripts/verify-agent-container-image.sh
+```
+
+That command builds the image, runs the fixture by immutable local image ID, and
+checks that:
+
+- `/workspace` is the mounted task workspace.
+- `codex` and `claude` are present.
+- only the scoped GitHub token names are present.
+- the container can run with `--network none`.
+
+Publish the image and configure Harness with a registry digest, not a mutable
+tag:
+
+```bash
+docker build -f docker/agent/Dockerfile -t ghcr.io/OWNER/harness-agent:2026-07-04 docker/agent
+docker push ghcr.io/OWNER/harness-agent:2026-07-04
+docker buildx imagetools inspect ghcr.io/OWNER/harness-agent:2026-07-04
+export HARNESS_AGENT_CONTAINER_IMAGE=ghcr.io/OWNER/harness-agent@sha256:...
+```
+
+Re-run the fixture against the published digest:
+
+```bash
+HARNESS_AGENT_CONTAINER_IMAGE=ghcr.io/OWNER/harness-agent@sha256:... \
+  scripts/verify-agent-container-image.sh
+```
+
+## Enable Container Routing
+
+Set an isolation rule for untrusted intake. Keep trusted work on `host` unless a
+project explicitly needs the stronger tier for all tasks.
+
+```toml
+[isolation]
+default_tier = "host"
+network_allowlist = [
+  "github.com",
+  "api.github.com",
+  "api.openai.com",
+  "api.anthropic.com",
+]
+
+[[isolation.rules]]
+trust = "non_collaborator"
+tier = "container"
+```
+
+Start the server with the pinned image in the environment:
+
+```bash
+export HARNESS_AGENT_CONTAINER_IMAGE=ghcr.io/OWNER/harness-agent@sha256:...
+harness --config harness.toml serve
+```
+
+If container tasks need network access, set an explicit egress proxy:
+
+```bash
+export HARNESS_AGENT_EGRESS_PROXY=http://127.0.0.1:8080
+```
+
+Without `HARNESS_AGENT_EGRESS_PROXY`, Harness keeps the container network closed
+even when an allowlist is configured. The allowlist is still passed into the
+container as `HARNESS_AGENT_EGRESS_ALLOWLIST` for proxy-side enforcement.
+
+## Health And Refusal Behavior
+
+On startup, Harness probes Docker. If a configured rule requires `container`
+and Docker is unavailable, health reports the `isolation` subsystem as degraded.
+Dispatch refuses matching untrusted intake instead of silently downgrading it to
+`host`.
+
+Check health before enabling the rule broadly:
+
+```bash
+curl -s http://127.0.0.1:9800/health | python3 -m json.tool
+```
+
+Roll out to one public repository first. Verify that a non-collaborator issue
+resolves to `container`, that the workspace mount is `/workspace`, and that the
+container environment exposes only the scoped token names needed by GitHub CLI
+or API calls.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -731,6 +731,11 @@ harness gc run .           # Detect signals, generate remediation drafts
 # Skills
 harness skill list         # List discovered skills
 
+# Container isolation
+See `docs/container-tier-operator-guide.md` to build the reference Codex/Claude
+agent image, pin it by digest, and route non-collaborator intake to the
+container tier.
+
 # ExecPlan
 harness plan init spec.md           # Initialize execution plan
 harness plan status exec-plan.md    # Check plan status

--- a/scripts/verify-agent-container-image.sh
+++ b/scripts/verify-agent-container-image.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="${HARNESS_AGENT_CONTAINER_IMAGE:-}"
+TMP_DIR="$(mktemp -d)"
+WORKSPACE=""
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+    if [[ -n "$WORKSPACE" ]]; then
+        rm -rf "$WORKSPACE"
+    fi
+}
+trap cleanup EXIT
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required to verify the agent container image" >&2
+    exit 127
+fi
+
+if [[ -z "$IMAGE" ]]; then
+    IID_FILE="$TMP_DIR/image.iid"
+    docker build \
+        --iidfile "$IID_FILE" \
+        -f "$ROOT/docker/agent/Dockerfile" \
+        -t harness-agent:fixture \
+        "$ROOT/docker/agent"
+    IMAGE="$(cat "$IID_FILE")"
+else
+    case "$IMAGE" in
+        *@sha256:*) docker pull "$IMAGE" ;;
+        sha256:*) ;;
+        *)
+            echo "HARNESS_AGENT_CONTAINER_IMAGE must be digest-pinned, for example ghcr.io/OWNER/harness-agent@sha256:..." >&2
+            exit 2
+            ;;
+    esac
+fi
+
+WORKSPACE="$(mktemp -d "$ROOT/.agent-container-fixture.XXXXXX")"
+printf "fixture workspace\n" >"$WORKSPACE/README.md"
+
+docker run \
+    --rm \
+    --workdir /workspace \
+    --mount "type=bind,src=$WORKSPACE,dst=/workspace" \
+    --network none \
+    --env GITHUB_TOKEN=fixture-scoped-token \
+    --env GH_TOKEN=fixture-scoped-token \
+    "$IMAGE" \
+    sh -lc '
+        set -eu
+        test "$(pwd)" = "/workspace"
+        test -f README.md
+        command -v codex >/dev/null
+        command -v claude >/dev/null
+        test "${GITHUB_TOKEN:-}" = "fixture-scoped-token"
+        test "${GH_TOKEN:-}" = "fixture-scoped-token"
+        if env | grep -E "^(ANTHROPIC_API_KEY|OPENAI_API_KEY|HARNESS_SCOPED_GITHUB_TOKEN)=" >/dev/null; then
+            echo "unexpected operator secret exposed in fixture" >&2
+            exit 1
+        fi
+    '
+
+echo "agent container fixture passed: $IMAGE"


### PR DESCRIPTION
## Summary
- Add a digest-pinned reference Dockerfile for the Harness agent container image with Codex and Claude CLIs installed.
- Add a fixture script that builds the image, runs it by immutable image ID, and verifies workspace mount, CLI presence, scoped token env, and closed-network execution.
- Add the operator guide for enabling container-tier routing and pinning a published agent image digest.

Closes #1450

## Verification
- scripts/verify-agent-container-image.sh
- HARNESS_AGENT_CONTAINER_IMAGE=sha256:ed0d80a45ec45322004ad3122c01241299af087889f0594ea84104c14985864d scripts/verify-agent-container-image.sh
- bash -n scripts/verify-agent-container-image.sh
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1450
- cargo test --workspace --no-run