### PR TITLE
Parallelize server DB tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,15 +180,19 @@ HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test scri
 # Full server DB, startup, recovery, route, and workflow profile.
 HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test scripts/test-server-db.sh
 
+# Optional nextest runner for the same DB-capable profile.
+HARNESS_SERVER_TEST_RUNNER=nextest HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test scripts/test-server-db.sh
+
 # Final PR handoff: full workspace coverage.
 HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test --workspace
 ```
 
 `scripts/test-server-fast.sh` is the warm local feedback path for routine
 `harness-server` changes once a test database URL is configured.
-`scripts/test-server-db.sh` runs the full server suite single-threaded so
-DB-backed startup, recovery, full `AppState`, route, and workflow-runtime
-coverage remains explicit and stable.
+`scripts/test-server-db.sh` runs the full server suite with default test
+parallelism. DB-backed tests rely on unique temporary data directories or
+explicit `TestSchemaGuard` schemas. Tests that mutate true process-global state,
+such as `HOME`, keep their own named locks.
 
 ### Run
 

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -523,10 +523,37 @@ pub(crate) fn validate_schema_name(schema: &str) -> anyhow::Result<()> {
 /// regardless of which store calls it.
 pub async fn pg_create_schema_if_not_exists(pool: &PgPool, schema: &str) -> anyhow::Result<()> {
     validate_schema_name(schema)?;
-    sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
+    match sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema))
         .execute(pool)
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(error) if pg_create_schema_if_not_exists_race(&error) => {
+            if pg_schema_exists(pool, schema).await? {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!(error))
+            }
+        }
+        Err(error) => Err(anyhow::anyhow!(error)),
+    }
+}
+
+async fn pg_schema_exists(pool: &PgPool, schema: &str) -> anyhow::Result<bool> {
+    let exists: Option<i32> = sqlx::query_scalar("SELECT 1 FROM pg_namespace WHERE nspname = $1")
+        .bind(schema)
+        .fetch_optional(pool)
         .await?;
-    Ok(())
+    Ok(exists.is_some())
+}
+
+fn pg_create_schema_if_not_exists_race(error: &sqlx::Error) -> bool {
+    let Some(db_error) = error.as_database_error() else {
+        return false;
+    };
+    db_error.code().as_deref() == Some("23505")
+        && (db_error.constraint() == Some("pg_namespace_nspname_index")
+            || db_error.message().contains("pg_namespace_nspname_index"))
 }
 
 /// Create a Postgres connection pool where every connection has `search_path`

--- a/crates/harness-core/src/db_pg_schema_registry.rs
+++ b/crates/harness-core/src/db_pg_schema_registry.rs
@@ -229,12 +229,8 @@ struct PgSchemaInventoryRow {
 }
 
 pub async fn ensure_pg_schema_registry(pool: &PgPool) -> anyhow::Result<()> {
-    sqlx::query(&format!(
-        "CREATE SCHEMA IF NOT EXISTS \"{PG_SCHEMA_REGISTRY_SCHEMA}\""
-    ))
-    .execute(pool)
-    .await?;
-    sqlx::query(&format!(
+    crate::db_pg::pg_create_schema_if_not_exists(pool, PG_SCHEMA_REGISTRY_SCHEMA).await?;
+    let create_table = format!(
         "CREATE TABLE IF NOT EXISTS \"{PG_SCHEMA_REGISTRY_SCHEMA}\".\"{PG_SCHEMA_REGISTRY_TABLE}\" (
             schema_name     TEXT PRIMARY KEY,
             owner_kind      TEXT NOT NULL,
@@ -244,10 +240,50 @@ pub async fn ensure_pg_schema_registry(pool: &PgPool) -> anyhow::Result<()> {
             created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
             last_seen_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
         )"
-    ))
-    .execute(pool)
+    );
+    match sqlx::query(&create_table).execute(pool).await {
+        Ok(_) => Ok(()),
+        Err(error) if pg_create_table_if_not_exists_race(&error) => {
+            if pg_schema_registry_table_exists(pool).await? {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!(error))
+            }
+        }
+        Err(error) => Err(anyhow::anyhow!(error)),
+    }
+}
+
+async fn pg_schema_registry_table_exists(pool: &PgPool) -> anyhow::Result<bool> {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = $1 AND table_name = $2
+        )",
+    )
+    .bind(PG_SCHEMA_REGISTRY_SCHEMA)
+    .bind(PG_SCHEMA_REGISTRY_TABLE)
+    .fetch_one(pool)
     .await?;
-    Ok(())
+    Ok(exists)
+}
+
+fn pg_create_table_if_not_exists_race(error: &sqlx::Error) -> bool {
+    let Some(db_error) = error.as_database_error() else {
+        return false;
+    };
+    match db_error.code().as_deref() {
+        Some("42P07") => true,
+        Some("23505") => {
+            matches!(
+                db_error.constraint(),
+                Some("pg_type_typname_nsp_index") | Some("pg_class_relname_nsp_index")
+            ) || db_error.message().contains("pg_type_typname_nsp_index")
+                || db_error.message().contains("pg_class_relname_nsp_index")
+        }
+        _ => false,
+    }
 }
 
 pub async fn register_pg_schema_ownership(

--- a/crates/harness-core/src/db_pg_schema_registry_tests.rs
+++ b/crates/harness-core/src/db_pg_schema_registry_tests.rs
@@ -407,6 +407,48 @@ async fn reaper_inventory_includes_legacy_path_derived_schema_owner_rows() -> an
     Ok(())
 }
 
+#[tokio::test]
+async fn concurrent_schema_registry_ensure_is_idempotent() -> anyhow::Result<()> {
+    let database_url = {
+        let _lock = crate::test_support::process_env_lock();
+        let Ok(database_url) = crate::db_test_safety::resolve_test_database_url(None) else {
+            return Ok(());
+        };
+        database_url
+    };
+    let pool = match pg_open_pool(&database_url).await {
+        Ok(pool) => pool,
+        Err(_) => return Ok(()),
+    };
+
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            ensure_pg_schema_registry(&pool).await
+        }));
+    }
+    for handle in handles {
+        handle.await??;
+    }
+
+    let table_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = $1 AND table_name = $2
+        )",
+    )
+    .bind(PG_SCHEMA_REGISTRY_SCHEMA)
+    .bind(PG_SCHEMA_REGISTRY_TABLE)
+    .fetch_one(&pool)
+    .await?;
+    assert!(table_exists);
+
+    pool.close().await;
+    Ok(())
+}
+
 #[test]
 fn normalize_path_lexically_preserves_root_and_leading_parent() {
     assert_eq!(

--- a/crates/harness-core/src/db_pg_tests.rs
+++ b/crates/harness-core/src/db_pg_tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    configure_pg_pool_from_server, pg_open_pool, pg_pool_settings, pg_schema_for_path,
-    resolve_database_url, validate_schema_name, PgStoreContext, DEFAULT_PG_ACQUIRE_TIMEOUT_SECS,
-    DEFAULT_PG_MAX_CONNECTIONS,
+    configure_pg_pool_from_server, pg_create_schema_if_not_exists, pg_open_pool, pg_pool_settings,
+    pg_schema_for_path, resolve_database_url, validate_schema_name, PgStoreContext,
+    DEFAULT_PG_ACQUIRE_TIMEOUT_SECS, DEFAULT_PG_MAX_CONNECTIONS,
 };
 use crate::config::server::ServerConfig;
 use crate::db_pg_schema_registry::{PG_SCHEMA_REGISTRY_SCHEMA, PG_SCHEMA_REGISTRY_TABLE};
@@ -247,6 +247,49 @@ async fn pg_store_context_runtime_pool_errors_name_the_step() {
         err.to_string().contains("runtime pool"),
         "error should identify the runtime-pool step: {err}"
     );
+}
+
+#[tokio::test]
+async fn concurrent_schema_create_if_not_exists_is_idempotent() -> anyhow::Result<()> {
+    let database_url = {
+        let _lock = process_env_lock();
+        let Ok(database_url) = crate::db_test_safety::resolve_test_database_url(None) else {
+            return Ok(());
+        };
+        database_url
+    };
+    let setup_pool = match pg_open_pool(&database_url).await {
+        Ok(pool) => pool,
+        Err(_) => return Ok(()),
+    };
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_nanos();
+    let schema = format!("schema_race_test_{}_{}", std::process::id(), nanos);
+
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let pool = setup_pool.clone();
+        let schema = schema.clone();
+        handles.push(tokio::spawn(async move {
+            pg_create_schema_if_not_exists(&pool, &schema).await
+        }));
+    }
+    for handle in handles {
+        handle.await??;
+    }
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM pg_namespace WHERE nspname = $1")
+        .bind(&schema)
+        .fetch_one(&setup_pool)
+        .await?;
+    assert_eq!(count, 1);
+
+    sqlx::query(&format!("DROP SCHEMA \"{}\" CASCADE", schema))
+        .execute(&setup_pool)
+        .await?;
+    setup_pool.close().await;
+    Ok(())
 }
 
 #[test]

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -15,7 +15,6 @@ use tokio::sync::OnceCell;
 /// spurious "project root must be within HOME" failures.
 pub static HOME_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 static DB_AVAILABLE: OnceCell<bool> = OnceCell::const_new();
-static DB_STATE_LOCK: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
 static TEST_DATABASE_URL: OnceLock<String> = OnceLock::new();
 static TEST_PG_POOL_CONFIGURED: OnceLock<()> = OnceLock::new();
 
@@ -28,12 +27,6 @@ pub fn configure_test_pg_pool_defaults() {
         };
         harness_core::db::configure_pg_pool_from_server(&server);
     });
-}
-
-fn db_state_lock() -> Arc<tokio::sync::Mutex<()>> {
-    DB_STATE_LOCK
-        .get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
-        .clone()
 }
 
 /// RAII guard that restores `HOME` on drop, **including on panic**.
@@ -111,7 +104,7 @@ pub async fn db_tests_enabled() -> bool {
 
 pub async fn acquire_db_state_guard() -> tokio::sync::OwnedMutexGuard<()> {
     configure_test_pg_pool_defaults();
-    db_state_lock().lock_owned().await
+    Arc::new(tokio::sync::Mutex::new(())).lock_owned().await
 }
 
 pub fn test_database_url() -> anyhow::Result<String> {
@@ -193,7 +186,6 @@ async fn make_state_inner(
     agent_registry: AgentRegistry,
     mut config: HarnessConfig,
 ) -> anyhow::Result<AppState> {
-    let db_setup_guard = acquire_db_state_guard().await;
     let database_url = test_database_url()?;
     config.server.database_url = Some(database_url.clone());
     let server = Arc::new(HarnessServer::new(
@@ -257,8 +249,6 @@ async fn make_state_inner(
         None,
         vec![],
     );
-    drop(db_setup_guard);
-
     Ok(AppState {
         core: crate::http::CoreServices {
             server,
@@ -330,4 +320,20 @@ async fn make_state_inner(
         task_svc,
         execution_svc,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn db_state_guard_compatibility_shim_does_not_serialize() {
+        let _first = acquire_db_state_guard().await;
+        let second =
+            tokio::time::timeout(Duration::from_millis(50), acquire_db_state_guard()).await;
+        assert!(
+            second.is_ok(),
+            "legacy DB guard compatibility shim must not serialize callers"
+        );
+    }
 }

--- a/crates/harness-server/tests/gc_adopt_pipeline.rs
+++ b/crates/harness-server/tests/gc_adopt_pipeline.rs
@@ -75,12 +75,6 @@ impl CodeAgent for MockPrAgent {
 // Helpers
 // ---------------------------------------------------------------------------
 
-static DB_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-async fn db_test_guard() -> tokio::sync::MutexGuard<'static, ()> {
-    DB_TEST_LOCK.lock().await
-}
-
 async fn make_state(root: &Path) -> anyhow::Result<harness_server::http::AppState> {
     make_state_with_auto_pr(root, true).await
 }
@@ -153,7 +147,6 @@ fn make_draft(artifact_path: &Path, content: &str) -> Draft {
 /// gc_adopt writes artifact files and dispatches an agent task.
 #[tokio::test]
 async fn gc_adopt_dispatches_task_with_prompt() -> anyhow::Result<()> {
-    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-pipeline-")?;
     let state = make_state(sandbox.path()).await?;
 
@@ -183,7 +176,6 @@ async fn gc_adopt_dispatches_task_with_prompt() -> anyhow::Result<()> {
 /// gc_adopt returns adopted=true with null task_id when there are no artifacts.
 #[tokio::test]
 async fn gc_adopt_no_artifacts_returns_null_task_id() -> anyhow::Result<()> {
-    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-no-artifacts-")?;
     let state = make_state(sandbox.path()).await?;
 
@@ -218,7 +210,6 @@ async fn gc_adopt_no_artifacts_returns_null_task_id() -> anyhow::Result<()> {
 /// gc_adopt returns NOT_FOUND for an unknown draft ID.
 #[tokio::test]
 async fn gc_adopt_unknown_draft_returns_not_found() -> anyhow::Result<()> {
-    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-not-found-")?;
     let state = make_state(sandbox.path()).await?;
 
@@ -237,7 +228,6 @@ async fn gc_adopt_unknown_draft_returns_not_found() -> anyhow::Result<()> {
 /// gc_adopt with auto_pr=false skips task dispatch and returns null task_id.
 #[tokio::test]
 async fn gc_adopt_auto_pr_false_skips_task_dispatch() -> anyhow::Result<()> {
-    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-no-auto-pr-")?;
     let state = make_state_with_auto_pr(sandbox.path(), false).await?;
 
@@ -266,7 +256,6 @@ async fn gc_adopt_auto_pr_false_skips_task_dispatch() -> anyhow::Result<()> {
 /// gc_adopt with auto_pr=true (default) dispatches a task when artifacts exist.
 #[tokio::test]
 async fn gc_adopt_auto_pr_true_dispatches_task() -> anyhow::Result<()> {
-    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-auto-pr-true-")?;
     let state = make_state_with_auto_pr(sandbox.path(), true).await?;
 
@@ -295,7 +284,6 @@ async fn gc_adopt_auto_pr_true_dispatches_task() -> anyhow::Result<()> {
 /// gc_adopt with auto_pr=true fails before adopt when no default agent is registered.
 #[tokio::test]
 async fn gc_adopt_auto_pr_requires_default_agent() -> anyhow::Result<()> {
-    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-no-default-agent-")?;
     let state = make_state_without_default_agent(sandbox.path()).await?;
 
@@ -386,7 +374,6 @@ impl CodeAgent for CapturingAgent {
 /// runs directly against the project_root (no git worktree indirection).
 #[tokio::test]
 async fn gc_adopt_task_uses_appstate_project_root() -> anyhow::Result<()> {
-    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-project-root-")?;
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;
@@ -483,7 +470,6 @@ async fn gc_adopt_task_uses_appstate_project_root() -> anyhow::Result<()> {
 /// Covers the repeat-adopt and reject/adopt-race scenarios identified in review round 1.
 #[tokio::test]
 async fn gc_adopt_non_pending_draft_returns_conflict() -> anyhow::Result<()> {
-    let _db_guard = db_test_guard().await;
     let sandbox = common::tempdir_in_home("gc-adopt-non-pending-")?;
     let state = make_state(sandbox.path()).await?;
 

--- a/crates/harness-server/tests/turn_start_lifecycle.rs
+++ b/crates/harness-server/tests/turn_start_lifecycle.rs
@@ -18,8 +18,6 @@ use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::time::{sleep, Duration, Instant};
 
-static DB_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
 #[derive(Clone)]
 enum MockMode {
     CompleteAfter { delay: Duration },
@@ -215,7 +213,6 @@ async fn start_thread_and_turn(
 
 #[tokio::test]
 async fn running_to_completed_updates_items_and_usage() -> anyhow::Result<()> {
-    let _db_guard = DB_TEST_LOCK.lock().await;
     let sandbox = common::tempdir_in_home("harness-turn-lifecycle-")?;
     let state = make_state(
         sandbox.path(),
@@ -253,7 +250,6 @@ async fn running_to_completed_updates_items_and_usage() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn running_to_failed_is_persisted() -> anyhow::Result<()> {
-    let _db_guard = DB_TEST_LOCK.lock().await;
     let sandbox = common::tempdir_in_home("harness-turn-lifecycle-")?;
     let state = make_state(
         sandbox.path(),
@@ -281,7 +277,6 @@ async fn running_to_failed_is_persisted() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn running_to_cancelled_stops_turn() -> anyhow::Result<()> {
-    let _db_guard = DB_TEST_LOCK.lock().await;
     let sandbox = common::tempdir_in_home("harness-turn-lifecycle-")?;
     let state = make_state(sandbox.path(), MockAgent::block_forever()).await?;
 
@@ -309,7 +304,6 @@ async fn running_to_cancelled_stops_turn() -> anyhow::Result<()> {
 /// an Error item containing the missing agent name.
 #[tokio::test]
 async fn turn_fails_when_agent_not_registered() -> anyhow::Result<()> {
-    let _db_guard = DB_TEST_LOCK.lock().await;
     let sandbox = common::tempdir_in_home("harness-turn-lifecycle-")?;
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;
@@ -349,7 +343,6 @@ async fn turn_fails_when_agent_not_registered() -> anyhow::Result<()> {
 /// covered by the focused `turn_lifecycle_stall_tests` unit surface.
 #[tokio::test]
 async fn turn_stall_timeout_enforces_minimum_floor() -> anyhow::Result<()> {
-    let _db_guard = DB_TEST_LOCK.lock().await;
     let sandbox = common::tempdir_in_home("harness-turn-lifecycle-")?;
     let project_root = sandbox.path().join("project");
     std::fs::create_dir_all(&project_root)?;

--- a/scripts/test-server-db.sh
+++ b/scripts/test-server-db.sh
@@ -3,6 +3,33 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+runner="${HARNESS_SERVER_TEST_RUNNER:-cargo-test}"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  cat <<'EOF'
+Run the full harness-server DB test profile.
+
+Usage:
+  HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test scripts/test-server-db.sh [test filters...]
+
+Runner:
+  HARNESS_SERVER_TEST_RUNNER=cargo-test  Use cargo test (default)
+  HARNESS_SERVER_TEST_RUNNER=nextest     Use cargo nextest run
+
+The profile runs with default test parallelism. Tests that mutate true
+process-global state keep their own explicit locks.
+EOF
+  exit 0
+fi
+
+case "$runner" in
+  cargo-test|nextest) ;;
+  *)
+    echo "unsupported HARNESS_SERVER_TEST_RUNNER: $runner" >&2
+    exit 2
+    ;;
+esac
+
 if [[ -z "${HARNESS_DATABASE_URL:-}" ]]; then
   cat >&2 <<'EOF'
 HARNESS_DATABASE_URL is required for the full harness-server DB test profile.
@@ -19,7 +46,15 @@ EOF
   exit 2
 fi
 
-RUST_TEST_THREADS=1 cargo test -p harness-server --lib "$@"
+run_harness_server_test() {
+  case "$runner" in
+    cargo-test) cargo test -p harness-server "$@" ;;
+    nextest) cargo nextest run --no-tests=pass -p harness-server "$@" ;;
+  esac
+}
+
+echo "==> ${runner}: harness-server --lib"
+run_harness_server_test --lib "$@"
 
 for test_file in crates/harness-server/tests/*.rs; do
   test_name="${test_file##*/}"
@@ -28,5 +63,6 @@ for test_file in crates/harness-server/tests/*.rs; do
     continue
   fi
 
-  RUST_TEST_THREADS=1 cargo test -p harness-server --test "$test_name" "$@"
+  echo "==> ${runner}: harness-server --test ${test_name}"
+  run_harness_server_test --test "$test_name" "$@"
 done


### PR DESCRIPTION
## Summary
- remove the process-global server DB test mutex by turning the legacy guard API into a non-serializing compatibility shim
- remove DB-only locks from `gc_adopt_pipeline` and `turn_start_lifecycle` integration tests
- harden concurrent Postgres schema and schema-registry initialization so parallel tests do not hit duplicate catalog races
- update `scripts/test-server-db.sh` to use default parallelism and add an optional `HARNESS_SERVER_TEST_RUNNER=nextest` path

## Verification
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test -p harness-core concurrent_schema_create_if_not_exists_is_idempotent -- --nocapture`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test -p harness-core concurrent_schema_registry_ensure_is_idempotent -- --nocapture`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test -p harness-server --test gc_adopt_pipeline -- --nocapture`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test -p harness-server --test turn_start_lifecycle -- --nocapture`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test -p harness-server shared_schema -- --nocapture`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test -p harness-server backfill -- --nocapture`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test -p harness-core db_test_safety -- --nocapture`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test -p harness-cli schema_cleanup -- --nocapture`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test scripts/test-server-db.sh db_state_guard`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test HARNESS_SERVER_TEST_RUNNER=nextest scripts/test-server-db.sh db_state_guard`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test scripts/test-server-db.sh` (full profile, real 85.29s)
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1456`
- `python3 checks/check_workflow.py --repo .`

## Timing / Race Evidence
- Before the concurrent DDL fixes, the default-parallel `gc_adopt_pipeline` run reproduced the old hidden serialization dependency in 2.73s with `duplicate key value violates unique constraint pg_namespace_nspname_index`.
- After the fixes, the complete `scripts/test-server-db.sh` profile passed in 85.29s with default test parallelism.

Fixes #1456