### PR TITLE
Add GH1439 usage monitor spec

### DIFF
--- a/specs/GH1439/product.md
+++ b/specs/GH1439/product.md
@@ -1,0 +1,94 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1439
+
+## User Problem
+
+The usage monitor can report `total_tokens = 0` and `request_count = 0` while
+workflow-runtime agents are actively burning tokens. Operators see active and
+high-burn agent invocations, but the dashboard's primary usage counters remain
+empty because workflow-runtime token usage is not persisted into the source the
+dashboard reads.
+
+Malformed usage rows are also dropped without a user-visible diagnostic. When
+the usage source is missing or corrupt, the dashboard can look clean while its
+numbers are incomplete.
+
+## Goals
+
+- Usage monitor totals include token usage emitted by workflow-runtime agent
+  turns, including `codex_exec` jobs.
+- Malformed usage payloads or corrupt runtime usage rows are surfaced as
+  diagnostics and error-level logs instead of disappearing silently.
+- Active invocation attribution does not depend on the historical runtime-row
+  limit, so running and pending jobs remain visible even when more than 200
+  recent jobs exist.
+- The existing legacy `llm_usage` event path continues to be counted while
+  workflow-runtime usage is migrated to a workflow-runtime-owned source.
+- The API response makes source confidence clear when token totals are exact,
+  partial, unavailable, or malformed.
+
+## Non-Goals
+
+- Adding billing enforcement, quotas, or automatic shutdown for high burn.
+- Replacing local Codex or Claude usage file summaries.
+- Changing agent runtime token accounting semantics.
+- Removing the legacy task-path `llm_usage` emitter.
+- Adding a new dashboard page or authentication surface.
+
+## User-Visible Behavior
+
+`GET /api/usage-monitor` and the `/usage` dashboard show nonzero token and
+request totals when workflow-runtime agents emit nonzero `TokenUsage` events
+inside the requested window. Totals remain grouped by agent, project, model,
+and candidate where attribution exists.
+
+If Harness cannot parse a usage payload, it records a diagnostic count and logs
+the malformed source at error level with enough identifying context to debug
+the row. The response must not present silently incomplete data as exact.
+
+Running and pending workflow-runtime invocations remain present in
+`agent_invocations` and active summaries regardless of the historical `limit`
+used for completed jobs.
+
+## Acceptance Criteria
+
+- [ ] Workflow-runtime `TokenUsage` events with nonzero token counts are
+      persisted in a workflow-runtime-owned usage source and included in
+      `summary.total_tokens`, `summary.request_count`, and grouping arrays.
+- [ ] The implementation does not rely on adding new writes to the generic
+      observability event store for workflow-runtime usage.
+- [ ] Legacy `llm_usage` events still count toward usage totals during the
+      migration period.
+- [ ] Malformed legacy usage events, malformed workflow-runtime usage rows, and
+      corrupt runtime invocation rows are reported through diagnostics and
+      error-level logs instead of being silently filtered out.
+- [ ] Running and pending runtime jobs are always loaded for active attribution;
+      the query `limit` only bounds historical, non-active rows.
+- [ ] Process sampling does not run a global sysinfo scan directly on the async
+      handler path.
+- [ ] Tests cover workflow-runtime usage persistence, usage monitor aggregation,
+      malformed-source diagnostics, and active-row limit behavior.
+
+## Edge Cases
+
+- Zero-placeholder token events remain ignored and must not create false
+  requests.
+- Multiple token updates for the same turn should avoid double-counting
+  cumulative totals.
+- Missing model, project, or candidate attribution should use the existing
+  unknown/unassigned labels rather than dropping the usage.
+- If the workflow runtime store is unavailable, the response must clearly mark
+  workflow-runtime usage as unavailable while still returning any legacy or
+  local-file usage that can be read.
+- If a usage row references a runtime job that has since been pruned, the token
+  totals should still count while runtime-job attribution falls back to
+  available stored fields.
+
+## Rollout Notes
+
+This is an observability correctness fix. It adds or wires a durable
+workflow-runtime usage source and changes dashboard diagnostics, but it does
+not change agent execution, review gates, or merge authorization.

