### PR TITLE
Add GH1567 operator recovery spec

### DIFF
--- a/specs/GH1567/product.md
+++ b/specs/GH1567/product.md
@@ -1,0 +1,118 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1567
+
+## User Problem
+
+Operators have no supported way to recover a workflow-runtime issue instance
+after it reaches `blocked`, `failed`, or `cancelled`.
+
+In the intake path, `runtime_issue_state_is_covered` treats those states as
+covered, so GitHub issue polling skips the issue forever. If a workflow blocks
+because it is waiting for maintainer input, and the maintainer later provides
+that input on the issue, Harness does not re-read the issue thread and does not
+dispatch follow-up work. The only known recovery path from the reported
+production incident was manual SQL deletion across workflow runtime tables,
+which is not acceptable operator behavior.
+
+## Goals
+
+1. Make blocked and failed workflow-runtime instances explain why they stopped
+   using structured, API-visible fields.
+2. Provide operator-authenticated HTTP actions to unblock blocked instances and
+   retry failed instances without direct Postgres edits.
+3. Ensure a successful unblock makes the related GitHub issue eligible for the
+   next intake tick instead of remaining covered forever.
+4. Document the supported recovery flow so operators do not rely on table
+   surgery.
+5. Keep automatic recovery conservative by default. A blocked workflow must not
+   resume unless an operator acts or a repository explicitly opts into a
+   recheck policy.
+
+## Non-Goals
+
+- No automatic retry of `blocked`, `failed`, or `cancelled` workflows by
+  default.
+- No new SpecRail-specific state machine inside Harness core. Repository policy
+  remains in the repository layer.
+- No direct mutation of GitHub labels, issue state, or comments from the
+  recovery API.
+- No deletion of workflow runtime rows as part of recovery.
+- No change to PR merge approval semantics.
+
+## User-Visible Behavior
+
+An operator viewing a stopped workflow can see:
+
+- the workflow state;
+- a stable `blocked_reason` or `failure_reason`;
+- a short `unblock_hint` or `retry_hint` when Harness can suggest the next
+  operator action;
+- the activity and runtime job that produced the stopped state when available.
+
+An operator can call an authenticated HTTP action to:
+
+- move a `blocked` workflow back into a dispatchable state after external input
+  has been provided;
+- retry a `failed` workflow when the failure is transient or after the operator
+  has corrected the external condition.
+
+After a successful unblock or retry, the next GitHub issue intake scan must not
+skip the issue solely because the previous workflow state was `blocked` or
+`failed`. The workflow should either dispatch new work or report a fresh,
+structured blocker.
+
+If an operator calls the wrong action for the current state, Harness returns a
+clear conflict response instead of silently doing nothing.
+
+## Acceptance Criteria
+
+- [ ] Blocked workflow-runtime instances expose `blocked_reason`,
+      `unblock_hint`, and source metadata through the runtime tree and operator
+      monitor APIs.
+- [ ] Failed workflow-runtime instances expose `failure_reason`, `error_kind`,
+      `retry_hint`, and source metadata through the same operator-visible
+      surfaces.
+- [ ] An authenticated operator can unblock a `blocked` workflow through HTTP
+      without editing Postgres directly.
+- [ ] An authenticated operator can retry a `failed` workflow through HTTP
+      without editing Postgres directly.
+- [ ] A successful unblock or retry records an audit event and updates the
+      workflow instance so the GitHub issue coverage gate no longer treats the
+      old terminal state as a permanent hold.
+- [ ] The next intake tick for the same issue can re-dispatch work or produce a
+      fresh structured blocker.
+- [ ] `cancelled` workflows are not automatically retried. Any support for
+      cancelled workflows must be an explicit follow-up with separate
+      acceptance criteria.
+- [ ] `docs/usage-guide.md` documents the recovery API, expected responses, and
+      the rule that direct DB edits are not part of the supported flow.
+
+## Edge Cases
+
+- The workflow runtime store is unavailable.
+- The workflow id is not found.
+- The workflow is already active or terminal in a state that the requested
+  action does not support.
+- A blocked workflow has no structured reason because it was created before
+  this feature shipped.
+- A failed workflow has a non-retryable `error_kind` such as `fatal` or
+  `configuration`.
+- The related GitHub issue is closed between the original block and the
+  operator recovery action.
+- The intake tick races with the operator action.
+
+## Rollout Notes
+
+This feature changes operator recovery behavior and should land in small PRs:
+
+1. structured stop-reason metadata;
+2. HTTP unblock/retry actions;
+3. coverage-gate and intake re-dispatch behavior;
+4. dashboard and usage-guide documentation.
+
+Existing blocked or failed rows may not have all structured fields. The UI and
+API must tolerate missing fields and fall back to existing event or activity
+summary text without fabricating reasons.

