### PR TITLE
Add SpecRail plan for GH1464 hook split

### DIFF
--- a/specs/GH1464/product.md
+++ b/specs/GH1464/product.md
@@ -1,0 +1,84 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1464
+
+## User Problem
+
+The local `.githooks/pre-commit` hook still runs formatting, clippy, and Rust
+tests on every commit. It already derives a staged cargo package scope, but the
+test step is still paid at commit time. Harness agents commit often during one
+task, so even scoped tests compound into slow iteration and make small commits
+feel expensive.
+
+Maintainers need the commit-time hook to stay quick while preserving the current
+full local safety gate before code leaves the machine.
+
+## Goals
+
+- Keep `.githooks/pre-commit` focused on fast commit-time validation:
+  `cargo fmt --all -- --check` plus clippy for the staged crate scope.
+- Move the full gate to a new executable `.githooks/pre-push` hook:
+  `cargo clippy --workspace --all-targets -- -D warnings` and
+  `cargo test --workspace --lib` with the existing local Postgres conditional.
+- Preserve the existing `GIT_INDEX_FILE`, `GIT_DIR`, and `GIT_WORK_TREE`
+  unsetting workaround for any hook that runs cargo commands.
+- Keep `build.rs` hook-path auto-configuration working through
+  `git config core.hooksPath .githooks`.
+- Update contributor and agent-facing documentation so local hook expectations
+  match the new split.
+
+## Non-Goals
+
+- Changing CI workflows or required GitHub status checks.
+- Changing clippy warning policy, lint levels, or which warnings fail CI.
+- Changing the staged crate scope derivation beyond what is needed to keep the
+  pre-commit hook reliable.
+- Adding new dependencies for shell linting or hook management.
+- Optimizing Rust compile times outside the hook split.
+
+## User-Visible Behavior
+
+Developers and agents should see faster local commits for scoped source changes.
+Pushes should run the full workspace clippy and lib test gate before the branch
+is uploaded. A push containing a clippy warning or failing lib test should be
+blocked locally before CI.
+
+## Acceptance Criteria
+
+- [ ] `.githooks/pre-commit` remains executable, uses bash with
+      `set -euo pipefail`, runs formatting, and runs clippy for the staged
+      cargo package scope.
+- [ ] `.githooks/pre-commit` no longer runs Rust tests.
+- [ ] `.githooks/pre-push` exists, is executable, uses bash with
+      `set -euo pipefail`, unsets the leaking git environment variables, and
+      runs the full workspace clippy gate.
+- [ ] `.githooks/pre-push` runs `cargo test --workspace --lib` when
+      `HARNESS_DATABASE_URL` is set, and otherwise keeps the current
+      live-Postgres skip behavior for local machines without a database.
+- [ ] A docs-only staged change can complete the pre-commit hook without
+      running clippy or tests for unrelated crates.
+- [ ] `build.rs` continues to configure `core.hooksPath` for `.githooks`.
+- [ ] `CLAUDE.md`, `AGENTS.md`, and `CONTRIBUTING.md` describe the new
+      pre-commit/pre-push split without stale references to per-commit tests.
+- [ ] `cargo fmt --all -- --check` passes.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes before PR
+      merge readiness.
+
+## Edge Cases
+
+- Workspace-level files such as `Cargo.toml`, `Cargo.lock`, or Rust files
+  outside `crates/` should continue to fall back to a full clippy scope.
+- Docs-only commits should not invoke unrelated Rust package checks in
+  pre-commit.
+- The pre-push hook must not break tests that create their own temporary git
+  repositories.
+- Machines without a local Postgres database should receive the same explicit
+  skip message that the current hook uses.
+
+## Rollout Notes
+
+Use `Refs #1464` for the spec PR. The implementation PR should use
+`Closes #1464` only after both hooks are executable, local verification passes,
+and the docs no longer describe the old per-commit test gate.

--- a/specs/GH1464/tasks.md
+++ b/specs/GH1464/tasks.md
@@ -1,0 +1,39 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1464
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1464-T001` Owner: `hook-scope` | Dependencies: none | Done when: `.githooks/pre-commit` keeps fmt plus staged-scope clippy and does not run Rust tests | Verify: inspect `.githooks/pre-commit` and run `bash -n .githooks/pre-commit`
+- [ ] `SP1464-T002` Owner: `push-gate` | Dependencies: `SP1464-T001` | Done when: executable `.githooks/pre-push` runs full workspace clippy and the existing Postgres-aware lib test gate | Verify: `bash -n .githooks/pre-push` and `.githooks/pre-push`
+- [ ] `SP1464-T003` Owner: `docs-only-fast-path` | Dependencies: `SP1464-T001` | Done when: docs-only staged changes do not cause pre-commit to run unrelated cargo clippy or tests | Verify: docs-only pre-commit simulation
+- [ ] `SP1464-T004` Owner: `docs` | Dependencies: `SP1464-T001`, `SP1464-T002` | Done when: `CLAUDE.md`, `AGENTS.md`, and `CONTRIBUTING.md` describe fast pre-commit and full pre-push behavior | Verify: `rg -n "pre-commit|pre-push|tests" CLAUDE.md AGENTS.md CONTRIBUTING.md`
+- [ ] `SP1464-T005` Owner: `verification` | Dependencies: all implementation tasks | Done when: syntax, hook, formatting, clippy, and SpecRail checks pass | Verify: `bash -n .githooks/pre-commit .githooks/pre-push`, `.githooks/pre-push`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1464`, and `python3 checks/check_workflow.py --repo .`
+
+## Parallelization
+
+Keep this implementation serial. The same hook files and high-context docs are
+shared surfaces, so parallel writable lanes would create avoidable conflicts.
+
+## Verification
+
+- `bash -n .githooks/pre-commit .githooks/pre-push`
+- docs-only pre-commit simulation
+- `.githooks/pre-push`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1464`
+- `python3 checks/check_workflow.py --repo .`
+
+## Handoff Notes
+
+Use `Refs #1464` for the spec PR. The implementation PR should use
+`Closes #1464` only after hook executable bits, docs, and verification are all
+complete.

