### PR TITLE
Record stalled candidate outcomes for selection

### DIFF
--- a/crates/harness-workflow/src/runtime/candidate_selection.rs
+++ b/crates/harness-workflow/src/runtime/candidate_selection.rs
@@ -69,6 +69,20 @@ impl CandidateEvidence {
         }
     }
 
+    pub fn stalled(candidate_id: impl Into<String>) -> Self {
+        Self {
+            outcome: CandidateOutcome::Stalled,
+            ..Self::succeeded(candidate_id)
+        }
+    }
+
+    pub fn cancelled(candidate_id: impl Into<String>) -> Self {
+        Self {
+            outcome: CandidateOutcome::Cancelled,
+            ..Self::succeeded(candidate_id)
+        }
+    }
+
     pub fn with_validation(mut self, validation: CandidateCheckConclusion) -> Self {
         self.validation = validation;
         self
@@ -373,6 +387,28 @@ mod tests {
             .ranking
             .iter()
             .all(|ranking| ranking.rank_reason == "ineligible_terminal_outcome"));
+    }
+
+    #[test]
+    fn candidate_stall_selection_ranks_remaining_terminal_candidates() {
+        let record = selection(vec![
+            CandidateEvidence::stalled("candidate-stalled")
+                .with_validation(CandidateCheckConclusion::Passed)
+                .with_ci(CandidateCheckConclusion::Passed)
+                .with_quality_score(100),
+            CandidateEvidence::succeeded("candidate-success")
+                .with_validation(CandidateCheckConclusion::Unknown)
+                .with_ci(CandidateCheckConclusion::Unknown)
+                .with_quality_score(10),
+        ]);
+
+        assert_eq!(
+            record.selected_candidate_id.as_deref(),
+            Some("candidate-success")
+        );
+        assert_eq!(record.ranking[0].candidate_id, "candidate-success");
+        assert_eq!(record.ranking[1].candidate_id, "candidate-stalled");
+        assert_eq!(record.ranking[1].rank_reason, "ineligible_terminal_outcome");
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/candidate_terminal.rs
+++ b/crates/harness-workflow/src/runtime/candidate_terminal.rs
@@ -1,0 +1,170 @@
+use super::candidate_selection::{CandidateEvidence, CandidateOutcome};
+use super::model::{
+    ActivityErrorKind, ActivityResult, ActivityStatus, WorkflowCommand, WorkflowDecision,
+    WorkflowEvent, WorkflowEvidence, WorkflowInstance,
+};
+use serde_json::Value;
+
+const IMPLEMENT_ISSUE_ACTIVITY: &str = "implement_issue";
+const DEFERRED_SUBMISSION_MODE: &str = "deferred";
+
+pub(super) fn deferred_candidate_terminal_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+    command: &WorkflowCommand,
+) -> Option<anyhow::Result<WorkflowDecision>> {
+    if (
+        instance.definition_id.as_str(),
+        instance.state.as_str(),
+        result.activity.as_str(),
+    ) != (
+        super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID,
+        "implementing",
+        IMPLEMENT_ISSUE_ACTIVITY,
+    ) {
+        return None;
+    }
+    if command
+        .command
+        .get("submission_mode")
+        .and_then(Value::as_str)
+        != Some(DEFERRED_SUBMISSION_MODE)
+    {
+        return None;
+    }
+    if !matches!(
+        result.status,
+        ActivityStatus::Failed | ActivityStatus::Cancelled
+    ) {
+        return None;
+    }
+    Some(deferred_candidate_terminal_decision_inner(
+        instance, event, result, command,
+    ))
+}
+
+fn deferred_candidate_terminal_decision_inner(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+    command: &WorkflowCommand,
+) -> anyhow::Result<WorkflowDecision> {
+    let candidate = DeferredCandidateMetadata::from_command(command)?;
+    let evidence = terminal_candidate_evidence(&candidate, event, result);
+    let outcome_label = candidate_outcome_label(evidence.outcome);
+    let reason = format!(
+        "deferred candidate {} reached terminal outcome `{outcome_label}`; recording evidence for candidate selection",
+        candidate.candidate_id
+    );
+
+    Ok(WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        format!("record_deferred_candidate_{outcome_label}"),
+        &instance.state,
+        reason,
+    )
+    .with_evidence(WorkflowEvidence::new(
+        "candidate_terminal",
+        candidate_terminal_summary(&candidate, &evidence, result),
+    ))
+    .high_confidence())
+}
+
+fn terminal_candidate_evidence(
+    candidate: &DeferredCandidateMetadata,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> CandidateEvidence {
+    let mut evidence = match candidate_outcome(result) {
+        CandidateOutcome::Failed => CandidateEvidence::failed(candidate.candidate_id.clone()),
+        CandidateOutcome::Stalled => CandidateEvidence::stalled(candidate.candidate_id.clone()),
+        CandidateOutcome::Cancelled => CandidateEvidence::cancelled(candidate.candidate_id.clone()),
+        CandidateOutcome::Succeeded => CandidateEvidence::succeeded(candidate.candidate_id.clone()),
+    }
+    .with_completed_at_epoch_ms(event.created_at.timestamp_millis());
+    if let Some(runtime_job_id) = event
+        .event
+        .get("runtime_job_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        evidence = evidence.with_runtime_job_id(runtime_job_id);
+    }
+    evidence
+}
+
+fn candidate_outcome(result: &ActivityResult) -> CandidateOutcome {
+    match result.status {
+        ActivityStatus::Failed if result.error_kind == Some(ActivityErrorKind::Timeout) => {
+            CandidateOutcome::Stalled
+        }
+        ActivityStatus::Failed => CandidateOutcome::Failed,
+        ActivityStatus::Cancelled => CandidateOutcome::Cancelled,
+        ActivityStatus::Blocked => CandidateOutcome::Failed,
+        ActivityStatus::Succeeded => CandidateOutcome::Succeeded,
+    }
+}
+
+fn candidate_terminal_summary(
+    candidate: &DeferredCandidateMetadata,
+    evidence: &CandidateEvidence,
+    result: &ActivityResult,
+) -> String {
+    let runtime_job_id = evidence.runtime_job_id.as_deref().unwrap_or("<unknown>");
+    let error_kind = result
+        .error_kind
+        .map(|kind| {
+            serde_json::to_value(kind)
+                .unwrap_or(Value::Null)
+                .to_string()
+        })
+        .unwrap_or_else(|| "null".to_string());
+    format!(
+        "candidate_group_id={} candidate_id={} outcome={} runtime_job_id={} error_kind={} terminal=true",
+        candidate.candidate_group_id,
+        candidate.candidate_id,
+        candidate_outcome_label(evidence.outcome),
+        runtime_job_id,
+        error_kind
+    )
+}
+
+fn candidate_outcome_label(outcome: CandidateOutcome) -> &'static str {
+    match outcome {
+        CandidateOutcome::Succeeded => "succeeded",
+        CandidateOutcome::Failed => "failed",
+        CandidateOutcome::Stalled => "stalled",
+        CandidateOutcome::Cancelled => "cancelled",
+    }
+}
+
+struct DeferredCandidateMetadata {
+    candidate_group_id: String,
+    candidate_id: String,
+}
+
+impl DeferredCandidateMetadata {
+    fn from_command(command: &WorkflowCommand) -> anyhow::Result<Self> {
+        let candidate = command.command.get("candidate").ok_or_else(|| {
+            anyhow::anyhow!("deferred implement_issue command is missing candidate metadata")
+        })?;
+        let candidate_group_id =
+            required_candidate_metadata_string(candidate, "candidate_group_id")?;
+        let candidate_id = required_candidate_metadata_string(candidate, "candidate_id")?;
+        Ok(Self {
+            candidate_group_id,
+            candidate_id,
+        })
+    }
+}
+
+fn required_candidate_metadata_string(value: &Value, field: &str) -> anyhow::Result<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("candidate metadata is missing {field}"))
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -8,6 +8,7 @@ pub mod bus;
 mod candidate_fanout;
 mod candidate_promotion;
 mod candidate_selection;