--- a/specs/GH1439/tasks.md
+++ b/specs/GH1439/tasks.md
@@ -1,0 +1,45 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1439
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1439-T001` Owner: `workflow-runtime-store` | Done when: a workflow-runtime-owned usage table, migration, typed record, query API, and idempotent upsert API persist nonzero runtime token usage without writing new generic `llm_usage` events | Verify: `cargo test -p harness-workflow runtime_usage`
+- [ ] `SP1439-T002` Owner: `runtime-worker` | Done when: workflow-runtime `StreamItem::TokenUsage` persists nonzero cumulative usage with runtime job, command, workflow, model, project, turn, and attribution metadata; zero placeholders are skipped | Verify: `cargo test -p harness-server workflow_runtime_worker token_usage`
+- [ ] `SP1439-T003` Owner: `usage-monitor` | Done when: `/api/usage-monitor` aggregates workflow-runtime usage rows with legacy `llm_usage` events and reports combined totals by agent, project, model, and candidate | Verify: `cargo test -p harness-server usage_monitor`
+- [ ] `SP1439-T004` Owner: `diagnostics` | Done when: malformed legacy usage events, malformed runtime usage rows, corrupt runtime invocation rows, and process sampler failures produce diagnostics plus error-level logs instead of silent filtering | Verify: `cargo test -p harness-server usage_monitor`
+- [ ] `SP1439-T005` Owner: `active-attribution` | Done when: running and pending runtime jobs are always included for active attribution while `limit` only bounds historical non-active rows | Verify: `cargo test -p harness-server usage_monitor`
+- [ ] `SP1439-T006` Owner: `process-sampling` | Done when: usage monitor process sampling runs through a blocking-safe wrapper and failure is reflected in diagnostics | Verify: `cargo test -p harness-server usage_monitor_process`
+
+## Parallelization
+
+T001 must land before T002 and T003 because both depend on the runtime usage
+store API. T002 and T003 can then proceed in parallel if they do not edit the
+same files. T004, T005, and T006 touch the usage monitor surface and should be
+sequenced after the aggregation shape is clear.
+
+## Verification
+
+- `cargo test -p harness-workflow runtime_usage`
+- `cargo test -p harness-server workflow_runtime_worker token_usage`
+- `cargo test -p harness-server usage_monitor`
+- `cargo test -p harness-server usage_monitor_process`
+- `cargo check -p harness-workflow --all-targets`
+- `cargo check -p harness-server --all-targets`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1439`
+- `python3 checks/check_workflow.py --repo .`
+
+## Handoff Notes
+
+Keep the new runtime usage source inside the workflow runtime store. Do not fix
+the zero-token dashboard by emitting new generic observability events from the
+workflow-runtime hot path. Treat diagnostic counters as part of the acceptance
+criteria because the original bug is both missing token ingestion and silent
+parse failure.

--- a/specs/GH1439/tech.md
+++ b/specs/GH1439/tech.md
@@ -1,0 +1,127 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1439
+
+## Product Spec
+
+See `specs/GH1439/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Usage monitor API | `crates/harness-server/src/handlers/usage_monitor.rs` | Aggregates `llm_usage` observability events and active runtime rows. `parse_usage_event` returns `Option`, so malformed events are filtered out without diagnostics. | This is the user-visible surface that reports zero usage. |
+| Legacy task usage emitter | `crates/harness-server/src/task_executor/helpers/streaming.rs` | Builds and logs `llm_usage` events for the legacy task path. | This remains a compatibility source but does not cover workflow-runtime hot paths. |
+| Workflow-runtime token bridge | `crates/harness-server/src/workflow_runtime_worker/turn_engine/helpers.rs` and `turn_lifecycle.rs` | Handles `StreamItem::TokenUsage` by updating thread state and notifying listeners. It does not persist usage for the usage monitor. | This is the missing runtime usage write path. |
+| Workflow runtime store | `crates/harness-workflow/src/runtime/store.rs` and `store_migrations.rs` | Owns runtime jobs, events, commands, and workflow tables. | New workflow-runtime usage persistence belongs here rather than the generic observability event store. |
+| Active runtime attribution | `crates/harness-server/src/handlers/usage_monitor.rs` | `load_runtime_usage_rows` applies one `LIMIT` to both active and historical runtime jobs. | More than 200 recent jobs can hide active jobs and inflate external process counts. |
+| Process sampling | `crates/harness-server/src/handlers/usage_monitor_process.rs` | Samples system processes through a global sampler lock on the request path. | The API should not block a Tokio worker during a full process scan. |
+
+## Proposed Design
+
+1. Add workflow-runtime usage persistence in `harness-workflow`.
+   - Add a migration for a runtime-owned usage table, tentatively
+     `runtime_usage_events`.
+   - Store enough stable fields to aggregate even after runtime jobs are
+     pruned: usage id, runtime job id, command id, workflow id, runtime kind,
+     runtime profile, agent label, model, project, optional turn id, optional
+     candidate/task attribution keys, token metrics, reported timestamp, and
+     updated timestamp.
+   - Enforce idempotence for cumulative turn updates with a natural key such
+     as `(runtime_job_id, turn_id)` when `turn_id` is available, or another
+     deterministic runtime-job scoped key. Upserts should replace cumulative
+     values rather than adding duplicates.
+2. Persist workflow-runtime `TokenUsage` events from the turn engine.
+   - Extend the runtime worker path so token updates have access to the current
+     runtime job, workflow command, workflow instance, model, project, and turn
+     identifiers needed for usage attribution.
+   - Ignore zero-placeholder events using the same semantics as the legacy
+     task-path emitter.
+   - If persistence fails, log an error and expose a runtime usage persistence
+     diagnostic; do not silently continue with an exact-looking zero.
+3. Update usage monitor aggregation.
+   - Read workflow-runtime usage rows for the requested window from the runtime
+     store and combine them with legacy `llm_usage` records.
+   - Keep existing grouping behavior for agent, project, model, and candidate
+     attribution.
+   - Add diagnostics for source availability and malformed/skipped counts,
+     including separate counts for legacy event parse failures,
+     workflow-runtime usage row parse failures, and runtime invocation row
+     parse failures.
+   - Set `diagnostics.token_source` or add a source detail field that reflects
+     the combined source instead of implying legacy-only `llm_usage_events`.
+4. Make active invocation loading independent of historical limits.
+   - Load all pending/running runtime jobs for active attribution.
+   - Apply `limit` only to completed or otherwise non-active rows inside the
+     selected time window.
+   - Preserve deterministic ordering for the combined active plus historical
+     result set.
+5. Move process sampling off the async handler path.
+   - Run the sysinfo process snapshot through `tokio::task::spawn_blocking`,
+     or an equivalent non-blocking wrapper.
+   - If the blocking task fails, return an empty process list with an error
+     diagnostic instead of blocking or panicking.
+
+## Data Flow
+
+Workflow-runtime agents emit `AgentEvent::TokenUsage`, which becomes
+`StreamItem::TokenUsage` in the turn lifecycle. The turn engine persists the
+latest nonzero cumulative usage snapshot to the workflow runtime store with
+runtime job, command, workflow, model, project, and attribution metadata.
+
+The usage monitor reads runtime usage rows for the requested window and legacy
+`llm_usage` events for compatibility. Parsed records flow into the existing
+aggregate helpers. Malformed sources increment diagnostics and emit error-level
+logs with source identifiers.
+
+Active runtime invocations are loaded from runtime jobs independently from the
+usage rows. Running and pending invocations are always included; historical rows
+are bounded by the request limit.
+
+## Alternatives Considered
+
+- Persist workflow-runtime usage by writing new `llm_usage` observability
+  events. Rejected because issue evidence notes the generic event store is on a
+  contraction path and this would pin new runtime behavior to it.
+- Infer token burn from active process count. Rejected because process presence
+  cannot provide exact token or request totals.
+- Keep silent parse filtering and add a dashboard footnote. Rejected because it
+  leaves operators without actionable evidence when numbers are incomplete.
+- Remove the runtime-row limit entirely. Rejected because historical rows still
+  need a bounded query; only active rows must be unbounded by that limit.
+
+## Risks
+
+- Data correctness: Agent streams may emit cumulative usage updates. The store
+  must upsert the latest cumulative snapshot to avoid double-counting.
+- Compatibility: Existing legacy task usage and overview usage aggregation must
+  continue to work.
+- Performance: Usage aggregation must index window and attribution lookups so
+  the dashboard remains cheap under many runtime jobs.
+- Maintenance: Runtime usage persistence should reuse `UsageMetrics` conversion
+  rules to avoid divergent token totals.
+- Security: Do not store secrets or full prompts in usage rows.
+
+## Test Plan
+
+- [ ] Unit tests: zero-placeholder usage is skipped; nonzero workflow-runtime
+      usage rows upsert by runtime job and turn key.
+- [ ] Handler tests: usage monitor totals include workflow-runtime usage and
+      legacy `llm_usage` events in the same window.
+- [ ] Handler tests: malformed legacy events, malformed runtime usage rows, and
+      corrupt invocation rows increment diagnostics and log error-level paths.
+- [ ] Runtime worker tests: `StreamItem::TokenUsage` on a workflow-runtime turn
+      persists usage with runtime job and workflow metadata.
+- [ ] Query tests: pending/running jobs are returned even when historical rows
+      exceed the request limit.
+- [ ] Async behavior tests or focused unit coverage: process sampling is
+      executed through the non-blocking wrapper and reports failure
+      diagnostically.
+
+## Rollback Plan
+
+Revert the runtime usage store migration and usage monitor read/write changes.
+Existing legacy `llm_usage` aggregation remains available. Runtime usage rows
+that were already written can remain inert if the reader is removed.


### PR DESCRIPTION
## Summary

- add the GH1439 product, technical, and task specs
- scope the usage-monitor fix around workflow-runtime token persistence, malformed-source diagnostics, active attribution limits, and process sampling

## Verification

- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1439
- python3 checks/check_workflow.py --repo .
- git diff --check
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings

Issue: #1439