### PR TITLE
Expose Postgres catalog bloat metrics

### DIFF
--- a/crates/harness-server/src/handlers/usage_monitor.rs
+++ b/crates/harness-server/src/handlers/usage_monitor.rs
@@ -63,6 +63,7 @@ struct UsageMonitorResponse {
     local_usage_sources: Vec<LocalUsageSourceSummary>,
     active_by_repo: Vec<ActiveCount>,
     active_by_activity: Vec<ActiveCount>,
+    postgres_catalog: crate::postgres_catalog::PostgresCatalogCensus,
     diagnostics: UsageDiagnostics,
 }
 
@@ -306,6 +307,7 @@ async fn build_usage_monitor_response(
         sample_agent_processes_for_monitor(now, runtime_attribution_tokens(&runtime_rows)).await;
     let external_agent_processes = process_sample.processes;
     let local_usage_sources = load_local_usage_summaries(window).await;
+    let postgres_catalog = state.postgres_catalog.snapshot().await;
 
     let tokens_by_agent =
         aggregate_usage(&usage_records, |record| record.agent.clone(), price_catalog);
@@ -398,6 +400,7 @@ async fn build_usage_monitor_response(
         active_by_activity: aggregate_active_counts(&agent_invocations, |invocation| {
             invocation.activity.clone()
         }),
+        postgres_catalog,
         agent_invocations,
         external_agent_processes,
         local_usage_sources,

--- a/crates/harness-server/src/handlers/usage_monitor_tests.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_tests.rs
@@ -32,6 +32,33 @@ fn usage_aggregate_requires_configured_price_for_cost() {
     assert_eq!(usage.estimated_cost_json(true), None);
 }
 
+#[tokio::test]
+async fn usage_monitor_response_includes_postgres_catalog_census() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = crate::test_helpers::make_test_state(dir.path()).await?;
+    let response = build_usage_monitor_response(
+        &state,
+        UsageMonitorQuery {
+            hours: Some(1),
+            limit: Some(1),
+        },
+    )
+    .await?;
+
+    assert_eq!(
+        response.postgres_catalog.state,
+        crate::postgres_catalog::PostgresCatalogState::Available
+    );
+    assert!(response.postgres_catalog.schema_count.is_some());
+    assert!(response.postgres_catalog.catalog_object_count.is_some());
+    assert!(response.postgres_catalog.database_size_bytes.is_some());
+    Ok(())
+}
+
 #[test]
 fn parse_runtime_usage_row_reports_corrupt_json_without_panicking() -> anyhow::Result<()> {
     let workflow = WorkflowInstance::new(

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -220,6 +220,11 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         .as_ref()
         .expect("critical task store should be present after startup validation")
         .clone();
+    let postgres_catalog = crate::postgres_catalog::PostgresCatalogMonitor::new(
+        tasks.postgres_pool(),
+        crate::postgres_catalog::PostgresCatalogThresholds::from_server(&server.config.server),
+    )
+    .await;
 
     // Phase 2: engines — rule engine, event store (+purge task), GC agent, skill store.
     // Depends on: storage (none directly, but must precede registry which uses storage.tasks).
@@ -369,6 +374,7 @@ pub async fn build_app_state(server: Arc<HarnessServer>) -> anyhow::Result<AppSt
         _db_state_guard: None,
         runtime_hosts: services.runtime_hosts,
         runtime_project_cache: services.runtime_project_cache,
+        postgres_catalog,
         isolation_availability,
         runtime_state_persist_lock: Mutex::new(()),
         runtime_state_dirty: AtomicBool::new(false),

--- a/crates/harness-server/src/http/misc_routes.rs
+++ b/crates/harness-server/src/http/misc_routes.rs
@@ -54,6 +54,8 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
     let runtime_degraded = circuit_breakers
         .iter()
         .any(|breaker| breaker.state != "closed");
+    let postgres_catalog = state.postgres_catalog.snapshot().await;
+    let postgres_catalog_degraded = postgres_catalog.threshold_breached;
     let unavailable_required_tiers = state
         .isolation_availability
         .unavailable_required_tiers(&state.core.server.config.isolation);
@@ -70,7 +72,12 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
             })
         })
         .collect();
