### PR TITLE
feat(workflow): add submission mode foundation

### DIFF
--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -2,7 +2,7 @@ use crate::task_runner::TaskId;
 use harness_core::config::isolation::IsolationTrustClass;
 use harness_workflow::runtime::{
     build_issue_submission_decision, build_prompt_submission_decision, DecisionValidator,
-    IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, ValidationContext,
+    IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, SubmissionMode, ValidationContext,
     WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance,
     WorkflowRuntimeStore, WorkflowSubject, PROMPT_TASK_DEFINITION_ID,
 };
@@ -148,6 +148,7 @@ async fn persist_issue_submission(
             depends_on: &depends_on_strings(ctx.depends_on),
             dependencies_blocked: ctx.dependencies_blocked,
             remote_fact_hash: ctx.remote_fact_hash,
+            submission_mode: SubmissionMode::Immediate,
         },
     );
     apply_decision(

--- a/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
@@ -2,7 +2,7 @@ use crate::task_runner::{TaskId, TaskStatus, TaskStore};
 use harness_workflow::runtime::{
     activity_result_value_has_closed_issue_evidence, build_issue_submission_decision,
     build_prompt_submission_decision, value_has_closed_issue_evidence,
-    IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, WorkflowCommand,
+    IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, SubmissionMode, WorkflowCommand,
     WorkflowCommandType, WorkflowDecision, WorkflowEvent, WorkflowInstance, WorkflowRuntimeStore,
     RUNTIME_JOB_COMPLETED_EVENT,
 };
@@ -341,6 +341,7 @@ async fn release_issue_after_dependencies(
             depends_on: &depends_on_strings(depends_on),
             dependencies_blocked: false,
             remote_fact_hash: None,
+            submission_mode: SubmissionMode::Immediate,
         },
     );
     let event = store

--- a/crates/harness-workflow/src/runtime/eval/run.rs
+++ b/crates/harness-workflow/src/runtime/eval/run.rs
@@ -1,9 +1,9 @@
 use super::manifest::EvalBenchmarkCase;
 use crate::runtime::{
     build_issue_submission_decision, IssueSubmissionDecisionInput, RuntimeCommandDispatcher,
-    RuntimeJobStatus, RuntimeProfile, ValidationContext, WorkflowCommand, WorkflowCommandStatus,
-    WorkflowCommandType, WorkflowDecision, WorkflowDecisionTransition, WorkflowDefinition,
-    WorkflowEvidence, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    RuntimeJobStatus, RuntimeProfile, SubmissionMode, ValidationContext, WorkflowCommand,
+    WorkflowCommandStatus, WorkflowCommandType, WorkflowDecision, WorkflowDecisionTransition,
+    WorkflowDefinition, WorkflowEvidence, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
     GITHUB_ISSUE_PR_DEFINITION_ID,
 };
 use chrono::Utc;
@@ -144,6 +144,7 @@ pub async fn enqueue_eval_case_workflow(
             depends_on: &[],
             dependencies_blocked: false,
             remote_fact_hash: None,
+            submission_mode: SubmissionMode::Immediate,
         },
     );
     let decision = with_eval_command_metadata(output.decision, input);
@@ -592,6 +593,7 @@ mod tests {
                 depends_on: &[],
                 dependencies_blocked: false,
                 remote_fact_hash: None,
+                submission_mode: SubmissionMode::Immediate,
             },
         );
         let decision = with_eval_command_metadata(output.decision, input);

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -118,7 +118,7 @@ pub use store::{
 };
 pub use submission::{
     build_issue_submission_decision, IssueSubmissionDecisionInput, IssueSubmissionDecisionOutput,
-    IssueSubmissionWorkflowAction,
+    IssueSubmissionWorkflowAction, SubmissionMode,
 };
 pub use terminal_state::{workflow_terminal_state, WorkflowTerminalState};
 pub use tier_resolution::{resolve_isolation_tier, IsolationTaskMetadata, IsolationTierResolution};

--- a/crates/harness-workflow/src/runtime/reducer/plan_issue_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/plan_issue_completion.rs
@@ -10,6 +10,7 @@ use crate::runtime::plan_issue::{
     ISSUE_PLAN_ACTIVITY, ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL,
 };
 use crate::runtime::reducer::GITHUB_ISSUE_PR_DEFINITION_ID;
+use crate::runtime::SubmissionMode;
 use serde_json::{json, Value};
 
 pub(super) fn issue_plan_decision_from_activity_result(
@@ -41,6 +42,7 @@ pub(super) fn issue_plan_decision_from_activity_result(
         issue_plan_summary(&issue_plan).unwrap_or_else(|| result.summary.trim().to_string());
     let completion_command_id =
         event_field_string(event, "command_id").unwrap_or_else(|| event.id.clone());
+    let submission_mode = submission_mode_from_event(event);
 
     Some(
         WorkflowDecision::new(
@@ -60,12 +62,22 @@ pub(super) fn issue_plan_decision_from_activity_result(
                 "activity": "implement_issue",
                 "issue_plan": issue_plan,
                 "issue_plan_summary": plan_summary,
+                "submission_mode": submission_mode.as_str(),
             }),
         ))
         .with_evidence(WorkflowEvidence::new("issue_plan", plan_summary))
         .with_evidence(runtime_completion_evidence(event, result))
         .high_confidence(),
     )
