### PR TITLE
Add GH1441 intake startup spec

### DIFF
--- a/specs/GH1441/product.md
+++ b/specs/GH1441/product.md
@@ -1,0 +1,107 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1441
+
+## User Problem
+
+Operators can configure GitHub intake for `webhook` or `hybrid` mode without a
+usable `server.github_webhook_secret`. The server starts, logs that webhook
+requests will be refused, and may still report `/health` as `ok`. In `webhook`
+mode this means GitHub issue intake is effectively off. In `hybrid` mode this
+means the configured webhook path is unavailable and polling silently carries
+the load.
+
+The resulting deployment is self-contradictory: the configured intake mode says
+webhooks should be accepted, but the only visible operator surface that notices
+the problem is the log stream.
+
+## Goals
+
+- Validate GitHub intake mode against webhook secret availability during server
+  startup.
+- When GitHub `webhook` or `hybrid` intake is enabled without a non-empty
+  webhook secret, make the server health degraded instead of fully healthy.
+- Keep webhook requests fail-closed when the secret is absent or invalid.
+- Make the effective GitHub intake mode and active drivers queryable from the
+  intake status surface.
+- Avoid exposing secret values or raw secret-adjacent error strings in API
+  responses.
+
+## Non-Goals
+
+- Changing webhook signature verification semantics.
+- Changing GitHub issue polling scheduling, sprint planning, or auto-merge
+  behavior.
+- Adding per-repo intake mode configuration; the current GitHub intake mode
+  remains global.
+- Introducing a new persistence table for intake configuration health.
+- Disabling all polling when only the webhook driver is misconfigured in
+  `hybrid` mode.
+
+## User-Visible Behavior
+
+When GitHub intake is enabled with mode `webhook` or `hybrid`, startup validates
+that `server.github_webhook_secret` is present and non-empty after trimming. If
+the secret is missing, blank, or whitespace-only, the server may continue to run
+so operators can inspect it, but `/health` reports `status: degraded` and names
+the GitHub webhook intake subsystem as degraded.
+
+Webhook requests continue to fail closed with a non-success response while the
+secret is unavailable. The response must not expose secret values.
+
+`GET /api/intake` exposes enough GitHub channel detail for operators to see the
+configured mode, whether webhook intake is currently accepting events, whether
+polling is active, and the effective per-repo entries derived from the single
+repo shorthand plus the `repos` array. In `webhook` mode with no usable secret,
+the GitHub channel is visible as configured but its webhook driver is degraded
+instead of looking like a working intake path.
+
+Poll-only GitHub intake does not require a webhook secret. Missing webhook
+secret configuration must not degrade health when GitHub intake is disabled or
+when the enabled GitHub mode is `poll`.
+
+## Acceptance Criteria
+
+- [ ] Startup validation treats a missing, empty, or whitespace-only
+      `server.github_webhook_secret` as unusable for GitHub `webhook` and
+      `hybrid` intake modes.
+- [ ] GitHub `webhook` mode without a usable secret starts in a degraded health
+      state or fails startup explicitly; if the server starts, `/health` reports
+      `status: degraded`.
+- [ ] GitHub `hybrid` mode without a usable secret reports degraded health while
+      preserving the polling driver when it is otherwise available.
+- [ ] GitHub `poll` mode and disabled GitHub intake do not require
+      `server.github_webhook_secret` and do not degrade health for that reason.
+- [ ] `GET /api/intake` reports the configured GitHub intake mode and active
+      drivers, including webhook acceptance state and polling state.
+- [ ] `GET /api/intake` reports effective GitHub repo entries after applying the
+      single `repo` shorthand and `repos` array merge rules.
+- [ ] API responses redact secret values and avoid raw secret-adjacent startup
+      error text.
+- [ ] Tests cover webhook-only, hybrid, poll-only, disabled, blank secret, and
+      whitespace-only secret cases.
+
+## Edge Cases
+
+- A TOML value of `github_webhook_secret = ""` is invalid for webhook-capable
+  GitHub intake.
+- A whitespace-only secret is invalid even if deserialization produces
+  `Some(value)`.
+- An empty `GITHUB_WEBHOOK_SECRET` environment variable does not override a
+  configured non-empty TOML secret and must not create a false degradation.
+- Hybrid mode may still have a functioning poller; health should be degraded
+  because one configured intake driver is unavailable, not because all intake is
+  stopped.
+- If the workflow runtime store is unavailable, `/api/intake` may already report
+  partial runtime submission data; the webhook-secret degradation must compose
+  with that existing degraded response.
+
+## Rollout Notes
+
+This is an operator-surface correctness fix. It changes startup validation and
+status reporting for self-contradictory GitHub intake configuration. Existing
+poll-only deployments are compatible. Webhook or hybrid deployments without a
+secret will become visibly degraded until `server.github_webhook_secret` or
+`GITHUB_WEBHOOK_SECRET` is configured with a non-empty value.

