### PR TITLE
Add GH1456 DB test parallelization spec

### DIFF
--- a/specs/GH1456/product.md
+++ b/specs/GH1456/product.md
@@ -1,0 +1,107 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1456
+
+## User Problem
+
+Postgres-backed Harness tests still serialize large portions of the
+`harness-server` suite behind process-global database locks. Even when each test
+uses an isolated temporary data directory, helpers such as
+`acquire_db_state_guard` and integration-local `DB_TEST_LOCK` values force tests
+to run one at a time. This keeps the server test profile slow, masks accidental
+shared-state coupling, and prevents safe adoption of `cargo-nextest`
+process-level parallelism.
+
+GH-1444 already made Postgres test setup safer by rejecting non-test databases
+and cleaning up known temporary test schemas. GH-1456 finishes the next step:
+database-backed tests must rely on per-test schema isolation instead of a global
+database mutex.
+
+## Goals
+
+- Remove database-wide serialization from the normal `harness-server` and
+  related Postgres test hot paths.
+- Preserve the GH-1444 safety contract: tests must still refuse non-test
+  databases and must not leak known temporary test schemas.
+- Ensure each DB-backed test gets isolated storage through a unique data path or
+  an explicit per-test schema guard.
+- Keep process-global locks only for true process-global state such as `HOME`
+  or environment-variable mutation.
+- Make the local DB test script and CI verification compatible with default
+  test parallelism and `cargo-nextest`.
+- Record before/after timing evidence for the affected server DB profile.
+
+## Non-Goals
+
+- Changing production database resolution, store schema names, or runtime
+  database routing.
+- Weakening DB-backed assertions into no-op tests to gain speed.
+- Removing `HOME_LOCK` from tests that intentionally mutate `HOME`.
+- Reworking every large test module unrelated to DB isolation.
+- Replacing all `cargo test` jobs in CI if a scoped nextest rollout is safer.
+
+## User-Visible Behavior
+
+When a developer runs the DB-backed test profile against a safe test database,
+tests that use independent temporary data directories or explicit
+`TestSchemaGuard` schemas run concurrently. A test that mutates only its own data
+directory must not wait for unrelated DB-backed tests. A test that mutates
+process-global state may still acquire the relevant process-global lock, but
+that lock must be named for the global it protects and must not stand in for DB
+isolation.
+
+The `scripts/test-server-db.sh` helper must no longer force
+`RUST_TEST_THREADS=1` for the whole profile. CI or local nextest configuration
+must document and preserve the remaining intentionally serial cases while
+letting DB-isolated tests run in parallel.
+
+If a test attempts to use a non-test database URL, it keeps the GH-1444 behavior:
+skip through the existing optional-DB path or fail before opening a pool, with
+credentials redacted from diagnostics.
+
+## Acceptance Criteria
+
+- [ ] No DB-backed test helper depends on a process-global database mutex for
+      correctness; `DB_STATE_LOCK` and integration-local DB-only locks are
+      removed or made non-serializing compatibility shims.
+- [ ] Tests that need shared Postgres state use unique data directories or
+      explicit `TestSchemaGuard` schemas, not a global DB lock.
+- [ ] Process-global locks remain only for true process-global state such as
+      `HOME`, current environment variables, or other documented globals.
+- [ ] `scripts/test-server-db.sh` runs the server DB profile with default
+      parallelism instead of forcing `RUST_TEST_THREADS=1`.
+- [ ] A `cargo-nextest` path is documented or configured for the DB-capable
+      workspace profile, with intentionally serial tests called out explicitly.
+- [ ] Focused tests prove that acquiring the legacy DB guard API no longer
+      serializes unrelated work.
+- [ ] Focused DB-backed test suites still pass with a safe
+      `HARNESS_DATABASE_URL=.../harness_test`.
+- [ ] Test database safety, schema cleanup, and leak cleanup behavior from
+      GH-1444 remain covered.
+- [ ] Before/after timing for the main server DB profile is recorded in the PR
+      body or verification artifact.
+
+## Edge Cases
+
+- Tests that mutate `HOME` remain serialized by `HOME_LOCK`; they are not a DB
+  isolation problem.
+- Tests that intentionally verify shared-schema behavior may run inside the
+  same schema, but that schema must be created with an explicit per-test guard.
+- Tests that mutate process environment variables must keep the existing env
+  lock or use an injected configuration path.
+- If `cargo-nextest` is not installed locally, the implementation should still
+  provide a deterministic `cargo test` fallback and document the nextest
+  command for CI or maintainers.
+- Panic cleanup must not require the process-wide DB mutex; owned test schemas
+  still need best-effort cleanup through the GH-1444 guard.
+
+## Rollout Notes
+
+This is a test-infrastructure performance and reliability change. Developers
+using a configured `HARNESS_DATABASE_URL` must continue using a test-designated
+database such as `harness_test`. If any hidden shared-state coupling appears
+after parallelism is restored, the fix is to give that test an explicit isolated
+schema or a precise process-global lock, not to restore database-wide
+serialization.

