### PR TITLE
Add minimal GitHub consumer example

### DIFF
--- a/examples/github/.github/ISSUE_TEMPLATE/specrail_feature.md
+++ b/examples/github/.github/ISSUE_TEMPLATE/specrail_feature.md
@@ -1,0 +1,37 @@
+---
+name: SpecRail Feature
+about: Propose issue-first work that may need a spec packet
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Problem
+
+What user or maintainer problem should this solve?
+
+## Search Evidence
+
+List related issues, PRs, docs, or code paths already checked.
+
+## Desired Outcome
+
+Describe the behavior users should see when this is done.
+
+## Non-Goals
+
+List work that should stay out of scope.
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+
+## Readiness
+
+Maintainers choose one readiness state before implementation:
+
+- `needs_info`
+- `ready_to_spec`
+- `ready_to_implement`
+- `reserved_internal`

--- a/examples/github/.github/pull_request_template.md
+++ b/examples/github/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+# Summary
+
+Describe the change in 1-3 sentences.
+
+## Linked Work
+
+- Issue:
+- Spec packet:
+
+## Readiness
+
+- [ ] The linked issue is ready for this route, or this is a documented small docs/test fix.
+- [ ] Product and tech specs are linked when the change needs a spec.
+- [ ] Security-sensitive work was handled through the repository's private process.
+
+## Review
+
+- [ ] Reviewers can map each acceptance criterion to changed files or evidence.
+- [ ] Actionable review threads are addressed.
+- [ ] Human final review is requested before merge when the repository requires it.
+
+## Verification
+
+- [ ] `python3 checks/check_workflow.py --repo .`
+- [ ] Spec packet check, when applicable:
+      `python3 checks/check_workflow.py --repo . --spec-dir specs/GH<number>`
+- [ ] Project-specific tests:
+
+## Release Notes
+
+- [ ] Not user-visible.
+- [ ] Changelog or release note needed.

--- a/examples/github/.github/workflows/specrail-check.yml
+++ b/examples/github/.github/workflows/specrail-check.yml
@@ -25,8 +25,14 @@ jobs:
       - name: Check workflow pack
         run: python3 checks/check_workflow.py --repo .
 
-      - name: Check sample spec packet
-        run: python3 checks/check_workflow.py --repo . --spec-dir specs/GH1
+      - name: Check spec packets
+        run: |
+          set -euo pipefail
+          for spec_dir in specs/GH*/; do
+            if [ -d "$spec_dir" ]; then
+              python3 checks/check_workflow.py --repo . --spec-dir "${spec_dir%/}"
+            fi
+          done
 
       - name: Check committed whitespace
         run: |

--- a/examples/github/.github/workflows/specrail-check.yml
+++ b/examples/github/.github/workflows/specrail-check.yml
@@ -1,0 +1,40 @@
+name: specrail-check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  specrail-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Check workflow pack
+        run: python3 checks/check_workflow.py --repo .
+
+      - name: Check sample spec packet
+        run: python3 checks/check_workflow.py --repo . --spec-dir specs/GH1
+
+      - name: Check committed whitespace
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff --check "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
+          elif git rev-parse HEAD^ >/dev/null 2>&1; then
+            git diff --check HEAD^ HEAD
+          else
+            git diff --check
+          fi

--- a/examples/github/README.md
+++ b/examples/github/README.md
@@ -1,11 +1,37 @@
-# GitHub Example
+# GitHub Consumer Example
 
-This directory is reserved for a minimal consumer example that adopts
-SpecRail without depending on a hosted bot or a specific agent runtime.
+This directory is a minimal GitHub setup for a repository that adopts a
+SpecRail-style workflow without relying on hosted bots or a specific agent
+runtime. Copy the files from this example into the root of a repository that
+already carries the SpecRail workflow pack files and `checks/check_workflow.py`.
 
-The first example should demonstrate:
+## Included Files
 
-- issue templates
-- pull request template
-- read-only workflow check
-- spec packet layout
+| Path | Purpose |
+| --- | --- |
+| `.github/ISSUE_TEMPLATE/specrail_feature.md` | Captures the problem, search evidence, acceptance criteria, and maintainer readiness state for issue-first work. |
+| `.github/pull_request_template.md` | Records linked issue/spec packet, readiness checks, review checks, and verification evidence. |
+| `.github/workflows/specrail-check.yml` | Runs read-only SpecRail validation and whitespace checks in GitHub Actions. |
+| `specs/GH1/product.md` | Sample product spec layout for a linked GitHub issue. |
+| `specs/GH1/tech.md` | Sample technical plan layout. |
+| `specs/GH1/tasks.md` | Sample task checklist with stable task IDs. |
+
+## How To Use
+
+1. Copy `.github/`, `specs/`, and the SpecRail workflow pack files into the
+   adopting repository.
+2. Keep issue numbers aligned with spec packet directories, such as
+   `specs/GH123/` for issue `#123`.
+3. Keep the workflow read-only. It validates committed files and does not post
+   comments, change labels, approve PRs, or call an agent runtime.
+4. For each new numbered spec packet, run:
+
+```bash
+python3 checks/check_workflow.py --repo . --spec-dir specs/GH<number>
+```
+
+Run the pack-level check before opening a PR:
+
+```bash
+python3 checks/check_workflow.py --repo .
+```

