### PR TITLE
Reconcile local review gate merged PRs

### DIFF
--- a/crates/harness-server/src/reconciliation_local_review_gate_tests.rs
+++ b/crates/harness-server/src/reconciliation_local_review_gate_tests.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+#[tokio::test]
+async fn local_review_gate_runtime_reconciliation_marks_merged_pr_done() -> anyhow::Result<()> {
+    let _env_guard = async_env_lock().lock().await;
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let api_base = github_state_server(vec![(
+        "/repos/owner/repo/pulls/79",
+        r#"{"state":"closed","merged_at":"2026-05-10T00:00:00Z"}"#,
+    )])
+    .await;
+    let _api_base_guard = ScopedEnvVar::set("HARNESS_GITHUB_API_BASE_URL", &api_base);
+    let Some(stores) = open_runtime_stores().await? else {
+        return Ok(());
+    };
+
+    let project_root = stores.dir.path().join("project-local-review");
+    std::fs::create_dir(&project_root)?;
+    let project_id = project_root.to_string_lossy();
+    stores
+        .issue_store
+        .record_issue_scheduled(&project_id, Some("owner/repo"), 47, "task-6", &[], false)
+        .await?;
+    stores
+        .issue_store
+        .record_pr_detected(
+            &project_id,
+            Some("owner/repo"),
+            47,
+            "task-6",
+            79,
+            "https://github.com/owner/repo/pull/79",
+        )
+        .await?;
+
+    let workflow_id =
+        harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 47);
+    let instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "local_review_gate",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:47"),
+    )
+    .with_id(&workflow_id)
+    .with_data(json!({
+        "project_id": project_id.as_ref(),
+        "repo": "owner/repo",
+        "issue_number": 47,
+        "task_id": "task-6",
+        "pr_number": 79,
+        "pr_url": "https://github.com/owner/repo/pull/79",
+    }));
+    stores.runtime_store.upsert_instance(&instance).await?;
+
+    let report = run_once_with_runtime_token(
+        &stores.task_store,
+        Some(&stores.runtime_store),
+        Some(&stores.issue_store),
+        20,
+        false,
+        None,
+    )
+    .await;
+
+    assert_eq!(report.workflow_transitions.len(), 1);
+    assert_eq!(report.workflow_transitions[0].from, "local_review_gate");
+    assert_eq!(report.workflow_transitions[0].to, "done");
+    assert!(report.workflow_transitions[0].applied);
+
+    let updated = stores
+        .runtime_store
+        .get_instance(&workflow_id)
+        .await?
+        .expect("workflow should remain persisted");
+    assert_eq!(updated.state, "done");
+    assert_eq!(updated.data["last_decision"], "reconcile_pr_merged");
+    assert_eq!(updated.data["external_pr_state"], "done");
+    assert_eq!(updated.data["pr_number"], 79);
+
+    let issue_workflow = stores
+        .issue_store
+        .get_by_issue(&project_id, Some("owner/repo"), 47)
+        .await?
+        .expect("issue workflow should exist");
+    assert_eq!(
+        issue_workflow.state,
+        harness_workflow::issue_lifecycle::IssueLifecycleState::Done
+    );
+
+    Ok(())
+}

--- a/crates/harness-server/src/reconciliation_tests.rs
+++ b/crates/harness-server/src/reconciliation_tests.rs
@@ -7,6 +7,8 @@ use tokio::sync::Mutex;
 
 #[path = "reconciliation_blocked_done_tests.rs"]
 mod blocked_done_tests;