--- a/specs/GH1456/tasks.md
+++ b/specs/GH1456/tasks.md
@@ -1,0 +1,52 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1456
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1456-T001` Owner: `server-test-helper` | Dependencies: GH-1444 merged | Done when: `DB_STATE_LOCK` no longer exists as a serializing mutex, `acquire_db_state_guard()` is removed or converted to a non-serializing compatibility shim, and a focused test proves overlapping acquisitions do not block each other | Verify: `cargo test -p harness-server db_state_guard -- --nocapture`
+- [ ] `SP1456-T002` Owner: `server-state-isolation` | Dependencies: `SP1456-T001` | Done when: `make_state_inner` and representative DB-backed server state tests rely on unique temp directories or `TestSchemaGuard`, not database-wide serialization | Verify: `cargo test -p harness-server shared_schema -- --nocapture && cargo test -p harness-server backfill -- --nocapture`
+- [ ] `SP1456-T003` Owner: `integration-lock-cleanup` | Dependencies: `SP1456-T001` | Done when: integration-local DB-only locks are removed or made non-serializing, while locks for `HOME` or environment mutation remain explicit and documented | Verify: `cargo test -p harness-server --test gc_adopt_pipeline -- --nocapture && cargo test -p harness-server --test turn_start_lifecycle -- --nocapture`
+- [ ] `SP1456-T004` Owner: `parallel-runner` | Dependencies: `SP1456-T001`, `SP1456-T002`, `SP1456-T003` | Done when: `scripts/test-server-db.sh` no longer forces `RUST_TEST_THREADS=1`, the DB-capable nextest path is documented or configured, and intentionally serial cases are called out explicitly | Verify: `scripts/test-server-db.sh --help` or equivalent usage output plus `cargo nextest run --workspace` when nextest is installed
+- [ ] `SP1456-T005` Owner: `verification` | Dependencies: all implementation tasks | Done when: focused DB suites, fallback cargo tests, formatting, clippy, and SpecRail checks pass, and before/after timing evidence for the main server DB profile is recorded in the PR body or artifact | Verify: `cargo fmt --all -- --check && cargo check --workspace --all-targets && cargo clippy --workspace --all-targets -- -D warnings && python3 checks/check_workflow.py --repo . --spec-dir specs/GH1456 && python3 checks/check_workflow.py --repo .`
+
+## Parallelization
+
+`SP1456-T001` should land first because the helper contract determines whether
+call sites can be cleaned mechanically or left as compatibility no-ops.
+`SP1456-T002` and `SP1456-T003` can proceed in parallel after that if file
+ownership is disjoint. `SP1456-T004` depends on the tests being safe to run in
+parallel. `SP1456-T005` is the final gate.
+
+## Verification
+
+- `cargo test -p harness-server db_state_guard -- --nocapture`
+- `cargo test -p harness-server shared_schema -- --nocapture`
+- `cargo test -p harness-server backfill -- --nocapture`
+- `cargo test -p harness-server --test gc_adopt_pipeline -- --nocapture`
+- `cargo test -p harness-server --test turn_start_lifecycle -- --nocapture`
+- `cargo test -p harness-core db_test_safety -- --nocapture`
+- `cargo test -p harness-cli schema_cleanup -- --nocapture`
+- `cargo test -p harness-server --lib`
+- `cargo nextest run --workspace` when installed, or the documented DB-capable nextest subset
+- `cargo check --workspace --all-targets`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1456`
+- `python3 checks/check_workflow.py --repo .`
+
+## Handoff Notes
+
+GH-1444 is a prerequisite and already owns non-test database rejection plus
+known temporary schema cleanup. GH-1456 must not undo that safety work. The
+implementation should treat `HOME_LOCK` and env locks as real process-global
+protection, while treating database-wide locks as compatibility debt to remove
+or neutralize. Do not close GH-1456 from a spec-only PR; use a closing keyword
+only on the final implementation PR that satisfies all acceptance criteria.

