### PR TITLE
Sync GH1434 Phase 1 spec packet

### DIFF
--- a/specs/GH1434/product.md
+++ b/specs/GH1434/product.md
@@ -4,75 +4,105 @@
 
 GH-1434
 
-## 用户问题
+## User Problem
 
-内核化收缩 Phase 1（架构分析与决策见 better/reports/harness-kernel-design.md，
-2026-07-03 拍板：直接删、不拆插件仓）。生产数据显示体量与价值严重倒挂：
+Kernel-contraction Phase 1 removes obsolete orchestration layers after the
+workflow runtime became the factual production path. The current repository
+still carries multiple older state machines:
 
-- workflow runtime：216,161 runtime_events / 67,436 jobs / 1,877 workflows——全部真实流量
-- thread/turn 生命周期层（16 个 JSON-RPC 方法 + thread_manager/thread_db）：历史共 **9 个 thread**
-- task 层（task_db/task_executor/task_runner）：历史共 **62 个 task**
-- harness-eval（848 LOC）：**0** 次 eval_runs
-- review_store：**0** 条 review_findings（评审实际走 GitHub bot）
+- workflow runtime: 216,161 runtime events, 67,436 jobs, and 1,877 workflows in
+  the production evidence cited by GH-1434
+- thread/turn lifecycle RPCs, `thread_manager`, and `thread_db`: 9 historical
+  threads
+- task layer (`task_db`, legacy `task_executor` paths, and `task_runner`): 62
+  historical tasks
+- `harness-eval`: 0 eval runs
+- `review_store`: 0 review findings while review evidence is handled by
+  GitHub bots
 
-三代状态机叠加，第三代（workflow runtime）已事实性取代前两代。死代码不仅是
-维护成本：它撑大了对外面（30 个 RPC 方法）、拖慢构建、并让新贡献者无法分辨
-哪条路径是活的。
+Keeping these layers makes the public surface larger, slows maintenance, and
+makes it unclear which path new contributors should use. The approved Phase 1
+direction is direct deletion after safety evidence, not plugin extraction.
 
-## 目标
+## Goals
 
-1. 删除零流量层：thread/turn RPC 面、task 层、harness-eval、review_store。
-2. 删除前有安全探针：每个待删面先落使用计数器，7 天零计数（或维护者显式
-   豁免并留档）后方可删除。
-3. 数据先归档后删码：9 threads + 62 tasks 及关联表 pg_dump 存档；本阶段
-   只归档不 drop 任何表。
-4. workflow runtime 主路径行为完全不变。
+1. Remove zero-traffic surfaces: thread/turn RPCs, deletable task-layer paths,
+   `harness-eval`, and `review_store`.
+2. Land safety probes before deletion and require at least 7 days of zero-count
+   probe evidence, or a maintainer waiver recorded in GH-1434 with scope and
+   reason, before each removal PR lands.
+3. Archive thread/task data before deleting code. The phase may dump data for
+   recovery, but it must not drop or rename Postgres tables.
+4. Keep workflow runtime behavior unchanged for serve, status, PR-fix flows,
+   webhook intake, and dashboard workflow-runtime views.
 
-## 非目标
+## Non-Goals
 
-- Phase 2（GitHub 事实核验替代 activity envelope）、Phase 3（智能层删除：
-  rules 非 execpolicy 部分/skills/GC/learn/self_evolution/q_value/
-  complexity_router）——各自另立 issue。
-- 不 drop 任何 Postgres 表或 schema。
-- 不改 workflow runtime 派发语义；不与 #1430 熔断工作冲突。
-- 不重构保留模块的代码风格（U-07）。
+- Phase 2 verify-over-envelope work.
+- Phase 3 intelligence-layer removal for non-execpolicy rules, skills, GC,
+  learn, self-evolution, `q_value`, or `complexity_router`.
+- Dropping, renaming, or migrating production Postgres tables in this phase.
+- Changing workflow-runtime dispatch semantics.
+- Changing the GH-1430 circuit-breaker behavior.
+- Restyling retained modules.
 
-## Behavior Invariants
+## User-Visible Behavior
 
-1. 删除动作仅在探针证据（7 天零计数）或书面豁免存在后发生；removal PR
-   必须引用计数结果。
-2. 归档先于删除：threads/tasks 相关表的 pg_dump 产物存在且可恢复
-   （文档记录恢复命令）后，代码删除才可合并。
-3. 每层删除是独立 PR（thread/turn、task、eval、review_store 至少四个），
-   任一可单独 revert（U-09）。
-4. 保留面的行为不变：`harness serve/status/pr fix/execpolicy/reconcile`、
-   webhook intake、dashboard 的 workflow 视图，删除前后输出一致。
-5. 删除后 workspace 无悬挂引用：protocol 定义、router 注册、CLI 子命令、
-   dashboard 面板同步清理；`cargo test --workspace` 与 clippy `-D warnings` 绿。
-6. 对外面收缩可见：RPC 方法数从 ~30 降到 ~14（thread×8 + turn×8 移除），
-   在 CHANGELOG 记录 breaking change 清单。
+1. Removal PRs are blocked until they cite either zero-count probe evidence from
+   at least 7 days of probe runtime or an explicit maintainer waiver recorded on
+   GH-1434.
+2. Thread/task archive data must exist before deletion PRs that remove the
+   corresponding code. The archive instructions must include restore commands.
+3. Each removal surface remains independently revertible. At minimum,
+   `harness-eval`, `review_store`, thread/turn RPC removal, and task-layer
+   removal are separate PRs.
+4. Retained workflow-runtime paths behave the same before and after deletion:
+   `harness serve`, `harness status`, `harness pr fix --help`, webhook intake,
+   and the dashboard first viewport must still work.
+5. Consumers must move before endpoints disappear. Dashboard, CLI, websocket,
+   protocol, and router references to removed surfaces must either be removed or
+   repointed to workflow-runtime equivalents before the old endpoints are
+   deleted.
+6. Public API contraction is documented. The breaking-change note lists the
+   removed thread/turn RPC methods and any task endpoint compatibility changes.
 
-## 验收标准
+## Acceptance Criteria
 