+#[path = "reconciliation_local_review_gate_tests.rs"]
+mod local_review_gate_tests;
 #[path = "reconciliation_ready_to_merge_tests.rs"]
 mod ready_to_merge_tests;
 

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -600,14 +600,20 @@ impl DecisionValidator {
         context: &ValidationContext,
     ) -> Result<bool, WorkflowDecisionRejection> {
         if self.kind != DecisionValidatorKind::GithubIssuePr
-            || !github_issue_pr_validation::is_blocked_done_transition(decision)
+            || !github_issue_pr_validation::is_reconciliation_only_pr_merge_done_transition(
+                decision,
+            )
         {
             return Ok(false);
         }
 
-        let rule = TransitionRule::new("blocked", "done", [WorkflowCommandType::MarkDone]);
+        let rule = TransitionRule::new(
+            decision.observed_state.as_str(),
+            "done",
+            [WorkflowCommandType::MarkDone],
+        );
         self.validate_commands(&rule, decision, context)?;
-        github_issue_pr_validation::validate_blocked_done_reconciliation(decision, context)?;
+        github_issue_pr_validation::validate_reconciliation_only_pr_merge_done(decision, context)?;
         Ok(true)
     }
 

--- a/crates/harness-workflow/src/runtime/validator_github_issue_pr.rs
+++ b/crates/harness-workflow/src/runtime/validator_github_issue_pr.rs
@@ -5,29 +5,25 @@ pub(super) fn validate_decision(
     decision: &WorkflowDecision,
     context: &ValidationContext,
 ) -> Result<(), WorkflowDecisionRejection> {
-    if is_blocked_done_transition(decision) {
-        validate_blocked_done_reconciliation(decision, context)?;
+    if is_reconciliation_only_pr_merge_done_transition(decision) {
+        validate_reconciliation_only_pr_merge_done(decision, context)?;
     }
     Ok(())
 }
 
-pub(super) fn is_blocked_done_transition(decision: &WorkflowDecision) -> bool {
-    decision.observed_state == "blocked" && decision.next_state == "done"
-}
-
-pub(super) fn validate_blocked_done_reconciliation(
+pub(super) fn validate_reconciliation_only_pr_merge_done(
     decision: &WorkflowDecision,
     context: &ValidationContext,
 ) -> Result<(), WorkflowDecisionRejection> {
     if context.actor != "reconciliation" || decision.decision != "reconcile_pr_merged" {
         return Err(missing_terminal_evidence(
-            "blocked issue workflows can only be marked done by PR-merge reconciliation",
+            "issue workflows in reconciliation-only states can only be marked done by PR-merge reconciliation",
         ));
     }
 
     if !decision.commands.iter().any(is_pr_merge_mark_done_command) {
         return Err(missing_terminal_evidence(
-            "blocked issue PR-merge reconciliation requires pr_number plus pr_url or repo evidence",
+            "issue PR-merge reconciliation requires pr_number plus pr_url or repo evidence",
         ));
     }
 
@@ -37,11 +33,18 @@ pub(super) fn validate_blocked_done_reconciliation(
         .any(|evidence| evidence.kind == "github_pr")
     {
         return Err(missing_terminal_evidence(
-            "blocked issue PR-merge reconciliation requires github_pr evidence",
+            "issue PR-merge reconciliation requires github_pr evidence",
         ));
     }
 
     Ok(())
+}
+
+pub(super) fn is_reconciliation_only_pr_merge_done_transition(decision: &WorkflowDecision) -> bool {
+    matches!(
+        decision.observed_state.as_str(),
+        "blocked" | "local_review_gate"
+    ) && decision.next_state == "done"
 }
 
 fn is_pr_merge_mark_done_command(command: &WorkflowCommand) -> bool {

--- a/crates/harness-workflow/src/runtime/validator_tests.rs
+++ b/crates/harness-workflow/src/runtime/validator_tests.rs
@@ -55,6 +55,28 @@ fn blocked_done_slug_pr_merge_decision(instance: &WorkflowInstance) -> WorkflowD
     ))
 }
 
+fn local_review_gate_done_pr_merge_decision(instance: &WorkflowInstance) -> WorkflowDecision {
+    WorkflowDecision::new(
+        instance.id.clone(),
+        "local_review_gate",
+        "reconcile_pr_merged",
+        "done",
+        "reconciled: PR merged externally",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkDone,
+        "runtime-reconcile:workflow-1:done:77",
+        json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77"
+        }),
+    ))
+    .with_evidence(WorkflowEvidence::new(
+        "github_pr",
+        "repo=owner/repo issue=123 pr=77 url=https://github.com/owner/repo/pull/77",
+    ))
+}
+
 #[test]
 fn github_issue_pr_validator_allows_blocked_done_for_pr_merge_reconciliation() {
     let instance = issue_instance("blocked");
@@ -67,6 +89,20 @@ fn github_issue_pr_validator_allows_blocked_done_for_pr_merge_reconciliation() {
             &ValidationContext::new("reconciliation", Utc::now()),
         )
         .expect("PR-merge reconciliation should finish a blocked issue workflow");
+}
+
+#[test]
+fn github_issue_pr_validator_allows_local_review_gate_done_for_pr_merge_reconciliation() {
+    let instance = issue_instance("local_review_gate");
+    let decision = local_review_gate_done_pr_merge_decision(&instance);
+
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("reconciliation", Utc::now()),
+        )
+        .expect("PR-merge reconciliation should finish a local review gate workflow");
 }
 
 #[test]
