### PR TITLE
Add GH1444 test database safety spec

### DIFF
--- a/specs/GH1444/product.md
+++ b/specs/GH1444/product.md
@@ -1,0 +1,109 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1444
+
+## User Problem
+
+Postgres-backed test suites can resolve the same database URL used by a local or
+production Harness instance. When those tests create per-run schemas such as
+`workspace_lease_scope_test_*`, `event_store_jsonl_test_*`,
+`event_store_backfill_test_*`, and `event_store_scope_test_*`, interrupted or
+panicking runs can leave the schemas behind. The existing schema reaper focuses
+on path-derived `h<hex>` schemas and does not remove these named test schemas.
+
+This makes `cargo test --workspace` unsafe as a readiness gate for later
+kernel-contraction work: running verification can mutate and pollute the
+operator's primary database.
+
+## Goals
+
+- Prevent Postgres-backed tests from running against a non-test-designated
+  database by default.
+- Keep test setup fail-closed: an unsafe configured database URL should skip or
+  fail test DB setup before creating schemas.
+- Drop temporary test schemas created by focused Postgres test helpers on normal
+  completion and panic unwind.
+- Provide a dry-run-first cleanup path for existing leaked `*_test_*` schemas.
+- Preserve CI behavior where `HARNESS_DATABASE_URL` already points at
+  `harness_test`.
+- Keep production server and CLI database resolution unchanged outside test
+  helpers and cleanup tooling.
+
+## Non-Goals
+
+- Solving full per-test parallel schema isolation; that is tracked by GH-1456.
+- Dropping path-derived `h<hex>` schemas; that remains owned by the existing
+  path-derived schema cleanup tools.
+- Changing production store schema names, migrations, or runtime database
+  routing.
+- Automatically deleting schemas without an explicit apply/confirm flag.
+- Requiring Docker for all local tests.
+
+## User-Visible Behavior
+
+When a Postgres-backed test helper resolves `HARNESS_DATABASE_URL` or the
+repository config fallback, it must confirm that the target database is marked
+as safe for tests before opening a pool that can create schemas. A database is
+safe when its database name is clearly test-designated, such as `harness_test`
+or a name ending in `_test`, or when an explicit escape hatch is set for
+maintainers who intentionally run tests against another disposable database.
+
+If the resolved URL is absent or points at a non-test-designated database, tests
+that already skip when no database is available continue to skip. Test helpers
+that require a configured Postgres database fail with a direct error before any
+schema is created. The error names the safety rule and the escape hatch without
+printing credentials.
+
+For test helpers that create ad hoc schemas matching `*_test_*`, a cleanup guard
+drops those schemas on normal completion and during panic unwind. Cleanup errors
+must not be silently swallowed in tests that can surface them; where `Drop`
+cannot return an error, the guard records the failure for explicit assertions or
+logs it with enough schema context for diagnosis.
+
+Operators also get a cleanup command or script that lists leaked test schemas in
+dry-run mode first. Applying cleanup requires an explicit flag and only targets
+schema names matching the bounded test-schema patterns used by this repository.
+
+## Acceptance Criteria
+
+- [ ] Test DB helpers reject or skip non-test-designated database URLs before
+      opening pools that can create schemas.
+- [ ] CI with `HARNESS_DATABASE_URL=.../harness_test` continues to run
+      Postgres-backed tests without extra configuration.
+- [ ] Maintainers have an explicit documented escape hatch for disposable
+      non-`*_test` database names.
+- [ ] Temporary named test schemas are dropped by an RAII-style guard on normal
+      completion and panic unwind.
+- [ ] A dry-run cleanup command reports existing leaked `*_test_*` schemas
+      without dropping them by default.
+- [ ] Applying cleanup requires an explicit flag and drops only known
+      repository test-schema patterns.
+- [ ] Tests cover safe URL detection, unsafe URL rejection, secret redaction in
+      database URL error text, cleanup planning, and guard cleanup behavior.
+- [ ] GH-1434 verification guidance can rely on workspace tests without
+      polluting the primary database.
+
+## Edge Cases
+
+- A URL such as `postgres://user:pass@localhost:5432/harness` is unsafe by
+  default even on localhost.
+- A URL such as `postgres://user:pass@localhost:5432/harness_test` is safe.
+- A URL whose database name is percent-encoded must be decoded or compared in a
+  way that cannot misclassify `harness` as safe.
+- Query parameters, passwords, and usernames must not appear in safety error
+  messages.
+- Cleanup must ignore schemas that merely contain `test` in the middle of an
+  unrelated name and must ignore path-derived `h<hex>` schemas.
+- If a cleanup guard cannot drop a schema because the database is already gone,
+  the failure should be visible to the test owner but must not trigger cleanup
+  of unrelated schemas.
+
+## Rollout Notes
+
+This is a test-infrastructure safety fix. Developers whose local config points
+at the primary Harness database will see Postgres-backed tests skip or fail
+before mutation until they set `HARNESS_DATABASE_URL` to a test database such as
+`postgres://harness:harness@localhost:5432/harness_test`. CI already uses a
+test-designated database name.

