### PR TITLE
Fix GitHub intake startup secret validation

### DIFF
--- a/crates/harness-server/src/http/github_intake_status.rs
+++ b/crates/harness-server/src/http/github_intake_status.rs
@@ -1,0 +1,185 @@
+use harness_core::config::{
+    intake::{GitHubIntakeConfig, IntakeMode},
+    server::ServerConfig,
+    HarnessConfig,
+};
+use serde_json::{json, Value};
+
+use super::state::StoreStartupResult;
+
+pub(crate) const GITHUB_WEBHOOK_INTAKE_SUBSYSTEM: &str = "github_webhook_intake";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitHubWebhookSecretError {
+    Missing,
+    Invalid,
+}
+
+impl GitHubWebhookSecretError {
+    pub(crate) fn reason(self) -> &'static str {
+        match self {
+            Self::Missing => "missing_webhook_secret",
+            Self::Invalid => "invalid_webhook_secret",
+        }
+    }
+}
+
+pub(crate) fn github_webhook_secret_for_request(
+    server: &ServerConfig,
+) -> Result<&str, GitHubWebhookSecretError> {
+    match server.github_webhook_secret.as_deref() {
+        None => Err(GitHubWebhookSecretError::Missing),
+        Some(secret) if secret.trim().is_empty() => Err(GitHubWebhookSecretError::Invalid),
+        Some(secret) => Ok(secret),
+    }
+}
+
+pub(crate) fn github_intake_requires_webhook_secret(github: Option<&GitHubIntakeConfig>) -> bool {
+    github
+        .filter(|config| config.enabled && config.mode.webhook_autonomous())
+        .is_some()
+}
+
+pub(crate) fn github_webhook_intake_startup_status(
+    config: &HarnessConfig,
+) -> Option<StoreStartupResult> {
+    if !github_intake_requires_webhook_secret(config.intake.github.as_ref()) {
+        return None;
+    }
+    github_webhook_secret_for_request(&config.server)
+        .err()
+        .map(|_| {
+            StoreStartupResult::optional(GITHUB_WEBHOOK_INTAKE_SUBSYSTEM).failed(
+                "server.github_webhook_secret is required for GitHub webhook-capable intake",
+            )
+        })
+}
+
+pub(crate) fn intake_mode_name(mode: IntakeMode) -> &'static str {
+    match mode {
+        IntakeMode::Poll => "poll",
+        IntakeMode::Webhook => "webhook",
+        IntakeMode::Hybrid => "hybrid",
+    }
+}
+
+pub(crate) fn github_intake_driver_metadata(
+    github: Option<&GitHubIntakeConfig>,
+    server: &ServerConfig,
+    active_poller_count: usize,
+) -> Value {
+    let enabled = github.map(|config| config.enabled).unwrap_or(false);
+    let mode = github.map(|config| config.mode);
+    let webhook_configured = enabled && mode.is_some_and(IntakeMode::webhook_autonomous);
+    let polling_configured = enabled && mode.is_some_and(IntakeMode::poller_enabled);
+    let webhook_secret_error = github_webhook_secret_for_request(server).err();
+    let webhook_degraded = webhook_configured && webhook_secret_error.is_some();
+    let webhook_reason = if webhook_degraded {
+        webhook_secret_error.map(GitHubWebhookSecretError::reason)
+    } else {
+        None
+    };
+    json!({
+        "webhook": {
+            "configured": webhook_configured,
+            "accepting": webhook_configured && !webhook_degraded,
+            "degraded": webhook_degraded,
+            "reason": webhook_reason,
+        },
+        "polling": {
+            "configured": polling_configured,
+            "active": polling_configured && active_poller_count > 0,
+            "degraded": polling_configured && active_poller_count == 0,
+        },
+    })
+}
+
+pub(crate) fn github_effective_repos(github: Option<&GitHubIntakeConfig>) -> Vec<Value> {
+    let Some(config) = github else {
+        return Vec::new();
+    };
+    let mode = intake_mode_name(config.mode);
+    config
+        .effective_repos()
+        .into_iter()
+        .map(|repo| {
+            json!({
+                "repo": repo.repo,
+                "label": repo.label,
+                "project_root": repo.project_root,
+                "mode": mode,
+                "drivers": {
+                    "webhook": config.enabled && config.mode.webhook_autonomous(),
+                    "polling": config.enabled && config.mode.poller_enabled(),
+                },
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn github_config(mode: IntakeMode) -> GitHubIntakeConfig {
+        GitHubIntakeConfig {
+            enabled: true,
+            mode,
+            repo: "owner/repo".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn webhook_secret_for_request_rejects_missing_empty_and_whitespace() {
+        let mut server = ServerConfig::default();
+        assert_eq!(
+            github_webhook_secret_for_request(&server),
+            Err(GitHubWebhookSecretError::Missing)
+        );
+
+        server.github_webhook_secret = Some(String::new());
+        assert_eq!(
+            github_webhook_secret_for_request(&server),
+            Err(GitHubWebhookSecretError::Invalid)
+        );
+
+        server.github_webhook_secret = Some("   ".to_string());
+        assert_eq!(
+            github_webhook_secret_for_request(&server),
+            Err(GitHubWebhookSecretError::Invalid)
+        );
+
+        server.github_webhook_secret = Some(" secret ".to_string());
+        assert_eq!(github_webhook_secret_for_request(&server), Ok(" secret "));
+    }
+
+    #[test]
+    fn webhook_capable_intake_without_secret_returns_startup_degradation() {
+        let mut config = HarnessConfig::default();
+        config.intake.github = Some(github_config(IntakeMode::Webhook));
+
+        let status = github_webhook_intake_startup_status(&config)
+            .expect("webhook mode without secret should degrade");
+
+        assert_eq!(status.name, GITHUB_WEBHOOK_INTAKE_SUBSYSTEM);
+        assert!(!status.ready);
+        assert!(!status.is_critical());
+        assert!(!status.error.unwrap_or_default().contains("secret-value"));
+    }
+
+    #[test]
+    fn hybrid_without_secret_degrades_but_poll_mode_and_disabled_do_not() {
+        let mut config = HarnessConfig::default();
+        config.intake.github = Some(github_config(IntakeMode::Hybrid));
+        assert!(github_webhook_intake_startup_status(&config).is_some());
+
+        config.intake.github = Some(github_config(IntakeMode::Poll));
+        assert!(github_webhook_intake_startup_status(&config).is_none());
+
+        let mut disabled = github_config(IntakeMode::Webhook);
+        disabled.enabled = false;
+        config.intake.github = Some(disabled);
+        assert!(github_webhook_intake_startup_status(&config).is_none());
+    }
+}

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -180,21 +180,30 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         log_retention_days = server.config.observe.log_retention_days,
         "config details (use RUST_LOG=debug to see)"
     );
-    match server.config.server.github_webhook_secret.as_deref() {
-        Some("") => {
-            tracing::warn!(
-                "server.github_webhook_secret is configured as empty string; refusing webhook requests until this is set to a non-empty value"
-            );
-        }
-        None => {
-            tracing::warn!(
-                "server.github_webhook_secret is not configured; refusing webhook requests until this is set to a non-empty value"
-            );
-        }
-        Some(_) => {}
-    }
-
     let mut startup_statuses = Vec::new();
+    if super::github_intake_status::github_intake_requires_webhook_secret(
+        server.config.intake.github.as_ref(),
+    ) {
+        match super::github_intake_status::github_webhook_secret_for_request(&server.config.server)
+        {
+            Err(super::github_intake_status::GitHubWebhookSecretError::Invalid) => {
+                tracing::warn!(
+                    "server.github_webhook_secret is configured as empty or whitespace-only; refusing webhook requests until this is set to a non-empty value"
+                );
+            }
+            Err(super::github_intake_status::GitHubWebhookSecretError::Missing) => {
+                tracing::warn!(
+                    "server.github_webhook_secret is not configured; refusing webhook requests until this is set to a non-empty value"
+                );
+            }
+            Ok(_) => {}
+        }
+        if let Some(status) =
+            super::github_intake_status::github_webhook_intake_startup_status(&server.config)
+        {
+            startup_statuses.push(status);
+        }
+    }
 
     // Phase 1: storage — dir validation (symlink check, chmod), task DB, eval store.
     let storage = builders::storage::build_storage_with_database_url(

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -488,27 +488,22 @@ pub(crate) async fn github_webhook(
     headers: HeaderMap,
     body: Bytes,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let secret = match state
-        .core
-        .server
-        .config
-        .server
-        .github_webhook_secret
-        .as_deref()
-    {
-        Some("") => {
+    let secret = match super::github_intake_status::github_webhook_secret_for_request(
+        &state.core.server.config.server,
+    ) {
+        Err(super::github_intake_status::GitHubWebhookSecretError::Invalid) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "invalid server.github_webhook_secret configuration"})),
             )
         }
-        Some(secret) => secret,
-        None => {
+        Err(super::github_intake_status::GitHubWebhookSecretError::Missing) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "missing server.github_webhook_secret configuration"})),
             )
         }
+        Ok(secret) => secret,
     };
     let signature = match headers
         .get("x-hub-signature-256")