+mod candidate_terminal;
 pub mod dispatcher;
 pub mod errors;
 pub mod eval;

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -35,6 +35,7 @@ use super::candidate_promotion::{
     candidate_promotion_success_decision, candidate_selection_record_from_activity_result,
     deferred_candidate_result_decision,
 };
+use super::candidate_terminal::deferred_candidate_terminal_decision;
 use super::model::{
     ActivityResult, ActivityStatus, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
     WorkflowEvent, WorkflowInstance,
@@ -85,6 +86,11 @@ pub fn reduce_runtime_job_completed(
         ActivityStatus::Failed => {
             if let Some(command) = event_workflow_command(event) {
                 if let Some(decision) =
+                    deferred_candidate_terminal_decision(instance, event, &result, &command)
+                {
+                    return decision.map(Some);
+                }
+                if let Some(decision) =
                     candidate_promotion_failure_decision(instance, event, &result, &command)
                 {
                     return decision.map(Some);
@@ -95,7 +101,16 @@ pub fn reduce_runtime_job_completed(
                     .unwrap_or_else(|| runtime_failed_decision(instance, event, &result)),
             )
         }
-        ActivityStatus::Cancelled => Some(runtime_cancelled_decision(instance, event, &result)),
+        ActivityStatus::Cancelled => {
+            if let Some(command) = event_workflow_command(event) {
+                if let Some(decision) =
+                    deferred_candidate_terminal_decision(instance, event, &result, &command)
+                {
+                    return decision.map(Some);
+                }
+            }
+            Some(runtime_cancelled_decision(instance, event, &result))
+        }
     };
     Ok(decision)
 }
@@ -488,7 +503,8 @@ fn prompt_task_has_validation_evidence(result: &ActivityResult) -> bool {
 mod tests {
     use super::*;
     use crate::runtime::model::{
-        ActivityResult, WorkflowCommandType, WorkflowEvent, WorkflowInstance, WorkflowSubject,
+        ActivityErrorKind, ActivityResult, WorkflowCommand, WorkflowCommandType, WorkflowEvent,
+        WorkflowInstance, WorkflowSubject,
     };
     use crate::runtime::validator::{DecisionValidator, ValidationContext};
     use chrono::Utc;
@@ -532,6 +548,68 @@ mod tests {
             &decision,
             &ValidationContext::new("runtime-1", Utc::now()),
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn candidate_stall_timeout_records_terminal_evidence_without_failing_workflow(
+    ) -> anyhow::Result<()> {
+        let instance = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            WorkflowSubject::new("issue", "issue:1449"),
+        )
+        .with_id("workflow-1449");
+        let command = WorkflowCommand::new(
+            WorkflowCommandType::EnqueueActivity,
+            "candidate-1",
+            json!({
+                "activity": "implement_issue",
+                "submission_mode": "deferred",
+                "candidate": {
+                    "candidate_group_id": "workflow-1449:candidate-group:issue-1449",
+                    "candidate_id": "workflow-1449:candidate-group:issue-1449:c1",
+                    "candidate_index": 1,
+                    "candidate_count": 2,
+                },
+            }),
+        );
+        let result = ActivityResult::failed(
+            "implement_issue",
+            "Candidate stalled before completion.",
+            "Agent stream stalled: no output for 300s",
+        )
+        .with_error_kind(ActivityErrorKind::Timeout);
+        let event = WorkflowEvent::new(
+            &instance.id,
+            1,
+            RUNTIME_JOB_COMPLETED_EVENT,
+            "runtime-worker",
+        )
+        .with_payload(json!({
+            "command_id": "command-c1",
+            "runtime_job_id": "job-c1",
+            "command": command,
+            "activity_result": result,
+        }));
+
+        let decision = reduce_runtime_job_completed(&instance, &event)?
+            .ok_or_else(|| anyhow::anyhow!("candidate timeout should produce a decision"))?;
+
+        assert_eq!(decision.decision, "record_deferred_candidate_stalled");
+        assert_eq!(decision.next_state, "implementing");
+        assert!(
+            decision.commands.is_empty(),
+            "candidate timeouts must not fail or retry the parent workflow"
+        );
+        let candidate_evidence = decision
+            .evidence
+            .iter()
+            .find(|evidence| evidence.kind == "candidate_terminal")
+            .ok_or_else(|| anyhow::anyhow!("missing candidate terminal evidence"))?;
+        assert!(candidate_evidence.summary.contains("outcome=stalled"));
+        assert!(candidate_evidence.summary.contains("runtime_job_id=job-c1"));
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Record failed/cancelled deferred candidate completions as terminal candidate evidence instead of failing or retrying the parent workflow.
- Classify timeout failures as stalled candidate outcomes so selection can continue with remaining terminal candidates.
- Add candidate_stall coverage for reducer behavior and deterministic selection ranking.

Issue: #1449
SpecRail: SP1449-T006

## Verification
- cargo test -p harness-workflow candidate_stall
- cargo check -p harness-workflow --all-targets
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1449
- python3 checks/check_workflow.py --repo .
- cargo fmt --all -- --check
- git diff --check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings