### PR TITLE
Add GH1438 reconciliation spec packet

### DIFF
--- a/specs/GH1438/product.md
+++ b/specs/GH1438/product.md
@@ -1,0 +1,80 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1438
+
+## User Problem
+
+The workflow reconciler repeatedly proposes `local_review_gate -> done` for
+workflows whose PR has already been merged externally. The workflow validator
+rejects that transition, so every reconciliation cycle logs the same
+`TransitionNotAllowed` failure and the workflow stays in `local_review_gate`.
+
+Operators see noisy logs instead of one terminal reconciliation result. The
+workflow also remains active even though the durable GitHub PR state says the
+work is complete.
+
+## Goals
+
+- A workflow in `local_review_gate` with evidence that its linked PR was merged
+  externally reaches `done` through a legal reconciliation path.
+- Reconciliation does not repeatedly emit the same invalid transition rejection
+  for the same merged PR.
+- The completion remains evidence-bound to GitHub PR state and the
+  reconciliation actor.
+- Existing local-review behavior remains unchanged for open PRs and PRs with
+  requested changes.
+
+## Non-Goals
+
+- Allowing arbitrary agents or API callers to bypass local review by marking
+  `local_review_gate` workflows `done`.
+- Changing the local review gate semantics for open PRs.
+- Changing PR feedback collection, quality gates, or merge authorization.
+- Adding a new operator UI surface.
+
+## User-Visible Behavior
+
+When reconciliation observes that a linked GitHub PR is merged while the
+workflow is in `local_review_gate`, Harness records the same external PR
+evidence it already uses for other reconciliation transitions and moves the
+workflow to `done` once.
+
+If the linked PR is still open, closed without merge, unknown, or missing
+required evidence, the workflow must not be marked done. Reconciliation should
+avoid repeated invalid transition spam and should surface the stuck state with a
+single clear reason when it cannot legally advance.
+
+## Acceptance Criteria
+
+- [ ] A `github_issue_pr` workflow in `local_review_gate` with a merged linked
+      PR is reconciled to `done` with `last_decision =
+      "reconcile_pr_merged"` and external PR evidence recorded in workflow
+      data.
+- [ ] The validator rejects non-reconciliation attempts to mark
+      `local_review_gate` as `done`.
+- [ ] Reconciliation does not re-log the same
+      `TransitionNotAllowed: 'local_review_gate' -> 'done'` warning on every
+      cycle for a workflow it cannot legally advance.
+- [ ] Existing `blocked -> done`, `ready_to_merge -> done`, and open-PR
+      reconciliation behavior remains unchanged.
+- [ ] Tests cover the successful merged-PR path and at least one rejected
+      unevidenced path.
+
+## Edge Cases
+
+- The workflow state changed after candidates were collected: reconciliation
+  must no-op rather than applying a stale transition.
+- The PR number is present but repo or issue metadata is missing: do not mark
+  done unless the existing reconciliation evidence rules accept the case.
+- The PR is closed but not merged: use the existing cancellation path, not
+  `done`.
+- The workflow is already terminal: skip without emitting a duplicate
+  transition.
+
+## Rollout Notes
+
+This is a reconciliation correctness fix. It changes how already-merged PRs are
+reflected in workflow state, but does not change merge authorization or agent
+review policy. No data migration is required.

--- a/specs/GH1438/tasks.md
+++ b/specs/GH1438/tasks.md
@@ -1,0 +1,37 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1438
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1438-T001` Owner: `workflow-validator` | Done when: `local_review_gate -> done` is accepted only for reconciliation decisions with merged PR evidence, and non-reconciliation or unevidenced attempts are rejected | Verify: `cargo test -p harness-workflow validator`
+- [ ] `SP1438-T002` Owner: `server-reconciliation` | Done when: runtime reconciliation moves a `local_review_gate` workflow with an externally merged linked PR to `done` and records `last_decision = "reconcile_pr_merged"` plus PR evidence fields | Verify: `cargo test -p harness-server reconciliation`
+- [ ] `SP1438-T003` Owner: `regression` | Done when: existing blocked, ready-to-merge, open PR, and closed PR reconciliation behavior remains unchanged | Verify: `cargo test -p harness-server reconciliation`
+
+## Parallelization
+
+T001 and T002 touch different crates but are behaviorally coupled. Implement
+T001 first so server reconciliation can rely on the validator contract. T003 is
+verification-only and runs after T001 and T002.
+
+## Verification
+
+- `cargo test -p harness-workflow validator`
+- `cargo test -p harness-server reconciliation`
+- `cargo check -p harness-workflow --all-targets`
+- `cargo check -p harness-server --all-targets`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1438`
+- `python3 checks/check_workflow.py --repo .`
+
+## Handoff Notes
+
+Keep `local_review_gate -> done` out of the advertised default transition
+allowlist. The intended fix is a reconciliation-only validator exception that
+reuses the existing PR-merge evidence requirements.

