### PR TITLE
Spec GH1463 background split

### DIFF
--- a/specs/GH1463/product.md
+++ b/specs/GH1463/product.md
@@ -1,0 +1,85 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1463
+
+## User Problem
+
+`crates/harness-server/src/http/background.rs` is still a 3,542-line
+maintenance hotspot on current main and requires a 3,600-line U-16 exemption in
+`CLAUDE.md`. Routine server background work forces agents and maintainers to
+load unrelated runtime dispatch, PR feedback, worker, and recovery code in one
+file. The file is also a concentrated merge-conflict surface.
+
+Maintainers need the file split into focused modules without changing route
+behavior, task recovery behavior, runtime command dispatch behavior, or public
+module paths.
+
+## Goals
+
+- Split `crates/harness-server/src/http/background.rs` into focused modules
+  under `crates/harness-server/src/http/background/`.
+- Keep `http::background` as the public module surface for existing callers by
+  re-exporting the moved `pub` and `pub(super)` items from the root module.
+- Keep the change mechanical: move code, fix imports and visibility, and avoid
+  behavior, response-shape, or scheduling policy changes.
+- Keep every resulting background module below about 1,200 lines.
+- Update the `CLAUDE.md` U-16 exemption so the old 3,600-line
+  `background.rs` allowance is removed or reduced to the new thin root.
+- Prove server and workspace compilation still pass with the unchanged public
+  surface.
+
+## Non-Goals
+
+- Changing route behavior, response payloads, scheduler timing, worker limits,
+  runtime dispatch policy, auto-merge policy, or recovery semantics.
+- Splitting other oversized files.
+- Moving call sites outside `crates/harness-server/src/http/background*`.
+- Adding new background workers, metrics, configuration, or tests beyond what
+  is required to preserve compile coverage for the move.
+
+## User-Visible Behavior
+
+There is no runtime behavior change. Operators and API clients should observe
+the same background worker, runtime command dispatch, PR feedback, and recovery
+behavior. Developers and agents should see smaller focused modules instead of a
+single oversized `background.rs` file.
+
+## Acceptance Criteria
+
+- [ ] `crates/harness-server/src/http/background.rs` becomes a thin module
+      entrypoint that declares and re-exports focused child modules.
+- [ ] Moved public items remain reachable through the existing
+      `http::background` module path, so existing call sites do not move.
+- [ ] No production behavior, response-shape, scheduling, runtime dispatch, or
+      recovery logic is intentionally changed.
+- [ ] No file in `crates/harness-server/src/http/background/` exceeds about
+      1,200 lines.
+- [ ] `CLAUDE.md` no longer grants
+      `**/harness-server/src/http/background.rs` a 3,600-line exemption.
+- [ ] `cargo check --workspace --all-targets` passes.
+- [ ] `cargo test -p harness-server` passes with the existing local Postgres
+      gating behavior.
+- [ ] `cargo fmt --all -- --check` passes.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes before PR
+      merge readiness.
+
+## Edge Cases
+
+- Background startup recovery must keep current behavior for runtime-host leases,
+  prompt orphan recovery, and task completion callbacks.
+- Runtime command dispatch must keep current profile resolution, project-root
+  resolution, command gate hashing, and outbox status transitions.
+- PR feedback sweeping and auto-merge request recovery must keep current guard
+  behavior and data extraction.
+- Worker supervision must keep current lease, shutdown, concurrency, and
+  external-owner checks.
+- Existing `pub(super)` consumers in sibling `http` modules must continue to
+  compile through the `http::background` root path.
+
+## Rollout Notes
+
+This is a mechanical maintainability refactor. The spec PR should use
+`Refs #1463`. The implementation PR should use `Closes #1463` only after the
+file-size target and verification commands pass.