--- a/specs/GH1444/tasks.md
+++ b/specs/GH1444/tasks.md
@@ -1,0 +1,46 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1444
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1444-T001` Owner: `test-db-safety` | Done when: a shared helper validates test-designated database URLs, redacts unsafe URL diagnostics, and supports the explicit disposable-database escape hatch | Verify: `cargo test -p harness-core test_database`
+- [ ] `SP1444-T002` Owner: `test-helper-wiring` | Done when: core, server, observe, and workflow Postgres-backed test setup paths validate safe database URLs before opening pools or return their existing skip path | Verify: `cargo test -p harness-server test_database && cargo test -p harness-observe test_database`
+- [ ] `SP1444-T003` Owner: `schema-cleanup` | Done when: named `*_test_*` schema helpers use an RAII cleanup guard that validates identifiers and drops owned schemas on normal completion with panic-unwind backup behavior | Verify: `cargo test -p harness-observe test_schema`
+- [ ] `SP1444-T004` Owner: `cleanup-tooling` | Done when: `harness-pg-schema-cleanup` can dry-run known leaked test schemas and requires explicit apply flags before dropping validated names | Verify: `cargo test -p harness-cli pg_schema_cleanup`
+- [ ] `SP1444-T005` Owner: `docs-verification` | Done when: local DB test documentation points to `harness_test`, SpecRail checks pass, and focused plus workspace checks are recorded | Verify: `cargo fmt --all -- --check && cargo check --workspace --all-targets && python3 checks/check_workflow.py --repo . --spec-dir specs/GH1444`
+
+## Parallelization
+
+T001 should land first because every other task depends on the shared safety
+contract. T002 and T003 can proceed after the helper API is stable. T004 can be
+implemented independently once the allowed leaked-schema prefix list is fixed.
+T005 is the final verification and documentation pass.
+
+## Verification
+
+- `cargo test -p harness-core test_database`
+- `cargo test -p harness-server test_database`
+- `cargo test -p harness-observe test_database`
+- `cargo test -p harness-observe test_schema`
+- `cargo test -p harness-cli pg_schema_cleanup`
+- `cargo check --workspace --all-targets`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1444`
+- `python3 checks/check_workflow.py --repo .`
+
+## Handoff Notes
+
+Keep the production database resolution path unchanged. The implementation must
+only add safety around test setup and explicit cleanup tooling. Do not weaken DB
+tests into no-op assertions; if an unsafe URL is detected, skip only through the
+existing optional-DB behavior or fail before opening a pool where the test
+requires Postgres.