@@ -720,10 +715,26 @@ pub(crate) async fn intake_status(State(state): State<Arc<AppState>>) -> Json<se
         })
         .count() as u64;
 
+    let github_cfg = intake_config.github.as_ref();
+    let github_mode =
+        github_cfg.map(|config| super::github_intake_status::intake_mode_name(config.mode));
+    let github_drivers = super::github_intake_status::github_intake_driver_metadata(
+        github_cfg,
+        &state.core.server.config.server,
+        state.intake.github_pollers.len(),
+    );
+    let github_effective_repos = super::github_intake_status::github_effective_repos(github_cfg);
+    let github_webhook_degraded = github_drivers["webhook"]["degraded"]
+        .as_bool()
+        .unwrap_or(false);
+
     let github_channel = json!({
         "name": "github",
-        "enabled": intake_config.github.as_ref().map(|c| c.enabled).unwrap_or(false),
-        "repo": intake_config.github.as_ref().map(|c| c.repo.as_str()).unwrap_or(""),
+        "enabled": github_cfg.map(|c| c.enabled).unwrap_or(false),
+        "repo": github_cfg.map(|c| c.repo.as_str()).unwrap_or(""),
+        "mode": github_mode,
+        "drivers": github_drivers,
+        "repos": github_effective_repos,
         "active": github_active,
     });
 
