### PR TITLE
Wire PromptParts layers into Claude caching

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -94,15 +94,22 @@ impl ClaudeCodeAgent {
     /// "Input must be provided" errors.
     fn base_args(&self, req: &AgentRequest) -> Vec<OsString> {
         let model = self.resolve_model(req);
+        let prompt = req.claude_main_prompt();
         let mut base_args = vec![
             OsString::from("-p"),
-            OsString::from(&req.prompt), // prompt MUST follow -p immediately
+            OsString::from(prompt.as_ref()), // prompt MUST follow -p immediately
             OsString::from("--output-format"),
             OsString::from("stream-json"),
             OsString::from("--model"),
             OsString::from(model),
             OsString::from("--verbose"),
         ];
+
+        if let Some(system_prompt) = req.claude_system_prompt() {
+            base_args.push(OsString::from("--append-system-prompt"));
+            base_args.push(OsString::from(system_prompt.as_ref()));
+            base_args.push(OsString::from("--exclude-dynamic-system-prompt-sections"));
+        }
 
         // Hard tool enforcement at the CLI boundary (issue #514):
         //   Full profile  (allowed_tools = None)    → --dangerously-skip-permissions
@@ -487,3 +494,7 @@ fn provider_wait_message(phase: ProviderPhase) -> String {
 #[cfg(test)]
 #[path = "claude_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "claude_prompt_layer_tests.rs"]
+mod prompt_layer_tests;

--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -228,14 +228,29 @@ impl CodeAgent for ClaudeCodeAgent {
             )
             .await?;
 
-        let child = cmd.spawn().map_err(|error| {
-            let message = crate::classify_missing_workspace_spawn_failure(
-                &error,
-                &req.project_root,
-                format!("failed to run claude: {error}"),
-            );
-            harness_core::error::HarnessError::AgentExecution(message)
-        })?;
+        let spawn_result = cmd.spawn();
+        let child = match spawn_result {
+            Ok(child) => child,
+            Err(ref error) if error.raw_os_error() == Some(26) => {
+                tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                cmd.spawn().map_err(|error| {
+                    let message = crate::classify_missing_workspace_spawn_failure(
+                        &error,
+                        &req.project_root,
+                        format!("failed to run claude: {error}"),
+                    );
+                    harness_core::error::HarnessError::AgentExecution(message)
+                })?
+            }
+            Err(error) => {
+                let message = crate::classify_missing_workspace_spawn_failure(
+                    &error,
+                    &req.project_root,
+                    format!("failed to run claude: {error}"),
+                );
+                return Err(harness_core::error::HarnessError::AgentExecution(message));
+            }
+        };
         if let Some(pid) = child.id() {
             crate::write_provisional_agent_run_binding(
                 &run_identity,

--- a/crates/harness-agents/src/claude_adapter.rs
+++ b/crates/harness-agents/src/claude_adapter.rs
@@ -64,11 +64,12 @@ impl AgentAdapter for ClaudeAdapter {
         }
 
         let model = req.model.as_deref().unwrap_or(&self.default_model);
+        let prompt = req.claude_main_prompt();
         let run_identity = crate::resolve_agent_run_identity(&HashMap::new());
         let mut cmd = Command::new(&self.cli_path);
         // Prompt MUST follow -p immediately: Claude CLI parses `-p <VALUE>`.
         cmd.arg("-p")
-            .arg(&req.prompt)
+            .arg(prompt.as_ref())
             .arg("--dangerously-skip-permissions")
             .arg("--output-format")
             .arg("stream-json")
@@ -80,6 +81,11 @@ impl AgentAdapter for ClaudeAdapter {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        if let Some(system_prompt) = req.claude_system_prompt() {
+            cmd.arg("--append-system-prompt")
+                .arg::<&str>(system_prompt.as_ref())
+                .arg("--exclude-dynamic-system-prompt-sections");
+        }
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
         crate::strip_claude_env(&mut cmd);
@@ -393,7 +399,7 @@ pub fn parse_stream_json_usage(line: &str) -> Option<TokenUsage> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harness_core::agent::ApprovalDecision;
+    use harness_core::agent::{AgentPromptLayers, ApprovalDecision};
     use harness_core::config::agents::ClaudeProviderBackpressureConfig;
     use harness_core::types::ExecutionPhase;
     use std::fs;
@@ -554,6 +560,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn start_turn_sends_layered_static_prompt_through_system_prompt_args(
+    ) -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let args_path = dir.path().join("args.txt");
+        let script = dir.path().join("mock-claude-layered.sh");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nset -eu\n: > '{}'\nfor arg in \"$@\"; do printf '%s\\n' \"$arg\" >> '{}'; done\nprintf '%s\\n' '{{\"type\":\"assistant\",\"message\":\"done\"}}'\nprintf '%s\\n' '{{\"type\":\"result\",\"result\":\"done\"}}'\n",
+                args_path.display(),
+                args_path.display()
+            ),
+        )?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script)?.permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script, perms)?;
+        }
+
+        let adapter = ClaudeAdapter::new(script, "test-model".into());
+        let mut request = turn_request("static-context-dynamic", dir.path().to_path_buf());
+        request.prompt_layers = Some(AgentPromptLayers::new("static", "context-", "dynamic"));
+        let (tx, mut rx) = mpsc::channel(8);
+
+        adapter.start_turn(request, tx).await?;
+        while rx.recv().await.is_some() {}
+
+        let args: Vec<String> = fs::read_to_string(args_path)?
+            .lines()
+            .map(str::to_string)
+            .collect();
+        assert_eq!(args[0], "-p");
+        assert_eq!(args[1], "context-dynamic");
+        assert!(args
+            .windows(2)
+            .any(|window| window == ["--append-system-prompt", "static"]));
+        assert!(args.contains(&"--exclude-dynamic-system-prompt-sections".to_string()));
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn start_turn_emits_provider_wait_warning_before_spawn() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let started = dir.path().join("started.txt");
@@ -647,6 +696,7 @@ mod tests {
     fn turn_request(prompt: &str, project_root: PathBuf) -> TurnRequest {
         TurnRequest {
             prompt: prompt.to_string(),
+            prompt_layers: None,
             project_root,
             model: None,
             reasoning_effort: None,

--- a/crates/harness-agents/src/claude_prompt_layer_tests.rs
+++ b/crates/harness-agents/src/claude_prompt_layer_tests.rs
@@ -1,0 +1,78 @@
+use super::*;
+use harness_core::agent::{AgentPromptLayers, AgentRequest};
+
+#[test]
+fn base_args_sends_static_layer_through_append_system_prompt() {
+    let agent = ClaudeCodeAgent::new(
+        PathBuf::from("claude"),
+        "test-model".to_string(),
+        SandboxMode::DangerFullAccess,
+    );
+    let req = AgentRequest {
+        prompt: "static\ncontext\ndynamic\n".to_string(),
+        prompt_layers: Some(AgentPromptLayers::new("static\n", "context\n", "dynamic\n")),
+        ..AgentRequest::default()
+    };
+
+    let args: Vec<String> = agent
+        .base_args(&req)
+        .iter()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(args[0], "-p");
+    assert_eq!(args[1], "context\ndynamic\n");
+    assert!(args
+        .windows(2)
+        .any(|window| window == ["--append-system-prompt", "static\n"]));
+    assert!(args.contains(&"--exclude-dynamic-system-prompt-sections".to_string()));
+}
+
+#[test]
+fn base_args_keeps_flattened_prompt_without_layers() {
+    let agent = ClaudeCodeAgent::new(
+        PathBuf::from("claude"),
+        "test-model".to_string(),
+        SandboxMode::DangerFullAccess,
+    );
+    let req = AgentRequest {
+        prompt: "flat prompt".to_string(),
+        ..AgentRequest::default()
+    };
+
+    let args: Vec<String> = agent
+        .base_args(&req)
+        .iter()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(args[0], "-p");
+    assert_eq!(args[1], "flat prompt");
+    assert!(!args.contains(&"--append-system-prompt".to_string()));
+    assert!(!args.contains(&"--exclude-dynamic-system-prompt-sections".to_string()));
+}
+
+#[test]
+fn base_args_keeps_flattened_prompt_for_static_only_layers() {
+    let agent = ClaudeCodeAgent::new(
+        PathBuf::from("claude"),
+        "test-model".to_string(),
+        SandboxMode::DangerFullAccess,
+    );
+    let req = AgentRequest {
+        prompt: "static only".to_string(),
+        prompt_layers: Some(AgentPromptLayers::new("static only", "", "")),
+        ..AgentRequest::default()
+    };
+
+    let args: Vec<String> = agent
+        .base_args(&req)
+        .iter()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(args[0], "-p");
+    assert_eq!(args[1], "static only");
+    assert!(!args.contains(&"--append-system-prompt".to_string()));
+    assert!(!args.contains(&"--exclude-dynamic-system-prompt-sections".to_string()));
+}

--- a/crates/harness-agents/src/codex_adapter_tests.rs
+++ b/crates/harness-agents/src/codex_adapter_tests.rs
@@ -241,6 +241,7 @@ fn approval_decision_result_uses_app_server_shape() {
 fn start_params_include_runtime_profile_overrides() {
     let req = TurnRequest {
         prompt: "ping".to_string(),
+        prompt_layers: None,
         project_root: PathBuf::from("/tmp/project"),
         model: Some("gpt-runtime".to_string()),
         reasoning_effort: Some("medium".to_string()),
@@ -346,6 +347,7 @@ async fn start_turn_missing_workspace_reports_workspace_missing() -> anyhow::Res
     let adapter = CodexAdapter::new(std::env::current_exe()?);
     let request = TurnRequest {
         prompt: "ping".to_string(),
+        prompt_layers: None,
         project_root: missing.clone(),
         model: None,
         reasoning_effort: None,
@@ -410,6 +412,7 @@ async fn start_turn_fails_when_stdout_eofs_before_terminal_event() {
 
     let req = TurnRequest {
         prompt: "ping".to_string(),
+        prompt_layers: None,
         project_root: PathBuf::from("/tmp/project"),
         model: None,
         reasoning_effort: None,

--- a/crates/harness-core/src/agent.rs
+++ b/crates/harness-core/src/agent.rs
@@ -3,6 +3,7 @@ use crate::config::agents::SandboxMode;
 use crate::types::*;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -24,7 +25,12 @@ pub trait CodeAgent: Send + Sync {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentRequest {
+    /// Canonical flattened prompt used for fallback execution and audit.
     pub prompt: String,
+    /// Optional layered prompt payload for adapters with cache-friendly
+    /// static prompt channels.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_layers: Option<AgentPromptLayers>,
     pub project_root: PathBuf,
     /// Tool restriction for the agent invocation.
     ///
@@ -76,12 +82,41 @@ impl AgentRequest {
     pub fn uses_dangerously_skip_permissions(&self) -> bool {
         self.allowed_tools.is_none()
     }
+
+    pub fn from_prompt_layers(prompt_layers: AgentPromptLayers, project_root: PathBuf) -> Self {
+        Self {
+            prompt: prompt_layers.to_prompt_string(),
+            prompt_layers: Some(prompt_layers),
+            project_root,
+            ..Self::default()
+        }
+    }
+
+    fn effective_prompt_layers(&self) -> Option<Cow<'_, AgentPromptLayers>> {
+        self.prompt_layers.as_ref().map(Cow::Borrowed).or_else(|| {
+            crate::prompts::prompt_layers_for_flattened_prompt(&self.prompt).map(Cow::Owned)
+        })
+    }
+
+    pub fn claude_main_prompt(&self) -> Cow<'_, str> {
+        self.effective_prompt_layers()
+            .and_then(|layers| layers.main_prompt_for_cache())
+            .map(Cow::Owned)
+            .unwrap_or_else(|| Cow::Borrowed(self.prompt.as_str()))
+    }
+
+    pub fn claude_system_prompt(&self) -> Option<Cow<'_, str>> {
+        self.effective_prompt_layers()
+            .and_then(|layers| layers.static_system_prompt_for_cache().map(str::to_string))
+            .map(Cow::Owned)
+    }
 }
 
 impl Default for AgentRequest {
     fn default() -> Self {
         Self {
             prompt: String::new(),
+            prompt_layers: None,
             project_root: PathBuf::from("."),
             allowed_tools: None,
             model: None,
@@ -94,6 +129,82 @@ impl Default for AgentRequest {
             env_vars: HashMap::new(),
             capability_token: None,
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentPromptLayers {
+    /// Role, workflow, and output-format instructions that are stable for
+    /// repeated tasks of the same prompt kind.
+    pub static_instructions: String,
+    /// Project and session context that should remain in the main prompt.
+    pub context: String,
+    /// Per-invocation task payload and appended runtime context.
+    pub dynamic_payload: String,
+}
+
+impl AgentPromptLayers {
+    pub fn new(
+        static_instructions: impl Into<String>,
+        context: impl Into<String>,
+        dynamic_payload: impl Into<String>,
+    ) -> Self {
+        Self {
+            static_instructions: static_instructions.into(),
+            context: context.into(),
+            dynamic_payload: dynamic_payload.into(),
+        }
+    }
+
+    pub fn to_prompt_string(&self) -> String {
+        format!(
+            "{}{}{}",
+            self.static_instructions, self.context, self.dynamic_payload
+        )
+    }
+
+    pub fn append_to_dynamic_payload(&mut self, text: &str) {
+        self.dynamic_payload.push_str(text);
+    }
+
+    pub fn static_system_prompt(&self) -> Option<&str> {
+        if self.static_instructions.trim().is_empty() {
+            None
+        } else {
+            Some(&self.static_instructions)
+        }
+    }
+
+    pub fn static_system_prompt_for_cache(&self) -> Option<&str> {
+        let has_main_prompt =
+            !self.context.trim().is_empty() || !self.dynamic_payload.trim().is_empty();
+        if has_main_prompt {
+            self.static_system_prompt()
+        } else {
+            None
+        }
+    }
+
+    pub fn main_prompt_for_cache(&self) -> Option<String> {
+        self.static_system_prompt_for_cache()?;
+        let mut prompt = String::with_capacity(self.context.len() + self.dynamic_payload.len());
+        prompt.push_str(&self.context);
+        prompt.push_str(&self.dynamic_payload);
+        if prompt.trim().is_empty() {
+            None
+        } else {
+            Some(prompt)
+        }
+    }
+}
+
+impl From<crate::prompts::PromptParts> for AgentPromptLayers {
+    fn from(parts: crate::prompts::PromptParts) -> Self {
+        Self::new(
+            parts.static_instructions,
+            parts.context,
+            parts.dynamic_payload,
+        )
     }
 }
 
@@ -197,6 +308,7 @@ pub enum ApprovalDecision {
 #[derive(Debug, Clone)]
 pub struct TurnRequest {
     pub prompt: String,
+    pub prompt_layers: Option<AgentPromptLayers>,
     pub project_root: PathBuf,
     pub model: Option<String>,
     pub reasoning_effort: Option<String>,
@@ -208,6 +320,22 @@ pub struct TurnRequest {
     pub timeout_secs: Option<u64>,
     /// Scoped write capability; checked for expiry before spawning.
     pub capability_token: Option<CapabilityToken>,
+}
+
+impl TurnRequest {
+    pub fn claude_main_prompt(&self) -> Cow<'_, str> {
+        self.prompt_layers
+            .as_ref()
+            .and_then(AgentPromptLayers::main_prompt_for_cache)
+            .map(Cow::Owned)
+            .unwrap_or_else(|| Cow::Borrowed(self.prompt.as_str()))
+    }
+
+    pub fn claude_system_prompt(&self) -> Option<&str> {
+        self.prompt_layers
+            .as_ref()
+            .and_then(AgentPromptLayers::static_system_prompt_for_cache)
+    }
 }
 
 /// Streaming agent adapter — coexists with legacy CodeAgent trait.

--- a/crates/harness-core/src/agent_tests.rs
+++ b/crates/harness-core/src/agent_tests.rs
@@ -1,0 +1,94 @@
+use crate::agent::{AgentPromptLayers, AgentRequest, TurnRequest};
+use crate::prompts;
+use std::path::PathBuf;
+
+#[test]
+fn agent_request_from_prompt_layers_keeps_flattened_fallback() {
+    let layers = AgentPromptLayers::new("static\n", "context\n", "dynamic\n");
+
+    let request = AgentRequest::from_prompt_layers(layers.clone(), PathBuf::from("/tmp/project"));
+
+    assert_eq!(request.prompt, "static\ncontext\ndynamic\n");
+    assert_eq!(request.prompt_layers, Some(layers));
+}
+
+#[test]
+fn claude_prompt_helpers_split_static_from_main_prompt() {
+    let request = AgentRequest::from_prompt_layers(
+        AgentPromptLayers::new("static instructions\n", "context\n", "dynamic\n"),
+        PathBuf::from("/tmp/project"),
+    );
+
+    assert_eq!(
+        request.claude_system_prompt().as_deref(),
+        Some("static instructions\n")
+    );
+    assert_eq!(request.claude_main_prompt(), "context\ndynamic\n");
+    assert_eq!(request.prompt, "static instructions\ncontext\ndynamic\n");
+}
+
+#[test]
+fn claude_prompt_helpers_fallback_to_flattened_prompt_without_layers() {
+    let request = AgentRequest {
+        prompt: "flat prompt".to_string(),
+        project_root: PathBuf::from("/tmp/project"),
+        ..AgentRequest::default()
+    };
+
+    assert_eq!(request.claude_system_prompt().as_deref(), None);
+    assert_eq!(request.claude_main_prompt(), "flat prompt");
+}
+
+#[test]
+fn claude_prompt_helpers_do_not_split_static_only_layers() {
+    let request = AgentRequest::from_prompt_layers(
+        AgentPromptLayers::new("static only\n", "", ""),
+        PathBuf::from("/tmp/project"),
+    );
+
+    assert_eq!(request.claude_system_prompt().as_deref(), None);
+    assert_eq!(request.claude_main_prompt(), "static only\n");
+}
+
+#[test]
+fn agent_request_recovers_layers_from_registered_flattened_prompt_with_runtime_additions() {
+    let flattened =
+        prompts::implement_from_issue(1471, None, Some("follow the spec")).to_prompt_string();
+    let request = AgentRequest {
+        prompt: format!("Constitution\n\n{flattened}\n\n## Available Skills\n- review"),
+        project_root: PathBuf::from("/tmp/project"),
+        ..AgentRequest::default()
+    };
+
+    let Some(system_prompt) = request.claude_system_prompt() else {
+        panic!("registered PromptParts should provide a Claude system prompt");
+    };
+    let main_prompt = request.claude_main_prompt();
+
+    assert!(system_prompt.contains("Senior Engineer"));
+    assert!(!system_prompt.contains("follow the spec"));
+    assert!(main_prompt.contains("Constitution"));
+    assert!(main_prompt.contains("follow the spec"));
+    assert!(main_prompt.contains("## Available Skills"));
+}
+
+#[test]
+fn turn_request_uses_same_claude_layer_split() {
+    let request = TurnRequest {
+        prompt: "static\ncontext\ndynamic\n".to_string(),
+        prompt_layers: Some(AgentPromptLayers::new("static\n", "context\n", "dynamic\n")),
+        project_root: PathBuf::from("/tmp/project"),
+        model: None,
+        reasoning_effort: None,
+        execution_phase: None,
+        sandbox_mode: None,
+        approval_policy: None,
+        allowed_tools: vec![],
+        context: vec![],
+        timeout_secs: None,
+        capability_token: None,
+    };
+
+    assert_eq!(request.claude_system_prompt(), Some("static\n"));
+    assert_eq!(request.claude_main_prompt(), "context\ndynamic\n");
+}

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod agent;
+#[cfg(test)]
+mod agent_tests;
 pub mod agents_md;
 pub mod capability;
 pub mod config;

--- a/crates/harness-core/src/prompts/context.rs
+++ b/crates/harness-core/src/prompts/context.rs
@@ -1,5 +1,7 @@
 use super::issue::wrap_external_data;
 
+pub const DEFAULT_AVAILABLE_SKILLS_LIMIT: usize = 20;
+
 /// Describes a sibling task running in parallel on the same project.
 ///
 /// Used by [`sibling_task_context`] to build a constraint block for the agent.
@@ -45,17 +47,29 @@ pub fn sibling_task_context(siblings: &[SiblingTask]) -> String {
 pub fn build_available_skills_listing<'a>(
     skills: impl IntoIterator<Item = (&'a str, &'a str)>,
 ) -> String {
-    let mut iter = skills.into_iter().peekable();
-    if iter.peek().is_none() {
+    let mut skills: Vec<(&str, &str)> = skills.into_iter().collect();
+    if skills.is_empty() {
         return String::new();
     }
+    skills.sort_by(|(left_name, left_desc), (right_name, right_desc)| {
+        left_name
+            .cmp(right_name)
+            .then_with(|| left_desc.cmp(right_desc))
+    });
     let mut out = "\n\n## Available Skills\n".to_string();
-    for (name, desc) in iter {
+    let visible_count = skills.len().min(DEFAULT_AVAILABLE_SKILLS_LIMIT);
+    for (name, desc) in skills.iter().take(visible_count) {
         out.push_str("- **");
         out.push_str(name);
         out.push_str("**: ");
         out.push_str(desc);
         out.push('\n');
+    }
+    let omitted = skills.len().saturating_sub(visible_count);
+    if omitted > 0 {
+        out.push_str(&format!(
+            "- ... {omitted} additional skills omitted from this broad listing. Matched skills still appear in full below.\n"
+        ));
     }
     out
 }
@@ -212,6 +226,25 @@ mod tests {
         assert!(result.contains("Code review tool"));
         assert!(result.contains("**deploy**"));
         assert!(result.contains("Deploy to production"));
+    }
+
+    #[test]
+    fn build_available_skills_listing_caps_broad_listing() {
+        let mut skills: Vec<(String, String)> = (0..25)
+            .map(|i| (format!("skill-{i:02}"), format!("description {i}")))
+            .collect();
+        skills.reverse();
+        let result = build_available_skills_listing(
+            skills
+                .iter()
+                .map(|(name, description)| (name.as_str(), description.as_str())),
+        );
+
+        assert!(result.contains("**skill-00**"));
+        assert!(result.contains("**skill-19**"));
+        assert!(!result.contains("**skill-20**"));
+        assert!(result.contains("5 additional skills omitted"));
+        assert!(result.contains("Matched skills still appear in full below"));
     }
 
     #[test]

--- a/crates/harness-core/src/prompts/issue.rs
+++ b/crates/harness-core/src/prompts/issue.rs
@@ -163,22 +163,24 @@ pub fn implement_from_issue(
         None => String::new(),
     };
     PromptParts {
-        static_instructions: format!(
-            "You are a Senior Engineer implementing a change for GitHub issue #{issue}.\n\n\
+        static_instructions: String::from(
+            "You are a Senior Engineer implementing a change for a GitHub issue.\n\n\
              Your job is to write correct, tested, minimal code. Do not add features beyond \
              what the issue requests. Do not refactor unrelated code.\n\
-             {plan_section}\n\
              Steps:\n\
-             1. Read the issue: `gh issue view {issue}`\n\
+             1. Read the target issue identified in the dynamic payload\n\
              2. Understand the requirements and existing code\n\
              3. Implement the change with the minimum necessary modifications\n\
              4. Run the project's validation commands before proceeding — fix any failures first\n\
              5. Create a feature branch, commit with a descriptive message, push\n\
-             6. Create a PR with `gh pr create` (see the mandatory PR body contract below).\n"
+             6. Create a PR with `gh pr create` (see the mandatory PR body contract below).\n",
         ),
         context: git_line,
         dynamic_payload: format!(
-            "PR body contract (enforced by reviewers and dashboards):\n\
+            "Target issue #{issue}\n\
+             Read the issue with: `gh issue view {issue}`\n\
+             {plan_section}\
+             PR body contract (enforced by reviewers and dashboards):\n\
              - The body MUST contain the following line verbatim on its own line, \
              with no surrounding text:\n\
              \n\
@@ -348,17 +350,30 @@ mod tests {
     #[test]
     fn test_implement_from_issue_with_plan() {
         let plan = "1. Modify src/lib.rs\n2. Add test";
-        let p = implement_from_issue(42, None, Some(plan)).to_prompt_string();
+        let parts = implement_from_issue(42, None, Some(plan));
+        let p = parts.to_prompt_string();
         assert!(p.contains("issue #42"));
         assert!(p.contains("implementation plan"));
         assert!(p.contains("Modify src/lib.rs"));
         assert!(p.contains("PLAN_ISSUE="));
+        assert!(!parts.static_instructions.contains("Modify src/lib.rs"));
+        assert!(parts.dynamic_payload.contains("Modify src/lib.rs"));
+    }
+
+    #[test]
+    fn test_implement_from_issue_static_layer_is_issue_stable() {
+        let parts = implement_from_issue(42, None, Some("issue-specific plan"));
+        assert!(!parts.static_instructions.contains("#42"));
+        assert!(!parts.static_instructions.contains("issue-specific plan"));
+        assert!(parts.dynamic_payload.contains("#42"));
+        assert!(parts.dynamic_payload.contains("issue-specific plan"));
     }
 
     #[test]
     fn test_prompt_parts_fields_are_accessible() {
         let parts = implement_from_issue(99, None, None);
-        assert!(parts.static_instructions.contains("issue #99"));
+        assert!(parts.static_instructions.contains("GitHub issue"));
+        assert!(parts.dynamic_payload.contains("issue #99"));
         assert!(parts.dynamic_payload.contains("PR_URL="));
         assert!(parts.context.is_empty());
     }

--- a/crates/harness-core/src/prompts/mod.rs
+++ b/crates/harness-core/src/prompts/mod.rs
@@ -1,5 +1,9 @@
 //! Prompt templates and output parsers shared across CLI and HTTP entries.
 
+use crate::agent::AgentPromptLayers;
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+
 pub mod context;
 pub mod contract;
 pub mod cross_review;
@@ -72,11 +76,73 @@ impl PromptParts {
     /// the prompt-building function. Callers that previously stored the return value as a
     /// `String` should call this method to obtain it.
     pub fn to_prompt_string(&self) -> String {
-        format!(
+        let prompt = format!(
             "{}{}{}",
             self.static_instructions, self.context, self.dynamic_payload
-        )
+        );
+        register_prompt_layers(
+            &prompt,
+            AgentPromptLayers::new(
+                self.static_instructions.clone(),
+                self.context.clone(),
+                self.dynamic_payload.clone(),
+            ),
+        );
+        prompt
     }
+}
+
+const PROMPT_LAYER_REGISTRY_LIMIT: usize = 256;
+
+#[derive(Debug, Clone)]
+struct RegisteredPromptLayers {
+    flattened_prompt: String,
+    layers: AgentPromptLayers,
+}
+
+static PROMPT_LAYER_REGISTRY: OnceLock<Mutex<VecDeque<RegisteredPromptLayers>>> = OnceLock::new();
+
+fn prompt_layer_registry() -> &'static Mutex<VecDeque<RegisteredPromptLayers>> {
+    PROMPT_LAYER_REGISTRY.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+fn register_prompt_layers(flattened_prompt: &str, layers: AgentPromptLayers) {
+    let mut registry = prompt_layer_registry().lock().unwrap();
+    if let Some(existing_index) = registry
+        .iter()
+        .position(|entry| entry.flattened_prompt == flattened_prompt)
+    {
+        registry.remove(existing_index);
+    }
+    registry.push_back(RegisteredPromptLayers {
+        flattened_prompt: flattened_prompt.to_string(),
+        layers,
+    });
+    while registry.len() > PROMPT_LAYER_REGISTRY_LIMIT {
+        registry.pop_front();
+    }
+}
+
+pub(crate) fn prompt_layers_for_flattened_prompt(prompt: &str) -> Option<AgentPromptLayers> {
+    let registry = prompt_layer_registry().lock().unwrap();
+    registry
+        .iter()
+        .rev()
+        .filter_map(|entry| {
+            prompt.find(&entry.flattened_prompt).map(|start| {
+                let end = start + entry.flattened_prompt.len();
+                let mut layers = entry.layers.clone();
+                if start > 0 {
+                    layers.context = format!("{}{}", &prompt[..start], layers.context);
+                }
+                if end < prompt.len() {
+                    layers.append_to_dynamic_payload(&prompt[end..]);
+                }
+                (entry.flattened_prompt.len(), layers)
+            })
+        })
+        .max_by_key(|(matched_len, _)| *matched_len)
+        .map(|(_, layers)| layers)
 }
 
 /// Wrap `s` in POSIX single quotes, escaping any embedded single quotes via `'\''`.

--- a/crates/harness-server/src/task_executor/helpers.rs
+++ b/crates/harness-server/src/task_executor/helpers.rs
@@ -511,7 +511,7 @@ pub(crate) async fn augment_prompt_with_skills(
 /// agents — this function injects skill content into the prompt text itself.
 ///
 /// Two sections are appended:
-/// - **Available Skills**: a brief listing of every skill (name + description).
+/// - **Available Skills**: a capped broad listing of skill names and descriptions.
 /// - **Relevant Skills**: full content of skills whose trigger patterns matched.
 ///
 /// Returns an empty string when the store is empty (no sections added).
@@ -595,6 +595,10 @@ pub(crate) async fn persist_artifact(
 #[cfg(test)]
 #[path = "helpers_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "helpers_prompt_cap_tests.rs"]
+mod prompt_cap_tests;
 
 #[cfg(test)]
 #[path = "helpers_stall_tests.rs"]

--- a/crates/harness-server/src/task_executor/helpers_prompt_cap_tests.rs
+++ b/crates/harness-server/src/task_executor/helpers_prompt_cap_tests.rs
@@ -1,0 +1,44 @@
+use super::*;
+use tokio::sync::RwLock;
+
+fn many_skill_store() -> harness_skills::store::SkillStore {
+    let mut store = harness_skills::store::SkillStore::new();
+    for i in (0..25).rev() {
+        let trigger = if i == 24 {
+            "special cap trigger"
+        } else {
+            "never-match"
+        };
+        store.create(
+            format!("skill-{i:02}"),
+            format!(
+                "# Skill {i}\n<!-- trigger-patterns: {trigger} -->\nFull content for skill {i}."
+            ),
+        );
+    }
+    store
+}
+
+#[tokio::test]
+async fn inject_skills_caps_available_listing_but_keeps_matched_content() {
+    let skills = RwLock::new(many_skill_store());
+
+    let result = inject_skills_into_prompt(&skills, "please use special cap trigger").await;
+
+    assert!(result.contains("## Available Skills"));
+    assert!(result.contains("**skill-00**"));
+    assert!(result.contains("**skill-19**"));
+    assert!(!result.contains("**skill-20**"));
+    assert!(result.contains("5 additional skills omitted"));
+    assert!(result.contains("## Relevant Skills"));
+    assert!(result.contains("### skill-24"));
+    assert!(result.contains("Full content for skill 24."));
+
+    let guard = skills.read().await;
+    let matched = guard
+        .list()
+        .iter()
+        .find(|skill| skill.name == "skill-24")
+        .unwrap();
+    assert_eq!(matched.usage_count, 1);
+}

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
@@ -246,6 +246,7 @@ pub(crate) async fn run_turn_lifecycle_with_options(
         });
         let turn_req = TurnRequest {
             prompt,
+            prompt_layers: None,
             project_root,
             model: options.model.clone(),
             reasoning_effort: options.reasoning_effort.clone(),


### PR DESCRIPTION
## Summary
- preserve PromptParts layering through AgentRequest/TurnRequest-compatible prompt helpers while keeping flattened prompt fallback and audit text
- send recoverable static instructions to Claude Code with --append-system-prompt and --exclude-dynamic-system-prompt-sections while keeping Codex flattened
- sort and cap the broad Available Skills listing while preserving matched skill full-content injection and usage recording

Closes #1471

## Verification
- cargo test -p harness-core prompts
- cargo test -p harness-core agent_tests
- cargo test -p harness-agents claude
- cargo test -p harness-agents codex
- cargo test -p harness-server inject_skills
- cargo test -p harness-server helpers::prompt_cap_tests
- cargo check -p harness-server --all-targets
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1471
- python3 checks/check_workflow.py --repo .
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings