### PR TITLE
Spec GH1469 turn budget default

### DIFF
--- a/specs/GH1469/product.md
+++ b/specs/GH1469/product.md
@@ -1,0 +1,71 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1469
+
+## User Problem
+
+Harness already has a per-task `max_turns` budget that is threaded through the
+task executor, validation retry path, agent review path, hosted review loop, and
+transient task retry accumulator. However, the global
+`concurrency.max_turns` default is currently `None`, so operators who do not
+set it explicitly get an unbounded task-level agent invocation budget.
+
+That means a persistently failing task can consume many agent CLI invocations
+across retries and review loops before a human sees the failure.
+
+## Goals
+
+- Make the default per-task agent invocation budget non-empty.
+- Use the existing `max_turns` budget path as the cross-layer ceiling rather
+  than adding a second counter.
+- Preserve request-level `max_turns` overrides as the highest-precedence budget.
+- Surface budget exhaustion as an explicit task failure/error reason.
+- Document the default budget and where operators can raise it.
+
+## Non-Goals
+
+- Changing quota/billing circuit breaker behavior.
+- Adding per-project differentiated budgets.
+- Changing workflow-runtime profile `max_turns`; that is a separate runtime
+  budget path.
+- Rewriting review-loop or transient retry behavior beyond honoring the shared
+  budget.
+
+## User-Visible Behavior
+
+With default configuration, legacy task execution should stop after 20 total
+agent invocations for one task unless a request supplies a smaller or larger
+`max_turns` override. The count includes implementation attempts, validation
+auto-retries, local agent review rounds, hosted review-loop rounds, provider
+review gates, non-implementation tasks, and transient task retries that re-run
+the task.
+
+When the budget is exhausted, the task should fail or stop retrying with an
+explicit message that names the turn budget exhaustion instead of silently
+continuing.
+
+## Acceptance Criteria
+
+- [ ] `concurrency.max_turns` defaults to `Some(20)`.
+- [ ] Config examples and usage docs document the default and that request-level
+      `max_turns` overrides the global value.
+- [ ] Existing explicit request-level `max_turns` overrides continue to win over
+      the global default.
+- [ ] Tests cover budget counting across at least two execution layers.
+- [ ] Budget exhaustion remains explicit in task failure/error output.
+
+## Edge Cases
+
+- A request with an explicit low `max_turns` should still be able to fail fast
+  before the default is reached.
+- Transient task retries should continue from the previous attempt's turn count
+  instead of resetting the budget.
+- Operators with unusually long local workflows can raise the global default;
+  the implementation should not add a hard-coded ceiling outside config.
+
+## Rollout Notes
+
+Use `Refs #1469` for the spec PR. The implementation PR should use
+`Closes #1469` after the default, docs, and tests land.

--- a/specs/GH1469/tasks.md
+++ b/specs/GH1469/tasks.md
@@ -1,0 +1,37 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1469
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1469-T001` Owner: `config` | Dependencies: none | Done when: `ConcurrencyConfig::default().max_turns` is `Some(20)` and existing explicit request overrides still win | Verify: `cargo test -p harness-core config`
+- [ ] `SP1469-T002` Owner: `executor` | Dependencies: `SP1469-T001` | Done when: focused tests show turn budget state crosses at least two execution layers without resetting | Verify: focused `cargo test -p harness-server <budget-test-filter>`
+- [ ] `SP1469-T003` Owner: `docs` | Dependencies: `SP1469-T001` | Done when: config example, README, and usage guide document the default and override semantics | Verify: `rg -n "max_turns|turn budget" README.md docs/usage-guide.md config/default.toml.example`
+- [ ] `SP1469-T004` Owner: `verification` | Dependencies: all implementation tasks | Done when: focused tests, server check, SpecRail checks, formatting, and clippy pass | Verify: `cargo test -p harness-core config`, focused server budget tests, `cargo check -p harness-server --all-targets`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1469`, `python3 checks/check_workflow.py --repo .`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Parallelization
+
+Keep this implementation serial. The config default, docs, and task-executor
+tests are small and share budget semantics.
+
+## Verification
+
+- `cargo test -p harness-core config`
+- focused `cargo test -p harness-server <budget-test-filter>`
+- `cargo check -p harness-server --all-targets`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1469`
+- `python3 checks/check_workflow.py --repo .`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Handoff Notes
+
+Use `Refs #1469` for the spec PR. The implementation PR should use
+`Closes #1469` after the default, docs, and tests merge.

