### PR TITLE
docs: GH1583 priority aging / anti-starvation spec packet

### DIFF
--- a/specs/GH1583/product.md
+++ b/specs/GH1583/product.md
@@ -1,0 +1,86 @@
+# GH1583 Product Spec: Priority Aging / Anti-Starvation for PriorityPermitQueue
+
+GitHub issue: `#1583`
+
+## Goals
+
+- Bound the wait time of low-priority tasks under sustained high-priority
+  load so unattended maintenance loops (quality scans, GC remediation,
+  learn loops) cannot stall silently.
+- Make queue wait time observable per priority level through the existing
+  queue stats/diagnostics surface.
+- Ship aging ON by default with a conservative slope; `aging off` must
+  preserve today's ordering semantics exactly.
+
+## Non-Goals
+
+- No fix for priority inversion caused by a permit *holder* (a running
+  low-priority task blocking a high-priority waiter) — aging only affects
+  waiters, not preemption.
+- No changes to the priority model itself (`0..=2`, DB column, request
+  validation) or to `max_queue_size` admission.
+- No new external metrics backend; reuse the existing stats/diagnostics
+  path only.
+
+## Users
+
+- Fleet operators running Harness unattended, where background maintenance
+  tasks are submitted at priority 0 while interactive work arrives at 1-2.
+- Dashboard consumers who need to see queue pressure and wait-time
+  distribution per priority level.
+
+## Behavior Invariants
+
+- B-001: With aging enabled, a waiter's effective priority increases by one
+  level per configured `interval_secs` of wait, capped at
+  `base + max_boost_levels` (and never above the maximum priority level).
+- B-002: Under a steady stream of maximum-priority arrivals, a priority-0
+  waiter is granted a permit within the deterministic aging bound
+  (`max_boost_levels * interval_secs` plus one FIFO turn at the capped
+  level) per queue stage, verified with a mocked/paused clock.
+- B-003: With aging disabled (`aging.enabled = false`), grant order is
+  identical to current behavior (priority DESC, FIFO within level) for any
+  arrival sequence; existing ordering tests pass unchanged.
+- B-004: Ties in effective priority (including ties created by aging) break
+  by enqueue sequence — the earlier waiter wins, deterministically.
+- B-005: Aging uses injected/monotonic time (tokio paused-clock compatible);
+  no wall-clock reads, so clock adjustments cannot reorder waiters.
+- B-006: A waiter cancelled mid-wait (future dropped) is never granted a
+  permit by aging, never leaks a permit, and is excluded from wait-time
+  metrics.
+- B-007: Aging applies independently to the project-stage and global-stage
+  queues; the documented end-to-end bound is the sum of both stage bounds.
+- B-008: Queue stats expose per-priority-level wait-time metrics (max and
+  p95 in milliseconds, grant count) for granted waiters, via the existing
+  `QueueStats`/`QueueDiagnostics` surface.
+- B-009: Config defaults are aging ON with a conservative slope; an
+  unconfigured `[concurrency.aging]` section deserializes to those defaults
+  and an existing config file without the section keeps loading.
+- B-010: Invalid aging config (e.g. `interval_secs = 0` with aging enabled)
+  is rejected at config load with an error, not silently clamped.
+
+## Boundary Checklist
+
+| Category | Coverage |
+|---|---|
+| Empty input | covered: B-009 (missing config section), plus empty-queue release path unchanged (B-003) |
+| Failure paths | covered: B-010 (invalid config rejected loudly) |
+| Authorization | N/A + reason: in-process scheduler; no auth boundary — priority validation stays in `execution.rs` request validation |
+| Concurrency | covered: B-002, B-004 (deterministic order under concurrent waiters, paused-clock tests) |
+| Retry + idempotency | covered: B-006 (release/reclaim CAS path unchanged; re-enqueue after cancel gets a fresh enqueue time) |
+| Illegal transitions | covered: B-001 (effective priority monotonically non-decreasing, hard cap; can never exceed max level) |
+| Compatibility | covered: B-003, B-009 (aging off is byte-identical semantics; old config files load) |
+| Degradation / fallback | covered: B-010 (no silent clamp); disabling aging is the explicit operator fallback (B-003) |
+| Evidence / audit | covered: B-008 (wait-time metrics per level on the diagnostics surface) |
+| Cancellation / partial | covered: B-006, B-007 (mid-wait drop at either stage; project permit released as today) |
+
+## Acceptance Criteria
+
+- Deterministic test with the tokio paused clock: a steady high-priority
+  stream cannot delay a low-priority task beyond the configured aging bound
+  (B-002).
+- `aging.enabled = false` reproduces today's ordering exactly; all existing
+  `task_queue_tests.rs` ordering/cancellation tests pass unchanged (B-003).
+- Wait-time metrics (max/p95 per priority level) visible through
+  `project_stats`/`diagnostics` consumers (B-008).
+- Aging is ON by default with conservative slope (B-009).

