### PR TITLE
docs: GH1584 auto-recovery policy spec packet

### DIFF
--- a/specs/GH1584/product.md
+++ b/specs/GH1584/product.md
@@ -1,0 +1,139 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1584
+
+## User Problem
+
+GH-1567 gave operators an escape hatch (`POST /api/workflows/runtime/unblock`
+and `/retry`) for `blocked` and `failed` workflow-runtime instances, with
+structured stop reasons. Recovery is intentionally conservative: every stopped
+workflow waits for a human, even when the block reason is transient and
+machine-recheckable — a GitHub rate limit that expires, a CI backend outage
+that heals, merge-base drift that a rebase already resolved, or a runtime
+circuit-breaker cooldown that has elapsed. Operators end up performing rote
+recheck-and-unblock actions that a bounded, audited policy could perform for
+them, while genuinely terminal blocks (maintainer approval needed, fatal or
+configuration failures) must keep waiting for a human forever.
+
+## Goals
+
+1. Classify structured stop reasons into `transient` (auto-recheckable) and
+   `terminal` (operator-only), extending the GH-1567 reason taxonomy.
+2. Provide a per-repo, default-OFF auto-recovery policy: transient reasons get
+   bounded rechecks (max attempts, exponential backoff, jitter); a successful
+   recheck re-runs exactly the same eligibility path as a manual unblock/retry.
+3. Record every automatic recheck and recovery as an audit event (reason
+   class, attempt count, outcome) before the recovery takes effect.
+4. When attempts are exhausted, escalate exactly like today: the workflow
+   stays stopped for the operator monitor, and an escalation event is emitted
+   for alerting once GH-1582 lands.
+5. Terminal reasons never auto-recover, regardless of configuration.
+
+## Non-Goals
+
+- No change to the manual unblock/retry API contract shipped by GH-1567.
+- No auto-recovery for `cancelled` workflows.
+- No force-retry of non-retryable `error_kind` values (`fatal`,
+  `configuration`).
+- No alerting transport in this issue — escalation emits events that GH-1582
+  consumes.
+- No global default-ON mode; policy is opt-in per repository.
+
+## Testable Invariants
+
+- B-001: Every structured stop reason maps to exactly one reason class,
+  `transient` or `terminal`, via a single classification function; the same
+  classifier is used by the scheduler, the API serialization, and the audit
+  events.
+- B-002: A stop reason that is missing, empty, unknown, or unclassifiable is
+  classified `terminal` (fail closed). It is never auto-rechecked, and the
+  classification decision itself is visible in the API payload.
+- B-003: With auto-recovery disabled (global default, or repo not opted in),
+  no automatic recheck, unblock, or retry ever occurs; runtime behavior is
+  byte-identical to GH-1567 semantics.
+- B-004: With auto-recovery enabled for a repo, only workflows whose active
+  stop reason classifies as `transient` are ever scheduled for recheck.
+- B-005: A successful automatic recheck transitions the instance through the
+  same recovery function as the manual operator action (same target state
+  `planning`, same plan-activity re-enqueue, same `last_stop` evidence
+  preservation, same active-stop-field clearing), differing only in the
+  recorded actor/source and reason text.
+- B-006: The number of automatic recovery attempts per stopped instance never
+  exceeds the configured `max_attempts`; the attempt counter is persisted in
+  the workflow instance data and survives server restart.
+- B-007: Recheck scheduling uses exponential backoff with jitter; the next
+  eligible recheck time is persisted, so a server restart neither resets the
+  backoff to zero nor causes an immediate recheck burst.
+- B-008: For every automatic recheck attempt, an audit event containing the
+  reason class, attempt number, and outcome is appended to the workflow event
+  log BEFORE the state transition is committed. There is no reachable state
+  in which an instance was auto-recovered but no audit event exists.
+- B-009: An automatic recheck that loses a race with a concurrent manual
+  operator unblock/retry (or any other state change) observes the changed
+  state, records the attempt outcome as `superseded`, performs no transition,
+  and does not consume the instance as double-recovered. Exactly one recovery
+  transition is committed per stop episode.
+- B-010: When attempts are exhausted, the instance remains in its stopped
+  state, appears in the operator monitor exactly as an unrecovered GH-1567
+  instance does, and a single `AutoRecoveryExhausted` escalation event is
+  emitted (consumable by GH-1582 alerting). Exhaustion never deletes or masks
+  stop evidence.
+- B-011: A fresh stop episode (the instance re-enters `blocked` or `failed`
+  after a successful recovery) resets the attempt counter; attempts are
+  counted per stop episode, not per instance lifetime.
+- B-012: Terminal-classified reasons are never auto-recovered even if a
+  configuration file, environment override, or API request attempts to force
+  it; the only recovery path for terminal reasons is the manual operator API.
+- B-013: Manual unblock/retry remains available and unchanged for both reason
+  classes at all times, including while a recheck is pending or backoff is in
+  progress.
+- B-014: Instances created before this feature (no reason-class field, legacy
+  free-text reasons) are treated as `terminal` and never auto-recovered; the
+  API tolerates the missing fields without fabricating a class.
+- B-015: A recheck whose transient condition still holds (recheck fails)
+  records the failed attempt with its evidence, increments the counter, and
+  reschedules with increased backoff; it performs no state transition.
+- B-016: Config validation rejects nonsensical policy values (zero or negative
+  `max_attempts` when enabled, backoff ceiling below floor, jitter ratio
+  outside [0, 1]) at startup rather than at recheck time.
+
+## Boundary Checklist
+
+| Category | Coverage |
+| --- | --- |
+| Empty input | covered: B-002 (missing/empty reason fails closed), B-014 (legacy rows without class) |
+| Failure paths | covered: B-015 (failed recheck), B-010 (exhaustion escalates, evidence preserved) |
+| Authorization | N/A + reason: the scheduler is an in-process trusted actor; the only externally callable surfaces remain the GH-1567 routes behind the existing API auth middleware, whose contract is unchanged (B-003, B-013). No new public endpoint is added. |
+| Concurrency | covered: B-009 (recheck vs manual operator race, single recovery per episode) |
+| Retry / idempotency | covered: B-006 (bounded attempts, persisted counter), B-007 (backoff persisted), B-011 (per-episode reset) |
+| Illegal transitions | covered: B-012 (terminal never auto-recovers), B-004 (only transient scheduled), B-005 (only the established recovery transition is used) |
+| Compatibility | covered: B-003 (default OFF is byte-identical to GH-1567), B-014 (legacy rows tolerated) |
+| Degradation / fallback | covered: B-002 (unknown class degrades to terminal, visibly, never silently to transient), B-016 (invalid config fails startup, no silent clamping) |
+| Evidence / audit | covered: B-008 (audit before effect), B-001 (class visible everywhere), B-010 (exhaustion event) |
+| Cancellation / partial | covered: B-009 (superseded attempt commits nothing partial); cancelled workflows are out of scope by Non-Goals and remain terminal-by-state |
+
+## Edge Cases
+
+- The workflow runtime store is unavailable when a recheck fires: the attempt
+  is skipped and rescheduled, not counted as consumed, and logged at error
+  level.
+- The server restarts mid-backoff: persisted `next_attempt_at` and attempt
+  counter resume the schedule (B-006, B-007).
+- The repo opts out of auto-recovery while attempts are pending: pending
+  rechecks for that repo stop firing; no partial state is left behind.
+- Two harness replicas or overlapping ticks pick up the same instance: the
+  state-guarded recovery commit ensures one winner (B-009).
+- The related GitHub issue is closed during backoff: the recheck re-runs the
+  standard eligibility path, which produces a fresh structured blocker rather
+  than dispatching work against a closed issue.
+
+## Rollout Notes
+
+Ship in small PRs: (1) reason classification + persistence of class on stop
+metadata; (2) policy config + validation; (3) recheck scheduler + audit
+events; (4) operator monitor / runtime tree exposure and docs. The feature is
+inert until a repo sets the opt-in flag, so each PR is safe to land
+independently. Rollback at any stage returns behavior to GH-1567 semantics
+because classification fields are additive JSON.

