### PR TITLE
Spec GH1458 GH1459 build config changes

### DIFF
--- a/specs/GH1458/product.md
+++ b/specs/GH1458/product.md
@@ -1,0 +1,90 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1458
+
+## User Problem
+
+Harness currently uses multiple Rust warning-policy build universes that share
+the same `target/debug` directory. Normal developer checks run without
+`RUSTFLAGS`, while hooks and CI inject `RUSTFLAGS=-Dwarnings`. Switching between
+those environments invalidates Cargo fingerprints and forces expensive rebuilds,
+which slows every agent and maintainer loop.
+
+The repository should express warning strictness in the workspace manifests so
+local checks, hooks, and CI compile under one consistent universe.
+
+## Goals
+
+- Move deny-warnings behavior from environment variables into the Cargo
+  workspace lint configuration.
+- Ensure every workspace crate opts into the shared lint policy.
+- Remove functional `RUSTFLAGS=-Dwarnings` usage from hooks, workflows, and
+  active developer commands.
+- Preserve CI-equivalent warning strictness for `cargo clippy` and normal
+  workspace checks.
+- Coordinate implementation timing with GH-1459 so the repository pays one
+  intended rebuild for both build-profile changes.
+
+## Non-Goals
+
+- Changing debug-info or profile settings; GH-1459 owns that behavior.
+- Restructuring the pre-commit or pre-push gate split; GH-1464 owns that
+  workflow change.
+- Editing historical docs that mention prior `RUSTFLAGS` commands only as
+  archival evidence.
+- Weakening warning failures to improve short-term build speed.
+
+## User-Visible Behavior
+
+Developers, hooks, and CI run the same warning policy without setting
+`RUSTFLAGS`. A clean tree passes `cargo clippy --workspace --all-targets` with
+no warning-related environment override. If a new Rust warning is introduced in
+workspace code, the normal workspace lint policy fails the relevant local or CI
+command instead of relying on a separate `RUSTFLAGS` universe.
+
+After a clean build, alternating between workspace check and clippy should reuse
+the same fingerprint universe. Repeating the same check/clippy sequence should
+not recompile unchanged crates just because the warning policy moved between
+the environment and manifest.
+
+## Acceptance Criteria
+
+- [ ] The root manifest defines workspace-level Rust warning denial with
+      `[workspace.lints.rust] warnings = "deny"`.
+- [ ] Every workspace crate manifest opts into workspace lint inheritance with
+      `[lints] workspace = true`.
+- [ ] Functional hook, workflow, script, and active developer-command uses of
+      `RUSTFLAGS=-Dwarnings` are removed or replaced with equivalent plain
+      cargo commands.
+- [ ] CI and local verification still fail on an intentionally introduced Rust
+      warning and pass again after reverting that warning.
+- [ ] `cargo check --workspace --all-targets` and
+      `cargo clippy --workspace --all-targets` run without warning-policy
+      environment variables.
+- [ ] A fingerprint-stability verification runs check, clippy, then repeats
+      both commands and records whether the second round avoids unnecessary
+      recompilation.
+- [ ] Documentation and PR notes call out that local inner-loop checks now
+      fail warnings earlier than before.
+
+## Edge Cases
+
+- Clippy-specific warnings remain governed by clippy's command-line settings
+  such as `-- -D warnings`; this spec only removes environment-level
+  `RUSTFLAGS=-Dwarnings`.
+- Historical docs may continue to mention old commands when they describe past
+  incidents or preserved evidence, but active setup, hook, workflow, and agent
+  instructions must not prescribe the old environment override.
+- Crates added later must opt into workspace lint inheritance; otherwise they
+  would silently leave the shared warning policy.
+- Build scripts and generated code must either be warning-clean or updated so
+  the manifest-level policy does not create a new CI-only failure.
+
+## Rollout Notes
+
+This is a build-behavior change. It intentionally moves warning failures
+earlier into normal local development. Implement GH-1458 and GH-1459 together
+or in immediately adjacent PRs so maintainers pay one expected rebuild when the
+workspace fingerprint universe and debug-info profile both change.

--- a/specs/GH1458/tasks.md
+++ b/specs/GH1458/tasks.md
@@ -1,0 +1,41 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1458
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1458-T001` Owner: `workspace-manifest` | Dependencies: none | Done when: the root `Cargo.toml` defines `[workspace.lints.rust] warnings = "deny"` and every workspace crate manifest opts into `[lints] workspace = true` | Verify: manifest grep or script over `crates/*/Cargo.toml`
+- [ ] `SP1458-T002` Owner: `ci-hooks` | Dependencies: `SP1458-T001` | Done when: `.github/workflows/ci.yml`, `.github/workflows/ci-disabled-modules.yml`, and `.githooks/pre-commit` no longer use `RUSTFLAGS=-Dwarnings` for warning policy | Verify: targeted `rg -n "RUSTFLAGS.*Dwarnings|Dwarnings.*RUSTFLAGS" .github .githooks`
+- [ ] `SP1458-T003` Owner: `active-docs` | Dependencies: `SP1458-T001` | Done when: active repo instructions and current developer commands describe no-env cargo checks plus clippy's `-- -D warnings` where needed | Verify: targeted `rg -n "RUSTFLAGS.*Dwarnings|Dwarnings.*RUSTFLAGS" AGENTS.md CLAUDE.md README.md scripts docs`
+- [ ] `SP1458-T004` Owner: `verification` | Dependencies: `SP1458-T001`, `SP1458-T002`, `SP1458-T003`, GH-1459 implementation when combined | Done when: clean no-env workspace check and clippy pass, an intentional warning fails before being reverted, and repeat check/clippy timing or no-op evidence is recorded | Verify: `cargo check --workspace --all-targets && cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `SP1458-T005` Owner: `specrail` | Dependencies: all implementation tasks | Done when: SpecRail workflow checks pass and the PR body records whether GH-1459 landed in the same implementation PR or an adjacent PR | Verify: `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1458 && python3 checks/check_workflow.py --repo .`
+
+## Parallelization
+
+`SP1458-T001` should land before hook and docs edits because the manifest policy
+is the replacement for the removed environment variable. `SP1458-T002` and
+`SP1458-T003` can proceed in parallel after the manifest change if file
+ownership is disjoint. `SP1458-T004` and `SP1458-T005` are final gates.
+
+## Verification
+
+- `rg -n "RUSTFLAGS.*Dwarnings|Dwarnings.*RUSTFLAGS" .github .githooks AGENTS.md CLAUDE.md README.md scripts docs`
+- manifest audit over `crates/*/Cargo.toml`
+- negative intentional-warning check, reverted before commit
+- `cargo check --workspace --all-targets`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1458`
+- `python3 checks/check_workflow.py --repo .`
+
+## Handoff Notes
+
+GH-1458 is intentionally coordinated with GH-1459. A combined implementation PR
+may close both issues only if it satisfies both spec packets. A spec-only PR
+must use `Refs #1458` and must not close the issue.

--- a/specs/GH1458/tech.md
+++ b/specs/GH1458/tech.md
@@ -1,0 +1,113 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1458
+
+## Product Spec
+
+See `specs/GH1458/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Workspace manifest | `Cargo.toml` | The root manifest defines workspace members and dependencies but does not define `[workspace.lints]`. | This is the canonical place for shared Cargo lint policy. |
+| Crate manifests | `crates/*/Cargo.toml` | Workspace crates do not currently opt into a shared lint table. | Cargo requires each package to opt into inherited workspace lints. |
+| GitHub CI | `.github/workflows/ci.yml`, `.github/workflows/ci-disabled-modules.yml` | CI injects `RUSTFLAGS=-Dwarnings` globally. | This creates a separate Cargo fingerprint universe from local no-env checks. |
+| Local hooks | `.githooks/pre-commit` | The hook invokes clippy with a warning-deny environment override. | Hook runs invalidate or reuse different build artifacts than normal checks. |
+| Agent and developer docs | `AGENTS.md`, `CLAUDE.md`, `README.md`, active workflow docs | Some active commands still describe `RUSTFLAGS=-Dwarnings`. | Active instructions should match the manifest-based policy. |
+| Historical docs | `docs/**/*.md` | Several older specs and audit notes mention `RUSTFLAGS` as past evidence. | These are not functional command sources and may stay unless they mislead active workflow usage. |
+
+## Proposed Design
+
+1. Add a root workspace lint policy:
+
+   ```toml
+   [workspace.lints.rust]
+   warnings = "deny"
+   ```
+
+2. Add workspace lint inheritance to every workspace crate manifest:
+
+   ```toml
+   [lints]
+   workspace = true
+   ```
+
+   Apply this to each package listed under `crates/*/Cargo.toml`. Search for
+   package manifests rather than assuming the crate count.
+
+3. Remove functional `RUSTFLAGS=-Dwarnings` usage from active execution paths:
+   - `.github/workflows/ci.yml`
+   - `.github/workflows/ci-disabled-modules.yml`
+   - `.githooks/pre-commit`
+   - active repo instructions such as `AGENTS.md` and `CLAUDE.md`
+   - scripts or docs that operators are expected to run as current commands
+
+4. Preserve clippy strictness with clippy's own command-line lint setting where
+   that is already the repo standard:
+
+   ```sh
+   cargo clippy --workspace --all-targets -- -D warnings
+   ```
+
+   This is not the same as `RUSTFLAGS=-Dwarnings`; it does not create a separate
+   rustc environment fingerprint universe.
+
+5. Keep GH-1459 coordinated. If the implementation branch also changes
+   `[profile.dev]`, the PR may close both GH-1458 and GH-1459 only after both
+   spec packets and acceptance criteria are satisfied.
+
+## Data Flow
+
+Cargo reads the root workspace lint table, each crate opts into inherited lints,
+and the same warning policy is applied during check, clippy, test builds, hooks,
+and CI without a warning-policy environment variable. CI and local hooks invoke
+plain cargo commands for rustc warning policy, with clippy-specific denial left
+as a clippy argument.
+
+## Alternatives Considered
+
+- Keep `RUSTFLAGS=-Dwarnings` and accept the rebuild cost. Rejected because it
+  preserves the fingerprint split this issue is meant to remove.
+- Move `rustflags = ["-Dwarnings"]` into `.cargo/config.toml`. Rejected because
+  it still models warning policy as compiler flags rather than package lint
+  policy and is easier to miss in review.
+- Remove all `-D warnings` spellings, including clippy's command-line lint
+  flag. Rejected because clippy-specific warning denial is part of the current
+  CI-equivalent gate and does not create the same rustc environment split.
+
+## Risks
+
+- Security: no direct security surface; changes are limited to build policy and
+  instructions.
+- Compatibility: developers may see warning failures earlier in normal local
+  checks. This is intended CI parity but should be called out in docs.
+- Performance: the first build after the manifest change will rebuild the
+  workspace. Repeated check/clippy cycles should be faster after the one-time
+  rebuild.
+- Maintenance: new crates must remember `[lints] workspace = true`; verification
+  should grep package manifests to prevent drift.
+
+## Test Plan
+
+- [ ] Manifest audit: every workspace crate manifest contains
+      `[lints] workspace = true`.
+- [ ] Search audit: no functional `RUSTFLAGS=-Dwarnings` usage remains in hooks,
+      workflows, scripts, or active instructions.
+- [ ] Negative warning check: temporarily introduce a Rust warning, verify the
+      no-env workspace command fails, then revert the warning before commit.
+- [ ] Local build checks: `cargo check --workspace --all-targets` and
+      `cargo clippy --workspace --all-targets -- -D warnings` pass.
+- [ ] Fingerprint check: run check, clippy, then repeat both and record the
+      second-round no-op behavior or timing evidence.
+- [ ] SpecRail checks: `python3 checks/check_workflow.py --repo .
+      --spec-dir specs/GH1458` and `python3 checks/check_workflow.py --repo .`
+      pass.
+
+## Rollback Plan
+
+Revert the manifest lint additions and restore the previous hook/workflow
+environment variables. This returns the repo to the old split fingerprint
+universe and does not require data migration.

--- a/specs/GH1459/product.md
+++ b/specs/GH1459/product.md
@@ -1,0 +1,82 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1459
+
+## User Problem
+
+Harness dev and test builds use Cargo's default full debug information because
+the workspace has no development profile override. With many test binaries,
+full debuginfo increases link time and grows `target/debug`, slowing local
+agent loops, hooks, and CI.
+
+Developers need backtraces and file-line information for failures, but the
+repository does not require full interactive debugger variable inspection for
+normal agent-driven builds.
+
+## Goals
+
+- Reduce dev and test build debug-info cost by setting the workspace dev
+  profile to line-table debug information.
+- Preserve panic backtraces with useful file and line information.
+- Decide explicitly whether dependency debuginfo should be stripped in the same
+  implementation PR.
+- Record the target directory size impact after a clean rebuild.
+- Coordinate implementation timing with GH-1458 so the build-profile and lint
+  universe changes are paid in one intended rebuild where practical.
+
+## Non-Goals
+
+- Changing `profile.release` or release artifact behavior.
+- Changing warning policy or `RUSTFLAGS`; GH-1458 owns that behavior.
+- Reworking hook scope or CI job selection; GH-1464 and GH-1454 own those
+  workflow changes.
+- Optimizing individual slow tests.
+
+## User-Visible Behavior
+
+Normal dev and test builds produce smaller debug artifacts while still
+preserving line-level panic diagnostics. A failing test backtrace should still
+show source file and line entries. Interactive debugger variable inspection may
+be less complete than with full debuginfo; that tradeoff is accepted for the
+default repository profile.
+
+If dependency debuginfo is stripped, the PR must call out that dependency stack
+frames may have less detail while workspace crate line information remains the
+primary debugging surface.
+
+## Acceptance Criteria
+
+- [ ] The root manifest defines `[profile.dev] debug = "line-tables-only"`.
+- [ ] The implementation PR explicitly decides whether to add
+      `[profile.dev.package."*"] debug = false`, with rationale in the PR body.
+- [ ] `cargo test --workspace --lib` passes with the repository's existing
+      Postgres-gated behavior.
+- [ ] A temporary forced panic or failing test confirms panic output still
+      includes file and line information, and the temporary change is reverted.
+- [ ] The PR records before/after `du -sh target/debug` evidence after a clean
+      rebuild or explains why the local measurement could not be collected.
+- [ ] If GH-1458 lands in the same PR, the verification report separates lint
+      fingerprint evidence from debug-info size evidence.
+
+## Edge Cases
+
+- `profile.test` inherits from `profile.dev`, so test binaries should benefit
+  without a separate test profile unless implementation evidence shows a
+  different setting is needed.
+- A developer needing full debuginfo for a local debugging session can override
+  locally; the repository default remains optimized for repeated agent and CI
+  loops.
+- Clean rebuild size measurements are machine- and cache-dependent, so the PR
+  should record the command and local context rather than treating the number
+  as a universal benchmark.
+- Postgres-dependent tests still require `HARNESS_DATABASE_URL`; missing local
+  Postgres should be reported as a verification limitation, not hidden.
+
+## Rollout Notes
+
+This is a build-profile change only. It should be implemented with GH-1458 or
+immediately adjacent to it so maintainers understand the one-time rebuild cost
+and the separate benefits: one compile fingerprint universe from GH-1458 and
+smaller dev/test artifacts from GH-1459.

--- a/specs/GH1459/tasks.md
+++ b/specs/GH1459/tasks.md
@@ -1,0 +1,41 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1459
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1459-T001` Owner: `workspace-profile` | Dependencies: none | Done when: root `Cargo.toml` sets `[profile.dev] debug = "line-tables-only"` and does not add unrelated release/profile changes | Verify: targeted manifest inspection
+- [ ] `SP1459-T002` Owner: `dependency-debug-decision` | Dependencies: `SP1459-T001` | Done when: the implementation either adds `[profile.dev.package."*"] debug = false` with evidence or records why dependency debuginfo stripping was deferred | Verify: PR body decision note plus manifest inspection
+- [ ] `SP1459-T003` Owner: `diagnostics-verification` | Dependencies: `SP1459-T001` | Done when: a temporary controlled panic or failing test proves file-line panic output still appears, and the temporary change is reverted before commit | Verify: captured command output or PR-body evidence
+- [ ] `SP1459-T004` Owner: `workspace-tests` | Dependencies: `SP1459-T001` | Done when: workspace lib tests pass under the new profile, using existing Postgres-gated behavior where applicable | Verify: `cargo test --workspace --lib`
+- [ ] `SP1459-T005` Owner: `size-evidence` | Dependencies: `SP1459-T001`, optional `SP1459-T002` | Done when: before/after `du -sh target/debug` evidence after a clean rebuild is recorded, or a limitation is explicitly documented | Verify: PR body evidence
+- [ ] `SP1459-T006` Owner: `specrail` | Dependencies: all implementation tasks | Done when: SpecRail workflow checks pass and the PR body records whether GH-1458 landed in the same implementation PR or an adjacent PR | Verify: `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1459 && python3 checks/check_workflow.py --repo .`
+
+## Parallelization
+
+`SP1459-T001` is the shared foundation. `SP1459-T002`, `SP1459-T003`, and
+`SP1459-T004` can proceed after the profile change if file ownership and
+temporary test edits stay isolated. `SP1459-T005` depends on the final profile
+choice. `SP1459-T006` is the final gate.
+
+## Verification
+
+- targeted `Cargo.toml` inspection
+- temporary controlled panic/backtrace check, reverted before commit
+- `cargo test --workspace --lib`
+- `du -sh target/debug` before and after clean rebuild, or documented limitation
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1459`
+- `python3 checks/check_workflow.py --repo .`
+
+## Handoff Notes
+
+GH-1459 is intentionally coordinated with GH-1458. A combined implementation PR
+may close both issues only if it satisfies both spec packets. A spec-only PR
+must use `Refs #1459` and must not close the issue.

--- a/specs/GH1459/tech.md
+++ b/specs/GH1459/tech.md
@@ -1,0 +1,101 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1459
+
+## Product Spec
+
+See `specs/GH1459/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Workspace manifest | `Cargo.toml` | The root manifest has no `[profile.dev]` or `[profile.test]` section. | Cargo defaults to full debuginfo for dev/test builds. |
+| Test builds | workspace crates under `crates/` | `cargo test --workspace --lib` links many test binaries using the inherited dev profile. | Link time and artifact size are the direct user problem. |
+| Local target dir | `target/debug` | The issue reports very large accumulated `deps` and `incremental` artifacts. | Size evidence should be captured before and after the profile change. |
+| Debugging behavior | panic output and backtraces | Full debuginfo is more detailed than line tables. | The implementation must prove panic diagnostics still include file-line data. |
+| GH-1458 coordination | `Cargo.toml`, hooks, workflows | GH-1458 changes lint policy in the same manifest. | A combined implementation avoids two separate full rebuilds. |
+
+## Proposed Design
+
+1. Add the dev profile override to the root `Cargo.toml`:
+
+   ```toml
+   [profile.dev]
+   debug = "line-tables-only"
+   ```
+
+2. Evaluate dependency debuginfo stripping in the implementation PR:
+
+   ```toml
+   [profile.dev.package."*"]
+   debug = false
+   ```
+
+   Include it only if local verification shows a clear size or link-time benefit
+   without unacceptable diagnostics loss. The PR body must record the decision.
+
+3. Rely on `profile.test` inheritance from `profile.dev` unless verification
+   shows test builds require an explicit test profile. Do not add a separate
+   `profile.test` setting without evidence.
+
+4. Verify panic diagnostics by temporarily forcing a controlled test panic or
+   assertion failure, running the focused test command with backtraces enabled,
+   inspecting file-line output, and reverting the temporary failure before
+   commit.
+
+5. Collect size evidence with `du -sh target/debug` before and after a clean
+   rebuild. If the local environment cannot afford a full clean rebuild, record
+   that limitation and provide the strongest available partial evidence.
+
+## Data Flow
+
+Cargo applies the dev profile to workspace dev builds and to test builds through
+the default profile inheritance. The produced artifacts retain line tables for
+source locations while omitting full variable-level debuginfo. Test and check
+commands use the same source code paths; only compiler profile settings change.
+
+## Alternatives Considered
+
+- Keep full debuginfo by default. Rejected because it preserves the reported
+  target-dir and link-time cost for every normal agent loop.
+- Set `debug = false` for all dev builds. Rejected because panic backtraces and
+  file-line diagnostics are an important default workflow surface.
+- Add only dependency stripping without line tables for workspace crates.
+  Rejected as the primary change because it does not address workspace test
+  binary debug-info cost as directly.
+- Add a separate `profile.test`. Rejected unless verification shows inheritance
+  is insufficient.
+
+## Risks
+
+- Security: no direct security surface; this changes compiler artifact detail.
+- Compatibility: interactive debugger sessions may lose variable inspection
+  detail. Developers can override locally for deep debugging.
+- Performance: the first profile change causes an expected rebuild. Subsequent
+  dev/test builds should link and store less debug data.
+- Maintenance: dependency debuginfo stripping may make third-party stack frames
+  less informative; the implementation PR must make that tradeoff explicit.
+
+## Test Plan
+
+- [ ] Build profile audit: root `Cargo.toml` contains
+      `[profile.dev] debug = "line-tables-only"`.
+- [ ] Optional dependency profile decision recorded in the PR body and, if
+      enabled, present under `[profile.dev.package."*"]`.
+- [ ] `cargo test --workspace --lib` passes, using documented Postgres
+      configuration or existing skips where applicable.
+- [ ] Backtrace check: a temporary failing test or panic still prints file-line
+      information with the new profile, and the temporary change is reverted.
+- [ ] Size check: record `du -sh target/debug` before and after a clean rebuild
+      or record a clear limitation.
+- [ ] SpecRail checks: `python3 checks/check_workflow.py --repo .
+      --spec-dir specs/GH1459` and `python3 checks/check_workflow.py --repo .`
+      pass.
+
+## Rollback Plan
+
+Revert the `[profile.dev]` and optional dependency-profile changes. This
+restores full dev/test debuginfo and does not require data migration.


### PR DESCRIPTION
## Summary
- Add SpecRail product, tech, and task plans for GH-1458 workspace lint unification.
- Add SpecRail product, tech, and task plans for GH-1459 dev-profile debuginfo reduction.
- Record the coordinated implementation relationship because both issues ask to land together.

Refs #1458
Refs #1459

## Verification
- `python3 checks/route_gate.py --repo . --route write_spec --issue 1458 --state ready_to_spec --json`
- `python3 checks/route_gate.py --repo . --route write_spec --issue 1459 --state ready_to_spec --json`
- `python3 checks/route_gate.py --repo . --route implement --issue 1458 --state ready_to_implement --json`
- `python3 checks/route_gate.py --repo . --route implement --issue 1459 --state ready_to_implement --json`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1458`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1459`
- `python3 checks/check_workflow.py --repo .`
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`