### PR TITLE
Add terminal task retention pruning

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -68,6 +68,10 @@ storage:
   runtime_retention_days: 30
   runtime_retention_batch_size: 1000
   runtime_retention_interval_secs: 3600
+  task_retention_enabled: false
+  task_retention_days: 30
+  task_retention_batch_size: 1000
+  task_retention_interval_secs: 3600
 activities:
   implement_issue:
     prompt: default

--- a/config/WORKFLOW.md
+++ b/config/WORKFLOW.md
@@ -73,6 +73,10 @@ storage:
   runtime_retention_days: 30
   runtime_retention_batch_size: 1000
   runtime_retention_interval_secs: 3600
+  task_retention_enabled: false
+  task_retention_days: 30
+  task_retention_batch_size: 1000
+  task_retention_interval_secs: 3600
 activities:
   implement_issue:
     prompt: default

--- a/config/default.toml.example
+++ b/config/default.toml.example
@@ -35,6 +35,10 @@ project_root = "."
 #   orphan_reaper_interval_secs: 3600
 #   orphan_reaper_legacy_enabled: true
 #   orphan_reaper_legacy_batch: 200
+#   task_retention_enabled: false
+#   task_retention_days: 30
+#   task_retention_batch_size: 1000
+#   task_retention_interval_secs: 3600
 
 [concurrency]
 # Default per-task agent invocation budget across implementation, validation

--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 mod candidates;
+mod storage;
 pub use candidates::WorkflowCandidatesPolicy;