--- a/specs/GH1583/tasks.md
+++ b/specs/GH1583/tasks.md
@@ -1,0 +1,44 @@
+# GH1583 Task Plan
+
+## Linked Issue
+
+GH-1583
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1583-T001` Owner: `config` | Done when: `PriorityAgingConfig { enabled: true, interval_secs: 300, max_boost_levels: 2 }` lands in `crates/harness-core/src/config/misc.rs`, nested in `ConcurrencyConfig` with `#[serde(default)]`; load-time validation rejects `enabled = true` with `interval_secs = 0`; empty-TOML deserialization keeps defaults | Verify: `cargo test -p harness-core config`
+- [ ] `SP1583-T002` Owner: `queue-core` | Done when: `Waiter` carries `enqueued_at: tokio::time::Instant`; `waiters` becomes `Vec<Waiter>`; `release()` selects by `(effective_priority DESC, seq ASC)` via lazy scan with cap `min(base + max_boost_levels, max level)`; `drain_cancelled` uses `Vec::retain`; aging-off path selects identically to the current BinaryHeap comparator; all 24 existing `task_queue_tests.rs` tests pass unmodified | Verify: `cargo test -p harness-workflow task_queue`
+- [ ] `SP1583-T003` Owner: `aging-tests` | Done when: paused-clock tests cover B-001/B-002/B-004/B-006/B-007 — boost-per-interval and cap; steady max-priority stream cannot delay a priority-0 waiter past the per-stage bound; aged tie breaks by seq; cancelled aged waiter never granted and excluded from metrics; two-stage bound documented and asserted; plus `aging_off_matches_legacy_order` (B-003) | Verify: `cargo test -p harness-workflow task_queue`
+- [ ] `SP1583-T004` Owner: `metrics` | Done when: `PriorityPermitQueue` records grant count / max wait / p95 (ring buffer) per base priority level at grant time only; `QueueStats` and `QueueDiagnostics` expose `wait_ms_by_priority` additively; server consumers (`dashboard.rs:165`, `dashboard_active_counts.rs:169`, `misc_routes.rs:118`, `execution.rs:249`) compile unchanged or with additive plumbing | Verify: `cargo test -p harness-workflow task_queue && cargo check -p harness-server`
+- [ ] `SP1583-T005` Owner: `wiring` | Done when: `TaskQueue::new`/`new_with_pressure` thread `ConcurrencyConfig.aging` into the global queue and every lazily created project queue; `TaskQueue::acquire` docs state the per-stage aging bound and that end-to-end bound is the sum of both stages | Verify: `cargo test -p harness-workflow task_queue && cargo check --workspace`
+
+## Parallelization
+
+- `SP1583-T001` (harness-core) and `SP1583-T002` (harness-workflow) touch
+  disjoint crates and can run in parallel; `T002` uses hardcoded aging
+  params in unit scope until `T005` wires config through.
+- `SP1583-T003` and `SP1583-T004` both edit `task_queue.rs`/
+  `task_queue_tests.rs` — keep serial after `T002`.
+- `SP1583-T005` last, after `T001` and `T004`.
+
+## Verification
+
+- `cargo test -p harness-core config`
+- `cargo test -p harness-workflow task_queue`
+- `cargo check --workspace`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+
+## Handoff Notes
+
+Aging ships ON by default with a conservative slope (300s per level, cap
++2). If field reports show unwanted reordering, the operator fallback is
+`[concurrency.aging] enabled = false`, which restores today's semantics
+exactly (B-003) — record any such downgrade decision in this packet.
+Priority inversion by permit holders remains out of scope; if it recurs,
+open a separate issue rather than widening this one.

