### PR TITLE
Unify build warning policy and dev debug profile

### DIFF
--- a/.github/workflows/ci-disabled-modules.yml
+++ b/.github/workflows/ci-disabled-modules.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -Dwarnings
 
 jobs:
   check-all-features:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -Dwarnings
 
 jobs:
   # ── Step 1: Detect changed paths ──────────────────────────────────────
@@ -121,7 +120,7 @@ jobs:
         with:
           name: web-dist
           path: web/dist
-      - run: cargo clippy --workspace --all-targets
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   # ── Step 4: Tests (scoped to affected crates) ─────────────────────────
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ All outputs MUST be in English, including:
 
 - `cargo check` after every change
 - `cargo test` before commit
-- Before pushing a PR, ALWAYS run `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets` to catch CI-equivalent errors (dead code, unused imports, missing match arms)
+- Before pushing a PR, ALWAYS run `cargo clippy --workspace --all-targets -- -D warnings` to catch CI-equivalent warnings and lints (dead code, unused imports, missing match arms, clippy findings)
 - When adding a new enum variant, grep ALL match sites for that enum and update them — CI uses exhaustive match checks
 - Run `cargo fmt --all` before every commit — CI enforces `cargo fmt --all -- --check`
 - Dead code in `#[cfg(test)]` modules still triggers `-D warnings` in CI; delete unused test helpers instead of suppressing with `#[allow(dead_code)]`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ license = "MIT"
 rust-version = "1.88"
 repository = "https://github.com/majiayu000/harness"
 
+[workspace.lints.rust]
+warnings = "deny"
+
 [workspace.dependencies]
 # Internal crates (version required so they can be published to crates.io)
 harness-core = { path = "crates/harness-core", version = "0.6.34" }
@@ -108,3 +111,9 @@ sysinfo = { version = "0.32", default-features = false, features = ["system"] }
 
 # Testing
 tempfile = "3"
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ check:
 
 lint:
 	cargo fmt --all -- --check
-	RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets
+	cargo clippy --workspace --all-targets -- -D warnings
 
 test:
 	cargo test --workspace

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,7 +36,8 @@ across parallel PRs.
 5. Verify locally:
    ```bash
    cargo fmt --all -- --check
-   RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
+   cargo check --workspace --all-targets
+   cargo clippy --workspace --all-targets -- -D warnings
    cargo test --workspace
    ```
 6. Commit (`-s` for DCO), open a PR titled `chore(release): vX.Y.Z`, wait for CI

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -75,7 +75,8 @@ activities:
       - cargo fmt --all -- --check
       - cargo check
       - cargo test
-      - RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets
+      - cargo check --workspace --all-targets
+      - cargo clippy --workspace --all-targets -- -D warnings
   run_local_review:
     prompt: pr_feedback
   inspect_pr_feedback:

--- a/crates/harness-agents/Cargo.toml
+++ b/crates/harness-agents/Cargo.toml
@@ -6,6 +6,9 @@ description = "Agent adapters (Claude Code, Codex) for the Harness orchestration
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 harness-observe = { workspace = true }

--- a/crates/harness-cli/Cargo.toml
+++ b/crates/harness-cli/Cargo.toml
@@ -6,6 +6,9 @@ description = "Command-line interface for the Harness agent orchestration layer"
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "harness"
 path = "src/main.rs"

--- a/crates/harness-context/Cargo.toml
+++ b/crates/harness-context/Cargo.toml
@@ -6,6 +6,9 @@ description = "Deterministic context composition for the Harness agent orchestra
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 harness-rules = { workspace = true }

--- a/crates/harness-core/Cargo.toml
+++ b/crates/harness-core/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 description = "Core domain model, configuration, prompts, and agent traits for Harness"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/harness-eval/Cargo.toml
+++ b/crates/harness-eval/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 serde = { workspace = true }

--- a/crates/harness-exec/Cargo.toml
+++ b/crates/harness-exec/Cargo.toml
@@ -6,6 +6,9 @@ description = "Process execution helpers for the Harness agent orchestration lay
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 serde = { workspace = true }

--- a/crates/harness-gc/Cargo.toml
+++ b/crates/harness-gc/Cargo.toml
@@ -6,6 +6,9 @@ description = "Garbage collection and workspace cleanup for the Harness agent or
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 harness-rules = { workspace = true }

--- a/crates/harness-observe/Cargo.toml
+++ b/crates/harness-observe/Cargo.toml
@@ -6,6 +6,9 @@ description = "Observability (logging, tracing, metrics) for the Harness agent o
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 serde = { workspace = true }

--- a/crates/harness-protocol/Cargo.toml
+++ b/crates/harness-protocol/Cargo.toml
@@ -6,6 +6,9 @@ description = "Protocol and message types for the Harness agent orchestration la
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 harness-core = { workspace = true }

--- a/crates/harness-rules/Cargo.toml
+++ b/crates/harness-rules/Cargo.toml
@@ -6,6 +6,9 @@ description = "Rule loading and evaluation for the Harness agent orchestration l
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 serde = { workspace = true }

--- a/crates/harness-sandbox/Cargo.toml
+++ b/crates/harness-sandbox/Cargo.toml
@@ -6,6 +6,9 @@ description = "Sandbox and isolation primitives for the Harness agent orchestrat
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -6,6 +6,9 @@ description = "HTTP server, task runner, and workflow runtime for the Harness ag
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 harness-protocol = { workspace = true }

--- a/crates/harness-skills/Cargo.toml
+++ b/crates/harness-skills/Cargo.toml
@@ -6,6 +6,9 @@ description = "Skill discovery and management for the Harness agent orchestratio
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 serde = { workspace = true }

--- a/crates/harness-workflow/Cargo.toml
+++ b/crates/harness-workflow/Cargo.toml
@@ -6,6 +6,9 @@ description = "Workflow runtime and state machine for the Harness agent orchestr
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 harness-core = { workspace = true }
 harness-observe = { workspace = true }


### PR DESCRIPTION
## Summary
- Move workspace warning denial into Cargo manifests with `[workspace.lints.rust] warnings = "deny"` and `[lints] workspace = true` in every workspace crate.
- Remove functional `RUSTFLAGS=-Dwarnings` usage from CI, hooks/Makefile, and active workflow/release instructions; keep clippy strictness via `-- -D warnings`.
- Set the dev profile to `debug = "line-tables-only"` and strip dependency debuginfo with `[profile.dev.package."*"] debug = false` to shrink dev/test artifacts while preserving file-line panic diagnostics.

Fixes #1458
Fixes #1459

## Dependency debuginfo decision
Included `[profile.dev.package."*"] debug = false`. The repository's default workflow favors fast agent/CI loops over dependency variable inspection, and the backtrace probe still showed file-line diagnostics for workspace code. Developers who need full dependency debuginfo can override locally.

## Evidence
- Functional RUSTFLAGS search over `.github .githooks CLAUDE.md AGENTS.md README.md RELEASING.md WORKFLOW.md Makefile scripts .cargo Cargo.toml`: no matches.
- Manifest audit: every `crates/*/Cargo.toml` contains `[lints] workspace = true`.
- Negative warning probe: temporary unused variable made `cargo check -p harness-core --lib` fail with `-D unused-variables` implied by `-D warnings`; probe reverted.
- Backtrace probe: temporary panic test printed `crates/harness-core/src/lib.rs:38:9` and stack frames with file-line output; probe reverted.
- Size evidence in this worktree: `target/debug` was 71G before cleaning mixed old artifacts; `cargo clean` removed 101.2GiB; after clean rebuild/test under the new profile, `target/debug` is 5.9G.
- Fingerprint stability: clean `cargo check --workspace --all-targets` 46.55s; first clippy 37.06s; repeated check 0.27s; repeated clippy 0.29s.

## Verification
- `cargo check --workspace --all-targets` (clean rebuild): passed, 46.55s
- `cargo clippy --workspace --all-targets -- -D warnings`: passed, 37.06s first run; final incremental run 0.31s
- `cargo test --workspace --lib` with `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test`: passed, 359 tests
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1458`: passed
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1459`: passed
- `python3 checks/check_workflow.py --repo .`: passed