@@ -762,11 +773,25 @@ pub(crate) async fn intake_status(State(state): State<Arc<AppState>>) -> Json<se
         "channels": [github_channel, feishu_channel, dashboard_channel],
         "recent_dispatches": recent_dispatches,
     });
+    let mut degraded_missing = Vec::new();
     if runtime_degraded {
+        degraded_missing.push("workflow_runtime_submissions");
+    }
+    if github_webhook_degraded {
+        degraded_missing.push(super::github_intake_status::GITHUB_WEBHOOK_INTAKE_SUBSYSTEM);
+    }
+    if !degraded_missing.is_empty() {
+        let reason = if runtime_degraded && !github_webhook_degraded {
+            "runtime_submission_summaries_unavailable"
+        } else if github_webhook_degraded && !runtime_degraded {
+            "github_webhook_secret_unavailable"
+        } else {
+            "intake_status_degraded"
+        };
         response["degraded"] = json!({
             "partial": true,
-            "missing": ["workflow_runtime_submissions"],
-            "reason": "runtime_submission_summaries_unavailable",
+            "missing": degraded_missing,
+            "reason": reason,
         });
     }
     Json(response)
@@ -923,21 +948,16 @@ pub(crate) async fn ingest_signal(
     headers: HeaderMap,
     body: Bytes,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let secret = match state
-        .core
-        .server
-        .config
-        .server
-        .github_webhook_secret
-        .as_deref()
-    {
-        Some("") | None => {
+    let secret = match super::github_intake_status::github_webhook_secret_for_request(
+        &state.core.server.config.server,
+    ) {
+        Err(_) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "server.github_webhook_secret not configured"})),
             )
         }
