### PR TITLE
Spec GH1462 runtime test split

### DIFF
--- a/specs/GH1462/product.md
+++ b/specs/GH1462/product.md
@@ -1,0 +1,79 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1462
+
+## User Problem
+
+`crates/harness-workflow/src/runtime/tests.rs` remains a very large test file
+even after earlier partial splits. On the current main branch it is 5,554 lines
+and still carries the 6,500-line U-16 exemption in `CLAUDE.md`. The file
+consumes too much agent context for routine workflow-runtime edits and remains a
+merge-conflict hotspot.
+
+Maintainers need this file split into focused test modules without changing the
+test inventory or behavior.
+
+## Goals
+
+- Split the remaining giant `runtime/tests.rs` body into focused modules under
+  `crates/harness-workflow/src/runtime/tests/`.
+- Keep the change mechanical: preserve test names, assertions, fixture data, and
+  behavior.
+- Move shared fixtures, helper constructors, and test executors into a common
+  test helper module consumed by the split files.
+- Keep every resulting test file below an agreed ceiling of about 1,200 lines.
+- Update the U-16 exemption in `CLAUDE.md` so `runtime/tests.rs` no longer has a
+  6,500-line allowance.
+- Prove the sorted `cargo test -p harness-workflow -- --list` inventory is
+  unchanged before and after the split.
+
+## Non-Goals
+
+- Adding, removing, renaming, weakening, or improving tests.
+- Changing workflow runtime behavior, schemas, reducers, validators, or command
+  dispatch semantics.
+- Splitting other oversized files.
+- Reorganizing production modules or changing public APIs.
+
+## User-Visible Behavior
+
+There is no product runtime behavior change. Developers and agents working on
+the workflow runtime see smaller, domain-focused test files instead of one
+oversized root test file. Test execution and test names remain the same.
+
+## Acceptance Criteria
+
+- [ ] `cargo test -p harness-workflow -- --list` produces the same sorted test
+      names before and after the split.
+- [ ] The root `crates/harness-workflow/src/runtime/tests.rs` contains shared
+      module declarations or is replaced by a module directory entrypoint, not a
+      multi-thousand-line test body.
+- [ ] Shared helpers are moved once and imported by focused modules; duplicate
+      fixture copies are not introduced.
+- [ ] No resulting test file in `crates/harness-workflow/src/runtime/tests/`
+      exceeds about 1,200 lines.
+- [ ] `CLAUDE.md` no longer grants
+      `**/harness-workflow/src/runtime/tests.rs` a 6,500-line exemption.
+- [ ] `cargo test -p harness-workflow` passes.
+- [ ] `cargo fmt --all -- --check` passes.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes before PR
+      merge readiness.
+
+## Edge Cases
+
+- Tests that rely on `resolve_database_url(None)` must keep their current skip
+  behavior when local Postgres is unavailable.
+- Async worker and dispatcher tests must keep their existing timing, lease, and
+  retry semantics.
+- Existing submodules under `runtime/tests/` must keep compiling while the root
+  helpers move.
+- Test inventory comparison must ignore ordering differences introduced by file
+  movement.
+
+## Rollout Notes
+
+This is a mechanical maintainability refactor. The implementation PR should use
+`Closes #1462` only after the test inventory diff is empty and the focused
+verification commands pass.