-- [ ] 探针 PR 先行合并，计数器对 thread/*、turn/*、task 执行路径、eval、
-      review_store 生效并可在日志/事件中查询。
-- [ ] 归档产物：threads(9)、tasks(62) 及关联表的 dump 文件 + 恢复文档。
-- [ ] 四个删除 PR 合并后：harness-eval crate 不在 workspace；review_store、
-      thread_manager/thread_db、task_db/task_executor/task_runner 模块不存在；
-      protocol 中 thread/turn 方法定义移除。
-- [ ] 净删除 LOC > 10k，在最终 PR 汇总。
-- [ ] `cargo test --workspace` 退出码 0；smoke：serve 启动 + status +
-      `pr fix --help` + dashboard 首屏加载。
+- [x] Usage probes have landed for the Phase 1 target surfaces. PR #1453 added
+      `UsageProbe`, `probe_report`, and target-surface instrumentation.
+- [ ] Deletion PRs cite at least 7 days of zero-count `probe_report` evidence
+      or a maintainer waiver recorded on GH-1434 with scope and reason.
+- [ ] Thread/task archive execution has produced dump artifacts and restore
+      instructions before related code is removed.
+- [ ] After all removal PRs merge, `harness-eval` is no longer a workspace
+      member, `review_store` is gone, removable thread/turn and task layers are
+      gone, and no dangling protocol/router/CLI/dashboard references remain.
+- [ ] The final Phase 1 summary reports net deleted LOC. The expected target is
+      more than 10,000 net deleted LOC.
+- [ ] `cargo test --workspace` exits 0.
+- [ ] Smoke checks pass: serve startup, status, `pr fix --help`, webhook
+      health, and dashboard first viewport.
 
-## 边界情况
+## Edge Cases
 
-- **暗流量**：event_store 只记 hook 类事件，可能存在不经它的调用路径——
-  这正是探针存在的原因；探针必须覆盖 RPC 入口和模块公开函数两层。
-- **CLI 兼容**：若 CLI 存在 thread 相关子命令，删除属 breaking change，
-  版本号按 SemVer MINOR（0.x 阶段）+ CHANGELOG 记录。
-- **dashboard 依赖**：若面板查询 thread/task 端点，先改面板后删端点，
-  避免中间态白屏。
-- **进行中分支**：feat/usage-monitor-dashboard 改的 usage_monitor 属保留面，
-  无冲突；若其触碰 task_db，删除 PR 需先 rebase 协调。
-- **workflow runtime 对 task 层的残余依赖**：task 层"合并进 runtime 或删除"
-  以依赖扫描结果为准——有真实依赖的部分并入，无依赖的删除。
+- Hidden traffic can bypass older event-store evidence. Probe coverage is
+  required at RPC entry points and public module entry points before deletion.
+- `task_executor` is not wholesale deletable. Maintainer evidence on GH-1434
+  says `task_executor/turn_lifecycle.rs` and `task_executor/helpers.rs` are live
+  workflow-runtime turn-engine code and must be extracted or retained.
+- `thread_manager` has a hot in-memory role for workflow-runtime jobs. Phase 1
+  may delete thread/turn RPCs and `thread_db` persistence, but the in-memory
+  role must remain or be inlined safely.
+- The dashboard currently uses `/tasks` as a compatibility surface for
+  workflow-runtime submission handles, details, logs, proof, and artifacts.
+  Deleting those consumers before equivalent runtime APIs exist would regress
+  the dashboard.
+- CLI compatibility changes for thread/turn/task endpoints are breaking
+  changes and must be documented.
+
+## Rollout Notes
+
+PR #1453 provided the probe and archive-script prerequisite, but the 7-day
+deletion gate is not satisfied as of 2026-07-05. Future removal PRs must either
+attach fresh zero-count probe evidence from the required window or cite an
+explicit maintainer waiver comment on GH-1434.

--- a/specs/GH1434/tasks.md
+++ b/specs/GH1434/tasks.md
@@ -1,25 +1,65 @@
-# GH1434 Tasks
+# Task Plan
 
-Issue: `#1434`
-Product spec: `specs/GH1434/product.md`
-Tech spec: `specs/GH1434/tech.md`
+## Linked Issue
 
-## Status
+GH-1434
 
-- [ ] `SP1434-T001` Owner: `observe` | Done when: UsageProbe 计数器覆盖 thread/*、turn/* 路由分发点与 thread_manager/task_db/task_executor/task_runner/harness-eval/review_store 公开入口，每日 probe_report 事件可查询，单测覆盖计数与日报 | Verify: `cargo test --package harness-server probe`
-- [ ] `SP1434-T002` Owner: `ops` | Done when: `scripts/archive-phase1-data.sh` 对 thread_db.threads、task_db.tasks 及关联表产出 pg_dump 存档 + RESTORE.md，恢复演练到临时库行数一致（threads=9, tasks=62 为当前值，以执行时实际行数为准） | Verify: `bash scripts/archive-phase1-data.sh && test -s archives/phase1-*/RESTORE.md`
-- [ ] `SP1434-T003` Owner: `gate` | Done when: 探针运行 ≥7 天且待删面计数为 0，或维护者在 issue #1434 留言豁免并说明理由；结论记录在各 removal PR 描述中 | Verify: probe_report 事件查询输出附在 PR
-- [ ] `SP1434-T004` Owner: `workspace` | Done when: harness-eval 移出 workspace members，相关引用清理，eval_store schema 数据原地留档 | Verify: `cargo test --workspace && ! grep -r harness-eval crates/*/Cargo.toml Cargo.toml`
-- [ ] `SP1434-T005` Owner: `server` | Done when: review_store 模块及 router/handlers 引用删除 | Verify: `cargo test --workspace && rg -l review_store crates | wc -l 输出 0`
-- [ ] `SP1434-T006` Owner: `consumers` | Done when: CLI 子命令、dashboard 面板、websocket 中对 thread/turn/task 端点的引用先行移除或改指 workflow runtime 等价物，dashboard 首屏无回归 | Verify: `cargo test --workspace` + dashboard 手动加载
-- [ ] `SP1434-T007` Owner: `server` | Done when: thread/* 与 turn/* 共 16 个 RPC 方法从 protocol 定义、router 注册、handlers 移除，thread_manager/thread_db 模块删除 | Verify: `cargo test --workspace && rg -l 'thread_manager|thread/start|turn/start' crates | wc -l 输出 0`
-- [ ] `SP1434-T008` Owner: `server` | Done when: 依赖扫描列出 workflow runtime 对 task_* 的真实引用；被引用部分仅搬运（diff 对照证明无语义改动）并入 runtime 邻近模块，其余 task_db/task_executor/task_runner 删除 | Verify: `cargo test --workspace` + PR 附搬运对照表
-- [ ] `SP1434-T009` Owner: `docs` | Done when: CHANGELOG 记录 16 个移除方法的 breaking 清单与归档/恢复指引；净删除 LOC 统计写入汇总 PR（预期 >10k） | Verify: 评审核对 + `git diff --shortstat` 汇总
-- [ ] `SP1434-T010` Owner: `tests` | Done when: 全 workspace 测试与 clippy -D warnings 通过，smoke 清单（serve 启动/status/pr fix --help/webhook 健康/dashboard 首屏）逐项通过并附输出 | Verify: `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings`
+## Spec Packet
+
+- Product: `specs/GH1434/product.md`
+- Tech: `specs/GH1434/tech.md`
+
+## Implementation Tasks
+
+- [x] `SP1434-T001` Owner: `observe` | Dependencies: none | Done when: usage probes cover thread/turn route dispatch and public entry points for `thread_manager`, `task_db`, legacy `task_executor`, `task_runner`, `harness-eval`, and `review_store`; `probe_report` can be emitted and queried | Verify: `cargo test --package harness-server probe`
+- [ ] `SP1434-T002` Owner: `ops` | Dependencies: none | Done when: `scripts/archive-phase1-data.sh` has produced thread/task dump artifacts and restore instructions for the deletion target | Verify: `bash scripts/archive-phase1-data.sh && test -s archives/phase1-*/RESTORE.md`
+- [ ] `SP1434-T003` Owner: `gate` | Dependencies: `SP1434-T001` | Done when: probes have run for at least 7 days with zero counts for the deletion surface, or a maintainer records an explicit GH-1434 waiver with scope and reason | Verify: attach `probe_report` query output or waiver URL to each removal PR
+- [ ] `SP1434-T004` Owner: `workspace` | Dependencies: `SP1434-T003` | Done when: `harness-eval` is removed from workspace members and related references are cleaned while eval-store data remains untouched | Verify: `cargo test --workspace && ! grep -r harness-eval crates/*/Cargo.toml Cargo.toml`
+- [ ] `SP1434-T005` Owner: `server` | Dependencies: `SP1434-T003` | Done when: `review_store` modules and router/handler references are removed | Verify: `cargo test --workspace && test "$(rg -l review_store crates | wc -l)" -eq 0`
+- [ ] `SP1434-T006` Owner: `consumers` | Dependencies: runtime replacement APIs for any live compatibility behavior being moved | Done when: CLI, dashboard, and websocket references to thread/turn/task endpoints are removed or repointed to workflow-runtime equivalents before the old endpoints are deleted | Verify: `cargo test --workspace` plus dashboard first-viewport smoke
+- [ ] `SP1434-T007` Owner: `server` | Dependencies: `SP1434-T003`, `SP1434-T006` | Done when: thread/turn RPC methods are removed from protocol definitions, router registration, and handlers; thread persistence is removed; the live in-memory role is retained or safely inlined | Verify: `cargo test --workspace && test "$(rg -l 'thread/start|turn/start|thread_db' crates | wc -l)" -eq 0`
+- [ ] `SP1434-T008` Owner: `server` | Dependencies: `SP1434-T003`, `SP1434-T006`, extraction evidence for live workflow-runtime turn-engine dependencies | Done when: dependency scanning identifies live `task_*` references; live pieces are moved without semantic changes into workflow-runtime-adjacent modules; removable task-layer code is deleted | Verify: `cargo test --workspace` plus a PR migration table showing moved code and unchanged behavior
+- [ ] `SP1434-T009` Owner: `docs` | Dependencies: all removal PRs | Done when: CHANGELOG documents removed RPC methods, task endpoint compatibility changes, and archive/restore instructions; final summary reports net deleted LOC | Verify: reviewer checks method list and `git diff --shortstat`
+- [ ] `SP1434-T010` Owner: `tests` | Dependencies: all removal PRs | Done when: full workspace tests, clippy, and smoke checks pass | Verify: `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings`
 
 ## Parallelization
 
-- Lane A (T001, T002): 探针与归档，立即可做，互不依赖。
-- Lane B (T004, T005): eval 与 review_store 删除，各自独立 PR，等 T003 门通过。
-- Lane C (T006 → T007 → T008): 消费方先行，再删 thread/turn，最后 task 层（依赖最多，压轴）。
-- T009/T010 收尾，依赖全部删除 PR 合并。
+- Lane A status: `SP1434-T001` landed in PR #1453, and the archive script
+  prerequisite for `SP1434-T002` landed in PR #1453. Archive execution remains
+  open before related code removal.
+- Lane B waits for `SP1434-T003`: `SP1434-T004` and `SP1434-T005` are
+  independent deletion PRs after evidence or waiver.
+- Lane C is serial: `SP1434-T006` consumer migration precedes `SP1434-T007`
+  thread/turn deletion and `SP1434-T008` task-layer deletion.
+- `SP1434-T009` and `SP1434-T010` are final closeout tasks after deletion PRs.
+
+## Verification
+
+- `python3 checks/check_workflow.py --repo .`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1434`
+- For spec-only updates, `cargo fmt --all -- --check` is sufficient before PR
+  creation. Code removal PRs must run the focused tests listed above plus the
+  final workspace gates.
+
+## Handoff Notes
+
+- PR #1453 merged the probe/archive-script prerequisite but does not satisfy
+  the 7-day deletion gate by itself.
+- PR #1453 is the evidence for `SP1434-T001` and for the archive-script
+  prerequisite of `SP1434-T002`. It is not evidence that archive execution has
+  completed.
+- `SP1434-T003` is blocked as of 2026-07-05 because PR #1453 has not run for 7
+  days and no broad Phase 1 deletion waiver is recorded.
+- Dashboard `/tasks` references are live compatibility paths for
+  workflow-runtime submission handles, details, streams, proof, artifacts,
+  merge, and cancel. Do not remove them until equivalent runtime APIs exist and
+  tests cover the replacement.
+- The GH-1434 maintainer comment from 2026-07-03 narrows the deletion boundary:
+  `task_executor/turn_lifecycle.rs` and `task_executor/helpers.rs` are live,
+  and the in-memory `thread_manager` role is live. Treat that as boundary
+  evidence, not as a broad deletion waiver.
+- The GH-1434 gate comment from 2026-07-05 records that deletion PRs need either
+  7 days of probe evidence or an explicit waiver with scope and reason.
+- `/tasks` is currently a workflow-runtime compatibility API for dashboard
+  submission handles and observation. Removing it requires replacement runtime
+  APIs first.

--- a/specs/GH1434/tech.md
+++ b/specs/GH1434/tech.md
@@ -8,89 +8,101 @@ GH-1434
 
 `specs/GH1434/product.md`
 
-## Codebase Context
+## Current System
 
-| Area | Files | Current behavior | Why relevant |
+| Area | Files | Current behavior | Phase 1 relevance |
 | --- | --- | --- | --- |
-| thread/turn RPC | `crates/harness-protocol/src`（thread/* ×8、turn/* ×8 方法定义）、`crates/harness-server/src/router/mod.rs`（注册）、`handlers/thread.rs` | 完整生命周期 RPC，历史仅 9 threads | 删除主体 1 |
-| thread 状态 | `crates/harness-server/src/thread_manager.rs`、`thread_db.rs`、`thread_manager_tests.rs` | 自有 thread 状态机 + Postgres（thread_db.threads） | 删除主体 1 |
-| task 层 | `crates/harness-server/src/task_db{,.rs}`、`task_executor/`、`task_runner/`、`task_queue_tests.rs` | 第二代任务状态机（task_db.tasks，62 行数据） | 删除主体 2；先做依赖扫描，runtime 仍引用的部分并入 |
-| eval | `crates/harness-eval`（848 LOC）、`eval_store` schema、workspace Cargo.toml | 0 eval_runs | 删除主体 3 |
-| review_store | `crates/harness-server/src/review_store/`、`review_store` schema | 0 findings | 删除主体 4 |
-| 消费方 | `crates/harness-cli/src/main.rs`、`crates/harness-server/src/dashboard.rs`、`websocket.rs`、`web/` | 可能引用 thread/task 端点 | 先改消费方后删端点（product 边界情况） |
-| 探针落点 | router 分发处 + 各模块公开入口 | 无使用计数 | T001 |
-| 事实来源 | workflow runtime（`workflow_runtime_*`、`crates/harness-workflow`） | 全部真实流量 | 保留面，行为不变的基准 |
+| Thread/turn RPCs | `crates/harness-protocol/src`, `crates/harness-server/src/router/mod.rs`, `crates/harness-server/src/handlers/thread.rs` | JSON-RPC lifecycle methods for thread and turn management. | Primary deletion surface after probe/waiver gate. |
+| Thread state | `crates/harness-server/src/thread_manager.rs`, `crates/harness-server/src/thread_db.rs`, thread manager tests | In-memory thread state plus persistence. Maintainer evidence says the in-memory role is still hot for workflow-runtime jobs. | Delete RPC and persistence only after preserving the live in-memory role. |
+| Task layer | `crates/harness-server/src/task_db.rs`, `crates/harness-server/src/task_executor/`, `crates/harness-server/src/task_runner/`, task queue tests | Legacy task state machine, plus compatibility APIs used by the dashboard and runtime submission handles. | Delete only after dependency scanning and replacement runtime APIs exist. |
+| Eval | `crates/harness-eval`, eval HTTP/API handlers, eval store schema references | Evaluation crate and routes with zero cited production runs. | Independent removal surface after probe/waiver gate. |
+| Review store | `crates/harness-server/src/review_store/`, review-store schema usage | Local review findings store with zero cited findings. | Independent removal surface after probe/waiver gate. |
+| Consumers | `crates/harness-cli/src/main.rs`, `crates/harness-server/src/http/http_router.rs`, `crates/harness-server/src/websocket.rs`, `web/` | CLI, HTTP, websocket, and dashboard references to task/thread/turn surfaces. | Must move before endpoints are deleted. |
+| Workflow runtime | `crates/harness-workflow`, `crates/harness-server/src/workflow_runtime_*`, runtime HTTP routes | Authoritative production workflow path. | Retained behavior baseline. |
+| Probes | `harness_core::usage_probe`, router dispatch, public module entry points | PR #1453 added probe counters and `probe_report`. | Provides deletion evidence after the required observation window. |
 
 ## Proposed Design
 
-**探针（先行 PR）**：轻量计数器 `UsageProbe`——`static AtomicU64` per surface +
-每日一条 info 事件汇总（`probe_report` 事件：surface → count）。覆盖两层：
-(a) router 里 thread/*、turn/* 方法分发点；(b) `thread_manager`、`task_db`、
-`task_executor`、`task_runner`、`harness-eval`、`review_store` 的公开函数入口
-（宏或手工，取实现简单者）。探针本身无配置、无持久化，7 天后读事件即可。
+Phase 1 remains a sequenced contraction, not a single large deletion PR.
 
-**归档**：`scripts/archive-phase1-data.sh`——对 `thread_db.threads`、
-`task_db.tasks` 及外键关联表、各 hash schema 中同名表执行
-`pg_dump --table` 到 `archives/phase1-<date>/`，附 `RESTORE.md`（恢复命令）。
-表保留原地不动（本阶段不 drop、不 rename，避免运行中代码踩空）。
-
-**删除顺序**（每步独立 PR，依赖从少到多）：
-1. `harness-eval`：从 workspace members 移除 crate；删 `evaluate.py` 中的
-   引用（如有）；eval_store schema 留档不动。
-2. `review_store`：删模块目录 + router/handlers 引用。
-3. thread/turn：先删 CLI/dashboard/websocket 消费方 → 删 handlers/thread.rs、
-   router 注册 → 删 protocol 方法定义 → 删 thread_manager/thread_db。
-4. task 层：`cargo tree`/`rg` 依赖扫描出 workflow runtime 对 task_* 的真实
-   引用清单；被引用的类型/函数移入 `workflow_runtime_*` 邻近模块（仅搬运，
-   不改语义），其余删除。
-
-**RPC 面收缩后**：protocol 保留 skill/*（Phase 3 处理）、gc/*（Phase 3）、
-rule/*、metrics/*、event/*、stats、task/classify（归属 runtime，改名或保留）、
-health。thread/turn 16 个方法移除进 CHANGELOG breaking 清单。
-
-## Product-to-Test Mapping
-
-| Product invariant | Implementation area | Verification |
-| --- | --- | --- |
-| P1 探针先行 + removal PR 引用计数 | UsageProbe + PR 模板纪律 | 探针单测 + PR 描述人工核对 |
-| P2 归档先于删除 | archive 脚本 + RESTORE.md | 脚本跑通、dump 文件存在、恢复演练一次 |
-| P3 每层独立 PR 可 revert | PR 切分 | git 历史 |
-| P4 保留面行为不变 | — | 删除前后 `harness status --json` diff 为空；smoke 清单 |
-| P5 无悬挂引用 | 全 workspace | `cargo test --workspace` + clippy `-D warnings` + `rg 'thread_manager|task_db|review_store|harness-eval'` 零命中（除 CHANGELOG/specs） |
-| P6 CHANGELOG breaking 清单 | CHANGELOG.md | 评审核对 16 个方法名 |
+1. Safety probes and archive tooling land first. PR #1453 has already added
+   `UsageProbe`, `probe_report`, target-surface instrumentation, and
+   `scripts/archive-phase1-data.sh`.
+2. The deletion gate is evaluated before each removal PR. A removal PR must
+   cite either:
+   - at least 7 days of zero-count probe evidence for the surface being
+     removed, or
+   - an explicit GH-1434 maintainer waiver with scope and reason.
+3. Archive execution precedes related code deletion. The script should dump the
+   thread/task data and generate restore instructions. Tables remain in place.
+4. Removal is split into independently revertible PRs:
+   - remove `harness-eval`
+   - remove `review_store`
+   - remove thread/turn RPCs, router registrations, handlers, and persistence
+   - remove legacy task-layer code after extracting or retaining live
+     workflow-runtime turn-engine dependencies
+5. Consumer migration precedes endpoint removal. Dashboard, CLI, websocket,
+   protocol, and router references must be moved to workflow-runtime
+   equivalents before the corresponding legacy endpoints disappear.
+6. The final PR or summary documents API contraction, restore instructions, and
+   net deleted LOC.
 
 ## Data Flow
 
-探针：AtomicU64 → 每日 probe_report 事件 → 人读。归档：Postgres → pg_dump
-文件（本地 archives/，不进 git——加 .gitignore）。删除不触碰任何运行时数据流。
+Probe data flows from atomic counters to daily `probe_report` events. Removal
+PRs reference those reports as human-readable evidence.
+
+Archive data flows from Postgres through `pg_dump` into a local archive
+directory with restore instructions. Phase 1 does not mutate production tables.
+
+Workflow-runtime submission, scheduling, job execution, merge, cancel, and
+dashboard observation remain on the workflow-runtime store and runtime HTTP
+routes. Any consumer moved away from `/tasks` must preserve equivalent behavior
+for submission handle lookup, status, detail, streaming logs, artifacts, proof,
+merge, and cancel before the compatibility endpoint can be removed.
 
 ## Alternatives Considered
 
-- **拆插件仓**：拒绝（用户拍板）——为"未来可能有人要"维护插件仓贵于
-  真需要时从 git 历史恢复。
-- **rename 表代替 pg_dump**：拒绝——运行中的旧二进制可能仍在写，rename
-  会制造运行时错误；dump + 原表不动最稳。
-- **一个大 PR 删完**：拒绝——不可局部 revert，review 不可读（U-09）。
-- **跳过探针直接删**：拒绝——event_store 只见 hook 类事件，暗流量风险
-  真实存在；探针成本一天，误删成本一周。
+- Plugin extraction: rejected by the Phase 1 decision because git history is the
+  archive and maintaining a plugin surface would preserve unnecessary cost.
+- Table rename or table drop: rejected for Phase 1 because running binaries may
+  still expect the existing schema.
+- One large deletion PR: rejected because it is hard to review and not locally
+  revertible.
+- Deleting without probes: rejected because event-store evidence can miss hidden
+  traffic.
+- Removing dashboard `/tasks` references immediately: rejected until equivalent
+  workflow-runtime APIs cover submit, list/detail, stream, proof, artifacts,
+  merge, and cancel semantics.
 
 ## Risks
 
-- Security: 无新对外面；删除减少攻击面。
-- Compatibility: thread/turn RPC 移除是 breaking——0.x 阶段 + CHANGELOG +
-  16 方法清单；已知消费方仅 CLI/dashboard（同仓同 PR 修）。
-- Performance: 探针为原子自增，可忽略。
-- Maintenance: task 层并入 runtime 的"仅搬运"边界要在 PR 里明示 diff 对照，
-  防止顺手重构（U-04/U-07）。
+- Security: removal reduces exposed surface area, but any temporary replacement
+  APIs must preserve existing auth rules.
+- Compatibility: thread/turn RPC removal and task endpoint changes are breaking
+  changes and require release notes.
+- Performance: probe counters are low overhead; deletion should reduce build and
+  runtime maintenance cost.
+- Maintenance: `task_executor` contains both legacy code and live
+  workflow-runtime turn-engine code, so dependency scanning and extraction
+  evidence are mandatory.
 
 ## Test Plan
 
-- [ ] Unit tests: UsageProbe 计数与日报事件
-- [ ] Integration tests: 删除后全量 `cargo test --workspace`
-- [ ] Manual verification: smoke 清单——serve 启动、`status`、`pr fix --help`、
-      webhook 健康、dashboard 首屏；归档恢复演练（restore 到临时库数一致）
+- [x] Probe tests for `UsageProbe` and `probe_report` behavior landed with
+      PR #1453.
+- [ ] Removal PRs run focused package tests for the touched crate or module.
+- [ ] Removal PRs run `cargo test --workspace`.
+- [ ] Final readiness runs `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Smoke checks cover serve startup, status, `pr fix --help`, webhook health,
+      and dashboard first viewport.
+- [ ] Archive restore is exercised against a temporary database before deleting
+      related code.
 
 ## Rollback Plan
 
-每层一个 PR，revert 即回滚该层；数据未动（表原地、dump 在手）。探针 PR
-可长期保留（保留面上的计数器对 Phase 2/3 同样有用）。
+Each removal surface is delivered in a separate PR so it can be reverted
+independently. Data rollback is not needed for Phase 1 because production tables
+are not dropped or renamed. If a replacement consumer path regresses, revert the
+consumer migration or re-enable the compatibility route while preserving the
+probe evidence.


### PR DESCRIPTION
# Summary

Translate the GH1434 Phase 1 SpecRail packet into English and sync it with the current probe/archive-script prerequisite state from PR #1453. This is a spec-only update; it does not remove code or bypass the GH1434 deletion gate.

## Linked Work

- Issue: Refs #1434
- Spec packet: `specs/GH1434/product.md`, `specs/GH1434/tech.md`, `specs/GH1434/tasks.md`

## Readiness Gate

- [x] Linked issue has an existing SpecRail packet and ready-to-implement route evidence.
- [x] Product/tech/tasks spec packet is linked and updated.
- [x] Security-sensitive changes were not made.

## Review Gate

- [x] Agent first-pass review completed.
- [ ] Human final review requested.
- [ ] Owner approval identified when ownership rules apply.

## Merge Gate

- [ ] PR head SHA recorded.
- [ ] CI/check rollup is complete and passing.
- [ ] Review threads were checked and unresolved actionable threads are addressed.
- [ ] Merge state is clean.
- [x] Human merge authorization is recorded in the current conversation.
- [ ] `python3 checks/github_pr_evidence.py --github-repo majiayu000/harness --pr <pr-number> --json > pr-evidence.json` result:
- [ ] `python3 checks/pr_gate.py --repo . --evidence <evidence.json>` result:

## Verification

- [x] `python3 checks/route_gate.py --repo . --route write_spec --issue 1434 --state ready_to_spec --json`
- [x] `python3 checks/route_gate.py --repo . --route implement --issue 1434 --state ready_to_implement --json`
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1434`
- [x] `python3 checks/check_workflow.py --repo .`
- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Manual proof: verified current dashboard `/tasks` references are live workflow-runtime compatibility paths, so this PR records the T006 boundary instead of removing them prematurely.
- [ ] Screenshots or logs when user-visible: not applicable.

## Release Notes

- [ ] Changelog or release note needed.
- [x] Not user-visible.

## Agent Disclosure

- [ ] No agent was used.
- [x] Agent assisted; human author reviewed the full diff.