--- a/examples/github/specs/GH1/product.md
+++ b/examples/github/specs/GH1/product.md
@@ -1,0 +1,41 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1
+
+## User Problem
+
+Contributors need a small, repeatable example of how to turn a GitHub issue
+into a spec packet before implementation starts.
+
+## Goals
+
+- Show the minimum product-facing sections expected in a spec packet.
+- Keep acceptance criteria visible and testable.
+- Keep the example independent of any hosted bot or agent runtime.
+
+## Non-Goals
+
+- No production code changes.
+- No automated labeling, approval, commenting, or merging.
+
+## User-Visible Behavior
+
+Maintainers can review the issue and spec packet using normal GitHub review
+tools and the read-only workflow check.
+
+## Acceptance Criteria
+
+- [ ] The linked issue describes the problem and readiness state.
+- [ ] The product spec describes goals, non-goals, behavior, and criteria.
+- [ ] The technical spec and task plan explain implementation and verification.
+
+## Edge Cases
+
+- The issue is not ready for implementation yet.
+- The spec packet needs more context before code changes are safe.
+
+## Rollout Notes
+
+Copy this layout and replace `GH-1` with the real linked issue number.

--- a/examples/github/specs/GH1/tasks.md
+++ b/examples/github/specs/GH1/tasks.md
@@ -1,0 +1,30 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1
+
+## Spec Packet
+
+- Product: `specs/GH1/product.md`
+- Tech: `specs/GH1/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1-T001` Owner: `docs` | Done when: the issue template, PR template, workflow check, and spec packet layout are copied into the adopting repository | Verify: `python3 checks/check_workflow.py --repo .`
+- [ ] `SP1-T002` Owner: `maintainer` | Done when: the linked issue readiness state is recorded before implementation begins | Verify: reviewer checks the issue readiness section
+
+## Parallelization
+
+Template review and spec packet review can run in parallel because they touch
+different files.
+
+## Verification
+
+- `python3 checks/check_workflow.py --repo .`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1`
+
+## Handoff Notes
+
+Replace the sample issue number, owners, and verification commands before using
+this packet for real work.

--- a/examples/github/specs/GH1/tech.md
+++ b/examples/github/specs/GH1/tech.md
@@ -1,0 +1,52 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1
+
+## Product Spec
+
+`specs/GH1/product.md`
+
+## Current System
+
+The adopting repository already has GitHub issues, pull requests, and the
+SpecRail workflow pack.
+
+## Proposed Design
+
+Keep the change scoped to the linked issue. Add only the files needed to satisfy
+the acceptance criteria, and keep generated or optional automation out of the
+first PR unless the issue explicitly requires it.
+
+## Data Flow
+
+GitHub stores the issue, pull request, checks, reviews, and final merge state.
+The workflow check reads committed files and reports pass or fail without
+writing labels, comments, or approvals.
+
+## Alternatives Considered
+
+- Implementing directly from issue text. Rejected when the change needs a spec
+  because the acceptance criteria should be reviewed before code changes.
+- Using a hosted bot. Rejected for this minimal example because GitHub Actions
+  can run the read-only checks.
+
+## Risks
+
+- Security: keep secrets out of issue text, specs, workflow logs, and PR
+  templates.
+- Compatibility: repository-specific checks may need additional commands.
+- Performance: keep the default workflow check lightweight and read-only.
+- Maintenance: update the sample if the local SpecRail pack changes its
+  required sections.
+
+## Test Plan
+
+- [ ] Run `python3 checks/check_workflow.py --repo .`.
+- [ ] Run `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1`.
+- [ ] Run project-specific tests named in the task plan.
+
+## Rollback Plan
+
+Revert the PR that introduced the spec packet or workflow example.


### PR DESCRIPTION
## Summary

- Replace the placeholder GitHub example with a copyable SpecRail consumer skeleton.
- Add a minimal issue template, pull request template, read-only workflow check, and sample `specs/GH1` packet.
- Keep the example independent of hosted bots and agent runtimes.

Fixes #1568

## Verification

- `python -m pytest tests/test_evaluate.py` *(environment note: local `python` executable is unavailable)*
- `uv run --with pytest python -m pytest tests/test_evaluate.py`
- `python3 checks/check_workflow.py --repo .`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