--- a/specs/GH1469/tech.md
+++ b/specs/GH1469/tech.md
@@ -1,0 +1,89 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1469
+
+## Product Spec
+
+See `specs/GH1469/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Config | `crates/harness-core/src/config/misc.rs` | `ConcurrencyConfig::max_turns` is `Option<u32>` and defaults to `None`. | This makes the existing budget inert by default. |
+| Request override | `crates/harness-server/src/task_runner/request.rs` | `TaskRequest::max_turns` can set a per-task budget. | Request-level overrides must keep priority. |
+| Task executor | `crates/harness-server/src/task_executor/run_task.rs` | Effective budget is `req.max_turns.or(server_config.concurrency.max_turns)` and is threaded through implementation, review, gates, and review loop. | This is the existing cross-layer ceiling. |
+| Transient retries | `crates/harness-server/src/task_runner/spawn.rs` | `total_turns_used` is carried across transient retry attempts. | Retries should not reset the task budget. |
+| Implementation phase | `crates/harness-server/src/task_executor/implement_pipeline.rs` | Checks budget before each implementation attempt and increments after each agent invocation. | Counts implementation and validation retry calls. |
+| Local review | `crates/harness-server/src/task_executor/agent_review.rs` | Checks budget before review and fix agent calls. | Counts review loop calls. |
+| Hosted review loop | `crates/harness-server/src/task_executor/review_loop/flow.rs` | Checks budget before hosted review-loop calls and marks budget exhaustion. | Counts another retry/review layer. |
+| Docs | `config/default.toml.example`, `docs/usage-guide.md`, `README.md` | Concurrency docs do not show a max-turns default. | Operators need to see the new default and override semantics. |
+
+## Proposed Design
+
+1. Add a default helper for legacy task `max_turns`.
+   - Default value: `Some(20)`.
+   - Keep `TaskRequest::max_turns` as the first-priority override.
+   - Do not change workflow-runtime profile `max_turns`.
+2. Update docs and examples.
+   - `config/default.toml.example` should show `max_turns = 20` in the
+     `[concurrency]` block.
+   - `docs/usage-guide.md` should describe the default and request override.
+   - README should keep its existing concurrency example coherent with the
+     default.
+3. Add focused tests.
+   - Config default test verifies `ConcurrencyConfig::default().max_turns ==
+     Some(20)`.
+   - Request override test verifies explicit request `max_turns` wins over the
+     global default.
+   - Existing review/implementation budget tests should be reused where
+     possible; add only the smallest missing test to prove the budget crosses at
+     least two layers.
+
+## Data Flow
+
+Task submission creates a `TaskRequest`, optional request-level `max_turns`
+rides with the request, and `run_task` computes
+`req.max_turns.or(config.concurrency.max_turns)`. The same mutable
+`turns_used` and `turns_used_acc` references flow through implementation,
+validation retries, local review, hosted review loop, gates, and transient
+retry attempts. Exhaustion returns an explicit error or marks the task with a
+budget-exhausted status, depending on the layer's existing behavior.
+
+## Alternatives Considered
+
+- Add a separate invocation-budget config. Rejected because the current
+  `max_turns` plumbing already represents total agent invocations across the
+  legacy task lifecycle; a second counter would create disagreement.
+- Keep unlimited by default. Rejected because the issue is specifically about
+  unbounded default spend.
+- Use a very small default. Rejected because normal implementation plus review
+  can need several agent calls; 20 matches the existing production
+  recommendation in config comments.
+
+## Risks
+
+- Some long-running tasks may fail earlier than before. Mitigate by documenting
+  the value and allowing request/global overrides.
+- A default change can affect tests that expected `None`. Mitigate by updating
+  only explicit default assertions and preserving request overrides.
+- Config file size constraints exist in `misc.rs`; keep the implementation small
+  and avoid unrelated refactors.
+
+## Test Plan
+
+- [ ] Run `cargo test -p harness-core config`.
+- [ ] Run the focused task-executor budget tests added or updated by this work.
+- [ ] Run `cargo check -p harness-server --all-targets`.
+- [ ] Run `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1469`.
+- [ ] Run `python3 checks/check_workflow.py --repo .`.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `cargo clippy --workspace --all-targets -- -D warnings` before PR
+      merge readiness.
+
+## Rollback Plan
+
+Revert the implementation commit. The legacy task budget returns to unlimited
+by default while preserving existing request-level `max_turns` behavior.


### PR DESCRIPTION
## Summary
- Add the product, technical, and task specs for GH1469.
- Scope the implementation to defaulting the existing cross-layer `max_turns` budget to 20, preserving request overrides, and adding docs/tests.

Refs #1469

## Verification
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1469`
- `python3 checks/check_workflow.py --repo .`
- `git diff --check`