### PR TITLE
feat(workflow): gate repo memory by config

### DIFF
--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -221,6 +221,12 @@ pub struct RuntimeActivityRetryPolicy {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkflowMemoryPolicy {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct WorkflowConfig {
     #[serde(default)]
     pub workflow: WorkflowIdentityPolicy,
@@ -244,6 +250,8 @@ pub struct WorkflowConfig {
     pub runtime_worker: RuntimeWorkerPolicy,
     #[serde(default)]
     pub runtime_retry_policy: RuntimeRetryPolicy,
+    #[serde(default)]
+    pub memory: WorkflowMemoryPolicy,
     #[serde(default)]
     pub storage: WorkflowStoragePolicy,
     #[serde(default)]

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -52,6 +52,7 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert_eq!(cfg.runtime_worker.concurrency, 10);
     assert_eq!(cfg.runtime_worker.lease_ttl_secs, 3900);
     assert!(cfg.runtime_retry_policy.is_empty());
+    assert!(!cfg.memory.enabled);
     assert!(cfg.issue_workflow.auto_replan_on_plan_issue);
     assert!(cfg.pr_scope_guard.enabled);
     assert_eq!(cfg.pr_scope_guard.max_files_changed, 30);
@@ -194,6 +195,8 @@ runtime_retry_policy:
       max_failed_activity_retries: 2
       retry_delay_secs: 10
       max_retry_delay_secs: 60
+memory:
+  enabled: true
 storage:
   schema_namespace: orchestration
   orphan_reaper_enabled: false
@@ -353,6 +356,7 @@ Body
             .and_then(|policy| policy.max_retry_delay_secs),
         Some(60)
     );
+    assert!(cfg.memory.enabled);
     assert_eq!(cfg.storage.schema_namespace, "orchestration");
     assert!(!cfg.storage.orphan_reaper_enabled);
     assert_eq!(cfg.storage.orphan_reaper_interval_secs, 44);

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -28,7 +28,7 @@ use super::prompt_input_telemetry::{
 use super::prompt_packet::{
     build_runtime_job_prompt, build_runtime_prompt_packet, prompt_packet_digest,
 };
-use super::repo_memory_prompt::repo_memory_for_prompt_packet;
+use super::repo_memory_prompt::{repo_memory_config_artifact, repo_memory_for_prompt_packet};
 use super::runtime_profile::{
     agent_name_for_runtime_kind, runtime_profile_approval_policy, runtime_profile_for_job,
     runtime_profile_sandbox_mode,
@@ -110,7 +110,9 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
         .await?;
         let activity_result: anyhow::Result<ActivityResult> = async {
             let project_root = runtime_workspace.run_project.clone();
+            let memory_enabled = workflow_document.config.memory.enabled;
             let repo_memory = repo_memory_for_prompt_packet(
+                memory_enabled,
                 self.state.core.workflow_runtime_store.as_deref(),
                 workflow.as_ref(),
                 &job,
@@ -123,7 +125,7 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                 &source_project_root,
                 &runtime_profile,
                 &workflow_document,
-                &repo_memory,
+                &repo_memory.records,
             );
             let prompt_packet_digest = prompt_packet_digest(&prompt_packet);
             self.record_prompt_packet_prepared(&job, &prompt_packet, &prompt_packet_digest)
@@ -205,7 +207,13 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                 agent_name,
                 &project_root,
                 &prompt_packet_digest,
-            );
+            )
+            .with_artifact(repo_memory_config_artifact(memory_enabled));
+            let result = if let Some(degradation) = repo_memory.degradation {
+                result.with_artifact(degradation)
+            } else {
+                result
+            };
             Ok(
                 verify_merge_completion_if_needed(self.state, &job, workflow.as_ref(), result)
                     .await,

--- a/crates/harness-server/src/workflow_runtime_worker/repo_memory_prompt.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/repo_memory_prompt.rs
@@ -1,28 +1,51 @@
 use harness_workflow::runtime::{
-    RepoMemoryRetrievalOptions, RetrievedRepoMemoryRecord, RuntimeJob, WorkflowInstance,
-    WorkflowRuntimeStore,
+    ActivityArtifact, RepoMemoryRetrievalOptions, RetrievedRepoMemoryRecord, RuntimeJob,
+    WorkflowInstance, WorkflowRuntimeStore, REPO_MEMORY_CONFIG_ARTIFACT,
+    REPO_MEMORY_DEGRADATION_ARTIFACT,
 };
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::data_helpers::activity_name;
 
+#[derive(Debug, Default)]
+pub(super) struct RepoMemoryPromptContext {
+    pub(super) records: Vec<RetrievedRepoMemoryRecord>,
+    pub(super) degradation: Option<ActivityArtifact>,
+}
+
 pub(super) async fn repo_memory_for_prompt_packet(
+    memory_enabled: bool,
     store: Option<&WorkflowRuntimeStore>,
     workflow: Option<&WorkflowInstance>,
     job: &RuntimeJob,
-) -> Vec<RetrievedRepoMemoryRecord> {
-    let Some(store) = store else {
-        return Vec::new();
-    };
+) -> RepoMemoryPromptContext {
+    if !memory_enabled {
+        return RepoMemoryPromptContext::default();
+    }
     let Some(repo) = repo_for_memory_prompt(workflow, job) else {
-        return Vec::new();
+        return RepoMemoryPromptContext::default();
     };
     let activity = activity_name(job);
+    let Some(store) = store else {
+        return RepoMemoryPromptContext {
+            records: Vec::new(),
+            degradation: Some(repo_memory_degradation_artifact(
+                job,
+                &repo,
+                &activity,
+                "workflow_runtime_store_unavailable",
+                None,
+            )),
+        };
+    };
     match store
         .retrieve_repo_memory_records(&repo, &activity, RepoMemoryRetrievalOptions::default())
         .await
     {
-        Ok(records) => records,
+        Ok(records) => RepoMemoryPromptContext {
+            records,
+            degradation: None,
+        },
         Err(error) => {
             tracing::warn!(
                 runtime_job_id = %job.id,
@@ -30,9 +53,49 @@ pub(super) async fn repo_memory_for_prompt_packet(
                 activity = %activity,
                 "failed to retrieve repo memory for runtime prompt packet: {error}"
             );
-            Vec::new()
+            RepoMemoryPromptContext {
+                records: Vec::new(),
+                degradation: Some(repo_memory_degradation_artifact(
+                    job,
+                    &repo,
+                    &activity,
+                    "repo_memory_retrieval_failed",
+                    Some(&error),
+                )),
+            }
         }
     }
+}
+
+pub(super) fn repo_memory_config_artifact(enabled: bool) -> ActivityArtifact {
+    ActivityArtifact::new(
+        REPO_MEMORY_CONFIG_ARTIFACT,
+        json!({
+            "schema": "harness.runtime.repo_memory_config.v1",
+            "enabled": enabled,
+        }),
+    )
+}
+
+fn repo_memory_degradation_artifact(
+    job: &RuntimeJob,
+    repo: &str,
+    activity: &str,
+    reason: &str,
+    error: Option<&anyhow::Error>,
+) -> ActivityArtifact {
+    let mut artifact = json!({
+        "schema": "harness.runtime.repo_memory_degradation.v1",
+        "memory_enabled": true,
+        "reason": reason,
+        "repo": repo,
+        "activity": activity,
+        "runtime_job_id": job.id,
+    });
+    if let Some(error) = error {
+        artifact["error"] = json!(error.to_string());
+    }
+    ActivityArtifact::new(REPO_MEMORY_DEGRADATION_ARTIFACT, artifact)
 }
 
 fn repo_for_memory_prompt(workflow: Option<&WorkflowInstance>, job: &RuntimeJob) -> Option<String> {
@@ -43,4 +106,49 @@ fn repo_for_memory_prompt(workflow: Option<&WorkflowInstance>, job: &RuntimeJob)
         .map(str::trim)
         .filter(|repo| !repo.is_empty())
         .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_workflow::runtime::{RuntimeJob, RuntimeKind};
+
+    fn repo_runtime_job() -> RuntimeJob {
+        RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": "implement_issue",
+                "repo": "owner/repo",
+            }),
+        )
+    }
+
+    #[tokio::test]
+    async fn memory_flag_degraded_disabled_flag_skips_prompt_memory_lookup() {
+        let context = repo_memory_for_prompt_packet(false, None, None, &repo_runtime_job()).await;
+
+        assert!(context.records.is_empty());
+        assert!(context.degradation.is_none());
+    }
+
+    #[tokio::test]
+    async fn memory_flag_degraded_enabled_store_unavailable_records_degradation() {
+        let job = repo_runtime_job();
+        let context = repo_memory_for_prompt_packet(true, None, None, &job).await;
+
+        assert!(context.records.is_empty());
+        let Some(degradation) = context.degradation else {
+            panic!("enabled memory without a store should produce visible evidence");
+        };
+        assert_eq!(degradation.artifact_type, REPO_MEMORY_DEGRADATION_ARTIFACT);
+        assert_eq!(
+            degradation.artifact["reason"],
+            "workflow_runtime_store_unavailable"
+        );
+        assert_eq!(degradation.artifact["repo"], "owner/repo");
+        assert_eq!(degradation.artifact["activity"], "implement_issue");
+        assert_eq!(degradation.artifact["memory_enabled"], true);
+    }
 }

--- a/crates/harness-workflow/src/runtime/memory_extract.rs
+++ b/crates/harness-workflow/src/runtime/memory_extract.rs
@@ -2,7 +2,9 @@ use super::model::{
     ActivityErrorKind, ActivityResult, ActivitySignal, ValidationRecord, WorkflowDecisionRecord,
     WorkflowEvent, WorkflowInstance,
 };
-use super::repo_memory::{RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord};
+use super::repo_memory::{
+    RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord, REPO_MEMORY_CONFIG_ARTIFACT,
+};
 use super::state_registry::WorkflowTerminalState;
 use super::store::WorkflowRuntimeStore;
 use serde_json::{json, Value};
@@ -60,6 +62,9 @@ fn extract_terminal_repo_memory_record(
         serde_json::from_value(event.event.get("activity_result").cloned().ok_or_else(|| {
             anyhow::anyhow!("RuntimeJobCompleted event missing activity_result")
         })?)?;
+    if !repo_memory_enabled_for_result(&result) {
+        return Ok(None);
+    }
     let Some(repo) = repo_from_completion(instance, event, &result) else {
         return Ok(None);
     };
@@ -88,6 +93,17 @@ fn extract_terminal_repo_memory_record(
         RepoMemoryRecord::new(repo, activity_class, outcome, kind, payload_json)
             .with_evidence_ref(format!("workflow:{}:event:{}", instance.id, event.id)),
     ))
+}
+
+fn repo_memory_enabled_for_result(result: &ActivityResult) -> bool {
+    result
+        .artifacts
+        .iter()
+        .rev()
+        .find(|artifact| artifact.artifact_type == REPO_MEMORY_CONFIG_ARTIFACT)
+        .and_then(|artifact| artifact.artifact.get("enabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn repo_memory_outcome(instance: &WorkflowInstance) -> Option<RepoMemoryOutcome> {
@@ -271,7 +287,8 @@ fn clean_string(value: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::runtime::model::{
-        ActivitySignal, RuntimeKind, WorkflowCommand, WorkflowDecision, WorkflowSubject,
+        ActivityArtifact, ActivitySignal, RuntimeKind, WorkflowCommand, WorkflowDecision,
+        WorkflowSubject,
     };
     use crate::runtime::prompt_task::{PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY};
     use chrono::{Duration, Utc};
@@ -325,18 +342,27 @@ mod tests {
         )
     }
 
+    fn with_repo_memory_enabled(result: ActivityResult) -> ActivityResult {
+        result.with_artifact(ActivityArtifact::new(
+            REPO_MEMORY_CONFIG_ARTIFACT,
+            json!({ "enabled": true }),
+        ))
+    }
+
     #[test]
     fn memory_extract_records_done_validation_commands() -> anyhow::Result<()> {
         let instance = test_prompt_workflow_instance("prompt-1", "done", Some("owner/repo"));
-        let result = ActivityResult::succeeded(
-            PROMPT_TASK_IMPLEMENT_ACTIVITY,
-            "Prompt implementation completed.",
-        )
-        .with_validation(ValidationRecord::new(
-            "cargo test -p harness-workflow memory_extract",
-            "passed",
-        ))
-        .with_validation(ValidationRecord::new("cargo clippy", "skipped"));
+        let result = with_repo_memory_enabled(
+            ActivityResult::succeeded(
+                PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                "Prompt implementation completed.",
+            )
+            .with_validation(ValidationRecord::new(
+                "cargo test -p harness-workflow memory_extract",
+                "passed",
+            ))
+            .with_validation(ValidationRecord::new("cargo clippy", "skipped")),
+        );
         let event = completion_event(&instance.id, result);
         let decision = accepted_decision(&instance.id, "done");
 
@@ -366,13 +392,15 @@ mod tests {
     #[test]
     fn memory_extract_records_failed_outcome_as_failure_lesson() -> anyhow::Result<()> {
         let instance = test_prompt_workflow_instance("prompt-2", "failed", Some("owner/repo"));
-        let result = ActivityResult::failed(
-            PROMPT_TASK_IMPLEMENT_ACTIVITY,
-            "Prompt implementation failed.",
-            "process timed out",
-        )
-        .with_error_kind(ActivityErrorKind::Timeout)
-        .with_validation(ValidationRecord::new("cargo test", "failed"));
+        let result = with_repo_memory_enabled(
+            ActivityResult::failed(
+                PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                "Prompt implementation failed.",
+                "process timed out",
+            )
+            .with_error_kind(ActivityErrorKind::Timeout)
+            .with_validation(ValidationRecord::new("cargo test", "failed")),
+        );
         let event = completion_event(&instance.id, result);
         let decision = accepted_decision(&instance.id, "failed");
 
@@ -391,12 +419,13 @@ mod tests {
     fn memory_extract_records_pr_feedback_category_when_no_validation_exists() -> anyhow::Result<()>
     {
         let instance = test_prompt_workflow_instance("prompt-3", "done", Some("owner/repo"));
-        let result =
+        let result = with_repo_memory_enabled(
             ActivityResult::succeeded("inspect_pr_feedback", "PR feedback inspection completed.")
                 .with_signal(ActivitySignal::new(
                     "PrReadyToMerge",
                     json!({ "repo": "owner/repo", "pr_number": 42 }),
-                ));
+                )),
+        );
         let event = completion_event(&instance.id, result);
         let decision = accepted_decision(&instance.id, "done");
 
@@ -419,15 +448,70 @@ mod tests {
     #[test]
     fn memory_extract_skips_terminal_runs_without_repo_scope() -> anyhow::Result<()> {
         let instance = test_prompt_workflow_instance("prompt-4", "done", None);
-        let result = ActivityResult::succeeded(
-            PROMPT_TASK_IMPLEMENT_ACTIVITY,
-            "Prompt implementation completed.",
-        )
-        .with_validation(ValidationRecord::new("cargo test", "passed"));
+        let result = with_repo_memory_enabled(
+            ActivityResult::succeeded(
+                PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                "Prompt implementation completed.",
+            )
+            .with_validation(ValidationRecord::new("cargo test", "passed")),
+        );
         let event = completion_event(&instance.id, result);
         let decision = accepted_decision(&instance.id, "done");
 
         assert!(extract_terminal_repo_memory_record(&instance, &event, &decision)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn memory_flag_degraded_disabled_flag_skips_repo_memory_extraction() -> anyhow::Result<()> {
+        let instance = test_prompt_workflow_instance("prompt-disabled", "done", Some("owner/repo"));
+        let decision = accepted_decision(&instance.id, "done");
+        let result_without_flag = ActivityResult::succeeded(
+            PROMPT_TASK_IMPLEMENT_ACTIVITY,
+            "Prompt implementation completed.",
+        )
+        .with_validation(ValidationRecord::new("cargo test", "passed"));
+        let event_without_flag = completion_event(&instance.id, result_without_flag);
+
+        assert!(
+            extract_terminal_repo_memory_record(&instance, &event_without_flag, &decision)?
+                .is_none()
+        );
+
+        let result_disabled = ActivityResult::succeeded(
+            PROMPT_TASK_IMPLEMENT_ACTIVITY,
+            "Prompt implementation completed.",
+        )
+        .with_artifact(ActivityArtifact::new(
+            REPO_MEMORY_CONFIG_ARTIFACT,
+            json!({ "enabled": false }),
+        ))
+        .with_validation(ValidationRecord::new("cargo test", "passed"));
+        let event_disabled = completion_event(&instance.id, result_disabled);
+
+        assert!(
+            extract_terminal_repo_memory_record(&instance, &event_disabled, &decision)?.is_none()
+        );
+
+        let result_server_disabled = ActivityResult::succeeded(
+            PROMPT_TASK_IMPLEMENT_ACTIVITY,
+            "Prompt implementation completed.",
+        )
+        .with_artifact(ActivityArtifact::new(
+            REPO_MEMORY_CONFIG_ARTIFACT,
+            json!({ "enabled": true }),
+        ))
+        .with_artifact(ActivityArtifact::new(
+            REPO_MEMORY_CONFIG_ARTIFACT,
+            json!({ "enabled": false }),
+        ))
+        .with_validation(ValidationRecord::new("cargo test", "passed"));
+        let event_server_disabled = completion_event(&instance.id, result_server_disabled);
+
+        assert!(
+            extract_terminal_repo_memory_record(&instance, &event_server_disabled, &decision)?
+                .is_none()
+        );
         Ok(())
     }
 
@@ -484,14 +568,16 @@ mod tests {
         let Some(store) = open_memory_extract_test_store().await? else {
             return Ok(());
         };
-        let result = ActivityResult::succeeded(
-            PROMPT_TASK_IMPLEMENT_ACTIVITY,
-            "Prompt implementation completed.",
-        )
-        .with_validation(ValidationRecord::new(
-            "cargo test -p harness-workflow memory_extract",
-            "passed",
-        ));
+        let result = with_repo_memory_enabled(
+            ActivityResult::succeeded(
+                PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                "Prompt implementation completed.",
+            )
+            .with_validation(ValidationRecord::new(
+                "cargo test -p harness-workflow memory_extract",
+                "passed",
+            )),
+        );
 
         let completion = commit_prompt_completion(&store, "prompt-commit-memory", &result)
             .await?
@@ -516,14 +602,16 @@ mod tests {
         sqlx::query("DROP TABLE workflow_repo_memory")
             .execute(store.pool())
             .await?;
-        let result = ActivityResult::succeeded(
-            PROMPT_TASK_IMPLEMENT_ACTIVITY,
-            "Prompt implementation completed.",
-        )
-        .with_validation(ValidationRecord::new(
-            "cargo test -p harness-workflow memory_extract",
-            "passed",
-        ));
+        let result = with_repo_memory_enabled(
+            ActivityResult::succeeded(
+                PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                "Prompt implementation completed.",
+            )
+            .with_validation(ValidationRecord::new(
+                "cargo test -p harness-workflow memory_extract",
+                "passed",
+            )),
+        );
 
         let completion = commit_prompt_completion(&store, "prompt-memory-insert-error", &result)
             .await?

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -101,7 +101,10 @@ pub use reducer::{
 pub use remote_facts::{
     remote_fact_command_dedupe_key, stable_remote_fact_hash, RemoteFactSnapshot,
 };
-pub use repo_memory::{RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord};
+pub use repo_memory::{
+    RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord, REPO_MEMORY_CONFIG_ARTIFACT,
+    REPO_MEMORY_DEGRADATION_ARTIFACT,
+};
 pub use state_registry::{
     known_workflow_definition_ids, workflow_state_definition, workflow_state_exists,
     workflow_states_for_definition, workflow_terminal_state_names_for_definition,

--- a/crates/harness-workflow/src/runtime/repo_memory.rs
+++ b/crates/harness-workflow/src/runtime/repo_memory.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
+pub const REPO_MEMORY_CONFIG_ARTIFACT: &str = "repo_memory_config";
+pub const REPO_MEMORY_DEGRADATION_ARTIFACT: &str = "repo_memory_degradation";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RepoMemoryOutcome {


### PR DESCRIPTION
## Summary

- Add `memory.enabled` to workflow config, defaulting off.
- Gate repo-memory prompt retrieval and terminal memory extraction on the config flag.
- Persist server-owned `repo_memory_config` evidence on runtime results and surface `repo_memory_degradation` evidence when enabled dispatch cannot access or query the memory store.
- Treat the last config artifact as authoritative so agent-supplied artifacts cannot bypass a disabled project flag.

Closes #1448

## Verification

- `cargo test -p harness-core load_workflow_config`
- `cargo test -p harness-workflow memory_extract`
- `cargo test -p harness-workflow memory_flag_degraded`
- `cargo test -p harness-server memory_flag_degraded`
- `cargo check -p harness-core --all-targets`
- `cargo check -p harness-workflow --all-targets`
- `cargo check -p harness-server --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1448`
- `python3 checks/check_workflow.py --repo .`
- `cargo clippy --workspace --all-targets -- -D warnings`