### PR TITLE
Attribute usage monitor totals by candidate

### DIFF
--- a/crates/harness-server/src/handlers/usage_monitor.rs
+++ b/crates/harness-server/src/handlers/usage_monitor.rs
@@ -20,12 +20,21 @@ use crate::http::AppState;
 
 #[path = "usage_monitor_active.rs"]
 mod usage_monitor_active;
+#[path = "usage_monitor_aggregate.rs"]
+mod usage_monitor_aggregate;
+#[path = "usage_monitor_candidate.rs"]
+mod usage_monitor_candidate;
 #[path = "usage_monitor_local_usage.rs"]
 mod usage_monitor_local_usage;
 #[path = "usage_monitor_process.rs"]
 mod usage_monitor_process;
 
 use usage_monitor_active::{aggregate_active_counts, burn_level, runtime_job_status, runtime_kind};
+use usage_monitor_aggregate::{aggregate_usage, total_usage_aggregate, UsageGroup};
+use usage_monitor_candidate::{
+    candidate_attribution_index, candidate_usage_groups, usage_record_candidate,
+    CandidateUsageGroup,
+};
 use usage_monitor_local_usage::{load_local_usage_summaries, LocalUsageSourceSummary};
 use usage_monitor_process::{sample_agent_processes, AgentProcess};
 