--- a/specs/GH1583/tech.md
+++ b/specs/GH1583/tech.md
@@ -50,13 +50,22 @@ GitHub issue: `#1583`
 ### Aging function
 
 ```text
+waited = now.saturating_duration_since(w.enqueued_at)
 effective_priority(w, now) =
-    min(w.priority + floor((now - w.enqueued_at) / interval), 
+    min(w.priority + floor(waited / interval),
         min(w.priority + max_boost_levels, MAX_LEVEL))
 ```
 
-- `MAX_LEVEL` is the queue-local max observed level ceiling (u8 space; the
-  server already caps requests at 2, the queue stays generic).
+- `MAX_LEVEL` is a static ceiling fixed at queue construction (the server
+  passes `MAX_TASK_PRIORITY`, `request.rs:9`; the queue stays generic over
+  u8). It is deliberately NOT derived from currently-enqueued waiters: a
+  dynamic observed ceiling would decrease when a high-priority waiter is
+  granted and leaves the queue, making effective priority non-monotonic
+  over wait time and violating B-001.
+- `saturating_duration_since` guards the `Instant` subtraction: a waiter
+  whose `enqueued_at` races ahead of the single `now` read in `release()`
+  (concurrent enqueue, paused-clock test anomalies) contributes zero wait
+  instead of panicking on `Instant` underflow.
 - Ordering key: `(effective_priority DESC, seq ASC)`. Aged-equal ties break
   by seq, so a long-waiting priority-0 waiter beats a fresh same-level
   arrival deterministically (B-004).
@@ -91,9 +100,15 @@ instants — same constraint the tests already satisfy.
 ### Wait-time metrics
 
 - `PriorityPermitQueue` gains a small per-base-priority-level aggregate:
