### PR TITLE
Default task turn budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ enabled = true
 
 [concurrency]
 max_concurrent_tasks = 3
+max_turns = 20
 ```
 
 ## HTTP REST API

--- a/config/default.toml.example
+++ b/config/default.toml.example
@@ -37,6 +37,9 @@ project_root = "."
 #   orphan_reaper_legacy_batch: 200
 
 [concurrency]
+# Default per-task agent invocation budget across implementation, validation
+# retries, and review loops. Per-request max_turns overrides this value.
+max_turns = 20
 # High-reasoning agent runs can stay silent for several minutes while thinking.
 # Increase this when using gpt-5.5/xhigh for background workflow runtime jobs.
 # Default: fail a silent stream after 600 seconds, before the 3600-second

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -137,7 +137,7 @@ pub struct ConcurrencyConfig {
     /// Maximum total agent API calls across all phases (implementation + validation retries +
     /// review rounds). `None` = unlimited. Counts every call including validation retries.
     /// Recommended production value: 20.
-    #[serde(default)]
+    #[serde(default = "default_max_turns")]
     pub max_turns: Option<u32>,
     /// Jaccard word-similarity threshold for review-loop detection.
     /// If two consecutive non-waiting review outputs have similarity >= this value,
@@ -177,6 +177,10 @@ fn default_memory_poll_interval_secs() -> u64 {
     5
 }
 
+fn default_max_turns() -> Option<u32> {
+    Some(20)
+}
+
 impl Default for ConcurrencyConfig {
     fn default() -> Self {
         Self {
@@ -184,7 +188,7 @@ impl Default for ConcurrencyConfig {
             max_queue_size: default_max_queue_size(),
             stall_timeout_secs: default_stall_timeout_secs(),
             per_project: HashMap::new(),
-            max_turns: None,
+            max_turns: default_max_turns(),
             loop_jaccard_threshold: default_loop_jaccard_threshold(),
             memory_pressure_threshold_mb: None,
             memory_poll_interval_secs: default_memory_poll_interval_secs(),
@@ -743,6 +747,7 @@ mod tests {
             cfg.memory_pressure_threshold_mb.is_none(),
             "memory monitor must be disabled by default"
         );
+        assert_eq!(cfg.max_turns, Some(20));
         assert_eq!(cfg.memory_poll_interval_secs, 5);
     }
 

--- a/crates/harness-server/src/handlers/worktrees.rs
+++ b/crates/harness-server/src/handlers/worktrees.rs
@@ -731,7 +731,7 @@ mod tests {
         assert_eq!(payload[0]["repo"], "owner/repo");
         assert_eq!(payload[0]["runtime_workflow_id"], "workflow-1");
         assert_eq!(payload[0]["turn"], 0);
-        assert_eq!(payload[0]["max_turns"], serde_json::Value::Null);
+        assert_eq!(payload[0]["max_turns"], 20);
         assert_eq!(
             payload[0]["project"].as_str(),
             Some(source_repo.to_string_lossy().as_ref())

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -466,6 +466,7 @@ Tempo walkthrough.
 |-------|---------|-------------|
 | `max_concurrent_tasks` | `4` | Global maximum concurrent tasks across all projects |
 | `max_queue_size` | `32` | Maximum queued tasks before rejecting |
+| `max_turns` | `20` | Default per-task agent invocation budget across implementation, validation retries, and review loops; request-level `max_turns` overrides this value |
 
 ### `[validation]`
 


### PR DESCRIPTION
## Summary
- Default legacy task `concurrency.max_turns` to 20 using the existing cross-layer turn-budget plumbing.
- Document the default in the example config, README, and usage guide.
- Update worktree API expectations so the default budget is visible instead of null.

Closes #1469

## Verification
- `cargo test -p harness-core config`
- `HARNESS_DATABASE_URL=postgres://harness:harness@127.0.0.1:5432/harness_test HARNESS_DATABASE_POOL_MAX_CONNECTIONS=16 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=60 cargo test -p harness-server agent_review`
- `HARNESS_DATABASE_URL=postgres://harness:harness@127.0.0.1:5432/harness_test HARNESS_DATABASE_POOL_MAX_CONNECTIONS=16 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=60 cargo test -p harness-server review_loop_wait_budget`
- `HARNESS_DATABASE_URL=postgres://harness:harness@127.0.0.1:5432/harness_test HARNESS_DATABASE_POOL_MAX_CONNECTIONS=16 HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS=60 cargo test -p harness-server worktrees`
- `cargo check -p harness-server --all-targets`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1469`
- `python3 checks/check_workflow.py --repo .`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`