### PR TITLE
Spec GH1461 catalog bloat metrics

### DIFF
--- a/specs/GH1461/product.md
+++ b/specs/GH1461/product.md
@@ -1,0 +1,89 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1461
+
+## User Problem
+
+Harness previously accumulated severe Postgres catalog growth before operators
+had a visible signal. The orphan-schema reaper now bounds one known leak path,
+but a stalled reaper or a new leak could again grow `pg_namespace`, `pg_class`,
+and total database size without showing up in the health surface or operator
+dashboard.
+
+Operators need a cheap, low-frequency catalog census that makes catalog size
+visible and loud when it crosses a configured threshold.
+
+## Goals
+
+- Add a Postgres catalog census for:
+  - `pg_namespace` row count.
+  - `pg_class` row count.
+  - `pg_database_size(current_database())`.
+- Expose the latest census in the existing `/health` response.
+- Expose the same values in the usage monitor payload and dashboard UI.
+- Emit an `error`-level log when catalog counts exceed a configurable threshold.
+- Keep census cost bounded to catalog-only counts and avoid user-table scans.
+- Test the threshold breach path with a lowered threshold.
+
+## Non-Goals
+
+- Running the one-time backlog cleanup for any operator database.
+- Changing orphan-schema reaper logic, cadence, or ownership.
+- Adding a new standalone observability service or metrics backend.
+- Scanning user tables, task rows, runtime events, or application data.
+- Blocking server startup solely because a catalog census query fails.
+
+## User-Visible Behavior
+
+When Harness is backed by Postgres, `/health` includes a `postgres_catalog`
+object containing schema count, catalog object count, database size in bytes,
+threshold metadata, sample time, and breach status. The usage monitor dashboard
+shows the same values so an operator can see whether catalog growth is normal,
+approaching the threshold, or already above threshold.
+
+If the census cannot be collected because the database is unavailable or the
+server is running without a Postgres-backed store, the response should report an
+explicit unavailable state instead of fabricating zero counts.
+
+When the configured threshold is breached, Harness logs an `error`-level line
+with the sampled values and threshold source. The health response remains
+available and includes the breach flag so automated checks can detect it.
+
+## Acceptance Criteria
+
+- [ ] `/health` includes schema count, catalog object count, database size, and
+      sample metadata when Postgres is available.
+- [ ] `/api/usage-monitor` includes the catalog census payload or an explicit
+      unavailable state.
+- [ ] The React usage monitor dashboard renders the three values and shows a
+      warning/error state when threshold is breached.
+- [ ] Thresholds are configurable, with safe defaults of schema count > 50,000
+      and a startup-relative breach when the current schema count exceeds 3x the
+      startup sample.
+- [ ] Threshold breach emits an `error`-level log, not only a warning.
+- [ ] Census queries only use catalog counts and `pg_database_size`; no
+      user-table scans are introduced.
+- [ ] Query frequency is bounded; normal dashboard polling does not issue
+      unbounded catalog queries on every request.
+- [ ] Unit or integration tests cover lowered-threshold breach behavior and the
+      unavailable/no-Postgres state.
+
+## Edge Cases
+
+- The server starts without a Postgres-backed workflow/task store.
+- The startup census succeeds but a later refresh fails.
+- The startup census has zero schemas or is unavailable, so the 3x relative
+  threshold cannot be computed.
+- Absolute and relative thresholds disagree; a breach of either one should be
+  loud.
+- Multiple concurrent health/dashboard polls happen while a census refresh is
+  already in progress.
+
+## Rollout Notes
+
+This is an observability change. It should be safe to ship behind the existing
+server configuration surface with default thresholds. Operators can use the new
+values to decide when to run existing cleanup tools, but this change must not
+perform cleanup automatically.

--- a/specs/GH1461/tasks.md
+++ b/specs/GH1461/tasks.md
@@ -1,0 +1,42 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1461
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1461-T001` Owner: `catalog-census-model` | Dependencies: none | Done when: a serializable catalog census payload and threshold evaluation helper exist with snake_case JSON fields and sanitized error states | Verify: threshold unit tests for absolute, relative, no-breach, and unavailable states
+- [ ] `SP1461-T002` Owner: `bounded-census-query` | Dependencies: `SP1461-T001` | Done when: the server can collect `pg_namespace`, `pg_class`, and `pg_database_size(current_database())` through catalog-only queries and cache the latest sample behind a bounded refresh interval | Verify: DB-backed or fake-pool tests prove query shape, cache reuse, and failure handling
+- [ ] `SP1461-T003` Owner: `health-surface` | Dependencies: `SP1461-T001`, `SP1461-T002` | Done when: `/health` includes `postgres_catalog`, keeps the route available on census errors, and marks/logs threshold breaches loudly | Verify: health route tests with lowered thresholds and unavailable/no-Postgres state
+- [ ] `SP1461-T004` Owner: `usage-monitor-api` | Dependencies: `SP1461-T001`, `SP1461-T002` | Done when: `/api/usage-monitor` includes the same catalog census payload without issuing independent unbounded queries | Verify: usage monitor handler tests include available and unavailable catalog payloads
+- [ ] `SP1461-T005` Owner: `usage-monitor-ui` | Dependencies: `SP1461-T004` | Done when: usage monitor types and UI render schema count, catalog object count, DB size, breach state, and unavailable state | Verify: focused web tests for `UsageMonitor`
+- [ ] `SP1461-T006` Owner: `verification` | Dependencies: all implementation tasks | Done when: focused Rust/web tests, SpecRail checks, formatting, and clippy pass | Verify: focused test commands, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1461`, `python3 checks/check_workflow.py --repo .`, `cargo fmt --all -- --check`, and `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Parallelization
+
+`SP1461-T001` is the foundation. `SP1461-T003`, `SP1461-T004`, and
+`SP1461-T005` touch different surfaces after the model/query helper exists, but
+they share the response schema and should not proceed with divergent field
+names. Keep writable ownership disjoint if parallel agents are used.
+
+## Verification
+
+- `cargo test -p harness-server health_route_tests::`
+- focused usage monitor handler tests
+- focused web tests for `UsageMonitor`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1461`
+- `python3 checks/check_workflow.py --repo .`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Handoff Notes
+
+Use `Refs #1461` for the spec PR. The implementation PR should use a closing
+keyword only after `/health`, `/api/usage-monitor`, UI, threshold logging, and
+verification are all complete.