--- a/specs/GH1441/tasks.md
+++ b/specs/GH1441/tasks.md
@@ -1,0 +1,41 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1441
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1441-T001` Owner: `startup-validation` | Done when: GitHub webhook-capable intake modes validate a normalized non-empty webhook secret during startup and record a sanitized `github_webhook_intake` degradation when unavailable | Verify: `cargo test -p harness-server health github_webhook_intake`
+- [ ] `SP1441-T002` Owner: `webhook-secret` | Done when: webhook request handling rejects missing, empty, and whitespace-only configured secrets before signature verification while preserving secret redaction | Verify: `cargo test -p harness-server github_webhook`
+- [ ] `SP1441-T003` Owner: `intake-status` | Done when: `/api/intake` reports GitHub mode, active webhook/polling driver state, degradation state, and effective repo entries without removing existing fields | Verify: `cargo test -p harness-server intake_status`
+- [ ] `SP1441-T004` Owner: `verification` | Done when: focused route tests, package check, fmt, clippy, and SpecRail workflow checks pass for GH1441 | Verify: `cargo test -p harness-server intake_status && cargo test -p harness-server health && cargo test -p harness-server github_webhook && cargo check -p harness-server --all-targets && python3 checks/check_workflow.py --repo . --spec-dir specs/GH1441`
+
+## Parallelization
+
+T001 and T002 both need the same normalized webhook-secret helper and should be
+sequenced to avoid conflicting helper ownership. T003 can follow once the helper
+and startup driver status names are stable. T004 is the final verification gate.
+
+## Verification
+
+- `cargo test -p harness-server intake_status`
+- `cargo test -p harness-server health`
+- `cargo test -p harness-server github_webhook`
+- `cargo check -p harness-server --all-targets`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1441`
+- `python3 checks/check_workflow.py --repo .`
+
+## Handoff Notes
+
+Keep the change scoped to startup validation and status surfaces. Do not change
+polling cadence, sprint planning, auto-merge policy, webhook event semantics, or
+per-repo intake configuration. The main invariant is that webhook-capable GitHub
+intake without a usable secret must never look fully healthy.