@@ -47,6 +56,7 @@ struct UsageMonitorResponse {
     tokens_by_agent: Vec<UsageGroup>,
     tokens_by_project: Vec<UsageGroup>,
     tokens_by_model: Vec<UsageGroup>,
+    candidate_usage: Vec<CandidateUsageGroup>,
     agent_invocations: Vec<AgentInvocation>,
     external_agent_processes: Vec<AgentProcess>,
     local_usage_sources: Vec<LocalUsageSourceSummary>,
@@ -102,63 +112,6 @@ struct UsageSummary {
     external_agent_processes: u64,
 }
 
-#[derive(Debug, Default, Clone)]
-struct UsageAggregate {
-    input_tokens: u64,
-    output_tokens: u64,
-    cache_read_input_tokens: u64,
-    cache_creation_input_tokens: u64,
-    request_count: u64,
-    estimated_cost_usd: f64,
-    missing_price: bool,
-}
-
-impl UsageAggregate {
-    fn add(&mut self, metrics: &UsageMetrics, estimated_cost_usd: Option<f64>) {
-        self.input_tokens = self.input_tokens.saturating_add(metrics.input_tokens);
-        self.output_tokens = self.output_tokens.saturating_add(metrics.output_tokens);
-        self.cache_read_input_tokens = self
-            .cache_read_input_tokens
-            .saturating_add(metrics.cache_read_input_tokens);
-        self.cache_creation_input_tokens = self
-            .cache_creation_input_tokens
-            .saturating_add(metrics.cache_creation_input_tokens);
-        self.request_count = self.request_count.saturating_add(1);
-        match estimated_cost_usd {
-            Some(cost) => self.estimated_cost_usd += cost,
-            None => self.missing_price = true,
-        }
-    }
-
-    fn total_tokens(&self) -> u64 {
-        self.input_tokens
-            .saturating_add(self.output_tokens)
-            .saturating_add(self.cache_read_input_tokens)
-            .saturating_add(self.cache_creation_input_tokens)
-    }
-
-    fn estimated_cost_json(&self, prices_configured: bool) -> Option<f64> {
-        if prices_configured && !self.missing_price {
-            Some(round_cost(self.estimated_cost_usd))
-        } else {
-            None
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-struct UsageGroup {
-    name: String,
-    input_tokens: u64,
-    output_tokens: u64,
-    cache_read_input_tokens: u64,
-    cache_creation_input_tokens: u64,
-    total_tokens: u64,
-    request_count: u64,
-    estimated_cost_usd: Option<f64>,
-    cost_confidence: &'static str,
-}
-
 #[derive(Debug)]
 struct UsageRecord {
     agent: String,
@@ -166,6 +119,7 @@ struct UsageRecord {
     project: String,
     metrics: UsageMetrics,
     estimated_cost_usd: Option<f64>,
+    candidate: Option<usage_monitor_candidate::CandidateUsageAttribution>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -327,8 +281,10 @@ async fn build_usage_monitor_response(
     let now = Utc::now();
     let window = UsageWindow::from_query(query.hours, now);
     let price_catalog = PriceCatalog::from_env_cached();
-    let usage_records = load_usage_records(state, window, price_catalog).await?;
     let runtime_rows = load_runtime_usage_rows(state, window.since, query.limit).await?;
+    let candidate_attributions = candidate_attribution_index(&runtime_rows);
+    let usage_records =
+        load_usage_records(state, window, price_catalog, &candidate_attributions).await?;
     let agent_invocations = runtime_rows
         .iter()
         .map(|row| agent_invocation_from_row(row, now))
@@ -346,6 +302,7 @@ async fn build_usage_monitor_response(
     );
     let tokens_by_model =
         aggregate_usage(&usage_records, |record| record.model.clone(), price_catalog);
+    let candidate_usage = candidate_usage_groups(&usage_records, price_catalog.configured());
     let total_usage = total_usage_aggregate(&usage_records);
 
     let running_agent_invocations = agent_invocations
@@ -417,6 +374,7 @@ async fn build_usage_monitor_response(
         tokens_by_agent,
         tokens_by_project,
         tokens_by_model,
+        candidate_usage,
         active_by_repo: aggregate_active_counts(&agent_invocations, |invocation| {
             invocation
                 .repo
@@ -442,6 +400,7 @@ async fn load_usage_records(
     state: &AppState,
     window: UsageWindow,
     price_catalog: &PriceCatalog,
+    candidate_attributions: &usage_monitor_candidate::CandidateAttributionIndex,
 ) -> anyhow::Result<Vec<UsageRecord>> {
     let events = state
         .observability
@@ -456,11 +415,15 @@ async fn load_usage_records(
         .await?;
     Ok(events
         .iter()
-        .filter_map(|event| parse_usage_event(event, price_catalog))
+        .filter_map(|event| parse_usage_event(event, price_catalog, candidate_attributions))
         .collect())
 }
 
-fn parse_usage_event(event: &Event, price_catalog: &PriceCatalog) -> Option<UsageRecord> {
+fn parse_usage_event(
+    event: &Event,
+    price_catalog: &PriceCatalog,
+    candidate_attributions: &usage_monitor_candidate::CandidateAttributionIndex,
+) -> Option<UsageRecord> {
     let content = event.content.as_deref()?;
     let payload: Value = serde_json::from_str(content).ok()?;
     let metrics = UsageMetrics::from_payload(&payload)?;
@@ -480,12 +443,14 @@ fn parse_usage_event(event: &Event, price_catalog: &PriceCatalog) -> Option<Usag
         .unwrap_or_default()
         .to_string();
     let estimated_cost_usd = price_catalog.estimate(&model, &metrics);
+    let candidate = usage_record_candidate(&payload, candidate_attributions);
     Some(UsageRecord {
         agent,
         model,
         project,
         metrics,
         estimated_cost_usd,
+        candidate,
     })
 }
 
@@ -717,59 +682,6 @@ fn runtime_profile_from_job(job: &RuntimeJob) -> Option<RuntimeProfile> {
     job.input
         .get("runtime_profile")
         .and_then(|value| serde_json::from_value(value.clone()).ok())
-}
-
-fn aggregate_usage<F>(
-    records: &[UsageRecord],
-    key_fn: F,
-    price_catalog: &PriceCatalog,
-) -> Vec<UsageGroup>
-where
-    F: Fn(&UsageRecord) -> String,
-{
-    let mut groups: BTreeMap<String, UsageAggregate> = BTreeMap::new();
-    for record in records {
-        groups
-            .entry(key_fn(record))
-            .or_default()
-            .add(&record.metrics, record.estimated_cost_usd);
-    }
-    let mut rows = groups
-        .into_iter()
-        .map(|(name, usage)| usage_group(name, usage, price_catalog.configured()))
-        .collect::<Vec<_>>();
-    rows.sort_by(|a, b| {
-        b.total_tokens
-            .cmp(&a.total_tokens)
-            .then_with(|| a.name.cmp(&b.name))
-    });
-    rows
-}
-
-fn total_usage_aggregate(records: &[UsageRecord]) -> UsageAggregate {
-    let mut usage = UsageAggregate::default();
-    for record in records {
-        usage.add(&record.metrics, record.estimated_cost_usd);
-    }
-    usage
-}
-
-fn usage_group(name: String, usage: UsageAggregate, prices_configured: bool) -> UsageGroup {
-    UsageGroup {
-        name,
-        input_tokens: usage.input_tokens,
-        output_tokens: usage.output_tokens,
-        cache_read_input_tokens: usage.cache_read_input_tokens,
-        cache_creation_input_tokens: usage.cache_creation_input_tokens,
-        total_tokens: usage.total_tokens(),
-        request_count: usage.request_count,
-        estimated_cost_usd: usage.estimated_cost_json(prices_configured),
-        cost_confidence: if prices_configured && !usage.missing_price {
-            "exact_tokens_estimated_price"
-        } else {
-            "price_unavailable"
-        },
-    }
 }
 
 fn string_field(value: &Value, field: &str) -> Option<String> {

--- a/crates/harness-server/src/handlers/usage_monitor_aggregate.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_aggregate.rs
@@ -1,0 +1,132 @@
+use super::{round_cost, PriceCatalog, UsageRecord};
+use harness_observe::usage::UsageMetrics;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Default, Clone)]
+pub(super) struct UsageAggregate {
+    pub(super) input_tokens: u64,
+    pub(super) output_tokens: u64,
+    pub(super) cache_read_input_tokens: u64,
+    pub(super) cache_creation_input_tokens: u64,
+    pub(super) request_count: u64,
+    pub(super) estimated_cost_usd: f64,
+    pub(super) missing_price: bool,
+}
+
+impl UsageAggregate {
+    pub(super) fn add(&mut self, metrics: &UsageMetrics, estimated_cost_usd: Option<f64>) {
+        self.input_tokens = self.input_tokens.saturating_add(metrics.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(metrics.output_tokens);
+        self.cache_read_input_tokens = self
+            .cache_read_input_tokens
+            .saturating_add(metrics.cache_read_input_tokens);
+        self.cache_creation_input_tokens = self
+            .cache_creation_input_tokens
+            .saturating_add(metrics.cache_creation_input_tokens);
+        self.request_count = self.request_count.saturating_add(1);
+        match estimated_cost_usd {
+            Some(cost) => self.estimated_cost_usd += cost,
+            None => self.missing_price = true,
+        }
+    }
+
+    pub(super) fn merge(&mut self, other: &Self) {
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.cache_read_input_tokens = self
+            .cache_read_input_tokens
+            .saturating_add(other.cache_read_input_tokens);
+        self.cache_creation_input_tokens = self
+            .cache_creation_input_tokens
+            .saturating_add(other.cache_creation_input_tokens);
+        self.request_count = self.request_count.saturating_add(other.request_count);
+        self.estimated_cost_usd += other.estimated_cost_usd;
+        self.missing_price |= other.missing_price;
+    }
+
+    pub(super) fn total_tokens(&self) -> u64 {
+        self.input_tokens
+            .saturating_add(self.output_tokens)
+            .saturating_add(self.cache_read_input_tokens)
+            .saturating_add(self.cache_creation_input_tokens)
+    }
+
+    pub(super) fn estimated_cost_json(&self, prices_configured: bool) -> Option<f64> {
+        if prices_configured && !self.missing_price {
+            Some(round_cost(self.estimated_cost_usd))
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct UsageGroup {
+    pub(super) name: String,
+    pub(super) input_tokens: u64,
+    pub(super) output_tokens: u64,
+    pub(super) cache_read_input_tokens: u64,
+    pub(super) cache_creation_input_tokens: u64,
+    pub(super) total_tokens: u64,
+    pub(super) request_count: u64,
+    pub(super) estimated_cost_usd: Option<f64>,
+    pub(super) cost_confidence: &'static str,
+}
+
+pub(super) fn aggregate_usage<F>(
+    records: &[UsageRecord],
+    key_fn: F,
+    price_catalog: &PriceCatalog,
+) -> Vec<UsageGroup>
+where
+    F: Fn(&UsageRecord) -> String,
+{
+    let mut groups: BTreeMap<String, UsageAggregate> = BTreeMap::new();
+    for record in records {
+        groups
+            .entry(key_fn(record))
+            .or_default()
+            .add(&record.metrics, record.estimated_cost_usd);
+    }
+    let mut rows = groups
+        .into_iter()
+        .map(|(name, usage)| usage_group(name, usage, price_catalog.configured()))
+        .collect::<Vec<_>>();
+    rows.sort_by(|a, b| {
+        b.total_tokens
+            .cmp(&a.total_tokens)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    rows
+}
+
+pub(super) fn total_usage_aggregate(records: &[UsageRecord]) -> UsageAggregate {
+    let mut usage = UsageAggregate::default();
+    for record in records {
+        usage.add(&record.metrics, record.estimated_cost_usd);
+    }
+    usage
+}
+
+pub(super) fn usage_group(
+    name: String,
+    usage: UsageAggregate,
+    prices_configured: bool,
+) -> UsageGroup {
+    UsageGroup {
+        name,
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_read_input_tokens: usage.cache_read_input_tokens,
+        cache_creation_input_tokens: usage.cache_creation_input_tokens,
+        total_tokens: usage.total_tokens(),
+        request_count: usage.request_count,
+        estimated_cost_usd: usage.estimated_cost_json(prices_configured),
+        cost_confidence: if prices_configured && !usage.missing_price {
+            "exact_tokens_estimated_price"
+        } else {
+            "price_unavailable"
+        },
+    }
+}

--- a/crates/harness-server/src/handlers/usage_monitor_candidate.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_candidate.rs
@@ -1,0 +1,239 @@
+use super::usage_monitor_aggregate::UsageAggregate;
+use super::{RuntimeUsageRow, UsageRecord};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+pub(super) type CandidateAttributionIndex = BTreeMap<String, CandidateUsageAttribution>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct CandidateUsageAttribution {
+    pub candidate_group_id: String,
+    pub candidate_id: String,
+    pub candidate_index: Option<u32>,
+    pub candidate_count: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct CandidateUsageGroup {
+    pub(super) candidate_group_id: String,
+    pub(super) input_tokens: u64,
+    pub(super) output_tokens: u64,
+    pub(super) cache_read_input_tokens: u64,
+    pub(super) cache_creation_input_tokens: u64,
+    pub(super) total_tokens: u64,
+    pub(super) request_count: u64,
+    pub(super) estimated_cost_usd: Option<f64>,
+    pub(super) cost_confidence: &'static str,
+    pub(super) candidates: Vec<CandidateUsageRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct CandidateUsageRow {
+    pub(super) candidate_id: String,
+    pub(super) candidate_index: Option<u32>,
+    pub(super) candidate_count: Option<u32>,
+    pub(super) input_tokens: u64,
+    pub(super) output_tokens: u64,
+    pub(super) cache_read_input_tokens: u64,
+    pub(super) cache_creation_input_tokens: u64,
+    pub(super) total_tokens: u64,
+    pub(super) request_count: u64,
+    pub(super) estimated_cost_usd: Option<f64>,
+    pub(super) cost_confidence: &'static str,
+}
+
+pub(super) fn candidate_attribution_index(rows: &[RuntimeUsageRow]) -> CandidateAttributionIndex {
+    let mut index = BTreeMap::new();
+    for row in rows {
+        let Some(attribution) = candidate_attribution_from_row(row) else {
+            continue;
+        };
+        insert_key(&mut index, row.command_id.as_str(), &attribution);
+        insert_key(&mut index, row.runtime_job.id.as_str(), &attribution);
+        insert_key(&mut index, attribution.candidate_id.as_str(), &attribution);
+        if let Some(task_id) = non_empty_string_field(&row.runtime_job.input, "task_id") {
+            insert_key(&mut index, &task_id, &attribution);
+        }
+        if let Some(task_id) = candidate_workspace_task_id(row, &attribution) {
+            insert_key(&mut index, &task_id, &attribution);
+        }
+    }
+    index
+}
+
+pub(super) fn usage_record_candidate(
+    payload: &Value,
+    index: &CandidateAttributionIndex,
+) -> Option<CandidateUsageAttribution> {
+    direct_candidate_attribution(payload).or_else(|| {
+        ["candidate_id", "runtime_job_id", "command_id", "task_id"]
+            .into_iter()
+            .filter_map(|field| non_empty_string_field(payload, field))
+            .find_map(|key| index.get(key.as_str()).cloned())
+    })
+}
+
+pub(super) fn candidate_usage_groups(
+    records: &[UsageRecord],
+    prices_configured: bool,
+) -> Vec<CandidateUsageGroup> {
+    let mut groups: BTreeMap<String, BTreeMap<String, CandidateUsageAccumulator>> = BTreeMap::new();
+    for record in records {
+        let Some(attribution) = record.candidate.clone() else {
+            continue;
+        };
+        groups
+            .entry(attribution.candidate_group_id.clone())
+            .or_default()
+            .entry(attribution.candidate_id.clone())
+            .or_insert_with(|| CandidateUsageAccumulator::new(attribution))
+            .usage
+            .add(&record.metrics, record.estimated_cost_usd);
+    }
+
+    let mut rows = groups
+        .into_iter()
+        .map(|(candidate_group_id, candidates)| {
+            candidate_usage_group(candidate_group_id, candidates, prices_configured)
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| {
+        right
+            .total_tokens
+            .cmp(&left.total_tokens)
+            .then_with(|| left.candidate_group_id.cmp(&right.candidate_group_id))
+    });
+    rows
+}
+
+fn candidate_usage_group(
+    candidate_group_id: String,
+    candidates: BTreeMap<String, CandidateUsageAccumulator>,
+    prices_configured: bool,
+) -> CandidateUsageGroup {
+    let mut total = UsageAggregate::default();
+    let mut candidate_rows = candidates
+        .into_values()
+        .map(|accumulator| {
+            total.merge(&accumulator.usage);
+            candidate_usage_row(accumulator, prices_configured)
+        })
+        .collect::<Vec<_>>();
+    candidate_rows.sort_by(|left, right| {
+        left.candidate_index
+            .cmp(&right.candidate_index)
+            .then_with(|| left.candidate_id.cmp(&right.candidate_id))
+    });
+
+    CandidateUsageGroup {
+        candidate_group_id,
+        input_tokens: total.input_tokens,
+        output_tokens: total.output_tokens,
+        cache_read_input_tokens: total.cache_read_input_tokens,
+        cache_creation_input_tokens: total.cache_creation_input_tokens,
+        total_tokens: total.total_tokens(),
+        request_count: total.request_count,
+        estimated_cost_usd: total.estimated_cost_json(prices_configured),
+        cost_confidence: if prices_configured && !total.missing_price {
+            "exact_tokens_estimated_price"
+        } else {
+            "price_unavailable"
+        },
+        candidates: candidate_rows,
+    }
+}
+
+fn candidate_usage_row(
+    accumulator: CandidateUsageAccumulator,
+    prices_configured: bool,
+) -> CandidateUsageRow {
+    CandidateUsageRow {
+        candidate_id: accumulator.attribution.candidate_id,
+        candidate_index: accumulator.attribution.candidate_index,
+        candidate_count: accumulator.attribution.candidate_count,
+        input_tokens: accumulator.usage.input_tokens,
+        output_tokens: accumulator.usage.output_tokens,
+        cache_read_input_tokens: accumulator.usage.cache_read_input_tokens,
+        cache_creation_input_tokens: accumulator.usage.cache_creation_input_tokens,
+        total_tokens: accumulator.usage.total_tokens(),
+        request_count: accumulator.usage.request_count,
+        estimated_cost_usd: accumulator.usage.estimated_cost_json(prices_configured),
+        cost_confidence: if prices_configured && !accumulator.usage.missing_price {
+            "exact_tokens_estimated_price"
+        } else {
+            "price_unavailable"
+        },
+    }
+}
+
+fn candidate_attribution_from_row(row: &RuntimeUsageRow) -> Option<CandidateUsageAttribution> {
+    let candidate = row
+        .runtime_job
+        .input
+        .pointer("/command/candidate")
+        .or_else(|| row.command.command.get("candidate"))?;
+    let candidate_group_id = non_empty_string_field(candidate, "candidate_group_id")?;
+    let candidate_id = non_empty_string_field(candidate, "candidate_id")?;
+    Some(CandidateUsageAttribution {
+        candidate_group_id,
+        candidate_id,
+        candidate_index: u32_field(candidate, "candidate_index"),
+        candidate_count: u32_field(candidate, "candidate_count"),
+    })
+}
+
+fn direct_candidate_attribution(payload: &Value) -> Option<CandidateUsageAttribution> {
+    let candidate_group_id = non_empty_string_field(payload, "candidate_group_id")?;
+    let candidate_id = non_empty_string_field(payload, "candidate_id")?;
+    Some(CandidateUsageAttribution {
+        candidate_group_id,
+        candidate_id,
+        candidate_index: u32_field(payload, "candidate_index"),
+        candidate_count: u32_field(payload, "candidate_count"),
+    })
+}
+
+fn candidate_workspace_task_id(
+    row: &RuntimeUsageRow,
+    attribution: &CandidateUsageAttribution,
+) -> Option<String> {
+    let issue_number = row.workflow.data.get("issue_number")?.as_u64()?;
+    let candidate_index = attribution.candidate_index?;
+    Some(format!("issue-{issue_number}-c{candidate_index}"))
+}
+
+fn insert_key(
+    index: &mut CandidateAttributionIndex,
+    key: &str,
+    attribution: &CandidateUsageAttribution,
+) {
+    if !key.trim().is_empty() {
+        index.insert(key.to_string(), attribution.clone());
+    }
+}
+
+fn non_empty_string_field(value: &Value, field: &str) -> Option<String> {
+    super::string_field(value, field).filter(|value| !value.trim().is_empty())
+}
+
+fn u32_field(value: &Value, field: &str) -> Option<u32> {
+    value
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+}
+
+struct CandidateUsageAccumulator {
+    attribution: CandidateUsageAttribution,
+    usage: UsageAggregate,
+}
+
+impl CandidateUsageAccumulator {
+    fn new(attribution: CandidateUsageAttribution) -> Self {
+        Self {
+            attribution,
+            usage: UsageAggregate::default(),
+        }
+    }
+}

--- a/crates/harness-server/src/handlers/usage_monitor_tests.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_tests.rs
@@ -1,5 +1,10 @@
+use super::usage_monitor_aggregate::UsageAggregate;
+use super::usage_monitor_candidate::{
+    candidate_attribution_index, candidate_usage_groups, CandidateUsageAttribution,
+};
 use super::*;
-use harness_workflow::runtime::RuntimeKind;
+use harness_core::types::{Decision, SessionId};
+use harness_workflow::runtime::{RuntimeKind, WorkflowCommandType};
 
 #[test]
 fn burn_level_marks_stale_running_job_high() {
@@ -93,6 +98,143 @@ fn runtime_attribution_tokens_include_runtime_job_and_command_ids() {
 
     assert!(tokens.contains("command-1"));
     assert!(tokens.contains(&runtime_job_id));
+}
+
+#[test]
+fn candidate_usage_attribution_index_matches_runtime_candidate_keys() {
+    let row = candidate_runtime_row(2);
+    let runtime_job_id = row.runtime_job.id.clone();
+    let index = candidate_attribution_index(&[row]);
+
+    assert_eq!(
+        index
+            .get("command-1449-c2")
+            .map(|candidate| candidate.candidate_id.as_str()),
+        Some("workflow-1449:candidate-group:issue-1449:c2")
+    );
+    assert_eq!(
+        index
+            .get(runtime_job_id.as_str())
+            .map(|candidate| candidate.candidate_id.as_str()),
+        Some("workflow-1449:candidate-group:issue-1449:c2")
+    );
+    assert_eq!(
+        index
+            .get("workflow-1449:candidate-group:issue-1449:c2")
+            .map(|candidate| candidate.candidate_index),
+        Some(Some(2))
+    );
+    assert_eq!(
+        index
+            .get("issue-1449-c2")
+            .map(|candidate| candidate.candidate_id.as_str()),
+        Some("workflow-1449:candidate-group:issue-1449:c2")
+    );
+    assert!(
+        !index.contains_key("workflow-task"),
+        "shared workflow task IDs must not be attributed to a single candidate"
+    );
+}
+
+#[test]
+fn candidate_usage_parse_event_uses_runtime_candidate_attribution() {
+    let row = candidate_runtime_row(2);
+    let index = candidate_attribution_index(&[row]);
+    let mut event = Event::new(SessionId::new(), "llm_usage", "codex", Decision::Complete);
+    event.content = Some(
+        serde_json::json!({
+            "agent": "codex",
+            "model": "gpt-5",
+            "task_id": "issue-1449-c2",
+            "project": "/repo",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_read_input_tokens": 3,
+            "cache_creation_input_tokens": 2,
+        })
+        .to_string(),
+    );
+
+    let record = parse_usage_event(&event, &PriceCatalog::default(), &index)
+        .expect("usage event should parse");
+    let candidate = record
+        .candidate
+        .expect("candidate attribution should be resolved");
+
+    assert_eq!(
+        candidate.candidate_group_id,
+        "workflow-1449:candidate-group:issue-1449"
+    );
+    assert_eq!(
+        candidate.candidate_id,
+        "workflow-1449:candidate-group:issue-1449:c2"
+    );
+    assert_eq!(candidate.candidate_index, Some(2));
+    assert_eq!(record.metrics.total_tokens(), 20);
+}
+
+#[test]
+fn candidate_usage_group_total_equals_candidate_sum() {
+    let records = vec![
+        candidate_usage_record(
+            1,
+            UsageMetrics {
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_read_input_tokens: 2,
+                cache_creation_input_tokens: 1,
+                reported_total_tokens: None,
+            },
+            Some(1.0),
+        ),
+        candidate_usage_record(
+            2,
+            UsageMetrics {
+                input_tokens: 7,
+                output_tokens: 9,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 3,
+                reported_total_tokens: None,
+            },
+            Some(2.0),
+        ),
+    ];
+
+    let groups = candidate_usage_groups(&records, true);
+
+    assert_eq!(groups.len(), 1);
+    let group = &groups[0];
+    assert_eq!(
+        group.candidate_group_id,
+        "workflow-1449:candidate-group:issue-1449"
+    );
+    assert_eq!(group.candidates.len(), 2);
+    assert_eq!(group.candidates[0].candidate_index, Some(1));
+    assert_eq!(group.candidates[1].candidate_index, Some(2));
+
+    let candidate_token_sum: u64 = group
+        .candidates
+        .iter()
+        .map(|candidate| candidate.total_tokens)
+        .sum();
+    let candidate_request_sum: u64 = group
+        .candidates
+        .iter()
+        .map(|candidate| candidate.request_count)
+        .sum();
+    let candidate_cost_sum: f64 = group
+        .candidates
+        .iter()
+        .map(|candidate| candidate.estimated_cost_usd.unwrap_or_default())
+        .sum();
+
+    assert_eq!(group.total_tokens, candidate_token_sum);
+    assert_eq!(group.request_count, candidate_request_sum);
+    assert_eq!(group.estimated_cost_usd, Some(candidate_cost_sum));
+    assert_eq!(group.input_tokens, 17);
+    assert_eq!(group.output_tokens, 14);
+    assert_eq!(group.cache_read_input_tokens, 2);
+    assert_eq!(group.cache_creation_input_tokens, 4);
 }
 
 #[test]
@@ -238,6 +380,86 @@ fn agent_invocation_ends_in_flight_after_latest_turn_result() {
     let invocation = agent_invocation_from_row(&row, now);
 
     assert!(!invocation.in_flight_model_turn);
+}
+
+fn candidate_runtime_row(candidate_index: u32) -> RuntimeUsageRow {
+    let workflow = WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1449"),
+    )
+    .with_id("workflow-1449")
+    .with_data(serde_json::json!({
+        "issue_number": 1449,
+        "task_id": "workflow-task",
+    }));
+    let command_id = format!("command-1449-c{candidate_index}");
+    let command = WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        format!("impl-1449-c{candidate_index}"),
+        serde_json::json!({
+            "activity": "implement_issue",
+            "candidate": candidate_metadata(candidate_index),
+        }),
+    );
+    let mut runtime_job = RuntimeJob::pending(
+        command_id.clone(),
+        RuntimeKind::CodexExec,
+        "codex-default",
+        serde_json::json!({
+            "workflow_id": "workflow-1449",
+            "command_id": command_id,
+            "activity": "implement_issue",
+            "command": command.command.clone(),
+        }),
+    );
+    runtime_job.id = format!("runtime-job-c{candidate_index}");
+
+    RuntimeUsageRow {
+        workflow,
+        command_id: format!("command-1449-c{candidate_index}"),
+        command_status: "dispatched".to_string(),
+        command,
+        runtime_job,
+        latest_runtime_event_type: None,
+        latest_runtime_event_at: None,
+        runtime_turn_started: false,
+        activity_result_ready_after_latest_turn: false,
+    }
+}
+
+fn candidate_usage_record(
+    candidate_index: u32,
+    metrics: UsageMetrics,
+    estimated_cost_usd: Option<f64>,
+) -> UsageRecord {
+    UsageRecord {
+        agent: "codex".to_string(),
+        model: "gpt-5".to_string(),
+        project: "/repo".to_string(),
+        metrics,
+        estimated_cost_usd,
+        candidate: Some(candidate_attribution(candidate_index)),
+    }
+}
+
+fn candidate_attribution(candidate_index: u32) -> CandidateUsageAttribution {
+    CandidateUsageAttribution {
+        candidate_group_id: "workflow-1449:candidate-group:issue-1449".to_string(),
+        candidate_id: format!("workflow-1449:candidate-group:issue-1449:c{candidate_index}"),
+        candidate_index: Some(candidate_index),
+        candidate_count: Some(2),
+    }
+}
+
+fn candidate_metadata(candidate_index: u32) -> serde_json::Value {
+    serde_json::json!({
+        "candidate_group_id": "workflow-1449:candidate-group:issue-1449",
+        "candidate_id": format!("workflow-1449:candidate-group:issue-1449:c{candidate_index}"),
+        "candidate_index": candidate_index,
+        "candidate_count": 2,
+    })
 }
 
 fn test_invocation(


### PR DESCRIPTION
## Summary
- Add candidate usage attribution for usage monitor token/cost records using runtime command metadata.
- Return per-candidate usage groups whose totals are computed from candidate rows.
- Split usage aggregation helpers out of the main handler to keep the handler under the file-size hard limit.

Issue: #1449
SpecRail: SP1449-T005

## Verification
- cargo test -p harness-server candidate_usage
- cargo test -p harness-server usage_monitor
- cargo check -p harness-server --all-targets
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1449
- python3 checks/check_workflow.py --repo .
- cargo fmt --all -- --check
- git diff --check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings