### PR TITLE
Add GH1440 status surfaces spec

### DIFF
--- a/specs/GH1440/product.md
+++ b/specs/GH1440/product.md
@@ -1,0 +1,83 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1440
+
+## User Problem
+
+Operators comparing Harness status surfaces during an incident can see
+contradictory active-work counts. `GET /projects/queue-stats` reports the
+in-memory task queue as empty while `GET /api/overview` reports many queued and
+running workflow-runtime tasks. At the same time, `GET /health` reports a
+runtime log `path_hint` such as `logs/harness-serve-...log`, but the server is
+actually writing the log under the configured runtime data directory, so the
+hint can point to a nonexistent project-relative path.
+
+When these endpoints disagree, operators cannot tell which status surface is
+trustworthy without querying the database or inspecting open file handles.
+
+## Goals
+
+- `/projects/queue-stats` and `/api/overview` use the same active-work source
+  for global and per-project running/queued counts.
+- Workflow-runtime-only work is visible in queue stats, not only legacy task
+  queue waiters.
+- Runtime log metadata returned by `/health` points to the actual active log
+  path when runtime logging is enabled.
+- Existing response shapes remain compatible unless a field is corrected to
+  represent the real source of truth.
+
+## Non-Goals
+
+- Redesigning the dashboard, overview page, or operator monitor UI.
+- Changing workflow scheduling, queue admission, or task execution semantics.
+- Adding new runtime persistence tables.
+- Rotating or retaining runtime logs; that belongs to log-retention work.
+- Exposing log file contents through the API.
+
+## User-Visible Behavior
+
+When workflow-runtime instances are active but the in-memory legacy queue is
+empty, `GET /projects/queue-stats` reports the same active running and queued
+counts that `GET /api/overview` uses for its active-task KPIs. Project entries
+are keyed by the same project identifiers used by the active-work projection.
+
+When runtime logging is enabled, `GET /health` returns a `runtime_logs.path_hint`
+that is a usable path to the actual active log file. If logging is disabled,
+the hint remains absent. If log setup is degraded before an active path exists,
+the degraded hint may remain the best non-secret setup hint available.
+
+## Acceptance Criteria
+
+- [ ] `GET /projects/queue-stats` global `running` and `queued` counts are
+      derived from the same canonical active-work aggregation as
+      `GET /api/overview`.
+- [ ] Queue stats include nonterminal workflow-runtime instances, including
+      workflows with no legacy task row.
+- [ ] Queue stats preserve per-project `running`, `queued`, and `limit` fields.
+- [ ] Existing queue stats capacity fields continue to report configured queue
+      limits rather than active-work counts.
+- [ ] `GET /health` reports the actual active runtime log path when runtime
+      logging is enabled.
+- [ ] Tests cover the queue-stats/overview consistency path and the corrected
+      runtime log path hint.
+
+## Edge Cases
+
+- Legacy active tasks and workflow-runtime instances that reference the same
+  task must not be double counted.
+- Terminal legacy tasks must not suppress active workflow-runtime work.
+- If active-task persistence is unavailable, queue stats may fall back to the
+  in-memory queue, but the response must not claim workflow-runtime-derived
+  counts in that fallback case.
+- Project identifiers may be absent for some active work; global counts still
+  include those rows.
+- Log paths on macOS may live outside the project root under Application
+  Support; the health hint must not invent a project-relative location.
+
+## Rollout Notes
+
+This is an observability correctness fix. It changes status reporting only and
+does not alter workflow scheduling, admission control, runtime execution, or
+merge/review gates.

--- a/specs/GH1440/tasks.md
+++ b/specs/GH1440/tasks.md
@@ -1,0 +1,42 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1440
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1440-T001` Owner: `status-counts` | Done when: the active-work aggregation used by `/api/overview` is callable from `/projects/queue-stats` without duplicating legacy/runtime dedupe logic | Verify: `cargo test -p harness-server overview active_counts`
+- [ ] `SP1440-T002` Owner: `queue-stats` | Done when: `/projects/queue-stats` reports canonical active running/queued counts globally and per project while preserving configured limit fields | Verify: `cargo test -p harness-server queue_stats`
+- [ ] `SP1440-T003` Owner: `runtime-logs` | Done when: enabled runtime log metadata exposes the actual active log path through `/health` `runtime_logs.path_hint`, with disabled/degraded cases preserved | Verify: `cargo test -p harness-server health_runtime_logs`
+- [ ] `SP1440-T004` Owner: `verification` | Done when: focused tests, package check, workflow check, fmt, and clippy pass for the changed surface | Verify: `cargo test -p harness-server queue_stats && cargo test -p harness-server health_runtime_logs && cargo check -p harness-server --all-targets && python3 checks/check_workflow.py --repo . --spec-dir specs/GH1440`
+
+## Parallelization
+
+T001 and T002 should be sequenced because queue-stats depends on the shared
+active-count source. T003 touches runtime log metadata and health tests, so it
+can be implemented independently from T001/T002. T004 is the final verification
+gate.
+
+## Verification
+
+- `cargo test -p harness-server queue_stats`
+- `cargo test -p harness-server health_runtime_logs`
+- `cargo check -p harness-server --all-targets`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1440`
+- `python3 checks/check_workflow.py --repo .`
+
+## Handoff Notes
+
+Keep this fix scoped to status correctness. Do not change scheduler admission,
+workflow-runtime state transitions, runtime log rotation, or dashboard UI
+layout. The central invariant is that `/projects/queue-stats` and
+`/api/overview` must not report contradictory active running/queued counts for
+the same server state.

--- a/specs/GH1440/tech.md
+++ b/specs/GH1440/tech.md
@@ -1,0 +1,107 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1440
+
+## Product Spec
+
+See `specs/GH1440/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Queue stats route | `crates/harness-server/src/http/misc_routes.rs` | `project_queue_stats` reads only `state.concurrency.task_queue` for global and per-project counts. | This misses workflow-runtime work and produced the observed `0/0` count. |
+| Overview active counts | `crates/harness-server/src/handlers/overview.rs` | `active_task_overview_counts` merges legacy active task summaries and nonterminal workflow-runtime instances, with an in-memory queue fallback only when both persisted sources are unavailable. | This is the count source that produced the nonzero active-work numbers. |
+| Dashboard active counts | `crates/harness-server/src/handlers/dashboard_active_counts.rs` | Dashboard status already has a richer active-work helper that avoids double counting and can include queue waiters. | This is the nearest existing pattern for canonical status counts. |
+| Runtime log metadata | `crates/harness-server/src/server.rs` | `RuntimeLogMetadata::public_path_hint` converts an active log path into `logs/<filename>`. | On installations whose logs live outside the project root, that hint is not usable. |
+| Health route tests | `crates/harness-server/src/http/tests/health_route_tests.rs` | Current tests require `/health` to redact the absolute active log path. | These tests encode the behavior that conflicts with GH-1440. |
+
+## Proposed Design
+
+1. Share the active-work count source between overview and queue stats.
+   - Make the overview active-work aggregation available to the queue-stats
+     route, or extract the shared logic into a small status-count helper.
+   - Preserve dedupe behavior between legacy task summaries and
+     workflow-runtime projections.
+   - Keep the queue capacity fields (`global.limit` and per-project `limit`)
+     sourced from the in-memory task queue configuration.
+2. Update `GET /projects/queue-stats`.
+   - Build `global.running` and `global.queued` from canonical active-work
+     counts, not from `TaskQueue::running_count()` and `queued_count()` alone.
+   - Build per-project `running` and `queued` from the same canonical
+     `by_project` map.
+   - Preserve project `limit` from `TaskQueue::project_stats` where available;
+     use the configured global limit for projected projects that have no
+     task-queue entry.
+3. Correct runtime log path hints.
+   - Change enabled runtime log metadata so `path_hint` is the actual active
+     path string.
+   - Keep disabled runtime logs as `path_hint: null`.
+   - For degraded setup with no active path, continue to return only the
+     degraded setup hint already available, avoiding raw setup error text.
+4. Update tests.
+   - Add a queue-stats route test that seeds a workflow-runtime active
+     instance with no legacy task row and asserts queue stats report it.
+   - Add or adjust an overview consistency assertion so queue-stats and
+     overview active counts agree for the seeded active work.
+   - Update health runtime-log tests to assert the actual active path rather
+     than a project-relative synthetic hint.
+
+## Data Flow
+
+The status path should derive active work from persisted task summaries plus
+workflow-runtime projections. The active count helper classifies each item as
+running or queued, dedupes workflow-runtime instances that are represented by
+an active legacy task row, and returns global plus per-project counts.
+
+`/api/overview` uses these counts for `kpi.active_tasks` and related global
+running/queued fields. `/projects/queue-stats` uses the same counts for
+`global.running`, `global.queued`, and project count fields while preserving
+capacity metadata from the task queue.
+
+Runtime log metadata is constructed during server bootstrap. Once an active log
+path exists, the server stores that exact path as the public health hint so the
+health response points to the file operators can inspect.
+
+## Alternatives Considered
+
+- Document `/projects/queue-stats` as legacy-queue-only. Rejected because the
+  endpoint name is used as a status surface and operators need the active
+  workflow-runtime view during incidents.
+- Make `/api/overview` read only the in-memory task queue. Rejected because it
+  would hide workflow-runtime work and regress the more complete surface.
+- Add a second health field for the absolute runtime log path while leaving
+  `path_hint` project-relative. Rejected because the bug is specifically that
+  `path_hint` points to a nonexistent location.
+
+## Risks
+
+- Compatibility: clients may have assumed queue stats were legacy queue-only.
+  Preserve field names and capacity fields to minimize response-shape churn.
+- Privacy: `/health` will expose a local absolute log path. This is necessary
+  for the issue, and it must expose only a path, never log contents or setup
+  error text.
+- Counting correctness: active legacy tasks and workflow-runtime projections
+  can represent the same work. Reuse existing dedupe logic instead of adding a
+  parallel ad hoc projection.
+
+## Test Plan
+
+- [ ] Handler/helper tests: active workflow-runtime work with no legacy task row
+      appears in the canonical active counts.
+- [ ] Route tests: `/projects/queue-stats` reports the same active global
+      running/queued values as `/api/overview` for seeded workflow-runtime
+      work.
+- [ ] Route tests: per-project queue stats include workflow-runtime active
+      counts and keep capacity fields.
+- [ ] Health tests: enabled runtime logs return the actual active path in
+      `runtime_logs.path_hint`.
+- [ ] Regression tests: disabled/degraded runtime log metadata remains safe and
+      does not expose raw setup errors.
+
+## Rollback Plan
+
+Revert the route/helper changes and runtime log metadata change. No data
+migration is involved.


### PR DESCRIPTION
## Summary
- add the GH1440 product, technical, and task specs for status-surface consistency
- define the queue-stats/overview active-count contract and runtime log path-hint behavior
- keep implementation tasks scoped to reporting correctness only

## Verification
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1440
- python3 checks/check_workflow.py --repo .

Issues: #1440