### PR TITLE
feat(server): add repo memory API

### DIFF
--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -16,6 +16,7 @@ pub mod overview;
 pub mod preflight;
 pub mod projects;
 pub mod reconcile;
+pub mod repo_memory_api;
 pub mod rules;
 pub mod runtime_hosts;
 pub mod runtime_project_cache;

--- a/crates/harness-server/src/handlers/repo_memory_api.rs
+++ b/crates/harness-server/src/handlers/repo_memory_api.rs
@@ -1,0 +1,98 @@
+use crate::http::AppState;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use harness_workflow::runtime::RepoMemoryRecord;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub async fn list_project_repo_memory_route(
+    State(state): State<Arc<AppState>>,
+    Path(repo): Path<String>,
+) -> (StatusCode, Json<Value>) {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "workflow runtime store unavailable" })),
+        );
+    };
+    let repo = repo.trim();
+    if repo.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "repo must not be empty" })),
+        );
+    }
+
+    match store.list_repo_memory_records(repo).await {
+        Ok(records) => (
+            StatusCode::OK,
+            Json(json!({
+                "repo": repo,
+                "records": records.into_iter().map(repo_memory_record_json).collect::<Vec<_>>(),
+            })),
+        ),
+        Err(error) => {
+            tracing::error!(repo, "failed to list repo memory records: {error}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to list repo memory records" })),
+            )
+        }
+    }
+}
+
+pub async fn delete_repo_memory_record_route(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> (StatusCode, Json<Value>) {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "workflow runtime store unavailable" })),
+        );
+    };
+    let id = match Uuid::parse_str(id.trim()) {
+        Ok(id) => id,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "memory id must be a UUID" })),
+            )
+        }
+    };
+
+    match store.delete_repo_memory_record(id).await {
+        Ok(true) => (StatusCode::OK, Json(json!({ "deleted": true, "id": id }))),
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "repo memory record not found", "id": id })),
+        ),
+        Err(error) => {
+            tracing::error!(%id, "failed to delete repo memory record: {error}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to delete repo memory record" })),
+            )
+        }
+    }
+}
+
+fn repo_memory_record_json(record: RepoMemoryRecord) -> Value {
+    json!({
+        "id": record.id,
+        "repo": record.repo,
+        "activity_class": record.activity_class,
+        "outcome": record.outcome.db_value(),
+        "kind": record.kind.db_value(),
+        "payload": record.payload_json,
+        "evidence_ref": record.evidence_ref,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+        "last_used_at": record.last_used_at,
+        "use_count": record.use_count,
+    })
+}

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -88,6 +88,16 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
             post(task_mutation_routes::cancel_workflow_runtime),
         )
         .route(
+            "/api/projects/{id}/memory",
+            get(crate::handlers::repo_memory_api::list_project_repo_memory_route),
+        )
+        .route(
+            "/api/memory/{id}",
+            axum::routing::delete(
+                crate::handlers::repo_memory_api::delete_repo_memory_record_route,
+            ),
+        )
+        .route(
             "/api/runtime-hosts",
             get(crate::handlers::runtime_hosts::list_runtime_hosts),
         )

--- a/crates/harness-server/src/http/tests/mod.rs
+++ b/crates/harness-server/src/http/tests/mod.rs
@@ -31,6 +31,7 @@ mod health_route_tests;
 mod intake_auth_list_tests;
 mod recovery_followup_tests;
 mod recovery_tests;
+mod repo_memory_api_tests;
 mod runtime_dispatch_tests;
 mod runtime_task_route_tests;
 mod runtime_tree_tests;