--- a/specs/GH1441/tech.md
+++ b/specs/GH1441/tech.md
@@ -1,0 +1,136 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1441
+
+## Product Spec
+
+See `specs/GH1441/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| GitHub intake config | `crates/harness-core/src/config/intake.rs` | `GitHubIntakeConfig` has global `enabled` and `mode` fields. `IntakeMode::webhook_autonomous()` is true for `Webhook` and `Hybrid`; `poller_enabled()` is true for `Poll` and `Hybrid`. | This is the source of truth for whether a webhook secret is required. |
+| Webhook secret config | `crates/harness-core/src/config/server.rs` | `ServerConfig.github_webhook_secret` is optional. Env override ignores empty `GITHUB_WEBHOOK_SECRET`, but TOML can still produce `Some("")` or whitespace. Debug output redacts configured values. | Startup validation must use normalized secret availability without leaking values. |
+| App state startup | `crates/harness-server/src/http/init.rs` | `build_app_state` logs a warning when the webhook secret is absent or empty, regardless of GitHub intake mode, but does not record degraded health. | This is where the startup validation and health degradation should be wired. |
+| GitHub poller construction | `crates/harness-server/src/http/builders/intake.rs` | Pollers are created only when GitHub intake is enabled and the mode allows polling. Webhook mode correctly creates no poller. | The fix must preserve poller behavior, especially for hybrid mode. |
+| Webhook route | `crates/harness-server/src/http/misc_routes.rs` | `github_webhook` fails closed when the secret is missing or exactly empty. Whitespace-only secrets are currently accepted as a configured value. | Route behavior should remain fail-closed and use the same secret usability rule as startup validation. |
+| Health route | `crates/harness-server/src/http/misc_routes.rs` | `/health` reports degraded when `degraded_subsystems` is non-empty, runtime state is dirty, circuit breakers open, or isolation is unavailable. | Startup validation can surface the misconfiguration through existing health machinery. |
+| Intake status route | `crates/harness-server/src/http/misc_routes.rs` | `/api/intake` reports GitHub channel `enabled`, one `repo`, active count, and recent dispatches, but not mode, driver state, or effective repos. | This is the operator surface requested by the issue. |
+
+## Proposed Design
+
+1. Add a small normalized GitHub webhook-secret validation helper.
+   - Treat `None`, empty string, and whitespace-only string as unusable.
+   - Treat only trimmed non-empty values as usable.
+   - Keep the helper value-oriented so tests can cover it without starting the
+     server.
+2. Evaluate GitHub intake mode during `build_app_state`.
+   - If `intake.github` is absent, disabled, or mode is `poll`, do not require a
+     webhook secret.
+   - If GitHub intake is enabled and mode is `webhook` or `hybrid`, require the
+     normalized secret to be usable.
+   - When the requirement is not met, append a sanitized optional startup status
+     and include a stable degraded subsystem name such as
+     `github_webhook_intake`.
+   - Continue server startup so `/health` and `/api/intake` remain available for
+     operators.
+3. Align the webhook handler with the normalized helper.
+   - Missing, empty, and whitespace-only secrets return the existing fail-closed
+     non-success response class.
+   - Do not include secret values in the response body or logs.
+4. Expand `GET /api/intake` GitHub channel metadata.
+   - Preserve existing top-level channel fields, including `name`, `enabled`,
+     `repo`, and `active`, for compatibility.
+   - Add `mode` using the configured `IntakeMode` string.
+   - Add driver state for `webhook` and `polling`, including whether each driver
+     is configured by mode and whether it is currently active or degraded.
+   - Add effective repo entries from `GitHubIntakeConfig::effective_repos()`,
+     including `repo`, `label`, optional `project_root`, and the effective
+     driver mode for that repo.
+   - If runtime submission summaries are already degraded, compose the existing
+     partial response with the webhook-secret driver degradation rather than
+     replacing it.
+5. Update tests.
+   - Unit-test the normalized secret rule.
+   - Add focused startup/health tests for webhook, hybrid, poll, disabled, empty
+     secret, and whitespace-only secret cases.
+   - Add intake status route tests for mode, driver state, and effective repos.
+   - Add webhook route regression coverage for whitespace-only secret handling.
+
+## Data Flow
+
+Configuration is loaded into `HarnessConfig`. During app-state construction,
+the startup validation reads `config.intake.github` and
+`config.server.github_webhook_secret`. It produces a normalized secret
+availability result and a GitHub intake driver status. If webhook-capable GitHub
+intake lacks a usable secret, `build_app_state` records a sanitized degraded
+subsystem before constructing `AppState`.
+
+`/health` reads the existing `degraded_subsystems` and `startup_statuses` from
+`AppState`. No secret value crosses into the health response; the response only
+names the degraded subsystem and uses the existing redacted startup error code.
+
+`/api/intake` reads the configured GitHub intake mode, effective repos, live
+poller registrations from `state.intake.github_pollers` and
+`github_poller_repos`, and the normalized secret availability. It reports which
+drivers are configured and currently usable. Runtime submission counts and
+recent dispatches continue to flow from the existing task and workflow-runtime
+queries.
+
+The webhook route reads the same normalized secret availability before
+signature verification. If the secret is unusable, the request fails before any
+payload dispatch logic runs.
+
+## Alternatives Considered
+
+- Fail server startup for webhook-capable GitHub intake without a secret.
+  Rejected for this issue because a degraded-but-running server keeps `/health`
+  and `/api/intake` available for operators and matches the issue title.
+- Keep logging only. Rejected because the problem is specifically invisible
+  healthy status despite a configured intake driver being unavailable.
+- Disable hybrid polling when the webhook secret is missing. Rejected because
+  hybrid mode intentionally keeps polling as a backstop; the correct behavior is
+  visible degradation, not removing the remaining working driver.
+- Add a separate `/api/intake/repos` endpoint. Rejected because the existing
+  intake status route already owns intake operator status.
+
+## Risks
+
+- Security: secret values must remain redacted in Debug output, health output,
+  intake status output, webhook errors, and logs.
+- Compatibility: clients that parse `/api/intake` should continue to find the
+  existing channel fields. New fields should be additive.
+- Performance: startup validation is local config inspection only. Intake status
+  should reuse existing in-memory poller and config data and avoid new network
+  calls.
+- Maintenance: driver-state computation should be centralized enough that
+  health and intake status do not drift on the definition of usable webhook
+  secret.
+
+## Test Plan
+
+- [ ] Unit tests: normalized webhook secret availability treats missing, empty,
+      and whitespace-only values as unusable and preserves non-empty values.
+- [ ] Startup/health tests: GitHub webhook mode without a usable secret reports
+      degraded health.
+- [ ] Startup/health tests: GitHub hybrid mode without a usable secret reports
+      degraded health while preserving polling registration when available.
+- [ ] Startup/health tests: GitHub poll mode and disabled GitHub intake do not
+      degrade health due to missing webhook secret.
+- [ ] Route tests: `/api/intake` reports GitHub mode, webhook driver state,
+      polling driver state, and effective repos.
+- [ ] Route tests: webhook handler rejects whitespace-only configured secrets
+      without accepting the request as signed.
+- [ ] Verification: `cargo test -p harness-server intake_status`.
+- [ ] Verification: `cargo test -p harness-server health`.
+- [ ] Verification: `cargo test -p harness-server github_webhook`.
+- [ ] Verification: `cargo check -p harness-server --all-targets`.
+
+## Rollback Plan
+
+Revert the startup validation, intake status metadata additions, and webhook
+secret normalization changes. No data migration or persisted state changes are
+required.


### PR DESCRIPTION
## Summary
- Add the GH1441 product spec for GitHub intake startup validation and degraded health
- Add the GH1441 tech spec covering startup validation, webhook fail-closed behavior, health, and intake status surfaces
- Add the GH1441 task plan for implementation and verification

## Verification
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1441
- python3 checks/check_workflow.py --repo .

Issues: #1441