--- a/specs/GH1567/tasks.md
+++ b/specs/GH1567/tasks.md
@@ -1,0 +1,59 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1567
+
+## Spec Packet
+
+- Product: `specs/GH1567/product.md`
+- Tech: `specs/GH1567/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1567-T001` Owner: `workflow-runtime` | Dependencies: none | Done when: blocked and failed reducer paths derive structured stop metadata (`blocked_reason`, `unblock_hint`, `failure_reason`, `retry_hint`, and `last_stop`) from activity results and persist it in workflow instance `data` without schema migration | Verify: `cargo test -p harness-workflow runtime_failure`
+- [ ] `SP1567-T002` Owner: `server-api` | Dependencies: `SP1567-T001` | Done when: `/api/workflows/runtime/unblock` exists, is authenticated by existing middleware, accepts `workflow_id` and `reason`, accepts only `blocked` workflows, records an audit event, and moves the workflow to a dispatchable state | Verify: `cargo test -p harness-server unblock`
+- [ ] `SP1567-T003` Owner: `server-api` | Dependencies: `SP1567-T001` | Done when: `/api/workflows/runtime/retry` exists, is authenticated by existing middleware, accepts only retryable `failed` workflows, rejects wrong-state and non-retryable failures, records an audit event, and moves the workflow to a dispatchable state | Verify: `cargo test -p harness-server retry`
+- [ ] `SP1567-T004` Owner: `intake` | Dependencies: `SP1567-T002`, `SP1567-T003` | Done when: GitHub issue coverage remains conservative for untouched `blocked`/`failed` workflows, but a workflow updated by unblock or retry no longer causes the next intake tick to skip the issue because of the old stopped state | Verify: `cargo test -p harness-server github_coverage_gate`
+- [ ] `SP1567-T005` Owner: `observe` | Dependencies: `SP1567-T001` | Done when: runtime tree and operator monitor payloads expose structured stopped-state fields and action eligibility without relying on free-text parsing | Verify: `cargo test -p harness-server operator_monitor runtime_tree`
+- [ ] `SP1567-T006` Owner: `web` | Dependencies: `SP1567-T002`, `SP1567-T003`, `SP1567-T005` | Done when: the operator monitor renders structured reason text, shows unblock/retry actions only when allowed, calls the new routes, and refreshes state after success | Verify: project web test command for `OperatorMonitorPanel`
+- [ ] `SP1567-T007` Owner: `docs` | Dependencies: `SP1567-T002`, `SP1567-T003` | Done when: `docs/usage-guide.md` documents the recovery API, response classes, supported states, and the rule that direct DB edits are not supported recovery | Verify: reviewer checks usage-guide section
+- [ ] `SP1567-T008` Owner: `policy` | Dependencies: all previous tasks | Done when: optional blocked recheck policy is either explicitly deferred or implemented behind disabled-by-default configuration with evidence-writing tests | Verify: implementation PR states the decision and matching tests or non-goal evidence
+
+## Parallelization
+
+- Lane A (`SP1567-T001`) is the first prerequisite and should land alone or with
+  minimal serialization tests.
+- Lane B (`SP1567-T002`, `SP1567-T003`) can be split into two server API PRs
+  after Lane A. They share route and store helpers, so do not run writable work
+  on the same files in parallel.
+- Lane C (`SP1567-T004`, `SP1567-T005`) follows the API semantics and can be
+  reviewed separately if file ownership stays disjoint.
+- Lane D (`SP1567-T006`, `SP1567-T007`) can proceed after API response shapes
+  stabilize.
+- `SP1567-T008` is a final policy decision and should not block the manual
+  operator escape hatch.
+
+## Verification
+
+- `python3 checks/check_workflow.py --repo .`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1567`
+- `python3 checks/route_gate.py --repo . --route implement --issue 1567 --state ready_to_implement --json`
+- For this spec-only PR: `cargo fmt --all -- --check`
+- For implementation PRs: run focused package tests from the task rows, then
+  run broader workspace checks when shared runtime behavior changes.
+
+## Handoff Notes
+
+- This spec intentionally keeps the first implementation manual/operator-driven.
+  Automatic blocked recheck is deferred unless a follow-up PR explicitly
+  enables it behind disabled-by-default configuration.
+- Use body-based runtime action routes for the first implementation because
+  current workflow ids can contain project paths and slashes. A path-style alias
+  requires URL-encoding tests.
+- Do not make `blocked` or `failed` globally uncovered in the coverage gate.
+  The operator action should change the workflow state; the gate should then
+  observe that updated state.
+- Do not retry `cancelled` workflows in this issue.
+- Do not close GH-1567 until the implementation PRs satisfy the acceptance
+  criteria, not merely this spec packet.

--- a/specs/GH1567/tech.md
+++ b/specs/GH1567/tech.md
@@ -1,0 +1,223 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1567
+
+## Product Spec
+
+`specs/GH1567/product.md`
+
+## Current System
+
+| Area | Files | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| GitHub issue coverage gate | `crates/harness-server/src/intake/github_coverage_gate.rs` | `runtime_issue_state_is_covered` treats `blocked`, `failed`, and `cancelled` as covered, so intake skips the issue. | This is the direct source of the stuck poll behavior. |
+| Runtime failure reducer | `crates/harness-workflow/src/runtime/reducer/runtime_failure.rs` | Failed decisions persist a reason and optional `error_kind` in command payloads; blocked decisions mark blocked with a free-text reason. | Stop reasons must become structured and visible on the instance/API. |
+| Activity result model | `crates/harness-workflow/src/runtime/model.rs` | `ActivityResult` carries `summary`, optional `error`, optional `error_kind`, artifacts, signals, and validation records. | This is the source material for structured stop metadata. |
+| Runtime instance store | `crates/harness-workflow/src/runtime/store/instances.rs` | `WorkflowRuntimeStore` can load and upsert instances and applies decision transitions. | Operator actions need atomic state updates and audit events. |
+| Runtime HTTP routes | `crates/harness-server/src/http/http_router.rs`, `task_mutation_routes.rs` | Runtime merge and cancel actions exist as body-based routes: `/api/workflows/runtime/merge` and `/api/workflows/runtime/cancel`. There is no unblock or retry route. | New recovery routes should follow the existing runtime-action style. |
+| Runtime tree API | `crates/harness-server/src/http/misc_routes_runtime_tree.rs` | Runtime instances, commands, jobs, events, and summaries are exposed to the dashboard. | Structured reasons should be visible here. |
+| Operator monitor | `crates/harness-server/src/handlers/operator_monitor.rs`, `web/src/routes/overview/OperatorMonitorPanel.tsx` | Aged stuck workflows are visible, but the surface does not expose actionable unblock/retry details. | This is the primary operator UI for stopped workflows. |
+| Usage guide | `docs/usage-guide.md` | Documents watchdog and retention, but not an operator unblock/retry workflow. | Operators need the supported flow documented. |
+
+## Proposed Design
+
+### Stop-Reason Metadata
+
+Add a small structured stop-reason payload stored in workflow instance `data`.
+Use additive JSON fields so no schema migration is required:
+
+```json
+{
+  "blocked_reason": "SpecRail task SP841-T2 requires maintainer approval",
+  "unblock_hint": "Post the approval comment on the GitHub issue, then call unblock.",
+  "failure_reason": "Codex proxy returned a transient transport error",
+  "retry_hint": "Retry after the proxy route is healthy.",
+  "last_stop": {
+    "state": "blocked",
+    "activity": "implement_issue",
+    "runtime_job_id": "runtime-job-id",
+    "event_id": 123,
+    "error_kind": "configuration",
+    "recorded_at": "2026-07-05T17:13:16Z"
+  }
+}
+```
+
+Reducers that transition a workflow into `blocked` or `failed` should populate
+the relevant fields from `ActivityResult.error`, `summary`, `error_kind`,
+signals, and runtime completion event metadata. Existing rows without these
+fields remain valid; APIs should fall back to current event/result text.
+
+### Operator Actions
+
+Add body-based runtime actions to match the existing merge/cancel routes and
+avoid path encoding problems with workflow ids that contain project paths and
+slashes:
+
+- `POST /api/workflows/runtime/unblock`
+- `POST /api/workflows/runtime/retry`
+
+Request shape:
+
+```json
+{
+  "workflow_id": "...",
+  "reason": "operator supplied the requested approval comment"
+}
+```
+
+Response shape on success:
+
+```json
+{
+  "status": "unblocked",
+  "execution_path": "workflow_runtime",
+  "workflow_id": "...",
+  "previous_state": "blocked",
+  "state": "discovered"
+}
+```
+
+The issue text proposed path-style endpoints such as
+`/api/workflows/instances/{id}/unblock`. Those can be added as aliases only if
+implementation includes URL-encoding tests for workflow ids containing `/`.
+The first implementation should prefer body-based routes for consistency with
+existing runtime merge/cancel.
+
+### State Transition Semantics
+
+`unblock`:
+
+- Allowed only from `blocked`.
+- Clears the coverage hold by moving the instance to a dispatchable state.
+- For GitHub issue workflows, the target state should be the earliest safe
+  re-dispatch state already accepted by the definition, such as `discovered` or
+  another existing pre-dispatch state chosen by the implementation after
+  checking the transition registry.
+- Preserves historical stop metadata under `last_stop` or an append-only audit
+  event; it must not erase evidence.
+
+`retry`:
+
+- Allowed only from `failed`.
+- Reuses the same dispatchable-state strategy as `unblock` when retry is
+  operator-approved.
+- Must reject non-retryable `error_kind` values such as `fatal` and
+  `configuration` unless the request explicitly includes a force flag and a
+  follow-up spec approves that force behavior. The first implementation should
+  omit force retry.
+
+`cancelled`:
+
+- No action in the first implementation. Return `409 Conflict` with the current
+  state if called on a cancelled workflow.
+
+Both actions must insert a workflow event or decision record that includes the
+operator-supplied reason, previous state, next state, and actor/source
+identifier available from the existing auth layer.
+
+### Coverage Gate Behavior
+
+After a successful operator action, the coverage gate should observe the
+updated state rather than the old stopped state. That means the next GitHub
+issue intake scan can create or continue work instead of returning
+`Covered { source: "workflow_runtime", state: "blocked" }`.
+
+Do not make `blocked` or `failed` globally uncovered. They should remain
+covered until the operator action changes state, because automatic redispatch
+without operator intent would violate the conservative default.
+
+### API And Dashboard Exposure
+
+Add the structured reason fields to runtime tree nodes and operator monitor
+stuck-workflow rows. The React operator monitor should display the reason and a
+compact action affordance only when the API reports the action is allowed.
+
+The UI implementation should call the new runtime action routes and refresh the
+operator monitor/runtime tree after success. It should not infer action
+eligibility from free-text messages.
+
+### Optional Recheck Policy
+
+Automatic blocked recheck remains a later tranche. The first implementation may
+define the configuration shape in the spec but should not implement polling
+unless a follow-up PR explicitly covers it:
+
+```yaml
+blocked_recheck_interval_secs: 0
+```
+
+`0` means disabled. Any enabled recheck must re-read remote issue facts and
+write explicit evidence before unblocking.
+
+## Data Flow
+
+Runtime job completion produces an `ActivityResult`. The reducer transitions
+the workflow into `blocked` or `failed`, derives structured stop metadata, and
+persists it in workflow instance `data` with a workflow event/decision. The
+runtime tree and operator monitor read those fields. An authenticated operator
+calls unblock or retry. The handler validates state, writes an audit event,
+updates the instance to a dispatchable state, and returns the new state. The
+next intake tick sees the updated state and can dispatch work normally.
+
+## Alternatives Considered
+
+- Make `blocked` and `failed` uncovered in `runtime_issue_state_is_covered`.
+  Rejected because it would create automatic redispatch for workflows that may
+  still be correctly waiting on humans or external repair.
+- Delete workflow runtime rows to force redispatch. Rejected because direct
+  table surgery is the problem this issue is removing.
+- Add only dashboard buttons without structured state. Rejected because actions
+  would still depend on free-text interpretation.
+- Use path parameters for workflow ids in the first route. Rejected for the
+  first implementation because workflow ids can include project paths and `/`;
+  body-based routes match existing runtime merge/cancel behavior.
+- Implement periodic blocked recheck immediately. Deferred because it changes
+  conservative default behavior and needs its own evidence and configuration
+  tests.
+
+## Risks
+
+- Security: recovery routes can re-dispatch agent work, so they must use the
+  existing authenticated API middleware and must not bypass human gates.
+- Compatibility: additive JSON fields are backward-compatible, but old rows may
+  lack structured stop metadata.
+- Logic: moving a workflow to the wrong state could duplicate work or skip
+  planning. Implementation must use the workflow definition and targeted tests
+  for each supported definition.
+- Data integrity: operator actions must preserve historical stop evidence and
+  record a fresh audit event.
+- Operations: retrying non-retryable configuration failures can create loops.
+  The first implementation should reject those failures instead of force
+  retrying them.
+
+## Test Plan
+
+- [ ] Unit tests for stop-reason derivation from blocked and failed
+      `ActivityResult` values.
+- [ ] Runtime reducer tests proving blocked and failed transitions persist the
+      structured metadata.
+- [ ] Store/action tests proving unblock is accepted only from `blocked` and
+      retry is accepted only from retryable `failed` workflows.
+- [ ] Coverage-gate test proving the same issue is covered before unblock and
+      not held by the old blocked state after unblock.
+- [ ] HTTP route tests for success, not found, store unavailable, wrong state,
+      and non-retryable failure responses.
+- [ ] Operator monitor/runtime tree tests proving structured reason fields are
+      serialized.
+- [ ] Web tests for rendering reason text and invoking allowed actions.
+- [ ] Usage guide docs update.
+- [ ] Focused Rust tests: `cargo test -p harness-workflow runtime_failure` and
+      targeted `cargo test -p harness-server` filters for the new routes and
+      coverage gate.
+- [ ] Web tests for the operator monitor when UI changes land.
+- [ ] Final readiness for implementation PRs: `cargo fmt --all -- --check` and
+      the relevant package tests.
+
+## Rollback Plan
+
+Disable or remove the unblock/retry routes and UI affordances, then revert the
+metadata serialization changes. Because the metadata is additive JSON inside
+workflow instance `data`, rollback does not require a database migration.

--- a/specs/GH1567/tech.md
+++ b/specs/GH1567/tech.md
@@ -68,7 +68,7 @@ Request shape:
 }
 ```
 
