### PR TITLE
feat(workflow): add candidate fanout

### DIFF
--- a/config/WORKFLOW.md
+++ b/config/WORKFLOW.md
@@ -59,6 +59,10 @@ runtime_retry_policy:
   retry_delay_secs: 30
   max_retry_delay_secs: 900
   activity_retries: {}
+candidates:
+  enabled: false
+  n: 2
+  trigger_label: best-of-n
 storage:
   schema_namespace: workflow
   workflow_watchdog_enabled: false

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -3,6 +3,9 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+mod candidates;
+pub use candidates::WorkflowCandidatesPolicy;
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct WorkflowDocument {
     #[serde(default)]
@@ -252,6 +255,8 @@ pub struct WorkflowConfig {
     pub runtime_retry_policy: RuntimeRetryPolicy,
     #[serde(default)]
     pub memory: WorkflowMemoryPolicy,
+    #[serde(default)]
+    pub candidates: WorkflowCandidatesPolicy,
     #[serde(default)]
     pub storage: WorkflowStoragePolicy,
     #[serde(default)]

--- a/crates/harness-core/src/config/workflow/candidates.rs
+++ b/crates/harness-core/src/config/workflow/candidates.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowCandidatesPolicy {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_candidate_count")]
+    pub n: u32,
+    #[serde(default = "default_candidate_trigger_label")]
+    pub trigger_label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_turns_per_candidate: Option<u32>,
+}
+
+impl Default for WorkflowCandidatesPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            n: default_candidate_count(),
+            trigger_label: default_candidate_trigger_label(),
+            max_turns_per_candidate: None,
+        }
+    }
+}
+
+fn default_candidate_count() -> u32 {
+    2
+}
+
+fn default_candidate_trigger_label() -> String {
+    "best-of-n".to_string()
+}

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -53,6 +53,10 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert_eq!(cfg.runtime_worker.lease_ttl_secs, 3900);
     assert!(cfg.runtime_retry_policy.is_empty());
     assert!(!cfg.memory.enabled);
+    assert!(!cfg.candidates.enabled);
+    assert_eq!(cfg.candidates.n, 2);
+    assert_eq!(cfg.candidates.trigger_label, "best-of-n");
+    assert_eq!(cfg.candidates.max_turns_per_candidate, None);
     assert!(cfg.issue_workflow.auto_replan_on_plan_issue);
     assert!(cfg.pr_scope_guard.enabled);
     assert_eq!(cfg.pr_scope_guard.max_files_changed, 30);
@@ -197,6 +201,11 @@ runtime_retry_policy:
       max_retry_delay_secs: 60
 memory:
   enabled: true
+candidates:
+  enabled: true
+  n: 3
+  trigger_label: frontier
+  max_turns_per_candidate: 4
 storage:
   schema_namespace: orchestration
   orphan_reaper_enabled: false
@@ -357,6 +366,10 @@ Body
         Some(60)
     );
     assert!(cfg.memory.enabled);
+    assert!(cfg.candidates.enabled);
+    assert_eq!(cfg.candidates.n, 3);
+    assert_eq!(cfg.candidates.trigger_label, "frontier");
+    assert_eq!(cfg.candidates.max_turns_per_candidate, Some(4));
     assert_eq!(cfg.storage.schema_namespace, "orchestration");
     assert!(!cfg.storage.orphan_reaper_enabled);
     assert_eq!(cfg.storage.orphan_reaper_interval_secs, 44);

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -1,10 +1,11 @@
 use crate::task_runner::TaskId;
 use harness_core::config::isolation::IsolationTrustClass;
 use harness_workflow::runtime::{
-    build_issue_submission_decision, build_prompt_submission_decision, DecisionValidator,
-    IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, SubmissionMode, ValidationContext,
-    WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition, WorkflowInstance,
-    WorkflowRuntimeStore, WorkflowSubject, PROMPT_TASK_DEFINITION_ID,
+    build_issue_submission_decision, build_prompt_submission_decision,
+    candidate_fanout_from_policy, candidate_fanout_from_value, CandidateFanoutRequest,
+    DecisionValidator, IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, SubmissionMode,
+    ValidationContext, WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition,
+    WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject, PROMPT_TASK_DEFINITION_ID,
 };
 use serde_json::json;
 use std::path::Path;
@@ -135,7 +136,15 @@ async fn persist_issue_submission(
             true,
         ),
     };
