### PR TITLE
Add bounded target GC tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,31 @@ HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/t
 HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness scripts/test-server-db.sh
 ```
 
+## Target Directory Cleanup
+
+Cargo build artifacts can accumulate across the default `target/` directory and
+auxiliary `target/cargo-*` target directories. Use the manual target GC command
+when disk usage grows unexpectedly or before large branch changes:
+
+```bash
+make gc-target
+```
+
+The command keeps artifacts newer than 14 days by default, prints before/after
+size reports, and summarizes freed bytes. Use a custom retention window when
+needed:
+
+```bash
+scripts/gc-target.sh --days 7
+scripts/gc-target.sh --days 30 --dry-run
+```
+
+If `cargo sweep` is installed, the script prefers it for the default Cargo
+target directory. Otherwise it falls back to bounded mtime cleanup under Cargo
+artifact subdirectories. Run this manually when no Cargo build is active;
+cleaning target directories during an active build can force rebuilds or
+conflict with Cargo's build directory activity.
+
 ## Pull Request Guidelines
 
 1. Keep PRs focused and small when possible.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup check test lint
+.PHONY: setup check test lint gc-target
 
 setup:
 	git config core.hooksPath .githooks
@@ -13,3 +13,6 @@ lint:
 
 test:
 	cargo test --workspace
+
+gc-target:
+	scripts/gc-target.sh

--- a/scripts/gc-target.sh
+++ b/scripts/gc-target.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Manually clean stale Cargo build artifacts from repository-local target dirs.
+set -euo pipefail
+
+DEFAULT_DAYS=14
+DAYS="$DEFAULT_DAYS"
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/gc-target.sh [--days N] [--dry-run]
+
+Manually removes stale Cargo build artifacts from repository-local target
+directories. The default retention window is 14 days.
+
+Options:
+  --days N    Keep artifacts newer than N days. N must be a non-negative integer.
+  --dry-run   Print stale artifact candidates without deleting them.
+  -h, --help  Show this help text.
+
+The script prefers cargo sweep when it is installed. Without cargo sweep, it
+falls back to mtime-based cleanup under target profile artifact directories.
+Do not run it while Cargo builds are active in this repository.
+EOF
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --days)
+      [ "$#" -ge 2 ] || fail "--days requires a value"
+      DAYS="$2"
+      shift 2
+      ;;
+    --days=*)
+      DAYS="${1#--days=}"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ ! "$DAYS" =~ ^[0-9]+$ ]]; then
+  fail "--days must be a non-negative integer"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET_ROOT="$REPO_ROOT/target"
+
+TARGET_UNIVERSES=()
+if [ -d "$TARGET_ROOT" ]; then
+  TARGET_UNIVERSES+=("$TARGET_ROOT")
+  for universe in "$TARGET_ROOT"/cargo-*; do
+    [ -d "$universe" ] || continue
+    TARGET_UNIVERSES+=("$universe")
+  done
+fi
+
+if [ "${#TARGET_UNIVERSES[@]}" -eq 0 ]; then
+  echo "No repository target directories found under $TARGET_ROOT; nothing to clean."
+  exit 0
+fi
+
+relative_path() {
+  local path="$1"
+  if [[ "$path" == "$REPO_ROOT/"* ]]; then
+    printf '%s\n' "${path#"$REPO_ROOT"/}"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
+dir_size_human() {
+  local path="$1"
+  du -sh "$path" 2>/dev/null | awk '{print $1}'
+}
+
+dir_size_bytes() {
+  local path="$1"
+  if [ ! -d "$path" ]; then
+    echo 0
+    return
+  fi
+  du -sk "$path" 2>/dev/null | awk '{print $1 * 1024}'
+}
+
+print_sizes() {
+  local label="$1"
+  local universe size
+
+  echo "$label target sizes:"
+  for universe in "${TARGET_UNIVERSES[@]}"; do
+    [ -d "$universe" ] || continue
+    size="$(dir_size_human "$universe")"
+    echo "  $(relative_path "$universe"): $size"
+  done
+}
+
+has_cargo_sweep() {
+  command -v cargo >/dev/null 2>&1 && cargo sweep --help >/dev/null 2>&1
+}
+
+run_cargo_sweep_default_target() {
+  echo "Using cargo sweep for target with retention ${DAYS}d."
+  (
+    cd "$REPO_ROOT"
+    cargo sweep --time "$DAYS"
+  )
+}
+
+FALLBACK_CANDIDATES=0
+FALLBACK_REMOVED=0
+
+cleanup_artifact_dir() {
+  local artifact_dir="$1"
+  local candidates path count
+
+  [ -d "$artifact_dir" ] || return 0
+
+  candidates="$(mktemp "${TMPDIR:-/tmp}/harness-gc-target.XXXXXX")"
+  if ! find "$artifact_dir" -depth -mindepth 1 -mtime +"$DAYS" -print0 > "$candidates"; then
+    rm -f "$candidates"
+    echo "failed to scan $(relative_path "$artifact_dir")" >&2
+    return 1
+  fi
+
+  count=0
+  while IFS= read -r -d '' path; do
+    count=$((count + 1))
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "  would remove $(relative_path "$path")"
+    elif [ -e "$path" ] || [ -L "$path" ]; then
+      rm -rf -- "$path"
+      FALLBACK_REMOVED=$((FALLBACK_REMOVED + 1))
+    fi
+  done < "$candidates"
+  rm -f "$candidates"
+
+  FALLBACK_CANDIDATES=$((FALLBACK_CANDIDATES + count))
+}
+
+run_fallback_for_universe() {
+  local universe="$1"
+  local name profile base
+
+  echo "Scanning $(relative_path "$universe") with fallback mtime cleanup."
+
+  for name in deps incremental build; do
+    cleanup_artifact_dir "$universe/$name"
+  done
+
+  for profile in "$universe"/*; do
+    [ -d "$profile" ] || continue
+    base="${profile##*/}"
+    if [ "$universe" = "$TARGET_ROOT" ] && [[ "$base" == cargo-* ]]; then
+      continue
+    fi
+    for name in deps incremental build; do
+      cleanup_artifact_dir "$profile/$name"
+    done
+  done
+}
+
+run_fallback_cleanup() {
+  local universe
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "Dry run: reporting stale fallback cleanup candidates older than ${DAYS}d."
+  else
+    echo "Using fallback mtime cleanup for artifacts older than ${DAYS}d."
+  fi
+
+  for universe in "${TARGET_UNIVERSES[@]}"; do
+    run_fallback_for_universe "$universe"
+  done
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "Dry run candidates: $FALLBACK_CANDIDATES"
+  else
+    echo "Fallback removed paths: $FALLBACK_REMOVED"
+  fi
+}
+
+print_sizes "Before"
+BEFORE_BYTES="$(dir_size_bytes "$TARGET_ROOT")"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  run_fallback_cleanup
+elif has_cargo_sweep; then
+  run_cargo_sweep_default_target
+  for universe in "${TARGET_UNIVERSES[@]}"; do
+    [ "$universe" != "$TARGET_ROOT" ] || continue
+    run_fallback_for_universe "$universe"
+  done
+else
+  run_fallback_cleanup
+fi
+
+AFTER_BYTES="$(dir_size_bytes "$TARGET_ROOT")"
+print_sizes "After"
+
+if [ "$BEFORE_BYTES" -gt "$AFTER_BYTES" ]; then
+  FREED_BYTES=$((BEFORE_BYTES - AFTER_BYTES))
+else
+  FREED_BYTES=0
+fi
+
+echo "Freed: ${FREED_BYTES} bytes"

--- a/scripts/test_gc_target.py
+++ b/scripts/test_gc_target.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Tests for scripts/gc-target.sh."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).parent
+SCRIPT = SCRIPT_DIR / "gc-target.sh"
+
+
+class GcTargetTests(unittest.TestCase):
+    def make_repo(self, tmp: Path) -> Path:
+        repo = tmp / "repo"
+        scripts = repo / "scripts"
+        scripts.mkdir(parents=True)
+        shutil.copy2(SCRIPT, scripts / "gc-target.sh")
+        (scripts / "gc-target.sh").chmod(0o755)
+        return repo
+
+    def run_script(
+        self,
+        repo: Path,
+        *args: str,
+        cargo_mode: str = "missing",
+    ) -> subprocess.CompletedProcess[str]:
+        bin_dir = repo / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        cargo = bin_dir / "cargo"
+
+        if cargo_mode == "missing":
+            cargo.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+        elif cargo_mode == "sweep":
+            log = repo / "cargo-sweep.log"
+            cargo.write_text(
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$*\" >> \""
+                + str(log)
+                + "\"\n"
+                "if [ \"$1\" = sweep ]; then exit 0; fi\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+        else:
+            raise ValueError(f"unknown cargo_mode: {cargo_mode}")
+
+        cargo.chmod(0o755)
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+
+        return subprocess.run(
+            [str(repo / "scripts" / "gc-target.sh"), *args],
+            cwd=repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def write_artifact(self, path: Path, age_days: int) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("artifact", encoding="utf-8")
+        timestamp = time.time() - age_days * 24 * 60 * 60
+        os.utime(path, (timestamp, timestamp))
+
+    def test_help_and_executable_bit(self) -> None:
+        mode = SCRIPT.stat().st_mode
+        self.assertTrue(mode & stat.S_IXUSR)
+
+        result = subprocess.run(
+            [str(SCRIPT), "--help"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--days N", result.stdout)
+        self.assertIn("--dry-run", result.stdout)
+
+    def test_no_target_is_successful_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = self.make_repo(Path(raw))
+
+            result = self.run_script(repo)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("nothing to clean", result.stdout)
+
+    def test_fallback_removes_only_stale_bounded_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = self.make_repo(Path(raw))
+            stale = repo / "target" / "debug" / "deps" / "old file.o"
+            fresh = repo / "target" / "debug" / "deps" / "fresh.o"
+            outside = repo / "target" / "debug" / "other" / "old.o"
+            aux_stale = repo / "target" / "cargo-check" / "debug" / "build" / "old.o"
+            self.write_artifact(stale, age_days=3)
+            self.write_artifact(fresh, age_days=0)
+            self.write_artifact(outside, age_days=3)
+            self.write_artifact(aux_stale, age_days=3)
+
+            result = self.run_script(repo, "--days", "1")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(stale.exists())
+            self.assertTrue(fresh.exists())
+            self.assertTrue(outside.exists())
+            self.assertFalse(aux_stale.exists())
+            self.assertIn("Fallback removed paths:", result.stdout)
+
+    def test_dry_run_reports_without_deleting(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = self.make_repo(Path(raw))
+            stale = repo / "target" / "debug" / "incremental" / "old"
+            self.write_artifact(stale, age_days=3)
+
+            result = self.run_script(repo, "--days=1", "--dry-run")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(stale.exists())
+            self.assertIn("would remove target/debug/incremental/old", result.stdout)
+            self.assertIn("Dry run candidates: 1", result.stdout)
+
+    def test_fallback_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = self.make_repo(Path(raw))
+            stale = repo / "target" / "debug" / "build" / "old"
+            self.write_artifact(stale, age_days=3)
+
+            first = self.run_script(repo, "--days", "1")
+            second = self.run_script(repo, "--days", "1")
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertIn("Fallback removed paths: 1", first.stdout)
+            self.assertIn("Fallback removed paths: 0", second.stdout)
+
+    def test_cargo_sweep_is_preferred_when_available(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = self.make_repo(Path(raw))
+            self.write_artifact(repo / "target" / "debug" / "deps" / "old", age_days=3)
+
+            result = self.run_script(repo, "--days", "9", cargo_mode="sweep")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Using cargo sweep", result.stdout)
+            log = (repo / "cargo-sweep.log").read_text(encoding="utf-8")
+            self.assertIn("sweep --help", log)
+            self.assertIn("sweep --time 9", log)
+
+    def test_invalid_days_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = self.make_repo(Path(raw))
+
+            result = self.run_script(repo, "--days", "-1")
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("non-negative integer", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `scripts/gc-target.sh` for manual repository-local Cargo target cleanup with `--days` and `--dry-run`.
- Adds `make gc-target` and contributor docs covering retention, cadence, and active-build caveats.
- Adds fixture tests for no-target no-op, fallback cleanup, dry-run, idempotence, invalid retention, and cargo-sweep preference.

Closes #1460

## Verification
- `scripts/gc-target.sh --help`
- `python3 scripts/test_gc_target.py`
- `make -n gc-target`
- `bash -n scripts/gc-target.sh`
- `shellcheck scripts/gc-target.sh` was not run because `shellcheck` is unavailable locally
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1460`
- `python3 checks/check_workflow.py --repo .`
- `git diff --check`
- `cargo fmt --all -- --check`
- `python3 -m py_compile scripts/test_gc_target.py`
- `cargo clippy --workspace --all-targets -- -D warnings`