--- a/specs/GH1444/tech.md
+++ b/specs/GH1444/tech.md
@@ -1,0 +1,130 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1444
+
+## Product Spec
+
+See `specs/GH1444/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Database URL resolution | `crates/harness-core/src/db_pg.rs` | `resolve_database_url` reads explicit config, `HARNESS_DATABASE_URL`, user config, and repository defaults. It is used by production code and tests. | Production behavior must remain unchanged, but tests need an additional safety gate. |
+| Core DB tests | `crates/harness-core/src/db_tests.rs` | Tests open path-derived schemas through `Db::open_legacy_path_schema` and helper pools. They do not currently guard the target database name. | These tests can create schemas in any resolved database. |
+| Server test helpers | `crates/harness-server/src/test_helpers.rs` | `db_tests_enabled` and `test_database_url` use `resolve_database_url(None)` and open pools directly. | This is the main reusable gate for server route and store tests. |
+| Observe event-store tests | `crates/harness-observe/src/event_store/*_tests.rs` | Shared-schema tests create named `*_test_*` schemas and close pools manually. | These schemas match the leaked production catalog evidence. |
+| Workflow/server store tests | `crates/harness-workflow`, `crates/harness-server` | Several tests perform local `resolve_database_url(None)` checks and skip if no DB exists. | The safety helper needs to be shared enough to avoid per-test drift. |
+| Existing cleanup | `crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs`, `scripts/pg-orphan-cleanup.sh` | Cleans registered/path-derived schemas and optionally legacy `h<hex>` schemas. | GH-1444 needs a separate bounded plan for repository test-schema names. |
+| CI | `.github/workflows/ci.yml` | Uses `HARNESS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/harness_test` for DB jobs. | The new safety gate must permit current CI. |
+
+## Proposed Design
+
+1. Add a test-only database safety helper in `harness-core`.
+   - Place the reusable parsing and redaction code in a normal module so
+     multiple crates can use it in tests and cleanup tooling.
+   - Provide `is_test_database_url(url: &str) -> bool` and
+     `validate_test_database_url(url: &str) -> anyhow::Result<()>`.
+   - Treat a URL as safe when the database name is exactly `harness_test`, ends
+     with `_test`, starts with `test_`, or when
+     `HARNESS_ALLOW_NON_TEST_DATABASE_FOR_TESTS=1` is set.
+   - Redact usernames, passwords, query strings, and fragments in errors.
+2. Route Postgres-backed test setup through the safety helper.
+   - In `harness-server::test_helpers`, make `db_tests_enabled` return `false`
+     for unsafe URLs and make `test_database_url()` error before returning an
+     unsafe URL.
+   - In `harness-core` DB tests, check the safety helper before opening a pool.
+   - In `harness-observe` shared-schema/store tests and workflow/server tests
+     that resolve database URLs directly, validate the URL before opening a
+     pool or use the common helper when available.
+3. Add an RAII schema cleanup helper for named test schemas.
+   - Introduce a `TestSchemaGuard` helper for tests that create named schemas
+     with `unique_test_schema`.
+   - The guard owns the schema name and setup pool/database URL and drops the
+     schema with `DROP SCHEMA IF EXISTS <validated_identifier> CASCADE`.
+   - Schema names must pass the existing identifier validation before being
+     interpolated into SQL.
+   - Tests should call an explicit async cleanup method where possible; `Drop`
+     should perform best-effort cleanup only when a runtime is still available
+     and record/log failures.
+4. Add bounded leaked-test-schema cleanup tooling.
+   - Extend `harness-pg-schema-cleanup` with `--test-schemas` dry-run mode and
+     `--apply --test-schema <name>` or `--apply --drop-test-schemas` for
+     explicit deletion.
+   - Match only known repository prefixes:
+     `workspace_lease_scope_test_%`, `event_store_jsonl_test_%`,
+     `event_store_backfill_test_%`, and `event_store_scope_test_%`.
+   - Print counts and schema names in dry-run mode. Do not drop by default.
+   - Reuse identifier validation and parameterized catalog queries.
+5. Document the local test database contract.
+   - Update `scripts/test-server-db.sh` usage text and docs that mention
+     `HARNESS_DATABASE_URL` to use a `harness_test` database.
+   - Document the escape hatch and make clear it is only for disposable
+     non-production databases.
+
+## Data Flow
+
+Test setup resolves the candidate database URL exactly as before. Before opening
+a Postgres pool, test helpers call the test database safety helper. Unsafe URLs
+produce a redacted diagnostic and no pool is opened. Safe URLs proceed into the
+existing store constructors and migrations.
+
+Tests that need named schemas request a `TestSchemaGuard` before passing the
+schema name into `PgStoreContext::from_schema`. The guard validates the schema
+identifier, records ownership for cleanup, and drops the schema at the end of
+the test. Store code remains unaware of the guard.
+
+Cleanup tooling connects to the operator-selected database URL, queries
+`pg_namespace` for known test-schema prefixes, prints a dry-run plan, and only
+drops validated names when explicit apply flags are provided.
+
+## Alternatives Considered
+
+- Require Docker for every DB test. Rejected because CI already supplies
+  Postgres and local developers may use any disposable Postgres instance.
+- Change `resolve_database_url` globally to reject non-test names during tests.
+  Rejected because production code and command tests may legitimately exercise
+  URL resolution without opening a DB or creating schemas.
+- Drop every schema matching `%test%`. Rejected as too broad and unsafe.
+- Leave cleanup to manual SQL. Rejected because GH-1444 needs a repeatable,
+  dry-run-first workflow that can be referenced by later verification gates.
+
+## Risks
+
+- Security: cleanup must validate identifiers before interpolation and use
+  parameterized catalog queries. Database URLs in errors and logs must redact
+  credentials.
+- Compatibility: developers using a database named `harness` for tests will need
+  to create/use `harness_test` or set the explicit disposable-db escape hatch.
+- Reliability: `Drop` cannot reliably perform async cleanup after runtime
+  shutdown. Tests should prefer explicit async cleanup and use `Drop` only as a
+  last-resort guard.
+- Maintenance: multiple crates currently have local DB availability helpers.
+  The safety helper should be small and shared to reduce future drift without
+  broad refactoring.
+
+## Test Plan
+
+- [ ] Unit tests: test database URL detection accepts `harness_test`, suffix
+      `_test`, prefix `test_`, and the explicit escape hatch.
+- [ ] Unit tests: unsafe URL errors redact credentials and query strings.
+- [ ] Unit tests: cleanup planning includes only known test-schema prefixes and
+      excludes unrelated names.
+- [ ] Integration tests: `db_tests_enabled` skips unsafe configured URLs before
+      opening a pool.
+- [ ] Integration tests: `test_database_url` rejects unsafe configured URLs.
+- [ ] Integration tests: `TestSchemaGuard` drops a schema it created in a safe
+      database.
+- [ ] Verification: `cargo test -p harness-core test_database`.
+- [ ] Verification: `cargo test -p harness-server test_database`.
+- [ ] Verification: `cargo test -p harness-observe test_schema`.
+- [ ] Verification: `cargo check --workspace --all-targets`.
+
+## Rollback Plan
+
+Revert the test safety helper, guard wiring, cleanup command additions, and
+documentation updates. No production migrations or persisted data changes are
+required. Existing leaked schemas remain untouched unless the explicit cleanup
+command has already been applied by an operator.


### PR DESCRIPTION
Issues: #1444

## Summary
- add the GH1444 product, technical, and task specs for Postgres test database safety
- define the fail-closed test database URL contract, temporary schema cleanup guard, and leaked test-schema cleanup tooling
- preserve production database resolution and CI harness_test behavior as explicit constraints

## Verification
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1444
- python3 checks/check_workflow.py --repo .