+}
+
+fn submission_mode_from_event(event: &WorkflowEvent) -> SubmissionMode {
+    event
+        .event
+        .pointer("/command/command/submission_mode")
+        .and_then(Value::as_str)
+        .and_then(SubmissionMode::from_wire_value)
+        .unwrap_or_default()
 }
 
 fn issue_plan_payload(result: &ActivityResult) -> Option<Value> {

--- a/crates/harness-workflow/src/runtime/submission.rs
+++ b/crates/harness-workflow/src/runtime/submission.rs
@@ -1,6 +1,32 @@
 use super::model::{WorkflowCommand, WorkflowDecision, WorkflowEvidence, WorkflowInstance};
 use super::plan_issue::ISSUE_PLAN_ACTIVITY;
 use super::remote_facts::remote_fact_command_dedupe_key;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubmissionMode {
+    #[default]
+    Immediate,
+    Deferred,
+}
+
+impl SubmissionMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Immediate => "immediate",
+            Self::Deferred => "deferred",
+        }
+    }
+
+    pub fn from_wire_value(value: &str) -> Option<Self> {
+        match value {
+            "immediate" => Some(Self::Immediate),
+            "deferred" => Some(Self::Deferred),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IssueSubmissionWorkflowAction {
@@ -20,6 +46,7 @@ pub struct IssueSubmissionDecisionInput<'a> {
     pub depends_on: &'a [String],
     pub dependencies_blocked: bool,
     pub remote_fact_hash: Option<&'a str>,
+    pub submission_mode: SubmissionMode,
 }
 
 #[derive(Debug, Clone)]
@@ -82,6 +109,7 @@ pub fn build_issue_submission_decision(
                     "fact_hash": input.remote_fact_hash,
                 },
                 "remote_fact_hash": input.remote_fact_hash,
+                "submission_mode": input.submission_mode.as_str(),
             }),
         ));
     } else if !input.dependencies_blocked {
@@ -106,6 +134,7 @@ pub fn build_issue_submission_decision(
                     "fact_hash": input.remote_fact_hash,
                 },
                 "remote_fact_hash": input.remote_fact_hash,
+                "submission_mode": input.submission_mode.as_str(),
             }),
         ));
     }

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -15,12 +15,12 @@ use super::{
     PrFeedbackDecisionInput, PrFeedbackOutcome, PrFeedbackSweepDecisionInput,
     PrFeedbackWorkflowAction, PromptSubmissionDecisionInput, QualityGateDecisionInput,
     QualityGateWorkflowAction, RuntimeCommandDispatcher, RuntimeJobExecutor,
-    RuntimeProfileSelector, RuntimeWorker, WorkflowCommandStatus, WorkflowDecisionTransition,
-    WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY,
-    PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL,
-    QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
-    SCOPE_TOO_LARGE_SIGNAL,
+    RuntimeProfileSelector, RuntimeWorker, SubmissionMode, WorkflowCommandStatus,
+    WorkflowDecisionTransition, WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID,
+    LOCAL_REVIEW_ACTIVITY, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
+    QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
+    QUALITY_PASSED_SIGNAL, SCOPE_TOO_LARGE_SIGNAL,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -184,6 +184,7 @@ fn issue_submission_decision_starts_discovered_issue_planning() {
             depends_on: &[],
             dependencies_blocked: false,
             remote_fact_hash: None,
+            submission_mode: SubmissionMode::Immediate,
         },
     );
 
@@ -228,6 +229,7 @@ fn issue_submission_decision_can_reopen_failed_issue_when_requested() {
             depends_on: &[],
             dependencies_blocked: false,
             remote_fact_hash: None,
+            submission_mode: SubmissionMode::Immediate,
         },
     );
 
@@ -257,6 +259,7 @@ fn issue_submission_decision_can_reopen_terminal_issue_for_planning() {
                 depends_on: &[],
                 dependencies_blocked: false,
                 remote_fact_hash: None,
+                submission_mode: SubmissionMode::Immediate,
             },
         );
 
@@ -295,6 +298,7 @@ fn issue_submission_decision_waits_for_dependencies_without_runtime_command() {
             depends_on: &depends_on,
             dependencies_blocked: true,
             remote_fact_hash: None,
+            submission_mode: SubmissionMode::Immediate,
         },
     );
 
@@ -325,6 +329,7 @@ fn issue_submission_decision_releases_dependencies_to_planning() {
             depends_on: &[],
             dependencies_blocked: false,
             remote_fact_hash: None,
+            submission_mode: SubmissionMode::Immediate,
         },
     );
 

