### PR TITLE
Fix status surface active counts

### DIFF
--- a/crates/harness-cli/src/commands/runtime_log_tests.rs
+++ b/crates/harness-cli/src/commands/runtime_log_tests.rs
@@ -28,11 +28,7 @@ fn prepare_logging_creates_runtime_log_for_serve() {
     assert!(active_path.exists(), "runtime log file should be created");
     assert_eq!(
         bootstrap.runtime_logs.path_hint.as_deref(),
-        active_path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .map(|name| format!("logs/{name}"))
-            .as_deref()
+        Some(active_path.to_string_lossy().as_ref())
     );
 }
 

--- a/crates/harness-server/src/handlers/operator_snapshot.rs
+++ b/crates/harness-server/src/handlers/operator_snapshot.rs
@@ -630,11 +630,11 @@ mod tests {
         let mut state = Arc::new(test_helpers::make_test_state(dir.path()).await?);
         let state_mut = Arc::get_mut(&mut state).expect("unique state");
         let server = Arc::get_mut(&mut state_mut.core.server).expect("unique server");
-        server.runtime_logs = crate::server::RuntimeLogMetadata::enabled(
-            dir.path()
-                .join("logs/harness-serve-20260430T120000Z-pid1.log"),
-            30,
-        );
+        let active_path = dir
+            .path()
+            .join("logs/harness-serve-20260430T120000Z-pid1.log");
+        let expected_path = active_path.display().to_string();
+        server.runtime_logs = crate::server::RuntimeLogMetadata::enabled(active_path, 30);
 
         let app = Router::new()
             .route("/api/operator-snapshot", get(operator_snapshot))
@@ -649,16 +649,11 @@ mod tests {
         assert_eq!(body["runtime_logs"]["state"], "enabled");
         assert_eq!(
             body["runtime_logs"]["active_path"],
-            serde_json::Value::String(
-                dir.path()
-                    .join("logs/harness-serve-20260430T120000Z-pid1.log")
-                    .display()
-                    .to_string(),
-            )
+            serde_json::Value::String(expected_path.clone())
         );
         assert_eq!(
             body["runtime_logs"]["path_hint"],
-            serde_json::Value::String("logs/harness-serve-20260430T120000Z-pid1.log".to_string())
+            serde_json::Value::String(expected_path)
         );
         Ok(())
     }

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -408,17 +408,17 @@ fn parse_llm_usage_event(event: &Event) -> Option<LlmUsageRecord> {
 }
 
 #[derive(Debug, Default)]
-struct ActiveTaskOverviewCounts {
-    total: u64,
-    running: u64,
-    queued: u64,
-    by_project: HashMap<String, ActiveProjectCounts>,
+pub(crate) struct ActiveTaskOverviewCounts {
+    pub(crate) total: u64,
+    pub(crate) running: u64,
+    pub(crate) queued: u64,
+    pub(crate) by_project: HashMap<String, ActiveProjectCounts>,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-struct ActiveProjectCounts {
-    running: u64,
-    queued: u64,
+pub(crate) struct ActiveProjectCounts {
+    pub(crate) running: u64,
+    pub(crate) queued: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -448,7 +448,7 @@ impl ActiveTaskOverviewCounts {
     }
 }
 
-async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCounts {
+pub(crate) async fn active_task_overview_counts(state: &AppState) -> ActiveTaskOverviewCounts {
     let mut counts = ActiveTaskOverviewCounts::default();
     let mut active_legacy_task_ids = HashSet::new();
     let mut loaded_legacy_tasks = false;

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 use harness_protocol::methods::RpcRequest;
 use serde_json::json;
+use std::collections::BTreeSet;
 use std::path::{Path as StdPath, PathBuf};
 use std::sync::Arc;
 
@@ -104,24 +105,37 @@ pub(crate) async fn project_queue_stats(
     State(state): State<Arc<AppState>>,
 ) -> Json<serde_json::Value> {
     let tq = &state.concurrency.task_queue;
-    let projects: serde_json::Map<String, serde_json::Value> = tq
-        .all_project_stats()
+    let active_counts = crate::handlers::overview::active_task_overview_counts(&state).await;
+    let queue_project_stats = tq.all_project_stats();
+    let mut project_ids: BTreeSet<String> = active_counts.by_project.keys().cloned().collect();
+    project_ids.extend(queue_project_stats.iter().map(|(id, _)| id.clone()));
+    let projects: serde_json::Map<String, serde_json::Value> = project_ids
         .into_iter()
-        .map(|(id, s)| {
+        .map(|id| {
+            let active = active_counts
+                .by_project
+                .get(&id)
+                .copied()
+                .unwrap_or_default();
+            let limit = queue_project_stats
+                .iter()
+                .find(|(project_id, _)| project_id == &id)
+                .map(|(_, stats)| stats.limit)
+                .unwrap_or_else(|| tq.project_stats(&id).limit);
             (
                 id,
                 json!({
-                    "running": s.running,
-                    "queued": s.queued,
-                    "limit": s.limit,
+                    "running": active.running,
+                    "queued": active.queued,
+                    "limit": limit,
                 }),
             )
         })
         .collect();
     Json(json!({
         "global": {
-            "running": tq.running_count(),
-            "queued": tq.queued_count(),
+            "running": active_counts.running,
+            "queued": active_counts.queued,
             "limit": tq.global_limit(),
         },
         "projects": projects,

--- a/crates/harness-server/src/http/tests/health_route_tests.rs
+++ b/crates/harness-server/src/http/tests/health_route_tests.rs
@@ -14,28 +14,24 @@ async fn health_degraded_when_runtime_state_dirty() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn health_runtime_logs_redacts_absolute_path() -> anyhow::Result<()> {
+async fn health_runtime_logs_reports_active_path_hint() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let mut state = make_read_only_route_test_state(dir.path()).await?;
     let state_mut = Arc::get_mut(&mut state).expect("unique state");
     let server = Arc::get_mut(&mut state_mut.core.server).expect("unique server");
-    server.runtime_logs = crate::server::RuntimeLogMetadata::enabled(
-        dir.path()
-            .join("logs/harness-serve-20260430T120000Z-pid1.log"),
-        45,
-    );
+    let active_path = dir
+        .path()
+        .join("logs/harness-serve-20260430T120000Z-pid1.log");
+    let expected_path = active_path.to_string_lossy().into_owned();
+    server.runtime_logs = crate::server::RuntimeLogMetadata::enabled(active_path, 45);
 
     let health = call_health(state).await?;
     assert_eq!(health.runtime_logs.state, "enabled");
     assert_eq!(
         health.runtime_logs.path_hint.as_deref(),
-        Some("logs/harness-serve-20260430T120000Z-pid1.log")
+        Some(expected_path.as_str())
     );
     assert_eq!(health.runtime_logs.retention_days, 45);
-    assert!(
-        !format!("{health:?}").contains(&dir.path().display().to_string()),
-        "health response must not expose an absolute runtime log path"
-    );
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests/mod.rs
+++ b/crates/harness-server/src/http/tests/mod.rs
@@ -29,6 +29,7 @@ use route_helpers::*;
 mod evals_api_tests;
 mod health_route_tests;
 mod intake_auth_list_tests;
+mod queue_stats_route_tests;
 mod recovery_followup_tests;
 mod recovery_tests;
 mod repo_memory_api_tests;

--- a/crates/harness-server/src/http/tests/queue_stats_route_tests.rs
+++ b/crates/harness-server/src/http/tests/queue_stats_route_tests.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+#[tokio::test]
+async fn queue_stats_matches_overview_for_runtime_active_work() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state_with_workflow_runtime(dir.path()).await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let project_id = dir.path().canonicalize()?.to_string_lossy().into_owned();
+    let running = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("prompt", "prompt:queue-stats-running"),
+    )
+    .with_id("queue-stats-running-workflow")
+    .with_data(serde_json::json!({
+        "project_id": project_id.clone(),
+        "task_id": "queue-stats-running-task",
+    }));
+    let queued = harness_workflow::runtime::WorkflowInstance::new(
+        harness_workflow::runtime::PROMPT_TASK_DEFINITION_ID,
+        1,
+        "ready_to_merge",
+        harness_workflow::runtime::WorkflowSubject::new("prompt", "prompt:queue-stats-queued"),
+    )
+    .with_id("queue-stats-queued-workflow")
+    .with_data(serde_json::json!({
+        "project_id": project_id.clone(),
+        "task_id": "queue-stats-queued-task",
+    }));
+    store.upsert_instance(&running).await?;
+    store.upsert_instance(&queued).await?;
+
+    let app = Router::new()
+        .route("/projects/queue-stats", get(project_queue_stats))
+        .route("/api/overview", get(crate::handlers::overview::overview))
+        .with_state(state);
+
+    let queue_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/projects/queue-stats")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(queue_response.status(), StatusCode::OK);
+    let queue_body = response_json(queue_response).await?;
+
+    let overview_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/overview")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(overview_response.status(), StatusCode::OK);
+    let overview_body = response_json(overview_response).await?;
+
+    assert_eq!(
+        queue_body["global"]["running"],
+        overview_body["global"]["running"]
+    );
+    assert_eq!(
+        queue_body["global"]["queued"],
+        overview_body["global"]["queued"]
+    );
+    assert_eq!(queue_body["global"]["running"], serde_json::json!(1));
+    assert_eq!(queue_body["global"]["queued"], serde_json::json!(1));
+    assert!(queue_body["global"]["limit"].is_number());
+    let project = &queue_body["projects"][project_id.as_str()];
+    assert_eq!(project["running"], serde_json::json!(1));
+    assert_eq!(project["queued"], serde_json::json!(1));
+    assert!(project["limit"].is_number());
+
+    Ok(())
+}

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -59,9 +59,7 @@ impl RuntimeLogMetadata {
     }
 
     pub fn public_path_hint(path: &Path) -> String {
-        path.file_name()
-            .map(|name| format!("logs/{}", name.to_string_lossy()))
-            .unwrap_or_else(|| "logs".to_string())
+        path.to_string_lossy().into_owned()
     }
 }
 
@@ -105,5 +103,24 @@ impl HarnessServer {
     /// Start in HTTP + WebSocket mode.
     pub async fn serve_http(self: Arc<Self>, addr: SocketAddr) -> anyhow::Result<()> {
         crate::http::serve(self, addr).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enabled_runtime_log_metadata_uses_active_path_as_hint() {
+        let active_path = PathBuf::from(
+            "/tmp/harness-codex-runtime/logs/harness-serve-20260430T120000Z-pid1.log",
+        );
+        let metadata = RuntimeLogMetadata::enabled(active_path.clone(), 30);
+
+        assert_eq!(metadata.active_path.as_deref(), Some(active_path.as_path()));
+        assert_eq!(
+            metadata.path_hint.as_deref(),
+            Some(active_path.to_string_lossy().as_ref())
+        );
     }
 }


### PR DESCRIPTION
## Summary
- make `/projects/queue-stats` use the same active-work counts as `/api/overview` for running and queued work
- preserve queue limit fields while adding workflow-runtime-only active work to per-project queue stats
- report the actual enabled runtime log path in runtime log metadata and update health/operator/CLI expectations

## Verification
- cargo test -p harness-server queue_stats
- cargo test -p harness-server enabled_runtime_log_metadata_uses_active_path_as_hint
- cargo test -p harness-cli prepare_logging_creates_runtime_log_for_serve
- cargo check -p harness-server --all-targets
- cargo check -p harness-cli --all-targets
- cargo fmt --all -- --check
- git diff --check
- cargo clippy --workspace --all-targets -- -D warnings
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1440
- python3 checks/check_workflow.py --repo .

## Notes
- Local `cargo test -p harness-server health_runtime_logs` is blocked without `HARNESS_DATABASE_URL`; the updated health route assertions are covered by CI DB-backed route tests and the local non-DB metadata test above.

Fixes #1440