@@ -84,12 +120,40 @@ fn github_issue_pr_validator_allows_slug_only_blocked_done_reconciliation() {
 }
 
 #[test]
+fn github_issue_pr_validator_does_not_advertise_reconciliation_only_local_review_gate_done() {
+    let validator = DecisionValidator::github_issue_pr();
+
+    assert!(!validator
+        .transition_rules_from("local_review_gate")
+        .any(|rule| rule.to_state == "done"));
+}
+
+#[test]
 fn github_issue_pr_validator_does_not_advertise_reconciliation_only_blocked_done() {
     let validator = DecisionValidator::github_issue_pr();
 
     assert!(!validator
         .transition_rules_from("blocked")
         .any(|rule| rule.to_state == "done"));
+}
+
+#[test]
+fn github_issue_pr_validator_rejects_non_reconciliation_local_review_gate_done() {
+    let instance = issue_instance("local_review_gate");
+    let decision = local_review_gate_done_pr_merge_decision(&instance);
+
+    let err = DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("controller-1", Utc::now()),
+        )
+        .expect_err("non-reconciliation actors must not finish local review gate workflows");
+
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::MissingTerminalEvidence
+    );
 }
 
 #[test]
@@ -104,6 +168,36 @@ fn github_issue_pr_validator_rejects_non_reconciliation_blocked_done() {
             &ValidationContext::new("controller-1", Utc::now()),
         )
         .expect_err("non-reconciliation actors must not finish blocked issue workflows");
+
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::MissingTerminalEvidence
+    );
+}
+
+#[test]
+fn github_issue_pr_validator_rejects_unevidenced_local_review_gate_done() {
+    let instance = issue_instance("local_review_gate");
+    let decision = WorkflowDecision::new(
+        instance.id.clone(),
+        "local_review_gate",
+        "agent_reported_done",
+        "done",
+        "The agent reported completion without external merge evidence.",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkDone,
+        "issue-123-done",
+        json!({ "reason": "done" }),
+    ));
+
+    let err = DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("reconciliation", Utc::now()),
+        )
+        .expect_err("local_review_gate -> done requires merged PR evidence");
 
     assert_eq!(
         err.kind,


### PR DESCRIPTION
## Summary
- Allow evidence-backed PR-merge reconciliation to mark local_review_gate workflows done without advertising a general local_review_gate -> done transition.
- Reuse the existing merged-PR evidence requirements for reconciliation-only terminal transitions.
- Add workflow validator coverage and a server reconciliation regression for externally merged PRs at local_review_gate.

Fixes #1438
SpecRail: SP1438-T001, SP1438-T002, SP1438-T003

## Verification
- cargo test -p harness-workflow validator
- cargo test -p harness-server reconciliation
- cargo check -p harness-workflow --all-targets
- cargo check -p harness-server --all-targets
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1438
- python3 checks/check_workflow.py --repo .
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings