### PR TITLE
Spec GH1471 prompt layer caching

### DIFF
--- a/specs/GH1471/product.md
+++ b/specs/GH1471/product.md
@@ -1,0 +1,82 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1471
+
+## User Problem
+
+Harness already models issue prompts as `PromptParts` with static, context, and
+dynamic layers. The call sites immediately flatten those layers into a single
+string before agent execution, so stable instructions are resent as normal user
+prompt text on every turn.
+
+The skills listing also injects every available skill name and description into
+agent prompts. As the skill store grows, prompt size grows linearly even when
+most skills are irrelevant to the task.
+
+## Goals
+
+- Preserve `PromptParts` layer boundaries through the agent request boundary.
+- Use a cache-friendly channel for at least one supported backend, starting
+  with Claude Code because the local CLI exposes `--append-system-prompt` and
+  `--exclude-dynamic-system-prompt-sections`.
+- Keep flattened prompt behavior as the fallback for backends without a
+  cacheable prompt channel.
+- Cap or relevance-filter the all-skills listing so prompt size is bounded.
+- Keep matched skill content injection and `skill_used` recording semantics.
+
+## Non-Goals
+
+- Rewriting prompt templates or changing their user-visible instructions.
+- Building a custom prompt-caching proxy.
+- Adding network calls to inspect provider cache state.
+- Removing the full flattened prompt path for Codex, Anthropic API, tests, or
+  any backend that cannot consume prompt layers.
+- Changing task artifact persistence or prompt redaction semantics beyond
+  preserving the effective prompt for audit.
+
+## User-Visible Behavior
+
+For Claude Code execution, stable prompt instructions should be passed through a
+system-prompt append path while dynamic task content remains the main `-p`
+prompt. Operators should see cache-related token metrics already parsed from
+Claude output when the provider reports them.
+
+For other backends, tasks should behave as they do today by using the flattened
+prompt string.
+
+When many skills exist, the available-skills listing should include only a
+bounded subset or a relevance-filtered subset. Matched skills should still
+appear in the relevant-skills section with full content.
+
+## Acceptance Criteria
+
+- [ ] `PromptParts` can be converted into a layered agent request without
+      losing the existing flattened string behavior.
+- [ ] Claude Code receives the static layer through `--append-system-prompt`
+      or an equivalent cache-friendly system-prompt path.
+- [ ] Claude Code uses `--exclude-dynamic-system-prompt-sections` when the
+      cache-friendly path is active, unless a compatibility check requires a
+      fallback.
+- [ ] Codex and Anthropic API keep a deterministic flattened fallback path.
+- [ ] The available-skills listing is capped or filtered, with focused tests
+      proving prompt size does not grow unboundedly with registered skills.
+- [ ] Matched skills still inject full content and still record usage events.
+- [ ] Existing prompt audit/redaction tests continue to pass.
+
+## Edge Cases
+
+- Empty static/context layers should not emit empty CLI arguments.
+- A backend that does not support layered prompts must receive exactly the
+  flattened prompt it would have received before this change.
+- Validation retry prompts that are built from a prior prompt must preserve the
+  correct flattened content even when the initial request was layered.
+- Skill caps must be deterministic so repeated runs with the same skill store
+  and prompt produce the same injected prompt.
+
+## Rollout Notes
+
+Use `Refs #1471` for the spec PR. The implementation PR should use
+`Closes #1471` after the layered request path, skills cap, docs if needed, and
+tests land.