-    let submitted_data = issue_submission_data(ctx, &project_id, &instance.data);
+    let workflow_cfg = harness_core::config::workflow::load_workflow_config(ctx.project_root)?;
+    let candidate_fanout = candidate_fanout_from_policy(
+        &instance.id,
+        ctx.issue_number,
+        ctx.labels,
+        &workflow_cfg.candidates,
+    )?;
+    let submitted_data =
+        issue_submission_data(ctx, &project_id, &instance.data, candidate_fanout.as_ref());
     let output = build_issue_submission_decision(
         &instance,
         IssueSubmissionDecisionInput {
@@ -149,6 +158,7 @@ async fn persist_issue_submission(
             dependencies_blocked: ctx.dependencies_blocked,
             remote_fact_hash: ctx.remote_fact_hash,
             submission_mode: SubmissionMode::Immediate,
+            candidate_fanout,
         },
     );
     apply_decision(
@@ -346,6 +356,7 @@ fn issue_submission_data(
     ctx: &IssueSubmissionRuntimeContext<'_>,
     project_id: &str,
     existing_data: &serde_json::Value,
+    candidate_fanout: Option<&CandidateFanoutRequest>,
 ) -> serde_json::Value {
     let last_remote_fact_hash = ctx
         .remote_fact_hash
@@ -369,6 +380,9 @@ fn issue_submission_data(
         "tracker_source": issue_tracker_source(ctx),
         "tracker_external_id": issue_tracker_external_id(ctx),
     });
+    if let (Some(object), Some(candidate_fanout)) = (data.as_object_mut(), candidate_fanout) {
+        object.insert("candidate_fanout".to_string(), json!(candidate_fanout));
+    }
     insert_author_trust_class(&mut data, ctx.author_trust_class);
     crate::workflow_runtime_policy::merge_runtime_retry_policy(ctx.project_root, data)
 }
@@ -464,6 +478,7 @@ struct IssueSubmissionFields {
     tracker_source: Option<String>,
     tracker_external_id: Option<String>,
     author_trust_class: Option<IsolationTrustClass>,
+    candidate_fanout: Option<CandidateFanoutRequest>,
 }
 
 fn issue_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<IssueSubmissionFields> {
@@ -485,6 +500,7 @@ fn issue_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<IssueS
         tracker_source: optional_string_field(&instance.data, "tracker_source"),
         tracker_external_id: optional_string_field(&instance.data, "tracker_external_id"),
         author_trust_class: author_trust_class_field(&instance.data)?,
+        candidate_fanout: candidate_fanout_from_value(&instance.data)?,
     })
 }
 

--- a/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
@@ -342,6 +342,7 @@ async fn release_issue_after_dependencies(
             dependencies_blocked: false,
             remote_fact_hash: None,
             submission_mode: SubmissionMode::Immediate,
+            candidate_fanout: fields.candidate_fanout,
         },
     );
     let event = store

--- a/crates/harness-server/src/workflow_runtime_submission/trust_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/trust_tests.rs
@@ -23,7 +23,7 @@ fn intake_trust_issue_submission_data_records_author_trust_class() -> anyhow::Re
         author_trust_class: Some(IsolationTrustClass::NonCollaborator),
     };
 