--- a/specs/GH1462/tasks.md
+++ b/specs/GH1462/tasks.md
@@ -1,0 +1,41 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1462
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1462-T001` Owner: `inventory-baseline` | Dependencies: none | Done when: pre-split `cargo test -p harness-workflow -- --list` output is captured and sorted into an untracked local artifact | Verify: sorted baseline file exists and includes the current runtime tests
+- [ ] `SP1462-T002` Owner: `common-fixtures` | Dependencies: `SP1462-T001` | Done when: shared runtime test imports, instance builders, enqueue helpers, completion event helpers, validation helpers, and test executors live in a common module without duplicate copies | Verify: `cargo check -p harness-workflow --tests`
+- [ ] `SP1462-T003` Owner: `decision-and-reducer-split` | Dependencies: `SP1462-T002` | Done when: decision-builder and runtime-completion reducer tests move into focused modules with unchanged test names and assertions | Verify: post-move test inventory diff for moved tests is empty
+- [ ] `SP1462-T004` Owner: `validator-worker-dispatcher-split` | Dependencies: `SP1462-T002` | Done when: decision validator, runtime worker, runtime command dispatcher, and remaining command/store tests move into focused modules with unchanged behavior | Verify: post-move test inventory diff for moved tests is empty
+- [ ] `SP1462-T005` Owner: `file-size-policy` | Dependencies: `SP1462-T003`, `SP1462-T004` | Done when: root `runtime/tests.rs` is thin, every runtime test module is about 1,200 lines or less, and `CLAUDE.md` no longer grants the old 6,500-line exemption | Verify: `wc -l crates/harness-workflow/src/runtime/tests.rs crates/harness-workflow/src/runtime/tests/*.rs`
+- [ ] `SP1462-T006` Owner: `verification` | Dependencies: all implementation tasks | Done when: inventory, package tests, SpecRail checks, formatting, and clippy all pass | Verify: sorted `--list` diff, `cargo test -p harness-workflow`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1462`, `python3 checks/check_workflow.py --repo .`, `cargo fmt --all -- --check`, and `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Parallelization
+
+This is mostly mechanical but touches one test tree. Avoid multiple writers in
+the same files. If parallel work is used, assign disjoint file ownership after
+`common.rs` is established; otherwise keep it serial.
+
+## Verification
+
+- `cargo test -p harness-workflow -- --list`
+- sorted pre/post test-name diff
+- `cargo test -p harness-workflow`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1462`
+- `python3 checks/check_workflow.py --repo .`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Handoff Notes
+
+Use `Refs #1462` for the spec PR. The implementation PR should use
+`Closes #1462` only after the test inventory is unchanged, the old U-16
+exemption is removed or reduced, and all verification commands pass.

--- a/specs/GH1462/tech.md
+++ b/specs/GH1462/tech.md
@@ -1,0 +1,101 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1462
+
+## Product Spec
+
+See `specs/GH1462/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Runtime test root | `crates/harness-workflow/src/runtime/tests.rs` | 5,554 lines on current main; contains root imports, shared fixtures, decision-builder tests, reducer tests, validator tests, worker tests, store tests, and dispatcher tests. | This is the remaining oversized surface to split. |
+| Existing split modules | `crates/harness-workflow/src/runtime/tests/*.rs` | Several domains already live in child modules and import root helpers with `use super::*`. | The implementation should continue this pattern or replace it with a common helper module. |
+| Workflow runtime code | `crates/harness-workflow/src/runtime/{model,store,validator,reducer,...}.rs` | Production runtime behavior is already covered by the tests being moved. | These files should not change for this issue. |
+| Agent file-size policy | `CLAUDE.md` | Still grants `**/harness-workflow/src/runtime/tests.rs` a 6,500-line U-16 exemption. | The exemption must be removed or reduced once the split lands. |
+
+## Proposed Design
+
+1. Capture the pre-split test inventory.
+   - Run `cargo test -p harness-workflow -- --list`.
+   - Save sorted test names to an untracked artifact for local comparison.
+2. Create a common test support module.
+   - Add `crates/harness-workflow/src/runtime/tests/common.rs`.
+   - Move shared imports, workflow instance constructors, job enqueue helpers,
+     event builders, validation context helpers, and simple test executors into
+     `common.rs`.
+   - Re-export only test support needed by sibling modules.
+3. Split the remaining root tests by domain.
+   - Suggested files:
+     - `decision_builders.rs` for issue/prompt/plan/PR feedback/quality-gate
+       decision construction tests.
+     - `completion_reducer.rs` for `reduce_runtime_job_completed` tests.
+     - `decision_validator.rs` for `DecisionValidator` tests.
+     - `worker_lifecycle.rs` for runtime worker and child-propagation tests.
+     - `command_dispatcher.rs` for `RuntimeCommandDispatcher` tests.
+     - `command_store.rs` or equivalent for remaining command/runtime-store
+       behavior not already covered by `runtime_store.rs`.
+   - Preserve existing child modules such as `issue_planning`,
+     `pr_repair_evidence`, `retry`, and `runtime_store`.
+4. Keep the root module thin.
+   - `runtime/tests.rs` should declare modules and import/re-export shared test
+     support only when needed.
+   - Avoid duplicating large import lists in each file when `common.rs` can own
+     them.
+5. Update file-size policy.
+   - Remove `**/harness-workflow/src/runtime/tests.rs` from `CLAUDE.md`, or
+     replace it with a much lower ceiling that matches the new thin root.
+6. Verify inventory and behavior.
+   - Run the pre/post sorted test-name diff.
+   - Run `cargo test -p harness-workflow`.
+   - Run formatting and clippy gates.
+
+## Data Flow
+
+No runtime data flow changes. Tests continue to construct workflow instances,
+commands, jobs, activity results, validation contexts, and database-backed
+stores exactly as before; only their source file locations change.
+
+## Alternatives Considered
+
+- Leave the root file partially split. Rejected because it remains far above the
+  normal U-16 ceiling and still requires a 6,500-line exemption.
+- Split by chronological order only. Rejected because domain-focused files are
+  easier to navigate and align with existing runtime concepts.
+- Rewrite helpers while moving tests. Rejected because the issue requires a
+  mechanical split and test-integrity protection.
+- Use generated include files. Rejected because normal Rust modules are easier
+  for agents and maintainers to search, review, and edit.
+
+## Risks
+
+- Test names can change if modules are renamed carelessly. Mitigate with sorted
+  `--list` comparison.
+- Helper visibility can accidentally broaden or break imports. Mitigate by
+  keeping helpers in a private test-only module and compiling with the full
+  package test.
+- Moving async DB tests can hide local failures when Postgres is unavailable.
+  Mitigate by preserving existing `resolve_database_url(None)` skip checks and
+  relying on CI DB coverage.
+- Large mechanical diffs can hide behavioral edits. Mitigate with move-only
+  review, inventory diff, and focused package tests.
+
+## Test Plan
+
+- [ ] Capture pre-split sorted inventory:
+      `cargo test -p harness-workflow -- --list`.
+- [ ] Capture post-split sorted inventory and verify the diff is empty.
+- [ ] Run `cargo test -p harness-workflow`.
+- [ ] Run `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1462`.
+- [ ] Run `python3 checks/check_workflow.py --repo .`.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `cargo clippy --workspace --all-targets -- -D warnings`.
+
+## Rollback Plan
+
+Revert the split commit. Because the implementation should only move tests and
+update the U-16 exemption, rollback restores the previous file layout without a
+data migration or production behavior change.


### PR DESCRIPTION
## Summary
- Adds the GH1462 product spec for splitting the oversized workflow runtime test root.
- Adds the technical split plan and task plan for a move-only implementation.

## Verification
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1462
- python3 checks/check_workflow.py --repo .

Refs #1462