-    let status = if degraded.is_empty() && !dirty && !runtime_degraded && !isolation_degraded {
+    let status = if degraded.is_empty()
+        && !dirty
+        && !runtime_degraded
+        && !isolation_degraded
+        && !postgres_catalog_degraded
+    {
         "ok"
     } else {
         "degraded"
@@ -93,6 +100,7 @@ pub(crate) async fn health_check(State(state): State<Arc<AppState>>) -> Json<ser
         "runtime": {
             "circuit_breakers": circuit_breakers,
         },
+        "postgres_catalog": postgres_catalog,
         "isolation": {
             "tiers": state.isolation_availability.tiers.clone(),
             "unavailable_required_tiers": unavailable_required_tiers,

--- a/crates/harness-server/src/http/state.rs
+++ b/crates/harness-server/src/http/state.rs
@@ -254,6 +254,7 @@ pub struct AppState {
     pub _db_state_guard: Option<crate::test_helpers::DbStateGuard>,
     pub runtime_hosts: Arc<crate::runtime_hosts::RuntimeHostManager>,
     pub runtime_project_cache: Arc<crate::runtime_project_cache::RuntimeProjectCacheManager>,
+    pub postgres_catalog: Arc<crate::postgres_catalog::PostgresCatalogMonitor>,
     pub isolation_availability: harness_core::config::isolation::IsolationAvailability,
     /// Serializes runtime snapshot writes to avoid out-of-order persistence.
     pub runtime_state_persist_lock: Mutex<()>,

--- a/crates/harness-server/src/http/test_fixtures.rs
+++ b/crates/harness-server/src/http/test_fixtures.rs
@@ -187,7 +187,7 @@ async fn make_read_only_route_test_state_with_project_root(
 
     Ok(Arc::new(AppState {
         core: CoreServices {
-            server,
+            server: server.clone(),
             project_root: project_root.to_path_buf(),
             home_dir: std::env::var("HOME")
                 .map(PathBuf::from)
@@ -226,6 +226,10 @@ async fn make_read_only_route_test_state_with_project_root(
         runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+        ),
+        postgres_catalog: crate::postgres_catalog::PostgresCatalogMonitor::unavailable(
+            crate::postgres_catalog::PostgresCatalogThresholds::from_server(&server.config.server),
+            "postgres_pool_unavailable",
         ),
         isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),

--- a/crates/harness-server/src/http/test_fixtures.rs
+++ b/crates/harness-server/src/http/test_fixtures.rs
@@ -157,6 +157,11 @@ async fn make_read_only_route_test_state_with_project_root(
         Some(database_url.as_str()),
     )
     .await?;
+    let postgres_catalog = crate::postgres_catalog::PostgresCatalogMonitor::new(
+        tasks.postgres_pool(),
+        crate::postgres_catalog::PostgresCatalogThresholds::from_server(&server.config.server),
+    )
+    .await;
     drop(db_state_guard);
 
     let password_reset_rate_limit = server.config.server.password_reset_rate_limit_per_hour;
@@ -227,10 +232,7 @@ async fn make_read_only_route_test_state_with_project_root(
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
-        postgres_catalog: crate::postgres_catalog::PostgresCatalogMonitor::unavailable(
-            crate::postgres_catalog::PostgresCatalogThresholds::from_server(&server.config.server),
-            "postgres_pool_unavailable",
-        ),
+        postgres_catalog,
         isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: AtomicBool::new(false),

--- a/crates/harness-server/src/http/tests/health_route_tests.rs
+++ b/crates/harness-server/src/http/tests/health_route_tests.rs
@@ -46,6 +46,54 @@ async fn health_degraded_when_runtime_state_dirty() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn health_reports_postgres_catalog_census() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_read_only_route_test_state(dir.path()).await?;
+    let health = call_health(state).await?;
+
+    assert_eq!(health.postgres_catalog["state"], "available");
+    assert!(health.postgres_catalog["schema_count"].as_u64().is_some());
+    assert!(health.postgres_catalog["catalog_object_count"]
+        .as_u64()
+        .is_some());
+    assert!(health.postgres_catalog["database_size_bytes"]
+        .as_u64()
+        .is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_reports_postgres_catalog_unavailable_state() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let mut state = make_read_only_route_test_state(dir.path()).await?;
+    let state_mut = Arc::get_mut(&mut state).expect("unique test state");
+    state_mut.postgres_catalog = crate::postgres_catalog::PostgresCatalogMonitor::unavailable(
+        crate::postgres_catalog::PostgresCatalogThresholds::from_server(
+            &state_mut.core.server.config.server,
+        ),
+        "postgres_pool_unavailable",
+    );
+
+    let health = call_health(state).await?;
+
+    assert_eq!(health.status, "ok");
+    assert_eq!(health.postgres_catalog["state"], "unavailable");
+    assert_eq!(
+        health.postgres_catalog["error"],
+        "postgres_pool_unavailable"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn health_degraded_when_github_webhook_intake_secret_missing() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/http/tests/route_helpers.rs
+++ b/crates/harness-server/src/http/tests/route_helpers.rs
@@ -497,6 +497,7 @@ pub(super) struct HealthResponse {
     pub(super) persistence: PersistenceBlock,
     pub(super) runtime_logs: RuntimeLogsBlock,
     pub(super) runtime: serde_json::Value,
+    pub(super) postgres_catalog: serde_json::Value,
     pub(super) isolation: serde_json::Value,
 }
 

--- a/crates/harness-server/src/http/tests/state_support.rs
+++ b/crates/harness-server/src/http/tests/state_support.rs
@@ -271,6 +271,11 @@ pub(super) async fn make_test_state_with_project_root(
         Some(&database_url),
     )
     .await?;
+    let postgres_catalog = crate::postgres_catalog::PostgresCatalogMonitor::new(
+        tasks.postgres_pool(),
+        crate::postgres_catalog::PostgresCatalogThresholds::from_server(&server.config.server),
+    )
+    .await;
     let events = Arc::new(
         harness_observe::event_store::EventStore::new_with_database_url(dir, Some(&database_url))
             .await?,
@@ -370,6 +375,7 @@ pub(super) async fn make_test_state_with_project_root(
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        postgres_catalog,
         isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
@@ -456,6 +462,7 @@ pub(super) async fn make_test_state_with_issue_workflows(
         _db_state_guard: None,
         runtime_hosts: state.runtime_hosts.clone(),
         runtime_project_cache: state.runtime_project_cache.clone(),
+        postgres_catalog: state.postgres_catalog.clone(),
         isolation_availability: state.isolation_availability.clone(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),
@@ -577,6 +584,7 @@ pub(super) async fn make_test_state_with_workflow_runtime_config_and_registry(
         _db_state_guard: None,
         runtime_hosts: state.runtime_hosts.clone(),
         runtime_project_cache: state.runtime_project_cache.clone(),
+        postgres_catalog: state.postgres_catalog.clone(),
         isolation_availability: state.isolation_availability.clone(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -39,6 +39,7 @@ pub mod periodic_reviewer;
 pub mod reconciliation;
 pub use harness_workflow::plan_db;
 pub mod post_validator;
+pub(crate) mod postgres_catalog;
 pub mod project_registry;
 pub mod quality_trigger;
 pub mod redact;

--- a/crates/harness-server/src/postgres_catalog.rs
+++ b/crates/harness-server/src/postgres_catalog.rs
@@ -1,0 +1,373 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sqlx::postgres::PgPool;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+const DEFAULT_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PostgresCatalogThresholds {
+    pub(crate) absolute_schema_threshold: u64,
+    pub(crate) relative_schema_multiplier: f64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PostgresCatalogState {
+    Available,
+    Unavailable,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct PostgresCatalogCensus {
+    pub(crate) state: PostgresCatalogState,
+    pub(crate) schema_count: Option<u64>,
+    pub(crate) catalog_object_count: Option<u64>,
+    pub(crate) database_size_bytes: Option<u64>,
+    pub(crate) sampled_at: Option<DateTime<Utc>>,
+    pub(crate) startup_schema_count: Option<u64>,
+    pub(crate) absolute_schema_threshold: u64,
+    pub(crate) relative_schema_multiplier: f64,
+    pub(crate) threshold_breached: bool,
+    pub(crate) breach_reasons: Vec<String>,
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Debug)]
+struct CatalogMonitorState {
+    cached: PostgresCatalogCensus,
+    last_refresh_at: Option<Instant>,
+    startup_schema_count: Option<u64>,
+}
+
+#[derive(Debug)]
+pub struct PostgresCatalogMonitor {
+    pool: Option<PgPool>,
+    thresholds: PostgresCatalogThresholds,
+    refresh_interval: Duration,
+    state: Mutex<CatalogMonitorState>,
+}
+
+#[derive(Debug)]
+struct RawCatalogCensus {
+    schema_count: u64,
+    catalog_object_count: u64,
+    database_size_bytes: u64,
+    sampled_at: DateTime<Utc>,
+}
+
+impl PostgresCatalogThresholds {
+    pub(crate) fn from_server(_config: &harness_core::config::server::ServerConfig) -> Self {
+        Self {
+            absolute_schema_threshold: parse_u64_env(
+                "HARNESS_POSTGRES_CATALOG_SCHEMA_THRESHOLD",
+                50_000,
+            ),
+            relative_schema_multiplier: parse_f64_env(
+                "HARNESS_POSTGRES_CATALOG_RELATIVE_THRESHOLD_MULTIPLIER",
+                3.0,
+            ),
+        }
+    }
+}
+
+impl PostgresCatalogMonitor {
+    pub(crate) async fn new(pool: PgPool, thresholds: PostgresCatalogThresholds) -> Arc<Self> {
+        let initial = match collect_catalog_census(&pool).await {
+            Ok(raw) => PostgresCatalogCensus::available(&thresholds, Some(raw.schema_count), raw),
+            Err(_) => PostgresCatalogCensus::error(&thresholds, None, "catalog_census_failed"),
+        };
+        if initial.threshold_breached {
+            log_catalog_breach(&initial);
+        }
+        Arc::new(Self {
+            pool: Some(pool),
+            thresholds,
+            refresh_interval: DEFAULT_REFRESH_INTERVAL,
+            state: Mutex::new(CatalogMonitorState {
+                startup_schema_count: initial.startup_schema_count,
+                cached: initial,
+                last_refresh_at: Some(Instant::now()),
+            }),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn unavailable(
+        thresholds: PostgresCatalogThresholds,
+        reason: &'static str,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            pool: None,
+            thresholds,
+            refresh_interval: DEFAULT_REFRESH_INTERVAL,
+            state: Mutex::new(CatalogMonitorState {
+                cached: PostgresCatalogCensus::unavailable(&thresholds, reason),
+                last_refresh_at: None,
+                startup_schema_count: None,
+            }),
+        })
+    }
+
+    pub(crate) async fn snapshot(&self) -> PostgresCatalogCensus {
+        let mut state = self.state.lock().await;
+        if state
+            .last_refresh_at
+            .is_some_and(|last| last.elapsed() < self.refresh_interval)
+        {
+            return state.cached.clone();
+        }
+
+        let Some(pool) = self.pool.as_ref() else {
+            state.cached =
+                PostgresCatalogCensus::unavailable(&self.thresholds, "postgres_pool_unavailable");
+            state.last_refresh_at = Some(Instant::now());
+            return state.cached.clone();
+        };
+
+        let refreshed = match collect_catalog_census(pool).await {
+            Ok(raw) => {
+                let startup_schema_count = state.startup_schema_count.or(Some(raw.schema_count));
+                PostgresCatalogCensus::available(&self.thresholds, startup_schema_count, raw)
+            }
+            Err(_) => PostgresCatalogCensus::error(
+                &self.thresholds,
+                state.startup_schema_count,
+                "catalog_census_failed",
+            ),
+        };
+        if refreshed.threshold_breached {
+            log_catalog_breach(&refreshed);
+        }
+        state.startup_schema_count = refreshed.startup_schema_count;
+        state.cached = refreshed;
+        state.last_refresh_at = Some(Instant::now());
+        state.cached.clone()
+    }
+}
+
+impl PostgresCatalogCensus {
+    fn available(
+        thresholds: &PostgresCatalogThresholds,
+        startup_schema_count: Option<u64>,
+        raw: RawCatalogCensus,
+    ) -> Self {
+        let breach_reasons = threshold_breach_reasons(
+            raw.schema_count,
+            startup_schema_count,
+            thresholds.absolute_schema_threshold,
+            thresholds.relative_schema_multiplier,
+        );
+        Self {
+            state: PostgresCatalogState::Available,
+            schema_count: Some(raw.schema_count),
+            catalog_object_count: Some(raw.catalog_object_count),
+            database_size_bytes: Some(raw.database_size_bytes),
+            sampled_at: Some(raw.sampled_at),
+            startup_schema_count,
+            absolute_schema_threshold: thresholds.absolute_schema_threshold,
+            relative_schema_multiplier: thresholds.relative_schema_multiplier,
+            threshold_breached: !breach_reasons.is_empty(),
+            breach_reasons,
+            error: None,
+        }
+    }
+
+    fn unavailable(thresholds: &PostgresCatalogThresholds, reason: &'static str) -> Self {
+        Self {
+            state: PostgresCatalogState::Unavailable,
+            schema_count: None,
+            catalog_object_count: None,
+            database_size_bytes: None,
+            sampled_at: None,
+            startup_schema_count: None,
+            absolute_schema_threshold: thresholds.absolute_schema_threshold,
+            relative_schema_multiplier: thresholds.relative_schema_multiplier,
+            threshold_breached: false,
+            breach_reasons: vec![],
+            error: Some(reason.to_string()),
+        }
+    }
+
+    fn error(
+        thresholds: &PostgresCatalogThresholds,
+        startup_schema_count: Option<u64>,
+        reason: &'static str,
+    ) -> Self {
+        Self {
+            state: PostgresCatalogState::Error,
+            schema_count: None,
+            catalog_object_count: None,
+            database_size_bytes: None,
+            sampled_at: Some(Utc::now()),
+            startup_schema_count,
+            absolute_schema_threshold: thresholds.absolute_schema_threshold,
+            relative_schema_multiplier: thresholds.relative_schema_multiplier,
+            threshold_breached: false,
+            breach_reasons: vec![],
+            error: Some(reason.to_string()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_counts_for_test(
+        thresholds: PostgresCatalogThresholds,
+        startup_schema_count: Option<u64>,
+        schema_count: u64,
+        catalog_object_count: u64,
+        database_size_bytes: u64,
+    ) -> Self {
+        Self::available(
+            &thresholds,
+            startup_schema_count,
+            RawCatalogCensus {
+                schema_count,
+                catalog_object_count,
+                database_size_bytes,
+                sampled_at: Utc::now(),
+            },
+        )
+    }
+}
+
+fn threshold_breach_reasons(
+    schema_count: u64,
+    startup_schema_count: Option<u64>,
+    absolute_schema_threshold: u64,
+    relative_schema_multiplier: f64,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if schema_count > absolute_schema_threshold {
+        reasons.push("schema_count_gt_absolute_threshold".to_string());
+    }
+    if let Some(startup) = startup_schema_count.filter(|value| *value > 0) {
+        let relative_threshold = (startup as f64) * relative_schema_multiplier;
+        if relative_schema_multiplier.is_finite()
+            && relative_schema_multiplier > 0.0
+            && (schema_count as f64) > relative_threshold
+        {
+            reasons.push("schema_count_gt_startup_relative_threshold".to_string());
+        }
+    }
+    reasons
+}
+
+async fn collect_catalog_census(pool: &PgPool) -> anyhow::Result<RawCatalogCensus> {
+    let (schema_count, catalog_object_count, database_size_bytes): (i64, i64, i64) =
+        sqlx::query_as(
+            "SELECT
+                 (SELECT count(*)::BIGINT FROM pg_catalog.pg_namespace) AS schema_count,
+                 (SELECT count(*)::BIGINT FROM pg_catalog.pg_class) AS catalog_object_count,
+                 pg_database_size(current_database())::BIGINT AS database_size_bytes",
+        )
+        .fetch_one(pool)
+        .await?;
+    Ok(RawCatalogCensus {
+        schema_count: u64::try_from(schema_count)?,
+        catalog_object_count: u64::try_from(catalog_object_count)?,
+        database_size_bytes: u64::try_from(database_size_bytes)?,
+        sampled_at: Utc::now(),
+    })
+}
+
+fn log_catalog_breach(census: &PostgresCatalogCensus) {
+    tracing::error!(
+        schema_count = census.schema_count,
+        catalog_object_count = census.catalog_object_count,
+        database_size_bytes = census.database_size_bytes,
+        startup_schema_count = census.startup_schema_count,
+        absolute_schema_threshold = census.absolute_schema_threshold,
+        relative_schema_multiplier = census.relative_schema_multiplier,
+        breach_reasons = ?census.breach_reasons,
+        "postgres catalog census threshold breached"
+    );
+}
+
+fn parse_u64_env(name: &'static str, default: u64) -> u64 {
+    let Ok(raw) = std::env::var(name) else {
+        return default;
+    };
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return default;
+    }
+    match raw.parse::<u64>() {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::error!(env = name, "invalid Postgres catalog threshold: {error}");
+            default
+        }
+    }
+}
+
+fn parse_f64_env(name: &'static str, default: f64) -> f64 {
+    let Ok(raw) = std::env::var(name) else {
+        return default;
+    };
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return default;
+    }
+    match raw.parse::<f64>() {
+        Ok(value) if value.is_finite() && value > 0.0 => value,
+        Ok(_) => {
+            tracing::error!(
+                env = name,
+                "invalid Postgres catalog threshold: value must be greater than 0"
+            );
+            default
+        }
+        Err(error) => {
+            tracing::error!(env = name, "invalid Postgres catalog threshold: {error}");
+            default
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn thresholds() -> PostgresCatalogThresholds {
+        PostgresCatalogThresholds {
+            absolute_schema_threshold: 50,
+            relative_schema_multiplier: 3.0,
+        }
+    }
+
+    #[test]
+    fn absolute_threshold_breach_is_reported() {
+        let census =
+            PostgresCatalogCensus::from_counts_for_test(thresholds(), Some(20), 51, 100, 1);
+
+        assert!(census.threshold_breached);
+        assert_eq!(
+            census.breach_reasons,
+            ["schema_count_gt_absolute_threshold"]
+        );
+    }
+
+    #[test]
+    fn relative_threshold_breach_is_reported() {
+        let census =
+            PostgresCatalogCensus::from_counts_for_test(thresholds(), Some(10), 31, 100, 1);
+
+        assert!(census.threshold_breached);
+        assert_eq!(
+            census.breach_reasons,
+            ["schema_count_gt_startup_relative_threshold"]
+        );
+    }
+
+    #[test]
+    fn unavailable_state_has_no_fabricated_counts() {
+        let census = PostgresCatalogCensus::unavailable(&thresholds(), "postgres_pool_unavailable");
+
+        assert_eq!(census.state, PostgresCatalogState::Unavailable);
+        assert_eq!(census.schema_count, None);
+        assert!(!census.threshold_breached);
+    }
+}

--- a/crates/harness-server/src/router/tests.rs
+++ b/crates/harness-server/src/router/tests.rs
@@ -73,7 +73,7 @@ async fn make_test_state_with_config_and_registry(
     );
     Ok(AppState {
         core: crate::http::CoreServices {
-            server,
+            server: server.clone(),
             project_root: dir.to_path_buf(),
             home_dir: std::env::var("HOME")
                 .map(std::path::PathBuf::from)
@@ -114,6 +114,10 @@ async fn make_test_state_with_config_and_registry(
         runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+        ),
+        postgres_catalog: crate::postgres_catalog::PostgresCatalogMonitor::unavailable(
+            crate::postgres_catalog::PostgresCatalogThresholds::from_server(&server.config.server),
+            "postgres_pool_unavailable",
         ),
         isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
@@ -1834,7 +1838,7 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
     );
     Ok(AppState {
         core: crate::http::CoreServices {
-            server,
+            server: server.clone(),
             project_root: dir.to_path_buf(),
             home_dir: std::env::var("HOME")
                 .map(std::path::PathBuf::from)
@@ -1875,6 +1879,10 @@ async fn make_test_state_with_plan_db(dir: &std::path::Path) -> anyhow::Result<A
         runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+        ),
+        postgres_catalog: crate::postgres_catalog::PostgresCatalogMonitor::unavailable(
+            crate::postgres_catalog::PostgresCatalogThresholds::from_server(&server.config.server),
+            "postgres_pool_unavailable",
         ),
         isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),

--- a/crates/harness-server/src/stdio.rs
+++ b/crates/harness-server/src/stdio.rs
@@ -231,7 +231,7 @@ mod tests {
 
         Ok(AppState {
             core: crate::http::CoreServices {
-                server,
+                server: server.clone(),
                 project_root: dir.to_path_buf(),
                 home_dir: std::env::var("HOME")
                     .map(std::path::PathBuf::from)
@@ -272,6 +272,12 @@ mod tests {
             runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
             runtime_project_cache: Arc::new(
                 crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+            ),
+            postgres_catalog: crate::postgres_catalog::PostgresCatalogMonitor::unavailable(
+                crate::postgres_catalog::PostgresCatalogThresholds::from_server(
+                    &server.config.server,
+                ),
+                "postgres_pool_unavailable",
             ),
             isolation_availability: Default::default(),
             runtime_state_persist_lock: tokio::sync::Mutex::new(()),

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -116,6 +116,10 @@ impl TaskDb {
         &self.schema
     }
 
+    pub(crate) fn postgres_pool(&self) -> PgPool {
+        self.pool.clone()
+    }
+
     pub fn store_key_for_data_dir(data_dir: &Path) -> anyhow::Result<String> {
         record_task_db_usage();
         let canonical = data_dir.canonicalize().map_err(|error| {

--- a/crates/harness-server/src/task_runner/store.rs
+++ b/crates/harness-server/src/task_runner/store.rs
@@ -359,6 +359,10 @@ impl TaskStore {
         self.cache.len()
     }
 
+    pub(crate) fn postgres_pool(&self) -> sqlx::PgPool {
+        self.db.postgres_pool()
+    }
+
     #[cfg(test)]
     pub(crate) fn pool_for_test(&self) -> &sqlx::PgPool {
         self.db.pool_for_test()

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -199,6 +199,11 @@ async fn make_state_inner(
         Some(&database_url),
     )
     .await?;
+    let postgres_catalog = crate::postgres_catalog::PostgresCatalogMonitor::new(
+        tasks.postgres_pool(),
+        crate::postgres_catalog::PostgresCatalogThresholds::from_server(&server.config.server),
+    )
+    .await;
     let events = Arc::new(
         harness_observe::event_store::EventStore::new_with_database_url(dir, Some(&database_url))
             .await?,
@@ -291,6 +296,7 @@ async fn make_state_inner(
         runtime_project_cache: Arc::new(
             crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
         ),
+        postgres_catalog,
         isolation_availability: Default::default(),
         runtime_state_persist_lock: tokio::sync::Mutex::new(()),
         runtime_state_dirty: std::sync::atomic::AtomicBool::new(false),

--- a/crates/harness-server/src/websocket.rs
+++ b/crates/harness-server/src/websocket.rs
@@ -335,7 +335,7 @@ mod tests {
 
         Ok(AppState {
             core: crate::http::CoreServices {
-                server,
+                server: server.clone(),
                 project_root: dir.to_path_buf(),
                 home_dir: std::env::var("HOME")
                     .map(std::path::PathBuf::from)
@@ -376,6 +376,12 @@ mod tests {
             runtime_hosts: Arc::new(crate::runtime_hosts::RuntimeHostManager::new()),
             runtime_project_cache: Arc::new(
                 crate::runtime_project_cache::RuntimeProjectCacheManager::new(),
+            ),
+            postgres_catalog: crate::postgres_catalog::PostgresCatalogMonitor::unavailable(
+                crate::postgres_catalog::PostgresCatalogThresholds::from_server(
+                    &server.config.server,
+                ),
+                "postgres_pool_unavailable",
             ),
             isolation_availability: Default::default(),
             runtime_state_persist_lock: tokio::sync::Mutex::new(()),

--- a/web/src/routes/UsageMonitor.test.tsx
+++ b/web/src/routes/UsageMonitor.test.tsx
@@ -1,0 +1,131 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PaletteProvider } from "@/lib/palette";
+import type { UsageMonitorPayload } from "@/types";
+import { UsageMonitor } from "./UsageMonitor";
+
+vi.mock("@/lib/queries", () => ({
+  useUsageMonitor: vi.fn(),
+}));
+
+import { useUsageMonitor } from "@/lib/queries";
+
+const mockUseUsageMonitor = useUsageMonitor as ReturnType<typeof vi.fn>;
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <PaletteProvider>
+        <MemoryRouter>{ui}</MemoryRouter>
+      </PaletteProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function makePayload(): UsageMonitorPayload {
+  return {
+    window: {
+      hours: 24,
+      since: "2026-07-04T00:00:00Z",
+      now: "2026-07-05T00:00:00Z",
+    },
+    cost: {
+      currency: "USD",
+      configured: false,
+      source: "HARNESS_USAGE_PRICE_CATALOG_JSON",
+      missing_model_count: 0,
+      message: "price catalog unavailable",
+    },
+    summary: {
+      total_tokens: 0,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      request_count: 0,
+      estimated_cost_usd: null,
+      running_agent_invocations: 0,
+      active_leased_agent_invocations: 0,
+      expired_or_missing_lease_agent_invocations: 0,
+      pending_agent_invocations: 0,
+      stale_agent_invocations: 0,
+      high_burn_invocations: 0,
+      external_agent_processes: 0,
+    },
+    tokens_by_agent: [],
+    tokens_by_project: [],
+    tokens_by_model: [],
+    agent_invocations: [],
+    external_agent_processes: [],
+    local_usage_sources: [],
+    active_by_repo: [],
+    active_by_activity: [],
+    postgres_catalog: {
+      state: "available",
+      schema_count: 16_980,
+      catalog_object_count: 172_043,
+      database_size_bytes: 5_900_000_000,
+      sampled_at: "2026-07-05T00:00:00Z",
+      startup_schema_count: 16_000,
+      absolute_schema_threshold: 50_000,
+      relative_schema_multiplier: 3,
+      threshold_breached: false,
+      breach_reasons: [],
+      error: null,
+    },
+    diagnostics: {
+      runtime_store_available: true,
+      token_source: "workflow_runtime_usage_and_llm_usage_events",
+      active_cost_confidence: "estimated_from_agent_invocation_state",
+      process_source: "external_cli_process_snapshot",
+    },
+  };
+}
+
+describe("<UsageMonitor>", () => {
+  beforeEach(() => {
+    mockUseUsageMonitor.mockReset();
+  });
+
+  it("renders Postgres catalog counts and breached state", () => {
+    const payload = makePayload();
+    payload.postgres_catalog.threshold_breached = true;
+    payload.postgres_catalog.breach_reasons = ["schema_count_gt_absolute_threshold"];
+    mockUseUsageMonitor.mockReturnValue({ data: payload, isError: false });
+
+    wrap(<UsageMonitor />);
+
+    expect(screen.getByText("Postgres catalog")).toBeInTheDocument();
+    expect(screen.getByText("16,980")).toBeInTheDocument();
+    expect(screen.getByText("172,043")).toBeInTheDocument();
+    expect(screen.getByText("5.5GB")).toBeInTheDocument();
+    expect(screen.getByText("breached")).toBeInTheDocument();
+    expect(screen.getByText("schema_count_gt_absolute_threshold")).toBeInTheDocument();
+  });
+
+  it("renders Postgres catalog unavailable state", () => {
+    const payload = makePayload();
+    payload.postgres_catalog = {
+      state: "unavailable",
+      schema_count: null,
+      catalog_object_count: null,
+      database_size_bytes: null,
+      sampled_at: null,
+      startup_schema_count: null,
+      absolute_schema_threshold: 50_000,
+      relative_schema_multiplier: 3,
+      threshold_breached: false,
+      breach_reasons: [],
+      error: "postgres_pool_unavailable",
+    };
+    mockUseUsageMonitor.mockReturnValue({ data: payload, isError: false });
+
+    wrap(<UsageMonitor />);
+
+    expect(screen.getByText("postgres_pool_unavailable")).toBeInTheDocument();
+    expect(screen.getByText("unavailable")).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/UsageMonitor.tsx
+++ b/web/src/routes/UsageMonitor.tsx
@@ -7,7 +7,14 @@ import { PaletteFab } from "@/components/PaletteFab";
 import { DOCS_URL } from "@/lib/links";
 import { fmtInt } from "@/lib/format";
 import { useUsageMonitor } from "@/lib/queries";
-import type { ActiveCount, AgentInvocation, AgentProcess, LocalUsageSourceSummary, UsageGroup } from "@/types";
+import type {
+  ActiveCount,
+  AgentInvocation,
+  AgentProcess,
+  LocalUsageSourceSummary,
+  PostgresCatalogCensus,
+  UsageGroup,
+} from "@/types";
 
 function fmtTokens(tokens: number | null | undefined): string {
   if (tokens == null || !Number.isFinite(tokens)) return "-";
@@ -35,6 +42,51 @@ function fmtBytes(bytes: number): string {
   if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(0)}MB`;
   if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)}KB`;
   return `${bytes}B`;
+}
+
+function fmtNullableInt(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "-";
+  return fmtInt(value);
+}
+
+function fmtNullableBytes(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "-";
+  return fmtBytes(value);
+}
+
+function catalogSub(catalog: PostgresCatalogCensus | undefined): string {
+  if (!catalog) return "loading";
+  if (catalog.state !== "available") return catalog.error ?? catalog.state;
+  if (catalog.threshold_breached) return catalog.breach_reasons.join(", ") || "threshold breached";
+  return `threshold ${fmtInt(catalog.absolute_schema_threshold)} schemas / ${catalog.relative_schema_multiplier}x startup`;
+}
+
+function CatalogMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[11px] uppercase tracking-[0.08em] text-ink-4">{label}</div>
+      <div className="font-mono text-lg text-ink truncate" title={value}>{value}</div>
+    </div>
+  );
+}
+
+function PostgresCatalogPanel({ catalog }: { catalog: PostgresCatalogCensus | undefined }) {
+  const tone = catalog?.threshold_breached ? "text-danger" : catalog?.state === "available" ? "text-ok" : "text-warn";
+  return (
+    <Panel title="Postgres catalog" sub={catalogSub(catalog)}>
+      <div className="grid grid-cols-4 gap-4 p-4">
+        <CatalogMetric label="schemas" value={fmtNullableInt(catalog?.schema_count)} />
+        <CatalogMetric label="objects" value={fmtNullableInt(catalog?.catalog_object_count)} />
+        <CatalogMetric label="db size" value={fmtNullableBytes(catalog?.database_size_bytes)} />
+        <div className="min-w-0">
+          <div className="text-[11px] uppercase tracking-[0.08em] text-ink-4">state</div>
+          <div className={`font-mono text-lg truncate ${tone}`} title={catalog?.state ?? "loading"}>
+            {catalog?.threshold_breached ? "breached" : (catalog?.state ?? "loading")}
+          </div>
+        </div>
+      </div>
+    </Panel>
+  );
 }
 
 function burnClass(level: AgentInvocation["burn_level"]): string {
@@ -316,6 +368,8 @@ export function UsageMonitor() {
             <KpiCard label="External procs" value={fmtInt(data?.summary.external_agent_processes)} delta="local CLI only" />
             <KpiCard label="Models" value={fmtInt(data?.tokens_by_model.length)} delta={`${fmtInt(data?.cost.missing_model_count)} unpriced`} />
           </div>
+
+          <PostgresCatalogPanel catalog={data?.postgres_catalog} />
 
           <div className="grid grid-cols-[1.2fr_1fr]">
             <Panel title="Agent invocations" sub={`${fmtInt(data?.agent_invocations.length)} recent or active`} className="border-r border-line">

--- a/web/src/types/usage_monitor.ts
+++ b/web/src/types/usage_monitor.ts
@@ -136,6 +136,22 @@ export interface UsageDiagnostics {
   process_source: string;
 }
 
+export type PostgresCatalogState = "available" | "unavailable" | "error";
+
+export interface PostgresCatalogCensus {
+  state: PostgresCatalogState;
+  schema_count: number | null;
+  catalog_object_count: number | null;
+  database_size_bytes: number | null;
+  sampled_at: string | null;
+  startup_schema_count: number | null;
+  absolute_schema_threshold: number;
+  relative_schema_multiplier: number;
+  threshold_breached: boolean;
+  breach_reasons: string[];
+  error: string | null;
+}
+
 export interface UsageMonitorPayload {
   window: UsageWindow;
   cost: UsageCostConfig;
@@ -148,5 +164,6 @@ export interface UsageMonitorPayload {
   local_usage_sources: LocalUsageSourceSummary[];
   active_by_repo: ActiveCount[];
   active_by_activity: ActiveCount[];
+  postgres_catalog: PostgresCatalogCensus;
   diagnostics: UsageDiagnostics;
 }


### PR DESCRIPTION
## Summary
- Adds a cached Postgres catalog census over `pg_namespace`, `pg_class`, and `pg_database_size(current_database())`.
- Exposes the census in `/health` and `/api/usage-monitor`, including threshold breach state and unavailable/error states.
- Renders catalog metrics in the Usage monitor dashboard and adds Rust/Web focused tests.

Closes #1461

## Configuration
- `HARNESS_POSTGRES_CATALOG_SCHEMA_THRESHOLD` overrides the default absolute schema threshold of `50000`.
- `HARNESS_POSTGRES_CATALOG_RELATIVE_THRESHOLD_MULTIPLIER` overrides the default startup-relative multiplier of `3.0`.

## Verification
- `cargo check -p harness-server --all-targets`
- `cargo test -p harness-server postgres_catalog::tests -- --nocapture`
- `cargo test -p harness-server health_reports_postgres_catalog -- --nocapture`
- `cargo test -p harness-server usage_monitor_response_includes_postgres_catalog_census -- --nocapture`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1461`
- `python3 checks/check_workflow.py --repo .`
- `git diff --check`
- `cargo fmt --all -- --check`
- `bun run --cwd web typecheck`
- `bun run --cwd web test -- UsageMonitor.test.tsx`
- `bun run --cwd web build`
- `cargo clippy --workspace --all-targets -- -D warnings`