--- a/crates/harness-server/src/http/tests/repo_memory_api_tests.rs
+++ b/crates/harness-server/src/http/tests/repo_memory_api_tests.rs
@@ -1,0 +1,180 @@
+use super::*;
+use crate::handlers::repo_memory_api::{
+    delete_repo_memory_record_route, list_project_repo_memory_route,
+};
+use axum::{http::Method, routing::delete};
+use harness_workflow::runtime::{
+    RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord, RepoMemoryRetrievalOptions,
+};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+
+#[tokio::test]
+async fn memory_api_lists_repo_and_prunes_from_retrieval() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let keep = store
+        .insert_repo_memory_record(
+            &RepoMemoryRecord::new(
+                "owner/repo",
+                "implement_issue",
+                RepoMemoryOutcome::Done,
+                RepoMemoryKind::ValidationCommand,
+                json!({"validation": [{"command": "cargo test", "status": "passed"}]}),
+            )
+            .with_evidence_ref("workflow:run-1:event:event-1"),
+        )
+        .await?;
+    let prune = store
+        .insert_repo_memory_record(
+            &RepoMemoryRecord::new(
+                "owner/repo",
+                "implement_issue",
+                RepoMemoryOutcome::Failed,
+                RepoMemoryKind::FailureLesson,
+                json!({"failure_class": "ci_warning", "lesson": "run clippy before pushing"}),
+            )
+            .with_evidence_ref("workflow:run-2:event:event-2"),
+        )
+        .await?;
+    store
+        .insert_repo_memory_record(&RepoMemoryRecord::new(
+            "owner/other",
+            "implement_issue",
+            RepoMemoryOutcome::Done,
+            RepoMemoryKind::EnvironmentNote,
+            json!({"note": "other repo"}),
+        ))
+        .await?;
+    let app = memory_api_app(state.clone());
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/projects/owner%2Frepo/memory")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["repo"], "owner/repo");
+    let records = body["records"]
+        .as_array()
+        .expect("records should be an array");
+    assert_eq!(records.len(), 2);
+    assert!(records
+        .iter()
+        .any(|record| record["id"] == keep.id.to_string()));
+    assert!(records
+        .iter()
+        .any(|record| record["id"] == prune.id.to_string()));
+    assert!(records.iter().all(|record| record["repo"] == "owner/repo"));
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri(format!("/api/memory/{}", prune.id))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["deleted"], true);
+    assert_eq!(body["id"], prune.id.to_string());
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/memory/not-a-uuid")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/projects/owner%2Frepo/memory")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    let records = body["records"]
+        .as_array()
+        .expect("records should be an array");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["id"], keep.id.to_string());
+
+    let retrieved = store
+        .retrieve_repo_memory_records(
+            "owner/repo",
+            "implement_issue",
+            RepoMemoryRetrievalOptions::default(),
+        )
+        .await?;
+    assert!(retrieved.iter().any(|entry| entry.record.id == keep.id));
+    assert!(retrieved.iter().all(|entry| entry.record.id != prune.id));
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_api_rejects_missing_store() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    let app = memory_api_app(state);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/projects/owner%2Frepo/memory")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/memory/not-a-uuid")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    Ok(())
+}
+
+fn memory_api_app(state: std::sync::Arc<crate::http::AppState>) -> Router {
+    Router::new()
+        .route(
+            "/api/projects/{id}/memory",
+            get(list_project_repo_memory_route),
+        )
+        .route("/api/memory/{id}", delete(delete_repo_memory_record_route))
+        .with_state(state)
+}
+
+async fn response_json(response: axum::response::Response) -> anyhow::Result<Value> {
+    let body = response.into_body().collect().await?.to_bytes();
+    Ok(serde_json::from_slice(&body)?)
+}


### PR DESCRIPTION
## Summary
- add GET /api/projects/{id}/memory to list repo-scoped memory records
- add DELETE /api/memory/{id} to prune one repo memory record
- verify pruned records disappear from subsequent API listing and retrieval

Linked work: #1448
Refs #1448

## Verification
- cargo test -p harness-server memory_api
- cargo check -p harness-server --all-targets
- cargo fmt --all -- --check
- git diff --check
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1448
- python3 checks/check_workflow.py --repo .
- cargo clippy --workspace --all-targets -- -D warnings