### PR TITLE
Persist runtime stop metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ascii-canvas"
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/harness-workflow/src/runtime/candidate_promotion.rs
+++ b/crates/harness-workflow/src/runtime/candidate_promotion.rs
@@ -330,6 +330,10 @@ fn candidate_promotion_failure_decision_inner(
         Ok(decision) => Ok(decision),
         Err(CandidatePromotionPlanError::NoPromotableCandidate) => {
             let reason = "candidate PR promotion failed for all succeeded candidates";
+            let mut payload = failed_candidate_promotion_payload(reason, event, result);
+            if let Some(object) = payload.as_object_mut() {
+                object.insert("failed_promotions".to_string(), json!(failures));
+            }
             Ok(WorkflowDecision::new(
                 &instance.id,
                 &instance.state,
@@ -340,11 +344,7 @@ fn candidate_promotion_failure_decision_inner(
             .with_command(WorkflowCommand::new(
                 WorkflowCommandType::MarkFailed,
                 format!("candidate-promotion:{}:all-failed", event.id),
-                json!({
-                    "reason": reason,
-                    "activity": result.activity,
-                    "failed_promotions": failures,
-                }),
+                payload,
             ))
             .with_evidence(WorkflowEvidence::new(
                 CANDIDATE_SELECTION_RECORD_TYPE,
@@ -354,6 +354,35 @@ fn candidate_promotion_failure_decision_inner(
         }
         Err(error) => Err(error.into()),
     }
+}
+
+fn failed_candidate_promotion_payload(
+    reason: &str,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Value {
+    let mut payload = json!({
+        "reason": reason,
+        "failure_reason": reason,
+        "activity": result.activity,
+        "retry_hint": "Fix the candidate promotion failures, then call the workflow runtime retry API.",
+        "last_stop": {
+            "state": "failed",
+            "activity": result.activity,
+            "runtime_job_id": event.event.get("runtime_job_id").and_then(Value::as_str),
+            "event_id": event.id,
+            "recorded_at": event.created_at,
+        },
+    });
+    if let Some(error_kind) = result.error_kind {
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("error_kind".to_string(), json!(error_kind));
+        }
+        if let Some(last_stop) = payload.get_mut("last_stop").and_then(Value::as_object_mut) {
+            last_stop.insert("error_kind".to_string(), json!(error_kind));
+        }
+    }
+    payload
 }
 
 fn promote_candidate_command(
@@ -635,6 +664,25 @@ mod tests {
         assert_eq!(
             decision.commands[0].command["promotion_chain"][0]["to_candidate_id"],
             "wf-1:candidate-group:issue-1449:c2"
+        );
+        let final_decision = candidate_promotion_failure_decision_inner(
+            &issue_instance(),
+            &event(decision.commands[0].clone()),
+            &result,
+            &decision.commands[0],
+        )?;
+        assert_eq!(final_decision.decision, "fail_candidate_promotion");
+        assert_eq!(
+            final_decision.commands[0].command["failure_reason"],
+            final_decision.reason
+        );
+        assert_eq!(
+            final_decision.commands[0].command["last_stop"]["state"],
+            "failed"
+        );
+        assert_eq!(
+            final_decision.commands[0].command["last_stop"]["runtime_job_id"],
+            "job-1"
         );
         Ok(())
     }

--- a/crates/harness-workflow/src/runtime/candidate_promotion.rs
+++ b/crates/harness-workflow/src/runtime/candidate_promotion.rs
@@ -330,10 +330,7 @@ fn candidate_promotion_failure_decision_inner(
         Ok(decision) => Ok(decision),
         Err(CandidatePromotionPlanError::NoPromotableCandidate) => {
             let reason = "candidate PR promotion failed for all succeeded candidates";
-            let mut payload = failed_candidate_promotion_payload(reason, event, result);
-            if let Some(object) = payload.as_object_mut() {
-                object.insert("failed_promotions".to_string(), json!(failures));
-            }
+            let payload = failed_candidate_promotion_payload(reason, event, result, &failures);
             Ok(WorkflowDecision::new(
                 &instance.id,
                 &instance.state,
@@ -360,11 +357,13 @@ fn failed_candidate_promotion_payload(
     reason: &str,
     event: &WorkflowEvent,
     result: &ActivityResult,
+    failures: &[CandidatePromotionFailure],
 ) -> Value {
     let mut payload = json!({
         "reason": reason,
         "failure_reason": reason,
         "activity": result.activity,
+        "failed_promotions": failures,
         "retry_hint": "Fix the candidate promotion failures, then call the workflow runtime retry API.",
         "last_stop": {
             "state": "failed",
@@ -375,12 +374,8 @@ fn failed_candidate_promotion_payload(
         },
     });
     if let Some(error_kind) = result.error_kind {
-        if let Some(object) = payload.as_object_mut() {
-            object.insert("error_kind".to_string(), json!(error_kind));
-        }
-        if let Some(last_stop) = payload.get_mut("last_stop").and_then(Value::as_object_mut) {
-            last_stop.insert("error_kind".to_string(), json!(error_kind));
-        }
+        payload["error_kind"] = json!(error_kind);
+        payload["last_stop"]["error_kind"] = json!(error_kind);
     }
     payload
 }

--- a/crates/harness-workflow/src/runtime/reducer/github_issue_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/github_issue_completion.rs
@@ -1,4 +1,6 @@
-use super::support::{event_field_string, non_empty_json_string, runtime_completion_evidence};
+use super::support::{
+    event_field_string, non_empty_json_string, runtime_blocked_command, runtime_completion_evidence,
+};
 use super::{
     GITHUB_ISSUE_PR_DEFINITION_ID, ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL,
     ISSUE_STATE_ARTIFACT, SCOPE_TOO_LARGE_SIGNAL,
@@ -35,12 +37,14 @@ pub(super) fn issue_implementation_missing_result_decision(
             "blocked",
             reason,
         )
-        .with_command(WorkflowCommand::mark_blocked(
+        .with_command(runtime_blocked_command(
             reason,
             format!(
                 "runtime-completion:{}:missing-implementation:block",
                 event.id
             ),
+            event,
+            result,
         ))
         .with_command(WorkflowCommand::new(
             WorkflowCommandType::RequestOperatorAttention,
@@ -91,9 +95,11 @@ pub(super) fn scope_too_large_decision(
             "blocked",
             &reason,
         )
-        .with_command(WorkflowCommand::mark_blocked(
-            reason.clone(),
+        .with_command(runtime_blocked_command(
+            &reason,
             format!("runtime-completion:{}:scope-too-large:block", event.id),
+            event,
+            result,
         ))
         .with_command(WorkflowCommand::new(
             WorkflowCommandType::RequestOperatorAttention,

--- a/crates/harness-workflow/src/runtime/reducer/runtime_failure.rs
+++ b/crates/harness-workflow/src/runtime/reducer/runtime_failure.rs
@@ -1,6 +1,6 @@
 use super::support::{
     event_command_type, event_field_string, event_workflow_command, optional_json_string,
-    runtime_completion_evidence,
+    runtime_blocked_command, runtime_completion_evidence, runtime_failed_command,
 };
 use super::{
     GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID, PR_FEEDBACK_DEFINITION_ID,
@@ -26,9 +26,11 @@ pub(super) fn runtime_blocked_decision(
         "blocked",
         &reason,
     )
-    .with_command(WorkflowCommand::mark_blocked(
+    .with_command(runtime_blocked_command(
         &reason,
         format!("runtime-completion:{}:blocked", event.id),
+        event,
+        result,
     ))
     .with_evidence(runtime_completion_evidence(event, result))
     .high_confidence()
@@ -40,12 +42,6 @@ pub(super) fn runtime_failed_decision(
     result: &ActivityResult,
 ) -> WorkflowDecision {
     let reason = runtime_failure_reason(result, "Runtime activity failed.");
-    let mut command_payload = json!({ "reason": reason.as_str() });
-    if let Some(error_kind) = result.error_kind {
-        if let Some(object) = command_payload.as_object_mut() {
-            object.insert("error_kind".to_string(), json!(error_kind));
-        }
-    }
     WorkflowDecision::new(
         &instance.id,
         &instance.state,
@@ -53,10 +49,11 @@ pub(super) fn runtime_failed_decision(
         "failed",
         &reason,
     )
-    .with_command(WorkflowCommand::new(
-        WorkflowCommandType::MarkFailed,
+    .with_command(runtime_failed_command(
+        &reason,
         format!("runtime-completion:{}:failed", event.id),
-        command_payload,
+        event,
+        result,
     ))
     .with_evidence(runtime_completion_evidence(event, result))
     .high_confidence()

--- a/crates/harness-workflow/src/runtime/reducer/support.rs
+++ b/crates/harness-workflow/src/runtime/reducer/support.rs
@@ -1,6 +1,6 @@
 use crate::runtime::model::{
-    ActivityResult, WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowEvent,
-    WorkflowEvidence, WorkflowInstance,
+    ActivityErrorKind, ActivityResult, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
+    WorkflowEvent, WorkflowEvidence, WorkflowInstance,
 };
 use serde_json::{json, Value};
 
@@ -17,9 +17,11 @@ pub(super) fn invalid_agent_output_blocked_decision(
         "blocked",
         reason,
     )
-    .with_command(WorkflowCommand::mark_blocked(
+    .with_command(runtime_blocked_command(
         reason,
         format!("runtime-completion:{}:invalid-output:block", event.id),
+        event,
+        result,
     ))
     .with_command(WorkflowCommand::new(
         WorkflowCommandType::RequestOperatorAttention,
@@ -115,6 +117,105 @@ pub(super) fn event_workflow_command(event: &WorkflowEvent) -> Option<WorkflowCo
 
 pub(super) fn optional_json_string(value: Option<String>) -> Value {
     value.map(Value::String).unwrap_or(Value::Null)
+}
+
+pub(super) fn runtime_blocked_command(
+    reason: impl Into<String>,
+    dedupe_key: impl Into<String>,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> WorkflowCommand {
+    let reason = reason.into();
+    WorkflowCommand::new(
+        WorkflowCommandType::MarkBlocked,
+        dedupe_key,
+        runtime_blocked_payload(&reason, event, result),
+    )
+}
+
+pub(super) fn runtime_failed_command(
+    reason: impl Into<String>,
+    dedupe_key: impl Into<String>,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> WorkflowCommand {
+    let reason = reason.into();
+    WorkflowCommand::new(
+        WorkflowCommandType::MarkFailed,
+        dedupe_key,
+        runtime_failed_payload(&reason, event, result),
+    )
+}
+
+pub(super) fn runtime_blocked_payload(
+    reason: &str,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Value {
+    json!({
+        "reason": reason,
+        "blocked_reason": reason,
+        "unblock_hint": blocked_unblock_hint(),
+        "last_stop": runtime_stop_metadata("blocked", event, result),
+    })
+}
+
+pub(super) fn runtime_failed_payload(
+    reason: &str,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Value {
+    let mut payload = json!({
+        "reason": reason,
+        "failure_reason": reason,
+        "retry_hint": failed_retry_hint(result.error_kind),
+        "last_stop": runtime_stop_metadata("failed", event, result),
+    });
+    if let Some(error_kind) = result.error_kind {
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("error_kind".to_string(), json!(error_kind));
+        }
+    }
+    payload
+}
+
+fn runtime_stop_metadata(state: &str, event: &WorkflowEvent, result: &ActivityResult) -> Value {
+    let mut metadata = json!({
+        "state": state,
+        "activity": stop_activity_name(event, result),
+        "runtime_job_id": optional_json_string(event_field_string(event, "runtime_job_id")),
+        "event_id": event.id,
+        "recorded_at": event.created_at,
+    });
+    if let Some(error_kind) = result.error_kind {
+        if let Some(object) = metadata.as_object_mut() {
+            object.insert("error_kind".to_string(), json!(error_kind));
+        }
+    }
+    metadata
+}
+
+fn stop_activity_name(event: &WorkflowEvent, result: &ActivityResult) -> String {
+    event_workflow_command(event)
+        .as_ref()
+        .and_then(WorkflowCommand::activity_name)
+        .or_else(|| (!result.activity.trim().is_empty()).then_some(result.activity.as_str()))
+        .or_else(|| event_command_type(event))
+        .unwrap_or("<unknown>")
+        .to_string()
+}
+
+fn blocked_unblock_hint() -> &'static str {
+    "Resolve the blocked condition, then call the workflow runtime unblock API."
+}
+
+fn failed_retry_hint(error_kind: Option<ActivityErrorKind>) -> &'static str {
+    match error_kind {
+        Some(ActivityErrorKind::Fatal | ActivityErrorKind::Configuration) => {
+            "Fix the non-retryable failure before retrying this workflow."
+        }
+        _ => "Fix the transient condition, then call the workflow runtime retry API.",
+    }
 }
 
 pub(super) fn runtime_completion_evidence(

--- a/crates/harness-workflow/src/runtime/reducer/support.rs
+++ b/crates/harness-workflow/src/runtime/reducer/support.rs
@@ -172,9 +172,7 @@ pub(super) fn runtime_failed_payload(
         "last_stop": runtime_stop_metadata("failed", event, result),
     });
     if let Some(error_kind) = result.error_kind {
-        if let Some(object) = payload.as_object_mut() {
-            object.insert("error_kind".to_string(), json!(error_kind));
-        }
+        payload["error_kind"] = json!(error_kind);
     }
     payload
 }
@@ -188,9 +186,7 @@ fn runtime_stop_metadata(state: &str, event: &WorkflowEvent, result: &ActivityRe
         "recorded_at": event.created_at,
     });
     if let Some(error_kind) = result.error_kind {
-        if let Some(object) = metadata.as_object_mut() {
-            object.insert("error_kind".to_string(), json!(error_kind));
-        }
+        metadata["error_kind"] = json!(error_kind);
     }
     metadata
 }

--- a/crates/harness-workflow/src/runtime/tests/retry.rs
+++ b/crates/harness-workflow/src/runtime/tests/retry.rs
@@ -200,7 +200,85 @@ fn runtime_completion_reducer_retries_spawn_failure_when_policy_allows() {
 }
 
 #[test]
-fn runtime_completion_reducer_does_not_retry_fatal_activity_failure() {
+fn runtime_failure_blocked_decision_carries_structured_stop_metadata() {
+    let instance = issue_instance("implementing");
+    let result = ActivityResult {
+        activity: "implement_issue".to_string(),
+        status: ActivityStatus::Blocked,
+        summary: "Implementation is waiting for maintainer approval.".to_string(),
+        artifacts: Vec::new(),
+        signals: Vec::new(),
+        validation: Vec::new(),
+        error: Some("Maintainer approval is required.".to_string()),
+        error_kind: Some(ActivityErrorKind::Configuration),
+    };
+    let event = runtime_completion_event(&instance, "implement_issue", result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("blocked activity should block the workflow");
+
+    assert_eq!(decision.decision, "block_after_runtime_activity");
+    assert_eq!(decision.next_state, "blocked");
+    let command = &decision.commands[0];
+    assert_eq!(
+        command.command["blocked_reason"],
+        "Maintainer approval is required."
+    );
+    assert_eq!(command.command["last_stop"]["state"], "blocked");
+    assert_eq!(command.command["last_stop"]["activity"], "implement_issue");
+    assert_eq!(command.command["last_stop"]["runtime_job_id"], "job-1");
+    assert_eq!(command.command["last_stop"]["error_kind"], "configuration");
+    assert!(command.command["unblock_hint"].as_str().is_some());
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("blocked failure decision should validate");
+}
+
+#[test]
+fn runtime_failure_scope_guard_block_carries_structured_stop_metadata() {
+    let instance = issue_instance("implementing");
+    let result = ActivityResult {
+        activity: "implement_issue".to_string(),
+        status: ActivityStatus::Blocked,
+        summary: "Scope guard rejected the implementation.".to_string(),
+        artifacts: Vec::new(),
+        signals: Vec::new(),
+        validation: Vec::new(),
+        error: None,
+        error_kind: None,
+    }
+    .with_signal(ActivitySignal::new(
+        SCOPE_TOO_LARGE_SIGNAL,
+        json!({
+            "base_ref": "origin/main",
+            "files_changed": 42,
+            "lines_added": 1600,
+            "max_files_changed": 30,
+            "max_lines_added": 1500,
+            "decomposition_skeleton": [{"title": "Split reducer behavior"}]
+        }),
+    ));
+    let event = runtime_completion_event(&instance, "implement_issue", result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("scope guard should block the workflow");
+
+    assert_eq!(decision.decision, "block_scope_too_large");
+    let command = &decision.commands[0];
+    assert_eq!(command.command["blocked_reason"], decision.reason);
+    assert_eq!(command.command["last_stop"]["state"], "blocked");
+    assert_eq!(command.command["last_stop"]["activity"], "implement_issue");
+    assert_eq!(command.command["last_stop"]["runtime_job_id"], "job-1");
+}
+
+#[test]
+fn runtime_failure_does_not_retry_fatal_activity_failure() {
     let instance = issue_instance("implementing").with_data(json!({
         "runtime_retry_policy": {
             "max_failed_activity_retries": 3
@@ -233,6 +311,22 @@ fn runtime_completion_reducer_does_not_retry_fatal_activity_failure() {
     assert_eq!(decision.decision, "fail_after_runtime_activity");
     assert_eq!(decision.next_state, "failed");
     assert_eq!(decision.commands[0].command["error_kind"], "fatal");
+    assert_eq!(
+        decision.commands[0].command["failure_reason"],
+        "repository instructions forbid this operation"
+    );
+    assert_eq!(decision.commands[0].command["last_stop"]["state"], "failed");
+    assert_eq!(
+        decision.commands[0].command["last_stop"]["activity"],
+        "implement_issue"
+    );
+    assert_eq!(
+        decision.commands[0].command["last_stop"]["error_kind"],
+        "fatal"
+    );
+    assert!(decision.commands[0].command["retry_hint"]
+        .as_str()
+        .is_some());
     DecisionValidator::github_issue_pr()
         .validate(
             &instance,

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -427,10 +427,7 @@ fn merge_child_completion_payload(
     payload
 }
 
-/// Persist the terminal-failure `reason` into the instance `data` under
-/// `failure_reason` so task queries surface it as the task `error`. Without
-/// this the reason lives only in the command payload/event log and the task
-/// projection reports `error: null` (silent degradation).
+/// Persist stopped-state metadata into instance data for operator surfaces.
 pub(super) fn apply_failure_reason_side_effect(
     instance: &mut WorkflowInstance,
     command: &WorkflowCommand,
@@ -441,9 +438,14 @@ pub(super) fn apply_failure_reason_side_effect(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|reason| !reason.is_empty());
-    let Some(reason) = reason else {
+    if reason.is_none()
+        && !STOP_STRING_FIELDS
+            .iter()
+            .any(|field| command_string_field(command, field).is_some())
+        && command.command.get("last_stop").is_none()
+    {
         return Ok(());
-    };
+    }
     if !instance.data.is_object() {
         instance.data = json!({});
     }
@@ -451,8 +453,38 @@ pub(super) fn apply_failure_reason_side_effect(
         .data
         .as_object_mut()
         .context("workflow instance data is not an object")?;
-    data.insert("failure_reason".to_string(), json!(reason));
+    if let Some(reason) = reason {
+        data.insert("failure_reason".to_string(), json!(reason));
+        if command.command_type == super::model::WorkflowCommandType::MarkBlocked {
+            data.insert("blocked_reason".to_string(), json!(reason));
+        }
+    }
+    for field in STOP_STRING_FIELDS {
+        if let Some(value) = command_string_field(command, field) {
+            data.insert((*field).to_string(), json!(value));
+        }
+    }
+    if let Some(last_stop) = command.command.get("last_stop") {
+        data.insert("last_stop".to_string(), last_stop.clone());
+    }
     Ok(())
+}
+
+const STOP_STRING_FIELDS: &[&str] = &[
+    "blocked_reason",
+    "unblock_hint",
+    "failure_reason",
+    "retry_hint",
+    "error_kind",
+];
+
+fn command_string_field<'a>(command: &'a WorkflowCommand, field: &str) -> Option<&'a str> {
+    command
+        .command
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
 }
 
 fn runtime_profile_for_job(job: &RuntimeJob) -> anyhow::Result<Option<RuntimeProfile>> {
@@ -716,18 +748,11 @@ mod tests {
 
     #[test]
     fn mark_failed_inline_command_persists_failure_reason_into_data() {
-        use crate::runtime::WorkflowSubject;
-
-        let mut instance = WorkflowInstance::new(
-            "prompt_task",
-            1,
-            "implementing",
-            WorkflowSubject::new("prompt", "1"),
-        );
+        let mut instance = prompt_task_instance();
         let command = WorkflowCommand::new(
             WorkflowCommandType::MarkFailed,
             "runtime-completion:evt-1:failed",
-            json!({ "reason": "Agent turn timed out after 900s" }),
+            json!({ "reason": "Agent turn timed out after 900s", "error_kind": "timeout", "retry_hint": "Retry after route repair.", "last_stop": {"state": "failed", "runtime_job_id": "job-1"} }),
         );
 
         apply_failure_reason_side_effect(&mut instance, &command).unwrap();
@@ -737,26 +762,39 @@ mod tests {
             Some("Agent turn timed out after 900s"),
             "MarkFailed must surface its reason as the queryable failure_reason"
         );
+        assert_eq!(instance.data["error_kind"], "timeout");
+        assert_eq!(instance.data["retry_hint"], "Retry after route repair.");
+        assert_eq!(instance.data["last_stop"]["runtime_job_id"], "job-1");
     }
 
     #[test]
-    fn mark_failed_without_reason_leaves_data_untouched() {
-        use crate::runtime::WorkflowSubject;
-
-        let mut instance = WorkflowInstance::new(
-            "prompt_task",
-            1,
-            "implementing",
-            WorkflowSubject::new("prompt", "1"),
-        );
+    fn mark_blocked_inline_command_persists_stop_metadata_into_data() {
+        let mut instance = prompt_task_instance();
         let command = WorkflowCommand::new(
-            WorkflowCommandType::MarkFailed,
-            "runtime-completion:evt-2:failed",
-            json!({}),
+            WorkflowCommandType::MarkBlocked,
+            "runtime-completion:evt-2:blocked",
+            json!({"reason": "Waiting for maintainer approval.", "unblock_hint": "Post approval, then call unblock.", "last_stop": {"state": "blocked", "runtime_job_id": "job-2"}}),
         );
 
         apply_failure_reason_side_effect(&mut instance, &command).unwrap();
 
-        assert!(instance.data.get("failure_reason").is_none());
+        assert_eq!(
+            instance.data["blocked_reason"],
+            "Waiting for maintainer approval."
+        );
+        assert_eq!(
+            instance.data["unblock_hint"],
+            "Post approval, then call unblock."
+        );
+        assert_eq!(instance.data["last_stop"]["runtime_job_id"], "job-2");
+    }
+
+    fn prompt_task_instance() -> WorkflowInstance {
+        WorkflowInstance::new(
+            "prompt_task",
+            1,
+            "implementing",
+            WorkflowSubject::new("p", "1"),
+        )
     }
 }


### PR DESCRIPTION
## Summary

- Adds structured stopped-state metadata for workflow runtime blocked and failed reducer paths.
- Persists stopped-state fields into workflow instance data for operator-visible surfaces.
- Covers generic blocked/failed paths plus missing-result, scope guard, invalid-output, and candidate-promotion terminal failure paths.

Related: #1567

Refs #1567

## Verification

- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1567
- git diff --check
- cargo fmt --all -- --check
- cargo check -p harness-workflow --all-targets
- cargo test -p harness-workflow runtime_failure
- cargo test -p harness-workflow mark_failed_inline_command_persists_failure_reason_into_data
- cargo test -p harness-workflow mark_blocked_inline_command_persists_stop_metadata_into_data
- cargo test -p harness-workflow candidate_promotion_failure_promotes_runner_up
- cargo clippy --workspace --all-targets -- -D warnings

## Notes

This is the first implementation slice for GH1567. It does not add unblock/retry HTTP routes, coverage-gate redispatch behavior, dashboard actions, or usage-guide documentation.