--- a/specs/GH1584/tasks.md
+++ b/specs/GH1584/tasks.md
@@ -1,0 +1,46 @@
+# GH1584 Task Plan
+
+## Linked Issue
+
+GH-1584
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1584-T001` Owner: `reason-class` | Done when: `StopReasonClass` and the single `classify_stop` classifier land in `harness-workflow` with the full classification table, failing closed to `Terminal` for unknown/missing input (B-001, B-002, B-012, B-014) | Verify: `cargo test -p harness-workflow reason_class`
+- [ ] `SP1584-T002` Owner: `stop-metadata` | Done when: blocked/failed payload builders (`support.rs:150`, `:163`) persist `stop_reason_code` and derived `reason_class` into instance data and `last_stop`, with terminal codes set explicitly at human-wait decision sites; additive JSON only | Verify: `cargo test -p harness-workflow runtime_failure`
+- [ ] `SP1584-T003` Owner: `policy-config` | Done when: `[intake.github.auto_recovery]` global section (default OFF) plus per-repo `auto_recovery: Option<bool>` on `GitHubRepoConfig` exist with load-time validation of attempts/backoff/jitter bounds (B-003, B-016) | Verify: `cargo test -p harness-core intake`
+- [ ] `SP1584-T004` Owner: `attempt-state` | Done when: `auto_recovery` attempt object (episode id, attempts, `next_attempt_at`, last outcome) persists in instance data, resets per stop episode, and is cleared by successful recovery (B-006, B-007, B-011) | Verify: `cargo test -p harness-server auto_recovery_state`
+- [ ] `SP1584-T005` Owner: `scheduler` | Done when: `http/background/auto_recovery.rs` tick loop selects only transient-classified instances of opted-in repos, appends the `AutoRecoveryAttempt` audit event before acting, reuses `unblock_submission_by_workflow_id`/`retry_submission_by_workflow_id`, applies bounded backoff+jitter, and is not spawned when globally disabled (B-004, B-005, B-008, B-015) | Verify: `cargo test -p harness-server auto_recovery`
+- [ ] `SP1584-T006` Owner: `race-hardening` | Done when: recovery commit carries an `expected_state` guard (store location per tech.md "to locate"), guard failure maps to `superseded` without consuming an attempt, and manual unblock during a pending recheck wins cleanly (B-009, B-013) | Verify: `cargo test -p harness-server recover`
+- [ ] `SP1584-T007` Owner: `escalation` | Done when: exhausted episodes emit exactly one idempotent `AutoRecoveryExhausted` event (GH-1582 alerting consumer), and the instance remains visible in the operator monitor as today (B-010) | Verify: `cargo test -p harness-server auto_recovery_exhaust`
+- [ ] `SP1584-T008` Owner: `exposure-docs` | Done when: `StuckWorkflow` and runtime tree expose optional `reason_class`, attempt count, `next_recheck_at`, `auto_recovery_exhausted`; `docs/usage-guide.md` documents the opt-in policy and its default-OFF stance | Verify: `cargo test -p harness-server operator_monitor` and docs review in PR
+
+## Parallelization
+
+- `SP1584-T001` first (classifier is the shared dependency).
+- `SP1584-T002` (harness-workflow) and `SP1584-T003` (harness-core) are
+  disjoint crates and can run in parallel after T001.
+- `SP1584-T004` -> `SP1584-T005` are serial (scheduler consumes attempt
+  state). `SP1584-T006` can proceed in parallel with T005 in the recover/store
+  files, distinct from the new scheduler module.
+- `SP1584-T007` and `SP1584-T008` last, after the scheduler exists.
+
+## Verification
+
+- `cargo check --workspace`
+- `cargo test -p harness-workflow -p harness-core -p harness-server`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+
+## Handoff Notes
+
+Feature ships globally disabled and requires per-repo opt-in. Terminal
+classification is the fail-closed default; expanding the transient table is a
+config/spec change, never a runtime inference. Escalation events are the
+integration point for GH-1582 alerting — keep the event type name stable once
+merged.

--- a/specs/GH1584/tech.md
+++ b/specs/GH1584/tech.md
@@ -65,6 +65,12 @@ Classification table (initial):
 | `error_kind`: `fatal`, `configuration`, `unknown` | Terminal |
 | both absent / legacy rows | Terminal (B-002, B-014) |
 
+Naming note: the `error_kind` rows list the snake_case wire/serde codes;
+in Rust they are the corresponding `ActivityErrorKind` PascalCase variants
+(e.g. `retryable` ↔ `ActivityErrorKind::Retryable`). `classify_stop` takes
+the enum; the snake_case forms appear only in persisted JSON and audit
+events.
+
 `runtime_blocked_payload` / `runtime_failed_payload` (`support.rs:150`, `:163`)
 gain an optional `stop_reason_code` parameter threaded from decision sites and
 persist `stop_reason_code` + derived `reason_class` into instance data and
@@ -88,8 +94,10 @@ tick_interval_secs = 60
 
 Plus per-repo `auto_recovery: Option<bool>` on `GitHubRepoConfig` (mirrors
 `intake.rs:18`); effective policy = repo override else global flag. Validation
-at load (B-016): when enabled, `max_attempts >= 1`,
+at load (B-016): when enabled, `1 <= max_attempts <= 16`,
 `initial_backoff_secs <= max_backoff_secs`, `jitter_ratio` in `[0, 1]`.
+The `max_attempts <= 16` bound plus saturating arithmetic in the backoff
+computation (below) rules out integer overflow in `2^attempts`.
 
 ### 3. Attempt state (persisted in instance data)
 
@@ -123,17 +131,25 @@ Each tick:
 2. Skip unless `classify_stop(...) == Transient` (B-004, B-012).
 3. Skip if `next_attempt_at` is in the future or `attempts >= max_attempts`.
 4. Append an `AutoRecoveryAttempt` audit event (reason class, attempt number)
-   BEFORE any action (B-008), then run the recheck: re-read remote facts /
-   the transient condition where checkable, and call the existing
+   BEFORE any action (B-008). Crash consistency: an `AutoRecoveryAttempt`
+   with no matching outcome event for the same episode (server crashed or
+   the recheck hung between the two writes) is reconciled at the next tick —
+   the scheduler appends a synthetic `AutoRecoveryOutcome{interrupted}` and
+   counts the attempt as consumed, so a crash can neither orphan the audit
+   trail nor grant free retries beyond `max_attempts`. Then run the recheck:
+   re-read remote facts / the transient condition where checkable, and call
+   the existing
    `unblock_submission_by_workflow_id` / `retry_submission_by_workflow_id`
    (`recover.rs:77`, `:86`) with an automated actor reason such as
    `"auto-recovery attempt 2/3: rate_limited cooldown elapsed"` (B-005).
 5. Map outcomes: `Recovered` → append `AutoRecoveryOutcome{succeeded}`;
    `WrongState` → outcome `superseded`, stop scheduling, do not increment
    (B-009); recheck condition still failing → increment attempts, persist
-   `next_attempt_at = now + min(max, initial * 2^attempts) * (1 ± jitter)`,
-   outcome `recheck_failed` (B-015); store error → error-level log, no
-   counter consumption.
+   `next_attempt_at = now + min(max, initial.saturating_mul(1 << attempts))
+   * (1 ± jitter)` — with `attempts` bounded by `max_attempts <= 16` and
+   saturating multiplication, the shift cannot overflow — outcome
+   `recheck_failed` (B-015); store error → error-level log, no counter
+   consumption.
 6. On `attempts == max_attempts` with no success: append one
    `AutoRecoveryExhausted` event (idempotent per episode) for GH-1582
    alerting; instance stays stopped for the operator monitor (B-010).

--- a/specs/GH1584/tech.md
+++ b/specs/GH1584/tech.md
@@ -1,0 +1,208 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1584
+
+## Product Spec
+
+`specs/GH1584/product.md`
+
+## Codebase Context (verified anchors)
+
+| Area | Anchor | Current behavior | Why relevant |
+| --- | --- | --- | --- |
+| Operator recovery handlers | `crates/harness-server/src/http/task_mutation_routes.rs:222` (`unblock_workflow_runtime`), `:231` (`retry_workflow_runtime`), `:260` (`recover_workflow_runtime`) | Body-based operator actions dispatch to the recover module and map outcomes to 200/404/409/500/503. | Auto-recovery must reuse the same outcome semantics, not the HTTP layer. |
+| Routes | `crates/harness-server/src/http/http_router.rs:90-97` | `/api/workflows/runtime/unblock` and `/retry` registered behind `auth::api_auth_middleware` (`:198-201`). | API contract stays unchanged (B-003, B-013). |
+| Recovery core | `crates/harness-server/src/workflow_runtime_submission/recover.rs:77` (`unblock_submission_by_workflow_id`), `:86` (`retry_...`), `:130` (`recover_submission`), `:33` (`RECOVERY_STATE = "planning"`), `:22` (`ACTIVE_STOP_FIELDS`), `:227` (`clear_active_stop_fields`) | Validates definition + state, appends an audit event first (`:157`), commits a decision with a plan-activity re-enqueue (`:170-190`), preserves `last_stop`, writes `last_recovery`. | This is the single eligibility path a successful recheck must re-run (B-005, B-008). |
+| Non-retryable gate | `crates/harness-server/src/workflow_runtime_submission/recover.rs:205` (`non_retryable_error_kind`) | `fatal` and `configuration` reject retry. | Seed of the terminal class for failed workflows. |
+| Decision commit | `crates/harness-server/src/workflow_runtime_submission.rs:239` (`commit_runtime_decision`) | Validates the decision against the in-memory instance state, records rejected decisions, then upserts. No store-level compare-and-swap on `state`. | Race hardening for B-009 lands here or in the store (see Edge Cases). |
+| Stop metadata producers | `crates/harness-workflow/src/runtime/reducer/support.rs:150` (`runtime_blocked_payload`), `:163` (`runtime_failed_payload`), `:180` (`runtime_stop_metadata`), `:208` (`failed_retry_hint`) | Blocked/failed payloads persist `blocked_reason`/`failure_reason`, hints, `error_kind`, `last_stop`. Reasons are free text; `error_kind` is the only machine-stable field. | Classification needs a stable `stop_reason_code` written here. |
+| Blocked/failed decision sites | `crates/harness-workflow/src/runtime/reducer/runtime_failure.rs:29` and `:52`; `crates/harness-workflow/src/runtime/reducer/github_issue_completion.rs:40`, `:98` | All transitions into `blocked`/`failed` flow through `runtime_blocked_command`/`runtime_failed_command` (`support.rs:122`, `:136`). | Single choke point to attach reason codes. |
+| Error-kind taxonomy | `crates/harness-workflow/src/runtime/model.rs:652` (`ActivityErrorKind`: `Retryable`, `SpawnFailure`, `Timeout`, `Fatal`, `Configuration`, `ExternalDependency`, `Unknown`) | Serialized snake_case into stop payloads. | Basis for classifying failed workflows. |
+| Coverage gate | `crates/harness-server/src/intake/github_coverage_gate.rs:34` (`runtime_issue_state_is_covered`), `:101` (`check_github_issue_coverage`) | `blocked`/`failed` are covered, so intake skips the issue until state changes. | Recovery to `planning` clears the hold; the gate itself is untouched. |
+| Per-repo config precedent | `crates/harness-core/src/config/intake.rs:7` (`GitHubRepoConfig`), `:18` (`auto_merge: Option<bool>` per-repo opt-in), `:168` (global `auto_merge: GitHubAutoMergeConfig`), `:189` (`effective_repos`) | Per-repo `Option<bool>` overrides a global policy section, default OFF. | Exact precedent for `auto_recovery`. |
+| Background worker placement | `crates/harness-server/src/http/background/system_recovery.rs:5` (`spawn_system_task_recovery`), re-exported at `crates/harness-server/src/http/background.rs:75`, spawned at `crates/harness-server/src/http/mod.rs:237` | Recovery-style background loops live under `http/background/` and are spawned during server startup. | Recheck scheduler goes here. |
+| Periodic retry escalation | `crates/harness-server/src/periodic_retry.rs:31` (`start`), `:42` (`retry_loop`), `:57` (`run_retry_tick`), `~:302` (already-escalated stuck handling) | Stalled-task scanner with tick loop, escalation dedupe, and summary events. | Pattern for tick cadence, dedupe of repeated escalation, and summary evidence. |
+| Operator monitor | `crates/harness-server/src/handlers/operator_monitor.rs:95` (`StuckWorkflow`), `:138` (handler), `:257` (`list_stuck_workflows`) | Stopped workflows surface to operators with state/age; no reason-class or attempt info. | Exposure surface for class, attempts, next recheck. |
+| Existing tests | `crates/harness-server/src/workflow_runtime_submission/recover_tests.rs` | Covers manual unblock/retry outcomes. | Extend for automated-actor path and races. |
+
+To locate during implementation: (a) whether `WorkflowRuntimeStore::upsert_instance`
+(`crates/harness-workflow/src/runtime/store/instances.rs`) can enforce an
+`expected_state` guard for the CAS in B-009; (b) the GH-1582 escalation event
+naming convention once that issue lands (cross-reference only; emit a stable
+event type here).
+
+## Proposed Design
+
+### 1. Reason classification (harness-workflow)
+
+New module `crates/harness-workflow/src/runtime/reason_class.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopReasonClass {
+    Transient,
+    Terminal,
+}
+
+/// Single classifier used by scheduler, API serialization, and audit events
+/// (B-001). Fail closed: anything unrecognized is Terminal (B-002).
+pub fn classify_stop(
+    stop_reason_code: Option<&str>,
+    error_kind: Option<ActivityErrorKind>,
+) -> StopReasonClass
+```
+
+Classification table (initial):
+
+| Input | Class |
+| --- | --- |
+| `stop_reason_code`: `rate_limited`, `ci_backend_unavailable`, `merge_base_drift`, `circuit_breaker_cooldown` | Transient |
+| `error_kind`: `retryable`, `timeout`, `spawn_failure`, `external_dependency` | Transient |
+| `stop_reason_code`: `maintainer_input_required`, `invalid_agent_output`, anything else | Terminal |
+| `error_kind`: `fatal`, `configuration`, `unknown` | Terminal |
+| both absent / legacy rows | Terminal (B-002, B-014) |
+
+`runtime_blocked_payload` / `runtime_failed_payload` (`support.rs:150`, `:163`)
+gain an optional `stop_reason_code` parameter threaded from decision sites and
+persist `stop_reason_code` + derived `reason_class` into instance data and
+`last_stop`. Additive JSON only; no migration. Blocked decision sites that
+represent "waiting for a human" (e.g. `github_issue_completion.rs:40`) set
+terminal codes explicitly.
+
+### 2. Policy config (harness-core)
+
+Follow the `auto_merge` precedent in `crates/harness-core/src/config/intake.rs`:
+
+```toml
+[intake.github.auto_recovery]
+enabled = false            # global default OFF
+max_attempts = 3
+initial_backoff_secs = 300
+max_backoff_secs = 14400
+jitter_ratio = 0.2
+tick_interval_secs = 60
+```
+
+Plus per-repo `auto_recovery: Option<bool>` on `GitHubRepoConfig` (mirrors
+`intake.rs:18`); effective policy = repo override else global flag. Validation
+at load (B-016): when enabled, `max_attempts >= 1`,
+`initial_backoff_secs <= max_backoff_secs`, `jitter_ratio` in `[0, 1]`.
+
+### 3. Attempt state (persisted in instance data)
+
+Written under an `auto_recovery` object in workflow instance `data` (additive,
+survives restart — B-006/B-007):
+
+```json
+{
+  "auto_recovery": {
+    "episode_event_id": "evt-of-current-stop",
+    "attempts": 2,
+    "next_attempt_at": "2026-07-11T10:00:00Z",
+    "last_outcome": "recheck_failed"
+  }
+}
+```
+
+`episode_event_id` ties attempts to the current stop episode; a new stop
+episode (different `last_stop.event_id`) resets the counter (B-011).
+`clear_active_stop_fields` (`recover.rs:227`) additionally clears
+`auto_recovery` on successful recovery.
+
+### 4. Recheck scheduler (harness-server)
+
+New `crates/harness-server/src/http/background/auto_recovery.rs`, spawned from
+`http/mod.rs` next to `spawn_system_task_recovery` (`mod.rs:237`), gated on the
+config flag so the task is not even spawned when globally disabled (B-003).
+Each tick:
+
+1. List runtime instances in `blocked`/`failed` for opted-in repos.
+2. Skip unless `classify_stop(...) == Transient` (B-004, B-012).
+3. Skip if `next_attempt_at` is in the future or `attempts >= max_attempts`.
+4. Append an `AutoRecoveryAttempt` audit event (reason class, attempt number)
+   BEFORE any action (B-008), then run the recheck: re-read remote facts /
+   the transient condition where checkable, and call the existing
+   `unblock_submission_by_workflow_id` / `retry_submission_by_workflow_id`
+   (`recover.rs:77`, `:86`) with an automated actor reason such as
+   `"auto-recovery attempt 2/3: rate_limited cooldown elapsed"` (B-005).
+5. Map outcomes: `Recovered` → append `AutoRecoveryOutcome{succeeded}`;
+   `WrongState` → outcome `superseded`, stop scheduling, do not increment
+   (B-009); recheck condition still failing → increment attempts, persist
+   `next_attempt_at = now + min(max, initial * 2^attempts) * (1 ± jitter)`,
+   outcome `recheck_failed` (B-015); store error → error-level log, no
+   counter consumption.
+6. On `attempts == max_attempts` with no success: append one
+   `AutoRecoveryExhausted` event (idempotent per episode) for GH-1582
+   alerting; instance stays stopped for the operator monitor (B-010).
+
+Race hardening (B-009): before committing, `recover_submission` already
+re-checks `instance.state` (`recover.rs:144`), but `commit_runtime_decision`
+(`workflow_runtime_submission.rs:239`) has no store-level CAS. Add an
+`expected_state` guard to the instance upsert path (location to confirm in
+`store/instances.rs`); a guard failure maps to `WrongState`/`superseded`.
+
+### 5. Exposure
+
+`StuckWorkflow` (`operator_monitor.rs:95`) and the runtime tree gain optional
+`reason_class`, `auto_recovery_attempts`, `next_recheck_at`,
+`auto_recovery_exhausted` fields (serde-optional; absent for legacy rows).
+
+## Edge Cases
+
+- Store unavailable at tick: log error, reschedule, attempt not consumed.
+- Restart mid-backoff: schedule derives entirely from persisted
+  `next_attempt_at`; no in-memory timer state.
+- Repo opts out mid-episode: tick filter excludes the repo; stale
+  `auto_recovery` data is inert and cleared on the next stop/recovery.
+- Concurrent manual unblock: automated attempt observes `WrongState`,
+  records `superseded`, exits (B-009).
+- Issue closed during backoff: recovery re-enters `planning`; the plan
+  activity produces a fresh structured blocker (same as manual path).
+- Config enabled but no repos opted in: scheduler runs, matches nothing.
+
+## Compatibility with GH-1567 API
+
+Request/response shapes of `/api/workflows/runtime/unblock` and `/retry` are
+unchanged. `RuntimeRecoverOutcome` and `RuntimeRecoverError` are reused, not
+forked. New JSON fields are additive with `#[serde(default)]` /
+`skip_serializing_if` so existing dashboard consumers keep working.
+
+## Product-to-Test Mapping
+
+| Invariant | Area | Verification |
+| --- | --- | --- |
+| B-001 | reason_class | `cargo test -p harness-workflow reason_class` — table test: every `stop_reason_code`/`error_kind` combination maps to one class; scheduler/API/audit call the same fn (grep-guard test asserting single classifier export) |
+| B-002 | reason_class | unit test: `None`/empty/garbage codes → `Terminal`; serialized payload includes the class |
+| B-003 | scheduler | `cargo test -p harness-server auto_recovery` — with global flag off (default config), spawn is skipped and a seeded blocked instance is untouched after N ticks |
+| B-004 | scheduler | tick test: terminal-classified blocked instance is never selected; transient one is |
+| B-005 | recover core | test: automated recovery result equals manual `unblock_submission_by_workflow_id` result (state `planning`, plan command enqueued, `last_stop` preserved, active fields cleared), diffing only actor/reason |
+| B-006 | attempt state | test: persist attempts=`max`, restart-simulated fresh scheduler → no further attempts; counter read from instance data, not memory |
+| B-007 | attempt state | test: `next_attempt_at` computed with exponential growth capped at `max_backoff_secs`, jitter within `[1-r, 1+r]`; fresh scheduler honors persisted future timestamp |
+| B-008 | audit | test: mock store failing the state commit — `AutoRecoveryAttempt` event exists, no transition; ordering asserted via event log sequence |
+| B-009 | concurrency | test: instance state changed between listing and recovery → `WrongState` mapped to `superseded`, attempts not incremented, single decision recorded; store-guard test once CAS lands |
+| B-010 | escalation | test: exhausting attempts emits exactly one `AutoRecoveryExhausted` per episode (idempotent across ticks); instance still listed by `list_stuck_workflows` |
+| B-011 | attempt state | test: new stop episode (different `last_stop.event_id`) resets attempts to 0 |
+| B-012 | reason_class + scheduler | test: `error_kind = fatal` with policy enabled and a forged `stop_reason_code = rate_limited` — classifier returns Terminal for failed+fatal and scheduler skips (classifier precedence test) |
+| B-013 | HTTP | existing `recover_tests.rs` suite green unchanged; new test: manual unblock succeeds while a recheck is pending |
+| B-014 | compat | test: legacy instance data without `stop_reason_code`/`reason_class` → classified Terminal, monitor serialization omits optional fields |
+| B-015 | scheduler | test: failed recheck increments counter, reschedules with larger backoff, no state transition, outcome event `recheck_failed` |
+| B-016 | config | `cargo test -p harness-core intake` — invalid policy values rejected at config load with descriptive errors |
+
+## Verification Plan
+
+- `cargo check --workspace` during implementation.
+- `cargo test -p harness-workflow reason_class`,
+  `cargo test -p harness-server auto_recovery`,
+  `cargo test -p harness-server recover`,
+  `cargo test -p harness-core intake`.
+- Pre-PR: `cargo clippy --workspace --all-targets -- -D warnings` and
+  `cargo fmt --all -- --check` (repo CI gates).
+
+## Rollback Plan
+
+Remove the scheduler spawn and config section; classification fields are
+additive JSON in instance data and serde-optional in APIs, so no migration is
+needed. Manual GH-1567 recovery is untouched at every rollback stage.