--- a/crates/harness-workflow/src/runtime/tests/issue_planning.rs
+++ b/crates/harness-workflow/src/runtime/tests/issue_planning.rs
@@ -16,6 +16,7 @@ fn issue_submission_decision_force_execute_starts_implementation() {
             depends_on: &[],
             dependencies_blocked: false,
             remote_fact_hash: None,
+            submission_mode: SubmissionMode::Immediate,
         },
     );
 
@@ -58,6 +59,7 @@ fn issue_submission_decision_uses_remote_fact_hash_for_implementation_dedupe() {
             depends_on: &[],
             dependencies_blocked: false,
             remote_fact_hash: Some("sha256:abc"),
+            submission_mode: SubmissionMode::Immediate,
         },
     );
 
@@ -73,6 +75,43 @@ fn issue_submission_decision_uses_remote_fact_hash_for_implementation_dedupe() {
         output.decision.commands[0].command["dispatch_gate"]["fact_hash"],
         "sha256:abc"
     );
+}
+
+#[test]
+fn submission_mode_threads_through_issue_submission_commands() {
+    let labels = Vec::new();
+    let instance = issue_instance("discovered");
+
+    for (mode, expected) in [
+        (SubmissionMode::Immediate, "immediate"),
+        (SubmissionMode::Deferred, "deferred"),
+    ] {
+        let output = build_issue_submission_decision(
+            &instance,
+            IssueSubmissionDecisionInput {
+                task_id: "task-submission-mode",
+                repo: Some("owner/repo"),
+                issue_number: 123,
+                labels: &labels,
+                force_execute: true,
+                additional_prompt: None,
+                depends_on: &[],
+                dependencies_blocked: false,
+                remote_fact_hash: None,
+                submission_mode: mode,
+            },
+        );
+
+        assert_eq!(output.decision.next_state, "implementing");
+        assert_eq!(
+            output.decision.commands[0].activity_name(),
+            Some("implement_issue")
+        );
+        assert_eq!(
+            output.decision.commands[0].command["submission_mode"],
+            expected
+        );
+    }
 }
 
 #[test]
@@ -110,6 +149,7 @@ fn issue_plan_success_starts_implementation_with_plan_payload() {
         decision.commands[0].command["issue_plan_summary"],
         "Patch the PR repair completion reducer before touching prompts."
     );
+    assert_eq!(decision.commands[0].command["submission_mode"], "immediate");
     DecisionValidator::github_issue_pr()
         .validate(
             &instance,
@@ -117,6 +157,55 @@ fn issue_plan_success_starts_implementation_with_plan_payload() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("issue plan completion decision should validate");
+}
+
+#[test]
+fn submission_mode_deferred_survives_issue_plan_completion() {
+    let instance = issue_instance("planning");
+    let plan_payload = json!({
+        "summary": "Patch the submission reducer.",
+        "task_class": "runtime_or_data",
+        "target_files": [
+            "crates/harness-workflow/src/runtime/submission.rs"
+        ],
+        "validation_plan": ["cargo test -p harness-workflow submission_mode"],
+        "blockers": []
+    });
+    let result = ActivityResult::succeeded(super::super::ISSUE_PLAN_ACTIVITY, "Issue plan ready.")
+        .with_artifact(ActivityArtifact::new(
+            super::super::ISSUE_PLAN_ARTIFACT,
+            plan_payload,
+        ));
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        super::super::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(json!({
+        "command_id": "plan-command-deferred",
+        "command": WorkflowCommand::new(
+            WorkflowCommandType::EnqueueActivity,
+            "plan-command-deferred",
+            json!({
+                "activity": super::super::ISSUE_PLAN_ACTIVITY,
+                "submission_mode": "deferred",
+            }),
+        ),
+        "runtime_job_id": "job-1",
+        "activity_result": result,
+    }));
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("issue planning success should start implementation");
+
+    assert_eq!(decision.decision, "start_implementation_after_issue_plan");
+    assert_eq!(
+        decision.commands[0].activity_name(),
+        Some("implement_issue")
+    );
+    assert_eq!(decision.commands[0].command["submission_mode"], "deferred");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add a typed `SubmissionMode` (`immediate` / `deferred`) to issue submission decisions.
- Thread `submission_mode` into issue planning and implementation commands, with all current server/eval paths explicitly using `immediate`.
- Preserve deferred mode through the plan_issue -> implement_issue handoff for future candidate fan-out work.

Issues: #1449

## SpecRail

- Implements `SP1449-T001`.
- Does not enable candidate fan-out or change current single-candidate behavior.

## Verification

- `cargo test -p harness-workflow submission_mode`
- `cargo test -p harness-workflow issue_planning`
- `cargo check -p harness-workflow --all-targets`
- `cargo check -p harness-server --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1449`
- `python3 checks/check_workflow.py --repo .`
- `cargo clippy --workspace --all-targets -- -D warnings`