### PR TITLE
Spec GH1470 reviewer commit gate

### DIFF
--- a/specs/GH1470/product.md
+++ b/specs/GH1470/product.md
@@ -1,0 +1,77 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1470
+
+## User Problem
+
+The periodic reviewer currently enqueues the primary review agent on each due
+tick and asks the agent to run `git log --since=<last_review>` from the prompt.
+When no commits changed, the agent returns `REVIEW_SKIPPED`, but the system has
+already spent one agent invocation.
+
+For idle projects this turns every periodic tick into quota and queue pressure.
+At large project counts, the default cadence can create thousands of no-op
+agent invocations per day.
+
+## Goals
+
+- Add a cheap local gate before primary periodic review enqueue.
+- Skip primary, secondary, and synthesis agent work when the project has no
+  commits newer than the last completed periodic review watermark.
+- Keep the existing agent-side `REVIEW_SKIPPED` sentinel as defense in depth.
+- Record local skips observably so operators can tell a tick was intentionally
+  skipped rather than silently dropped.
+- Preserve the current review cadence, review content, and successful-review
+  watermark behavior when new commits exist.
+
+## Non-Goals
+
+- Changing periodic review interval semantics.
+- Changing the periodic review prompt checklist beyond aligning skip wording
+  with the new local gate.
+- Removing agent-side `REVIEW_SKIPPED` handling.
+- Adding network GitHub checks or remote branch polling.
+- Reworking cross-review, synthesis, or auto-fix task spawning.
+
+## User-Visible Behavior
+
+When a project has a prior completed periodic review watermark and no newer
+local commits, the scheduler should log or emit a local skip and should not
+enqueue the primary review task. Cross-review and synthesis tasks should not be
+created for that tick.
+
+When the project has no prior watermark, the first eligible tick should still
+run. When the project has at least one local commit newer than the watermark,
+the scheduler should enqueue the primary periodic review task exactly as it
+does today.
+
+## Acceptance Criteria
+
+- [ ] An unchanged project with a prior periodic review watermark produces zero
+      primary agent task enqueues for that tick.
+- [ ] A project with a commit newer than the watermark still enqueues the
+      primary periodic review task.
+- [ ] First-run projects without a watermark still enqueue review work.
+- [ ] Local skips are observable through structured tracing and/or EventStore
+      data that names the project and skip reason.
+- [ ] Agent-side `REVIEW_SKIPPED` handling remains intact for defense in depth.
+- [ ] The implementation does not add a direct `Command::new("git")` call in
+      `periodic_reviewer.rs`.
+
+## Edge Cases
+
+- If the local commit check fails, the scheduler should fail the tick visibly
+  or log a warning and fall back to the current agent-side skip path; it must
+  not silently drop review work.
+- The local gate should use the same effective watermark as the prompt:
+  EventStore timestamp merged with the in-memory fallback timestamp.
+- Path-specific watermark keys must remain isolated per project root.
+- Commits that arrive while a review is running should remain covered by the
+  existing watermark-bound logic after the review completes.
+
+## Rollout Notes
+
+Use `Refs #1470` for the spec PR. The implementation PR should use
+`Closes #1470` after the local gate, observability, docs, and tests land.

--- a/specs/GH1470/tasks.md
+++ b/specs/GH1470/tasks.md
@@ -1,0 +1,39 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1470
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1470-T001` Owner: `reviewer-gate` | Dependencies: none | Done when: `run_review_tick` can ask a local commit gate whether to run, skip, or fall back without direct `Command::new("git")` in `periodic_reviewer.rs` | Verify: `cargo test -p harness-server periodic_reviewer`
+- [ ] `SP1470-T002` Owner: `scheduler` | Dependencies: `SP1470-T001` | Done when: unchanged projects with an existing watermark return before primary review enqueue and still preserve first-run behavior | Verify: focused periodic reviewer enqueue-decision tests
+- [ ] `SP1470-T003` Owner: `observability` | Dependencies: `SP1470-T002` | Done when: local no-change skips emit structured observability with project, watermark, and reason without advancing the successful-review watermark | Verify: focused periodic reviewer skip-observability test or EventStore assertion
+- [ ] `SP1470-T004` Owner: `docs` | Dependencies: `SP1470-T002` | Done when: usage and periodic-review docs accurately describe the local gate plus prompt-side fallback | Verify: `rg -n "REVIEW_SKIPPED|local gate|new commits" docs/usage-guide.md docs/periodic-review.md`
+- [ ] `SP1470-T005` Owner: `verification` | Dependencies: all implementation tasks | Done when: focused tests, server check, SpecRail checks, formatting, and clippy pass | Verify: `cargo test -p harness-server periodic_reviewer`, `cargo check -p harness-server --all-targets`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1470`, `python3 checks/check_workflow.py --repo .`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Parallelization
+
+Keep this implementation serial. The enqueue decision, local gate, and
+observability all touch `periodic_reviewer.rs`, and W-14 requires explicit
+disjoint ownership before parallel edits.
+
+## Verification
+
+- `cargo test -p harness-server periodic_reviewer`
+- `cargo check -p harness-server --all-targets`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1470`
+- `python3 checks/check_workflow.py --repo .`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Handoff Notes
+
+Use `Refs #1470` for the spec PR. The implementation PR should use
+`Closes #1470` after the local commit gate, observability, docs, and tests
+merge.

--- a/specs/GH1470/tech.md
+++ b/specs/GH1470/tech.md
@@ -1,0 +1,99 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1470
+
+## Product Spec
+
+See `specs/GH1470/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Scheduler | `crates/harness-server/src/periodic_reviewer.rs` | `run_review_tick` computes the effective watermark, builds a prompt, and enqueues the primary review task before any commit-presence check. | This is the no-op agent spawn path. |
+| Prompt | `crates/harness-core/src/prompts/review.rs` | The prompt tells the agent to run `git log --since=<watermark>` and output `REVIEW_SKIPPED` when empty. | This remains defense in depth, but should no longer be the normal idle path. |
+| Watermark | `periodic_reviewer.rs` EventStore query plus `ReviewState::fallback_ts` | The scheduler merges persisted and fallback timestamps into the `since_arg` used by the prompt. | The local gate must use the same lower bound. |
+| Cross-review | `periodic_reviewer.rs` poll task | Secondary and synthesis tasks are already deferred until the primary produces real review output. | Local primary skips should naturally prevent downstream review work. |
+| Observability | `periodic_reviewer.rs` tracing plus EventStore | Successful parsed reviews log `periodic_review` events; skipped agent output only logs tracing today. | Local skips need an explicit observable signal. |
+| Docs | `docs/usage-guide.md`, `docs/periodic-review.md` | Docs already describe a pre-agent skip path even though implementation still relies on the agent. | Docs should match the implementation after the fix. |
+
+## Proposed Design
+
+1. Introduce a small local commit-gate helper used by `run_review_tick` before
+   building/enqueueing the primary review task.
+   - Input: project root and effective `last_review_ts`.
+   - Output: `Run`, `SkipNoNewCommits`, or `Unknown`.
+   - First run (`last_review_ts == None`) returns `Run`.
+2. Implement the gate through an isolated repository-query boundary rather than
+   embedding process spawning in `periodic_reviewer.rs`.
+   - Do not add direct `Command::new("git")` text to `periodic_reviewer.rs`.
+   - Reuse the existing sanitized git execution conventions if the
+     implementation needs a local git query.
+   - Keep command arguments as arrays, never shell strings.
+3. On `SkipNoNewCommits`, return before `ensure_review_queue_limit`,
+   `CreateTaskRequest`, and `enqueue_task_background_in_domain`.
+   - Emit structured tracing with project name/root, watermark, and reason.
+   - Log an EventStore event or equivalent observable signal that does not
+     advance the successful-review watermark past the checked bound.
+4. On `Unknown`, preserve review coverage.
+   - Log the failure visibly.
+   - Fall back to the current prompt-side `REVIEW_SKIPPED` behavior so the
+     scheduler does not skip potentially changed code.
+5. Keep agent-side `REVIEW_SKIPPED` handling unchanged.
+   - It still protects races, first-run anomalies, and local gate failures.
+   - Existing exact-match sentinel detection must stay exact-match only.
+6. Update docs only where needed.
+   - `docs/usage-guide.md` and `docs/periodic-review.md` should describe the
+     local gate and fallback behavior accurately.
+
+## Data Flow
+
+`run_review_tick` queries EventStore, merges `ReviewState::fallback_ts`, and
+gets the effective watermark. Before constructing `base_prompt`, it asks the
+local gate whether the project has commits after that watermark. If there are
+none, the function logs the local skip and returns `Ok(())`. If there are new
+commits or the gate cannot determine the answer, the existing enqueue and poll
+flow continues.
+
+Successful review parsing continues to write the normal `periodic_review`
+watermark after real review output is available. Local no-change skips should
+not move that successful-review watermark forward in a way that could hide a
+commit that appears after the check.
+
+## Alternatives Considered
+
+- Rely only on the agent prompt. Rejected because this is the current behavior
+  and is the source of the quota waste.
+- Advance the `periodic_review` watermark on every local skip. Rejected because
+  `periodic_review` currently means a completed review checkpoint; advancing it
+  on no-op skips risks changing downstream assumptions.
+- Remove the prompt-side sentinel. Rejected because it is a useful safety net
+  for races and local-gate failures.
+- Add remote GitHub polling. Rejected because the requirement is a cheap local
+  gate against the registered project workspace.
+
+## Risks
+
+- A broken local gate could skip needed review work. Mitigate by treating
+  uncertainty as `Unknown` and falling back to agent-side review.
+- Commit timestamps can be imprecise around boundary times. Mitigate by using a
+  deterministic “newer than watermark” query and keeping the agent fallback.
+- Tests around `run_review_tick` may need dependency injection to avoid a real
+  agent queue. Keep the seam narrow and test the gate plus enqueue decision.
+
+## Test Plan
+
+- [ ] Unit-test the local gate: no watermark runs, empty commit query skips, and
+      newer commit query runs.
+- [ ] Test unchanged project with prior watermark produces zero primary review
+      enqueues.
+- [ ] Test project with newer commit enqueues primary review work.
+- [ ] Test gate failure falls back to enqueue path and logs the failure.
+- [ ] Keep `test_git_guard_removed` or equivalent structural coverage for
+      `periodic_reviewer.rs`.
+- [ ] Run `cargo test -p harness-server periodic_reviewer`.
+- [ ] Run `cargo check -p harness-server --all-targets`.
+- [ ] Run `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1470`.
+- [ ] Run `python3 checks/check_workflow.py --repo .`.


### PR DESCRIPTION
## Summary
- Add the SpecRail product, technical, and task plan for GH1470.
- Define the local periodic reviewer commit gate before primary agent enqueue.
- Preserve the agent-side REVIEW_SKIPPED fallback and the no-direct-git constraint in periodic_reviewer.rs.

## Verification
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1470
- python3 checks/check_workflow.py --repo .
- git diff --check

Refs #1470