### PR TITLE
Split git hook validation gates

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,17 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Unset git env vars that leak into test subprocesses during commit.
-# GIT_INDEX_FILE points to a temp file during commit, breaking workspace
-# tests that spawn their own git repos in temp directories.
+# Unset git env vars that can leak into cargo subprocesses during commit.
 unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE 2>/dev/null || true
 
-# Derive the cargo package scope from staged files so clippy/test only cover
-# the crates touched by this commit. Falls back to the full workspace when:
+# Derive the cargo package scope from staged files so clippy only covers the
+# crates touched by this commit. Falls back to the full workspace when:
 #   - workspace-level manifests (Cargo.toml / Cargo.lock) are staged
 #   - Rust files outside crates/ are staged
 #   - a staged path maps to a directory that is not a cargo package
-#   - no crate paths are staged at all (safe default)
+# Docs, specs, hooks, and other non-Rust paths do not require clippy.
 # harness-core is depended on by nearly every crate, so a core change expands
 # to its main dependents (mirrors the server/agents path filters in ci.yml).
 derive_scope() {
@@ -53,9 +51,9 @@ derive_scope() {
                 ;;
         esac
     fi
-    if [ "$full" -eq 1 ] || [ "$pkgs" = " " ]; then
+    if [ "$full" -eq 1 ]; then
         echo "--workspace"
-    else
+    elif [ "$pkgs" != " " ]; then
         scope=""
         for p in $pkgs; do
             scope="$scope -p $p"
@@ -65,25 +63,17 @@ derive_scope() {
 }
 
 scope=$(derive_scope)
-echo "=== pre-commit: cargo scope: $scope ==="
 
 echo "=== pre-commit: fmt ==="
 cargo fmt --all -- --check
 
-echo "=== pre-commit: clippy ==="
-# shellcheck disable=SC2086 # scope is an intentional word-split flag list
-cargo clippy $scope --all-targets -- -D warnings
-
-echo "=== pre-commit: test ==="
-# Live Postgres tests require a configured Harness database URL.
-# Run them when available; otherwise skip only the known live-Postgres lib tests
-# and let CI or a configured local database provide full DB coverage.
-# shellcheck disable=SC2086 # scope is an intentional word-split flag list
-if [ -n "${HARNESS_DATABASE_URL:-}" ]; then
-    cargo test $scope --lib
+if [ -n "$scope" ]; then
+    echo "=== pre-commit: cargo scope: $scope ==="
+    echo "=== pre-commit: clippy ==="
+    # shellcheck disable=SC2086 # scope is an intentional word-split flag list
+    cargo clippy $scope --all-targets -- -D warnings
 else
-    echo "HARNESS_DATABASE_URL not set — skipping live Postgres lib tests"
-    cargo test $scope --lib -- --skip db::tests
+    echo "=== pre-commit: no cargo packages staged; skipping clippy ==="
 fi
 
-echo "=== pre-commit: all checks passed ==="
+echo "=== pre-commit: fast checks passed ==="

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unset git env vars that leak into test subprocesses during push.
+# GIT_INDEX_FILE can point to a temp file during hook execution, breaking
+# workspace tests that spawn their own git repos in temp directories.
+unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE 2>/dev/null || true
+
+echo "=== pre-push: clippy ==="
+cargo clippy --workspace --all-targets -- -D warnings
+
+echo "=== pre-push: test ==="
+# Keep HARNESS_DATABASE_URL scoped to harness-server. Some non-server tests
+# exercise process-global environment behavior and should not inherit DB config.
+echo "=== pre-push: non-server lib tests ==="
+env \
+    -u HARNESS_DATABASE_URL \
+    -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS \
+    -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS \
+    cargo test --workspace --exclude harness-server --lib
+
+if [ -n "${HARNESS_DATABASE_URL:-}" ]; then
+    echo "=== pre-push: harness-server lib tests ==="
+    cargo test -p harness-server --lib
+else
+    echo "HARNESS_DATABASE_URL not set — skipping harness-server DB-backed lib tests"
+fi
+
+echo "=== pre-push: all checks passed ==="

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,13 +16,14 @@ All outputs MUST be in English, including:
   - Cross-crate API change: `cargo check --workspace --all-targets`
   - Targeted behavior change: run the relevant `cargo test -p <crate> <test_filter>`
 - Do not run the CI-equivalent workspace check after every edit. Use it for final PR readiness or when warning-sensitive code changed.
-- Before committing, run `cargo fmt --all -- --check` plus the relevant package tests. Run full workspace tests when the change affects shared behavior, persistence, workflow runtime, or agent adapters.
+- Before committing, run `cargo fmt --all -- --check` plus the relevant package tests for behavior-changing code. Run full workspace tests when the change affects shared behavior, persistence, workflow runtime, or agent adapters.
 - Before pushing a PR, ALWAYS run `cargo clippy --workspace --all-targets -- -D warnings` to catch CI-equivalent warnings and lints (dead code, unused imports, missing match arms, clippy findings)
 - When adding a new enum variant, grep ALL match sites for that enum and update them — CI uses exhaustive match checks
 - Run `cargo fmt --all` before every commit — CI enforces `cargo fmt --all -- --check`
 - Dead code in `#[cfg(test)]` modules still triggers `-D warnings` in CI; delete unused test helpers instead of suppressing with `#[allow(dead_code)]`
-- Pre-commit hook (`.githooks/pre-commit`) runs fmt + clippy + tests as a final local gate. After cloning, activate with: `git config core.hooksPath .githooks`
-- Local Postgres-dependent tests require `HARNESS_DATABASE_URL`. Without it, the pre-commit hook skips the known live-Postgres lib tests and leaves full DB coverage to CI or a configured local database.
+- Pre-commit hook (`.githooks/pre-commit`) runs fmt + staged-scope clippy as a fast commit gate. After cloning, activate with: `git config core.hooksPath .githooks`
+- Pre-push hook (`.githooks/pre-push`) runs full workspace clippy, non-server workspace lib tests, and `harness-server` lib tests when `HARNESS_DATABASE_URL` is configured.
+- Local Postgres-dependent `harness-server` tests require `HARNESS_DATABASE_URL`. Without it, the pre-push hook skips `harness-server` and leaves full DB coverage to CI or a configured local database.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,15 @@ All outputs MUST be in English, including:
 
 ## Build
 
-- `cargo check` after every change
-- `cargo test` before commit
+- Use the smallest validation command that covers the changed surface during implementation.
+- Run relevant tests before committing behavior-changing code.
 - Before pushing a PR, ALWAYS run `cargo clippy --workspace --all-targets -- -D warnings` to catch CI-equivalent warnings and lints (dead code, unused imports, missing match arms, clippy findings)
 - When adding a new enum variant, grep ALL match sites for that enum and update them — CI uses exhaustive match checks
 - Run `cargo fmt --all` before every commit — CI enforces `cargo fmt --all -- --check`
 - Dead code in `#[cfg(test)]` modules still triggers `-D warnings` in CI; delete unused test helpers instead of suppressing with `#[allow(dead_code)]`
-- Pre-commit hook (`.githooks/pre-commit`) runs fmt + clippy + test automatically. After cloning, activate with: `git config core.hooksPath .githooks`
+- Pre-commit hook (`.githooks/pre-commit`) runs fmt + staged-scope clippy as a fast commit gate. After cloning, activate with: `git config core.hooksPath .githooks`
+- Pre-push hook (`.githooks/pre-push`) runs full workspace clippy, non-server workspace lib tests, and `harness-server` lib tests when `HARNESS_DATABASE_URL` is configured.
+- Local Postgres-dependent `harness-server` tests require `HARNESS_DATABASE_URL`; without it, pre-push skips `harness-server` locally.
 
 ## Local Cargo Concurrency
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,22 @@ cargo build
 cargo test
 ```
 
+5. Activate local git hooks:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The pre-commit hook is intentionally fast: it runs `cargo fmt --all -- --check`
+and clippy for the cargo packages touched by staged files. Docs-only staged
+changes skip clippy.
+
+The pre-push hook is the full local gate before upload: it runs
+`cargo clippy --workspace --all-targets -- -D warnings`, non-server workspace
+lib tests, and `harness-server` lib tests when `HARNESS_DATABASE_URL` is
+configured. Without `HARNESS_DATABASE_URL`, the hook skips `harness-server`
+locally and leaves full DB coverage to CI or a configured local database.
+
 For `harness-server` work, start with the fast local ladder and reserve the
 full DB profile for final handoff or changes that touch startup, recovery,
 full `AppState`, route persistence, or workflow runtime behavior:

--- a/specs/GH1464/product.md
+++ b/specs/GH1464/product.md
@@ -54,9 +54,9 @@ blocked locally before CI.
 - [ ] `.githooks/pre-push` exists, is executable, uses bash with
       `set -euo pipefail`, unsets the leaking git environment variables, and
       runs the full workspace clippy gate.
-- [ ] `.githooks/pre-push` runs `cargo test --workspace --lib` when
-      `HARNESS_DATABASE_URL` is set, and otherwise keeps the current
-      live-Postgres skip behavior for local machines without a database.
+- [ ] `.githooks/pre-push` runs non-server workspace lib tests without leaking
+      `HARNESS_DATABASE_URL`, then runs `harness-server` lib tests only when
+      `HARNESS_DATABASE_URL` is set.
 - [ ] A docs-only staged change can complete the pre-commit hook without
       running clippy or tests for unrelated crates.
 - [ ] `build.rs` continues to configure `core.hooksPath` for `.githooks`.
@@ -74,8 +74,8 @@ blocked locally before CI.
   pre-commit.
 - The pre-push hook must not break tests that create their own temporary git
   repositories.
-- Machines without a local Postgres database should receive the same explicit
-  skip message that the current hook uses.
+- Machines without a local Postgres database should receive an explicit
+  `harness-server` skip message and still run non-server workspace lib tests.
 
 ## Rollout Notes
 

--- a/specs/GH1464/tasks.md
+++ b/specs/GH1464/tasks.md
@@ -12,10 +12,10 @@ GH-1464
 ## Implementation Tasks
 
 - [ ] `SP1464-T001` Owner: `hook-scope` | Dependencies: none | Done when: `.githooks/pre-commit` keeps fmt plus staged-scope clippy and does not run Rust tests | Verify: inspect `.githooks/pre-commit` and run `bash -n .githooks/pre-commit`
-- [ ] `SP1464-T002` Owner: `push-gate` | Dependencies: `SP1464-T001` | Done when: executable `.githooks/pre-push` runs full workspace clippy and the existing Postgres-aware lib test gate | Verify: `bash -n .githooks/pre-push` and `.githooks/pre-push`
+- [ ] `SP1464-T002` Owner: `push-gate` | Dependencies: `SP1464-T001` | Done when: executable `.githooks/pre-push` runs full workspace clippy, non-server workspace lib tests without DB env leakage, and `harness-server` lib tests only when `HARNESS_DATABASE_URL` is set | Verify: `bash -n .githooks/pre-push` and `.githooks/pre-push`
 - [ ] `SP1464-T003` Owner: `docs-only-fast-path` | Dependencies: `SP1464-T001` | Done when: docs-only staged changes do not cause pre-commit to run unrelated cargo clippy or tests | Verify: docs-only pre-commit simulation
 - [ ] `SP1464-T004` Owner: `docs` | Dependencies: `SP1464-T001`, `SP1464-T002` | Done when: `CLAUDE.md`, `AGENTS.md`, and `CONTRIBUTING.md` describe fast pre-commit and full pre-push behavior | Verify: `rg -n "pre-commit|pre-push|tests" CLAUDE.md AGENTS.md CONTRIBUTING.md`
-- [ ] `SP1464-T005` Owner: `verification` | Dependencies: all implementation tasks | Done when: syntax, hook, formatting, clippy, and SpecRail checks pass | Verify: `bash -n .githooks/pre-commit .githooks/pre-push`, `.githooks/pre-push`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1464`, and `python3 checks/check_workflow.py --repo .`
+- [ ] `SP1464-T005` Owner: `verification` | Dependencies: all implementation tasks | Done when: syntax, docs-only pre-commit, both default and DB-configured pre-push paths, formatting, clippy, and SpecRail checks pass | Verify: `bash -n .githooks/pre-commit .githooks/pre-push`, docs-only pre-commit simulation, `.githooks/pre-push`, `HARNESS_DATABASE_URL=<test-db> .githooks/pre-push`, `cargo fmt --all -- --check`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1464`, and `python3 checks/check_workflow.py --repo .`
 
 ## Parallelization
 
@@ -27,8 +27,8 @@ shared surfaces, so parallel writable lanes would create avoidable conflicts.
 - `bash -n .githooks/pre-commit .githooks/pre-push`
 - docs-only pre-commit simulation
 - `.githooks/pre-push`
+- `HARNESS_DATABASE_URL=<test-db> .githooks/pre-push`
 - `cargo fmt --all -- --check`
-- `cargo clippy --workspace --all-targets -- -D warnings`
 - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1464`
 - `python3 checks/check_workflow.py --repo .`
 

--- a/specs/GH1464/tech.md
+++ b/specs/GH1464/tech.md
@@ -35,15 +35,22 @@ See `specs/GH1464/product.md`.
    - Unset `GIT_INDEX_FILE`, `GIT_DIR`, and `GIT_WORK_TREE` before running
      cargo commands.
    - Run `cargo clippy --workspace --all-targets -- -D warnings`.
-   - Run `cargo test --workspace --lib` when `HARNESS_DATABASE_URL` is set.
-   - When `HARNESS_DATABASE_URL` is unset, print the existing skip message and
-     run `cargo test --workspace --lib -- --skip db::tests`.
+   - Run `cargo test --workspace --exclude harness-server --lib` with
+     `HARNESS_DATABASE_URL` unset for the command, so DB configuration does not
+     leak into non-server tests that exercise process-global environment
+     behavior.
+   - When `HARNESS_DATABASE_URL` is set, run `cargo test -p harness-server
+     --lib` after the non-server workspace pass.
+   - When `HARNESS_DATABASE_URL` is unset, print an explicit skip message for
+     `harness-server`, matching the CI convention that `harness-server` uses a
+     dedicated DB profile.
 4. Keep hook installation unchanged.
    - `build.rs` and `Makefile` can keep configuring `.githooks`; no special
      pre-push registration is needed once the hooks path is set.
 5. Update docs.
    - `CLAUDE.md` and `AGENTS.md` should say pre-commit is fast fmt plus scoped
-     clippy, and pre-push is the full workspace clippy plus lib test gate.
+     clippy, and pre-push is full workspace clippy plus the split lib test
+     gate.
    - `CONTRIBUTING.md` should tell contributors how to activate hooks and what
      runs at commit versus push time.
 
@@ -87,6 +94,8 @@ developer git hook execution.
 - [ ] Run `cargo fmt --all -- --check`.
 - [ ] Run `cargo clippy --workspace --all-targets -- -D warnings`.
 - [ ] Run `.githooks/pre-push` with local environment defaults.
+- [ ] Run `.githooks/pre-push` with `HARNESS_DATABASE_URL` configured for a
+      local test database.
 - [ ] Run `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1464`.
 - [ ] Run `python3 checks/check_workflow.py --repo .`.
 


### PR DESCRIPTION
## Summary
- Keep pre-commit fast with fmt plus staged-scope clippy, and skip clippy for docs-only staged changes.
- Add an executable pre-push hook for full workspace clippy plus split lib test gates.
- Scope HARNESS_DATABASE_URL to harness-server tests so DB config does not leak into non-server workspace tests.
- Update AGENTS.md, CLAUDE.md, CONTRIBUTING.md, and the GH1464 SpecRail packet to describe the new hook behavior.

## Verification
- bash -n .githooks/pre-commit .githooks/pre-push
- docs-only pre-commit simulation: git add CONTRIBUTING.md && .githooks/pre-commit && git restore --staged CONTRIBUTING.md
- .githooks/pre-push
- HARNESS_DATABASE_URL=postgres://harness:harness@127.0.0.1:5432/harness_test HARNESS_DATABASE_POOL_MAX_CONNECTIONS=16 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=60 .githooks/pre-push
- cargo fmt --all -- --check
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1464
- python3 checks/check_workflow.py --repo .
- git diff --check

Closes #1464