-  grant count, max wait, and a fixed ring buffer (e.g. 128 samples) for p95,
-  recorded in `release()` at grant time (successful `tx.send`). Cancelled
-  waiters and CAS-reclaimed sends are excluded (B-006).
+  grant count, max wait, and a fixed ring buffer (e.g. 128 samples) for p95.
+  Recording happens on the waiter side, after `rx.await` resolves and the
+  grant is actually consumed — not in `release()` at `tx.send` time. This
+  closes the mid-send race: if a waiter is cancelled after `tx.send`
+  succeeds but before `rx.await` completes, the permit is CAS-reclaimed by
+  `AcquireGuard::drop` and no sample is ever recorded for that waiter, so
+  cancelled and reclaimed grants are structurally excluded (B-006) rather
+  than filtered after the fact. The waiter records via the shared queue
+  handle it already holds.
 - `QueueStats` gains `wait_ms_by_priority: Vec<PriorityWaitStats>` with
   `#[serde(default)]`-safe additive fields (`QueueStats` derives
   `Serialize` only, so consumers at `dashboard.rs:165`,

--- a/specs/GH1583/tech.md
+++ b/specs/GH1583/tech.md
@@ -1,0 +1,179 @@
+# GH1583 Tech Spec: Priority Aging / Anti-Starvation for PriorityPermitQueue
+
+Product spec: `specs/GH1583/product.md`
+GitHub issue: `#1583`
+
+## Codebase Context (verified anchors)
+
+- `crates/harness-workflow/src/task_queue.rs:122-126` —
+  `PriorityPermitQueue { available, next_seq, waiters: BinaryHeap<Waiter> }`.
+- `crates/harness-workflow/src/task_queue.rs:68-109` — `Waiter { priority: u8,
+  seq: u64, tx, permit_granted, cancelled }` with `Ord` = priority DESC,
+  seq ASC (FIFO within level).
+- `crates/harness-workflow/src/task_queue.rs:117-121` — doc comment naming
+  priority inversion and low-priority starvation as unhandled follow-ups
+  (this issue).
+- `crates/harness-workflow/src/task_queue.rs:143-162` —
+  `try_acquire_or_enqueue(priority)` pushes a `Waiter` when no slot is free.
+- `crates/harness-workflow/src/task_queue.rs:171-221` — `release()` pops the
+  top waiter, skips `cancelled` entries, CAS-reclaims on failed send.
+- `crates/harness-workflow/src/task_queue.rs:231-234` — `drain_cancelled()`
+  (`BinaryHeap::retain`).
+- `crates/harness-workflow/src/task_queue.rs:539-638` — two-stage
+  `TaskQueue::acquire(project_id, priority)`: project queue first, then
+  global; cancellation-safe via `AcquireGuard` (`:283-402`).
+- `crates/harness-workflow/src/task_queue.rs:15-23, 694-757` — `QueueStats`
+  (Serialize), `diagnostics()`, `project_stats()`.
+- `crates/harness-workflow/src/task_queue_tests.rs` — 625 lines; ordering
+  tests `high_priority_acquired_before_low_when_slots_full` (`:251`),
+  `same_priority_is_fifo` (`:287`); cancellation tests (`:351-513`); all
+  timing tests use `#[tokio::test(start_paused = true)]` (paused clock).
+  `tokio = { features = ["test-util"] }` already in dev-deps
+  (`crates/harness-workflow/Cargo.toml:34`).
+- `crates/harness-core/src/config/misc.rs:110-158` — `ConcurrencyConfig`
+  with serde defaults (`:160-197`); target home for the aging sub-config.
+- Priority origin: `crates/harness-server/src/task_runner/request.rs:9`
+  (`MAX_TASK_PRIORITY = 2`), `crates/harness-server/src/task_runner/state.rs:311-314`
+  (`pub priority: u8`, 0=normal 1=high 2=critical), validated at
+  `crates/harness-server/src/services/execution.rs:367-371`, passed to
+  `queue.acquire(...)` at `execution.rs:1095` and `execution.rs:1193`.
+  DB column: migration v12 at
+  `crates/harness-server/src/task_db/migrations.rs:101-102`.
+- Stats consumers: `crates/harness-server/src/handlers/dashboard.rs:165`,
+  `crates/harness-server/src/handlers/dashboard_active_counts.rs:169`,
+  `crates/harness-server/src/http/misc_routes.rs:118`, and admission-failure
+  logging via `diagnostics()` at
+  `crates/harness-server/src/services/execution.rs:249`.
+
+## Proposed Design
+
+### Aging function
+
+```text
+effective_priority(w, now) =
+    min(w.priority + floor((now - w.enqueued_at) / interval), 
+        min(w.priority + max_boost_levels, MAX_LEVEL))
+```
+
+- `MAX_LEVEL` is the queue-local max observed level ceiling (u8 space; the
+  server already caps requests at 2, the queue stays generic).
+- Ordering key: `(effective_priority DESC, seq ASC)`. Aged-equal ties break
+  by seq, so a long-waiting priority-0 waiter beats a fresh same-level
+  arrival deterministically (B-004).
+
+### Data-structure change: BinaryHeap -> Vec with lazy scan
+
+`BinaryHeap` ordering is fixed at push time, but aging makes the key
+time-varying, silently invalidating the heap invariant. Replace
+`waiters: BinaryHeap<Waiter>` with `Vec<Waiter>` and select the winner in
+`release()` via a linear max-scan using `effective_priority(now)`.
+`waiters.len()` is bounded by `max_queue_size` (default 32,
+`misc.rs:164-166`), so O(n) per release is negligible against permit
+lifetimes (task executions). `drain_cancelled()` becomes `Vec::retain`
+(same semantics). With aging disabled, the scan key is exactly
+`(priority DESC, seq ASC)` — the current comparator — so grant order is
+unchanged (B-003).
+
+### Clock
+
+`Waiter` gains `enqueued_at: tokio::time::Instant` captured in
+`try_acquire_or_enqueue`. `tokio::time::Instant` is monotonic and obeys the
+paused test clock (`start_paused = true`), giving deterministic aging tests
+via `tokio::time::advance` (B-005). `release()` reads `Instant::now()` once
+per call and passes it to the comparator. No `std::time::SystemTime`
+anywhere in the queue.
+
+Note: `release()` is also called from `Drop` impls
+(`task_queue.rs:58-64, 336-402`); `tokio::time::Instant::now()` is a plain
+read, safe outside an async context as long as a runtime created the
+instants — same constraint the tests already satisfy.
+
+### Wait-time metrics
+
+- `PriorityPermitQueue` gains a small per-base-priority-level aggregate:
+  grant count, max wait, and a fixed ring buffer (e.g. 128 samples) for p95,
+  recorded in `release()` at grant time (successful `tx.send`). Cancelled
+  waiters and CAS-reclaimed sends are excluded (B-006).
+- `QueueStats` gains `wait_ms_by_priority: Vec<PriorityWaitStats>` with
+  `#[serde(default)]`-safe additive fields (`QueueStats` derives
+  `Serialize` only, so consumers at `dashboard.rs:165`,
+  `dashboard_active_counts.rs:169`, `misc_routes.rs:118` get the new field
+  additively). `QueueDiagnostics` gains the same for the global queue,
+  surfacing in admission-failure logs (`execution.rs:249`).
+
+### Config (harness-core)
+
+New struct in `crates/harness-core/src/config/misc.rs`, nested in
+`ConcurrencyConfig` following the existing serde-default pattern:
+
+```toml
+[concurrency.aging]
+enabled = true          # default ON
+interval_secs = 300     # +1 effective level per 300s waited (conservative)
+max_boost_levels = 2    # cap: base + 2, never above max level
+```
+
+`ConcurrencyConfig` gains `#[serde(default)] pub aging: PriorityAgingConfig`
+so existing config files load unchanged (B-009). Config validation rejects
+`enabled = true` with `interval_secs = 0` at load with an error (B-010) —
+no silent clamp (U-29). `TaskQueue::new` threads the aging parameters into
+each `PriorityPermitQueue` it creates (project queues created lazily at
+`task_queue.rs:497-505` receive the same parameters).
+
+## Edge Cases
+
+- **Aging + cancellation**: a cancelled waiter is skipped by the scan
+  regardless of aged priority; `drain_cancelled` unchanged in effect. A
+  caller that retries `acquire` after cancel gets a fresh `enqueued_at`
+  (no wait-time carryover) — documented, intentional.
+- **Aging + per-project vs global**: the two stages age independently;
+  end-to-end bound = sum of stage bounds (B-007). Documented on
+  `TaskQueue::acquire`.
+- **Ties after aging**: strictly `(effective DESC, seq ASC)`; no randomness.
+- **`reconfigure_capacity` / `set_project_limit`**: orthogonal — aging
+  parameters are per-queue constants, capacity changes untouched.
+- **Boost overflow**: u8 saturating arithmetic; cap applied before compare.
+
+## Compatibility
+
+- `aging.enabled = false` short-circuits `effective_priority` to the base
+  priority; the Vec max-scan with key `(priority DESC, seq ASC)` selects the
+  same waiter the BinaryHeap pop selects today for every sequence (B-003).
+- All existing tests in `task_queue_tests.rs` must pass without
+  modification (aging defaults do not alter any existing test because those
+  tests never advance the paused clock past `interval_secs`).
+- Additive `Serialize` fields only; no field removed or renamed on
+  `QueueStats`/`QueueDiagnostics` (dashboard JSON stays a superset).
+
+## Product-to-Test Mapping
+
+| Invariant | Implementation area | Verification |
+|---|---|---|
+| B-001 | `effective_priority` fn, `task_queue.rs` | `cargo test -p harness-workflow task_queue` (unit test: boost per interval, cap) |
+| B-002 | `release()` scan + paused clock | `cargo test -p harness-workflow task_queue` (test: `aged_low_priority_not_starved_beyond_bound`) |
+| B-003 | scan comparator with aging off | `cargo test -p harness-workflow task_queue` (existing `high_priority_acquired_before_low_when_slots_full`, `same_priority_is_fifo` unchanged + new `aging_off_matches_legacy_order`) |
+| B-004 | tie-break by seq | `cargo test -p harness-workflow task_queue` (test: aged tie resolves to earlier seq) |
+| B-005 | `tokio::time::Instant` only | `cargo test -p harness-workflow task_queue` (all aging tests use `start_paused`) + `rg -n "SystemTime|Utc::now" crates/harness-workflow/src/task_queue.rs` returns nothing |
+| B-006 | cancelled-skip in scan, metrics exclusion | `cargo test -p harness-workflow task_queue` (extend `cancelled_project_wait_does_not_leak_queued_count` family with aging on) |
+| B-007 | two-stage acquire docs + test | `cargo test -p harness-workflow task_queue` (test: bound holds per stage with both queues contended) |
+| B-008 | `QueueStats`/`QueueDiagnostics` fields | `cargo test -p harness-workflow task_queue` (stats assertions) + `cargo check -p harness-server` (consumers compile) |
+| B-009 | `PriorityAgingConfig` serde defaults | `cargo test -p harness-core config` (empty-TOML deserialization test, mirrors `misc.rs:770`) |
+| B-010 | config load validation | `cargo test -p harness-core config` (invalid `interval_secs = 0` returns error) |
+
+## Verification Plan
+
+- `cargo test -p harness-workflow task_queue` — full queue suite (existing
+  24 tests + new aging tests), all deterministic via paused clock, no
+  wall-clock sleeps.
+- `cargo test -p harness-core config` — config defaults + validation.
+- `cargo check --workspace` then
+  `cargo clippy --workspace --all-targets -- -D warnings` (CI parity).
+
+## Rollback
+
+- Operator rollback: set `[concurrency.aging] enabled = false` — restores
+  current ordering semantics exactly with no redeploy of data (no schema or
+  DB change in this issue).
+- Code rollback: single-PR revert; the only cross-crate surface is the
+  additive config struct and additive stats fields, so a revert cannot
+  break config files or dashboard consumers.


### PR DESCRIPTION
## Summary

Spec packet for #1583 — priority aging / anti-starvation in `PriorityPermitQueue`.

- `specs/GH1583/product.md` — behavior invariants (B-001..) + boundary checklist: bounded low-priority wait under sustained high-priority load, deterministic tie-breaking, injected/monotonic time only, cancelled-waiter safety, `aging off` preserves current ordering exactly.
- `specs/GH1583/tech.md` — verified anchors into `crates/harness-workflow/src/task_queue.rs` (documented starvation follow-up at `task_queue.rs:117-121`), config placement, full Product-to-Test Mapping.
- `specs/GH1583/tasks.md` — `SP1583-Txxx` plan with per-task verify commands.

## Open questions for review

1. Ordering structure: spec proposes replacing the BinaryHeap with a bounded Vec + lazy max-scan since aging makes the ordering key time-varying — vs. periodic re-heapify.
2. The aging bound is per queue stage (per-project + global), so the end-to-end bound is the sum of stages; spec documents this explicitly — confirm intent.
3. Wait-time percentiles use a fixed 128-sample ring buffer (p95), not full percentile export.

Docs-only PR; no code changes.

Closes nothing (spec packet only; implementation tracked by #1583 tasks).