### PR TITLE
Spec GH1460 target GC tooling

### DIFF
--- a/specs/GH1460/product.md
+++ b/specs/GH1460/product.md
@@ -1,0 +1,99 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1460
+
+## User Problem
+
+Harness developer target directories can grow without bound across normal
+workspace builds and parallel `CARGO_TARGET_DIR` universes. The reported primary
+machine had `target/` at 176 GB, including large `deps`, `incremental`, and
+auxiliary `target/cargo-*` directories. This consumes disk and makes workspace
+checks spend substantial time on filesystem metadata for stale artifacts.
+
+Developers need a bounded, manual cleanup tool that makes the size of each
+target universe visible, removes stale build artifacts safely, and can be run
+repeatedly without destructive surprises.
+
+## Goals
+
+- Provide a manual `scripts/gc-target.sh` cleanup command for `target/` and
+  auxiliary `target/cargo-*` directories.
+- Prefer `cargo sweep --time <days>` when the optional `cargo-sweep` tool is
+  installed.
+- Provide a deterministic fallback that removes stale files or directories by
+  mtime when `cargo-sweep` is unavailable.
+- Print before/after per-universe size reports and a clear freed-space summary.
+- Add a `make gc-target` alias.
+- Document usage, default retention, cadence, and safety caveats in
+  `CONTRIBUTING.md`.
+
+## Non-Goals
+
+- Automatic scheduling through launchd, cron, CI, or background runtime tasks.
+- Performing or recording the one-time cleanup of any specific developer
+  machine's existing backlog.
+- Changing Cargo profile settings or lint policy; those were handled by
+  GH-1458 and GH-1459.
+- Touching the `harness-gc` crate, which owns agent workspace cleanup and is a
+  different domain.
+- Deleting source files, Cargo manifests, lockfiles, or any path outside
+  repository-local target directories.
+
+## User-Visible Behavior
+
+A developer can run the target GC script from the repository root. By default it
+keeps artifacts newer than 14 days and considers the repository-local `target/`
+directory plus auxiliary `target/cargo-*` directories. The script prints a size
+table before cleanup, performs either the `cargo-sweep` path or fallback mtime
+cleanup, and prints the size table again with bytes freed.
+
+If `target/` does not exist, the command exits successfully with a clear no-op
+message. If the command is run twice with the same retention window, the second
+run should report no additional cleanup beyond any files that aged into the
+window between runs.
+
+The documentation must warn that running target GC while a Cargo build is
+active can force rebuilds or conflict with Cargo's build directory activity.
+The tool remains manual so the operator controls timing.
+
+## Acceptance Criteria
+
+- [ ] `scripts/gc-target.sh` exists, is executable, and supports a default
+      retention window of 14 days.
+- [ ] The script accepts a configurable retention window without requiring
+      source edits.
+- [ ] The script reports per-universe sizes before and after cleanup.
+- [ ] When `cargo sweep` is installed, the script prefers `cargo sweep --time`
+      or the equivalent installed CLI for supported target directories.
+- [ ] When `cargo sweep` is not installed, the script falls back to bounded
+      mtime-based cleanup inside `target/*/{deps,incremental,build}` and
+      equivalent auxiliary `target/cargo-*` universes.
+- [ ] Running the script with no `target/` directory succeeds as a no-op.
+- [ ] Running the script twice in a row is idempotent; the second run reports
+      no additional removals when no artifacts aged into scope.
+- [ ] `make gc-target` runs the script.
+- [ ] `CONTRIBUTING.md` documents usage, recommended cadence, retention, and
+      the caveat about avoiding active Cargo builds.
+- [ ] The script is `shellcheck` clean.
+
+## Edge Cases
+
+- `target/` exists but some expected child directories do not; the script should
+  skip missing paths without error.
+- File names may include spaces or unusual characters; cleanup should avoid
+  unsafe word splitting.
+- Running from a subdirectory should either resolve the repository root or fail
+  with an explicit message.
+- An artifact can disappear between size calculation and deletion; the script
+  should tolerate that race and continue.
+- If `cargo-sweep` fails for a target universe, the script should surface the
+  failure instead of silently reporting success.
+
+## Rollout Notes
+
+This is a manual developer tooling change. The implementation PR should not
+claim to have cleaned any operator machine. It should verify behavior against a
+temporary target fixture and document real local disk measurements only as
+environment-specific evidence.

--- a/specs/GH1460/tasks.md
+++ b/specs/GH1460/tasks.md
@@ -1,0 +1,42 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1460
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1460-T001` Owner: `target-gc-script` | Dependencies: none | Done when: `scripts/gc-target.sh` exists, is executable, parses `--days` and `--dry-run`, discovers repository-local target universes, reports before/after sizes, and refuses invalid retention values | Verify: `scripts/gc-target.sh --help` and fixture-based script tests
+- [ ] `SP1460-T002` Owner: `cargo-sweep-path` | Dependencies: `SP1460-T001` | Done when: the script prefers `cargo sweep` when installed and surfaces any sweep failure instead of silently falling back to success | Verify: PATH shim test that records `cargo sweep` invocation
+- [ ] `SP1460-T003` Owner: `fallback-cleanup` | Dependencies: `SP1460-T001` | Done when: the fallback path removes only stale artifacts under bounded `deps`, `incremental`, and `build` directories, skips missing paths, avoids symlink traversal, and supports dry-run | Verify: temporary fixture tests for stale, fresh, missing, and dry-run cases
+- [ ] `SP1460-T004` Owner: `make-and-docs` | Dependencies: `SP1460-T001` | Done when: `make gc-target` invokes the script and `CONTRIBUTING.md` documents usage, cadence, retention, and active-build caveats | Verify: `make -n gc-target` plus documentation review
+- [ ] `SP1460-T005` Owner: `verification` | Dependencies: all implementation tasks | Done when: shell lint, focused script tests, formatting, clippy, and SpecRail checks pass, with any unavailable optional local tooling explicitly recorded | Verify: `shellcheck scripts/gc-target.sh`, focused fixture tests, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1460`, and `python3 checks/check_workflow.py --repo .`
+
+## Parallelization
+
+`SP1460-T001` is the foundation. `SP1460-T002`, `SP1460-T003`, and
+`SP1460-T004` can proceed after the script shape is established if file
+ownership is kept disjoint. `SP1460-T005` is the final verification gate.
+
+## Verification
+
+- `scripts/gc-target.sh --help`
+- focused fixture tests for no-target, stale cleanup, idempotence, dry-run, and
+  cargo-sweep preference
+- `make -n gc-target`
+- `shellcheck scripts/gc-target.sh`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1460`
+- `python3 checks/check_workflow.py --repo .`
+
+## Handoff Notes
+
+Do not close GH-1460 from a spec-only PR. Use `Refs #1460` for the spec PR and
+reserve a closing keyword for the implementation PR that adds the script, make
+alias, docs, and verification evidence.

--- a/specs/GH1460/tech.md
+++ b/specs/GH1460/tech.md
@@ -1,0 +1,113 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1460
+
+## Product Spec
+
+See `specs/GH1460/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Scripts | `scripts/` | The repo has operational shell scripts but no target-dir cleanup script. | New tooling belongs under `scripts/` and should follow existing shell style. |
+| Make aliases | `Makefile` | Existing aliases cover setup, check, lint, and test. | `make gc-target` should be a thin wrapper around the script. |
+| Contributor docs | `CONTRIBUTING.md` | Development setup describes build and test commands but no target-dir maintenance. | This is the canonical place for manual cadence and caveats. |
+| Build outputs | `target/`, `target/cargo-*` | Build artifacts can accumulate across default and auxiliary target universes. | These are the only directories in scope for deletion. |
+| Cargo profiles | `Cargo.toml` | GH-1458/GH-1459 already moved warning policy and dev debuginfo. | GH-1460 should not modify profile or lint settings. |
+| Agent GC | `crates/harness-gc/` | Handles agent workspace cleanup. | It is intentionally unrelated to Cargo target cleanup. |
+
+## Proposed Design
+
+1. Add `scripts/gc-target.sh`.
+   - Use `set -euo pipefail`.
+   - Resolve the repository root from the script path or `git rev-parse
+     --show-toplevel`.
+   - Default retention to 14 days.
+   - Support a documented flag such as `--days <N>` and `--dry-run`.
+   - Reject invalid or negative retention values with a clear error.
+2. Discover target universes.
+   - Include the root `target/` directory when present.
+   - Include direct child directories matching `target/cargo-*`.
+   - Keep the universe list repository-local; do not inspect global Cargo
+     caches or sibling repositories.
+3. Report sizes.
+   - Print `du -sh` for each discovered universe before cleanup.
+   - Print the same report after cleanup.
+   - Compute total bytes before and after using a stable command available on
+     macOS and Linux, with a fallback if exact byte accounting is unavailable.
+4. Prefer `cargo sweep`.
+   - If `cargo sweep` is available, run it for each target universe with the
+     configured retention window.
+   - Pass the target directory explicitly where the installed CLI supports it;
+     otherwise run from the repository root for the default `target/` and use
+     the fallback for auxiliary universes that cannot be addressed safely.
+5. Fallback cleanup.
+   - When `cargo sweep` is not available, use `find` against bounded artifact
+     subtrees: `deps`, `incremental`, and `build` under each universe.
+   - Remove only paths older than the retention window.
+   - Avoid following symlinks.
+   - Support `--dry-run` by reporting what would be removed.
+6. Wire `make gc-target`.
+   - Add a phony target that invokes `scripts/gc-target.sh`.
+7. Document usage in `CONTRIBUTING.md`.
+   - Include default and custom retention examples.
+   - Recommend running manually when disk grows or before large branch changes.
+   - Warn not to run during active Cargo builds.
+
+## Data Flow
+
+The operator invokes `make gc-target` or `scripts/gc-target.sh`. The script
+parses retention options, discovers repository-local target universes, captures
+before sizes, executes either `cargo-sweep` or fallback cleanup for each
+universe, captures after sizes, and prints the freed-space summary. No
+application data, databases, remote services, or Harness runtime state are read
+or modified.
+
+## Alternatives Considered
+
+- Add an automatic scheduled cleanup. Rejected because GH-1460 explicitly leaves
+  cadence to the owner and requires manual safety.
+- Put this in `harness-gc`. Rejected because `harness-gc` is for agent
+  workspace cleanup, not Cargo build artifact maintenance.
+- Delete all of `target/` unconditionally. Rejected because bounded stale
+  cleanup is safer and keeps recent incremental artifacts.
+- Require `cargo-sweep`. Rejected because the script must remain useful on a
+  fresh developer machine without additional tools.
+
+## Risks
+
+- Security: shell path handling must avoid unsafe word splitting and must not
+  delete outside repository-local target directories.
+- Compatibility: `find`, `stat`, and `du` flags differ between macOS and Linux;
+  the implementation should use portable forms or guarded helpers.
+- Performance: size calculation over very large target directories can be slow,
+  but it is part of the explicit manual maintenance command.
+- Maintenance: `cargo-sweep` CLI flags may differ by version; the script should
+  keep fallback cleanup deterministic and visible.
+
+## Test Plan
+
+- [ ] Script unit/fixture test: create a temporary target fixture with old and
+      fresh files, run the fallback path, and assert only stale artifacts are
+      removed.
+- [ ] Idempotence test: run the script twice against the same fixture and assert
+      the second run removes nothing.
+- [ ] Fresh clone test: run the script when `target/` is absent and assert a
+      successful no-op.
+- [ ] Dry-run test: assert `--dry-run` reports candidates without deleting
+      them.
+- [ ] Shell lint: `shellcheck scripts/gc-target.sh` passes when shellcheck is
+      installed; otherwise record that shellcheck is unavailable locally and
+      rely on CI if configured.
+- [ ] Repository checks: `cargo fmt --all -- --check`,
+      `cargo clippy --workspace --all-targets -- -D warnings`, and SpecRail
+      workflow checks pass.
+
+## Rollback Plan
+
+Remove `scripts/gc-target.sh`, the `make gc-target` alias, and the
+`CONTRIBUTING.md` documentation. Because this is manual developer tooling, no
+runtime state or persisted data rollback is required.


### PR DESCRIPTION
## Summary
- Add the SpecRail product spec for GH-1460 target-dir GC tooling.
- Add the technical design for a manual `scripts/gc-target.sh` flow with cargo-sweep preference and fallback cleanup.
- Add the task plan for script, make alias, docs, tests, shell lint, and verification.

Refs #1460

## Verification
- `python3 checks/route_gate.py --repo . --route write_spec --issue 1460 --state ready_to_spec --json`
- `python3 checks/route_gate.py --repo . --route implement --issue 1460 --state ready_to_implement --json`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1460`
- `python3 checks/check_workflow.py --repo .`
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`