-    let data = issue_submission_data(&ctx, &project_root.to_string_lossy(), &json!({}));
+    let data = issue_submission_data(&ctx, &project_root.to_string_lossy(), &json!({}), None);
 
     assert_eq!(
         data["author_trust_class"],

--- a/crates/harness-server/src/workflow_runtime_worker/workspace.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/workspace.rs
@@ -296,9 +296,28 @@ pub(super) fn stable_runtime_workspace_task_id(
     workflow: Option<&WorkflowInstance>,
 ) -> TaskId {
     if let Some(workflow) = workflow {
+        if let Some(candidate_index) = runtime_candidate_index(job) {
+            if let Some(issue_number) = workflow
+                .data
+                .get("issue_number")
+                .and_then(|value| value.as_u64())
+            {
+                return TaskId::from_str(&format!("issue-{issue_number}-c{candidate_index}"));
+            }
+            let base = stable_runtime_workspace_task_id_for_workflow(workflow);
+            return TaskId::from_str(&format!("{}-c{candidate_index}", base.as_str()));
+        }
         return stable_runtime_workspace_task_id_for_workflow(workflow);
     }
     TaskId::from_str(&format!("runtime-job-{}", stable_hash_8(&job.id)))
+}
+
+fn runtime_candidate_index(job: &RuntimeJob) -> Option<u64> {
+    let candidate = job.input.get("command")?.get("candidate")?;
+    candidate
+        .get("candidate_index")?
+        .as_u64()
+        .filter(|index| *index > 0)
 }
 
 fn stable_runtime_workspace_task_id_for_workflow(workflow: &WorkflowInstance) -> TaskId {
@@ -397,6 +416,53 @@ mod tests {
             .as_str()
             .chars()
             .all(|ch| ch.is_ascii_alphanumeric() || ch == '-'));
+    }
+
+    #[test]
+    fn candidate_fanout_workspace_task_id_uses_candidate_index() {
+        let workflow = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            WorkflowSubject::new("issue", "issue:124"),
+        )
+        .with_id("/repo/root::repo:owner/repo::issue:124")
+        .with_data(json!({
+            "issue_number": 124,
+        }));
+        let first_job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": "implement_issue",
+                "command": {
+                    "candidate": {
+                        "candidate_index": 1,
+                    },
+                },
+            }),
+        );
+        let second_job = RuntimeJob::pending(
+            "command-2",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": "implement_issue",
+                "command": {
+                    "candidate": {
+                        "candidate_index": 2,
+                    },
+                },
+            }),
+        );
+
+        let first = stable_runtime_workspace_task_id(&first_job, Some(&workflow));
+        let second = stable_runtime_workspace_task_id(&second_job, Some(&workflow));
+
+        assert_eq!(first.as_str(), "issue-124-c1");
+        assert_eq!(second.as_str(), "issue-124-c2");
+        assert_ne!(first, second);
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/candidate_fanout.rs
+++ b/crates/harness-workflow/src/runtime/candidate_fanout.rs
@@ -1,0 +1,165 @@
+use harness_core::config::workflow::WorkflowCandidatesPolicy;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+pub const CANDIDATE_FANOUT_BUDGET_STRATEGY: &str = "split_runtime_profile_max_turns";
+pub const CANDIDATE_FANOUT_MIN_COUNT: u32 = 2;
+pub const CANDIDATE_FANOUT_MAX_COUNT: u32 = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CandidateFanoutRequest {
+    pub candidate_group_id: String,
+    pub candidate_count: u32,
+    pub trigger_label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_turns_per_candidate: Option<u32>,
+}
+
+impl CandidateFanoutRequest {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.candidate_group_id.trim().is_empty() {
+            anyhow::bail!("candidate_group_id must not be empty");
+        }
+        if !(CANDIDATE_FANOUT_MIN_COUNT..=CANDIDATE_FANOUT_MAX_COUNT)
+            .contains(&self.candidate_count)
+        {
+            anyhow::bail!(
+                "candidate_count must be between {CANDIDATE_FANOUT_MIN_COUNT} and {CANDIDATE_FANOUT_MAX_COUNT}"
+            );
+        }
+        if self.trigger_label.trim().is_empty() {
+            anyhow::bail!("trigger_label must not be empty");
+        }
+        if self.max_turns_per_candidate == Some(0) {
+            anyhow::bail!("max_turns_per_candidate must be greater than zero");
+        }
+        Ok(())
+    }
+
+    pub fn candidate_id(&self, candidate_index: u32) -> String {
+        format!("{}:c{}", self.candidate_group_id, candidate_index)
+    }
+
+    pub fn command_metadata(&self, candidate_index: u32) -> Value {
+        let candidate_id = self.candidate_id(candidate_index);
+        json!({
+            "candidate_group_id": self.candidate_group_id,
+            "candidate_id": candidate_id,
+            "candidate_index": candidate_index,
+            "candidate_count": self.candidate_count,
+            "trigger_label": self.trigger_label,
+            "budget": {
+                "strategy": CANDIDATE_FANOUT_BUDGET_STRATEGY,
+                "candidate_count": self.candidate_count,
+                "max_turns_per_candidate": self.max_turns_per_candidate,
+            },
+        })
+    }
+}
+
+pub fn candidate_fanout_from_policy(
+    workflow_id: &str,
+    issue_number: u64,
+    labels: &[String],
+    policy: &WorkflowCandidatesPolicy,
+) -> anyhow::Result<Option<CandidateFanoutRequest>> {
+    if !policy.enabled {
+        return Ok(None);
+    }
+    let trigger_label = policy.trigger_label.trim();
+    if trigger_label.is_empty() {
+        anyhow::bail!("candidates.trigger_label must not be empty");
+    }
+    if !labels.iter().any(|label| label.trim() == trigger_label) {
+        return Ok(None);
+    }
+    if policy.max_turns_per_candidate == Some(0) {
+        anyhow::bail!("candidates.max_turns_per_candidate must be greater than zero");
+    }
+    let request = CandidateFanoutRequest {
+        candidate_group_id: format!("{workflow_id}:candidate-group:issue-{issue_number}"),
+        candidate_count: policy
+            .n
+            .clamp(CANDIDATE_FANOUT_MIN_COUNT, CANDIDATE_FANOUT_MAX_COUNT),
+        trigger_label: trigger_label.to_string(),
+        max_turns_per_candidate: policy.max_turns_per_candidate,
+    };
+    request.validate()?;
+    Ok(Some(request))
+}
+
+pub fn candidate_fanout_from_value(
+    value: &Value,
+) -> anyhow::Result<Option<CandidateFanoutRequest>> {
+    let Some(raw) = value.get("candidate_fanout") else {
+        return Ok(None);
+    };
+    if raw.is_null() {
+        return Ok(None);
+    }
+    let request: CandidateFanoutRequest = serde_json::from_value(raw.clone())?;
+    request.validate()?;
+    Ok(Some(request))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy(enabled: bool, n: u32) -> WorkflowCandidatesPolicy {
+        WorkflowCandidatesPolicy {
+            enabled,
+            n,
+            trigger_label: "best-of-n".to_string(),
+            max_turns_per_candidate: None,
+        }
+    }
+
+    #[test]
+    fn candidate_fanout_requires_config_and_trigger_label() -> anyhow::Result<()> {
+        let labels = vec!["best-of-n".to_string()];
+
+        assert!(candidate_fanout_from_policy("wf-1", 123, &labels, &policy(false, 2))?.is_none());
+        assert!(candidate_fanout_from_policy("wf-1", 123, &[], &policy(true, 2))?.is_none());
+        assert!(candidate_fanout_from_policy("wf-1", 123, &labels, &policy(true, 2))?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn candidate_fanout_clamps_count_and_preserves_budget_override() -> anyhow::Result<()> {
+        let labels = vec!["best-of-n".to_string()];
+        let mut cfg = policy(true, 9);
+        cfg.max_turns_per_candidate = Some(4);
+
+        let request = candidate_fanout_from_policy("wf-1", 123, &labels, &cfg)?
+            .expect("label plus enabled config should fan out");
+
+        assert_eq!(request.candidate_count, 3);
+        assert_eq!(request.max_turns_per_candidate, Some(4));
+        Ok(())
+    }
+
+    #[test]
+    fn candidate_fanout_command_metadata_is_indexed() -> anyhow::Result<()> {
+        let request = CandidateFanoutRequest {
+            candidate_group_id: "wf-1:candidate-group:issue-123".to_string(),
+            candidate_count: 2,
+            trigger_label: "best-of-n".to_string(),
+            max_turns_per_candidate: None,
+        };
+
+        let metadata = request.command_metadata(2);
+
+        assert_eq!(metadata["candidate_index"], 2);
+        assert_eq!(metadata["candidate_count"], 2);
+        assert_eq!(
+            metadata["candidate_id"],
+            "wf-1:candidate-group:issue-123:c2"
+        );
+        assert_eq!(
+            metadata["budget"]["strategy"],
+            CANDIDATE_FANOUT_BUDGET_STRATEGY
+        );
+        Ok(())
+    }
+}

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Duration, Utc};
 use harness_core::config::isolation::{
     IsolationAvailability, IsolationConfig, IsolationTrustClass,
 };
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use uuid::Uuid;
 
@@ -232,7 +232,8 @@ impl<'a> RuntimeCommandDispatcher<'a> {
         }
 
         let activity = command.command.runtime_activity_key().to_string();
-        let runtime_profile = self.profile_for_command(&command).await?;
+        let mut runtime_profile = self.profile_for_command(&command).await?;
+        apply_candidate_runtime_budget(&mut runtime_profile, &command.command.command)?;
         let isolation =
             isolation_resolution_for_instance(instance.as_ref(), &self.isolation_config)
                 .with_context(|| {
@@ -327,6 +328,56 @@ impl<'a> RuntimeCommandDispatcher<'a> {
     }
 }
 
+fn apply_candidate_runtime_budget(
+    runtime_profile: &mut RuntimeProfile,
+    command_payload: &Value,
+) -> anyhow::Result<()> {
+    let Some(candidate) = command_payload.get("candidate") else {
+        return Ok(());
+    };
+    let candidate_count = required_positive_u32(candidate, "candidate_count")?;
+    let max_turns_per_candidate = optional_positive_u32(
+        candidate.pointer("/budget/max_turns_per_candidate"),
+        "candidate.budget.max_turns_per_candidate",
+    )?;
+    let max_turns = max_turns_per_candidate.or_else(|| {
+        runtime_profile
+            .max_turns
+            .map(|max_turns| (max_turns / candidate_count).max(1))
+    });
+    if let Some(max_turns) = max_turns {
+        runtime_profile.max_turns = Some(max_turns);
+    }
+    Ok(())
+}
+
+fn required_positive_u32(value: &Value, field: &str) -> anyhow::Result<u32> {
+    let raw = value
+        .get(field)
+        .ok_or_else(|| anyhow::anyhow!("candidate metadata missing {field}"))?;
+    positive_u32(raw, field)
+}
+
+fn optional_positive_u32(value: Option<&Value>, field: &str) -> anyhow::Result<Option<u32>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    positive_u32(value, field).map(Some)
+}
+
+fn positive_u32(value: &Value, field: &str) -> anyhow::Result<u32> {
+    let Some(raw) = value.as_u64() else {
+        anyhow::bail!("{field} must be an unsigned integer");
+    };
+    if raw == 0 || raw > u64::from(u32::MAX) {
+        anyhow::bail!("{field} must be between 1 and {}", u32::MAX);
+    }
+    Ok(raw as u32)
+}
+
 fn isolation_resolution_for_instance(
     instance: Option<&super::model::WorkflowInstance>,
     config: &IsolationConfig,
@@ -395,6 +446,44 @@ mod tests {
         assert_eq!(profile.model.as_deref(), Some("gpt-5.5"));
         assert_eq!(profile.reasoning_effort.as_deref(), Some("high"));
         assert_eq!(profile.timeout_secs, None);
+    }
+
+    #[test]
+    fn candidate_fanout_budget_splits_runtime_profile_max_turns() -> anyhow::Result<()> {
+        let mut profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
+        profile.max_turns = Some(9);
+        let payload = json!({
+            "candidate": {
+                "candidate_count": 3,
+                "budget": {
+                    "max_turns_per_candidate": null,
+                },
+            },
+        });
+
+        apply_candidate_runtime_budget(&mut profile, &payload)?;
+
+        assert_eq!(profile.max_turns, Some(3));
+        Ok(())
+    }
+
+    #[test]
+    fn candidate_fanout_budget_override_wins_over_split() -> anyhow::Result<()> {
+        let mut profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
+        profile.max_turns = Some(9);
+        let payload = json!({
+            "candidate": {
+                "candidate_count": 3,
+                "budget": {
+                    "max_turns_per_candidate": 5,
+                },
+            },
+        });
+
+        apply_candidate_runtime_budget(&mut profile, &payload)?;
+
+        assert_eq!(profile.max_turns, Some(5));
+        Ok(())
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/eval/run.rs
+++ b/crates/harness-workflow/src/runtime/eval/run.rs
@@ -145,6 +145,7 @@ pub async fn enqueue_eval_case_workflow(
             dependencies_blocked: false,
             remote_fact_hash: None,
             submission_mode: SubmissionMode::Immediate,
+            candidate_fanout: None,
         },
     );
     let decision = with_eval_command_metadata(output.decision, input);
@@ -594,6 +595,7 @@ mod tests {
                 dependencies_blocked: false,
                 remote_fact_hash: None,
                 submission_mode: SubmissionMode::Immediate,
+                candidate_fanout: None,
             },
         );
         let decision = with_eval_command_metadata(output.decision, input);

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -5,6 +5,7 @@
 //! instances, accepted commands, runtime jobs, and structured activity results.
 
 pub mod bus;
+mod candidate_fanout;
 mod candidate_selection;
 pub mod dispatcher;
 pub mod errors;
@@ -41,6 +42,10 @@ mod tests;
 mod tier_resolution_dispatch_tests;
 
 pub use bus::InMemoryWorkflowBus;
+pub use candidate_fanout::{
+    candidate_fanout_from_policy, candidate_fanout_from_value, CandidateFanoutRequest,
+    CANDIDATE_FANOUT_BUDGET_STRATEGY, CANDIDATE_FANOUT_MAX_COUNT, CANDIDATE_FANOUT_MIN_COUNT,
+};
 pub use candidate_selection::{
     select_candidate, CandidateCheckConclusion, CandidateDiffScope, CandidateEvidence,
     CandidateOutcome, CandidatePromotionRecord, CandidateRankingRecord, CandidateSelectionInput,

--- a/crates/harness-workflow/src/runtime/reducer/plan_issue_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/plan_issue_completion.rs
@@ -10,7 +10,8 @@ use crate::runtime::plan_issue::{
     ISSUE_PLAN_ACTIVITY, ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL,
 };
 use crate::runtime::reducer::GITHUB_ISSUE_PR_DEFINITION_ID;
-use crate::runtime::SubmissionMode;
+use crate::runtime::submission::append_candidate_commands;
+use crate::runtime::{candidate_fanout_from_value, SubmissionMode};
 use serde_json::{json, Value};
 
 pub(super) fn issue_plan_decision_from_activity_result(
@@ -43,32 +44,45 @@ pub(super) fn issue_plan_decision_from_activity_result(
     let completion_command_id =
         event_field_string(event, "command_id").unwrap_or_else(|| event.id.clone());
     let submission_mode = submission_mode_from_event(event);
+    let candidate_fanout = match candidate_fanout_from_value(&instance.data) {
+        Ok(candidate_fanout) => candidate_fanout,
+        Err(error) => {
+            let reason =
+                format!("runtime issue workflow has invalid candidate_fanout metadata: {error}");
+            return Some(invalid_agent_output_blocked_decision(
+                instance, event, result, &reason,
+            ));
+        }
+    };
 
-    Some(
-        WorkflowDecision::new(
-            &instance.id,
-            &instance.state,
-            "start_implementation_after_issue_plan",
-            "implementing",
-            "issue planning activity produced a structured plan",
-        )
-        .with_command(WorkflowCommand::new(
-            WorkflowCommandType::EnqueueActivity,
-            format!(
-                "issue-plan:{}:implement:{completion_command_id}",
-                instance.id
-            ),
-            json!({
-                "activity": "implement_issue",
-                "issue_plan": issue_plan,
-                "issue_plan_summary": plan_summary,
-                "submission_mode": submission_mode.as_str(),
-            }),
-        ))
-        .with_evidence(WorkflowEvidence::new("issue_plan", plan_summary))
-        .with_evidence(runtime_completion_evidence(event, result))
-        .high_confidence(),
+    let command = WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        format!(
+            "issue-plan:{}:implement:{completion_command_id}",
+            instance.id
+        ),
+        json!({
+            "activity": "implement_issue",
+            "issue_plan": issue_plan,
+            "issue_plan_summary": plan_summary,
+            "submission_mode": submission_mode.as_str(),
+        }),
+    );
+    let decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "start_implementation_after_issue_plan",
+        "implementing",
+        "issue planning activity produced a structured plan",
     )
+    .with_evidence(WorkflowEvidence::new("issue_plan", plan_summary))
+    .with_evidence(runtime_completion_evidence(event, result))
+    .high_confidence();
+    Some(append_candidate_commands(
+        decision,
+        command,
+        candidate_fanout.as_ref(),
+    ))
 }
 
 fn submission_mode_from_event(event: &WorkflowEvent) -> SubmissionMode {

--- a/crates/harness-workflow/src/runtime/submission.rs
+++ b/crates/harness-workflow/src/runtime/submission.rs
@@ -1,7 +1,11 @@
-use super::model::{WorkflowCommand, WorkflowDecision, WorkflowEvidence, WorkflowInstance};
+use super::candidate_fanout::CandidateFanoutRequest;
+use super::model::{
+    WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowEvidence, WorkflowInstance,
+};
 use super::plan_issue::ISSUE_PLAN_ACTIVITY;
 use super::remote_facts::remote_fact_command_dedupe_key;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -35,7 +39,7 @@ pub enum IssueSubmissionWorkflowAction {
     WaitForDependencies,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct IssueSubmissionDecisionInput<'a> {
     pub task_id: &'a str,
     pub repo: Option<&'a str>,
@@ -47,6 +51,7 @@ pub struct IssueSubmissionDecisionInput<'a> {
     pub dependencies_blocked: bool,
     pub remote_fact_hash: Option<&'a str>,
     pub submission_mode: SubmissionMode,
+    pub candidate_fanout: Option<CandidateFanoutRequest>,
 }
 
 #[derive(Debug, Clone)]
@@ -98,10 +103,10 @@ pub fn build_issue_submission_decision(
                 input.task_id
             ),
         );
-        decision = decision.with_command(WorkflowCommand::new(
-            super::model::WorkflowCommandType::EnqueueActivity,
+        let command = WorkflowCommand::new(
+            WorkflowCommandType::EnqueueActivity,
             dedupe_key,
-            serde_json::json!({
+            json!({
                 "activity": "implement_issue",
                 "additional_prompt": input.additional_prompt,
                 "dispatch_gate": {
@@ -111,7 +116,8 @@ pub fn build_issue_submission_decision(
                 "remote_fact_hash": input.remote_fact_hash,
                 "submission_mode": input.submission_mode.as_str(),
             }),
-        ));
+        );
+        decision = append_candidate_commands(decision, command, input.candidate_fanout.as_ref());
     } else if !input.dependencies_blocked {
         let dedupe_key = submission_command_dedupe_key(
             ISSUE_PLAN_ACTIVITY,
@@ -124,9 +130,9 @@ pub fn build_issue_submission_decision(
             ),
         );
         decision = decision.with_command(WorkflowCommand::new(
-            super::model::WorkflowCommandType::EnqueueActivity,
+            WorkflowCommandType::EnqueueActivity,
             dedupe_key,
-            serde_json::json!({
+            json!({
                 "activity": ISSUE_PLAN_ACTIVITY,
                 "additional_prompt": input.additional_prompt,
                 "dispatch_gate": {
@@ -155,6 +161,51 @@ pub fn build_issue_submission_decision(
     .high_confidence();
 
     IssueSubmissionDecisionOutput { action, decision }
+}
+
+pub(crate) fn append_candidate_commands(
+    mut decision: WorkflowDecision,
+    command: WorkflowCommand,
+    candidate_fanout: Option<&CandidateFanoutRequest>,
+) -> WorkflowDecision {
+    let Some(candidate_fanout) = candidate_fanout else {
+        return decision.with_command(command);
+    };
+    for candidate_index in 1..=candidate_fanout.candidate_count {
+        decision = decision.with_command(candidate_command(
+            &command,
+            candidate_fanout,
+            candidate_index,
+        ));
+    }
+    decision
+}
+
+pub(crate) fn candidate_command(
+    command: &WorkflowCommand,
+    candidate_fanout: &CandidateFanoutRequest,
+    candidate_index: u32,
+) -> WorkflowCommand {
+    let mut candidate_payload = command.command.clone();
+    if let Some(object) = candidate_payload.as_object_mut() {
+        object.insert(
+            "submission_mode".to_string(),
+            json!(SubmissionMode::Deferred.as_str()),
+        );
+        object.insert(
+            "candidate".to_string(),
+            candidate_fanout.command_metadata(candidate_index),
+        );
+    }
+    WorkflowCommand::new(
+        command.command_type,
+        candidate_dedupe_key(&command.dedupe_key, candidate_index),
+        candidate_payload,
+    )
+}
+
+pub(crate) fn candidate_dedupe_key(base: &str, candidate_index: u32) -> String {
+    format!("{base}:candidate:c{candidate_index}")
 }
 
 fn labels_summary(labels: &[String]) -> String {

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -9,18 +9,18 @@ use super::validator::{DecisionValidator, ValidationContext, WorkflowDecisionRej
 use super::{
     build_issue_submission_decision, build_plan_issue_decision, build_pr_detected_decision,
     build_pr_feedback_decision, build_pr_feedback_sweep_decision, build_prompt_submission_decision,
-    build_quality_gate_run_decision, reduce_runtime_job_completed, CommandDispatchOutcome,
-    InMemoryWorkflowBus, IssueSubmissionDecisionInput, IssueSubmissionWorkflowAction,
-    PlanIssueDecisionInput, PlanIssueWorkflowAction, PrDetectedDecisionInput,
-    PrFeedbackDecisionInput, PrFeedbackOutcome, PrFeedbackSweepDecisionInput,
-    PrFeedbackWorkflowAction, PromptSubmissionDecisionInput, QualityGateDecisionInput,
-    QualityGateWorkflowAction, RuntimeCommandDispatcher, RuntimeJobExecutor,
-    RuntimeProfileSelector, RuntimeWorker, SubmissionMode, WorkflowCommandStatus,
-    WorkflowDecisionTransition, WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID,
-    LOCAL_REVIEW_ACTIVITY, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
-    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
-    QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
-    QUALITY_PASSED_SIGNAL, SCOPE_TOO_LARGE_SIGNAL,
+    build_quality_gate_run_decision, reduce_runtime_job_completed, CandidateFanoutRequest,
+    CommandDispatchOutcome, InMemoryWorkflowBus, IssueSubmissionDecisionInput,
+    IssueSubmissionWorkflowAction, PlanIssueDecisionInput, PlanIssueWorkflowAction,
+    PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
+    PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, PromptSubmissionDecisionInput,
+    QualityGateDecisionInput, QualityGateWorkflowAction, RuntimeCommandDispatcher,
+    RuntimeJobExecutor, RuntimeProfileSelector, RuntimeWorker, SubmissionMode,
+    WorkflowCommandStatus, WorkflowDecisionTransition, WorkflowRuntimeStore,
+    GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY, PROMPT_TASK_DEFINITION_ID,
+    PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
+    QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
+    QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL, SCOPE_TOO_LARGE_SIGNAL,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -185,6 +185,7 @@ fn issue_submission_decision_starts_discovered_issue_planning() {
             dependencies_blocked: false,
             remote_fact_hash: None,
             submission_mode: SubmissionMode::Immediate,
+            candidate_fanout: None,
         },
     );
 
@@ -230,6 +231,7 @@ fn issue_submission_decision_can_reopen_failed_issue_when_requested() {
             dependencies_blocked: false,
             remote_fact_hash: None,
             submission_mode: SubmissionMode::Immediate,
+            candidate_fanout: None,
         },
     );
 
@@ -260,6 +262,7 @@ fn issue_submission_decision_can_reopen_terminal_issue_for_planning() {
                 dependencies_blocked: false,
                 remote_fact_hash: None,
                 submission_mode: SubmissionMode::Immediate,
+                candidate_fanout: None,
             },
         );
 
@@ -299,6 +302,7 @@ fn issue_submission_decision_waits_for_dependencies_without_runtime_command() {
             dependencies_blocked: true,
             remote_fact_hash: None,
             submission_mode: SubmissionMode::Immediate,
+            candidate_fanout: None,
         },
     );
 
@@ -330,6 +334,7 @@ fn issue_submission_decision_releases_dependencies_to_planning() {
             dependencies_blocked: false,
             remote_fact_hash: None,
             submission_mode: SubmissionMode::Immediate,
+            candidate_fanout: None,
         },
     );
 

--- a/crates/harness-workflow/src/runtime/tests/issue_planning.rs
+++ b/crates/harness-workflow/src/runtime/tests/issue_planning.rs
@@ -17,6 +17,7 @@ fn issue_submission_decision_force_execute_starts_implementation() {
             dependencies_blocked: false,
             remote_fact_hash: None,
             submission_mode: SubmissionMode::Immediate,
+            candidate_fanout: None,
         },
     );
 
@@ -60,6 +61,7 @@ fn issue_submission_decision_uses_remote_fact_hash_for_implementation_dedupe() {
             dependencies_blocked: false,
             remote_fact_hash: Some("sha256:abc"),
             submission_mode: SubmissionMode::Immediate,
+            candidate_fanout: None,
         },
     );
 
@@ -99,6 +101,7 @@ fn submission_mode_threads_through_issue_submission_commands() {
                 dependencies_blocked: false,
                 remote_fact_hash: None,
                 submission_mode: mode,
+                candidate_fanout: None,
             },
         );
 
@@ -112,6 +115,69 @@ fn submission_mode_threads_through_issue_submission_commands() {
             expected
         );
     }
+}
+
+#[test]
+fn candidate_fanout_force_execute_starts_deferred_candidate_commands() -> anyhow::Result<()> {
+    let labels = vec!["best-of-n".to_string()];
+    let instance = issue_instance("discovered");
+    let fanout = CandidateFanoutRequest {
+        candidate_group_id: "wf-1:candidate-group:issue-123".to_string(),
+        candidate_count: 2,
+        trigger_label: "best-of-n".to_string(),
+        max_turns_per_candidate: Some(4),
+    };
+
+    let output = build_issue_submission_decision(
+        &instance,
+        IssueSubmissionDecisionInput {
+            task_id: "task-candidates",
+            repo: Some("owner/repo"),
+            issue_number: 123,
+            labels: &labels,
+            force_execute: true,
+            additional_prompt: None,
+            depends_on: &[],
+            dependencies_blocked: false,
+            remote_fact_hash: Some("sha256:fanout"),
+            submission_mode: SubmissionMode::Immediate,
+            candidate_fanout: Some(fanout),
+        },
+    );
+
+    assert_eq!(
+        output.action,
+        IssueSubmissionWorkflowAction::RunImplementation
+    );
+    assert_eq!(output.decision.commands.len(), 2);
+    assert_eq!(
+        output.decision.commands[0].dedupe_key,
+        "implement_issue:sha256:fanout:candidate:c1"
+    );
+    assert_eq!(
+        output.decision.commands[1].dedupe_key,
+        "implement_issue:sha256:fanout:candidate:c2"
+    );
+    for (index, command) in output.decision.commands.iter().enumerate() {
+        let candidate_index = index + 1;
+        assert_eq!(command.activity_name(), Some("implement_issue"));
+        assert_eq!(command.command["submission_mode"], "deferred");
+        assert_eq!(
+            command.command["candidate"]["candidate_index"],
+            candidate_index
+        );
+        assert_eq!(command.command["candidate"]["candidate_count"], 2);
+        assert_eq!(
+            command.command["candidate"]["budget"]["max_turns_per_candidate"],
+            4
+        );
+    }
+    DecisionValidator::github_issue_pr().validate(
+        &instance,
+        &output.decision,
+        &ValidationContext::new("workflow-policy", Utc::now()),
+    )?;
+    Ok(())
 }
 
 #[test]
@@ -157,6 +223,56 @@ fn issue_plan_success_starts_implementation_with_plan_payload() {
             &ValidationContext::new("runtime-1", Utc::now()),
         )
         .expect("issue plan completion decision should validate");
+}
+
+#[test]
+fn candidate_fanout_issue_plan_completion_uses_persisted_metadata() -> anyhow::Result<()> {
+    let fanout = CandidateFanoutRequest {
+        candidate_group_id: "wf-1:candidate-group:issue-123".to_string(),
+        candidate_count: 2,
+        trigger_label: "best-of-n".to_string(),
+        max_turns_per_candidate: None,
+    };
+    let instance = issue_instance("planning").with_data(json!({
+        "candidate_fanout": fanout,
+    }));
+    let plan_payload = json!({
+        "summary": "Patch the submission reducer.",
+        "task_class": "runtime_or_data",
+        "target_files": [
+            "crates/harness-workflow/src/runtime/submission.rs"
+        ],
+        "validation_plan": ["cargo test -p harness-workflow candidate_fanout"],
+        "blockers": []
+    });
+    let result = ActivityResult::succeeded(super::super::ISSUE_PLAN_ACTIVITY, "Issue plan ready.")
+        .with_artifact(ActivityArtifact::new(
+            super::super::ISSUE_PLAN_ARTIFACT,
+            plan_payload,
+        ));
+    let event = runtime_completion_event(&instance, super::super::ISSUE_PLAN_ACTIVITY, result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)?
+        .ok_or_else(|| anyhow::anyhow!("issue planning success should start implementation"))?;
+
+    assert_eq!(decision.decision, "start_implementation_after_issue_plan");
+    assert_eq!(decision.next_state, "implementing");
+    assert_eq!(decision.commands.len(), 2);
+    assert_eq!(decision.commands[0].command["submission_mode"], "deferred");
+    assert_eq!(
+        decision.commands[0].command["candidate"]["candidate_index"],
+        1
+    );
+    assert_eq!(
+        decision.commands[1].command["candidate"]["candidate_index"],
+        2
+    );
+    DecisionValidator::github_issue_pr().validate(
+        &instance,
+        &decision,
+        &ValidationContext::new("runtime-1", Utc::now()),
+    )?;
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Add disabled-by-default `candidates` workflow config for best-of-N issue runs.
- Emit N deferred `implement_issue` candidate commands when config and trigger label opt in.
- Persist candidate fan-out metadata, split runtime max-turn budgets per candidate, and isolate candidate workspace task ids/branches.

SpecRail:
- Implements SP1449-T002 only.
- Candidate selection, winner PR promotion, usage attribution, and stalled-candidate readiness remain in later GH1449 tasks.

Issues: #1449

Verification:
- cargo test -p harness-core load_workflow_config
- cargo test -p harness-workflow candidate_fanout
- cargo test -p harness-server candidate_fanout_workspace_task_id
- cargo check -p harness-server --all-targets
- cargo check --workspace --all-targets
- cargo fmt --all -- --check
- git diff --check
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1449
- python3 checks/check_workflow.py --repo .
- cargo clippy --workspace --all-targets -- -D warnings