### PR TITLE
Fix Postgres test database safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,24 +160,28 @@ database_url = "postgres://user:password@host:5432/dbname"
 **Running tests against a real database:**
 
 ```bash
-HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test --workspace
+createdb harness_test
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test --workspace
 ```
 
 Integration tests that require a database (e.g. `runtime_state_store`,
 `thread_db`, `q_value_store`) skip automatically when no Harness database URL
-is configured.
+is configured. Postgres-backed tests reject non-test database names by default;
+use `harness_test`, a name ending in `_test`, or a name starting with `test_`.
+For intentionally disposable databases with a different name, set
+`HARNESS_ALLOW_NON_TEST_DATABASE_FOR_TESTS=1`.
 
 **Harness-server validation ladder:**
 
 ```bash
 # Routine server work: fast module and lightweight route path.
-HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-fast.sh
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test scripts/test-server-fast.sh
 
 # Full server DB, startup, recovery, route, and workflow profile.
-HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test scripts/test-server-db.sh
 
 # Final PR handoff: full workspace coverage.
-HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness cargo test --workspace
+HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test --workspace
 ```
 
 `scripts/test-server-fast.sh` is the warm local feedback path for routine

--- a/crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs
+++ b/crates/harness-cli/src/bin/harness-pg-schema-cleanup.rs
@@ -1,9 +1,10 @@
 use clap::Parser;
 use harness_core::config::HarnessConfig;
 use harness_core::db::{
-    apply_pg_schema_cleanup, configure_pg_pool_from_server, pg_open_pool, pg_schema_cleanup_plan,
+    apply_pg_schema_cleanup, apply_pg_test_schema_cleanup, configure_pg_pool_from_server,
+    pg_open_pool, pg_schema_cleanup_plan, pg_test_schema_cleanup_plan,
     reap_orphaned_path_schemas_with_workspace_roots, resolve_database_url, PgSchemaCleanupAction,
-    PgSchemaCleanupPlan,
+    PgSchemaCleanupPlan, PgTestSchemaCleanupPlan,
 };
 use std::path::PathBuf;
 
@@ -35,6 +36,16 @@ struct Args {
     /// longer exists. Dry-run unless combined with --confirm-drop.
     #[arg(long)]
     reap_orphans: bool,
+    /// Dry-run known Harness test schemas such as event_store_*_test_*.
+    #[arg(long)]
+    test_schemas: bool,
+    /// Explicit test schema to drop with --apply. Repeatable.
+    #[arg(long = "test-schema")]
+    test_schema: Vec<String>,
+    /// With --apply and --confirm-drop, drop every known test schema in the
+    /// dry-run plan.
+    #[arg(long)]
+    drop_test_schemas: bool,
     /// Print JSON output.
     #[arg(long)]
     json: bool,
@@ -85,6 +96,45 @@ async fn main() -> anyhow::Result<()> {
             if !report.dropped {
                 println!("Re-run with --confirm-drop to drop them.");
             }
+        }
+        pool.close().await;
+        return Ok(());
+    }
+
+    if args.test_schemas || args.drop_test_schemas || !args.test_schema.is_empty() {
+        let plan = pg_test_schema_cleanup_plan(&pool).await?;
+        if args.apply {
+            if !args.confirm_drop {
+                anyhow::bail!("--apply for test schemas requires --confirm-drop");
+            }
+            let schemas = if args.drop_test_schemas {
+                plan.candidates
+                    .iter()
+                    .map(|candidate| candidate.schema_name.clone())
+                    .collect::<Vec<_>>()
+            } else {
+                args.test_schema.clone()
+            };
+            if schemas.is_empty() {
+                anyhow::bail!(
+                    "--apply for test schemas requires --test-schema or --drop-test-schemas"
+                );
+            }
+            let dropped = apply_pg_test_schema_cleanup(&pool, &schemas).await?;
+            if args.json {
+                println!("{}", serde_json::to_string_pretty(&dropped)?);
+            } else if dropped.is_empty() {
+                println!("No test schemas dropped");
+            } else {
+                println!("Dropped {} test schema(s):", dropped.len());
+                for result in dropped {
+                    println!("  {}", result.schema_name);
+                }
+            }
+        } else if args.json {
+            println!("{}", serde_json::to_string_pretty(&plan)?);
+        } else {
+            print_test_schema_plan(&plan);
         }
         pool.close().await;
         return Ok(());
@@ -193,6 +243,23 @@ fn print_plan(plan: &PgSchemaCleanupPlan) {
     }
 }
 
+fn print_test_schema_plan(plan: &PgTestSchemaCleanupPlan) {
+    println!("Postgres test schema cleanup dry-run");
+    println!("  drop candidates: {}", plan.candidates.len());
+    for candidate in &plan.candidates {
+        println!(
+            "DROP_CANDIDATE\t{}\ttables={}\testimated_rows={}\tknown Harness test schema",
+            candidate.schema_name, candidate.table_count, candidate.estimated_row_count
+        );
+    }
+    if !plan.candidates.is_empty() {
+        println!("Re-run with --test-schemas --apply --confirm-drop --drop-test-schemas to drop all listed schemas.");
+        println!(
+            "Or pass --test-schema <name> with --apply --confirm-drop to drop selected schemas."
+        );
+    }
+}
+
 fn print_legacy_scan_errors(errors: &[String]) {
     for error in errors {
         println!("Legacy scan skipped: {error}");
@@ -219,6 +286,26 @@ mod tests {
         assert_eq!(
             configured_workspace_roots(&config),
             vec![PathBuf::from("/tmp/harness-workspaces")]
+        );
+    }
+
+    #[test]
+    fn parses_test_schema_cleanup_flags() {
+        let args = Args::parse_from([
+            "harness-pg-schema-cleanup",
+            "--test-schemas",
+            "--apply",
+            "--confirm-drop",
+            "--test-schema",
+            "event_store_scope_test_1783054126968028000_0",
+        ]);
+
+        assert!(args.test_schemas);
+        assert!(args.apply);
+        assert!(args.confirm_drop);
+        assert_eq!(
+            args.test_schema,
+            vec!["event_store_scope_test_1783054126968028000_0"]
         );
     }
 }

--- a/crates/harness-core/src/db.rs
+++ b/crates/harness-core/src/db.rs
@@ -17,6 +17,13 @@ pub use crate::db_pg_schema_registry::{
     PgSchemaOwnership, PgSchemaReapReport, DEFAULT_ORPHAN_REAPER_LEGACY_BATCH,
     PG_SCHEMA_REGISTRY_SCHEMA, PG_SCHEMA_REGISTRY_TABLE,
 };
+pub use crate::db_test_safety::{
+    apply_pg_test_schema_cleanup, drop_test_schema_if_exists, is_known_test_schema_name,
+    is_test_database_url, pg_test_schema_cleanup_plan, redact_database_url,
+    resolve_test_database_url, unique_test_schema_name, validate_test_database_url,
+    PgTestSchemaCleanupCandidate, PgTestSchemaCleanupPlan, TestSchemaGuard,
+    ALLOW_NON_TEST_DATABASE_FOR_TESTS_ENV, KNOWN_TEST_SCHEMA_PREFIXES,
+};
 
 /// Create a legacy path-derived Postgres connection pool for the logical store at `path`.
 ///

--- a/crates/harness-core/src/db_pg_schema_registry_tests.rs
+++ b/crates/harness-core/src/db_pg_schema_registry_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::db_pg::{pg_open_pool, resolve_database_url};
+use crate::db_pg::pg_open_pool;
 use std::collections::HashSet;
 
 fn create_normalized_workspace_root(parent: &Path, name: &str) -> anyhow::Result<PathBuf> {
@@ -346,7 +346,7 @@ fn orphaned_path_schema_names_ignores_opaque_legacy_schema_owner_key() {
 async fn reaper_inventory_includes_legacy_path_derived_schema_owner_rows() -> anyhow::Result<()> {
     let database_url = {
         let _lock = crate::test_support::process_env_lock();
-        let Ok(database_url) = resolve_database_url(None) else {
+        let Ok(database_url) = crate::db_test_safety::resolve_test_database_url(None) else {
             return Ok(());
         };
         database_url

--- a/crates/harness-core/src/db_pg_tests.rs
+++ b/crates/harness-core/src/db_pg_tests.rs
@@ -256,7 +256,7 @@ fn pg_store_context_can_reuse_shared_setup_pool() {
         .build()
         .expect("tokio runtime");
     let _lock = process_env_lock();
-    let Ok(database_url) = resolve_database_url(None) else {
+    let Ok(database_url) = crate::db_test_safety::resolve_test_database_url(None) else {
         return;
     };
     runtime.block_on(async {
@@ -282,7 +282,7 @@ fn pg_store_context_can_reuse_shared_setup_pool() {
 async fn pg_store_context_registers_path_schema_with_shared_setup_pool() -> anyhow::Result<()> {
     let database_url = {
         let _lock = process_env_lock();
-        let Ok(database_url) = resolve_database_url(None) else {
+        let Ok(database_url) = crate::db_test_safety::resolve_test_database_url(None) else {
             return Ok(());
         };
         database_url

--- a/crates/harness-core/src/db_test_safety.rs
+++ b/crates/harness-core/src/db_test_safety.rs
@@ -1,0 +1,367 @@
+use serde::Serialize;
+use sqlx::postgres::{PgConnectOptions, PgPool};
+use std::collections::HashSet;
+use std::str::FromStr as _;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::db_pg::{pg_open_pool, validate_schema_name};
+use crate::db_pg_schema_registry::PgSchemaDropResult;
+
+pub const ALLOW_NON_TEST_DATABASE_FOR_TESTS_ENV: &str = "HARNESS_ALLOW_NON_TEST_DATABASE_FOR_TESTS";
+
+pub const KNOWN_TEST_SCHEMA_PREFIXES: &[&str] = &[
+    "event_store_backfill_test",
+    "event_store_jsonl_test",
+    "event_store_scope_test",
+    "eval_store_migration_test",
+    "eval_store_missing_legacy_test",
+    "eval_store_scope_test",
+    "plan_db_backfill_test",
+    "project_registry_migration_test",
+    "project_registry_scope_test",
+    "review_store_test",
+    "runtime_state_store_test",
+    "task_db_backfill_test",
+    "task_db_scope_test",
+    "thread_db_shared_scope_test",
+    "thread_db_test",
+    "workspace_lease_scope_test",
+];
+
+static TEST_SCHEMA_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub fn is_test_database_url(database_url: &str) -> bool {
+    test_database_name(database_url).is_some_and(|name| is_test_database_name(&name))
+}
+
+pub fn validate_test_database_url(database_url: &str) -> anyhow::Result<()> {
+    if non_test_database_override_enabled() || is_test_database_url(database_url) {
+        return Ok(());
+    }
+
+    let database_name = test_database_name(database_url).unwrap_or_else(|| "<unknown>".to_string());
+    anyhow::bail!(
+        "refusing to run Postgres-backed tests against non-test database '{}' from {}; use a database named harness_test, ending in _test, starting with test_, or set {}=1 only for a disposable database",
+        database_name,
+        redact_database_url(database_url),
+        ALLOW_NON_TEST_DATABASE_FOR_TESTS_ENV
+    )
+}
+
+pub fn resolve_test_database_url(configured_database_url: Option<&str>) -> anyhow::Result<String> {
+    let database_url = crate::db_pg::resolve_database_url(configured_database_url)?;
+    validate_test_database_url(&database_url)?;
+    Ok(database_url)
+}
+
+pub fn redact_database_url(database_url: &str) -> String {
+    let trimmed = database_url.trim();
+    let without_query = trimmed
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(trimmed)
+        .to_string();
+    let Some(scheme_end) = without_query.find("://") else {
+        return "<redacted database URL>".to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let Some(path_start) = without_query[authority_start..].find('/') else {
+        return without_query;
+    };
+    let path_start = authority_start + path_start;
+    let authority = &without_query[authority_start..path_start];
+    let redacted_authority = match authority.rsplit_once('@') {
+        Some((_, host)) => format!("<redacted>@{host}"),
+        None => authority.to_string(),
+    };
+    format!(
+        "{}{}{}",
+        &without_query[..authority_start],
+        redacted_authority,
+        &without_query[path_start..]
+    )
+}
+
+pub fn is_known_test_schema_name(schema: &str) -> bool {
+    KNOWN_TEST_SCHEMA_PREFIXES.iter().any(|prefix| {
+        generated_test_schema_matches_prefix(schema, prefix)
+            || legacy_single_suffix_test_schema_matches_prefix(schema, prefix)
+    })
+}
+
+pub fn unique_test_schema_name(prefix: &str) -> anyhow::Result<String> {
+    if !KNOWN_TEST_SCHEMA_PREFIXES.contains(&prefix) {
+        anyhow::bail!("unknown test schema prefix: {prefix}");
+    }
+    let count = TEST_SCHEMA_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| anyhow::anyhow!("system clock before UNIX epoch: {error}"))?
+        .as_nanos();
+    let schema = format!("{prefix}_{nanos}_{count}");
+    validate_schema_name(&schema)?;
+    Ok(schema)
+}
+
+pub async fn drop_test_schema_if_exists(pool: &PgPool, schema: &str) -> anyhow::Result<()> {
+    validate_schema_name(schema)?;
+    if !is_known_test_schema_name(schema) {
+        anyhow::bail!("refusing to drop unknown test schema: {schema}");
+    }
+    sqlx::query(&format!("DROP SCHEMA IF EXISTS \"{schema}\" CASCADE"))
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub struct TestSchemaGuard {
+    database_url: String,
+    schema_name: String,
+    cleaned: bool,
+}
+
+impl TestSchemaGuard {
+    pub fn new(database_url: impl Into<String>, prefix: &str) -> anyhow::Result<Self> {
+        let database_url = database_url.into();
+        validate_test_database_url(&database_url)?;
+        Ok(Self {
+            database_url,
+            schema_name: unique_test_schema_name(prefix)?,
+            cleaned: false,
+        })
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema_name
+    }
+
+    pub async fn cleanup_with_pool(&mut self, pool: &PgPool) -> anyhow::Result<()> {
+        drop_test_schema_if_exists(pool, &self.schema_name).await?;
+        self.cleaned = true;
+        Ok(())
+    }
+}
+
+impl Drop for TestSchemaGuard {
+    fn drop(&mut self) {
+        if self.cleaned {
+            return;
+        }
+        let database_url = self.database_url.clone();
+        let schema = self.schema_name.clone();
+        let result = std::thread::Builder::new()
+            .name("harness-test-schema-cleanup".to_string())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()?;
+                runtime.block_on(async {
+                    let pool = pg_open_pool(&database_url).await?;
+                    let result = drop_test_schema_if_exists(&pool, &schema).await;
+                    pool.close().await;
+                    result
+                })
+            })
+            .and_then(|handle| {
+                handle
+                    .join()
+                    .map_err(|_| std::io::Error::other("test schema cleanup thread panicked"))?
+                    .map_err(std::io::Error::other)
+            });
+        if let Err(error) = result {
+            tracing::warn!(schema = %self.schema_name, error = %error, "failed to clean up test schema");
+        } else {
+            self.cleaned = true;
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PgTestSchemaCleanupCandidate {
+    pub schema_name: String,
+    pub table_count: i64,
+    pub estimated_row_count: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PgTestSchemaCleanupPlan {
+    pub candidates: Vec<PgTestSchemaCleanupCandidate>,
+}
+
+pub async fn pg_test_schema_cleanup_plan(pool: &PgPool) -> anyhow::Result<PgTestSchemaCleanupPlan> {
+    let rows = sqlx::query_as::<_, (String, i64, i64)>(
+        "SELECT
+            n.nspname AS schema_name,
+            COUNT(c.oid) FILTER (WHERE c.relkind IN ('r', 'p'))::BIGINT AS table_count,
+            COALESCE(SUM(GREATEST(c.reltuples, 0::REAL)), 0)::BIGINT AS estimated_row_count
+         FROM pg_namespace n
+         LEFT JOIN pg_class c
+           ON c.relnamespace = n.oid AND c.relkind IN ('r', 'p')
+         WHERE n.nspname LIKE '%\\_test\\_%' ESCAPE '\\'
+         GROUP BY n.nspname
+         ORDER BY n.nspname",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let candidates = rows
+        .into_iter()
+        .filter(|(schema_name, _, _)| is_known_test_schema_name(schema_name))
+        .map(
+            |(schema_name, table_count, estimated_row_count)| PgTestSchemaCleanupCandidate {
+                schema_name,
+                table_count,
+                estimated_row_count,
+            },
+        )
+        .collect();
+    Ok(PgTestSchemaCleanupPlan { candidates })
+}
+
+pub async fn apply_pg_test_schema_cleanup(
+    pool: &PgPool,
+    schemas: &[String],
+) -> anyhow::Result<Vec<PgSchemaDropResult>> {
+    let requested: HashSet<String> = schemas.iter().cloned().collect();
+    for schema in &requested {
+        validate_schema_name(schema)?;
+        if !is_known_test_schema_name(schema) {
+            anyhow::bail!("refusing to drop unknown test schema: {schema}");
+        }
+    }
+    let plan = pg_test_schema_cleanup_plan(pool).await?;
+    let available: HashSet<String> = plan
+        .candidates
+        .iter()
+        .map(|candidate| candidate.schema_name.clone())
+        .collect();
+    if let Some(missing) = requested.difference(&available).next() {
+        anyhow::bail!("test schema '{}' was not found in cleanup plan", missing);
+    }
+
+    let mut results = Vec::new();
+    for schema in requested {
+        drop_test_schema_if_exists(pool, &schema).await?;
+        results.push(PgSchemaDropResult {
+            schema_name: schema,
+            registered: false,
+            dropped: true,
+        });
+    }
+    Ok(results)
+}
+
+fn test_database_name(database_url: &str) -> Option<String> {
+    PgConnectOptions::from_str(database_url)
+        .ok()
+        .and_then(|options| options.get_database().map(ToOwned::to_owned))
+}
+
+fn is_test_database_name(name: &str) -> bool {
+    name == "harness_test" || name.ends_with("_test") || name.starts_with("test_")
+}
+
+fn non_test_database_override_enabled() -> bool {
+    std::env::var(ALLOW_NON_TEST_DATABASE_FOR_TESTS_ENV)
+        .ok()
+        .is_some_and(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
+}
+
+fn generated_test_schema_matches_prefix(schema: &str, prefix: &str) -> bool {
+    let Some(rest) = schema
+        .strip_prefix(prefix)
+        .and_then(|rest| rest.strip_prefix('_'))
+    else {
+        return false;
+    };
+    let Some((nanos, counter)) = rest.rsplit_once('_') else {
+        return false;
+    };
+    !nanos.is_empty()
+        && !counter.is_empty()
+        && nanos.chars().all(|ch| ch.is_ascii_digit())
+        && counter.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn legacy_single_suffix_test_schema_matches_prefix(schema: &str, prefix: &str) -> bool {
+    if prefix != "review_store_test" {
+        return false;
+    }
+    let Some(rest) = schema
+        .strip_prefix(prefix)
+        .and_then(|rest| rest.strip_prefix('_'))
+    else {
+        return false;
+    };
+    !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::process_env_lock;
+
+    #[test]
+    fn test_database_url_detection_accepts_test_names() {
+        assert!(is_test_database_url(
+            "postgres://user:pass@localhost:5432/harness_test"
+        ));
+        assert!(is_test_database_url(
+            "postgres://user:pass@localhost:5432/project_test"
+        ));
+        assert!(is_test_database_url(
+            "postgres://user:pass@localhost:5432/test_project"
+        ));
+    }
+
+    #[test]
+    fn test_database_url_detection_rejects_primary_name() {
+        assert!(!is_test_database_url(
+            "postgres://user:pass@localhost:5432/harness"
+        ));
+    }
+
+    #[test]
+    fn unsafe_database_url_error_redacts_credentials_and_query() {
+        let err = validate_test_database_url(
+            "postgres://user:secret@localhost:5432/harness?sslmode=require",
+        )
+        .expect_err("primary database URL must be rejected");
+        let message = err.to_string();
+        assert!(message.contains("postgres://<redacted>@localhost:5432/harness"));
+        assert!(!message.contains("user"));
+        assert!(!message.contains("secret"));
+        assert!(!message.contains("sslmode"));
+    }
+
+    #[test]
+    fn explicit_escape_hatch_allows_non_test_database() {
+        let _lock = process_env_lock();
+        temp_env::with_var(ALLOW_NON_TEST_DATABASE_FOR_TESTS_ENV, Some("1"), || {
+            validate_test_database_url("postgres://user:secret@localhost:5432/harness")
+                .expect("explicit disposable-db override should allow non-test names");
+        });
+    }
+
+    #[test]
+    fn known_test_schema_matches_generated_shape_only() {
+        assert!(is_known_test_schema_name(
+            "event_store_scope_test_1783054126968028000_0"
+        ));
+        assert!(!is_known_test_schema_name("event_store_scope_test"));
+        assert!(!is_known_test_schema_name(
+            "event_store_scope_test_1783054126968028000"
+        ));
+        assert!(!is_known_test_schema_name(
+            "unrelated_test_1783054126968028000_0"
+        ));
+    }
+
+    #[test]
+    fn known_test_schema_matches_legacy_single_numeric_suffix() {
+        assert!(is_known_test_schema_name(
+            "review_store_test_1783054126968028000"
+        ));
+        assert!(!is_known_test_schema_name("review_store_test_alpha"));
+    }
+}

--- a/crates/harness-core/src/db_tests.rs
+++ b/crates/harness-core/src/db_tests.rs
@@ -46,6 +46,9 @@ where
         .enable_all()
         .build()?;
     let _lock = crate::test_support::process_env_lock();
+    if crate::db_test_safety::resolve_test_database_url(None).is_err() {
+        return Ok(());
+    }
     runtime.block_on(test())
 }
 

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod db;
 pub mod db_pg;
 pub mod db_pg_schema_registry;
 mod db_pg_split;
+pub mod db_test_safety;
 pub mod error;
 pub mod interceptor;
 pub mod lang_detect;

--- a/crates/harness-observe/src/event_store/shared_schema_tests.rs
+++ b/crates/harness-observe/src/event_store/shared_schema_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
+use harness_core::db::{pg_open_pool, resolve_test_database_url, PgStoreContext, TestSchemaGuard};
 use harness_core::types::EventId;
 use sqlx::postgres::PgPool;
 use std::path::Path;
@@ -14,16 +14,6 @@ fn db_semaphore() -> Arc<tokio::sync::Semaphore> {
         .clone()
 }
 
-fn unique_test_schema(prefix: &str) -> String {
-    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
-        .as_nanos();
-    format!("{prefix}_{nanos}_{count}")
-}
-
 fn is_db_unavailable(err: &anyhow::Error) -> bool {
     let msg = format!("{:#}", err);
     msg.contains("pool timed out while waiting for an open connection")
@@ -34,7 +24,7 @@ fn is_db_unavailable(err: &anyhow::Error) -> bool {
 
 async fn setup_pool() -> anyhow::Result<Option<(String, PgPool, tokio::sync::OwnedSemaphorePermit)>>
 {
-    let Ok(database_url) = resolve_database_url(None) else {
+    let Ok(database_url) = resolve_test_database_url(None) else {
         return Ok(None);
     };
     let permit = db_semaphore()
@@ -103,8 +93,8 @@ async fn shared_schema_keeps_events_and_watermarks_isolated() -> anyhow::Result<
         return Ok(());
     };
     let dir = tempfile::tempdir()?;
-    let shared_schema = unique_test_schema("event_store_scope_test");
-    let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let mut shared_schema = TestSchemaGuard::new(&database_url, "event_store_scope_test")?;
+    let shared_context = PgStoreContext::from_schema(shared_schema.schema(), Some(&database_url))?;
     let store_a_dir = dir.path().join("store-a");
     let store_b_dir = dir.path().join("store-b");
 
@@ -118,8 +108,8 @@ async fn shared_schema_keeps_events_and_watermarks_isolated() -> anyhow::Result<
         return Ok(());
     };
 
-    assert_eq!(store_a.schema(), shared_schema);
-    assert_eq!(store_b.schema(), shared_schema);
+    assert_eq!(store_a.schema(), shared_schema.schema());
+    assert_eq!(store_b.schema(), shared_schema.schema());
     assert_ne!(store_a.store_key(), store_b.store_key());
 
     store_a
@@ -159,6 +149,7 @@ async fn shared_schema_keeps_events_and_watermarks_isolated() -> anyhow::Result<
 
     store_a.close().await;
     store_b.close().await;
+    shared_schema.cleanup_with_pool(&setup_pool).await?;
     setup_pool.close().await;
     Ok(())
 }
@@ -169,8 +160,8 @@ async fn jsonl_migration_is_idempotent_per_store_key() -> anyhow::Result<()> {
         return Ok(());
     };
     let dir = tempfile::tempdir()?;
-    let shared_schema = unique_test_schema("event_store_jsonl_test");
-    let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let mut shared_schema = TestSchemaGuard::new(&database_url, "event_store_jsonl_test")?;
+    let shared_context = PgStoreContext::from_schema(shared_schema.schema(), Some(&database_url))?;
     let store_a_dir = dir.path().join("store-a");
     let store_b_dir = dir.path().join("store-b");
     std::fs::create_dir_all(&store_a_dir)?;
@@ -206,6 +197,7 @@ async fn jsonl_migration_is_idempotent_per_store_key() -> anyhow::Result<()> {
 
     store_a.close().await;
     store_b.close().await;
+    shared_schema.cleanup_with_pool(&setup_pool).await?;
     setup_pool.close().await;
     Ok(())
 }
@@ -232,8 +224,8 @@ async fn shared_schema_backfills_legacy_path_schema_once() -> anyhow::Result<()>
         .await?;
     legacy_store.close().await;
 
-    let target_schema = unique_test_schema("event_store_backfill_test");
-    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let mut target_schema = TestSchemaGuard::new(&database_url, "event_store_backfill_test")?;
+    let target_context = PgStoreContext::from_schema(target_schema.schema(), Some(&database_url))?;
     let target_store =
         EventStore::new_shared_with_context(&legacy_data_dir, &target_context, &setup_pool).await?;
 
@@ -265,6 +257,7 @@ async fn shared_schema_backfills_legacy_path_schema_once() -> anyhow::Result<()>
     assert_eq!(events_after_second_backfill[0].id, legacy_event.id);
 
     target_store.close().await;
+    target_schema.cleanup_with_pool(&setup_pool).await?;
     setup_pool.close().await;
     Ok(())
 }

--- a/crates/harness-server/src/eval_store_tests.rs
+++ b/crates/harness-server/src/eval_store_tests.rs
@@ -1,18 +1,8 @@
 use super::*;
 use futures::FutureExt;
-use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
+use harness_core::db::{pg_open_pool, resolve_test_database_url, PgStoreContext, TestSchemaGuard};
 use serde_json::json;
 use tempfile::tempdir;
-
-fn unique_test_schema(prefix: &str) -> String {
-    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
-        .as_nanos();
-    format!("{prefix}_{nanos}_{count}")
-}
 
 #[test]
 fn shared_schema_context_uses_fixed_eval_store_schema() -> anyhow::Result<()> {
@@ -42,14 +32,14 @@ fn store_key_for_missing_data_dir_errors() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn shared_schema_eval_store_keeps_store_rows_isolated() -> anyhow::Result<()> {
-    let database_url = match resolve_database_url(None) {
+    let database_url = match resolve_test_database_url(None) {
         Ok(url) => url,
         Err(_) => return Ok(()),
     };
     let dir = tempdir()?;
     let setup_pool = pg_open_pool(&database_url).await?;
-    let shared_schema = unique_test_schema("eval_store_scope_test");
-    let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let mut shared_schema = TestSchemaGuard::new(&database_url, "eval_store_scope_test")?;
+    let shared_context = PgStoreContext::from_schema(shared_schema.schema(), Some(&database_url))?;
     let store_a_dir = dir.path().join("store-a");
     let store_b_dir = dir.path().join("store-b");
     std::fs::create_dir_all(&store_a_dir)?;
@@ -60,8 +50,8 @@ async fn shared_schema_eval_store_keeps_store_rows_isolated() -> anyhow::Result<
         EvalStore::open_shared_with_data_dir(&shared_context, &setup_pool, &store_b_dir).await?;
 
     let result = std::panic::AssertUnwindSafe(async {
-        assert_eq!(store_a.schema(), shared_schema);
-        assert_eq!(store_b.schema(), shared_schema);
+        assert_eq!(store_a.schema(), shared_schema.schema());
+        assert_eq!(store_b.schema(), shared_schema.schema());
         assert_ne!(store_a.store_key(), store_b.store_key());
 
         let run_a = store_a.create_run(pr_repair_run()).await?;
@@ -134,22 +124,21 @@ async fn shared_schema_eval_store_keeps_store_rows_isolated() -> anyhow::Result<
 
     store_a.pool.close().await;
     store_b.pool.close().await;
-    let _ = sqlx::query(&format!(
-        "DROP SCHEMA IF EXISTS \"{shared_schema}\" CASCADE"
-    ))
-    .execute(&setup_pool)
-    .await;
+    let cleanup_result = shared_schema.cleanup_with_pool(&setup_pool).await;
     setup_pool.close().await;
 
     match result {
-        Ok(result) => result,
+        Ok(result) => {
+            cleanup_result?;
+            result
+        }
         Err(payload) => std::panic::resume_unwind(payload),
     }
 }
 
 #[tokio::test]
 async fn legacy_eval_store_migration_backfills_once() -> anyhow::Result<()> {
-    let database_url = match resolve_database_url(None) {
+    let database_url = match resolve_test_database_url(None) {
         Ok(url) => url,
         Err(_) => return Ok(()),
     };
@@ -162,9 +151,9 @@ async fn legacy_eval_store_migration_backfills_once() -> anyhow::Result<()> {
     let legacy_schema = PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
         .schema()
         .to_owned();
-    let target_schema = unique_test_schema("eval_store_migration_test");
     let setup_pool = pg_open_pool(&database_url).await?;
-    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let mut target_schema = TestSchemaGuard::new(&database_url, "eval_store_migration_test")?;
+    let target_context = PgStoreContext::from_schema(target_schema.schema(), Some(&database_url))?;
     let target_store =
         EvalStore::open_shared_with_data_dir(&target_context, &setup_pool, &target_data_dir)
             .await?;
@@ -251,22 +240,21 @@ async fn legacy_eval_store_migration_backfills_once() -> anyhow::Result<()> {
     ))
     .execute(&setup_pool)
     .await;
-    let _ = sqlx::query(&format!(
-        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
-    ))
-    .execute(&setup_pool)
-    .await;
+    let cleanup_result = target_schema.cleanup_with_pool(&setup_pool).await;
     setup_pool.close().await;
 
     match result {
-        Ok(result) => result,
+        Ok(result) => {
+            cleanup_result?;
+            result
+        }
         Err(payload) => std::panic::resume_unwind(payload),
     }
 }
 
 #[tokio::test]
 async fn legacy_eval_store_migration_ignores_missing_legacy_schema() -> anyhow::Result<()> {
-    let database_url = match resolve_database_url(None) {
+    let database_url = match resolve_test_database_url(None) {
         Ok(url) => url,
         Err(_) => return Ok(()),
     };
@@ -274,9 +262,9 @@ async fn legacy_eval_store_migration_ignores_missing_legacy_schema() -> anyhow::
     let target_data_dir = dir.path().join("target-data");
     std::fs::create_dir_all(&target_data_dir)?;
     let missing_legacy_path = dir.path().join("missing-legacy").join("evals.db");
-    let target_schema = unique_test_schema("eval_store_missing_legacy_test");
     let setup_pool = pg_open_pool(&database_url).await?;
-    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let mut target_schema = TestSchemaGuard::new(&database_url, "eval_store_missing_legacy_test")?;
+    let target_context = PgStoreContext::from_schema(target_schema.schema(), Some(&database_url))?;
     let target_store =
         EvalStore::open_shared_with_data_dir(&target_context, &setup_pool, &target_data_dir)
             .await?;
@@ -295,15 +283,14 @@ async fn legacy_eval_store_migration_ignores_missing_legacy_schema() -> anyhow::
     .await;
 
     target_store.pool.close().await;
-    let _ = sqlx::query(&format!(
-        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
-    ))
-    .execute(&setup_pool)
-    .await;
+    let cleanup_result = target_schema.cleanup_with_pool(&setup_pool).await;
     setup_pool.close().await;
 
     match result {
-        Ok(result) => result,
+        Ok(result) => {
+            cleanup_result?;
+            result
+        }
         Err(payload) => std::panic::resume_unwind(payload),
     }
 }

--- a/crates/harness-server/src/http/builders/registry_tests.rs
+++ b/crates/harness-server/src/http/builders/registry_tests.rs
@@ -5,7 +5,10 @@ use harness_core::config::HarnessConfig;
 
 async fn make_test_server_and_tasks(
     dir: &Path,
-) -> (Arc<HarnessServer>, Arc<crate::task_runner::TaskStore>) {
+) -> Option<(Arc<HarnessServer>, Arc<crate::task_runner::TaskStore>)> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return None;
+    }
     let server = Arc::new(HarnessServer::new(
         HarnessConfig::default(),
         ThreadManager::new(),
@@ -16,13 +19,15 @@ async fn make_test_server_and_tasks(
     ))
     .await
     .expect("open tasks db");
-    (server, tasks)
+    Some((server, tasks))
 }
 
 #[tokio::test]
 async fn empty_data_dir_produces_empty_project_registry() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+    let Some((server, tasks)) = make_test_server_and_tasks(dir.path()).await else {
+        return;
+    };
     let bundle = build_registry(&server, dir.path(), dir.path(), &tasks)
         .await
         .expect("build_registry should succeed");
@@ -44,7 +49,9 @@ async fn empty_data_dir_produces_empty_project_registry() {
 #[tokio::test]
 async fn plan_cache_hydrated_from_db() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+    let Some((server, tasks)) = make_test_server_and_tasks(dir.path()).await else {
+        return;
+    };
 
     let plan_db = crate::plan_db::PlanDb::open(&harness_core::config::dirs::default_db_path(
         dir.path(),
@@ -69,7 +76,9 @@ async fn plan_cache_hydrated_from_db() {
 #[tokio::test]
 async fn build_registry_opens_thread_db_from_shared_schema() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+    let Some((server, tasks)) = make_test_server_and_tasks(dir.path()).await else {
+        return;
+    };
     let bundle = build_registry(&server, dir.path(), dir.path(), &tasks)
         .await
         .expect("build_registry should succeed");
@@ -83,7 +92,9 @@ async fn build_registry_opens_thread_db_from_shared_schema() {
 #[tokio::test]
 async fn build_registry_opens_project_registry_from_shared_schema() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+    let Some((server, tasks)) = make_test_server_and_tasks(dir.path()).await else {
+        return;
+    };
     let bundle = build_registry(&server, dir.path(), dir.path(), &tasks)
         .await
         .expect("build_registry should succeed");
@@ -100,7 +111,9 @@ async fn build_registry_opens_project_registry_from_shared_schema() {
 #[tokio::test]
 async fn runtime_state_failure_is_recorded_as_optional() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+    let Some((server, tasks)) = make_test_server_and_tasks(dir.path()).await else {
+        return;
+    };
     let bundle = super::super::with_forced_startup_failures(
         &[(
             "runtime_state_store",
@@ -136,7 +149,9 @@ async fn invalid_workflow_schema_namespace_disables_optional_workflow_stores() {
         "---\nstorage:\n  schema_namespace: invalid-name\n---\n",
     )
     .expect("write workflow config");
-    let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+    let Some((server, tasks)) = make_test_server_and_tasks(dir.path()).await else {
+        return;
+    };
 
     let bundle = build_registry(&server, dir.path(), dir.path(), &tasks)
         .await
@@ -176,7 +191,9 @@ fn bootstrap_failure_records_workspace_manager_status() {
 #[tokio::test]
 async fn project_registry_failure_is_recorded_as_critical() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (server, tasks) = make_test_server_and_tasks(dir.path()).await;
+    let Some((server, tasks)) = make_test_server_and_tasks(dir.path()).await else {
+        return;
+    };
     let bundle = super::super::with_forced_startup_failures(
         &[("project_registry", "failed to open Postgres bootstrap pool")],
         build_registry(&server, dir.path(), dir.path(), &tasks),

--- a/crates/harness-server/src/project_registry_tests.rs
+++ b/crates/harness-server/src/project_registry_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use futures::FutureExt;
-use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
+use harness_core::db::{pg_open_pool, resolve_test_database_url, PgStoreContext, TestSchemaGuard};
 
 fn unique_test_schema(prefix: &str) -> String {
     static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -25,7 +25,7 @@ fn project(id: &str, root: &str) -> Project {
 }
 
 async fn open_test_registry(name: &str) -> anyhow::Result<Option<Arc<ProjectRegistry>>> {
-    if resolve_database_url(None).is_err() {
+    if resolve_test_database_url(None).is_err() {
         return Ok(None);
     }
     let dir = tempfile::tempdir()?;
@@ -66,14 +66,14 @@ fn store_key_for_missing_relative_data_dir_is_absolute() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn shared_schema_project_registry_keeps_store_rows_isolated() -> anyhow::Result<()> {
-    let database_url = match resolve_database_url(None) {
+    let database_url = match resolve_test_database_url(None) {
         Ok(url) => url,
         Err(_) => return Ok(()),
     };
     let dir = tempfile::tempdir()?;
     let setup_pool = pg_open_pool(&database_url).await?;
-    let shared_schema = unique_test_schema("project_registry_scope_test");
-    let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let mut shared_schema = TestSchemaGuard::new(&database_url, "project_registry_scope_test")?;
+    let shared_context = PgStoreContext::from_schema(shared_schema.schema(), Some(&database_url))?;
     let store_a_dir = dir.path().join("store-a");
     let store_b_dir = dir.path().join("store-b");
     let registry_a =
@@ -124,22 +124,21 @@ async fn shared_schema_project_registry_keeps_store_rows_isolated() -> anyhow::R
 
     registry_a.pool().close().await;
     registry_b.pool().close().await;
-    let _ = sqlx::query(&format!(
-        "DROP SCHEMA IF EXISTS \"{shared_schema}\" CASCADE"
-    ))
-    .execute(&setup_pool)
-    .await;
+    let cleanup_result = shared_schema.cleanup_with_pool(&setup_pool).await;
     setup_pool.close().await;
 
     match result {
-        Ok(result) => result,
+        Ok(result) => {
+            cleanup_result?;
+            result
+        }
         Err(payload) => std::panic::resume_unwind(payload),
     }
 }
 
 #[tokio::test]
 async fn legacy_project_registry_migration_backfills_once() -> anyhow::Result<()> {
-    let database_url = match resolve_database_url(None) {
+    let database_url = match resolve_test_database_url(None) {
         Ok(url) => url,
         Err(_) => return Ok(()),
     };
@@ -150,9 +149,9 @@ async fn legacy_project_registry_migration_backfills_once() -> anyhow::Result<()
     let legacy_schema = PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
         .schema()
         .to_owned();
-    let target_schema = unique_test_schema("project_registry_migration_test");
     let setup_pool = pg_open_pool(&database_url).await?;
-    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let mut target_schema = TestSchemaGuard::new(&database_url, "project_registry_migration_test")?;
+    let target_context = PgStoreContext::from_schema(target_schema.schema(), Some(&database_url))?;
     let target_registry =
         ProjectRegistry::open_shared_with_data_dir(&target_context, &setup_pool, &target_data_dir)
             .await?;
@@ -240,15 +239,14 @@ async fn legacy_project_registry_migration_backfills_once() -> anyhow::Result<()
     ))
     .execute(&setup_pool)
     .await;
-    let _ = sqlx::query(&format!(
-        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
-    ))
-    .execute(&setup_pool)
-    .await;
+    let cleanup_result = target_schema.cleanup_with_pool(&setup_pool).await;
     setup_pool.close().await;
 
     match result {
-        Ok(result) => result,
+        Ok(result) => {
+            cleanup_result?;
+            result
+        }
         Err(payload) => std::panic::resume_unwind(payload),
     }
 }
@@ -363,7 +361,7 @@ async fn resolve_path_returns_root() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn survives_reopen() -> anyhow::Result<()> {
-    if resolve_database_url(None).is_err() {
+    if resolve_test_database_url(None).is_err() {
         return Ok(());
     }
     let dir = tempfile::tempdir()?;

--- a/crates/harness-server/src/review_store/store_tests.rs
+++ b/crates/harness-server/src/review_store/store_tests.rs
@@ -1,22 +1,14 @@
 use super::*;
 use chrono::Utc;
-use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
+use harness_core::db::{pg_open_pool, resolve_test_database_url, PgStoreContext, TestSchemaGuard};
 
 async fn open_test_store() -> anyhow::Result<Option<ReviewStore>> {
-    if resolve_database_url(None).is_err() {
+    if resolve_test_database_url(None).is_err() {
         return Ok(None);
     }
     let dir = tempfile::tempdir()?;
     let store = ReviewStore::open(&dir.path().join("review.db")).await?;
     Ok(Some(store))
-}
-
-fn unique_test_schema(prefix: &str) -> String {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
-        .as_nanos();
-    format!("{prefix}_{nanos}")
 }
 
 fn make_finding(id: &str, rule_id: &str, file: &str, priority: &str) -> ReviewFinding {
@@ -38,7 +30,7 @@ fn make_finding(id: &str, rule_id: &str, file: &str, priority: &str) -> ReviewFi
 
 #[tokio::test]
 async fn legacy_review_store_migration_backfills_shared_schema() -> anyhow::Result<()> {
-    let database_url = match resolve_database_url(None) {
+    let database_url = match resolve_test_database_url(None) {
         Ok(url) => url,
         Err(_) => return Ok(()),
     };
@@ -47,9 +39,9 @@ async fn legacy_review_store_migration_backfills_shared_schema() -> anyhow::Resu
     let legacy_schema = PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
         .schema()
         .to_owned();
-    let target_schema = unique_test_schema("review_store_test");
     let setup_pool = pg_open_pool(&database_url).await?;
-    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let mut target_schema = TestSchemaGuard::new(&database_url, "review_store_test")?;
+    let target_context = PgStoreContext::from_schema(target_schema.schema(), Some(&database_url))?;
     let target_store = ReviewStore::open_with_context(&target_context, &setup_pool).await?;
     let legacy_store =
         ReviewStore::open_with_database_url(&legacy_path, Some(&database_url)).await?;
@@ -89,11 +81,7 @@ async fn legacy_review_store_migration_backfills_shared_schema() -> anyhow::Resu
     ))
     .execute(&setup_pool)
     .await?;
-    sqlx::query(&format!(
-        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
-    ))
-    .execute(&setup_pool)
-    .await?;
+    target_schema.cleanup_with_pool(&setup_pool).await?;
     setup_pool.close().await;
 
     result

--- a/crates/harness-server/src/runtime_state_store_tests.rs
+++ b/crates/harness-server/src/runtime_state_store_tests.rs
@@ -7,18 +7,8 @@ use chrono::Utc;
 use futures::FutureExt;
 use harness_agents::registry::AgentRegistry;
 use harness_core::config::HarnessConfig;
-use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
+use harness_core::db::{pg_open_pool, resolve_test_database_url, PgStoreContext, TestSchemaGuard};
 use std::sync::Arc;
-
-fn unique_test_schema(prefix: &str) -> String {
-    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
-        .as_nanos();
-    format!("{prefix}_{nanos}_{count}")
-}
 
 #[test]
 fn shared_schema_context_uses_fixed_runtime_state_store_schema() -> anyhow::Result<()> {
@@ -35,6 +25,9 @@ fn shared_schema_context_uses_fixed_runtime_state_store_schema() -> anyhow::Resu
 
 #[tokio::test]
 async fn build_app_state_opens_runtime_state_store_from_shared_schema() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
     let _lock = crate::test_helpers::HOME_LOCK.lock().await;
     let project_root = crate::test_helpers::tempdir_in_home("runtime-state-root-")?;
     let data_dir = tempfile::tempdir()?;
@@ -61,7 +54,7 @@ async fn build_app_state_opens_runtime_state_store_from_shared_schema() -> anyho
 
 #[tokio::test]
 async fn legacy_runtime_state_migration_backfills_once() -> anyhow::Result<()> {
-    let database_url = match resolve_database_url(None) {
+    let database_url = match resolve_test_database_url(None) {
         Ok(url) => url,
         Err(_) => return Ok(()),
     };
@@ -72,9 +65,9 @@ async fn legacy_runtime_state_migration_backfills_once() -> anyhow::Result<()> {
     let legacy_schema = PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
         .schema()
         .to_owned();
-    let target_schema = unique_test_schema("runtime_state_store_test");
     let setup_pool = pg_open_pool(&database_url).await?;
-    let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+    let mut target_schema = TestSchemaGuard::new(&database_url, "runtime_state_store_test")?;
+    let target_context = PgStoreContext::from_schema(target_schema.schema(), Some(&database_url))?;
     let target_store = RuntimeStateStore::open_shared_with_data_dir(
         &target_context,
         &setup_pool,
@@ -167,15 +160,14 @@ async fn legacy_runtime_state_migration_backfills_once() -> anyhow::Result<()> {
     ))
     .execute(&setup_pool)
     .await;
-    let _ = sqlx::query(&format!(
-        "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
-    ))
-    .execute(&setup_pool)
-    .await;
+    let cleanup_result = target_schema.cleanup_with_pool(&setup_pool).await;
     setup_pool.close().await;
 
     match result {
-        Ok(result) => result,
+        Ok(result) => {
+            cleanup_result?;
+            result
+        }
         Err(payload) => std::panic::resume_unwind(payload),
     }
 }

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -5,7 +5,7 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use harness_core::db::{pg_open_pool, pg_schema_for_path, resolve_database_url};
+use harness_core::db::{pg_open_pool, pg_schema_for_path, resolve_test_database_url};
 use tokio::sync::OnceCell;
 
 /// Serialises every test that reads or mutates the process-global `HOME` env
@@ -49,7 +49,7 @@ impl HomeGuard {
     pub unsafe fn set(path: &std::path::Path) -> Self {
         let original = std::env::var("HOME").ok();
         if TEST_DATABASE_URL.get().is_none() {
-            if let Ok(database_url) = resolve_database_url(None) {
+            if let Ok(database_url) = resolve_test_database_url(None) {
                 let _ = TEST_DATABASE_URL.set(database_url);
             }
         }
@@ -93,13 +93,9 @@ pub fn tempdir_in_home(prefix: &str) -> anyhow::Result<tempfile::TempDir> {
 
 pub async fn db_tests_enabled() -> bool {
     configure_test_pg_pool_defaults();
-    if resolve_database_url(None).is_err() {
-        return false;
-    }
-
     *DB_AVAILABLE
         .get_or_init(|| async {
-            let Ok(database_url) = resolve_database_url(None) else {
+            let Ok(database_url) = resolve_test_database_url(None) else {
                 return false;
             };
             match tokio::time::timeout(Duration::from_secs(2), pg_open_pool(&database_url)).await {
@@ -133,7 +129,7 @@ pub fn test_database_url() -> anyhow::Result<String> {
         }
     }
 
-    let url = resolve_database_url(None)?;
+    let url = resolve_test_database_url(None)?;
     let _ = TEST_DATABASE_URL.set(url.clone());
     Ok(url)
 }
@@ -155,7 +151,7 @@ pub async fn make_test_state(dir: &std::path::Path) -> anyhow::Result<AppState> 
 
 pub async fn drop_tasks_table(dir: &std::path::Path) -> anyhow::Result<()> {
     let db_path = harness_core::config::dirs::default_db_path(dir, "tasks");
-    let database_url = harness_core::db::resolve_database_url(None)?;
+    let database_url = harness_core::db::resolve_test_database_url(None)?;
     let schema = pg_schema_for_path(&db_path)?;
     let pool = harness_core::db::pg_open_pool_schematized(&database_url, &schema).await?;
     sqlx::query("DROP TABLE tasks CASCADE")

--- a/crates/harness-server/src/thread_db.rs
+++ b/crates/harness-server/src/thread_db.rs
@@ -314,21 +314,11 @@ impl ThreadRow {
 mod tests {
     use super::*;
     use futures::FutureExt;
-    use harness_core::db::{pg_open_pool, resolve_database_url};
+    use harness_core::db::{pg_open_pool, resolve_test_database_url, TestSchemaGuard};
     use std::path::PathBuf;
 
-    fn unique_test_schema(prefix: &str) -> String {
-        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-        let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system clock before UNIX epoch")
-            .as_nanos();
-        format!("{prefix}_{nanos}_{count}")
-    }
-
     async fn open_test_db() -> anyhow::Result<Option<ThreadDb>> {
-        if resolve_database_url(None).is_err() {
+        if resolve_test_database_url(None).is_err() {
             return Ok(None);
         }
         let dir = tempfile::tempdir()?;
@@ -377,7 +367,7 @@ mod tests {
 
     #[tokio::test]
     async fn thread_db_survives_reopen() -> anyhow::Result<()> {
-        if resolve_database_url(None).is_err() {
+        if resolve_test_database_url(None).is_err() {
             return Ok(());
         }
         let dir = tempfile::tempdir()?;
@@ -488,14 +478,15 @@ mod tests {
 
     #[tokio::test]
     async fn shared_schema_thread_db_keeps_store_rows_isolated() -> anyhow::Result<()> {
-        let database_url = match resolve_database_url(None) {
+        let database_url = match resolve_test_database_url(None) {
             Ok(url) => url,
             Err(_) => return Ok(()),
         };
         let dir = tempfile::tempdir()?;
         let setup_pool = pg_open_pool(&database_url).await?;
-        let shared_schema = unique_test_schema("thread_db_shared_scope_test");
-        let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+        let mut shared_schema = TestSchemaGuard::new(&database_url, "thread_db_shared_scope_test")?;
+        let shared_context =
+            PgStoreContext::from_schema(shared_schema.schema(), Some(&database_url))?;
         let store_a_dir = dir.path().join("store-a");
         let store_b_dir = dir.path().join("store-b");
         let store_a =
@@ -559,15 +550,14 @@ mod tests {
 
         store_a.pool.close().await;
         store_b.pool.close().await;
-        let _ = sqlx::query(&format!(
-            "DROP SCHEMA IF EXISTS \"{shared_schema}\" CASCADE"
-        ))
-        .execute(&setup_pool)
-        .await;
+        let cleanup_result = shared_schema.cleanup_with_pool(&setup_pool).await;
         setup_pool.close().await;
 
         match result {
-            Ok(result) => result,
+            Ok(result) => {
+                cleanup_result?;
+                result
+            }
             Err(payload) => std::panic::resume_unwind(payload),
         }
     }
@@ -586,7 +576,7 @@ mod tests {
 
     #[tokio::test]
     async fn legacy_thread_db_migration_backfills_shared_schema() -> anyhow::Result<()> {
-        let database_url = match resolve_database_url(None) {
+        let database_url = match resolve_test_database_url(None) {
             Ok(url) => url,
             Err(_) => return Ok(()),
         };
@@ -598,9 +588,10 @@ mod tests {
             PgStoreContext::from_legacy_path_schema(&legacy_path, Some(&database_url))?
                 .schema()
                 .to_owned();
-        let target_schema = unique_test_schema("thread_db_test");
         let setup_pool = pg_open_pool(&database_url).await?;
-        let target_context = PgStoreContext::from_schema(&target_schema, Some(&database_url))?;
+        let mut target_schema = TestSchemaGuard::new(&database_url, "thread_db_test")?;
+        let target_context =
+            PgStoreContext::from_schema(target_schema.schema(), Some(&database_url))?;
         let target_db =
             ThreadDb::open_shared_with_data_dir(&target_context, &setup_pool, &target_data_dir)
                 .await?;
@@ -663,15 +654,14 @@ mod tests {
         ))
         .execute(&setup_pool)
         .await;
-        let _ = sqlx::query(&format!(
-            "DROP SCHEMA IF EXISTS \"{target_schema}\" CASCADE"
-        ))
-        .execute(&setup_pool)
-        .await;
+        let cleanup_result = target_schema.cleanup_with_pool(&setup_pool).await;
         setup_pool.close().await;
 
         match result {
-            Ok(result) => result,
+            Ok(result) => {
+                cleanup_result?;
+                result
+            }
             Err(payload) => std::panic::resume_unwind(payload),
         }
     }

--- a/crates/harness-server/src/workspace_lease_store_tests.rs
+++ b/crates/harness-server/src/workspace_lease_store_tests.rs
@@ -1,15 +1,6 @@
 use super::test_support::*;
 use super::*;
-
-fn unique_test_schema(prefix: &str) -> String {
-    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
-        .as_nanos();
-    format!("{prefix}_{nanos}_{count}")
-}
+use harness_core::db::TestSchemaGuard;
 
 #[tokio::test]
 async fn workspace_lease_store_persists_and_releases_active_slots() -> anyhow::Result<()> {
@@ -57,15 +48,15 @@ async fn workspace_lease_store_persists_and_releases_active_slots() -> anyhow::R
 
 #[tokio::test]
 async fn workspace_lease_store_shared_schema_keeps_data_dirs_isolated() -> anyhow::Result<()> {
-    let database_url = match harness_core::db::resolve_database_url(None) {
+    let database_url = match harness_core::db::resolve_test_database_url(None) {
         Ok(url) => url,
         Err(_) => return Ok(()),
     };
     let dir = tempfile::tempdir().expect("tempdir");
     let setup_pool = harness_core::db::pg_open_pool(&database_url).await?;
-    let shared_schema = unique_test_schema("workspace_lease_scope_test");
+    let mut shared_schema = TestSchemaGuard::new(&database_url, "workspace_lease_scope_test")?;
     let shared_context =
-        harness_core::db::PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+        harness_core::db::PgStoreContext::from_schema(shared_schema.schema(), Some(&database_url))?;
     let store_a_dir = dir.path().join("store-a");
     let store_b_dir = dir.path().join("store-b");
     std::fs::create_dir_all(&store_a_dir)?;
@@ -119,6 +110,7 @@ async fn workspace_lease_store_shared_schema_keeps_data_dirs_isolated() -> anyho
     assert_eq!(leased_a[0].task_id, record_a.task_id);
     assert_eq!(leased_b[0].task_id, record_b.task_id);
 
+    shared_schema.cleanup_with_pool(&setup_pool).await?;
     setup_pool.close().await;
     Ok(())
 }

--- a/crates/harness-server/tests/task_db_shared_schema.rs
+++ b/crates/harness-server/tests/task_db_shared_schema.rs
@@ -1,17 +1,7 @@
-use harness_core::db::{pg_open_pool, resolve_database_url, PgStoreContext};
+use harness_core::db::{pg_open_pool, resolve_test_database_url, PgStoreContext, TestSchemaGuard};
 use harness_core::types::TaskId as CoreTaskId;
 use harness_server::task_db::{migrate_legacy_task_db_if_needed, TaskDb, TASK_DB_SCHEMA};
 use harness_server::task_runner::{TaskKind, TaskPhase, TaskSchedulerState, TaskState, TaskStatus};
-
-fn unique_test_schema(prefix: &str) -> String {
-    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
-        .as_nanos();
-    format!("{prefix}_{nanos}_{count}")
-}
 
 fn make_task(id: &str, description: &str) -> TaskState {
     TaskState {
@@ -78,14 +68,14 @@ fn store_key_for_data_dir_fails_when_path_cannot_be_canonicalized() -> anyhow::R
 
 #[tokio::test]
 async fn shared_schema_task_db_keeps_data_dirs_isolated() -> anyhow::Result<()> {
-    let database_url = match resolve_database_url(None) {
+    let database_url = match resolve_test_database_url(None) {
         Ok(url) => url,
         Err(_) => return Ok(()),
     };
     let dir = tempfile::tempdir()?;
     let setup_pool = pg_open_pool(&database_url).await?;
-    let shared_schema = unique_test_schema("task_db_scope_test");
-    let shared_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let mut shared_schema = TestSchemaGuard::new(&database_url, "task_db_scope_test")?;
+    let shared_context = PgStoreContext::from_schema(shared_schema.schema(), Some(&database_url))?;
     let store_a_dir = dir.path().join("store-a");
     let store_b_dir = dir.path().join("store-b");
     std::fs::create_dir_all(&store_a_dir)?;
@@ -96,8 +86,8 @@ async fn shared_schema_task_db_keeps_data_dirs_isolated() -> anyhow::Result<()> 
     let db_b =
         TaskDb::open_shared_with_data_dir(&shared_context, &setup_pool, &store_b_dir).await?;
 
-    assert_eq!(db_a.schema(), shared_schema);
-    assert_eq!(db_b.schema(), shared_schema);
+    assert_eq!(db_a.schema(), shared_schema.schema());
+    assert_eq!(db_b.schema(), shared_schema.schema());
     assert_ne!(db_a.store_key(), db_b.store_key());
 
     db_a.insert(&make_task("same-task-id", "store-a")).await?;
@@ -116,13 +106,14 @@ async fn shared_schema_task_db_keeps_data_dirs_isolated() -> anyhow::Result<()> 
     assert_eq!(db_a.list().await?.len(), 1);
     assert_eq!(db_b.list().await?.len(), 1);
 
+    shared_schema.cleanup_with_pool(&setup_pool).await?;
     setup_pool.close().await;
     Ok(())
 }
 
 #[tokio::test]
 async fn legacy_path_task_db_backfill_is_idempotent_and_one_time() -> anyhow::Result<()> {
-    let database_url = match resolve_database_url(None) {
+    let database_url = match resolve_test_database_url(None) {
         Ok(url) => url,
         Err(_) => return Ok(()),
     };
@@ -148,8 +139,8 @@ async fn legacy_path_task_db_backfill_is_idempotent_and_one_time() -> anyhow::Re
         .save_task_prompt("legacy-task", 1, "plan", "prompt")
         .await?;
 
-    let shared_schema = unique_test_schema("task_db_backfill_test");
-    let target_context = PgStoreContext::from_schema(&shared_schema, Some(&database_url))?;
+    let mut shared_schema = TestSchemaGuard::new(&database_url, "task_db_backfill_test")?;
+    let target_context = PgStoreContext::from_schema(shared_schema.schema(), Some(&database_url))?;
     let target_data_dir = dir.path().join("target");
     std::fs::create_dir_all(&target_data_dir)?;
     let target_db =
@@ -184,6 +175,7 @@ async fn legacy_path_task_db_backfill_is_idempotent_and_one_time() -> anyhow::Re
         "backfill marker should prevent stale legacy reimport on later startup"
     );
 
+    shared_schema.cleanup_with_pool(&setup_pool).await?;
     setup_pool.close().await;
     Ok(())
 }

--- a/scripts/test-server-db.sh
+++ b/scripts/test-server-db.sh
@@ -11,7 +11,10 @@ Start the local dev database with:
   bash scripts/dev-db.sh
 
 Then run:
-  HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh
+  HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test scripts/test-server-db.sh
+
+Postgres-backed tests refuse non-test database names by default. Use a database
+named harness_test, ending in _test, or starting with test_.
 EOF
   exit 2
 fi


### PR DESCRIPTION
Fixes #1444

## Summary
- add a shared test database safety helper that rejects non-test database names by default and redacts unsafe URL diagnostics
- route core/server/observe DB-backed test helpers and named shared-schema tests through safe database resolution plus TestSchemaGuard cleanup
- extend harness-pg-schema-cleanup with dry-run/apply handling for known leaked *_test_* schemas
- update local test docs to use harness_test and document the disposable database escape hatch

## Verification
- cargo test -p harness-core db_test_safety -- --nocapture
- cargo test -p harness-cli schema_cleanup -- --nocapture
- cargo test -p harness-observe shared_schema -- --nocapture
- cargo test -p harness-server shared_schema -- --nocapture
- cargo test -p harness-server backfill -- --nocapture
- HARNESS_DATABASE_URL=postgres://user:secret@localhost:5432/harness cargo test -p harness-server workspace_lease_store_shared_schema_keeps_data_dirs_isolated -- --nocapture
- HARNESS_DATABASE_URL=postgres://user:secret@localhost:5432/harness cargo test -p harness-core upsert_and_get_roundtrip -- --nocapture
- cargo check --workspace --all-targets
- cargo fmt --all -- --check
- git diff --check
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1444
- python3 checks/check_workflow.py --repo .
- cargo clippy --workspace --all-targets -- -D warnings