### PR TITLE
Implement direct REST GitHub backlog discovery

### DIFF
--- a/config/default.toml.example
+++ b/config/default.toml.example
@@ -177,6 +177,8 @@ enabled = false
 
 # [intake.github]
 # enabled = true
+# mode = "poll" # "poll", "webhook", or "hybrid"
+# discovery_driver = "direct_rest" # zero-agent REST discovery; "agent" is opt-in
 # poll_interval_secs = 300
 # planner_agent = "codex"
 # sprint_timeout_secs = 10800

--- a/crates/harness-core/src/config/intake.rs
+++ b/crates/harness-core/src/config/intake.rs
@@ -117,6 +117,26 @@ impl IntakeMode {
     }
 }
 
+/// How poll-capable GitHub intake discovers repository backlog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GitHubPollDiscoveryDriver {
+    /// Discover issues through direct GitHub REST calls without an agent.
+    #[default]
+    DirectRest,
+    /// Reserve a richer agent-driven backlog analysis path for opt-in use.
+    Agent,
+}
+
+impl fmt::Display for GitHubPollDiscoveryDriver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DirectRest => f.write_str("direct_rest"),
+            Self::Agent => f.write_str("agent"),
+        }
+    }
+}
+
 /// GitHub Issues intake configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitHubIntakeConfig {
@@ -127,6 +147,9 @@ pub struct GitHubIntakeConfig {
     /// poller off), or `hybrid` (both). Default: `poll`.
     #[serde(default)]
     pub mode: IntakeMode,
+    /// Poll-capable backlog discovery driver. Default: `direct_rest`.
+    #[serde(default)]
+    pub discovery_driver: GitHubPollDiscoveryDriver,
     /// Single repo (backward compat shorthand).
     #[serde(default)]
     pub repo: String,
@@ -281,6 +304,7 @@ impl Default for GitHubIntakeConfig {
         Self {
             enabled: false,
             mode: IntakeMode::default(),
+            discovery_driver: GitHubPollDiscoveryDriver::default(),
             repo: String::new(),
             label: default_intake_label(),
             poll_interval_secs: default_poll_interval_secs(),
@@ -443,6 +467,31 @@ mod tests {
         assert_eq!(repo.repo, "owner/default");
         assert_eq!(repo.label, "triage");
         assert_eq!(repo.project_root, None);
+    }
+
+    #[test]
+    fn github_discovery_driver_defaults_to_direct_rest() {
+        let config = GitHubIntakeConfig::default();
+
+        assert_eq!(
+            config.discovery_driver,
+            GitHubPollDiscoveryDriver::DirectRest
+        );
+        assert_eq!(config.discovery_driver.to_string(), "direct_rest");
+    }
+
+    #[test]
+    fn github_discovery_driver_parses_agent() -> Result<(), toml::de::Error> {
+        let config: GitHubIntakeConfig = toml::from_str(
+            r#"
+enabled = true
+discovery_driver = "agent"
+repo = "owner/repo"
+"#,
+        )?;
+
+        assert_eq!(config.discovery_driver, GitHubPollDiscoveryDriver::Agent);
+        Ok(())
     }
 
     #[test]

--- a/crates/harness-server/src/http/builders/intake.rs
+++ b/crates/harness-server/src/http/builders/intake.rs
@@ -94,8 +94,10 @@ pub(crate) async fn build_intake(
         );
     }
     let github_pollers: Vec<(String, Arc<dyn crate::intake::IntakeSource>)> = if let Some(cfg) =
-        github_runtime_polling_config(github_cfg, registry.workflow_runtime_store.is_some())
+        github_direct_rest_polling_config(github_cfg, registry.workflow_runtime_store.is_some())
     {
+        let github_throttle =
+            Arc::new(crate::intake::github_issues::GitHubRateLimitThrottle::default());
         cfg.effective_repos()
             .into_iter()
             .map(|repo_cfg| {
@@ -105,11 +107,13 @@ pub(crate) async fn build_intake(
                     "intake: GitHub issue polling registered with server-side coverage gate"
                 );
                 let key = format!("github:{}", repo_cfg.repo);
-                let poller = crate::intake::github_issues::GitHubIssuesPoller::new_with_token(
-                    &repo_cfg,
-                    None,
-                    server.config.server.github_token.clone(),
-                );
+                let poller =
+                    crate::intake::github_issues::GitHubIssuesPoller::new_with_token_and_throttle(
+                        &repo_cfg,
+                        None,
+                        server.config.server.github_token.clone(),
+                        Arc::clone(&github_throttle),
+                    );
                 (
                     key,
                     Arc::new(poller) as Arc<dyn crate::intake::IntakeSource>,
@@ -117,10 +121,24 @@ pub(crate) async fn build_intake(
             })
             .collect()
     } else {
-        if github_cfg.is_some() && registry.workflow_runtime_store.is_none() {
-            tracing::error!(
-                "intake: GitHub issue polling requires workflow_runtime_store; pollers disabled"
-            );
+        if let Some(cfg) = github_cfg {
+            match cfg.discovery_driver {
+                harness_core::config::intake::GitHubPollDiscoveryDriver::DirectRest
+                    if registry.workflow_runtime_store.is_none() =>
+                {
+                    tracing::error!(
+                        discovery_driver = %cfg.discovery_driver,
+                        "intake: GitHub direct REST polling requires workflow_runtime_store; pollers disabled"
+                    );
+                }
+                harness_core::config::intake::GitHubPollDiscoveryDriver::Agent => {
+                    tracing::info!(
+                        discovery_driver = %cfg.discovery_driver,
+                        "intake: GitHub agent discovery selected; direct REST pollers disabled"
+                    );
+                }
+                _ => {}
+            }
         }
         Vec::new()
     };
@@ -194,11 +212,14 @@ fn github_polling_config(
     cfg.filter(|cfg| cfg.enabled && cfg.mode.poller_enabled())
 }
 
-fn github_runtime_polling_config(
+fn github_direct_rest_polling_config(
     cfg: Option<&harness_core::config::intake::GitHubIntakeConfig>,
     workflow_runtime_store_available: bool,
 ) -> Option<&harness_core::config::intake::GitHubIntakeConfig> {
-    cfg.filter(|_| workflow_runtime_store_available)
+    cfg.filter(|cfg| {
+        cfg.discovery_driver == harness_core::config::intake::GitHubPollDiscoveryDriver::DirectRest
+            && workflow_runtime_store_available
+    })
 }
 
 async fn runtime_issue_concurrency_config(
@@ -327,12 +348,15 @@ mod tests {
 
     async fn make_minimal_bundles(
         dir: &std::path::Path,
-    ) -> (
+    ) -> Option<(
         Arc<HarnessServer>,
         StorageBundle,
         EnginesBundle,
         RegistryBundle,
-    ) {
+    )> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return None;
+        }
         let server = Arc::new(HarnessServer::new(
             HarnessConfig::default(),
             ThreadManager::new(),
@@ -352,7 +376,7 @@ mod tests {
         )
         .await
         .expect("registry");
-        (server, storage, engines, registry)
+        Some((server, storage, engines, registry))
     }
 
     fn registry_project(
@@ -375,7 +399,10 @@ mod tests {
     #[tokio::test]
     async fn no_intake_config_produces_empty_intake() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let (server, storage, engines, registry) = make_minimal_bundles(dir.path()).await;
+        let Some((server, storage, engines, registry)) = make_minimal_bundles(dir.path()).await
+        else {
+            return;
+        };
         let bundle = build_intake(
             &server,
             &storage,
@@ -397,7 +424,7 @@ mod tests {
     }
 
     #[test]
-    fn github_runtime_polling_config_requires_workflow_runtime_store() {
+    fn github_direct_rest_polling_config_requires_workflow_runtime_store() {
         let cfg = harness_core::config::intake::GitHubIntakeConfig {
             enabled: true,
             repo: "owner/repo".to_string(),
@@ -406,12 +433,30 @@ mod tests {
         };
         let cfg = github_polling_config(Some(&cfg));
 
-        assert!(github_runtime_polling_config(cfg, true).is_some());
-        assert!(github_runtime_polling_config(cfg, false).is_none());
+        assert!(github_direct_rest_polling_config(cfg, true).is_some());
+        assert!(github_direct_rest_polling_config(cfg, false).is_none());
+    }
+
+    #[test]
+    fn github_direct_rest_polling_config_skips_agent_discovery() {
+        let cfg = harness_core::config::intake::GitHubIntakeConfig {
+            enabled: true,
+            discovery_driver: harness_core::config::intake::GitHubPollDiscoveryDriver::Agent,
+            repo: "owner/repo".to_string(),
+            label: "harness".to_string(),
+            ..Default::default()
+        };
+        let cfg = github_polling_config(Some(&cfg));
+
+        assert!(github_direct_rest_polling_config(cfg, true).is_none());
     }
 
     #[tokio::test]
     async fn github_intake_registers_server_side_poller() {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return;
+        }
+
         let dir = tempfile::tempdir().expect("tempdir");
         let mut config = HarnessConfig::default();
         config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
@@ -464,6 +509,10 @@ mod tests {
 
     #[tokio::test]
     async fn github_intake_webhook_mode_does_not_register_server_side_poller() {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return;
+        }
+
         let dir = tempfile::tempdir().expect("tempdir");
         let mut config = HarnessConfig::default();
         config.intake.github = Some(harness_core::config::intake::GitHubIntakeConfig {
@@ -623,7 +672,9 @@ mod tests {
         }];
 
         let dir = tempfile::tempdir().expect("tempdir");
-        let (_, _, _, registry) = make_minimal_bundles(dir.path()).await;
+        let Some((_, _, _, registry)) = make_minimal_bundles(dir.path()).await else {
+            return;
+        };
         let cfg = runtime_review_concurrency_config(&server, &registry).await;
 
         assert_eq!(cfg.max_concurrent_tasks, 3);
@@ -642,7 +693,9 @@ mod tests {
         server.config.server.project_root = std::path::PathBuf::from("/tmp/fallback");
 
         let dir = tempfile::tempdir().expect("tempdir");
-        let (_, _, _, registry) = make_minimal_bundles(dir.path()).await;
+        let Some((_, _, _, registry)) = make_minimal_bundles(dir.path()).await else {
+            return;
+        };
         let cfg = runtime_review_concurrency_config(&server, &registry).await;
 
         assert_eq!(cfg.max_concurrent_tasks, 2);
@@ -652,7 +705,10 @@ mod tests {
     #[tokio::test]
     async fn runtime_review_concurrency_includes_registry_projects() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let (server, _storage, _engines, registry) = make_minimal_bundles(temp.path()).await;
+        let Some((server, _storage, _engines, registry)) = make_minimal_bundles(temp.path()).await
+        else {
+            return;
+        };
         let runtime_project_root = temp.path().join("runtime-project");
         std::fs::create_dir_all(&runtime_project_root).expect("create runtime project");
         registry

--- a/crates/harness-server/src/http/github_intake_status.rs
+++ b/crates/harness-server/src/http/github_intake_status.rs
@@ -1,5 +1,5 @@
 use harness_core::config::{
-    intake::{GitHubIntakeConfig, IntakeMode},
+    intake::{GitHubIntakeConfig, GitHubPollDiscoveryDriver, IntakeMode},
     server::ServerConfig,
     HarnessConfig,
 };
@@ -79,6 +79,18 @@ pub(crate) fn github_intake_driver_metadata(
     } else {
         None
     };
+    let discovery_driver = github
+        .map(|config| config.discovery_driver)
+        .unwrap_or_default();
+    let polling_active = polling_configured && active_poller_count > 0;
+    let polling_degraded = polling_configured && !polling_active;
+    let polling_reason = if !polling_degraded {
+        None
+    } else if discovery_driver == GitHubPollDiscoveryDriver::Agent {
+        Some("agent_discovery_selected")
+    } else {
+        Some("no_active_pollers")
+    };
     json!({
         "webhook": {
             "configured": webhook_configured,
@@ -87,9 +99,11 @@ pub(crate) fn github_intake_driver_metadata(
             "reason": webhook_reason,
         },
         "polling": {
+            "discovery_driver": discovery_driver.to_string(),
             "configured": polling_configured,
-            "active": polling_configured && active_poller_count > 0,
-            "degraded": polling_configured && active_poller_count == 0,
+            "active": polling_active,
+            "degraded": polling_degraded,
+            "reason": polling_reason,
         },
     })
 }
@@ -111,6 +125,7 @@ pub(crate) fn github_effective_repos(github: Option<&GitHubIntakeConfig>) -> Vec
                 "drivers": {
                     "webhook": config.enabled && config.mode.webhook_autonomous(),
                     "polling": config.enabled && config.mode.poller_enabled(),
+                    "discovery_driver": config.discovery_driver.to_string(),
                 },
             })
         })

--- a/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
+++ b/crates/harness-server/src/http/tests/intake_auth_list_tests.rs
@@ -204,12 +204,20 @@ async fn intake_status_reports_github_mode_drivers_and_effective_repos() -> anyh
     assert_eq!(github["drivers"]["webhook"]["degraded"], false);
     assert_eq!(github["drivers"]["polling"]["configured"], true);
     assert_eq!(github["drivers"]["polling"]["active"], true);
+    assert_eq!(
+        github["drivers"]["polling"]["discovery_driver"],
+        "direct_rest"
+    );
+    assert_eq!(
+        github["drivers"]["polling"]["reason"],
+        serde_json::Value::Null
+    );
     let repos = github["repos"]
         .as_array()
         .expect("repos should be an array");
-    assert!(repos
-        .iter()
-        .any(|repo| repo["repo"] == "owner/main" && repo["mode"] == "hybrid"));
+    assert!(repos.iter().any(|repo| repo["repo"] == "owner/main"
+        && repo["mode"] == "hybrid"
+        && repo["drivers"]["discovery_driver"] == "direct_rest"));
     assert!(repos.iter().any(|repo| {
         repo["repo"] == "owner/secondary"
             && repo["label"] == "bugs"

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -2,16 +2,18 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use harness_core::config::isolation::IsolationTrustClass;
-use reqwest::header::{ACCEPT, LINK, USER_AGENT};
+use reqwest::header::{HeaderMap, ACCEPT, LINK, RETRY_AFTER, USER_AGENT};
+use reqwest::StatusCode;
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use super::{IncomingIssue, IntakeSource, TaskCompletionResult};
 use crate::task_runner::TaskId;
 
 const GITHUB_ISSUES_MAX_PAGES: usize = 20;
+const DEFAULT_RATE_LIMIT_RETRY_SECS: i64 = 60;
 
 #[async_trait]
 pub(crate) trait DispatchedTaskChecker: Send + Sync {
@@ -70,6 +72,39 @@ pub struct GitHubIssuesPoller {
     persist_path: Option<PathBuf>,
     task_checker: Option<Arc<dyn DispatchedTaskChecker>>,
     github_token: Option<String>,
+    throttle: Arc<GitHubRateLimitThrottle>,
+}
+
+#[derive(Debug, Default)]
+pub struct GitHubRateLimitThrottle {
+    retry_after: Mutex<Option<DateTime<Utc>>>,
+}
+
+impl GitHubRateLimitThrottle {
+    fn current_retry_after(&self, now: DateTime<Utc>) -> anyhow::Result<Option<DateTime<Utc>>> {
+        let mut retry_after = self
+            .retry_after
+            .lock()
+            .map_err(|_| anyhow::anyhow!("GitHub rate-limit throttle lock poisoned"))?;
+        if retry_after.as_ref().is_some_and(|at| *at <= now) {
+            *retry_after = None;
+        }
+        Ok(retry_after.to_owned())
+    }
+
+    fn record_retry_after(&self, retry_at: DateTime<Utc>) -> anyhow::Result<()> {
+        let mut retry_after = self
+            .retry_after
+            .lock()
+            .map_err(|_| anyhow::anyhow!("GitHub rate-limit throttle lock poisoned"))?;
+        if retry_after
+            .as_ref()
+            .is_none_or(|current| retry_at > *current)
+        {
+            *retry_after = Some(retry_at);
+        }
+        Ok(())
+    }
 }
 
 impl GitHubIssuesPoller {
@@ -85,6 +120,20 @@ impl GitHubIssuesPoller {
         data_dir: Option<&Path>,
         github_token: Option<String>,
     ) -> Self {
+        Self::new_with_token_and_throttle(
+            repo_config,
+            data_dir,
+            github_token,
+            Arc::new(GitHubRateLimitThrottle::default()),
+        )
+    }
+
+    pub fn new_with_token_and_throttle(
+        repo_config: &harness_core::config::intake::GitHubRepoConfig,
+        data_dir: Option<&Path>,
+        github_token: Option<String>,
+        throttle: Arc<GitHubRateLimitThrottle>,
+    ) -> Self {
         let repo_slug = repo_config.repo.replace('/', "_");
         let persist_path = data_dir.map(|d| d.join(format!("github_dispatched_{repo_slug}.json")));
         let dispatched = Self::load_dispatched(persist_path.as_deref());
@@ -97,6 +146,7 @@ impl GitHubIssuesPoller {
             persist_path,
             task_checker: None,
             github_token,
+            throttle,
         }
     }
 
@@ -221,6 +271,16 @@ impl GitHubIssuesPoller {
         &self,
         api_base_url: &str,
     ) -> anyhow::Result<Vec<IncomingIssue>> {
+        let now = Utc::now();
+        if let Some(retry_at) = self.throttle.current_retry_after(now)? {
+            tracing::debug!(
+                repo = %self.repo,
+                retry_at = %retry_at.to_rfc3339(),
+                "GitHub issue polling skipped while token is rate-limited"
+            );
+            return Ok(Vec::new());
+        }
+
         let mut next_url = Some(github_issues_url(api_base_url, &self.repo, &self.label)?);
         let mut seen_urls = HashSet::new();
         let mut page_count = 0usize;
@@ -250,13 +310,27 @@ impl GitHubIssuesPoller {
                 break;
             }
 
-            let page = fetch_github_issue_page(
+            let page = match fetch_github_issue_page(
                 &self.client,
                 &url,
                 &self.repo,
                 self.github_token.as_deref(),
             )
-            .await?;
+            .await?
+            {
+                GitHubIssuePageFetch::Page(page) => page,
+                GitHubIssuePageFetch::RateLimited(limit) => {
+                    self.throttle.record_retry_after(limit.retry_at)?;
+                    tracing::warn!(
+                        repo = %self.repo,
+                        status = %limit.status,
+                        retry_at = %limit.retry_at.to_rfc3339(),
+                        "GitHub issue polling paused after rate-limit response"
+                    );
+                    complete_open_issue_set = false;
+                    break;
+                }
+            };
             let parsed = parse_gh_output(
                 &page.body,
                 &self.repo,
@@ -418,12 +492,22 @@ struct GitHubIssuePage {
     next_url: Option<String>,
 }
 
+enum GitHubIssuePageFetch {
+    Page(GitHubIssuePage),
+    RateLimited(GitHubRateLimit),
+}
+
+struct GitHubRateLimit {
+    status: StatusCode,
+    retry_at: DateTime<Utc>,
+}
+
 async fn fetch_github_issue_page(
     client: &reqwest::Client,
     url: &str,
     repo: &str,
     github_token: Option<&str>,
-) -> anyhow::Result<GitHubIssuePage> {
+) -> anyhow::Result<GitHubIssuePageFetch> {
     let mut request = client
         .get(url)
         .header(ACCEPT, "application/vnd.github+json")
@@ -432,15 +516,81 @@ async fn fetch_github_issue_page(
         request = request.bearer_auth(token);
     }
     let response = request.send().await?;
-    if !response.status().is_success() {
+    let status = response.status();
+    if !status.is_success() {
+        if let Some(retry_at) = rate_limit_retry_at(status, response.headers(), Utc::now()) {
+            return Ok(GitHubIssuePageFetch::RateLimited(GitHubRateLimit {
+                status,
+                retry_at,
+            }));
+        }
         anyhow::bail!(
             "GitHub issue list failed for {repo} at {url} with status {}",
-            response.status()
+            status
         );
     }
     let next_url = next_link_from_headers(response.headers());
     let body = response.bytes().await?.to_vec();
-    Ok(GitHubIssuePage { body, next_url })
+    Ok(GitHubIssuePageFetch::Page(GitHubIssuePage {
+        body,
+        next_url,
+    }))
+}
+
+fn rate_limit_retry_at(
+    status: StatusCode,
+    headers: &HeaderMap,
+    now: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    let retry_after = retry_after_header_time(headers, now);
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        return Some(retry_after.unwrap_or_else(|| default_rate_limit_retry_at(now)));
+    }
+
+    if status != StatusCode::FORBIDDEN {
+        return None;
+    }
+
+    if retry_after.is_some() || x_rate_limit_remaining_is_zero(headers) {
+        return Some(retry_after.unwrap_or_else(|| {
+            x_rate_limit_reset_time(headers).unwrap_or_else(|| default_rate_limit_retry_at(now))
+        }));
+    }
+
+    None
+}
+
+fn retry_after_header_time(headers: &HeaderMap, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    let seconds = headers
+        .get(RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<i64>()
+        .ok()?;
+    Some(now + chrono::Duration::seconds(seconds.max(0)))
+}
+
+fn x_rate_limit_reset_time(headers: &HeaderMap) -> Option<DateTime<Utc>> {
+    let epoch_seconds = headers
+        .get("x-ratelimit-reset")?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<i64>()
+        .ok()?;
+    DateTime::<Utc>::from_timestamp(epoch_seconds, 0)
+}
+
+fn x_rate_limit_remaining_is_zero(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-ratelimit-remaining")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.trim() == "0")
+}
+
+fn default_rate_limit_retry_at(now: DateTime<Utc>) -> DateTime<Utc> {
+    now + chrono::Duration::seconds(DEFAULT_RATE_LIMIT_RETRY_SECS)
 }
 
 fn next_link_from_headers(headers: &reqwest::header::HeaderMap) -> Option<String> {
@@ -534,6 +684,10 @@ impl IntakeSource for GitHubIssuesPoller {
 #[cfg(test)]
 #[path = "github_issues_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "github_issues_rate_limit_tests.rs"]
+mod rate_limit_tests;
 
 #[cfg(test)]
 #[path = "github_issues_trust_tests.rs"]

--- a/crates/harness-server/src/intake/github_issues.rs
+++ b/crates/harness-server/src/intake/github_issues.rs
@@ -89,7 +89,7 @@ impl GitHubRateLimitThrottle {
         if retry_after.as_ref().is_some_and(|at| *at <= now) {
             *retry_after = None;
         }
-        Ok(retry_after.to_owned())
+        Ok(*retry_after)
     }
 
     fn record_retry_after(&self, retry_at: DateTime<Utc>) -> anyhow::Result<()> {
@@ -568,7 +568,7 @@ fn retry_after_header_time(headers: &HeaderMap, now: DateTime<Utc>) -> Option<Da
         .trim()
         .parse::<i64>()
         .ok()?;
-    Some(now + chrono::Duration::seconds(seconds.max(0)))
+    retry_at_from_seconds(now, seconds)
 }
 
 fn x_rate_limit_reset_time(headers: &HeaderMap) -> Option<DateTime<Utc>> {
@@ -590,7 +590,12 @@ fn x_rate_limit_remaining_is_zero(headers: &HeaderMap) -> bool {
 }
 
 fn default_rate_limit_retry_at(now: DateTime<Utc>) -> DateTime<Utc> {
-    now + chrono::Duration::seconds(DEFAULT_RATE_LIMIT_RETRY_SECS)
+    retry_at_from_seconds(now, DEFAULT_RATE_LIMIT_RETRY_SECS).unwrap_or(now)
+}
+
+fn retry_at_from_seconds(now: DateTime<Utc>, seconds: i64) -> Option<DateTime<Utc>> {
+    let duration = chrono::Duration::try_seconds(seconds.max(0))?;
+    now.checked_add_signed(duration)
 }
 
 fn next_link_from_headers(headers: &reqwest::header::HeaderMap) -> Option<String> {

--- a/crates/harness-server/src/intake/github_issues_rate_limit_tests.rs
+++ b/crates/harness-server/src/intake/github_issues_rate_limit_tests.rs
@@ -1,0 +1,77 @@
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn repo_config_for(repo: &str) -> harness_core::config::intake::GitHubRepoConfig {
+    harness_core::config::intake::GitHubRepoConfig {
+        repo: repo.to_string(),
+        label: "harness".to_string(),
+        project_root: None,
+        auto_merge: None,
+        merge_method: None,
+        delete_branch: None,
+        require_review_threads_resolved: None,
+        require_clean_merge_state: None,
+    }
+}
+
+#[tokio::test]
+async fn poll_shares_rate_limit_throttle_across_repos() -> anyhow::Result<()> {
+    async fn rate_limited_issue_page(
+        axum::extract::State(requests): axum::extract::State<Arc<AtomicUsize>>,
+    ) -> axum::response::Response {
+        use axum::response::IntoResponse;
+
+        requests.fetch_add(1, Ordering::SeqCst);
+        (
+            axum::http::StatusCode::TOO_MANY_REQUESTS,
+            [(axum::http::header::RETRY_AFTER, "120")],
+            "rate limited",
+        )
+            .into_response()
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let base_url = format!("http://{}", listener.local_addr()?);
+    let requests = Arc::new(AtomicUsize::new(0));
+    let app = axum::Router::new()
+        .route(
+            "/repos/owner/repo/issues",
+            axum::routing::get(rate_limited_issue_page),
+        )
+        .route(
+            "/repos/owner/other/issues",
+            axum::routing::get(rate_limited_issue_page),
+        )
+        .with_state(Arc::clone(&requests));
+    let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+    let throttle = Arc::new(GitHubRateLimitThrottle::default());
+    let first = GitHubIssuesPoller::new_with_token_and_throttle(
+        &repo_config_for("owner/repo"),
+        None,
+        Some("token".to_string()),
+        Arc::clone(&throttle),
+    );
+    let second = GitHubIssuesPoller::new_with_token_and_throttle(
+        &repo_config_for("owner/other"),
+        None,
+        Some("token".to_string()),
+        Arc::clone(&throttle),
+    );
+
+    let first_issues = first.poll_from_api_base_url(&base_url).await?;
+    let second_issues = second.poll_from_api_base_url(&base_url).await?;
+
+    server.abort();
+    match server.await {
+        Err(join_error) if join_error.is_cancelled() => {}
+        Err(join_error) => return Err(join_error.into()),
+        Ok(Err(error)) => return Err(error.into()),
+        Ok(Ok(())) => {}
+    }
+
+    assert!(first_issues.is_empty());
+    assert!(second_issues.is_empty());
+    assert_eq!(requests.load(Ordering::SeqCst), 1);
+    Ok(())
+}

--- a/crates/harness-server/src/intake/github_issues_rate_limit_tests.rs
+++ b/crates/harness-server/src/intake/github_issues_rate_limit_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 fn repo_config_for(repo: &str) -> harness_core::config::intake::GitHubRepoConfig {
@@ -12,6 +13,19 @@ fn repo_config_for(repo: &str) -> harness_core::config::intake::GitHubRepoConfig
         require_review_threads_resolved: None,
         require_clean_merge_state: None,
     }
+}
+
+#[test]
+fn retry_after_header_time_rejects_overflowing_duration() {
+    let mut headers = HeaderMap::new();
+    headers.insert(RETRY_AFTER, HeaderValue::from_static("9223372036854775807"));
+    let now = Utc::now();
+
+    assert_eq!(retry_after_header_time(&headers, now), None);
+    assert_eq!(
+        rate_limit_retry_at(StatusCode::TOO_MANY_REQUESTS, &headers, now),
+        Some(default_rate_limit_retry_at(now))
+    );
 }
 
 #[tokio::test]

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -331,6 +331,27 @@ curl -X DELETE http://127.0.0.1:9800/projects/new-project
 | `github_webhook_secret` | — | HMAC-SHA256 secret for GitHub webhook verification |
 | `notification_broadcast_capacity` | `256` | Internal notification channel capacity |
 
+### `[intake.github]`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `false` | Enables GitHub issue intake. |
+| `mode` | `"poll"` | Selects intake transport: `"poll"` lists GitHub issues periodically, `"webhook"` accepts GitHub issue events through `/webhook`, and `"hybrid"` enables both. |
+| `discovery_driver` | `"direct_rest"` | Selects the poll-capable backlog discovery driver. `"direct_rest"` lists issues through GitHub REST without spawning an agent for discovery; `"agent"` reserves agent-driven backlog analysis as an explicit opt-in. |
+| `repo` | — | Single-repository shorthand in `owner/repo` form. |
+| `poll_interval_secs` | `30` | Interval between poll sweeps when polling is enabled. |
+| `planner_agent` | server default | Agent used after an accepted issue is dispatched for work. Discovery with `direct_rest` does not use this agent. |
+| `sprint_timeout_secs` | `10800` | Maximum seconds for the issue work cycle after dispatch. |
+| `retry_backoff_base_secs` | `15` | Base seconds for retry backoff after transient intake enqueue failures. |
+| `retry_backoff_max_secs` | `120` | Maximum retry backoff after transient intake enqueue failures. |
+
+REST discovery requires workflow runtime persistence before pollers start. If
+the persistence layer is unavailable, Harness fails closed and reports polling
+as degraded instead of repeatedly listing GitHub issues that cannot be
+persisted or dispatched. GitHub rate-limit responses pause REST polling across
+repositories sharing the token until the safe retry time from `Retry-After`,
+`X-RateLimit-Reset`, or a bounded fallback.
+
 ### `[intake.github.auto_merge]`
 
 | Field | Default | Description |


### PR DESCRIPTION
## Summary
- Add explicit `GitHubPollDiscoveryDriver` config with `direct_rest` as the compatibility default and `agent` as opt-in.
- Register direct REST GitHub pollers only for poll-capable `direct_rest` intake when workflow runtime storage is available, sharing token-level rate-limit throttle state across repos.
- Expose the selected discovery driver in intake status and docs, and add rate-limit coverage for GitHub REST polling.

## Verification
- `cargo test -p harness-core config::intake`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test -p harness-server http::builders::intake`
- `cargo test -p harness-server intake::github_issues`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo test -p harness-server http::tests::intake_auth_list_tests`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo check -p harness-server --all-targets`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1473`
- `python3 checks/check_workflow.py --repo .`
- `cargo fmt --all -- --check`
- `HARNESS_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_test cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

Closes #1473