--- a/specs/GH1461/tech.md
+++ b/specs/GH1461/tech.md
@@ -1,0 +1,128 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1461
+
+## Product Spec
+
+See `specs/GH1461/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| HTTP health | `crates/harness-server/src/http/misc_routes.rs` | `/health` returns task count, persistence degradation, runtime logs, circuit breakers, and isolation health. | This is the existing status endpoint named by GH-1461. |
+| Health tests | `crates/harness-server/src/http/tests/health_route_tests.rs`, `route_helpers.rs` | Tests deserialize a fixed `HealthResponse` shape and cover degraded states. | The test helper must be extended when `/health` gains a catalog block. |
+| Usage monitor API | `crates/harness-server/src/handlers/usage_monitor.rs` | `/api/usage-monitor` builds token, runtime, process, and diagnostic payloads. | The same catalog census should be exposed here for the dashboard. |
+| Usage monitor UI | `web/src/types/usage_monitor.ts`, `web/src/routes/UsageMonitor.tsx` | React renders usage KPIs, active pressure, tables, and diagnostics from `/api/usage-monitor`. | The dashboard surface for catalog counts belongs here. |
+| Postgres test pattern | `crates/harness-server/src/http/tests/*`, `crate::test_helpers::db_tests_enabled()` | DB-backed tests skip without local `HARNESS_DATABASE_URL`. | Catalog tests should follow existing DB skip/lock patterns or isolate query logic with fakes. |
+| Orphan cleanup | `scripts/pg-orphan-cleanup.sh`, `crates/harness-server/src/http/orphan_reaper.rs` | Existing cleanup/reaper behavior is separate. | GH-1461 must observe catalog size, not change cleanup. |
+
+## Proposed Design
+
+1. Add a catalog census model in the server layer.
+   - Define a serializable payload, for example `PostgresCatalogCensus`, with:
+     - `state`: `available`, `unavailable`, or `error`.
+     - `schema_count`.
+     - `catalog_object_count`.
+     - `database_size_bytes`.
+     - `sampled_at`.
+     - `startup_schema_count`.
+     - `absolute_schema_threshold`.
+     - `relative_schema_multiplier`.
+     - `threshold_breached`.
+     - `breach_reasons`.
+     - sanitized `error` for unavailable/error states.
+   - Keep field names snake_case to match existing Rust JSON payloads.
+2. Add bounded census collection.
+   - Query only:
+     - `select count(*) from pg_catalog.pg_namespace`.
+     - `select count(*) from pg_catalog.pg_class`.
+     - `select pg_database_size(current_database())`.
+   - Prefer one small helper module rather than embedding SQL in unrelated
+     handlers.
+   - Cache the latest sample in `AppState` or a dedicated state helper with a
+     short minimum refresh interval so `/health` and dashboard polling do not
+     run catalog queries every request.
+   - Capture an initial startup sample when Postgres is available, or record an
+     unavailable baseline when it is not.
+3. Add threshold configuration.
+   - Add server config fields for absolute schema threshold and relative
+     multiplier if no equivalent config already exists.
+   - Defaults:
+     - absolute schema threshold: `50_000`.
+     - relative schema multiplier: `3.0`.
+   - Disable only with an explicit config value if the existing config style
+     supports optionals; do not silently disable on invalid values.
+4. Emit breach logging.
+   - On refresh, if either threshold is breached, emit `tracing::error!` with
+     schema count, catalog object count, database size, thresholds, and reasons.
+   - Avoid logging raw connection strings or database errors that may include
+     secrets.
+5. Wire `/health`.
+   - Add `postgres_catalog` to the `/health` JSON body.
+   - Keep `/health` itself available when census is unavailable; the nested
+     payload carries the error/unavailable state.
+   - Treat a threshold breach as degraded unless implementation discovers an
+     existing health policy that separates advisory health from degraded health.
+     If not degraded, document the reason in the implementation PR.
+6. Wire `/api/usage-monitor`.
+   - Add the same catalog payload to `UsageMonitorResponse`.
+   - Reuse the cached sample instead of running a second query path.
+7. Wire the React dashboard.
+   - Extend `web/src/types/usage_monitor.ts`.
+   - Add a compact catalog KPI/panel in `web/src/routes/UsageMonitor.tsx`.
+   - Show unavailable/error text when no sample is available.
+   - Use existing formatting helpers for bytes and integers.
+
+## Data Flow
+
+The server collects or refreshes a catalog census from Postgres catalog tables,
+stores the latest sanitized sample with threshold evaluation, and exposes that
+sample through `/health` and `/api/usage-monitor`. The React usage monitor reads
+the existing API payload and renders the counts. No cleanup or mutation is
+performed.
+
+## Alternatives Considered
+
+- Run catalog counts on every dashboard poll. Rejected because GH-1461 requires
+  bounded frequency.
+- Store census history in a new table. Rejected for this issue; the requested
+  behavior needs latest-value visibility and threshold logging, not retention.
+- Put the values only in `/health`. Rejected because GH-1461 also requires the
+  usage monitor dashboard to show them.
+- Change orphan reaper cadence. Rejected because reaper behavior is a non-goal.
+
+## Risks
+
+- Performance: catalog counts over very large catalogs can still cost time.
+  Mitigate with low frequency and no user-table scans.
+- Reliability: health/dashboard handlers must not fail wholesale when the
+  census query fails.
+- Alert noise: repeated dashboard polls could emit repeated errors. Mitigate by
+  logging on refresh decisions rather than every response serialization, and
+  consider suppressing duplicate breach logs within the refresh interval.
+- Config drift: threshold field names and defaults must match existing config
+  conventions in `harness-core`.
+
+## Test Plan
+
+- [ ] Unit test threshold evaluation with absolute and startup-relative breaches.
+- [ ] Unit test no-breach and unavailable baseline states.
+- [ ] Handler test `/health` includes `postgres_catalog` and marks breach
+      visibly with lowered thresholds.
+- [ ] Usage monitor handler test includes the same catalog payload.
+- [ ] Web test renders catalog counts and unavailable state in
+      `web/src/routes/UsageMonitor` tests.
+- [ ] Run focused Rust tests for health/usage monitor.
+- [ ] Run focused web tests for usage monitor.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `cargo clippy --workspace --all-targets -- -D warnings`.
+
+## Rollback Plan
+
+Remove the catalog census helper/state, remove the `/health` and
+`/api/usage-monitor` payload fields, remove the React panel/type additions, and
+remove the new config fields. No data migration or cleanup rollback is required
+because the implementation only reads Postgres catalog metadata.


### PR DESCRIPTION
## Summary
- Adds the product, technical, and task specs for GH1461 Postgres catalog bloat visibility.
- Defines `/health`, `/api/usage-monitor`, UI, threshold logging, and bounded census requirements.
- Captures implementation tasks and verification scope for the follow-up implementation PR.

Refs #1461

## Verification
- `python3 checks/route_gate.py --repo . --route write_spec --issue 1461 --state ready_to_spec --json`
- `python3 checks/route_gate.py --repo . --route implement --issue 1461 --state ready_to_implement --json`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1461`
- `python3 checks/check_workflow.py --repo .`
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