-        Some(s) => s,
+        Ok(secret) => secret,
     };
 
     let signature = match headers

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod auth;
 pub(crate) mod auto_merge;
 pub(crate) mod background;
 pub(crate) mod builders;
+pub(crate) mod github_intake_status;
 pub(crate) mod http_router;
 pub(crate) mod init;
 pub(crate) mod misc_routes;

--- a/crates/harness-server/src/http/tests/health_route_tests.rs
+++ b/crates/harness-server/src/http/tests/health_route_tests.rs
@@ -1,5 +1,37 @@
 use super::*;
 
+async fn state_after_github_intake_startup_validation(
+    dir: &std::path::Path,
+    config: harness_core::config::HarnessConfig,
+) -> anyhow::Result<Arc<AppState>> {
+    let mut state = make_read_only_route_test_state_with(
+        dir,
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let state_mut = Arc::get_mut(&mut state).expect("unique state");
+    if let Some(status) = crate::http::github_intake_status::github_webhook_intake_startup_status(
+        &state_mut.core.server.config,
+    ) {
+        let subsystem = status.name;
+        state_mut.startup_statuses.push(status);
+        state_mut.degraded_subsystems.push(subsystem);
+    }
+    Ok(state)
+}
+
+fn github_intake_config(
+    mode: harness_core::config::intake::IntakeMode,
+) -> harness_core::config::intake::GitHubIntakeConfig {
+    harness_core::config::intake::GitHubIntakeConfig {
+        enabled: true,
+        mode,
+        repo: "owner/repo".to_string(),
+        ..Default::default()
+    }
+}
+
 #[tokio::test]
 async fn health_degraded_when_runtime_state_dirty() -> anyhow::Result<()> {
     use std::sync::atomic::Ordering;
@@ -10,6 +42,83 @@ async fn health_degraded_when_runtime_state_dirty() -> anyhow::Result<()> {
     assert_eq!(health.status, "degraded");
     assert!(health.persistence.degraded_subsystems.is_empty());
     assert!(health.persistence.runtime_state_dirty);
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_degraded_when_github_webhook_intake_secret_missing() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.intake.github = Some(github_intake_config(
+        harness_core::config::intake::IntakeMode::Webhook,
+    ));
+    let health =
+        call_health(state_after_github_intake_startup_validation(dir.path(), config).await?)
+            .await?;
+
+    assert_eq!(health.status, "degraded");
+    assert_eq!(
+        health.persistence.degraded_subsystems,
+        [crate::http::github_intake_status::GITHUB_WEBHOOK_INTAKE_SUBSYSTEM]
+    );
+    assert_eq!(health.persistence.startup.stores.len(), 1);
+    assert_eq!(
+        health.persistence.startup.stores[0].name,
+        crate::http::github_intake_status::GITHUB_WEBHOOK_INTAKE_SUBSYSTEM
+    );
+    assert_eq!(
+        health.persistence.startup.stores[0].error.as_deref(),
+        Some("startup_failed")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_degraded_when_github_hybrid_intake_secret_is_whitespace() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.intake.github = Some(github_intake_config(
+        harness_core::config::intake::IntakeMode::Hybrid,
+    ));
+    config.server.github_webhook_secret = Some("   ".to_string());
+    let health =
+        call_health(state_after_github_intake_startup_validation(dir.path(), config).await?)
+            .await?;
+
+    assert_eq!(health.status, "degraded");
+    assert_eq!(
+        health.persistence.degraded_subsystems,
+        [crate::http::github_intake_status::GITHUB_WEBHOOK_INTAKE_SUBSYSTEM]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_ok_when_github_poll_intake_has_no_webhook_secret() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.intake.github = Some(github_intake_config(
+        harness_core::config::intake::IntakeMode::Poll,
+    ));
+    let health =
+        call_health(state_after_github_intake_startup_validation(dir.path(), config).await?)
+            .await?;
+
+    assert_eq!(health.status, "ok");
+    assert!(health.persistence.degraded_subsystems.is_empty());
+    assert!(health.persistence.startup.stores.is_empty());
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
+++ b/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
@@ -1,5 +1,36 @@
 use super::*;
 
+struct DummyGithubPoller;
+
+#[async_trait]
+impl crate::intake::IntakeSource for DummyGithubPoller {
+    fn name(&self) -> &str {
+        "github"
+    }
+
+    async fn poll(&self) -> anyhow::Result<Vec<crate::intake::IncomingIssue>> {
+        Ok(Vec::new())
+    }
+
+    async fn mark_dispatched(
+        &self,
+        _external_id: &str,
+        _task_id: &task_runner::TaskId,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn unmark_dispatched(&self, _external_id: &str) {}
+
+    async fn on_task_complete(
+        &self,
+        _external_id: &str,
+        _result: &crate::intake::TaskCompletionResult,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn intake_status_returns_three_channels() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
@@ -107,6 +138,138 @@ async fn intake_status_shows_github_repo_when_configured() -> anyhow::Result<()>
         .expect("github channel present");
     assert_eq!(github["enabled"], true);
     assert_eq!(github["repo"], "owner/myrepo");
+    Ok(())
+}
+
+#[tokio::test]
+async fn intake_status_reports_github_mode_drivers_and_effective_repos() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.server.github_webhook_secret = Some("secret".to_string());
+    config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+        enabled: true,
+        mode: harness_core::config::intake::IntakeMode::Hybrid,
+        repo: "owner/main".to_string(),
+        label: "harness".to_string(),
+        repos: vec![harness_core::config::intake::GitHubRepoConfig {
+            repo: "owner/secondary".to_string(),
+            label: "bugs".to_string(),
+            project_root: Some("/tmp/secondary".to_string()),
+            auto_merge: None,
+            merge_method: None,
+            delete_branch: None,
+            require_review_threads_resolved: None,
+            require_clean_merge_state: None,
+        }],
+        ..Default::default()
+    });
+    let mut state = make_read_only_route_test_state_with(
+        dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let state_mut = Arc::get_mut(&mut state).expect("unique state");
+    state_mut
+        .intake
+        .github_pollers
+        .push(Arc::new(DummyGithubPoller));
+    state_mut
+        .intake
+        .github_poller_repos
+        .push("owner/main".to_string());
+    let app = intake_app(state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/intake").body(Body::empty())?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = response_json(response).await?;
+    let github = json["channels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["name"] == "github")
+        .expect("github channel present");
+    assert_eq!(github["enabled"], true);
+    assert_eq!(github["repo"], "owner/main");
+    assert_eq!(github["mode"], "hybrid");
+    assert_eq!(github["drivers"]["webhook"]["configured"], true);
+    assert_eq!(github["drivers"]["webhook"]["accepting"], true);
+    assert_eq!(github["drivers"]["webhook"]["degraded"], false);
+    assert_eq!(github["drivers"]["polling"]["configured"], true);
+    assert_eq!(github["drivers"]["polling"]["active"], true);
+    let repos = github["repos"]
+        .as_array()
+        .expect("repos should be an array");
+    assert!(repos
+        .iter()
+        .any(|repo| repo["repo"] == "owner/main" && repo["mode"] == "hybrid"));
+    assert!(repos.iter().any(|repo| {
+        repo["repo"] == "owner/secondary"
+            && repo["label"] == "bugs"
+            && repo["project_root"] == "/tmp/secondary"
+    }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn intake_status_reports_webhook_driver_degraded_without_secret() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let mut config = harness_core::config::HarnessConfig::default();
+    config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
+        enabled: true,
+        mode: harness_core::config::intake::IntakeMode::Webhook,
+        repo: "owner/webhook".to_string(),
+        ..Default::default()
+    });
+    let state = make_read_only_route_test_state_with(
+        dir.path(),
+        config,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let app = intake_app(state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/intake").body(Body::empty())?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = response_json(response).await?;
+    let github = json["channels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["name"] == "github")
+        .expect("github channel present");
+    assert_eq!(github["mode"], "webhook");
+    assert_eq!(github["drivers"]["webhook"]["configured"], true);
+    assert_eq!(github["drivers"]["webhook"]["accepting"], false);
+    assert_eq!(github["drivers"]["webhook"]["degraded"], true);
+    assert_eq!(
+        github["drivers"]["webhook"]["reason"],
+        "missing_webhook_secret"
+    );
+    assert_eq!(github["drivers"]["polling"]["configured"], false);
+    assert_eq!(json["degraded"]["partial"], true);
+    assert_eq!(
+        json["degraded"]["missing"],
+        serde_json::json!([crate::http::github_intake_status::GITHUB_WEBHOOK_INTAKE_SUBSYSTEM])
+    );
+    assert_eq!(
+        json["degraded"]["reason"],
+        "github_webhook_secret_unavailable"
+    );
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests/webhook_task_tests.rs
+++ b/crates/harness-server/src/http/tests/webhook_task_tests.rs
@@ -303,6 +303,43 @@ async fn webhook_empty_secret_configuration_fails_closed() -> anyhow::Result<()>
 }
 
 #[tokio::test]
+async fn webhook_whitespace_secret_configuration_fails_closed() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let (state, _agent) = make_test_state_with_agent(dir.path(), Some("   ")).await?;
+    let app = webhook_app(state);
+
+    let payload = serde_json::json!({
+        "action": "created",
+        "issue": { "number": 106 },
+        "comment": { "body": "@harness please handle this issue" },
+        "repository": { "full_name": "majiayu000/harness" }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/webhook")
+                .header("x-github-event", "issue_comment")
+                .header("content-type", "application/json")
+                .body(Body::from(payload.to_string()))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let json = response_json(response).await?;
+    assert_eq!(
+        json["error"],
+        "invalid server.github_webhook_secret configuration"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn webhook_missing_secret_configuration_fails_closed() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
     let (state, _agent) = make_test_state_with_agent(dir.path(), None).await?;


### PR DESCRIPTION
## Summary
- validate GitHub webhook-capable intake modes against usable webhook secret configuration during startup
- surface missing/blank webhook secret as degraded health and additive /api/intake driver metadata
- reject whitespace-only GitHub webhook secrets before signature verification

## Verification
- cargo check -p harness-server --all-targets
- cargo test -p harness-server webhook_secret_for_request
- cargo test -p harness-server webhook_capable_intake_without_secret_returns_startup_degradation
- cargo test -p harness-server hybrid_without_secret_degrades_but_poll_mode_and_disabled_do_not
- cargo test -p harness-server github_webhook_intake
- cargo test -p harness-server github_hybrid_intake_secret_is_whitespace
- cargo test -p harness-server github_poll_intake_has_no_webhook_secret
- cargo test -p harness-server intake_status_reports
- cargo test -p harness-server webhook_whitespace_secret_configuration_fails_closed
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1441
- python3 checks/check_workflow.py --repo .

Fixes #1441