--- a/specs/GH1438/tech.md
+++ b/specs/GH1438/tech.md
@@ -1,0 +1,89 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1438
+
+## Product Spec
+
+See `specs/GH1438/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Runtime reconciliation | `crates/harness-server/src/reconciliation.rs` | `runtime_transition_for_github_state` maps merged PRs to target state `done`, and `apply_runtime_workflow_transition` builds a `MarkDone` decision for the current workflow state. | This is where the rejected `local_review_gate -> done` proposal is created. |
+| Transition validation | `crates/harness-workflow/src/runtime/validator.rs` and `validator_github_issue_pr.rs` | The default allowlist permits `done` from several states, but not from `local_review_gate`. A special validator currently allows `blocked -> done` only for PR-merge reconciliation. | GH1438 needs the same evidence-bound exception for `local_review_gate`, without broadly weakening the gate. |
+| Reconciliation tests | `crates/harness-server/src/reconciliation_tests.rs`, `reconciliation_blocked_done_tests.rs`, `reconciliation_ready_to_merge_tests.rs` | Existing tests cover merged PR reconciliation from other states. | Add regression coverage for `local_review_gate`. |
+| Validator tests | `crates/harness-workflow/src/runtime/validator_tests.rs` | Existing tests prove the `blocked -> done` exception is reconciliation-only and evidence-bound. | Add equivalent rejection and allow tests for `local_review_gate`. |
+
+## Proposed Design
+
+1. Extend the GitHub issue PR validator with a reconciliation-only
+   `local_review_gate -> done` exception when:
+   - the actor is `reconciliation`;
+   - the decision name is `reconcile_pr_merged`;
+   - the decision contains a `MarkDone` command;
+   - the command payload includes merged PR evidence compatible with the
+     existing reconciliation evidence rules.
+2. Keep the public transition allowlist from advertising
+   `local_review_gate -> done`. This prevents agents from discovering or using
+   the transition outside reconciliation.
+3. Update server reconciliation tests so a runtime workflow in
+   `local_review_gate` with an externally merged PR transitions to `done`.
+4. Add validator tests proving:
+   - reconciliation with merged PR evidence is accepted;
+   - a non-reconciliation actor is rejected;
+   - missing PR evidence is rejected.
+5. If a reconciliation proposal is still rejected, keep it a single
+   operator-visible warning path and avoid adding retries or fallback state
+   changes in this tranche.
+
+## Data Flow
+
+Input: runtime workflow candidate with current state `local_review_gate` and
+linked PR metadata. Reconciliation resolves the GitHub PR state. If the PR is
+merged, it creates a `WorkflowDecision` named `reconcile_pr_merged` with a
+`MarkDone` command and `github_pr` evidence. The workflow validator accepts the
+decision only for the reconciliation actor and evidence-bound command payload.
+The runtime store records the decision transition and updates workflow data with
+`last_decision`, `external_pr_state`, `pr_number`, `pr_url`, `repo`, and
+`issue_number`.
+
+## Alternatives Considered
+
+- Add `local_review_gate -> done` to the default allowlist. Rejected because it
+  would advertise a bypass path to non-reconciliation actors.
+- Suppress the rejected warning without fixing the transition. Rejected because
+  it hides the stuck workflow and leaves durable state wrong.
+- Move merged PR workflows to `awaiting_feedback` first. Rejected because the
+  PR is already merged, so an intermediate feedback state is not user-visible
+  value.
+
+## Risks
+
+- Security: The transition must remain reconciliation-only and evidence-bound
+  so an agent cannot skip local review.
+- Compatibility: Existing reconciliation states must continue to behave the
+  same way.
+- Performance: No new polling or external calls.
+- Maintenance: The exception should share the existing PR-merge validation
+  helper to avoid divergent evidence rules.
+
+## Test Plan
+
+- [ ] Unit tests: validator allows evidence-backed reconciliation and rejects
+      non-reconciliation or missing-evidence decisions.
+- [ ] Integration tests: server reconciliation marks a
+      `local_review_gate` workflow `done` when GitHub reports the linked PR
+      merged.
+- [ ] Regression tests: existing blocked, ready-to-merge, open PR, and closed
+      PR reconciliation tests still pass.
+- [ ] Manual verification: inspect a reconciliation report and confirm the
+      transition appears once with `from = "local_review_gate"` and `to =
+      "done"`.
+
+## Rollback Plan
+
+Revert the validator and reconciliation test changes. Workflows that are
+already reconciled to `done` remain terminal; no schema rollback is required.


### PR DESCRIPTION
## Summary
- Add the GH1438 product spec for evidence-backed reconciliation from local_review_gate to done.
- Add the GH1438 tech spec grounded in the runtime reconciliation and validator modules.
- Add the GH1438 task plan for validator, server reconciliation, and regression coverage.

Issue: #1438
SpecRail: write_spec

## Verification
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1438
- python3 checks/check_workflow.py --repo .
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings