### PR TITLE
Fix workflow runtime usage monitor ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,6 +1484,7 @@ dependencies = [
  "futures",
  "harness-core",
  "harness-exec",
+ "harness-observe",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/harness-server/src/handlers/usage_monitor.rs
+++ b/crates/harness-server/src/handlers/usage_monitor.rs
@@ -5,7 +5,6 @@ use axum::{
     Json,
 };
 use chrono::{DateTime, Duration, Utc};
-use harness_core::types::{Event, EventFilters};
 use harness_observe::usage::UsageMetrics;
 use harness_workflow::runtime::{
     runtime_job_running_lease_state_at, RuntimeJob, RuntimeJobStatus, RuntimeProfile,
@@ -28,15 +27,17 @@ mod usage_monitor_candidate;
 mod usage_monitor_local_usage;
 #[path = "usage_monitor_process.rs"]
 mod usage_monitor_process;
+#[path = "usage_monitor_records.rs"]
+mod usage_monitor_records;
 
 use usage_monitor_active::{aggregate_active_counts, burn_level, runtime_job_status, runtime_kind};
 use usage_monitor_aggregate::{aggregate_usage, total_usage_aggregate, UsageGroup};
 use usage_monitor_candidate::{
-    candidate_attribution_index, candidate_usage_groups, usage_record_candidate,
-    CandidateUsageGroup,
+    candidate_attribution_index, candidate_usage_groups, CandidateUsageGroup,
 };
 use usage_monitor_local_usage::{load_local_usage_summaries, LocalUsageSourceSummary};
-use usage_monitor_process::{sample_agent_processes, AgentProcess};
+use usage_monitor_process::{sample_agent_processes_for_monitor, AgentProcess};
+use usage_monitor_records::load_usage_records;
 
 const DEFAULT_USAGE_WINDOW_HOURS: i64 = 24;
 const MAX_USAGE_WINDOW_HOURS: i64 = 24 * 14;
@@ -120,6 +121,12 @@ struct UsageRecord {
     metrics: UsageMetrics,
     estimated_cost_usd: Option<f64>,
     candidate: Option<usage_monitor_candidate::CandidateUsageAttribution>,
+}
+
+#[derive(Debug, Default)]
+struct RuntimeRowsLoad {
+    rows: Vec<RuntimeUsageRow>,
+    malformed_rows: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -255,6 +262,10 @@ struct UsageDiagnostics {
     token_source: &'static str,
     active_cost_confidence: &'static str,
     process_source: &'static str,
+    malformed_legacy_usage_events: u64,
+    malformed_runtime_usage_rows: u64,
+    malformed_runtime_invocation_rows: u64,
+    process_sampler_errors: u64,
 }
 
 pub(crate) async fn usage_monitor(
@@ -281,16 +292,19 @@ async fn build_usage_monitor_response(
     let now = Utc::now();
     let window = UsageWindow::from_query(query.hours, now);
     let price_catalog = PriceCatalog::from_env_cached();
-    let runtime_rows = load_runtime_usage_rows(state, window.since, query.limit).await?;
+    let runtime_rows_load = load_runtime_usage_rows(state, window.since, query.limit).await?;
+    let runtime_rows = runtime_rows_load.rows;
     let candidate_attributions = candidate_attribution_index(&runtime_rows);
-    let usage_records =
+    let usage_load =
         load_usage_records(state, window, price_catalog, &candidate_attributions).await?;
+    let usage_records = usage_load.records;
     let agent_invocations = runtime_rows
         .iter()
         .map(|row| agent_invocation_from_row(row, now))
         .collect::<Vec<_>>();
-    let external_agent_processes =
-        sample_agent_processes(now, &runtime_attribution_tokens(&runtime_rows));
+    let process_sample =
+        sample_agent_processes_for_monitor(now, runtime_attribution_tokens(&runtime_rows)).await;
+    let external_agent_processes = process_sample.processes;
     let local_usage_sources = load_local_usage_summaries(window).await;
 
     let tokens_by_agent =
@@ -389,68 +403,14 @@ async fn build_usage_monitor_response(
         local_usage_sources,
         diagnostics: UsageDiagnostics {
             runtime_store_available: state.core.workflow_runtime_store.is_some(),
-            token_source: "llm_usage_events",
+            token_source: "workflow_runtime_usage_and_llm_usage_events",
             active_cost_confidence: "estimated_from_agent_invocation_state",
             process_source: "external_cli_process_snapshot",
+            malformed_legacy_usage_events: usage_load.diagnostics.malformed_legacy_usage_events,
+            malformed_runtime_usage_rows: usage_load.diagnostics.malformed_runtime_usage_rows,
+            malformed_runtime_invocation_rows: runtime_rows_load.malformed_rows,
+            process_sampler_errors: process_sample.error_count,
         },
-    })
-}
-
-async fn load_usage_records(
-    state: &AppState,
-    window: UsageWindow,
-    price_catalog: &PriceCatalog,
-    candidate_attributions: &usage_monitor_candidate::CandidateAttributionIndex,
-) -> anyhow::Result<Vec<UsageRecord>> {
-    let events = state
-        .observability
-        .events
-        .query(&EventFilters {
-            hook: Some("llm_usage".to_string()),
-            since: Some(window.since),
-            until: Some(window.now),
-            include_content: true,
-            ..Default::default()
-        })
-        .await?;
-    Ok(events
-        .iter()
-        .filter_map(|event| parse_usage_event(event, price_catalog, candidate_attributions))
-        .collect())
-}
-
-fn parse_usage_event(
-    event: &Event,
-    price_catalog: &PriceCatalog,
-    candidate_attributions: &usage_monitor_candidate::CandidateAttributionIndex,
-) -> Option<UsageRecord> {
-    let content = event.content.as_deref()?;
-    let payload: Value = serde_json::from_str(content).ok()?;
-    let metrics = UsageMetrics::from_payload(&payload)?;
-    let agent = payload
-        .get("agent")
-        .and_then(Value::as_str)
-        .unwrap_or(event.tool.as_str())
-        .to_string();
-    let model = payload
-        .get("model")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown")
-        .to_string();
-    let project = payload
-        .get("project")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let estimated_cost_usd = price_catalog.estimate(&model, &metrics);
-    let candidate = usage_record_candidate(&payload, candidate_attributions);
-    Some(UsageRecord {
-        agent,
-        model,
-        project,
-        metrics,
-        estimated_cost_usd,
-        candidate,
     })
 }
 
@@ -458,101 +418,160 @@ async fn load_runtime_usage_rows(
     state: &AppState,
     recent_since: DateTime<Utc>,
     limit: Option<i64>,
-) -> anyhow::Result<Vec<RuntimeUsageRow>> {
+) -> anyhow::Result<RuntimeRowsLoad> {
     let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return Ok(Vec::new());
+        return Ok(RuntimeRowsLoad::default());
     };
     let limit = limit
         .unwrap_or(DEFAULT_RUNTIME_JOB_LIMIT)
         .clamp(1, DEFAULT_RUNTIME_JOB_LIMIT);
     let rows: Vec<RuntimeUsageSqlRow> = sqlx::query_as(
         "SELECT
-             workflow.id,
-             workflow.data::text,
-             command.id,
-             command.status,
-             command.data::text,
-             job.data::text,
-             latest_event.event_type,
-             latest_event.created_at,
-             latest_turn.sequence IS NOT NULL,
-             COALESCE(event_flags.activity_result_ready, false)
-         FROM runtime_jobs job
-         JOIN workflow_commands command ON command.id = job.command_id
-         JOIN workflow_instances workflow ON workflow.id = command.workflow_id
-         LEFT JOIN LATERAL (
-             SELECT event_type, created_at
-             FROM runtime_events event
-             WHERE event.runtime_job_id = job.id
-             ORDER BY sequence DESC
-             LIMIT 1
-         ) latest_event ON true
-         LEFT JOIN LATERAL (
-             SELECT sequence FROM runtime_events event
-             WHERE event.runtime_job_id = job.id AND event.event_type = 'RuntimeTurnStarted'
-             ORDER BY sequence DESC LIMIT 1
-         ) latest_turn ON true
-         LEFT JOIN LATERAL (
-             SELECT BOOL_OR(event_type = 'ActivityResultReady') AS activity_result_ready
-             FROM runtime_events event
-             WHERE event.runtime_job_id = job.id AND event.sequence > latest_turn.sequence
-         ) event_flags ON true
-         WHERE job.status IN ('pending', 'running')
-            OR job.updated_at >= $1
+             workflow_id,
+             workflow_data,
+             command_id,
+             command_status,
+             command_data,
+             runtime_job_data,
+             latest_event_type,
+             latest_event_created_at,
+             runtime_turn_started,
+             activity_result_ready_after_latest_turn
+         FROM (
+             SELECT
+                 workflow.id AS workflow_id,
+                 workflow.data::text AS workflow_data,
+                 command.id AS command_id,
+                 command.status AS command_status,
+                 command.data::text AS command_data,
+                 job.data::text AS runtime_job_data,
+                 latest_event.event_type AS latest_event_type,
+                 latest_event.created_at AS latest_event_created_at,
+                 latest_turn.sequence IS NOT NULL AS runtime_turn_started,
+                 COALESCE(event_flags.activity_result_ready, false)
+                    AS activity_result_ready_after_latest_turn,
+                 0 AS sort_priority,
+                 job.status AS sort_status,
+                 job.updated_at AS sort_updated_at,
+                 job.id AS sort_job_id
+             FROM runtime_jobs job
+             JOIN workflow_commands command ON command.id = job.command_id
+             JOIN workflow_instances workflow ON workflow.id = command.workflow_id
+             LEFT JOIN LATERAL (
+                 SELECT event_type, created_at
+                 FROM runtime_events event
+                 WHERE event.runtime_job_id = job.id
+                 ORDER BY sequence DESC
+                 LIMIT 1
+             ) latest_event ON true
+             LEFT JOIN LATERAL (
+                 SELECT sequence FROM runtime_events event
+                 WHERE event.runtime_job_id = job.id AND event.event_type = 'RuntimeTurnStarted'
+                 ORDER BY sequence DESC LIMIT 1
+             ) latest_turn ON true
+             LEFT JOIN LATERAL (
+                 SELECT BOOL_OR(event_type = 'ActivityResultReady') AS activity_result_ready
+                 FROM runtime_events event
+                 WHERE event.runtime_job_id = job.id AND event.sequence > latest_turn.sequence
+             ) event_flags ON true
+             WHERE job.status IN ('pending', 'running')
+             UNION ALL
+             SELECT * FROM (
+                 SELECT
+                     workflow.id AS workflow_id,
+                     workflow.data::text AS workflow_data,
+                     command.id AS command_id,
+                     command.status AS command_status,
+                     command.data::text AS command_data,
+                     job.data::text AS runtime_job_data,
+                     latest_event.event_type AS latest_event_type,
+                     latest_event.created_at AS latest_event_created_at,
+                     latest_turn.sequence IS NOT NULL AS runtime_turn_started,
+                     COALESCE(event_flags.activity_result_ready, false)
+                        AS activity_result_ready_after_latest_turn,
+                     1 AS sort_priority,
+                     job.status AS sort_status,
+                     job.updated_at AS sort_updated_at,
+                     job.id AS sort_job_id
+                 FROM runtime_jobs job
+                 JOIN workflow_commands command ON command.id = job.command_id
+                 JOIN workflow_instances workflow ON workflow.id = command.workflow_id
+                 LEFT JOIN LATERAL (
+                     SELECT event_type, created_at
+                     FROM runtime_events event
+                     WHERE event.runtime_job_id = job.id
+                     ORDER BY sequence DESC
+                     LIMIT 1
+                 ) latest_event ON true
+                 LEFT JOIN LATERAL (
+                     SELECT sequence FROM runtime_events event
+                     WHERE event.runtime_job_id = job.id
+                       AND event.event_type = 'RuntimeTurnStarted'
+                     ORDER BY sequence DESC LIMIT 1
+                 ) latest_turn ON true
+                 LEFT JOIN LATERAL (
+                     SELECT BOOL_OR(event_type = 'ActivityResultReady') AS activity_result_ready
+                     FROM runtime_events event
+                     WHERE event.runtime_job_id = job.id AND event.sequence > latest_turn.sequence
+                 ) event_flags ON true
+                 WHERE job.status NOT IN ('pending', 'running')
+                   AND job.updated_at >= $1
+                 ORDER BY job.updated_at DESC, job.id DESC
+                 LIMIT $2
+             ) historical_rows
+         ) combined_rows
          ORDER BY
-             CASE job.status
+             sort_priority ASC,
+             CASE sort_status
                  WHEN 'running' THEN 0
                  WHEN 'pending' THEN 1
                  ELSE 2
              END ASC,
-             job.updated_at DESC,
-             job.id DESC
-         LIMIT $2",
+             sort_updated_at DESC,
+             sort_job_id DESC",
     )
     .bind(recent_since)
     .bind(limit)
     .fetch_all(store.pool())
     .await?;
 
-    Ok(rows
-        .into_iter()
-        .filter_map(
-            |(
-                workflow_id,
-                workflow,
-                command_id,
-                command_status,
-                command,
-                runtime_job,
-                latest_runtime_event_type,
-                latest_runtime_event_at,
-                runtime_turn_started,
-                activity_result_ready_after_latest_turn,
-            )| {
-                match parse_runtime_usage_row(
-                    &workflow_id,
-                    command_id,
-                    command_status,
-                    &workflow,
-                    &command,
-                    &runtime_job,
-                    latest_runtime_event_type,
-                    latest_runtime_event_at,
-                    runtime_turn_started,
-                    activity_result_ready_after_latest_turn,
-                ) {
-                    Ok(row) => Some(row),
-                    Err(error) => {
-                        tracing::warn!(
-                            workflow_id = %workflow_id,
-                            "usage_monitor: skipping invalid runtime row: {error}"
-                        );
-                        None
-                    }
-                }
-            },
-        )
-        .collect())
+    let mut load = RuntimeRowsLoad::default();
+    for (
+        workflow_id,
+        workflow,
+        command_id,
+        command_status,
+        command,
+        runtime_job,
+        latest_runtime_event_type,
+        latest_runtime_event_at,
+        runtime_turn_started,
+        activity_result_ready_after_latest_turn,
+    ) in rows
+    {
+        match parse_runtime_usage_row(
+            &workflow_id,
+            command_id,
+            command_status,
+            &workflow,
+            &command,
+            &runtime_job,
+            latest_runtime_event_type,
+            latest_runtime_event_at,
+            runtime_turn_started,
+            activity_result_ready_after_latest_turn,
+        ) {
+            Ok(row) => load.rows.push(row),
+            Err(error) => {
+                load.malformed_rows += 1;
+                tracing::error!(
+                    workflow_id = %workflow_id,
+                    "usage_monitor: skipping invalid runtime row: {error}"
+                );
+            }
+        }
+    }
+    Ok(load)
 }
 
 fn parse_runtime_usage_row(

--- a/crates/harness-server/src/handlers/usage_monitor_process.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_process.rs
@@ -16,16 +16,49 @@ pub(crate) struct AgentProcess {
     pub(crate) command_label: &'static str,
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct ProcessSample {
+    pub(crate) processes: Vec<AgentProcess>,
+    pub(crate) error_count: u64,
+}
+
 static PROCESS_SYSTEM: OnceLock<Mutex<System>> = OnceLock::new();
 
-pub(crate) fn sample_agent_processes(
+pub(crate) async fn sample_agent_processes_for_monitor(
+    now: DateTime<Utc>,
+    attribution_tokens: BTreeSet<String>,
+) -> ProcessSample {
+    match tokio::task::spawn_blocking(move || try_sample_agent_processes(now, &attribution_tokens))
+        .await
+    {
+        Ok(Ok(processes)) => ProcessSample {
+            processes,
+            error_count: 0,
+        },
+        Ok(Err(error)) => {
+            tracing::error!("usage_monitor: process sampling failed: {error}");
+            ProcessSample {
+                processes: Vec::new(),
+                error_count: 1,
+            }
+        }
+        Err(error) => {
+            tracing::error!("usage_monitor: process sampler task failed: {error}");
+            ProcessSample {
+                processes: Vec::new(),
+                error_count: 1,
+            }
+        }
+    }
+}
+
+pub(crate) fn try_sample_agent_processes(
     now: DateTime<Utc>,
     attribution_tokens: &BTreeSet<String>,
-) -> Vec<AgentProcess> {
+) -> Result<Vec<AgentProcess>, &'static str> {
     let process_system = PROCESS_SYSTEM.get_or_init(|| Mutex::new(System::new()));
     let Ok(mut system) = process_system.lock() else {
-        tracing::error!("usage_monitor: process sampler lock poisoned");
-        return Vec::new();
+        return Err("process sampler lock poisoned");
     };
     system.refresh_processes_specifics(
         ProcessesToUpdate::All,
@@ -69,7 +102,7 @@ pub(crate) fn sample_agent_processes(
         })
         .collect::<Vec<_>>();
     processes.sort_by(|a, b| b.age_secs.cmp(&a.age_secs).then_with(|| a.pid.cmp(&b.pid)));
-    processes
+    Ok(processes)
 }
 
 fn classify_agent_process(name: &str, executable: &str, command: &str) -> Option<&'static str> {

--- a/crates/harness-server/src/handlers/usage_monitor_records.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_records.rs
@@ -1,0 +1,134 @@
+use super::{usage_monitor_candidate, AppState, PriceCatalog, UsageRecord, UsageWindow};
+use harness_core::types::{Event, EventFilters};
+use harness_observe::usage::UsageMetrics;
+use harness_workflow::runtime::RuntimeUsageRecord;
+use serde_json::{json, Value};
+
+#[derive(Debug, Default)]
+pub(super) struct UsageLoadDiagnostics {
+    pub(super) malformed_legacy_usage_events: u64,
+    pub(super) malformed_runtime_usage_rows: u64,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct UsageRecordsLoad {
+    pub(super) records: Vec<UsageRecord>,
+    pub(super) diagnostics: UsageLoadDiagnostics,
+}
+
+pub(super) async fn load_usage_records(
+    state: &AppState,
+    window: UsageWindow,
+    price_catalog: &PriceCatalog,
+    candidate_attributions: &usage_monitor_candidate::CandidateAttributionIndex,
+) -> anyhow::Result<UsageRecordsLoad> {
+    let events = state
+        .observability
+        .events
+        .query(&EventFilters {
+            hook: Some("llm_usage".to_string()),
+            since: Some(window.since),
+            until: Some(window.now),
+            include_content: true,
+            ..Default::default()
+        })
+        .await?;
+    let mut load = UsageRecordsLoad::default();
+    for event in &events {
+        match parse_usage_event(event, price_catalog, candidate_attributions) {
+            Ok(record) => load.records.push(record),
+            Err(error) => {
+                load.diagnostics.malformed_legacy_usage_events += 1;
+                tracing::error!(
+                    event_id = %event.id.as_str(),
+                    "usage_monitor: malformed llm_usage event: {error}"
+                );
+            }
+        }
+    }
+    if let Some(store) = state.core.workflow_runtime_store.as_ref() {
+        for record in store
+            .runtime_usage_between(window.since, window.now)
+            .await?
+        {
+            match usage_record_from_runtime_usage(record, price_catalog, candidate_attributions) {
+                Ok(record) => load.records.push(record),
+                Err(error) => {
+                    load.diagnostics.malformed_runtime_usage_rows += 1;
+                    tracing::error!("usage_monitor: malformed workflow runtime usage row: {error}");
+                }
+            }
+        }
+    }
+    Ok(load)
+}
+
+pub(super) fn parse_usage_event(
+    event: &Event,
+    price_catalog: &PriceCatalog,
+    candidate_attributions: &usage_monitor_candidate::CandidateAttributionIndex,
+) -> anyhow::Result<UsageRecord> {
+    let content = event
+        .content
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("missing content"))?;
+    let payload: Value = serde_json::from_str(content)?;
+    let metrics = UsageMetrics::from_payload(&payload)
+        .ok_or_else(|| anyhow::anyhow!("missing token metrics"))?;
+    let agent = payload
+        .get("agent")
+        .and_then(Value::as_str)
+        .unwrap_or(event.tool.as_str())
+        .to_string();
+    let model = payload
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let project = payload
+        .get("project")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let estimated_cost_usd = price_catalog.estimate(&model, &metrics);
+    let candidate =
+        usage_monitor_candidate::usage_record_candidate(&payload, candidate_attributions);
+    Ok(UsageRecord {
+        agent,
+        model,
+        project,
+        metrics,
+        estimated_cost_usd,
+        candidate,
+    })
+}
+
+pub(super) fn usage_record_from_runtime_usage(
+    record: RuntimeUsageRecord,
+    price_catalog: &PriceCatalog,
+    candidate_attributions: &usage_monitor_candidate::CandidateAttributionIndex,
+) -> anyhow::Result<UsageRecord> {
+    if record.metrics.total_tokens() == 0 {
+        anyhow::bail!("runtime usage row {} has zero tokens", record.id);
+    }
+    let payload = json!({
+        "runtime_job_id": record.runtime_job_id,
+        "command_id": record.command_id,
+        "task_id": record.task_id,
+        "candidate_group_id": record.candidate_group_id,
+        "candidate_id": record.candidate_id,
+        "candidate_index": record.candidate_index,
+        "candidate_count": record.candidate_count,
+    });
+    let estimated_cost_usd = price_catalog.estimate(&record.model, &record.metrics);
+    let candidate =
+        usage_monitor_candidate::usage_record_candidate(&payload, candidate_attributions);
+    Ok(UsageRecord {
+        agent: record.agent,
+        model: record.model,
+        project: record.project,
+        metrics: record.metrics,
+        estimated_cost_usd,
+        candidate,
+    })
+}

--- a/crates/harness-server/src/handlers/usage_monitor_tests.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_tests.rs
@@ -2,9 +2,10 @@ use super::usage_monitor_aggregate::UsageAggregate;
 use super::usage_monitor_candidate::{
     candidate_attribution_index, candidate_usage_groups, CandidateUsageAttribution,
 };
+use super::usage_monitor_records::{parse_usage_event, usage_record_from_runtime_usage};
 use super::*;
-use harness_core::types::{Decision, SessionId};
-use harness_workflow::runtime::{RuntimeKind, WorkflowCommandType};
+use harness_core::types::{Decision, Event, SessionId};
+use harness_workflow::runtime::{RuntimeKind, RuntimeUsageRecord, WorkflowCommandType};
 
 #[test]
 fn burn_level_marks_stale_running_job_high() {
@@ -171,6 +172,69 @@ fn candidate_usage_parse_event_uses_runtime_candidate_attribution() {
     );
     assert_eq!(candidate.candidate_index, Some(2));
     assert_eq!(record.metrics.total_tokens(), 20);
+}
+
+#[test]
+fn parse_usage_event_reports_malformed_payload() {
+    let mut event = Event::new(SessionId::new(), "llm_usage", "codex", Decision::Complete);
+    event.content = Some(r#"{"agent":"codex","model":"gpt-5"}"#.to_string());
+
+    let error = parse_usage_event(
+        &event,
+        &PriceCatalog::default(),
+        &candidate_attribution_index(&[]),
+    )
+    .expect_err("missing usage metrics should be reported");
+
+    assert!(error.to_string().contains("missing token metrics"));
+}
+
+#[test]
+fn runtime_usage_record_becomes_usage_record_with_candidate() -> anyhow::Result<()> {
+    let runtime_record = RuntimeUsageRecord {
+        id: "usage-1".to_string(),
+        runtime_job_id: "runtime-job-1".to_string(),
+        usage_key: "turn:turn-1".to_string(),
+        command_id: "command-1".to_string(),
+        workflow_id: "workflow-1".to_string(),
+        turn_id: Some("turn-1".to_string()),
+        runtime_kind: "codex_exec".to_string(),
+        runtime_profile: "codex-default".to_string(),
+        agent: "codex".to_string(),
+        model: "gpt-5".to_string(),
+        project: "/repo".to_string(),
+        task_id: Some("issue-1449-c2".to_string()),
+        candidate_group_id: Some("workflow-1449:candidate-group:issue-1449".to_string()),
+        candidate_id: Some("workflow-1449:candidate-group:issue-1449:c2".to_string()),
+        candidate_index: Some(2),
+        candidate_count: Some(3),
+        metrics: UsageMetrics {
+            input_tokens: 21,
+            output_tokens: 8,
+            cache_read_input_tokens: 1,
+            cache_creation_input_tokens: 0,
+            reported_total_tokens: Some(30),
+        },
+        reported_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+
+    let record = usage_record_from_runtime_usage(
+        runtime_record,
+        &PriceCatalog::default(),
+        &candidate_attribution_index(&[]),
+    )?;
+
+    assert_eq!(record.agent, "codex");
+    assert_eq!(record.metrics.total_tokens(), 30);
+    assert_eq!(
+        record
+            .candidate
+            .as_ref()
+            .map(|candidate| candidate.candidate_id.as_str()),
+        Some("workflow-1449:candidate-group:issue-1449:c2")
+    );
+    Ok(())
 }
 
 #[test]

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -13,6 +13,7 @@ mod prompt_input_telemetry;
 mod prompt_packet;
 mod repo_memory_prompt;
 mod runtime_profile;
+mod runtime_usage;
 mod server_merge;
 pub(crate) mod turn_engine;
 mod workspace;

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -33,6 +33,7 @@ use super::runtime_profile::{
     agent_name_for_runtime_kind, runtime_profile_approval_policy, runtime_profile_for_job,
     runtime_profile_sandbox_mode,
 };
+use super::runtime_usage::runtime_usage_context;
 use super::server_merge::{execute_server_merge, server_merge_execution_enabled};
 use super::turn_engine::turn_lifecycle::{run_turn_lifecycle_with_options, TurnLifecycleOptions};
 use super::workspace::{finish_runtime_workspace, prepare_runtime_workspace};
@@ -186,6 +187,14 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                     force_code_agent: matches!(
                         job.runtime_kind,
                         RuntimeKind::CodexExec | RuntimeKind::CodexJsonrpc
+                    ),
+                    runtime_usage: runtime_usage_context(
+                        self.state,
+                        &job,
+                        workflow.as_ref(),
+                        &runtime_profile,
+                        agent_name,
+                        &source_project_root,
                     ),
                 },
             )

--- a/crates/harness-server/src/workflow_runtime_worker/runtime_profile.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/runtime_profile.rs
@@ -55,18 +55,8 @@ pub(super) fn runtime_profile_approval_policy(
         RuntimeKind::CodexExec | RuntimeKind::CodexJsonrpc => Ok(Some(raw.to_string())),
         other => anyhow::bail!(
             "runtime profile approval_policy `{raw}` is only supported for Codex runtime kinds, not {}",
-            runtime_kind_label(other)
+            other.as_str()
         ),
-    }
-}
-
-fn runtime_kind_label(kind: RuntimeKind) -> &'static str {
-    match kind {
-        RuntimeKind::CodexExec => "codex_exec",
-        RuntimeKind::CodexJsonrpc => "codex_jsonrpc",
-        RuntimeKind::ClaudeCode => "claude_code",
-        RuntimeKind::AnthropicApi => "anthropic_api",
-        RuntimeKind::RemoteHost => "remote_host",
     }
 }
 

--- a/crates/harness-server/src/workflow_runtime_worker/runtime_usage.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/runtime_usage.rs
@@ -1,0 +1,53 @@
+use super::data_helpers::{optional_data_string, optional_string};
+use super::turn_engine::helpers::RuntimeUsageContext;
+use crate::http::AppState;
+use harness_workflow::runtime::{RuntimeJob, RuntimeProfile, WorkflowInstance};
+use serde_json::Value;
+use std::path::Path;
+
+pub(super) fn runtime_usage_context(
+    state: &AppState,
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+    runtime_profile: &RuntimeProfile,
+    agent_name: &str,
+    source_project_root: &Path,
+) -> Option<RuntimeUsageContext> {
+    let store = state.core.workflow_runtime_store.as_ref()?.clone();
+    let workflow_id = workflow
+        .map(|workflow| workflow.id.clone())
+        .or_else(|| optional_string(&job.input, "workflow_id"))
+        .unwrap_or_else(|| "unknown".to_string());
+    let candidate = job.input.pointer("/command/candidate");
+    Some(RuntimeUsageContext {
+        store,
+        runtime_job_id: job.id.clone(),
+        command_id: job.command_id.clone(),
+        workflow_id,
+        runtime_kind: job.runtime_kind,
+        runtime_profile: job.runtime_profile.clone(),
+        agent: agent_name.to_string(),
+        model: runtime_profile
+            .model
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string()),
+        project: workflow
+            .and_then(|workflow| optional_data_string(workflow, "project_id"))
+            .unwrap_or_else(|| source_project_root.to_string_lossy().into_owned()),
+        task_id: workflow
+            .and_then(|workflow| optional_data_string(workflow, "task_id"))
+            .or_else(|| optional_string(&job.input, "task_id")),
+        candidate_group_id: candidate
+            .and_then(|value| optional_string(value, "candidate_group_id")),
+        candidate_id: candidate.and_then(|value| optional_string(value, "candidate_id")),
+        candidate_index: candidate.and_then(|value| optional_u32_value(value, "candidate_index")),
+        candidate_count: candidate.and_then(|value| optional_u32_value(value, "candidate_count")),
+    })
+}
+
+fn optional_u32_value(value: &Value, field: &str) -> Option<u32> {
+    value
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+}

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/helpers.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/helpers.rs
@@ -1,6 +1,85 @@
 use harness_core::agent::StreamItem;
-use harness_core::types::{ThreadId, TurnId, TurnStatus};
+use harness_core::types::{ThreadId, TokenUsage, TurnId, TurnStatus};
 use harness_protocol::{notifications::Notification, notifications::RpcNotification};
+use harness_workflow::runtime::{
+    RuntimeKind, RuntimeUsageMetrics, RuntimeUsageUpsert, RuntimeUsageUpsertOutcome,
+    WorkflowRuntimeStore,
+};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub(crate) struct RuntimeUsageContext {
+    pub(crate) store: Arc<WorkflowRuntimeStore>,
+    pub(crate) runtime_job_id: String,
+    pub(crate) command_id: String,
+    pub(crate) workflow_id: String,
+    pub(crate) runtime_kind: RuntimeKind,
+    pub(crate) runtime_profile: String,
+    pub(crate) agent: String,
+    pub(crate) model: String,
+    pub(crate) project: String,
+    pub(crate) task_id: Option<String>,
+    pub(crate) candidate_group_id: Option<String>,
+    pub(crate) candidate_id: Option<String>,
+    pub(crate) candidate_index: Option<u32>,
+    pub(crate) candidate_count: Option<u32>,
+}
+
+impl std::fmt::Debug for RuntimeUsageContext {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RuntimeUsageContext")
+            .field("runtime_job_id", &self.runtime_job_id)
+            .field("command_id", &self.command_id)
+            .field("workflow_id", &self.workflow_id)
+            .field("runtime_kind", &self.runtime_kind)
+            .field("runtime_profile", &self.runtime_profile)
+            .field("agent", &self.agent)
+            .field("model", &self.model)
+            .field("project", &self.project)
+            .field("task_id", &self.task_id)
+            .field("candidate_group_id", &self.candidate_group_id)
+            .field("candidate_id", &self.candidate_id)
+            .field("candidate_index", &self.candidate_index)
+            .field("candidate_count", &self.candidate_count)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RuntimeUsageContext {
+    async fn persist_token_usage(
+        &self,
+        turn_id: &TurnId,
+        usage: &TokenUsage,
+    ) -> anyhow::Result<()> {
+        match self
+            .store
+            .upsert_runtime_usage(&RuntimeUsageUpsert {
+                runtime_job_id: self.runtime_job_id.clone(),
+                command_id: self.command_id.clone(),
+                workflow_id: self.workflow_id.clone(),
+                turn_id: Some(turn_id.as_str().to_string()),
+                runtime_kind: self.runtime_kind,
+                runtime_profile: self.runtime_profile.clone(),
+                agent: self.agent.clone(),
+                model: self.model.clone(),
+                project: self.project.clone(),
+                task_id: self.task_id.clone(),
+                candidate_group_id: self.candidate_group_id.clone(),
+                candidate_id: self.candidate_id.clone(),
+                candidate_index: self.candidate_index,
+                candidate_count: self.candidate_count,
+                metrics: RuntimeUsageMetrics::from_token_usage(usage),
+                reported_at: chrono::Utc::now(),
+            })
+            .await?
+        {
+            RuntimeUsageUpsertOutcome::SkippedZeroUsage => {}
+            RuntimeUsageUpsertOutcome::Persisted => {}
+        }
+        Ok(())
+    }
+}
 
 pub(crate) fn emit_runtime_notification(
     notify_tx: &Option<crate::notify::NotifySender>,
@@ -30,6 +109,7 @@ pub(crate) async fn process_stream_item(
     thread_db: &Option<crate::thread_db::ThreadDb>,
     notify_tx: &Option<crate::notify::NotifySender>,
     notification_tx: &tokio::sync::broadcast::Sender<RpcNotification>,
+    runtime_usage: Option<&RuntimeUsageContext>,
     thread_id: &ThreadId,
     turn_id: &TurnId,
     stream_item: StreamItem,
@@ -86,9 +166,19 @@ pub(crate) async fn process_stream_item(
                 notification_tx,
                 Notification::TokenUsageUpdated {
                     thread_id: thread_id.clone(),
-                    usage,
+                    usage: usage.clone(),
                 },
             );
+            if let Some(context) = runtime_usage {
+                if let Err(error) = context.persist_token_usage(turn_id, &usage).await {
+                    tracing::error!(
+                        runtime_job_id = %context.runtime_job_id,
+                        command_id = %context.command_id,
+                        workflow_id = %context.workflow_id,
+                        "failed to persist workflow runtime token usage: {error}"
+                    );
+                }
+            }
         }
         StreamItem::Error { message } => {
             if let Err(err) = server.thread_manager.add_item(
@@ -184,4 +274,92 @@ pub(crate) async fn mark_turn_failed(
         },
     );
     tracing::error!("turn failed: {error}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{server::HarnessServer, thread_manager::ThreadManager};
+    use harness_agents::registry::AgentRegistry;
+    use harness_core::{
+        config::HarnessConfig,
+        db::resolve_database_url,
+        types::{AgentId, TokenUsage},
+    };
+    use harness_workflow::runtime::{RuntimeKind, WorkflowRuntimeStore};
+
+    #[tokio::test]
+    async fn workflow_runtime_worker_token_usage_persists_runtime_usage() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = Arc::new(WorkflowRuntimeStore::open(&dir.path().join("runtime")).await?);
+        let mut config = HarnessConfig::default();
+        config.server.project_root = dir.path().to_path_buf();
+        let server = HarnessServer::new(config, ThreadManager::new(), AgentRegistry::new("codex"));
+        let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+        let turn_id = server.thread_manager.start_turn(
+            &thread_id,
+            "prompt".to_string(),
+            AgentId::from_str("codex"),
+        )?;
+        let (notification_tx, _) = tokio::sync::broadcast::channel(16);
+        let context = RuntimeUsageContext {
+            store: store.clone(),
+            runtime_job_id: "runtime-job-1".to_string(),
+            command_id: "command-1".to_string(),
+            workflow_id: "workflow-1".to_string(),
+            runtime_kind: RuntimeKind::CodexExec,
+            runtime_profile: "codex-default".to_string(),
+            agent: "codex".to_string(),
+            model: "gpt-5".to_string(),
+            project: dir.path().to_string_lossy().into_owned(),
+            task_id: Some("issue-1439".to_string()),
+            candidate_group_id: Some("candidate-group".to_string()),
+            candidate_id: Some("candidate-1".to_string()),
+            candidate_index: Some(1),
+            candidate_count: Some(2),
+        };
+
+        process_stream_item(
+            &server,
+            &None,
+            &None,
+            &notification_tx,
+            Some(&context),
+            &thread_id,
+            &turn_id,
+            StreamItem::TokenUsage {
+                usage: TokenUsage {
+                    input_tokens: 11,
+                    output_tokens: 7,
+                    total_tokens: 20,
+                    cost_usd: 0.0,
+                },
+            },
+        )
+        .await;
+
+        let records = store
+            .runtime_usage_between(
+                chrono::Utc::now() - chrono::Duration::minutes(1),
+                chrono::Utc::now(),
+            )
+            .await?;
+        let turn = server
+            .thread_manager
+            .get_turn(&thread_id, &turn_id)
+            .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].runtime_job_id, "runtime-job-1");
+        assert_eq!(records[0].metrics.input_tokens, 11);
+        assert_eq!(records[0].metrics.output_tokens, 7);
+        assert_eq!(records[0].metrics.total_tokens(), 20);
+        assert_eq!(records[0].candidate_id.as_deref(), Some("candidate-1"));
+        assert_eq!(turn.token_usage.total_tokens, 20);
+        Ok(())
+    }
 }

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
@@ -1,5 +1,6 @@
 use super::helpers::{
     emit_runtime_notification, mark_turn_failed, persist_runtime_thread, process_stream_item,
+    RuntimeUsageContext,
 };
 use harness_core::agent::{AgentEvent, AgentRequest, StreamItem, TurnRequest};
 use harness_core::config::agents::SandboxMode;
@@ -93,6 +94,7 @@ pub(crate) struct TurnLifecycleOptions {
     pub stall_timeout_secs: Option<u64>,
     pub force_code_agent: bool,
     pub env_vars: HashMap<String, String>,
+    pub runtime_usage: Option<RuntimeUsageContext>,
 }
 
 pub(crate) async fn run_turn_lifecycle_with_options(
@@ -301,6 +303,7 @@ pub(crate) async fn run_turn_lifecycle_with_options(
                             &thread_db,
                             &notify_tx,
                             &notification_tx,
+                            options.runtime_usage.as_ref(),
                             &thread_id,
                             &turn_id,
                             item,

--- a/crates/harness-workflow/Cargo.toml
+++ b/crates/harness-workflow/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 harness-core = { workspace = true }
+harness-observe = { workspace = true }
 harness-exec = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -130,7 +130,8 @@ pub use state_registry::{
 };
 pub use status::WorkflowCommandStatus;
 pub use store::{
-    RuntimeHistoryPruneSummary, WorkflowDecisionTransition, WorkflowRejectedDecisionTransition,
+    RuntimeHistoryPruneSummary, RuntimeUsageMetrics, RuntimeUsageRecord, RuntimeUsageUpsert,
+    RuntimeUsageUpsertOutcome, WorkflowDecisionTransition, WorkflowRejectedDecisionTransition,
     WorkflowRuntimeStore, WorkflowSubmissionDecisionCommit, WorkflowSubmissionDecisionTransition,
     WorkflowSubmissionPromptPayload,
 };

--- a/crates/harness-workflow/src/runtime/model.rs
+++ b/crates/harness-workflow/src/runtime/model.rs
@@ -468,6 +468,18 @@ pub enum RuntimeKind {
     RemoteHost,
 }
 
+impl RuntimeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CodexExec => "codex_exec",
+            Self::CodexJsonrpc => "codex_jsonrpc",
+            Self::ClaudeCode => "claude_code",
+            Self::AnthropicApi => "anthropic_api",
+            Self::RemoteHost => "remote_host",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeProfile {
     pub name: String,

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -26,8 +26,13 @@ mod command_store;
 mod instances;
 #[path = "store/runtime_completion.rs"]
 mod runtime_completion;
+#[path = "store/runtime_usage.rs"]
+mod runtime_usage;
 #[path = "store/submission_commit.rs"]
 mod submission_commit;
+pub use runtime_usage::{
+    RuntimeUsageMetrics, RuntimeUsageRecord, RuntimeUsageUpsert, RuntimeUsageUpsertOutcome,
+};
 pub use submission_commit::{
     WorkflowSubmissionDecisionCommit, WorkflowSubmissionDecisionTransition,
     WorkflowSubmissionPromptPayload,

--- a/crates/harness-workflow/src/runtime/store/runtime_usage.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_usage.rs
@@ -1,0 +1,260 @@
+use super::super::model::RuntimeKind;
+use super::WorkflowRuntimeStore;
+use chrono::{DateTime, Utc};
+use harness_observe::usage::UsageMetrics;
+
+pub type RuntimeUsageMetrics = UsageMetrics;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeUsageUpsert {
+    pub runtime_job_id: String,
+    pub command_id: String,
+    pub workflow_id: String,
+    pub turn_id: Option<String>,
+    pub runtime_kind: RuntimeKind,
+    pub runtime_profile: String,
+    pub agent: String,
+    pub model: String,
+    pub project: String,
+    pub task_id: Option<String>,
+    pub candidate_group_id: Option<String>,
+    pub candidate_id: Option<String>,
+    pub candidate_index: Option<u32>,
+    pub candidate_count: Option<u32>,
+    pub metrics: RuntimeUsageMetrics,
+    pub reported_at: DateTime<Utc>,
+}
+
+impl RuntimeUsageUpsert {
+    fn usage_key(&self) -> String {
+        self.turn_id
+            .as_deref()
+            .filter(|turn_id| !turn_id.trim().is_empty())
+            .map(|turn_id| format!("turn:{turn_id}"))
+            .unwrap_or_else(|| "runtime_job".to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeUsageUpsertOutcome {
+    SkippedZeroUsage,
+    Persisted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeUsageRecord {
+    pub id: String,
+    pub runtime_job_id: String,
+    pub usage_key: String,
+    pub command_id: String,
+    pub workflow_id: String,
+    pub turn_id: Option<String>,
+    pub runtime_kind: String,
+    pub runtime_profile: String,
+    pub agent: String,
+    pub model: String,
+    pub project: String,
+    pub task_id: Option<String>,
+    pub candidate_group_id: Option<String>,
+    pub candidate_id: Option<String>,
+    pub candidate_index: Option<u32>,
+    pub candidate_count: Option<u32>,
+    pub metrics: RuntimeUsageMetrics,
+    pub reported_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(sqlx::FromRow)]
+struct RuntimeUsageDbRow {
+    id: String,
+    runtime_job_id: String,
+    usage_key: String,
+    command_id: String,
+    workflow_id: String,
+    turn_id: Option<String>,
+    runtime_kind: String,
+    runtime_profile: String,
+    agent: String,
+    model: String,
+    project: String,
+    task_id: Option<String>,
+    candidate_group_id: Option<String>,
+    candidate_id: Option<String>,
+    candidate_index: Option<i64>,
+    candidate_count: Option<i64>,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_input_tokens: i64,
+    cache_creation_input_tokens: i64,
+    reported_total_tokens: Option<i64>,
+    reported_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl WorkflowRuntimeStore {
+    pub async fn upsert_runtime_usage(
+        &self,
+        usage: &RuntimeUsageUpsert,
+    ) -> anyhow::Result<RuntimeUsageUpsertOutcome> {
+        if usage_metrics_are_zero(&usage.metrics) {
+            return Ok(RuntimeUsageUpsertOutcome::SkippedZeroUsage);
+        }
+        let usage_key = usage.usage_key();
+        let id = format!("runtime_usage:{}:{usage_key}", usage.runtime_job_id);
+        sqlx::query(
+            "INSERT INTO runtime_usage_events
+                (id, runtime_job_id, usage_key, command_id, workflow_id, turn_id,
+                 runtime_kind, runtime_profile, agent, model, project, task_id,
+                 candidate_group_id, candidate_id, candidate_index, candidate_count,
+                 input_tokens, output_tokens, cache_read_input_tokens,
+                 cache_creation_input_tokens, reported_total_tokens, reported_at)
+             VALUES
+                ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+                 $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+             ON CONFLICT (runtime_job_id, usage_key) DO UPDATE SET
+                command_id = EXCLUDED.command_id,
+                workflow_id = EXCLUDED.workflow_id,
+                turn_id = EXCLUDED.turn_id,
+                runtime_kind = EXCLUDED.runtime_kind,
+                runtime_profile = EXCLUDED.runtime_profile,
+                agent = EXCLUDED.agent,
+                model = EXCLUDED.model,
+                project = EXCLUDED.project,
+                task_id = EXCLUDED.task_id,
+                candidate_group_id = EXCLUDED.candidate_group_id,
+                candidate_id = EXCLUDED.candidate_id,
+                candidate_index = EXCLUDED.candidate_index,
+                candidate_count = EXCLUDED.candidate_count,
+                input_tokens = EXCLUDED.input_tokens,
+                output_tokens = EXCLUDED.output_tokens,
+                cache_read_input_tokens = EXCLUDED.cache_read_input_tokens,
+                cache_creation_input_tokens = EXCLUDED.cache_creation_input_tokens,
+                reported_total_tokens = EXCLUDED.reported_total_tokens,
+                reported_at = EXCLUDED.reported_at,
+                updated_at = CURRENT_TIMESTAMP",
+        )
+        .bind(&id)
+        .bind(&usage.runtime_job_id)
+        .bind(&usage_key)
+        .bind(&usage.command_id)
+        .bind(&usage.workflow_id)
+        .bind(&usage.turn_id)
+        .bind(usage.runtime_kind.as_str())
+        .bind(&usage.runtime_profile)
+        .bind(&usage.agent)
+        .bind(&usage.model)
+        .bind(&usage.project)
+        .bind(&usage.task_id)
+        .bind(&usage.candidate_group_id)
+        .bind(&usage.candidate_id)
+        .bind(usage.candidate_index.map(i64::from))
+        .bind(usage.candidate_count.map(i64::from))
+        .bind(u64_to_i64(usage.metrics.input_tokens, "input_tokens")?)
+        .bind(u64_to_i64(usage.metrics.output_tokens, "output_tokens")?)
+        .bind(u64_to_i64(
+            usage.metrics.cache_read_input_tokens,
+            "cache_read_input_tokens",
+        )?)
+        .bind(u64_to_i64(
+            usage.metrics.cache_creation_input_tokens,
+            "cache_creation_input_tokens",
+        )?)
+        .bind(
+            usage
+                .metrics
+                .reported_total_tokens
+                .map(|value| u64_to_i64(value, "reported_total_tokens"))
+                .transpose()?,
+        )
+        .bind(usage.reported_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(RuntimeUsageUpsertOutcome::Persisted)
+    }
+
+    pub async fn runtime_usage_between(
+        &self,
+        since: DateTime<Utc>,
+        until: DateTime<Utc>,
+    ) -> anyhow::Result<Vec<RuntimeUsageRecord>> {
+        let rows: Vec<RuntimeUsageDbRow> = sqlx::query_as(
+            "SELECT
+                id, runtime_job_id, usage_key, command_id, workflow_id, turn_id,
+                runtime_kind, runtime_profile, agent, model, project, task_id,
+                candidate_group_id, candidate_id, candidate_index, candidate_count,
+                input_tokens, output_tokens, cache_read_input_tokens,
+                cache_creation_input_tokens, reported_total_tokens, reported_at, updated_at
+             FROM runtime_usage_events
+             WHERE reported_at >= $1 AND reported_at <= $2
+             ORDER BY reported_at DESC, id DESC",
+        )
+        .bind(since)
+        .bind(until)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(runtime_usage_record_from_row)
+            .collect()
+    }
+}
+
+fn runtime_usage_record_from_row(row: RuntimeUsageDbRow) -> anyhow::Result<RuntimeUsageRecord> {
+    Ok(RuntimeUsageRecord {
+        id: row.id,
+        runtime_job_id: row.runtime_job_id,
+        usage_key: row.usage_key,
+        command_id: row.command_id,
+        workflow_id: row.workflow_id,
+        turn_id: row.turn_id,
+        runtime_kind: row.runtime_kind,
+        runtime_profile: row.runtime_profile,
+        agent: row.agent,
+        model: row.model,
+        project: row.project,
+        task_id: row.task_id,
+        candidate_group_id: row.candidate_group_id,
+        candidate_id: row.candidate_id,
+        candidate_index: row
+            .candidate_index
+            .map(|value| i64_to_u32(value, "candidate_index"))
+            .transpose()?,
+        candidate_count: row
+            .candidate_count
+            .map(|value| i64_to_u32(value, "candidate_count"))
+            .transpose()?,
+        metrics: RuntimeUsageMetrics {
+            input_tokens: i64_to_u64(row.input_tokens, "input_tokens")?,
+            output_tokens: i64_to_u64(row.output_tokens, "output_tokens")?,
+            cache_read_input_tokens: i64_to_u64(
+                row.cache_read_input_tokens,
+                "cache_read_input_tokens",
+            )?,
+            cache_creation_input_tokens: i64_to_u64(
+                row.cache_creation_input_tokens,
+                "cache_creation_input_tokens",
+            )?,
+            reported_total_tokens: row
+                .reported_total_tokens
+                .map(|value| i64_to_u64(value, "reported_total_tokens"))
+                .transpose()?,
+        },
+        reported_at: row.reported_at,
+        updated_at: row.updated_at,
+    })
+}
+
+fn usage_metrics_are_zero(metrics: &RuntimeUsageMetrics) -> bool {
+    metrics.input_tokens == 0 && metrics.output_tokens == 0 && metrics.total_tokens() == 0
+}
+
+fn u64_to_i64(value: u64, field: &str) -> anyhow::Result<i64> {
+    i64::try_from(value).map_err(|_| anyhow::anyhow!("{field} exceeds i64::MAX"))
+}
+
+fn i64_to_u64(value: i64, field: &str) -> anyhow::Result<u64> {
+    u64::try_from(value).map_err(|_| anyhow::anyhow!("{field} is negative"))
+}
+
+fn i64_to_u32(value: i64, field: &str) -> anyhow::Result<u32> {
+    u32::try_from(value).map_err(|_| anyhow::anyhow!("{field} is outside u32 range"))
+}

--- a/crates/harness-workflow/src/runtime/store_migrations.rs
+++ b/crates/harness-workflow/src/runtime/store_migrations.rs
@@ -430,4 +430,51 @@ pub(super) static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
         CREATE INDEX IF NOT EXISTS idx_workflow_repo_memory_repo_outcome_kind
           ON workflow_repo_memory (repo, outcome, kind)",
     },
+    Migration {
+        version: 18,
+        description: "create workflow runtime usage records",
+        sql: "CREATE TABLE IF NOT EXISTS runtime_usage_events (
+            id                          TEXT PRIMARY KEY,
+            runtime_job_id              TEXT NOT NULL,
+            usage_key                   TEXT NOT NULL,
+            command_id                  TEXT NOT NULL,
+            workflow_id                 TEXT NOT NULL,
+            turn_id                     TEXT,
+            runtime_kind                TEXT NOT NULL,
+            runtime_profile             TEXT NOT NULL,
+            agent                       TEXT NOT NULL,
+            model                       TEXT NOT NULL,
+            project                     TEXT NOT NULL,
+            task_id                     TEXT,
+            candidate_group_id          TEXT,
+            candidate_id                TEXT,
+            candidate_index             BIGINT,
+            candidate_count             BIGINT,
+            input_tokens                BIGINT NOT NULL,
+            output_tokens               BIGINT NOT NULL,
+            cache_read_input_tokens     BIGINT NOT NULL,
+            cache_creation_input_tokens BIGINT NOT NULL,
+            reported_total_tokens       BIGINT,
+            reported_at                 TIMESTAMPTZ NOT NULL,
+            created_at                  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at                  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE (runtime_job_id, usage_key),
+            CONSTRAINT runtime_usage_events_tokens_nonnegative
+                CHECK (
+                    input_tokens >= 0
+                    AND output_tokens >= 0
+                    AND cache_read_input_tokens >= 0
+                    AND cache_creation_input_tokens >= 0
+                    AND (reported_total_tokens IS NULL OR reported_total_tokens >= 0)
+                )
+        );
+        CREATE INDEX IF NOT EXISTS idx_runtime_usage_events_reported_at
+          ON runtime_usage_events (reported_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_runtime_usage_events_runtime_job
+          ON runtime_usage_events (runtime_job_id);
+        CREATE INDEX IF NOT EXISTS idx_runtime_usage_events_command
+          ON runtime_usage_events (command_id);
+        CREATE INDEX IF NOT EXISTS idx_runtime_usage_events_workflow
+          ON runtime_usage_events (workflow_id)",
+    },
 ];

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -39,6 +39,7 @@ mod pr_repair_evidence;
 mod replay_determinism;
 mod retry;
 mod runtime_store;
+mod runtime_usage;
 
 fn issue_instance(state: &str) -> WorkflowInstance {
     WorkflowInstance::new(

--- a/crates/harness-workflow/src/runtime/tests/runtime_usage.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_usage.rs
@@ -1,0 +1,81 @@
+use super::*;
+use crate::runtime::{RuntimeUsageMetrics, RuntimeUsageUpsert, RuntimeUsageUpsertOutcome};
+
+#[tokio::test]
+async fn runtime_usage_upsert_skips_zero_placeholders() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let usage = runtime_usage_upsert(RuntimeUsageMetrics::default());
+
+    let outcome = store.upsert_runtime_usage(&usage).await?;
+    let records = store
+        .runtime_usage_between(Utc::now() - Duration::minutes(1), Utc::now())
+        .await?;
+
+    assert_eq!(outcome, RuntimeUsageUpsertOutcome::SkippedZeroUsage);
+    assert!(records.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_usage_upsert_replaces_cumulative_turn_usage() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let first = runtime_usage_upsert(RuntimeUsageMetrics {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reported_total_tokens: Some(15),
+    });
+    let mut second = first.clone();
+    second.metrics = RuntimeUsageMetrics {
+        input_tokens: 20,
+        output_tokens: 7,
+        cache_read_input_tokens: 3,
+        cache_creation_input_tokens: 0,
+        reported_total_tokens: Some(30),
+    };
+    second.model = "gpt-5.1".to_string();
+
+    store.upsert_runtime_usage(&first).await?;
+    let outcome = store.upsert_runtime_usage(&second).await?;
+    let records = store
+        .runtime_usage_between(Utc::now() - Duration::minutes(1), Utc::now())
+        .await?;
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].metrics.total_tokens(), 30);
+    assert_eq!(records[0].model, "gpt-5.1");
+    assert!(matches!(outcome, RuntimeUsageUpsertOutcome::Persisted));
+    Ok(())
+}
+
+fn runtime_usage_upsert(metrics: RuntimeUsageMetrics) -> RuntimeUsageUpsert {
+    RuntimeUsageUpsert {
+        runtime_job_id: "runtime-job-1".to_string(),
+        command_id: "command-1".to_string(),
+        workflow_id: "workflow-1".to_string(),
+        turn_id: Some("turn-1".to_string()),
+        runtime_kind: RuntimeKind::CodexExec,
+        runtime_profile: "codex-default".to_string(),
+        agent: "codex".to_string(),
+        model: "gpt-5".to_string(),
+        project: "/repo".to_string(),
+        task_id: Some("issue-1439".to_string()),
+        candidate_group_id: None,
+        candidate_id: None,
+        candidate_index: None,
+        candidate_count: None,
+        metrics,
+        reported_at: Utc::now(),
+    }
+}


### PR DESCRIPTION
## Summary

- add workflow-runtime-owned token usage persistence with idempotent per-turn upserts
- persist workflow-runtime TokenUsage snapshots from runtime worker turns
- aggregate workflow-runtime usage with legacy llm_usage events in /api/usage-monitor
- add malformed-source diagnostics, unbounded active invocation loading, and blocking-safe process sampling

## Verification

- cargo test -p harness-workflow runtime_usage
- cargo test -p harness-server workflow_runtime_worker_token_usage
- cargo test -p harness-server usage_monitor
- cargo test -p harness-server usage_monitor_process
- cargo check -p harness-workflow --all-targets
- cargo check -p harness-server --all-targets
- cargo fmt --all -- --check
- git diff --check
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1439
- python3 checks/check_workflow.py --repo .
- cargo clippy --workspace --all-targets -- -D warnings

Note: local HARNESS_DATABASE_URL is unset, so existing Postgres-backed guarded tests skip local database execution; CI remains the full database coverage path.

Fixes #1439