--- a/specs/GH1463/tasks.md
+++ b/specs/GH1463/tasks.md
@@ -1,0 +1,42 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1463
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1463-T001` Owner: `module-map` | Dependencies: none | Done when: the current `background.rs` functions and types are mapped to focused child modules with no planned behavior changes | Verify: module list matches the concern groups in `tech.md`
+- [ ] `SP1463-T002` Owner: `root-entrypoint` | Dependencies: `SP1463-T001` | Done when: `background.rs` is a thin module entrypoint that declares child modules and re-exports existing public or `pub(super)` surface items | Verify: `cargo check -p harness-server --all-targets`
+- [ ] `SP1463-T003` Owner: `dispatch-and-profiles` | Dependencies: `SP1463-T002` | Done when: runtime command dispatch and runtime profile code lives in focused modules with unchanged function names and behavior | Verify: `cargo check -p harness-server --all-targets`
+- [ ] `SP1463-T004` Owner: `feedback-and-workers` | Dependencies: `SP1463-T002` | Done when: PR feedback sweeping and runtime worker supervision code lives in focused modules with unchanged function names and behavior | Verify: `cargo check -p harness-server --all-targets`
+- [ ] `SP1463-T005` Owner: `recovery-modules` | Dependencies: `SP1463-T002` | Done when: awaiting dependency, PR, system task, checkpoint, and orphan pending recovery code lives in focused modules with unchanged function names and behavior | Verify: `cargo check -p harness-server --all-targets`
+- [ ] `SP1463-T006` Owner: `file-size-policy` | Dependencies: `SP1463-T003`, `SP1463-T004`, `SP1463-T005` | Done when: every `http/background*` file is about 1,200 lines or less and `CLAUDE.md` no longer grants the old 3,600-line `background.rs` exemption | Verify: `wc -l crates/harness-server/src/http/background.rs crates/harness-server/src/http/background/*.rs`
+- [ ] `SP1463-T007` Owner: `verification` | Dependencies: all implementation tasks | Done when: workspace check, harness-server tests, SpecRail checks, formatting, and clippy all pass | Verify: `cargo check --workspace --all-targets`, `cargo test -p harness-server`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1463`, `python3 checks/check_workflow.py --repo .`, `cargo fmt --all -- --check`, and `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Parallelization
+
+The implementation is move-only but touches one production module family. Keep
+the root entrypoint and shared helpers serial. If parallel work is used later,
+assign disjoint child modules after the re-export shape is established.
+
+## Verification
+
+- `cargo check --workspace --all-targets`
+- `cargo test -p harness-server`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1463`
+- `python3 checks/check_workflow.py --repo .`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `wc -l crates/harness-server/src/http/background.rs crates/harness-server/src/http/background/*.rs`
+
+## Handoff Notes
+
+Use `Refs #1463` for the spec PR. The implementation PR should use
+`Closes #1463` only after the old U-16 exemption is removed or reduced, the
+background files meet the size target, and all verification commands pass.

--- a/specs/GH1463/tech.md
+++ b/specs/GH1463/tech.md
@@ -1,0 +1,106 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1463
+
+## Product Spec
+
+See `specs/GH1463/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Background root | `crates/harness-server/src/http/background.rs` | 3,542 lines on current main; contains shared recovery helpers, dependency watchers, runtime command dispatch, runtime profile resolution, PR feedback sweeping, runtime job workers, and startup recovery flows. | This is the oversized surface to split. |
+| HTTP siblings | `crates/harness-server/src/http/*.rs` | Sibling modules call items through `http::background` and `pub(super)` visibility. | The split must preserve the module surface and avoid moving call sites. |
+| File-size policy | `CLAUDE.md` | Grants `**/harness-server/src/http/background.rs` a 3,600-line U-16 exemption. | The exemption must be removed or reduced once the root is thin. |
+| Server behavior | `crates/harness-server` tests and workspace checks | Existing tests cover route startup, runtime command dispatch, task recovery, and background worker interactions. | Verification must prove the move did not break compile-time or test-covered behavior. |
+
+## Proposed Design
+
+1. Keep `background.rs` as the module entrypoint.
+   - Declare child modules under `crates/harness-server/src/http/background/`.
+   - Re-export moved items that are currently used through `http::background`.
+   - Keep root-only glue minimal.
+2. Split by existing concern groups.
+   - `support.rs`: shared parse helpers, recovered task request construction,
+     reviewer resolution, background task failure, prompt orphan recovery
+     helpers, and startup recovery readiness helpers.
+   - `awaiting_deps.rs`: `spawn_awaiting_deps_watcher` and dependency-ready
+     task dispatch.
+   - `runtime_command_dispatch.rs`: runtime command dispatch ticks,
+     command-specific project/root helpers, gate fact hashing, dispatch metrics,
+     and outbox status transitions.
+   - `runtime_profiles.rs`: runtime kind/profile resolution, profile selector
+     creation, manifest persistence, approval policy mapping, and profile
+     override handling.
+   - `pr_feedback.rs`: PR feedback sweep ticks, auto-merge request recovery,
+     and `spawn_runtime_pr_feedback_sweeper`.
+   - `runtime_workers.rs`: runtime worker lease state, worker tick spawning,
+     open-slot calculation, shutdown handling, and job worker supervision.
+   - `pr_recovery.rs`: PR recovery startup scan and workflow/task candidate
+     collection.
+   - `system_recovery.rs`: system task recovery startup flow.
+   - `checkpoint_recovery.rs`: checkpoint recovery startup flow.
+   - `orphan_pending_recovery.rs`: orphan pending task recovery startup flow.
+3. Preserve behavior while fixing module boundaries.
+   - Move imports with the code that needs them.
+   - Use `pub(super)` only where sibling `http` modules need the item through
+     `http::background`; keep implementation helpers private where possible.
+   - Avoid renaming functions, changing log fields, changing retry intervals,
+     or changing match behavior.
+4. Update file-size policy.
+   - Remove the old `**/harness-server/src/http/background.rs` U-16 exemption
+     from `CLAUDE.md`, or reduce it to a thin-root ceiling if the policy format
+     requires an explicit entry.
+5. Verify the public surface and behavior.
+   - Run workspace check to catch missed re-exports and visibility regressions.
+   - Run harness-server tests for covered behavior.
+   - Run fmt, clippy, and SpecRail checks.
+
+## Data Flow
+
+No data flow changes are planned. Existing background loops continue to read and
+mutate task store state, workflow runtime state, command records, GitHub PR
+snapshots, runtime profile manifests, leases, and recovery candidates exactly as
+before. Only the source-file layout changes.
+
+## Alternatives Considered
+
+- Leave `background.rs` as-is. Rejected because it remains near the exemption
+  ceiling and continues to force unrelated background domains into one context.
+- Use `include!` fragments. Rejected because production modules should be
+  navigable Rust modules with normal imports and visibility.
+- Split and redesign worker boundaries at the same time. Rejected because GH1463
+  requires a move-only refactor and behavior changes would make review harder.
+- Move call sites to child modules. Rejected because the issue requires the
+  public `http::background` surface to remain unchanged.
+
+## Risks
+
+- Visibility can break sibling module imports. Mitigate with
+  `cargo check --workspace --all-targets`.
+- Shared helper placement can accidentally broaden access. Mitigate by using
+  private helpers unless an existing `pub(super)` consumer requires re-export.
+- Mechanical movement can hide behavior edits. Mitigate by keeping function
+  names and bodies unchanged except for imports and visibility, then reviewing
+  the diff as a move.
+- File-size goals can fail if concern groups are too coarse. Mitigate by
+  splitting large groups before PR readiness.
+
+## Test Plan
+
+- [ ] Run `cargo check --workspace --all-targets`.
+- [ ] Run `cargo test -p harness-server`.
+- [ ] Run `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1463`.
+- [ ] Run `python3 checks/check_workflow.py --repo .`.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Run `wc -l crates/harness-server/src/http/background.rs crates/harness-server/src/http/background/*.rs`.
+
+## Rollback Plan
+
+Revert the implementation commit. Because the implementation should only move
+code and update `CLAUDE.md`, rollback restores the previous file layout without
+a migration, data repair, or runtime configuration change.


### PR DESCRIPTION
## Summary
- Add the GH1463 product, tech, and task specs for splitting http/background.rs into focused modules.
- Constrain implementation to a mechanical move that preserves the http::background surface and behavior.

## Verification
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1463
- python3 checks/check_workflow.py --repo .
- git diff --check

Refs #1463