--- a/specs/GH1464/tech.md
+++ b/specs/GH1464/tech.md
@@ -1,0 +1,97 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1464
+
+## Product Spec
+
+See `specs/GH1464/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Commit hook | `.githooks/pre-commit` | Runs fmt, staged-scope clippy, and staged-scope lib tests. Unsets git environment variables before cargo commands. | The issue asks to make commit-time validation fast by removing tests from pre-commit. |
+| Push hook | `.githooks/pre-push` | Does not exist. | The full local gate needs a new pre-push entrypoint. |
+| Hook path setup | `build.rs`, `Makefile` | Configures `core.hooksPath` to `.githooks` when the pre-commit hook exists. | The new pre-push hook should work through the same hooks path without extra setup. |
+| Agent docs | `CLAUDE.md`, `AGENTS.md` | Describe pre-commit as running fmt, clippy, and tests. | These instructions will become stale after the split. |
+| Contributor docs | `CONTRIBUTING.md` | Describes generic test expectations but not the local hook split. | Contributors need the new local workflow documented. |
+
+## Proposed Design
+
+1. Keep the staged-scope derivation in `.githooks/pre-commit`.
+   - Continue using `git diff --cached --name-only`.
+   - Continue falling back to `--workspace` for ambiguous Rust or workspace
+     files.
+   - Keep `harness-core` dependent expansion because that mirrors the existing
+     local and CI assumptions.
+2. Remove test execution from `.githooks/pre-commit`.
+   - Keep fmt first.
+   - Keep clippy second.
+   - End with a message that the fast pre-commit checks passed.
+3. Add `.githooks/pre-push`.
+   - Use `#!/usr/bin/env bash` and `set -euo pipefail`.
+   - Unset `GIT_INDEX_FILE`, `GIT_DIR`, and `GIT_WORK_TREE` before running
+     cargo commands.
+   - Run `cargo clippy --workspace --all-targets -- -D warnings`.
+   - Run `cargo test --workspace --lib` when `HARNESS_DATABASE_URL` is set.
+   - When `HARNESS_DATABASE_URL` is unset, print the existing skip message and
+     run `cargo test --workspace --lib -- --skip db::tests`.
+4. Keep hook installation unchanged.
+   - `build.rs` and `Makefile` can keep configuring `.githooks`; no special
+     pre-push registration is needed once the hooks path is set.
+5. Update docs.
+   - `CLAUDE.md` and `AGENTS.md` should say pre-commit is fast fmt plus scoped
+     clippy, and pre-push is the full workspace clippy plus lib test gate.
+   - `CONTRIBUTING.md` should tell contributors how to activate hooks and what
+     runs at commit versus push time.
+
+## Data Flow
+
+No application data flow changes are planned. The only runtime effect is local
+developer git hook execution.
+
+## Alternatives Considered
+
+- Keep tests in pre-commit but scope them more aggressively. Rejected because
+  the issue explicitly moves full tests to pre-push and tests still add
+  meaningful commit-time latency.
+- Disable local full tests entirely and rely on CI. Rejected because the desired
+  outcome keeps a local pre-push gate that blocks bad pushes.
+- Add a hook manager dependency. Rejected because git's native hooks path is
+  already configured and sufficient.
+- Move full `cargo test --workspace --all-targets` to pre-push. Rejected
+  because the current local gate is `cargo test --workspace --lib`; widening
+  scope belongs in a separate decision.
+
+## Risks
+
+- Pre-push can feel slower than the current push path. This is the intended
+  safety trade-off; CI remains the remote backstop.
+- Removing tests from pre-commit can allow broken intermediate commits. This is
+  accepted by the issue and mitigated by pre-push plus CI.
+- Docs-only staged changes can still fall back to full clippy if scope
+  derivation treats all non-crate files as ambiguous. Mitigate by making
+  docs-only paths no-op for cargo scope while preserving full fallback for
+  workspace-level Rust or cargo files.
+- High-context docs can drift if only one instruction file is updated. Mitigate
+  by updating `CLAUDE.md`, `AGENTS.md`, and `CONTRIBUTING.md` together.
+
+## Test Plan
+
+- [ ] Run `bash -n .githooks/pre-commit .githooks/pre-push`.
+- [ ] Run a docs-only pre-commit simulation:
+      `git add CONTRIBUTING.md && .githooks/pre-commit`, then unstage if
+      needed.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Run `.githooks/pre-push` with local environment defaults.
+- [ ] Run `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1464`.
+- [ ] Run `python3 checks/check_workflow.py --repo .`.
+
+## Rollback Plan
+
+Revert the implementation commit. That restores the previous single pre-commit
+gate and removes the pre-push hook without migrations, runtime state changes, or
+data cleanup.


### PR DESCRIPTION
## Summary
- Add the GH1464 product spec, technical spec, and task plan for splitting fast pre-commit checks from the full pre-push gate.
- Capture the docs scope for CLAUDE.md, AGENTS.md, and CONTRIBUTING.md so hook instructions stay consistent.

## Verification
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1464
- python3 checks/check_workflow.py --repo .
- git diff --check
- cargo fmt --all -- --check

Refs #1464