### PR TITLE
Add SpecRail plan for GH1467 log retention

### DIFF
--- a/specs/GH1467/product.md
+++ b/specs/GH1467/product.md
@@ -1,0 +1,81 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1467
+
+## User Problem
+
+`harness serve` creates one runtime log file per startup under
+`server.data_dir/logs/`. Current main already applies age-based cleanup through
+`observe.log_retention_days`, but the default 90-day window still allows many
+startup logs to accumulate when operators restart the server often. The issue
+was observed with dozens of logs and tens of megabytes still within the age
+window.
+
+Operators need runtime logs to stay bounded without losing the most recent log
+needed for debugging the current server process.
+
+## Goals
+
+- Preserve existing age-based cleanup controlled by `observe.log_retention_days`.
+- Add a count-based runtime log cap so each data-dir `logs/` directory keeps a
+  bounded number of `harness-serve-<timestamp>-pid<PID>.log` files.
+- Default the cap conservatively to keep the 30 newest runtime logs.
+- Allow disabling the count cap explicitly with `0` for operators who want
+  age-only retention.
+- Keep the active log file and newest matching runtime logs; ignore unrelated
+  files such as cloudflared logs or notes.
+- Surface cleanup warnings without preventing `harness serve` from starting.
+- Document the new config field and local behavior.
+
+## Non-Goals
+
+- Changing runtime log naming or location.
+- Compressing, uploading, or archiving old logs.
+- Changing event-store retention, workflow runtime retention, task retention, or
+  GC behavior.
+- Deleting unrelated files in the `logs/` directory.
+- Adding a background retention worker; startup cleanup is sufficient for this
+  issue.
+
+## User-Visible Behavior
+
+On each `harness serve` startup, Harness should create the current log file,
+delete stale runtime logs older than the age window, then delete the oldest
+extra runtime logs beyond the configured max-files cap. The current startup log
+must remain present. Operators should continue to see a runtime log status block
+in health/operator surfaces and warning logs for cleanup entries that could not
+be removed.
+
+## Acceptance Criteria
+
+- [ ] `observe.log_retention_max_files` is configurable and defaults to `30`.
+- [ ] `observe.log_retention_max_files = 0` disables the count cap while
+      preserving existing age-based cleanup.
+- [ ] Runtime log cleanup deletes matching stale logs older than
+      `log_retention_days`.
+- [ ] Runtime log cleanup deletes the oldest extra matching runtime logs beyond
+      `log_retention_max_files`.
+- [ ] Runtime log cleanup keeps the active/current log and the newest matching
+      runtime logs.
+- [ ] Runtime log cleanup ignores non-matching files in the same `logs/`
+      directory.
+- [ ] Delete failures are reported as warnings and do not stop server startup.
+- [ ] README and usage-guide docs describe age and max-files retention.
+- [ ] Tests cover age pruning, count pruning, disabling the count cap, ignoring
+      unrelated files, and deletion warning behavior.
+
+## Edge Cases
+
+- Multiple logs with the same timestamp but different PIDs should sort
+  deterministically so count pruning is stable.
+- Malformed runtime log filenames should be ignored, not deleted.
+- A missing `logs/` directory should produce no warning.
+- Retention should run before opening the new log file or otherwise explicitly
+  protect the current log from count pruning.
+
+## Rollout Notes
+
+Use `Refs #1467` for the spec PR. The implementation PR should use
+`Closes #1467` after the count cap, docs, and tests are merged.

--- a/specs/GH1467/tasks.md
+++ b/specs/GH1467/tasks.md
@@ -1,0 +1,38 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1467
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1467-T001` Owner: `config` | Dependencies: none | Done when: `ObserveConfig` exposes `log_retention_max_files` with serde-compatible default `30` and config examples include it | Verify: `cargo test -p harness-core config`
+- [ ] `SP1467-T002` Owner: `metadata` | Dependencies: `SP1467-T001` | Done when: runtime log metadata carries both retention days and max-files through CLI/server health surfaces without breaking existing callers | Verify: `cargo check -p harness-server --all-targets`
+- [ ] `SP1467-T003` Owner: `cleanup` | Dependencies: `SP1467-T001` | Done when: runtime log startup cleanup prunes by age first, then prunes oldest matching logs beyond the configured max-files cap while ignoring unrelated files | Verify: `cargo test -p harness-cli runtime_log`
+- [ ] `SP1467-T004` Owner: `docs` | Dependencies: `SP1467-T001`, `SP1467-T003` | Done when: README and usage guide document runtime log age and count retention, including `0` disabling the count cap | Verify: `rg -n "log_retention_(days|max_files)|runtime log" README.md docs/usage-guide.md`
+- [ ] `SP1467-T005` Owner: `verification` | Dependencies: all implementation tasks | Done when: focused tests, server check, SpecRail checks, formatting, and clippy pass | Verify: `cargo test -p harness-cli runtime_log`, `cargo test -p harness-core config`, `cargo check -p harness-server --all-targets`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1467`, `python3 checks/check_workflow.py --repo .`, `cargo fmt --all -- --check`, and `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Parallelization
+
+Keep implementation serial. Config, metadata, cleanup, docs, and tests share
+small files and should stay in one branch to avoid avoidable conflicts.
+
+## Verification
+
+- `cargo test -p harness-cli runtime_log`
+- `cargo test -p harness-core config`
+- `cargo check -p harness-server --all-targets`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1467`
+- `python3 checks/check_workflow.py --repo .`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Handoff Notes
+
+Use `Refs #1467` for the spec PR. The implementation PR should use
+`Closes #1467` after count pruning, docs, and verification pass.