### PR DESCRIPTION
## Summary

Spec packet for #1584 — opt-in automatic recheck/recovery for blocked and failed runtime workflows, extending the GH-1567 operator escape hatch.

- `specs/GH1584/product.md` — 16 invariants (B-001..B-016) + 10-category boundary checklist: exhaustive reason classification with unknown→terminal (fail closed), default OFF per repo, bounded attempts with exponential backoff + jitter, audit event recorded before recovery takes effect, attempt counters survive restart, terminal reasons never auto-recover, race safety vs concurrent manual unblock.
- `specs/GH1584/tech.md` — verified anchors from the GH-1567 implementation (`task_mutation_routes.rs`, `http_router.rs`, decision/eligibility path), reason-code taxonomy, policy config following the per-repo `auto_merge` precedent, full Product-to-Test Mapping.
- `specs/GH1584/tasks.md` — `SP1584-T001..T008` with per-task verify commands.

## Open questions for review

1. `commit_runtime_decision` (`workflow_runtime_submission.rs:239`) has no store-level state CAS; the race invariant (B-009) needs an `expected_state` guard whose exact site in `runtime/store/instances.rs` is marked "to locate" for the implementation task.
2. `AutoRecoveryExhausted` event name to be confirmed against #1582's alerting consumer once that lands.
3. Current blocked reasons are free text — the initial transient code set (`rate_limited`, `ci_backend_unavailable`, `merge_base_drift`, `circuit_breaker_cooldown`) is introduced at the decision sites in T002.

Depends conceptually on #1582 (escalation channel) but implementable independently. Docs-only PR; no code changes.