+pub use storage::WorkflowStoragePolicy;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct WorkflowDocument {
@@ -263,55 +265,6 @@ pub struct WorkflowConfig {
     pub activities: BTreeMap<String, WorkflowActivityPolicy>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WorkflowStoragePolicy {
-    #[serde(default = "default_workflow_schema_namespace")]
-    pub schema_namespace: String,
-    /// Whether the background orphan-path-schema reaper runs. Bounds Postgres
-    /// catalog growth automatically by dropping path-derived schemas whose
-    /// owning workspace directory has been removed.
-    #[serde(default = "default_true")]
-    pub orphan_reaper_enabled: bool,
-    /// Interval, in seconds, between background orphan-schema reap passes.
-    #[serde(default = "default_orphan_reaper_interval_secs")]
-    pub orphan_reaper_interval_secs: u64,
-    /// Whether the orphan reaper also scans legacy unregistered path-derived
-    /// schemas by subtracting live workspace-derived schema hashes.
-    #[serde(default = "default_true")]
-    pub orphan_reaper_legacy_enabled: bool,
-    /// Maximum legacy unregistered path-derived schemas to drop per tick.
-    #[serde(default = "default_orphan_reaper_legacy_batch")]
-    pub orphan_reaper_legacy_batch: usize,
-    /// Enable workflow-runtime stuck-instance reporting. Off by default so
-    /// existing deployments keep their current background behavior on upgrade.
-    #[serde(default)]
-    pub workflow_watchdog_enabled: bool,
-    /// Minimum age, in minutes, before blocked/awaiting-feedback workflows are
-    /// reported as stuck.
-    #[serde(default = "default_workflow_watchdog_age_minutes")]
-    pub workflow_watchdog_age_minutes: u64,
-    /// Interval, in seconds, between workflow watchdog scans.
-    #[serde(default = "default_workflow_watchdog_interval_secs")]
-    pub workflow_watchdog_interval_secs: u64,
-    /// Maximum stuck workflow rows scanned/logged per watchdog tick.
-    #[serde(default = "default_workflow_watchdog_batch_size")]
-    pub workflow_watchdog_batch_size: u32,
-    /// Enable pruning of terminal workflow-runtime history. Off by default
-    /// because deleted runtime history is not recoverable.
-    #[serde(default)]
-    pub runtime_retention_enabled: bool,
-    /// Terminal workflow families older than this many days are eligible for
-    /// retention pruning.
-    #[serde(default = "default_runtime_retention_days")]
-    pub runtime_retention_days: u64,
-    /// Maximum terminal root families pruned per retention tick.
-    #[serde(default = "default_runtime_retention_batch_size")]
-    pub runtime_retention_batch_size: u32,
-    /// Interval, in seconds, between retention prune passes.
-    #[serde(default = "default_runtime_retention_interval_secs")]
-    pub runtime_retention_interval_secs: u64,
-}
-
 impl Default for IssueWorkflowPolicy {
     fn default() -> Self {
         Self {
@@ -416,26 +369,6 @@ impl Default for RuntimeWorkerPolicy {
             interval_secs: default_runtime_worker_interval_secs(),
             concurrency: default_runtime_worker_concurrency(),
             lease_ttl_secs: default_runtime_worker_lease_ttl_secs(),
-        }
-    }
-}
-
-impl Default for WorkflowStoragePolicy {
-    fn default() -> Self {
-        Self {
-            schema_namespace: default_workflow_schema_namespace(),
-            orphan_reaper_enabled: true,
-            orphan_reaper_interval_secs: default_orphan_reaper_interval_secs(),
-            orphan_reaper_legacy_enabled: true,
-            orphan_reaper_legacy_batch: default_orphan_reaper_legacy_batch(),
-            workflow_watchdog_enabled: false,
-            workflow_watchdog_age_minutes: default_workflow_watchdog_age_minutes(),
-            workflow_watchdog_interval_secs: default_workflow_watchdog_interval_secs(),
-            workflow_watchdog_batch_size: default_workflow_watchdog_batch_size(),
-            runtime_retention_enabled: false,
-            runtime_retention_days: default_runtime_retention_days(),
-            runtime_retention_batch_size: default_runtime_retention_batch_size(),
-            runtime_retention_interval_secs: default_runtime_retention_interval_secs(),
         }
     }
 }
@@ -574,42 +507,6 @@ fn default_runtime_worker_concurrency() -> u32 {
 
 fn default_runtime_worker_lease_ttl_secs() -> u64 {
     3900
-}
-
-fn default_workflow_schema_namespace() -> String {
-    "workflow".to_string()
-}
-
-fn default_orphan_reaper_interval_secs() -> u64 {
-    3600
-}
-
-fn default_orphan_reaper_legacy_batch() -> usize {
-    crate::db_pg_schema_registry::DEFAULT_ORPHAN_REAPER_LEGACY_BATCH
-}
-
-fn default_workflow_watchdog_age_minutes() -> u64 {
-    240
-}
-
-fn default_workflow_watchdog_interval_secs() -> u64 {
-    300
-}
-
-fn default_workflow_watchdog_batch_size() -> u32 {
-    100
-}
-
-fn default_runtime_retention_days() -> u64 {
-    30
-}
-
-fn default_runtime_retention_batch_size() -> u32 {
-    1_000
-}
-
-fn default_runtime_retention_interval_secs() -> u64 {
-    3_600
 }
 
 fn default_true() -> bool {

--- a/crates/harness-core/src/config/workflow/storage.rs
+++ b/crates/harness-core/src/config/workflow/storage.rs
@@ -1,0 +1,140 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowStoragePolicy {
+    #[serde(default = "default_workflow_schema_namespace")]
+    pub schema_namespace: String,
+    /// Whether the background orphan-path-schema reaper runs. Bounds Postgres
+    /// catalog growth automatically by dropping path-derived schemas whose
+    /// owning workspace directory has been removed.
+    #[serde(default = "default_true")]
+    pub orphan_reaper_enabled: bool,
+    /// Interval, in seconds, between background orphan-schema reap passes.
+    #[serde(default = "default_orphan_reaper_interval_secs")]
+    pub orphan_reaper_interval_secs: u64,
+    /// Whether the orphan reaper also scans legacy unregistered path-derived
+    /// schemas by subtracting live workspace-derived schema hashes.
+    #[serde(default = "default_true")]
+    pub orphan_reaper_legacy_enabled: bool,
+    /// Maximum legacy unregistered path-derived schemas to drop per tick.
+    #[serde(default = "default_orphan_reaper_legacy_batch")]
+    pub orphan_reaper_legacy_batch: usize,
+    /// Enable workflow-runtime stuck-instance reporting. Off by default so
+    /// existing deployments keep their current background behavior on upgrade.
+    #[serde(default)]
+    pub workflow_watchdog_enabled: bool,
+    /// Minimum age, in minutes, before blocked/awaiting-feedback workflows are
+    /// reported as stuck.
+    #[serde(default = "default_workflow_watchdog_age_minutes")]
+    pub workflow_watchdog_age_minutes: u64,
+    /// Interval, in seconds, between workflow watchdog scans.
+    #[serde(default = "default_workflow_watchdog_interval_secs")]
+    pub workflow_watchdog_interval_secs: u64,
+    /// Maximum stuck workflow rows scanned/logged per watchdog tick.
+    #[serde(default = "default_workflow_watchdog_batch_size")]
+    pub workflow_watchdog_batch_size: u32,
+    /// Enable pruning of terminal workflow-runtime history. Off by default
+    /// because deleted runtime history is not recoverable.
+    #[serde(default)]
+    pub runtime_retention_enabled: bool,
+    /// Terminal workflow families older than this many days are eligible for
+    /// retention pruning.
+    #[serde(default = "default_runtime_retention_days")]
+    pub runtime_retention_days: u64,
+    /// Maximum terminal root families pruned per retention tick.
+    #[serde(default = "default_runtime_retention_batch_size")]
+    pub runtime_retention_batch_size: u32,
+    /// Interval, in seconds, between runtime-retention prune passes.
+    #[serde(default = "default_runtime_retention_interval_secs")]
+    pub runtime_retention_interval_secs: u64,
+    /// Enable pruning of terminal task rows and task-owned child rows. Off by
+    /// default because deleted task history is not recoverable.
+    #[serde(default)]
+    pub task_retention_enabled: bool,
+    /// Terminal tasks older than this many days are eligible for retention
+    /// pruning.
+    #[serde(default = "default_task_retention_days")]
+    pub task_retention_days: u64,
+    /// Maximum terminal tasks pruned per task-retention tick.
+    #[serde(default = "default_task_retention_batch_size")]
+    pub task_retention_batch_size: u32,
+    /// Interval, in seconds, between task-retention prune passes.
+    #[serde(default = "default_task_retention_interval_secs")]
+    pub task_retention_interval_secs: u64,
+}
+
+impl Default for WorkflowStoragePolicy {
+    fn default() -> Self {
+        Self {
+            schema_namespace: default_workflow_schema_namespace(),
+            orphan_reaper_enabled: true,
+            orphan_reaper_interval_secs: default_orphan_reaper_interval_secs(),
+            orphan_reaper_legacy_enabled: true,
+            orphan_reaper_legacy_batch: default_orphan_reaper_legacy_batch(),
+            workflow_watchdog_enabled: false,
+            workflow_watchdog_age_minutes: default_workflow_watchdog_age_minutes(),
+            workflow_watchdog_interval_secs: default_workflow_watchdog_interval_secs(),
+            workflow_watchdog_batch_size: default_workflow_watchdog_batch_size(),
+            runtime_retention_enabled: false,
+            runtime_retention_days: default_runtime_retention_days(),
+            runtime_retention_batch_size: default_runtime_retention_batch_size(),
+            runtime_retention_interval_secs: default_runtime_retention_interval_secs(),
+            task_retention_enabled: false,
+            task_retention_days: default_task_retention_days(),
+            task_retention_batch_size: default_task_retention_batch_size(),
+            task_retention_interval_secs: default_task_retention_interval_secs(),
+        }
+    }
+}
+
+fn default_workflow_schema_namespace() -> String {
+    "workflow".to_string()
+}
+
+fn default_orphan_reaper_interval_secs() -> u64 {
+    3600
+}
+
+fn default_orphan_reaper_legacy_batch() -> usize {
+    crate::db_pg_schema_registry::DEFAULT_ORPHAN_REAPER_LEGACY_BATCH
+}
+
+fn default_workflow_watchdog_age_minutes() -> u64 {
+    240
+}
+
+fn default_workflow_watchdog_interval_secs() -> u64 {
+    300
+}
+
+fn default_workflow_watchdog_batch_size() -> u32 {
+    100
+}
+
+fn default_runtime_retention_days() -> u64 {
+    30
+}
+
+fn default_runtime_retention_batch_size() -> u32 {
+    1_000
+}
+
+fn default_runtime_retention_interval_secs() -> u64 {
+    3_600
+}
+
+fn default_task_retention_days() -> u64 {
+    30
+}
+
+fn default_task_retention_batch_size() -> u32 {
+    1_000
+}
+
+fn default_task_retention_interval_secs() -> u64 {
+    3_600
+}
+
+fn default_true() -> bool {
+    true
+}

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -74,6 +74,10 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert_eq!(cfg.storage.runtime_retention_days, 30);
     assert_eq!(cfg.storage.runtime_retention_batch_size, 1000);
     assert_eq!(cfg.storage.runtime_retention_interval_secs, 3600);
+    assert!(!cfg.storage.task_retention_enabled);
+    assert_eq!(cfg.storage.task_retention_days, 30);
+    assert_eq!(cfg.storage.task_retention_batch_size, 1000);
+    assert_eq!(cfg.storage.task_retention_interval_secs, 3600);
     assert!(!cfg.issue_workflow.require_human_gate_before_merge);
     assert!(cfg.activities.is_empty());
     Ok(())
@@ -220,6 +224,10 @@ storage:
   runtime_retention_days: 45
   runtime_retention_batch_size: 46
   runtime_retention_interval_secs: 47
+  task_retention_enabled: true
+  task_retention_days: 48
+  task_retention_batch_size: 49
+  task_retention_interval_secs: 50
 activities:
   implement_issue:
     prompt: issue-default
@@ -383,6 +391,10 @@ Body
     assert_eq!(cfg.storage.runtime_retention_days, 45);
     assert_eq!(cfg.storage.runtime_retention_batch_size, 46);
     assert_eq!(cfg.storage.runtime_retention_interval_secs, 47);
+    assert!(cfg.storage.task_retention_enabled);
+    assert_eq!(cfg.storage.task_retention_days, 48);
+    assert_eq!(cfg.storage.task_retention_batch_size, 49);
+    assert_eq!(cfg.storage.task_retention_interval_secs, 50);
     let activity = cfg
         .activities
         .get("implement_issue")

--- a/crates/harness-core/src/db_test_safety.rs
+++ b/crates/harness-core/src/db_test_safety.rs
@@ -22,6 +22,8 @@ pub const KNOWN_TEST_SCHEMA_PREFIXES: &[&str] = &[
     "review_store_test",
     "runtime_state_store_test",
     "task_db_backfill_test",
+    "task_db_retention_batch_test",
+    "task_db_retention_scope_test",
     "task_db_scope_test",
     "thread_db_shared_scope_test",
     "thread_db_test",

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod sse_routes;
 pub(crate) mod state;
 pub(crate) mod task_mutation_routes;
 pub(crate) mod task_query_routes;
+mod task_retention;
 pub(crate) mod task_routes;
 pub(crate) mod task_submission_routes;
 mod workflow_watchdog;
@@ -259,6 +260,10 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     // Periodically prune terminal workflow-runtime history when explicitly
     // enabled by workflow storage policy.
     runtime_retention::spawn_runtime_retention(&state);
+
+    // Periodically prune terminal task-owned rows when explicitly enabled by
+    // workflow storage policy.
+    task_retention::spawn_task_retention(&state);
 
     // Convert workflow command outbox rows into runtime jobs when the workflow
     // policy keeps the dispatcher enabled.

--- a/crates/harness-server/src/http/task_retention.rs
+++ b/crates/harness-server/src/http/task_retention.rs
@@ -1,0 +1,86 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use crate::http::AppState;
+
+const CONFIG_RETRY_SECS: u64 = 30;
+const MAX_TASK_RETENTION_DAYS: u64 = 36_500;
+
+pub(super) fn spawn_task_retention(state: &Arc<AppState>) {
+    let weak_state = Arc::downgrade(state);
+    tokio::spawn(async move {
+        loop {
+            let Some(state) = weak_state.upgrade() else {
+                break;
+            };
+            let workflow_cfg = match harness_core::config::workflow::load_workflow_config(
+                &state.core.project_root,
+            ) {
+                Ok(config) => config,
+                Err(error) => {
+                    tracing::warn!("task retention config load failed: {error}");
+                    drop(state);
+                    tokio::time::sleep(std::time::Duration::from_secs(CONFIG_RETRY_SECS)).await;
+                    continue;
+                }
+            };
+            let interval = std::time::Duration::from_secs(
+                workflow_cfg.storage.task_retention_interval_secs.max(1),
+            );
+            if workflow_cfg.storage.task_retention_enabled {
+                let cutoff =
+                    task_retention_cutoff(Utc::now(), workflow_cfg.storage.task_retention_days);
+                match state
+                    .core
+                    .tasks
+                    .prune_terminal_tasks_before(
+                        cutoff,
+                        workflow_cfg.storage.task_retention_batch_size,
+                    )
+                    .await
+                {
+                    Ok(summary) if !summary.is_empty() => tracing::info!(
+                        tasks = summary.tasks_deleted,
+                        artifacts = summary.artifacts_deleted,
+                        prompts = summary.prompts_deleted,
+                        checkpoints = summary.checkpoints_deleted,
+                        "task retention pruned terminal task history"
+                    ),
+                    Ok(_) => {}
+                    Err(error) => tracing::warn!("task retention tick failed: {error}"),
+                }
+            } else {
+                tracing::debug!("task retention disabled by config; re-checking next interval");
+            }
+
+            drop(state);
+            tokio::time::sleep(interval).await;
+        }
+    });
+}
+
+fn task_retention_cutoff(
+    now: chrono::DateTime<Utc>,
+    configured_days: u64,
+) -> chrono::DateTime<Utc> {
+    let days = configured_days.min(MAX_TASK_RETENTION_DAYS) as i64;
+    now - chrono::Duration::days(days)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_retention_cutoff_caps_large_day_values() {
+        let now = chrono::DateTime::<Utc>::from(
+            std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_783_209_600),
+        );
+
+        assert_eq!(
+            task_retention_cutoff(now, u64::MAX),
+            now - chrono::Duration::days(MAX_TASK_RETENTION_DAYS as i64)
+        );
+    }
+}

--- a/crates/harness-server/src/task_db.rs
+++ b/crates/harness-server/src/task_db.rs
@@ -2,11 +2,14 @@ mod migrations;
 mod queries_aux;
 mod queries_metrics;
 mod queries_recovery;
+mod queries_retention;
 mod queries_tasks;
 mod raw_column_test_overrides;
 mod types;
 
-pub use types::{RecoveryResult, TaskArtifact, TaskCheckpoint, TaskPrompt};
+pub use types::{
+    RecoveryResult, TaskArtifact, TaskCheckpoint, TaskPrompt, TaskRetentionPruneSummary,
+};
 
 use harness_core::db::{PgMigrator, PgStoreContext};
 use harness_core::store_backend::{PostgresBackend, StoreLocation};

--- a/crates/harness-server/src/task_db/migrations.rs
+++ b/crates/harness-server/src/task_db/migrations.rs
@@ -336,5 +336,15 @@ mod tests {
             migration.sql.contains("task_db_legacy_backfills"),
             "v26 should create legacy backfill markers"
         );
+        assert!(
+            migration.sql.contains("idx_task_artifacts_store_task_id"),
+            "v26 should keep artifacts-by-task reads backed by a scoped index"
+        );
+        assert!(
+            migration
+                .sql
+                .contains("ON task_artifacts(store_key, task_id, turn, id)"),
+            "artifact index should match the store_key + task_id query predicate"
+        );
     }
 }

--- a/crates/harness-server/src/task_db/queries_retention.rs
+++ b/crates/harness-server/src/task_db/queries_retention.rs
@@ -1,0 +1,87 @@
+use chrono::{DateTime, Utc};
+
+use super::types::TaskRetentionPruneSummary;
+use super::TaskDb;
+use crate::task_runner::TaskStatus;
+
+impl TaskDb {
+    pub async fn prune_terminal_tasks_before(
+        &self,
+        cutoff: DateTime<Utc>,
+        batch_size: u32,
+    ) -> anyhow::Result<TaskRetentionPruneSummary> {
+        super::record_task_db_usage();
+        if batch_size == 0 {
+            return Ok(TaskRetentionPruneSummary::default());
+        }
+
+        let terminal_statuses = TaskStatus::terminal_statuses();
+        let placeholders = Self::numbered_placeholders(3, terminal_statuses.len());
+        let batch_param = terminal_statuses.len() + 3;
+        let select_sql = format!(
+            "SELECT id FROM tasks \
+             WHERE store_key = $1 AND updated_at < $2 AND status IN ({placeholders}) \
+             ORDER BY updated_at ASC, id ASC LIMIT ${batch_param} FOR UPDATE SKIP LOCKED"
+        );
+
+        let mut tx = self.pool.begin().await?;
+        let mut select_query = sqlx::query_as::<_, (String,)>(&select_sql)
+            .bind(&self.store_key)
+            .bind(cutoff);
+        for status in terminal_statuses {
+            select_query = select_query.bind(*status);
+        }
+        let task_ids: Vec<String> = select_query
+            .bind(i64::from(batch_size))
+            .fetch_all(&mut *tx)
+            .await?
+            .into_iter()
+            .map(|(id,)| id)
+            .collect();
+
+        if task_ids.is_empty() {
+            tx.commit().await?;
+            return Ok(TaskRetentionPruneSummary::default());
+        }
+
+        let artifacts_deleted =
+            sqlx::query("DELETE FROM task_artifacts WHERE store_key = $1 AND task_id = ANY($2)")
+                .bind(&self.store_key)
+                .bind(&task_ids)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+
+        let prompts_deleted =
+            sqlx::query("DELETE FROM task_prompts WHERE store_key = $1 AND task_id = ANY($2)")
+                .bind(&self.store_key)
+                .bind(&task_ids)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+
+        let checkpoints_deleted =
+            sqlx::query("DELETE FROM task_checkpoints WHERE store_key = $1 AND task_id = ANY($2)")
+                .bind(&self.store_key)
+                .bind(&task_ids)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+
+        let tasks_deleted = sqlx::query("DELETE FROM tasks WHERE store_key = $1 AND id = ANY($2)")
+            .bind(&self.store_key)
+            .bind(&task_ids)
+            .execute(&mut *tx)
+            .await?
+            .rows_affected();
+
+        tx.commit().await?;
+        Ok(TaskRetentionPruneSummary {
+            pruned_task_ids: task_ids,
+            tasks_deleted,
+            artifacts_deleted,
+            prompts_deleted,
+            checkpoints_deleted,
+        })
+    }
+}

--- a/crates/harness-server/src/task_db/raw_column_test_overrides.rs
+++ b/crates/harness-server/src/task_db/raw_column_test_overrides.rs
@@ -20,4 +20,19 @@ impl TaskDb {
             .await?;
         Ok(())
     }
+
+    #[doc(hidden)]
+    pub async fn overwrite_updated_at_for_test(
+        &self,
+        task_id: &str,
+        updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> anyhow::Result<()> {
+        sqlx::query("UPDATE tasks SET updated_at = $1 WHERE store_key = $2 AND id = $3")
+            .bind(updated_at)
+            .bind(&self.store_key)
+            .bind(task_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
 }

--- a/crates/harness-server/src/task_db/types.rs
+++ b/crates/harness-server/src/task_db/types.rs
@@ -60,6 +60,24 @@ pub struct RecoveryResult {
     pub transient_failed: u32,
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct TaskRetentionPruneSummary {
+    pub pruned_task_ids: Vec<String>,
+    pub tasks_deleted: u64,
+    pub artifacts_deleted: u64,
+    pub prompts_deleted: u64,
+    pub checkpoints_deleted: u64,
+}
+
+impl TaskRetentionPruneSummary {
+    pub fn is_empty(&self) -> bool {
+        self.tasks_deleted == 0
+            && self.artifacts_deleted == 0
+            && self.prompts_deleted == 0
+            && self.checkpoints_deleted == 0
+    }
+}
+
 /// Row returned by the checkpoint JOIN query inside `recover_in_progress`.
 #[derive(sqlx::FromRow)]
 pub(super) struct RecoveryRow {

--- a/crates/harness-server/src/task_runner/mod.rs
+++ b/crates/harness-server/src/task_runner/mod.rs
@@ -174,6 +174,29 @@ impl TaskStore {
         record_task_runner_usage();
         self.db.list_recent_failed(limit).await
     }
+
+    pub async fn prune_terminal_tasks_before(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+        batch_size: u32,
+    ) -> anyhow::Result<crate::task_db::TaskRetentionPruneSummary> {
+        record_task_runner_usage();
+        let summary = self
+            .db
+            .prune_terminal_tasks_before(cutoff, batch_size)
+            .await?;
+        for task_id in &summary.pruned_task_ids {
+            let task_id = TaskId::from_str(task_id);
+            if self
+                .cache
+                .get(&task_id)
+                .is_some_and(|entry| entry.status.is_terminal())
+            {
+                self.cache.remove(&task_id);
+            }
+        }
+        Ok(summary)
+    }
 }
 
 #[cfg(test)]
@@ -195,7 +218,7 @@ mod usage_probe_tests {
             return Ok(());
         }
         let dir = tempfile::tempdir()?;
-        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let store = TaskStore::open(&dir.path().join("tasks-store")).await?;
         let task_id = TaskId::from_str("probe-task");
         let mut task = TaskState::new(task_id.clone());
         task.project_root = Some(dir.path().to_path_buf());
@@ -231,6 +254,37 @@ mod usage_probe_tests {
         assert!(!store.abort_task(&task_id));
 
         assert!(task_runner_count() >= before + 11);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prune_terminal_tasks_before_removes_terminal_cache_entry() -> anyhow::Result<()> {
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let dir = tempfile::tempdir()?;
+        let store = TaskStore::open(&dir.path().join("tasks.db")).await?;
+        let task_id = TaskId::from_str("retention-cache-terminal");
+        let mut task = TaskState::new(task_id.clone());
+        task.status = TaskStatus::Done;
+        task.scheduler.mark_terminal(&TaskStatus::Done);
+        store.insert(&task).await;
+        store
+            .db
+            .overwrite_updated_at_for_test(
+                task_id.as_str(),
+                chrono::Utc::now() - chrono::Duration::days(45),
+            )
+            .await?;
+
+        let summary = store
+            .prune_terminal_tasks_before(chrono::Utc::now() - chrono::Duration::days(30), 10)
+            .await?;
+
+        assert_eq!(summary.tasks_deleted, 1);
+        assert!(store.get(&task_id).is_none());
+        assert!(store.db.get(task_id.as_str()).await?.is_none());
         Ok(())
     }
 }

--- a/crates/harness-server/tests/task_db_retention.rs
+++ b/crates/harness-server/tests/task_db_retention.rs
@@ -1,0 +1,213 @@
+use harness_core::db::{pg_open_pool, resolve_test_database_url, PgStoreContext, TestSchemaGuard};
+use harness_core::types::TaskId as CoreTaskId;
+use harness_server::task_db::TaskDb;
+use harness_server::task_runner::{TaskKind, TaskPhase, TaskSchedulerState, TaskState, TaskStatus};
+
+fn retention_task_state(id: &str, status: TaskStatus) -> TaskState {
+    TaskState {
+        id: CoreTaskId(id.to_string()),
+        task_kind: TaskKind::Prompt,
+        status,
+        failure_kind: None,
+        turn: 1,
+        pr_url: None,
+        rounds: vec![],
+        error: None,
+        source: None,
+        external_id: None,
+        parent_id: None,
+        depends_on: vec![],
+        subtask_ids: vec![],
+        project_root: None,
+        workspace_path: None,
+        workspace_owner: None,
+        run_generation: 0,
+        issue: None,
+        description: None,
+        created_at: None,
+        updated_at: None,
+        priority: 0,
+        phase: TaskPhase::default(),
+        triage_output: None,
+        plan_output: None,
+        repo: None,
+        request_settings: None,
+        scheduler: TaskSchedulerState::queued(),
+        version: 0,
+    }
+}
+
+async fn insert_task_with_children(
+    db: &TaskDb,
+    id: &str,
+    status: TaskStatus,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> anyhow::Result<()> {
+    db.insert(&retention_task_state(id, status)).await?;
+    db.write_checkpoint(id, Some("triage"), Some("plan"), None, "plan_done")
+        .await?;
+    db.insert_artifact(id, 1, "summary", "artifact").await?;
+    db.save_task_prompt(id, 1, "implement", "prompt").await?;
+    db.overwrite_updated_at_for_test(id, updated_at).await?;
+    Ok(())
+}
+
+async fn assert_task_with_children_exists(db: &TaskDb, id: &str) -> anyhow::Result<()> {
+    assert!(db.get(id).await?.is_some(), "{id} task should exist");
+    assert_eq!(
+        db.list_artifacts(id).await?.len(),
+        1,
+        "{id} artifact should exist"
+    );
+    assert_eq!(
+        db.get_task_prompts(id).await?.len(),
+        1,
+        "{id} prompt should exist"
+    );
+    assert!(
+        db.load_checkpoint(id).await?.is_some(),
+        "{id} checkpoint should exist"
+    );
+    Ok(())
+}
+
+async fn assert_task_with_children_pruned(db: &TaskDb, id: &str) -> anyhow::Result<()> {
+    assert!(db.get(id).await?.is_none(), "{id} task should be pruned");
+    assert!(
+        db.list_artifacts(id).await?.is_empty(),
+        "{id} artifacts should be pruned"
+    );
+    assert!(
+        db.get_task_prompts(id).await?.is_empty(),
+        "{id} prompts should be pruned"
+    );
+    assert!(
+        db.load_checkpoint(id).await?.is_none(),
+        "{id} checkpoint should be pruned"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn prune_terminal_tasks_before_removes_only_eligible_terminal_batches() -> anyhow::Result<()>
+{
+    let database_url = match resolve_test_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempfile::tempdir()?;
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let mut schema = TestSchemaGuard::new(&database_url, "task_db_retention_batch_test")?;
+    let context = PgStoreContext::from_schema(schema.schema(), Some(&database_url))?;
+    let data_dir = dir.path().join("store");
+    std::fs::create_dir_all(&data_dir)?;
+    let db = TaskDb::open_shared_with_data_dir(&context, &setup_pool, &data_dir).await?;
+
+    let now = chrono::Utc::now();
+    let cutoff = now - chrono::Duration::days(30);
+    insert_task_with_children(
+        &db,
+        "cancelled-old",
+        TaskStatus::Cancelled,
+        now - chrono::Duration::days(53),
+    )
+    .await?;
+    insert_task_with_children(
+        &db,
+        "done-old",
+        TaskStatus::Done,
+        now - chrono::Duration::days(52),
+    )
+    .await?;
+    insert_task_with_children(
+        &db,
+        "failed-old",
+        TaskStatus::Failed,
+        now - chrono::Duration::days(51),
+    )
+    .await?;
+    insert_task_with_children(
+        &db,
+        "pending-old",
+        TaskStatus::Pending,
+        now - chrono::Duration::days(54),
+    )
+    .await?;
+    insert_task_with_children(
+        &db,
+        "implementing-old",
+        TaskStatus::Implementing,
+        now - chrono::Duration::days(55),
+    )
+    .await?;
+    insert_task_with_children(
+        &db,
+        "done-new",
+        TaskStatus::Done,
+        now - chrono::Duration::days(2),
+    )
+    .await?;
+
+    let first = db.prune_terminal_tasks_before(cutoff, 2).await?;
+    assert_eq!(first.tasks_deleted, 2);
+    assert_eq!(first.artifacts_deleted, 2);
+    assert_eq!(first.prompts_deleted, 2);
+    assert_eq!(first.checkpoints_deleted, 2);
+
+    assert_task_with_children_pruned(&db, "cancelled-old").await?;
+    assert_task_with_children_pruned(&db, "done-old").await?;
+    assert_task_with_children_exists(&db, "failed-old").await?;
+    assert_task_with_children_exists(&db, "pending-old").await?;
+    assert_task_with_children_exists(&db, "implementing-old").await?;
+    assert_task_with_children_exists(&db, "done-new").await?;
+
+    let second = db.prune_terminal_tasks_before(cutoff, 10).await?;
+    assert_eq!(second.tasks_deleted, 1);
+    assert_eq!(second.artifacts_deleted, 1);
+    assert_eq!(second.prompts_deleted, 1);
+    assert_eq!(second.checkpoints_deleted, 1);
+    assert_task_with_children_pruned(&db, "failed-old").await?;
+    assert_task_with_children_exists(&db, "pending-old").await?;
+    assert_task_with_children_exists(&db, "implementing-old").await?;
+    assert_task_with_children_exists(&db, "done-new").await?;
+
+    let third = db.prune_terminal_tasks_before(cutoff, 0).await?;
+    assert!(third.is_empty());
+    assert_task_with_children_exists(&db, "pending-old").await?;
+
+    schema.cleanup_with_pool(&setup_pool).await?;
+    setup_pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn prune_terminal_tasks_before_is_scoped_by_store_key() -> anyhow::Result<()> {
+    let database_url = match resolve_test_database_url(None) {
+        Ok(url) => url,
+        Err(_) => return Ok(()),
+    };
+    let dir = tempfile::tempdir()?;
+    let setup_pool = pg_open_pool(&database_url).await?;
+    let mut schema = TestSchemaGuard::new(&database_url, "task_db_retention_scope_test")?;
+    let context = PgStoreContext::from_schema(schema.schema(), Some(&database_url))?;
+    let store_a_dir = dir.path().join("store-a");
+    let store_b_dir = dir.path().join("store-b");
+    std::fs::create_dir_all(&store_a_dir)?;
+    std::fs::create_dir_all(&store_b_dir)?;
+    let db_a = TaskDb::open_shared_with_data_dir(&context, &setup_pool, &store_a_dir).await?;
+    let db_b = TaskDb::open_shared_with_data_dir(&context, &setup_pool, &store_b_dir).await?;
+
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(30);
+    let old = chrono::Utc::now() - chrono::Duration::days(45);
+    insert_task_with_children(&db_a, "same-id", TaskStatus::Done, old).await?;
+    insert_task_with_children(&db_b, "same-id", TaskStatus::Done, old).await?;
+
+    let summary = db_a.prune_terminal_tasks_before(cutoff, 10).await?;
+    assert_eq!(summary.tasks_deleted, 1);
+    assert_task_with_children_pruned(&db_a, "same-id").await?;
+    assert_task_with_children_exists(&db_b, "same-id").await?;
+
+    schema.cleanup_with_pool(&setup_pool).await?;
+    setup_pool.close().await;
+    Ok(())
+}

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -556,6 +556,10 @@ storage:
   runtime_retention_days: 30
   runtime_retention_batch_size: 1000
   runtime_retention_interval_secs: 3600
+  task_retention_enabled: false
+  task_retention_days: 30
+  task_retention_batch_size: 1000
+  task_retention_interval_secs: 3600
 ```
 
 The orphan schema reaper is enabled by default. It drops registered
@@ -572,6 +576,11 @@ deletes terminal workflow families older than `runtime_retention_days` in
 bounded batches and relies on the Postgres runtime-store cascade constraints to
 remove events, decisions, commands, jobs, runtime events, and artifacts. Active
 workflow families are never pruned.
+
+Enable `task_retention_enabled` only when historical task rows can be deleted.
+Retention deletes terminal tasks older than `task_retention_days` in bounded
+batches, including task-owned artifacts, prompts, and checkpoints. Active,
+pending, dependency-blocked, and resumable tasks are never pruned.
 
 ### 3. GC Runner (always on)
 

--- a/specs/GH1472/tasks.md
+++ b/specs/GH1472/tasks.md
@@ -13,7 +13,7 @@ GH-1472
 
 - [ ] `SP1472-T001` Owner: `schema-index` | Dependencies: none | Done when: artifact-by-task query/index coverage is protected without adding a duplicate unscoped index | Verify: `cargo test -p harness-server task_db::migrations`
 - [ ] `SP1472-T002` Owner: `config` | Dependencies: none | Done when: workflow storage config includes disabled-by-default task retention fields, defaults, parsing tests, and examples/docs | Verify: `cargo test -p harness-core config::workflow` and `rg -n "task_retention" WORKFLOW.md config/WORKFLOW.md docs/usage-guide.md config/default.toml.example`
-- [ ] `SP1472-T003` Owner: `task-db` | Dependencies: `SP1472-T001`, `SP1472-T002` | Done when: `TaskDb` can prune terminal tasks older than a cutoff in bounded batches, deletes artifacts/prompts/checkpoints before parent tasks, and returns structured counts | Verify: `cargo test -p harness-server task_db_retention`
+- [ ] `SP1472-T003` Owner: `task-db` | Dependencies: `SP1472-T001`, `SP1472-T002` | Done when: `TaskDb` can prune terminal tasks older than a cutoff in bounded batches, deletes artifacts/prompts/checkpoints before parent tasks, and returns structured counts | Verify: `cargo test -p harness-server --test task_db_retention`
 - [ ] `SP1472-T004` Owner: `server-loop` | Dependencies: `SP1472-T003` | Done when: an HTTP startup background loop reloads workflow config, respects `storage.task_retention_enabled`, computes cutoffs, calls the task retention DB method, and logs non-empty summaries | Verify: focused server retention tests or `cargo check -p harness-server --all-targets`
 - [ ] `SP1472-T005` Owner: `verification` | Dependencies: all implementation tasks | Done when: focused tests, server check, SpecRail checks, formatting, and clippy pass | Verify: focused tests above, `cargo check -p harness-server --all-targets`, `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1472`, `python3 checks/check_workflow.py --repo .`, `cargo fmt --all -- --check`, and `cargo clippy --workspace --all-targets -- -D warnings`
 
@@ -28,7 +28,7 @@ the pruning API. Avoid parallel writable lanes across `workflow.rs`,
 
 - `cargo test -p harness-server task_db::migrations`
 - `cargo test -p harness-core config::workflow`
-- `cargo test -p harness-server task_db_retention`
+- `cargo test -p harness-server --test task_db_retention`
 - `cargo check -p harness-server --all-targets`
 - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1472`
 - `python3 checks/check_workflow.py --repo .`

--- a/specs/GH1472/tech.md
+++ b/specs/GH1472/tech.md
@@ -104,7 +104,7 @@ logged by the loop.
 
 ## Test Plan
 
-- [ ] `cargo test -p harness-server task_db_retention`
+- [ ] `cargo test -p harness-server --test task_db_retention`
 - [ ] `cargo test -p harness-server task_db::migrations`
 - [ ] `cargo test -p harness-core config::workflow`
 - [ ] `cargo check -p harness-server --all-targets`


### PR DESCRIPTION
## Summary
- add disabled-by-default task retention storage settings and document them in workflow examples and usage docs
- prune terminal tasks in bounded, store-scoped batches with child artifacts, prompts, and checkpoints removed in the same transaction
- wire a background task-retention loop and remove pruned terminal entries from the TaskStore cache
- protect the existing scoped task_artifacts index and fix the GH1472 retention test command in the spec packet

## Verification
- cargo test -p harness-core config::workflow
- cargo test -p harness-server task_db::migrations
- cargo test -p harness-server --test task_db_retention -- --nocapture
- cargo test -p harness-server prune_terminal_tasks_before_removes_terminal_cache_entry
- cargo check -p harness-server --all-targets
- cargo fmt --all -- --check
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1472
- python3 checks/check_workflow.py --repo .
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check

Closes #1472