--- a/specs/GH1456/tech.md
+++ b/specs/GH1456/tech.md
@@ -1,0 +1,128 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1456
+
+## Product Spec
+
+See `specs/GH1456/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Server test helper | `crates/harness-server/src/test_helpers.rs` | `DB_STATE_LOCK` backs `acquire_db_state_guard()`, and `make_state_inner` holds it around construction of task, event, project, thread, and related stores. | This is the primary serialization point for many server tests. |
+| DB safety helper | `crates/harness-core/src/db_test_safety.rs` | GH-1444 added safe test database URL validation, `TestSchemaGuard`, known test-schema cleanup, and leak cleanup planning. | This is the safety foundation that lets tests parallelize without touching production databases. |
+| Server tests | `crates/harness-server/src/**/*tests*.rs`, `crates/harness-server/tests/*.rs` | Many tests still call `acquire_db_state_guard()` or local `DB_TEST_LOCK` helpers before building isolated app state. Many also correctly use `HOME_LOCK` for `HOME` mutation. | DB-only locks should be removed or made non-serializing; real process-global locks should remain. |
+| Core and observe tests | `crates/harness-core/src/*tests.rs`, `crates/harness-observe/src/**/*tests.rs` | Core uses a small env lock for environment mutation. Observe/server shared-schema tests now use `TestSchemaGuard` for named temporary schemas. | These patterns distinguish real process-global serialization from unnecessary DB serialization. |
+| Local script | `scripts/test-server-db.sh` | Forces `RUST_TEST_THREADS=1` for `harness-server` DB tests. | This hides shared-state bugs and prevents measuring the parallelized profile. |
+| CI | `.github/workflows/ci.yml` | Runs `cargo test` with `HARNESS_DATABASE_URL=.../harness_test`; no nextest profile is configured yet. | CI already uses a safe test database, so it can run the same isolated profile once remaining serial assumptions are removed. |
+
+## Proposed Design
+
+1. Replace the process-global DB mutex with a compatibility guard that does not
+   serialize unrelated tests.
+   - Remove `DB_STATE_LOCK` from `test_helpers.rs`.
+   - Keep `acquire_db_state_guard()` only as a short-term API compatibility shim
+     if removing every call site would require unrelated large-file churn.
+   - The compatibility guard must be a no-op value and must not hold a mutex.
+   - Add a focused test proving two guard acquisitions can overlap.
+2. Ensure state construction relies on per-test isolation.
+   - `make_state_inner` should use the caller's temporary data directory and
+     the GH-1444 safe database URL; it should not hold a database-wide guard.
+   - Tests that need shared-schema assertions must keep using
+     `TestSchemaGuard` with known prefixes.
+   - Tests that need process-global `HOME` changes should keep `HOME_LOCK` and
+     `HomeGuard`.
+3. Remove or neutralize local DB-only locks in integration tests.
+   - Replace local `DB_TEST_LOCK` helpers that only protect DB state with no-op
+     guards or direct per-test isolation.
+   - Keep locks only when the test mutates process environment variables,
+     process-wide configuration, global singleton state, or `HOME`.
+   - Name any remaining lock after the global it protects.
+4. Restore parallel DB test execution.
+   - Update `scripts/test-server-db.sh` to stop forcing
+     `RUST_TEST_THREADS=1`.
+   - Add a nextest configuration or documented command for the DB-capable
+     workspace profile. If nextest is not installed locally, keep `cargo test`
+     as the deterministic fallback.
+   - Call out intentionally serial test groups in config/docs rather than
+     serializing the whole server DB profile.
+5. Add leak and regression checks.
+   - Keep GH-1444 tests for safe URL validation and known temporary schema
+     cleanup.
+   - Add a focused server helper test that exercises concurrent DB guard
+     acquisition without waiting for another test's critical section.
+   - Run the focused server DB suites with `HARNESS_DATABASE_URL` pointing at a
+     safe test database and record elapsed-time evidence.
+
+## Data Flow
+
+Test setup resolves the candidate database URL through
+`resolve_test_database_url`, which validates the database name before any pool
+opens. Store constructors then derive path-based schemas from each test's
+temporary data directory, or receive an explicit schema from `TestSchemaGuard`
+for shared-schema tests. No process-global database mutex participates in this
+flow.
+
+Tests that need process-global state still acquire the corresponding global
+lock before mutation. That lock protects process state, not the database.
+
+## Alternatives Considered
+
+- Keep `DB_STATE_LOCK` and rely on nextest process isolation later. Rejected
+  because the in-process `cargo test` profile remains slow and the lock hides
+  missing per-test isolation.
+- Delete all `acquire_db_state_guard()` call sites in one large PR. Rejected as
+  unnecessary churn if the API can be made non-serializing first; follow-up
+  cleanup can remove dead calls module by module.
+- Make every DB-backed test create a named schema manually. Rejected because
+  path-derived schemas already provide isolation for tests with unique data
+  directories, while `TestSchemaGuard` is enough for explicit shared-schema
+  cases.
+- Remove `HOME_LOCK` while touching tests. Rejected because it protects real
+  process-global state and is outside the DB parallelization problem.
+
+## Risks
+
+- Security: database URL diagnostics must continue to redact credentials, and
+  schema cleanup must keep validating identifiers before interpolation.
+- Compatibility: tests with hidden shared data directories may start racing once
+  the DB lock is removed. Fix those tests by giving them unique paths or
+  explicit schemas.
+- Performance: opening multiple Postgres pools concurrently can increase
+  connection pressure. Existing test pool defaults should stay bounded, and CI
+  Postgres should be monitored during the rollout.
+- Maintenance: a no-op compatibility guard can become confusing if it remains
+  forever. The implementation should mark it as compatibility-only and prefer
+  removing new call sites.
+
+## Test Plan
+
+- [ ] Unit tests: the server DB guard compatibility API does not serialize
+      overlapping acquisitions.
+- [ ] Unit tests: `db_tests_enabled()` and `test_database_url()` retain GH-1444
+      safe database URL behavior.
+- [ ] Integration tests: server shared-schema and backfill tests pass against
+      `HARNESS_DATABASE_URL=.../harness_test`.
+- [ ] Integration tests: representative server route/state tests that used the
+      old DB guard pass without DB serialization.
+- [ ] Script verification: `scripts/test-server-db.sh --help` or dry-run output
+      no longer advertises forced `RUST_TEST_THREADS=1`.
+- [ ] Nextest verification: `cargo nextest run --workspace` or the documented
+      DB-capable nextest subset passes when the tool is installed.
+- [ ] Fallback verification: `cargo test -p harness-server --lib` and the
+      relevant integration tests pass with a safe test database.
+- [ ] Repository checks: `cargo fmt --all -- --check`,
+      `cargo check --workspace --all-targets`,
+      `cargo clippy --workspace --all-targets -- -D warnings`, and SpecRail
+      workflow checks pass.
+
+## Rollback Plan
+
+Revert the test helper, integration-test lock, script, and nextest/CI changes.
+Because this only changes test infrastructure, no production database migration
+or persisted data rollback is required. If a specific test proves non-isolated,
+prefer a targeted per-test schema or precise process-global lock over restoring
+the database-wide mutex.


### PR DESCRIPTION
## Summary
- add the GH1456 product spec for removing database-wide test serialization
- add the GH1456 tech spec grounded in the GH1444 test DB safety helpers
- add the GH1456 task plan for helper, integration-lock, script, nextest, and verification work

## Verification
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1456`
- `python3 checks/check_workflow.py --repo .`

Refs #1456