--- a/specs/GH1471/tasks.md
+++ b/specs/GH1471/tasks.md
@@ -1,0 +1,42 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1471
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1471-T001` Owner: `core-prompts` | Dependencies: none | Done when: `AgentRequest` can carry optional prompt-layer data while preserving the existing flattened `prompt` field | Verify: `cargo test -p harness-core prompts`
+- [ ] `SP1471-T002` Owner: `executor` | Dependencies: `SP1471-T001` | Done when: issue triage, planning, and implementation paths preserve `PromptParts` into `AgentRequest` where those builders already return layered prompts | Verify: focused `cargo test -p harness-server <prompt-layer-test-filter>`
+- [ ] `SP1471-T003` Owner: `claude-adapters` | Dependencies: `SP1471-T001` | Done when: both Claude Code spawn paths pass static instructions through `--append-system-prompt`, keep `-p <dynamic prompt>` ordering, and enable `--exclude-dynamic-system-prompt-sections` for layered prompts | Verify: `cargo test -p harness-agents claude claude_adapter`
+- [ ] `SP1471-T004` Owner: `skills` | Dependencies: none | Done when: broad available-skills listing is capped or deterministically filtered, matched skill full-content injection remains uncapped, and usage events still record matched skills | Verify: focused `cargo test -p harness-server inject_skills`
+- [ ] `SP1471-T005` Owner: `verification` | Dependencies: all implementation tasks | Done when: focused tests, server check, SpecRail checks, formatting, and clippy pass | Verify: focused tests above, `cargo check -p harness-server --all-targets`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1471`, `python3 checks/check_workflow.py --repo .`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Parallelization
+
+Keep implementation mostly serial. `AgentRequest` shape changes affect adapters,
+executor call sites, tests, and prompt persistence. Skills-list capping can be
+implemented independently after the core request shape is settled.
+
+## Verification
+
+- `cargo test -p harness-core prompts`
+- `cargo test -p harness-agents claude claude_adapter`
+- focused `cargo test -p harness-server <prompt-layer-test-filter>`
+- focused `cargo test -p harness-server inject_skills`
+- `cargo check -p harness-server --all-targets`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1471`
+- `python3 checks/check_workflow.py --repo .`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Handoff Notes
+
+Use `Refs #1471` for the spec PR. The implementation PR should use
+`Closes #1471` after the layered Claude Code path, skills cap, fallback tests,
+and verification land.

--- a/specs/GH1471/tech.md
+++ b/specs/GH1471/tech.md
@@ -1,0 +1,109 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1471
+
+## Product Spec
+
+See `specs/GH1471/product.md`.
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Prompt model | `crates/harness-core/src/prompts/mod.rs` | `PromptParts` stores static/context/dynamic layers, but callers usually call `to_prompt_string()`. | The layer data exists but is discarded before execution. |
+| Issue prompts | `crates/harness-core/src/prompts/issue.rs`, `contract.rs` | Issue triage, plan, implementation, and contract prompts return `PromptParts`. | These are the first practical candidates for layered execution. |
+| Agent boundary | `crates/harness-core/src/agent.rs` | `AgentRequest` contains only `prompt: String`. | Agents cannot receive separate static/context/dynamic layers today. |
+| Claude CLI adapter | `crates/harness-agents/src/claude.rs`, `claude_adapter.rs` | The prompt must immediately follow `-p`; no append-system-prompt args are used. | Claude CLI supports the first cache-friendly implementation path. |
+| Codex adapters | `crates/harness-agents/src/codex.rs`, `codex_adapter.rs` | Prompt is sent as a positional `codex exec` prompt or JSON-RPC text input. | Local help did not expose an equivalent system-prompt cache channel, so this remains flattened. |
+| Skills listing | `crates/harness-core/src/prompts/context.rs`, `crates/harness-server/src/task_executor/helpers.rs` | `build_available_skills_listing` formats every active skill description. | Prompt size grows with total skill count. |
+| Prompt persistence | `crates/harness-server/src/task_executor/helpers/streaming.rs` | The redacted `req.prompt` is persisted/audited. | Layering must preserve an auditable effective prompt. |
+
+## Proposed Design
+
+1. Add a layered prompt payload to `AgentRequest`.
+   - Keep `prompt: String` as the canonical flattened fallback and audit value.
+   - Add an optional field such as `prompt_parts: Option<PromptParts>` or a
+     serializable equivalent in `harness-core`.
+   - Provide constructors/helpers so call sites can build an `AgentRequest`
+     from `PromptParts` while automatically filling `prompt`.
+2. Wire issue/task prompt call sites to preserve layers.
+   - Start with `implement_from_issue`, `triage_prompt`, `plan_prompt`, and
+     the issue submission contract prompts where `PromptParts` already exists.
+   - Keep validation retry and continuation prompts flattened unless they have
+     reliable layer boundaries.
+3. Implement Claude Code layered execution.
+   - Preserve the critical `-p <prompt>` argument ordering.
+   - Put dynamic payload, plus any dynamic/context text that must remain user
+     prompt content, immediately after `-p`.
+   - Pass stable static instructions through `--append-system-prompt`.
+   - Add `--exclude-dynamic-system-prompt-sections` when the layered path is
+     active so Claude's dynamic default system sections do not reduce cache
+     reuse.
+   - Apply the same argument construction rule in both `claude.rs` and
+     `claude_adapter.rs`.
+4. Keep fallback behavior.
+   - Codex, Anthropic API, test agents, and any request without layers should
+     continue using `req.prompt`.
+   - Interceptors and prompt persistence should still see the flattened
+     effective prompt unless a later design adds layer-aware audit fields.
+5. Cap the available-skills listing.
+   - Add a deterministic cap at the listing builder or injection call site.
+   - Recommended first cap: include matched skills in full via
+     `build_matched_skills_section`, and limit the broad "Available Skills"
+     list to a small deterministic count such as 20 active skills.
+   - If the listing is truncated, include a short omitted-count line.
+   - Do not cap matched full-content injection for skills that actually match.
+
+## Data Flow
+
+A prompt builder returns `PromptParts`. The task executor creates an
+`AgentRequest` whose `prompt` is `parts.to_prompt_string()` and whose optional
+layer payload carries the original static/context/dynamic strings. Shared
+helpers and non-layer-aware agents continue reading `req.prompt`.
+
+Claude Code adapters inspect the optional layer payload. If present, they send
+the selected static layer via the system-prompt append argument and send the
+dynamic effective prompt through `-p`. If absent, they use the current flattened
+argument list.
+
+Skill injection remains a pre-agent prompt augmentation step. The broad
+available-skills listing is capped before it is appended, while matched skills
+remain full content and keep `skill_used` telemetry.
+
+## Alternatives Considered
+
+- Replace `prompt: String` with only layered fields. Rejected because many
+  adapters, interceptors, tests, prompt persistence paths, and retry builders
+  depend on a flattened prompt.
+- Implement cache_control through Anthropic API first. Rejected for this issue
+  because the current server path primarily exercises CLI agents and the local
+  Claude CLI already exposes a system-prompt append path.
+- Use semantic search for the skills listing as the first fix. Deferred because
+  a deterministic cap is smaller, testable, and directly addresses unbounded
+  growth. Relevance search can be layered on later.
+
+## Risks
+
+- Misordered Claude CLI arguments can break execution. Mitigate with tests that
+  assert `-p` is immediately followed by the dynamic prompt in both Claude
+  adapter paths.
+- Moving too much context into the system prompt could change model behavior.
+  Mitigate by starting with static instructions only and keeping the flattened
+  fallback available.
+- Skill caps might hide useful but unmatched skills. Mitigate by preserving
+  matched full-content injection and including a truncation count.
+- Prompt audit could become misleading if only dynamic content is persisted.
+  Mitigate by keeping `req.prompt` as the full flattened effective prompt.
+
+## Test Plan
+
+- [ ] `cargo test -p harness-core prompts`
+- [ ] `cargo test -p harness-agents claude`
+- [ ] `cargo test -p harness-agents claude_adapter`
+- [ ] Focused task-executor helper tests covering skills-list cap and matched
+      skill usage recording.
+- [ ] `cargo check -p harness-server --all-targets`
+- [ ] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1471`
+- [ ] `python3 checks/check_workflow.py --repo .`


### PR DESCRIPTION
## Summary
- Add the SpecRail product, technical, and task plan for GH1471.
- Scope layered PromptParts propagation through AgentRequest with Claude Code as the first cache-friendly backend.
- Define the deterministic available-skills listing cap while preserving matched skill content and usage telemetry.

## Verification
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1471
- python3 checks/check_workflow.py --repo .
- git diff --check

Refs #1471