--- a/specs/GH1467/tech.md
+++ b/specs/GH1467/tech.md
@@ -1,0 +1,89 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1467
+
+## Product Spec
+
+See `specs/GH1467/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Log path | `crates/harness-cli/src/commands.rs` | `runtime_log_path` writes `harness-serve-<timestamp>-pid<PID>.log` under `server.data_dir/logs/`. | Count pruning must target only this filename family. |
+| Startup logging | `prepare_runtime_logs` and `open_runtime_log_file` | Creates `logs/`, calls `purge_stale_runtime_logs`, and opens the active file. | This is the startup cleanup insertion point. |
+| Age cleanup | `purge_stale_runtime_logs_with` | Deletes matching runtime logs older than `observe.log_retention_days`; reports deletion errors as warnings. | The new count cap should extend this logic, not replace it. |
+| Config | `crates/harness-core/src/config/misc.rs` | `ObserveConfig` has `session_renewal_secs` and `log_retention_days`; default retention is 90 days. | Add max-files config with serde compatibility. |
+| Metadata | `crates/harness-server/src/server.rs` | `RuntimeLogMetadata` carries `retention_days` for health/operator surfaces. | Consider whether max-files should be exposed in metadata and docs. |
+| Docs | `README.md`, `docs/usage-guide.md` | Mention runtime log path and retention window. | Must describe count cap and disable behavior. |
+| Tests | `crates/harness-cli/src/commands/runtime_log_tests.rs` | Cover log creation, age pruning, unrelated files, and warning behavior. | Add count-cap coverage. |
+
+## Proposed Design
+
+1. Add `ObserveConfig::log_retention_max_files: usize`.
+   - Default: `30`.
+   - Serde default should preserve compatibility for existing config files that
+     only set `log_retention_days`.
+   - `0` disables count pruning.
+2. Thread max-files into runtime log metadata and cleanup.
+   - Extend `RuntimeLogMetadata` with `retention_max_files`.
+   - Update `disabled`, `enabled`, and `degraded` constructors.
+   - Update call sites in CLI/server builders and health/operator tests.
+3. Extend runtime log cleanup.
+   - Parse matching runtime log filenames into `(started_at, pid, path)`.
+   - First delete logs older than the age cutoff.
+   - Then sort remaining matching logs by `started_at` descending, PID
+     descending, and path as a final deterministic tiebreaker.
+   - Delete entries beyond `log_retention_max_files` when the cap is nonzero.
+   - Keep ignoring non-matching files and directories.
+   - Preserve warning collection for read-dir, entry-read, and delete failures.
+4. Update docs.
+   - Document `observe.log_retention_days`.
+   - Document `observe.log_retention_max_files`, default `30`, and `0`
+     disables the count cap.
+5. Verify with focused CLI tests and workspace gates.
+
+## Data Flow
+
+`harness serve` startup loads config, computes runtime log metadata, creates the
+logs directory, prunes old matching runtime log files according to age and count,
+opens the current log file, then exposes the runtime log state through existing
+health/operator surfaces. No database or HTTP request data flow changes.
+
+## Alternatives Considered
+
+- Age-only retention. Rejected because it is already present and still allows
+  high restart counts to accumulate many logs within the age window.
+- Byte-size cap. Deferred because count caps are simpler, deterministic, and
+  enough to bound per-startup log fanout without scanning file sizes or handling
+  partial active writes.
+- Background cleanup worker. Rejected because startup cleanup is deterministic
+  and the issue is low-severity disk growth.
+
+## Risks
+
+- A too-small default could remove useful logs. Mitigate with a conservative 30
+  file default and a `0` disable option.
+- Sorting bugs could delete the wrong log. Mitigate with tests for timestamp and
+  PID ordering.
+- Metadata changes can break health/operator tests. Mitigate with targeted
+  `harness-cli` and `harness-server` checks.
+
+## Test Plan
+
+- [ ] Run `cargo test -p harness-cli runtime_log`.
+- [ ] Run `cargo test -p harness-core config`.
+- [ ] Run `cargo check -p harness-server --all-targets`.
+- [ ] Run `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1467`.
+- [ ] Run `python3 checks/check_workflow.py --repo .`.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `cargo clippy --workspace --all-targets -- -D warnings` before PR
+      merge readiness.
+
+## Rollback Plan
+
+Revert the implementation commit. That removes the max-files config and count
+pruning while restoring the previous age-only runtime log cleanup behavior. No
+data migration is required.


### PR DESCRIPTION
## Summary
- Add the GH1467 product spec, technical spec, and task plan for bounded runtime log retention.
- Scope the implementation to preserving existing age cleanup while adding a configurable max-files cap.

## Verification
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1467
- python3 checks/check_workflow.py --repo .
- git diff --check
- cargo fmt --all -- --check

Refs #1467