-Response shape on success:
+Response shape on success for unblock:
 
 ```json
 {
@@ -76,6 +76,18 @@ Response shape on success:
   "execution_path": "workflow_runtime",
   "workflow_id": "...",
   "previous_state": "blocked",
+  "state": "discovered"
+}
+```
+
+Response shape on success for retry:
+
+```json
+{
+  "status": "retried",
+  "execution_path": "workflow_runtime",
+  "workflow_id": "...",
+  "previous_state": "failed",
   "state": "discovered"
 }
 ```
@@ -106,17 +118,21 @@ existing runtime merge/cancel.
   operator-approved.
 - Must reject non-retryable `error_kind` values such as `fatal` and
   `configuration` unless the request explicitly includes a force flag and a
-  follow-up spec approves that force behavior. The first implementation should
-  omit force retry.
+  follow-up spec approves that force behavior.
+- If `error_kind` is missing or null, such as in legacy failed workflows created
+  before this feature, treat the workflow as retryable by default and rely on
+  the operator-supplied reason plus the next runtime result to record fresh
+  evidence. The first implementation should omit force retry.
 
 `cancelled`:
 
 - No action in the first implementation. Return `409 Conflict` with the current
   state if called on a cancelled workflow.
 
-Both actions must insert a workflow event or decision record that includes the
-operator-supplied reason, previous state, next state, and actor/source
-identifier available from the existing auth layer.
+Both actions must execute the state update and audit write inside one database
+transaction. The transaction must insert a workflow event or decision record
+that includes the operator-supplied reason, previous state, next state, and
+actor/source identifier available from the existing auth layer.
 
 ### Coverage Gate Behavior
 
@@ -131,9 +147,12 @@ without operator intent would violate the conservative default.
 
 ### API And Dashboard Exposure
 
-Add the structured reason fields to runtime tree nodes and operator monitor
-stuck-workflow rows. The React operator monitor should display the reason and a
-compact action affordance only when the API reports the action is allowed.
+Add the structured reason fields to runtime tree nodes, operator monitor
+`StuckWorkflow` rows, and `OperatorAction` rows. The serialized fields should
+include `blocked_reason`, `unblock_hint`, `failure_reason`, `retry_hint`,
+`last_stop`, and action eligibility booleans such as `can_unblock` and
+`can_retry`. The React operator monitor should display the reason and a compact
+action affordance only when the API reports the action is allowed.
 
 The UI implementation should call the new runtime action routes and refresh the
 operator monitor/runtime tree after success. It should not infer action


### PR DESCRIPTION
## Summary
- add the GH-1567 product, tech, and task spec packet
- split the operator unblock/retry work into small implementation tranches
- document the body-based runtime action route choice and conservative coverage-gate behavior

## Verification
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1567
- python3 checks/route_gate.py --repo . --route implement --issue 1567 --state ready_to_implement --json
- cargo fmt --all -- --check
- git diff --check

Issue: #1567