### PR TITLE
feat: complete workflow runtime recovery operator flow

### DIFF
--- a/crates/harness-agents/src/codex_tests.rs
+++ b/crates/harness-agents/src/codex_tests.rs
@@ -457,9 +457,11 @@ async fn execute_kills_descendant_that_keeps_output_pipe_open_after_root_exit() 
 printf '%s\n' '{{"type":"item.completed","item":{{"id":"item_0","type":"agent_message","text":"root done"}}}}'
 printf '%s\n' '{{"type":"turn.completed","usage":{{"input_tokens":1,"output_tokens":1}}}}'
 ( echo descendant > "{}"; sleep 1; echo reached > "{}" ) &
+while [ ! -f "{}" ]; do sleep 0.01; done
 "#,
         descendant_marker.display(),
-        marker.display()
+        marker.display(),
+        descendant_marker.display()
     ));
 
     let agent = CodexAgent::new(script, SandboxMode::DangerFullAccess);
@@ -766,141 +768,5 @@ async fn run_id_execute_exports_agent_run_id_after_claude_env_strip() -> anyhow:
     Ok(())
 }
 
-#[test]
-fn codex_sandbox_mode_maps_to_codex_cli_values() {
-    assert_eq!(codex_sandbox_mode(SandboxMode::ReadOnly), "read-only");
-    assert_eq!(
-        codex_sandbox_mode(SandboxMode::ReadOnlyWithNetwork),
-        "read-only"
-    );
-    assert_eq!(
-        codex_sandbox_mode(SandboxMode::WorkspaceWrite),
-        "workspace-write"
-    );
-    assert_eq!(
-        codex_sandbox_mode(SandboxMode::DangerFullAccess),
-        "danger-full-access"
-    );
-}
-
-#[test]
-fn base_args_uses_request_reasoning_effort_sandbox_and_approval_policy() {
-    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::DangerFullAccess);
-    let request = AgentRequest {
-        prompt: "ping".to_string(),
-        project_root: PathBuf::from("/tmp/project"),
-        reasoning_effort: Some("medium".to_string()),
-        sandbox_mode: Some(SandboxMode::ReadOnly),
-        approval_policy: Some("on-request".to_string()),
-        ..Default::default()
-    };
-
-    let args: Vec<String> = agent
-        .base_args(&request)
-        .iter()
-        .map(|value| value.to_string_lossy().to_string())
-        .collect();
-
-    assert!(args
-        .windows(2)
-        .any(|window| window == ["-c", "model_reasoning_effort=\"medium\""]));
-    assert!(args.windows(2).any(|window| window == ["-s", "read-only"]));
-    assert!(args
-        .windows(2)
-        .any(|window| window == ["-c", "approval_policy=\"on-request\""]));
-    assert!(!args.iter().any(|arg| arg == "-a"));
-    assert_eq!(args.last().map(String::as_str), Some("ping"));
-}
-
-#[test]
-fn base_args_configures_read_only_with_network_profile() {
-    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::DangerFullAccess);
-    let request = AgentRequest {
-        prompt: "ping".to_string(),
-        project_root: PathBuf::from("/tmp/project"),
-        sandbox_mode: Some(SandboxMode::ReadOnlyWithNetwork),
-        ..Default::default()
-    };
-
-    let args: Vec<String> = agent
-        .base_args(&request)
-        .iter()
-        .map(|value| value.to_string_lossy().to_string())
-        .collect();
-
-    assert!(!args.iter().any(|arg| arg == "-s"));
-    assert!(args.windows(2).any(|window| {
-        window
-            == [
-                "-c",
-                "default_permissions=\"harness_read_only_with_network\"",
-            ]
-    }));
-    assert!(args.windows(2).any(|window| {
-        window == [
-            "-c",
-            "permissions.harness_read_only_with_network.filesystem={\":minimal\"=\"read\",\":project_roots\"={\".\"=\"read\"}}",
-        ]
-    }));
-    assert!(args.windows(2).any(|window| {
-        window
-            == [
-                "-c",
-                "permissions.harness_read_only_with_network.network.enabled=true",
-            ]
-    }));
-}
-
-#[test]
-fn spawn_diagnostics_resolve_relative_program_from_spawn_current_dir() {
-    let project = tempdir().expect("create project dir");
-    let bin_dir = project.path().join("bin");
-    fs::create_dir(&bin_dir).expect("create bin dir");
-    let program_path = bin_dir.join("codex");
-    fs::write(&program_path, "#!/bin/sh\n").expect("write program");
-
-    let resolved = resolve_program_for_spawn(Path::new("bin/codex"), project.path())
-        .expect("relative program should resolve from spawn current dir");
-
-    assert_eq!(resolved, program_path);
-}
-
-#[test]
-fn allowed_tools_does_not_override_configured_workspace_write_sandbox() {
-    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::WorkspaceWrite);
-    let request = AgentRequest {
-        prompt: "ping".to_string(),
-        project_root: PathBuf::from("/tmp/project"),
-        allowed_tools: Some(vec!["Read".to_string(), "Grep".to_string()]),
-        ..Default::default()
-    };
-
-    let args: Vec<String> = agent
-        .base_args(&request)
-        .iter()
-        .map(|value| value.to_string_lossy().to_string())
-        .collect();
-    assert!(args
-        .windows(2)
-        .any(|window| window == ["-s", "workspace-write"]));
-}
-
-#[test]
-fn deny_all_allowed_tools_keeps_configured_sandbox_mode() {
-    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::DangerFullAccess);
-    let request = AgentRequest {
-        prompt: "ping".to_string(),
-        project_root: PathBuf::from("/tmp/project"),
-        allowed_tools: Some(vec![]),
-        ..Default::default()
-    };
-
-    let args: Vec<String> = agent
-        .base_args(&request)
-        .iter()
-        .map(|value| value.to_string_lossy().to_string())
-        .collect();
-    assert!(args
-        .windows(2)
-        .any(|window| window == ["-s", "danger-full-access"]));
-}
+#[path = "codex_tests/config_args.rs"]
+mod config_args;

--- a/crates/harness-agents/src/codex_tests/config_args.rs
+++ b/crates/harness-agents/src/codex_tests/config_args.rs
@@ -1,0 +1,149 @@
+use super::*;
+
+#[test]
+fn codex_sandbox_mode_maps_to_codex_cli_values() {
+    assert_eq!(codex_sandbox_mode(SandboxMode::ReadOnly), "read-only");
+    assert_eq!(
+        codex_sandbox_mode(SandboxMode::ReadOnlyWithNetwork),
+        "read-only"
+    );
+    assert_eq!(
+        codex_sandbox_mode(SandboxMode::WorkspaceWrite),
+        "workspace-write"
+    );
+    assert_eq!(
+        codex_sandbox_mode(SandboxMode::DangerFullAccess),
+        "danger-full-access"
+    );
+}
+
+#[test]
+fn base_args_uses_request_reasoning_effort_sandbox_and_approval_policy() {
+    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::DangerFullAccess);
+    let request = AgentRequest {
+        prompt: "ping".to_string(),
+        project_root: PathBuf::from("/tmp/project"),
+        reasoning_effort: Some("medium".to_string()),
+        sandbox_mode: Some(SandboxMode::ReadOnly),
+        approval_policy: Some("on-request".to_string()),
+        ..Default::default()
+    };
+
+    let args: Vec<String> = agent
+        .base_args(&request)
+        .iter()
+        .map(|value| value.to_string_lossy().to_string())
+        .collect();
+
+    assert!(args
+        .windows(2)
+        .any(|window| window == ["-c", "model_reasoning_effort=\"medium\""]));
+    assert!(args.windows(2).any(|window| window == ["-s", "read-only"]));
+    assert!(args
+        .windows(2)
+        .any(|window| window == ["-c", "approval_policy=\"on-request\""]));
+    assert!(!args.iter().any(|arg| arg == "-a"));
+    assert_eq!(args.last().map(String::as_str), Some("ping"));
+}
+
+#[test]
+fn base_args_configures_read_only_with_network_profile() {
+    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::DangerFullAccess);
+    let request = AgentRequest {
+        prompt: "ping".to_string(),
+        project_root: PathBuf::from("/tmp/project"),
+        sandbox_mode: Some(SandboxMode::ReadOnlyWithNetwork),
+        ..Default::default()
+    };
+
+    let args: Vec<String> = agent
+        .base_args(&request)
+        .iter()
+        .map(|value| value.to_string_lossy().to_string())
+        .collect();
+
+    assert!(!args.iter().any(|arg| arg == "-s"));
+    assert!(args.windows(2).any(|window| {
+        window
+            == [
+                "-c",
+                "default_permissions=\"harness_read_only_with_network\"",
+            ]
+    }));
+    assert!(args.windows(2).any(|window| {
+        window == [
+            "-c",
+            "permissions.harness_read_only_with_network.filesystem={\":minimal\"=\"read\",\":project_roots\"={\".\"=\"read\"}}",
+        ]
+    }));
+    assert!(args.windows(2).any(|window| {
+        window
+            == [
+                "-c",
+                "permissions.harness_read_only_with_network.network.enabled=true",
+            ]
+    }));
+}
+
+#[test]
+fn spawn_diagnostics_resolve_relative_program_from_spawn_current_dir() {
+    let project = match tempdir() {
+        Ok(project) => project,
+        Err(error) => panic!("create project dir: {error}"),
+    };
+    let bin_dir = project.path().join("bin");
+    if let Err(error) = fs::create_dir(&bin_dir) {
+        panic!("create bin dir: {error}");
+    }
+    let program_path = bin_dir.join("codex");
+    if let Err(error) = fs::write(&program_path, "#!/bin/sh\n") {
+        panic!("write program: {error}");
+    }
+
+    let resolved = match resolve_program_for_spawn(Path::new("bin/codex"), project.path()) {
+        Some(resolved) => resolved,
+        None => panic!("relative program should resolve from spawn current dir"),
+    };
+
+    assert_eq!(resolved, program_path);
+}
+
+#[test]
+fn allowed_tools_does_not_override_configured_workspace_write_sandbox() {
+    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::WorkspaceWrite);
+    let request = AgentRequest {
+        prompt: "ping".to_string(),
+        project_root: PathBuf::from("/tmp/project"),
+        allowed_tools: Some(vec!["Read".to_string(), "Grep".to_string()]),
+        ..Default::default()
+    };
+
+    let args: Vec<String> = agent
+        .base_args(&request)
+        .iter()
+        .map(|value| value.to_string_lossy().to_string())
+        .collect();
+    assert!(args
+        .windows(2)
+        .any(|window| window == ["-s", "workspace-write"]));
+}
+
+#[test]
+fn deny_all_allowed_tools_keeps_configured_sandbox_mode() {
+    let agent = CodexAgent::new(PathBuf::from("codex"), SandboxMode::DangerFullAccess);
+    let request = AgentRequest {
+        prompt: "ping".to_string(),
+        project_root: PathBuf::from("/tmp/project"),
+        allowed_tools: Some(vec![]),
+        ..Default::default()
+    };
+
+    let args: Vec<String> = agent
+        .base_args(&request)
+        .iter()
+        .map(|value| value.to_string_lossy().to_string())
+        .collect();
+    assert!(args
+        .windows(2)
+        .any(|window| window == ["-s", "danger-full-access"]));
+}

--- a/crates/harness-server/src/intake/github_coverage_gate.rs
+++ b/crates/harness-server/src/intake/github_coverage_gate.rs
@@ -38,7 +38,9 @@ pub(crate) fn runtime_issue_state_is_covered(state: &str) -> bool {
             | "awaiting_dependencies"
             | "scheduled"
             | "implementing"
+            | "replanning"
             | "pr_open"
+            | "local_review_gate"
             | "awaiting_feedback"
             | "feedback_claimed"
             | "addressing_feedback"
@@ -140,12 +142,13 @@ pub(crate) async fn check_github_issue_coverage(
 #[cfg(test)]
 mod tests {
     use harness_workflow::runtime::{
-        RuntimeKind, WorkflowCommand, WorkflowInstance, WorkflowRuntimeRecoveryAction,
-        WorkflowRuntimeRecoveryOutcome, WorkflowRuntimeRecoveryRequest, WorkflowSubject,
-        GITHUB_ISSUE_PR_DEFINITION_ID,
+        RuntimeKind, WorkflowCommand, WorkflowCommandStatus, WorkflowInstance,
+        WorkflowRuntimeRecoveryAction, WorkflowRuntimeRecoveryOutcome,
+        WorkflowRuntimeRecoveryRequest, WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID,
     };
 
     use super::*;
+    use crate::task_runner::TaskId;
 
     #[test]
     fn lifecycle_coverage_includes_quiescent_and_terminal_states() {
@@ -164,10 +167,12 @@ mod tests {
     }
 
     #[test]
-    fn runtime_coverage_includes_ready_to_merge_and_blocked() {
+    fn runtime_coverage_includes_stopped_and_recovered_states() {
         assert!(runtime_issue_state_is_covered("ready_to_merge"));
         assert!(runtime_issue_state_is_covered("blocked"));
         assert!(runtime_issue_state_is_covered("failed"));
+        assert!(runtime_issue_state_is_covered("replanning"));
+        assert!(runtime_issue_state_is_covered("local_review_gate"));
         assert!(!runtime_issue_state_is_covered("unknown_scanning"));
     }
 
@@ -183,7 +188,9 @@ mod tests {
             Some(&crate::test_helpers::test_database_url()?),
         )
         .await?;
-        let project_id = "/project/github-coverage";
+        let project_root = dir.path().join("project");
+        std::fs::create_dir(&project_root)?;
+        let project_id = project_root.to_string_lossy().into_owned();
         let repo = "owner/repo";
 
         for (issue_number, stopped_state, action) in [
@@ -192,7 +199,7 @@ mod tests {
         ] {
             let workflow = store_stopped_replan_workflow(
                 &store,
-                project_id,
+                &project_id,
                 repo,
                 issue_number,
                 stopped_state,
@@ -200,7 +207,7 @@ mod tests {
             .await?;
 
             assert_eq!(
-                check_github_issue_coverage(None, Some(&store), project_id, repo, issue_number,)
+                check_github_issue_coverage(None, Some(&store), &project_id, repo, issue_number,)
                     .await?,
                 GitHubIssueCoverage::Covered {
                     source: "workflow_runtime",
@@ -221,10 +228,50 @@ mod tests {
                 WorkflowRuntimeRecoveryOutcome::Recovered { ref workflow, .. }
                     if workflow.state == "replanning"
             ));
+
+            let coverage =
+                check_github_issue_coverage(None, Some(&store), &project_id, repo, issue_number)
+                    .await?;
+            if coverage == GitHubIssueCoverage::Uncovered {
+                let task_id =
+                    TaskId::from_str(&format!("github-issue:{repo}:issue:{issue_number}"));
+                crate::workflow_runtime_submission::record_issue_submission(
+                    &store,
+                    crate::workflow_runtime_submission::IssueSubmissionRuntimeContext {
+                        project_root: &project_root,
+                        repo: Some(repo),
+                        issue_number,
+                        task_id: &task_id,
+                        labels: &[],
+                        force_execute: true,
+                        additional_prompt: None,
+                        depends_on: &[],
+                        dependencies_blocked: false,
+                        source: Some("github"),
+                        external_id: Some("recovered-coverage-test"),
+                        remote_fact_hash: None,
+                        author_trust_class: None,
+                    },
+                )
+                .await?;
+            }
+
+            let pending_command_count = store
+                .commands_for(&workflow.id)
+                .await?
+                .into_iter()
+                .filter(|command| command.status == WorkflowCommandStatus::Pending)
+                .count();
             assert_eq!(
-                check_github_issue_coverage(None, Some(&store), project_id, repo, issue_number,)
-                    .await?,
-                GitHubIssueCoverage::Uncovered
+                pending_command_count, 1,
+                "the intake tick must not enqueue work beside the recovery replay"
+            );
+            assert_eq!(
+                coverage,
+                GitHubIssueCoverage::Covered {
+                    source: "workflow_runtime",
+                    state: "replanning".to_string(),
+                }
             );
         }
 

--- a/crates/harness-server/src/intake/github_coverage_gate.rs
+++ b/crates/harness-server/src/intake/github_coverage_gate.rs
@@ -139,6 +139,12 @@ pub(crate) async fn check_github_issue_coverage(
 
 #[cfg(test)]
 mod tests {
+    use harness_workflow::runtime::{
+        RuntimeKind, WorkflowCommand, WorkflowInstance, WorkflowRuntimeRecoveryAction,
+        WorkflowRuntimeRecoveryOutcome, WorkflowRuntimeRecoveryRequest, WorkflowSubject,
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+    };
+
     use super::*;
 
     #[test]
@@ -165,6 +171,66 @@ mod tests {
         assert!(!runtime_issue_state_is_covered("unknown_scanning"));
     }
 
+    #[tokio::test]
+    async fn github_coverage_gate_observes_recovered_runtime_state() -> anyhow::Result<()> {
+        if !crate::test_helpers::db_tests_enabled().await {
+            return Ok(());
+        }
+        let _lock = crate::test_helpers::HOME_LOCK.lock().await;
+        let dir = crate::test_helpers::tempdir_in_home("harness-test-github-coverage-")?;
+        let store = WorkflowRuntimeStore::open_with_database_url(
+            &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
+            Some(&crate::test_helpers::test_database_url()?),
+        )
+        .await?;
+        let project_id = "/project/github-coverage";
+        let repo = "owner/repo";
+
+        for (issue_number, stopped_state, action) in [
+            (156_700, "blocked", WorkflowRuntimeRecoveryAction::Unblock),
+            (156_701, "failed", WorkflowRuntimeRecoveryAction::Retry),
+        ] {
+            let workflow = store_stopped_replan_workflow(
+                &store,
+                project_id,
+                repo,
+                issue_number,
+                stopped_state,
+            )
+            .await?;
+
+            assert_eq!(
+                check_github_issue_coverage(None, Some(&store), project_id, repo, issue_number,)
+                    .await?,
+                GitHubIssueCoverage::Covered {
+                    source: "workflow_runtime",
+                    state: stopped_state.to_string(),
+                }
+            );
+
+            let recovered = store
+                .recover_stopped_instance(WorkflowRuntimeRecoveryRequest {
+                    workflow_id: &workflow.id,
+                    action,
+                    reason: "external blocker resolved",
+                    actor: "operator",
+                })
+                .await?;
+            assert!(matches!(
+                recovered,
+                WorkflowRuntimeRecoveryOutcome::Recovered { ref workflow, .. }
+                    if workflow.state == "replanning"
+            ));
+            assert_eq!(
+                check_github_issue_coverage(None, Some(&store), project_id, repo, issue_number,)
+                    .await?,
+                GitHubIssueCoverage::Uncovered
+            );
+        }
+
+        Ok(())
+    }
+
     #[test]
     fn issue_remote_fact_snapshot_hash_is_stable_for_same_issue() {
         let issue = IncomingIssue {
@@ -186,5 +252,51 @@ mod tests {
         let right = issue_remote_fact_snapshot("owner/repo", 7, &issue).expect("snapshot");
 
         assert_eq!(left.fact_hash, right.fact_hash);
+    }
+
+    async fn store_stopped_replan_workflow(
+        store: &WorkflowRuntimeStore,
+        project_id: &str,
+        repo: &str,
+        issue_number: u64,
+        stopped_state: &str,
+    ) -> anyhow::Result<WorkflowInstance> {
+        let workflow_id = workflow_id(project_id, Some(repo), issue_number);
+        let mut workflow = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            stopped_state,
+            WorkflowSubject::new("issue", format!("issue:{issue_number}")),
+        )
+        .with_id(workflow_id)
+        .with_data(json!({
+            "project_id": project_id,
+            "repo": repo,
+            "issue_number": issue_number,
+            "error_kind": "timeout",
+            "last_stop": {
+                "state": stopped_state,
+                "activity": "replan_issue",
+                "error_kind": "timeout",
+            },
+        }));
+        store.upsert_instance(&workflow).await?;
+
+        let command = WorkflowCommand::enqueue_activity(
+            "replan_issue",
+            format!("stopped-replan-{issue_number}"),
+        );
+        let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+        let runtime_job = store
+            .enqueue_runtime_job(
+                &command_id,
+                RuntimeKind::CodexJsonrpc,
+                "codex-test",
+                command.command,
+            )
+            .await?;
+        workflow.data["last_stop"]["runtime_job_id"] = json!(runtime_job.id);
+        store.upsert_instance(&workflow).await?;
+        Ok(workflow)
     }
 }

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -530,97 +530,29 @@ Tempo walkthrough.
 
 ## Workflow Runtime Recovery API
 
-Use the recovery API when a GitHub issue workflow has stopped and an operator
-has resolved the external condition. Recovery is manual by default: Harness
-does not periodically retry stopped workflows, and these routes do not change
-GitHub labels, comments, or issue state.
+Use authenticated `POST /api/workflows/runtime/unblock` for `blocked` GitHub
+issue workflows and `POST /api/workflows/runtime/retry` for retryable `failed`
+workflows. Both requests require JSON `workflow_id` and `reason` fields.
+`cancelled`, active, unsupported, and non-retryable workflows fail closed.
 
-### Authentication
+Harness replays the supported stopped activity directly and resumes at its
+corresponding active state (`implementing`, `replanning`, `merging`,
+`local_review_gate`, `awaiting_feedback`, or `addressing_feedback`). The next
+intake tick treats that active state as covered so it cannot duplicate the
+recovery command.
 
-The recovery routes use the same API authentication as other non-public HTTP
-routes. Configure `[server].api_token` or `HARNESS_API_TOKEN`, then send the
-token as a bearer credential. Tokenless access is available only when the
-server was deliberately started with `allow_unauthenticated = true` for local
-development.
+| Response class | Meaning |
+|----------------|---------|
+| `200` | Recovery and replay command were committed. |
+| `400`, `415`, `422` | The JSON request is malformed, has the wrong content type, or has invalid fields. |
+| `401`, `404` | Authentication failed or the workflow was not found. |
+| `409` | State, retry eligibility, definition, or stopped activity is unsupported. |
+| `500`, `503` | The transaction failed or the runtime store is unavailable. |
 
-### Requests
-
-Both routes accept a JSON object with a non-empty workflow id and a non-empty
-operator reason. The reason is written to the workflow audit trail.
-
-```bash
-curl -sS -X POST http://127.0.0.1:9800/api/workflows/runtime/unblock \
-  -H "Authorization: Bearer ${HARNESS_API_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "workflow_id": "github-issue-workflow-id",
-    "reason": "maintainer supplied the requested approval"
-  }'
-
-curl -sS -X POST http://127.0.0.1:9800/api/workflows/runtime/retry \
-  -H "Authorization: Bearer ${HARNESS_API_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "workflow_id": "github-issue-workflow-id",
-    "reason": "the transient backend outage has been repaired"
-  }'
-```
-
-| Route | Required current state | Additional rules |
-|-------|------------------------|------------------|
-| `POST /api/workflows/runtime/unblock` | `blocked` | The stopped activity must be recoverable. |
-| `POST /api/workflows/runtime/retry` | `failed` | Failures classified as `fatal` or `configuration` are not retryable. |
-
-The first implementation supports only `github_issue_pr` workflow instances.
-`cancelled` and active workflows are not supported by either action. A legacy
-stopped instance with no structured stop metadata resumes at `implement_issue`;
-partial, malformed, or unsupported stop metadata fails closed without mutating
-the workflow.
-
-When structured stop metadata is present, Harness replays the original command
-for these activities and returns the corresponding dispatch state:
-
-| Stopped activity | New state |
-|------------------|-----------|
-| `implement_issue` | `implementing` |
-| `replan_issue` | `replanning` |
-| `merge_pr` | `merging` |
-| `run_local_review` | `local_review_gate` |
-| `sweep_pr_feedback`, `inspect_pr_feedback`, or `start_child_workflow` | `awaiting_feedback` |
-| `address_pr_feedback` | `addressing_feedback` |
-
-### Responses
-
-A successful request returns HTTP `200`. The `state` value depends on the
-replayed activity described above.
-
-```json
-{
-  "status": "unblocked",
-  "execution_path": "workflow_runtime",
-  "workflow_id": "github-issue-workflow-id",
-  "previous_state": "blocked",
-  "state": "implementing"
-}
-```
-
-Retry responses use `"status": "retried"` and
-`"previous_state": "failed"`.
-
-| HTTP status | Meaning |
-|-------------|---------|
-| `400 Bad Request` | `workflow_id` or `reason` is blank. |
-| `401 Unauthorized` | The bearer token is missing or invalid. |
-| `404 Not Found` | The workflow id does not exist. |
-| `409 Conflict` | The action does not match the current state, the failure is non-retryable, the workflow definition is unsupported, or the stopped activity cannot be reconstructed safely. |
-| `503 Service Unavailable` | The workflow runtime store is unavailable. |
-| `500 Internal Server Error` | Recovery failed while committing the transactional audit/state update. |
-
-Do not delete or edit workflow runtime rows to recover a stopped workflow.
-Direct database edits are unsupported and can break the event, decision,
-command, and runtime-job audit chain. Use the authenticated API so Harness can
-preserve stop evidence, supersede stale work safely, record the operator reason,
-and enqueue the correct follow-up command atomically.
+Direct database edits are not a supported recovery path because they break the
+runtime audit chain. See [Workflow Runtime Operations](workflow-runtime-operations.md)
+for authentication, request examples, activity mappings, exact response
+classes, and safe rollout guidance.
 
 ## Scheduled Background Systems
 
@@ -628,21 +560,9 @@ Harness runs several background schedulers automatically when the server starts:
 
 ### 1. Periodic Review (`[review]`)
 
-Whole-repo code review on a timer. Disabled by default.
-
-```toml
-[review]
-enabled = true
-interval_hours = 24
-# strategy = "cross"
-```
-
-**What happens when enabled:**
-- Every `interval_hours`, locally checks if new commits exist since the last review
-- If yes: gathers repo structure + diff stats + commit log → constructs review prompt → enqueues as a task
-- Agent reviews the entire codebase, may create a PR with fixes
-- If no new commits: cycle is skipped before any review agent is spawned
-- Review events are logged to EventStore for audit trail
+Whole-repo review is disabled by default. When enabled, Harness checks for new
+commits before enqueueing an agent and records its watermark in EventStore. See
+[Periodic Review](periodic-review.md) for configuration and execution details.
 
 ### 2. Health Tick (always on)
 
@@ -654,48 +574,10 @@ Every 24 hours, runs `RuleEngine::scan()` on the project root:
 
 ### Workflow Runtime Sweepers
 
-Workflow-runtime watchdog and retention sweepers are configured in
-`WORKFLOW.md` under `storage`. Both are disabled by default on first rollout:
-
-```yaml
-storage:
-  orphan_reaper_enabled: true
-  orphan_reaper_interval_secs: 3600
-  orphan_reaper_legacy_enabled: true
-  orphan_reaper_legacy_batch: 200
-  workflow_watchdog_enabled: false
-  workflow_watchdog_age_minutes: 240
-  workflow_watchdog_interval_secs: 300
-  workflow_watchdog_batch_size: 100
-  runtime_retention_enabled: false
-  runtime_retention_days: 30
-  runtime_retention_batch_size: 1000
-  runtime_retention_interval_secs: 3600
-  task_retention_enabled: false
-  task_retention_days: 30
-  task_retention_batch_size: 1000
-  task_retention_interval_secs: 3600
-```
-
-The orphan schema reaper is enabled by default. It drops registered
-path-derived schemas with dead owner paths and, in bounded batches, legacy
-unregistered `h<16-hex>` schemas that cannot be matched to a live workspace
-directory or known store path under the configured workspace root.
-
-Enable `workflow_watchdog_enabled` first. It is read-only: aged `blocked` and
-`awaiting_feedback` workflow instances appear in `/api/operator-monitor` under
-`stuck_workflows` and are logged at error level.
-
-Enable `runtime_retention_enabled` only after the stuck list is clean. Retention
-deletes terminal workflow families older than `runtime_retention_days` in
-bounded batches and relies on the Postgres runtime-store cascade constraints to
-remove events, decisions, commands, jobs, runtime events, and artifacts. Active
-workflow families are never pruned.
-
-Enable `task_retention_enabled` only when historical task rows can be deleted.
-Retention deletes terminal tasks older than `task_retention_days` in bounded
-batches, including task-owned artifacts, prompts, and checkpoints. Active,
-pending, dependency-blocked, and resumable tasks are never pruned.
+The watchdog is read-only; runtime and task retention remain disabled by
+default. Configure and roll them out in that order using
+[Workflow Runtime Operations](workflow-runtime-operations.md). See
+[Postgres Schema Cleanup](postgres-schema-cleanup.md) for orphan schema reaping.
 
 ### 3. GC Runner (always on)
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -528,6 +528,100 @@ Tempo walkthrough.
 10. Task status → done/failed
 ```
 
+## Workflow Runtime Recovery API
+
+Use the recovery API when a GitHub issue workflow has stopped and an operator
+has resolved the external condition. Recovery is manual by default: Harness
+does not periodically retry stopped workflows, and these routes do not change
+GitHub labels, comments, or issue state.
+
+### Authentication
+
+The recovery routes use the same API authentication as other non-public HTTP
+routes. Configure `[server].api_token` or `HARNESS_API_TOKEN`, then send the
+token as a bearer credential. Tokenless access is available only when the
+server was deliberately started with `allow_unauthenticated = true` for local
+development.
+
+### Requests
+
+Both routes accept a JSON object with a non-empty workflow id and a non-empty
+operator reason. The reason is written to the workflow audit trail.
+
+```bash
+curl -sS -X POST http://127.0.0.1:9800/api/workflows/runtime/unblock \
+  -H "Authorization: Bearer ${HARNESS_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workflow_id": "github-issue-workflow-id",
+    "reason": "maintainer supplied the requested approval"
+  }'
+
+curl -sS -X POST http://127.0.0.1:9800/api/workflows/runtime/retry \
+  -H "Authorization: Bearer ${HARNESS_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workflow_id": "github-issue-workflow-id",
+    "reason": "the transient backend outage has been repaired"
+  }'
+```
+
+| Route | Required current state | Additional rules |
+|-------|------------------------|------------------|
+| `POST /api/workflows/runtime/unblock` | `blocked` | The stopped activity must be recoverable. |
+| `POST /api/workflows/runtime/retry` | `failed` | Failures classified as `fatal` or `configuration` are not retryable. |
+
+The first implementation supports only `github_issue_pr` workflow instances.
+`cancelled` and active workflows are not supported by either action. A legacy
+stopped instance with no structured stop metadata resumes at `implement_issue`;
+partial, malformed, or unsupported stop metadata fails closed without mutating
+the workflow.
+
+When structured stop metadata is present, Harness replays the original command
+for these activities and returns the corresponding dispatch state:
+
+| Stopped activity | New state |
+|------------------|-----------|
+| `implement_issue` | `implementing` |
+| `replan_issue` | `replanning` |
+| `merge_pr` | `merging` |
+| `run_local_review` | `local_review_gate` |
+| `sweep_pr_feedback`, `inspect_pr_feedback`, or `start_child_workflow` | `awaiting_feedback` |
+| `address_pr_feedback` | `addressing_feedback` |
+
+### Responses
+
+A successful request returns HTTP `200`. The `state` value depends on the
+replayed activity described above.
+
+```json
+{
+  "status": "unblocked",
+  "execution_path": "workflow_runtime",
+  "workflow_id": "github-issue-workflow-id",
+  "previous_state": "blocked",
+  "state": "implementing"
+}
+```
+
+Retry responses use `"status": "retried"` and
+`"previous_state": "failed"`.
+
+| HTTP status | Meaning |
+|-------------|---------|
+| `400 Bad Request` | `workflow_id` or `reason` is blank. |
+| `401 Unauthorized` | The bearer token is missing or invalid. |
+| `404 Not Found` | The workflow id does not exist. |
+| `409 Conflict` | The action does not match the current state, the failure is non-retryable, the workflow definition is unsupported, or the stopped activity cannot be reconstructed safely. |
+| `503 Service Unavailable` | The workflow runtime store is unavailable. |
+| `500 Internal Server Error` | Recovery failed while committing the transactional audit/state update. |
+
+Do not delete or edit workflow runtime rows to recover a stopped workflow.
+Direct database edits are unsupported and can break the event, decision,
+command, and runtime-job audit chain. Use the authenticated API so Harness can
+preserve stop evidence, supersede stale work safely, record the operator reason,
+and enqueue the correct follow-up command atomically.
+
 ## Scheduled Background Systems
 
 Harness runs several background schedulers automatically when the server starts:

--- a/docs/workflow-runtime-operations.md
+++ b/docs/workflow-runtime-operations.md
@@ -1,0 +1,149 @@
+# Workflow Runtime Operations
+
+This guide covers manual recovery for stopped GitHub issue workflows and the
+watchdog/retention sweepers used to operate the workflow runtime safely.
+
+## Manual Recovery
+
+Use the recovery API after an operator resolves the external condition that
+left a workflow `blocked` or `failed`. Recovery is manual by default. Harness
+does not periodically retry stopped workflows, and these routes do not change
+GitHub labels, comments, or issue state.
+
+### Authentication
+
+The recovery routes use the same API authentication as other non-public HTTP
+routes. Configure `[server].api_token` or `HARNESS_API_TOKEN`, then send the
+token as a bearer credential. Tokenless access is available only when the
+server was deliberately started with `allow_unauthenticated = true` for local
+development.
+
+### Requests
+
+Both routes accept a JSON object with a non-empty workflow id and a non-empty
+operator reason. The reason is written to the workflow audit trail.
+
+```bash
+curl -sS -X POST http://127.0.0.1:9800/api/workflows/runtime/unblock \
+  -H "Authorization: Bearer ${HARNESS_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workflow_id": "github-issue-workflow-id",
+    "reason": "maintainer supplied the requested approval"
+  }'
+
+curl -sS -X POST http://127.0.0.1:9800/api/workflows/runtime/retry \
+  -H "Authorization: Bearer ${HARNESS_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workflow_id": "github-issue-workflow-id",
+    "reason": "the transient backend outage has been repaired"
+  }'
+```
+
+| Route | Required current state | Additional rules |
+|-------|------------------------|------------------|
+| `POST /api/workflows/runtime/unblock` | `blocked` | The stopped activity must be recoverable. |
+| `POST /api/workflows/runtime/retry` | `failed` | Failures classified as `fatal` or `configuration` are not retryable. |
+
+The first implementation supports only `github_issue_pr` workflow instances.
+`cancelled` and active workflows are not supported by either action. A legacy
+stopped instance with no structured stop metadata resumes at `implement_issue`;
+partial, malformed, or unsupported stop metadata fails closed without mutating
+the workflow.
+
+When structured stop metadata is present, Harness replays the original command
+and returns the corresponding active state:
+
+| Stopped activity | New state |
+|------------------|-----------|
+| `implement_issue` | `implementing` |
+| `replan_issue` | `replanning` |
+| `merge_pr` | `merging` |
+| `run_local_review` | `local_review_gate` |
+| `sweep_pr_feedback`, `inspect_pr_feedback`, or `start_child_workflow` | `awaiting_feedback` |
+| `address_pr_feedback` | `addressing_feedback` |
+
+Recovery enqueues this replay directly. The resumed active state remains
+covered by GitHub intake so the next poll cannot enqueue duplicate work beside
+the recovery command.
+
+### Responses
+
+A successful request returns HTTP `200`. The `state` value depends on the
+replayed activity described above.
+
+```json
+{
+  "status": "unblocked",
+  "execution_path": "workflow_runtime",
+  "workflow_id": "github-issue-workflow-id",
+  "previous_state": "blocked",
+  "state": "implementing"
+}
+```
+
+Retry responses use `"status": "retried"` and
+`"previous_state": "failed"`.
+
+| HTTP status | Meaning |
+|-------------|---------|
+| `400 Bad Request` | The JSON syntax is malformed, or `workflow_id` or `reason` is blank. |
+| `401 Unauthorized` | The bearer token is missing or invalid. |
+| `404 Not Found` | The workflow id does not exist. |
+| `409 Conflict` | The action does not match the current state, the failure is non-retryable, the workflow definition is unsupported, or the stopped activity cannot be reconstructed safely. |
+| `415 Unsupported Media Type` | The request does not declare a JSON content type. |
+| `422 Unprocessable Entity` | Required JSON fields are missing or have the wrong type. |
+| `500 Internal Server Error` | Recovery failed while committing the transactional audit/state update. |
+| `503 Service Unavailable` | The workflow runtime store is unavailable. |
+
+Do not delete or edit workflow runtime rows to recover a stopped workflow.
+Direct database edits are unsupported and can break the event, decision,
+command, and runtime-job audit chain. Use the authenticated API so Harness can
+preserve stop evidence, supersede stale work safely, record the operator reason,
+and enqueue the correct follow-up command atomically.
+
+## Watchdog And Retention Sweepers
+
+Workflow-runtime watchdog and retention sweepers are configured in
+`WORKFLOW.md` under `storage`. Both are disabled by default on first rollout:
+
+```yaml
+storage:
+  orphan_reaper_enabled: true
+  orphan_reaper_interval_secs: 3600
+  orphan_reaper_legacy_enabled: true
+  orphan_reaper_legacy_batch: 200
+  workflow_watchdog_enabled: false
+  workflow_watchdog_age_minutes: 240
+  workflow_watchdog_interval_secs: 300
+  workflow_watchdog_batch_size: 100
+  runtime_retention_enabled: false
+  runtime_retention_days: 30
+  runtime_retention_batch_size: 1000
+  runtime_retention_interval_secs: 3600
+  task_retention_enabled: false
+  task_retention_days: 30
+  task_retention_batch_size: 1000
+  task_retention_interval_secs: 3600
+```
+
+The orphan schema reaper is enabled by default. It drops registered
+path-derived schemas with dead owner paths and, in bounded batches, legacy
+unregistered `h<16-hex>` schemas that cannot be matched to a live workspace
+directory or known store path under the configured workspace root.
+
+Enable `workflow_watchdog_enabled` first. It is read-only: aged `blocked` and
+`awaiting_feedback` workflow instances appear in `/api/operator-monitor` under
+`stuck_workflows` and are logged at error level.
+
+Enable `runtime_retention_enabled` only after the stuck list is clean. Retention
+deletes terminal workflow families older than `runtime_retention_days` in
+bounded batches and relies on the Postgres runtime-store cascade constraints to
+remove events, decisions, commands, jobs, runtime events, and artifacts. Active
+workflow families are never pruned.
+
+Enable `task_retention_enabled` only when historical task rows can be deleted.
+Retention deletes terminal tasks older than `task_retention_days` in bounded
+batches, including task-owned artifacts, prompts, and checkpoints. Active,
+pending, dependency-blocked, and resumable tasks are never pruned.

--- a/specs/GH1567/product.md
+++ b/specs/GH1567/product.md
@@ -23,8 +23,8 @@ which is not acceptable operator behavior.
    using structured, API-visible fields.
 2. Provide operator-authenticated HTTP actions to unblock blocked instances and
    retry failed instances without direct Postgres edits.
-3. Ensure a successful unblock makes the related GitHub issue eligible for the
-   next intake tick instead of remaining covered forever.
+3. Ensure a successful unblock or retry immediately replays the stopped
+   activity and prevents the old stopped state from holding the issue forever.
 4. Document the supported recovery flow so operators do not rely on table
    surgery.
 5. Keep automatic recovery conservative by default. A blocked workflow must not
@@ -59,10 +59,12 @@ An operator can call an authenticated HTTP action to:
 - retry a `failed` workflow when the failure is transient or after the operator
   has corrected the external condition.
 
-After a successful unblock or retry, the next GitHub issue intake scan must not
-skip the issue solely because the previous workflow state was `blocked` or
-`failed`. The workflow should either dispatch new work or report a fresh,
-structured blocker.
+After a successful unblock or retry, Harness immediately enqueues one replay of
+the supported stopped activity and moves the instance to the corresponding
+active state. The next GitHub issue intake scan may treat that active state as
+covered, but it must not observe the old `blocked` or `failed` hold or enqueue a
+second command beside the recovery replay. The replay should either continue
+the workflow or report a fresh, structured blocker.
 
 If an operator calls the wrong action for the current state, Harness returns a
 clear conflict response instead of silently doing nothing.
@@ -82,8 +84,8 @@ clear conflict response instead of silently doing nothing.
 - [ ] A successful unblock or retry records an audit event and updates the
       workflow instance so the GitHub issue coverage gate no longer treats the
       old terminal state as a permanent hold.
-- [ ] The next intake tick for the same issue can re-dispatch work or produce a
-      fresh structured blocker.
+- [ ] Recovery enqueues exactly one replay command, and the next intake tick
+      recognizes the resumed active state without dispatching duplicate work.
 - [ ] `cancelled` workflows are not automatically retried. Any support for
       cancelled workflows must be an explicit follow-up with separate
       acceptance criteria.
@@ -110,7 +112,7 @@ This feature changes operator recovery behavior and should land in small PRs:
 
 1. structured stop-reason metadata;
 2. HTTP unblock/retry actions;
-3. coverage-gate and intake re-dispatch behavior;
+3. coverage-gate recovery-state and duplicate-dispatch behavior;
 4. dashboard and usage-guide documentation.
 
 Existing blocked or failed rows may not have all structured fields. The UI and

--- a/specs/GH1567/tasks.md
+++ b/specs/GH1567/tasks.md
@@ -14,11 +14,11 @@ GH-1567
 - [x] `SP1567-T001` Owner: `workflow-runtime` | Dependencies: none | Done when: blocked and failed reducer paths derive structured stop metadata (`blocked_reason`, `unblock_hint`, `failure_reason`, `retry_hint`, and `last_stop`) from activity results and persist it in workflow instance `data` without schema migration | Verify: `cargo test -p harness-workflow runtime_failure`
 - [x] `SP1567-T002` Owner: `server-api` | Dependencies: `SP1567-T001` | Done when: `/api/workflows/runtime/unblock` exists, is authenticated by existing middleware, accepts `workflow_id` and `reason`, accepts only `blocked` workflows, records an audit event, and moves the workflow to a dispatchable state | Verify: `cargo test -p harness-server unblock`
 - [x] `SP1567-T003` Owner: `server-api` | Dependencies: `SP1567-T001` | Done when: `/api/workflows/runtime/retry` exists, is authenticated by existing middleware, accepts only retryable `failed` workflows, rejects wrong-state and non-retryable failures, records an audit event, and moves the workflow to a dispatchable state | Verify: `cargo test -p harness-server retry`
-- [ ] `SP1567-T004` Owner: `intake` | Dependencies: `SP1567-T002`, `SP1567-T003` | Done when: GitHub issue coverage remains conservative for untouched `blocked`/`failed` workflows, but a workflow updated by unblock or retry no longer causes the next intake tick to skip the issue because of the old stopped state | Verify: `cargo test -p harness-server github_coverage_gate`
+- [x] `SP1567-T004` Owner: `intake` | Dependencies: `SP1567-T002`, `SP1567-T003` | Done when: GitHub issue coverage remains conservative for untouched `blocked`/`failed` workflows, but a workflow updated by unblock or retry no longer causes the next intake tick to skip the issue because of the old stopped state | Verify: `cargo test -p harness-server github_coverage_gate`
 - [x] `SP1567-T005` Owner: `observe` | Dependencies: `SP1567-T001` | Done when: runtime tree and operator monitor payloads expose structured stopped-state fields and action eligibility without relying on free-text parsing | Verify: `cargo test -p harness-server operator_monitor runtime_tree`
-- [ ] `SP1567-T006` Owner: `web` | Dependencies: `SP1567-T002`, `SP1567-T003`, `SP1567-T005` | Done when: the operator monitor renders structured reason text, shows unblock/retry actions only when allowed, calls the new routes, and refreshes state after success | Verify: project web test command for `OperatorMonitorPanel`
-- [ ] `SP1567-T007` Owner: `docs` | Dependencies: `SP1567-T002`, `SP1567-T003` | Done when: `docs/usage-guide.md` documents the recovery API, response classes, supported states, and the rule that direct DB edits are not supported recovery | Verify: reviewer checks usage-guide section
-- [ ] `SP1567-T008` Owner: `policy` | Dependencies: all previous tasks | Done when: optional blocked recheck policy is either explicitly deferred or implemented behind disabled-by-default configuration with evidence-writing tests | Verify: implementation PR states the decision and matching tests or non-goal evidence
+- [x] `SP1567-T006` Owner: `web` | Dependencies: `SP1567-T002`, `SP1567-T003`, `SP1567-T005` | Done when: the operator monitor renders structured reason text, shows unblock/retry actions only when allowed, calls the new routes, and refreshes state after success | Verify: project web test command for `OperatorMonitorPanel`
+- [x] `SP1567-T007` Owner: `docs` | Dependencies: `SP1567-T002`, `SP1567-T003` | Done when: `docs/usage-guide.md` documents the recovery API, response classes, supported states, and the rule that direct DB edits are not supported recovery | Verify: reviewer checks usage-guide section
+- [x] `SP1567-T008` Owner: `policy` | Dependencies: all previous tasks | Done when: optional blocked recheck policy is either explicitly deferred or implemented behind disabled-by-default configuration with evidence-writing tests | Verify: implementation PR states the decision and matching tests or non-goal evidence
 
 ## Parallelization
 
@@ -45,9 +45,9 @@ GH-1567
 
 ## Handoff Notes
 
-- This spec intentionally keeps the first implementation manual/operator-driven.
-  Automatic blocked recheck is deferred unless a follow-up PR explicitly
-  enables it behind disabled-by-default configuration.
+- This implementation remains manual/operator-driven. Automatic blocked
+  recheck is explicitly deferred to GH-1584 and stays disabled unless that
+  follow-up is approved and lands with evidence-writing policy tests.
 - Use body-based runtime action routes for the first implementation because
   current workflow ids can contain project paths and slashes. A path-style alias
   requires URL-encoding tests.

--- a/specs/GH1567/tasks.md
+++ b/specs/GH1567/tasks.md
@@ -53,7 +53,10 @@ GH-1567
   requires URL-encoding tests.
 - Do not make `blocked` or `failed` globally uncovered in the coverage gate.
   The operator action should change the workflow state; the gate should then
-  observe that updated state.
+  observe that updated state. Recovery directly enqueues the replay command,
+  so resumed active states remain covered to prevent the next intake tick from
+  dispatching duplicate work; they are no longer covered by the old stopped
+  state.
 - Do not retry `cancelled` workflows in this issue.
 - Do not close GH-1567 until the implementation PRs satisfy the acceptance
   criteria, not merely this spec packet.

--- a/specs/GH1567/tech.md
+++ b/specs/GH1567/tech.md
@@ -76,7 +76,7 @@ Response shape on success for unblock:
   "execution_path": "workflow_runtime",
   "workflow_id": "...",
   "previous_state": "blocked",
-  "state": "discovered"
+  "state": "implementing"
 }
 ```
 
@@ -88,9 +88,14 @@ Response shape on success for retry:
   "execution_path": "workflow_runtime",
   "workflow_id": "...",
   "previous_state": "failed",
-  "state": "discovered"
+  "state": "implementing"
 }
 ```
+
+The examples show an `implement_issue` or legacy fallback recovery. Structured
+stops resume their original phase: `replan_issue` returns `replanning`,
+`merge_pr` returns `merging`, local review returns `local_review_gate`, and PR
+feedback activities return `awaiting_feedback` or `addressing_feedback`.
 
 The issue text proposed path-style endpoints such as
 `/api/workflows/instances/{id}/unblock`. Those can be added as aliases only if
@@ -103,18 +108,19 @@ existing runtime merge/cancel.
 `unblock`:
 
 - Allowed only from `blocked`.
-- Clears the coverage hold by moving the instance to a dispatchable state.
-- For GitHub issue workflows, the target state should be the earliest safe
-  re-dispatch state already accepted by the definition, such as `discovered` or
-  another existing pre-dispatch state chosen by the implementation after
-  checking the transition registry.
+- Clears the stopped-state hold by moving the instance to the active state for
+  the stopped activity and atomically enqueueing one replay command.
+- For structured stops, derive the target state and command from
+  `last_stop.activity` and `last_stop.runtime_job_id`. Reject unsupported or
+  incomplete metadata instead of restarting an unrelated phase. A legacy row
+  with no structured stop metadata may fall back to `implement_issue`.
 - Preserves historical stop metadata under `last_stop` or an append-only audit
   event; it must not erase evidence.
 
 `retry`:
 
 - Allowed only from `failed`.
-- Reuses the same dispatchable-state strategy as `unblock` when retry is
+- Reuses the same phase-aware replay strategy as `unblock` when retry is
   operator-approved.
 - Must reject non-retryable `error_kind` values such as `fatal` and
   `configuration` unless the request explicitly includes a force flag and a
@@ -129,17 +135,19 @@ existing runtime merge/cancel.
 - No action in the first implementation. Return `409 Conflict` with the current
   state if called on a cancelled workflow.
 
-Both actions must execute the state update and audit write inside one database
-transaction. The transaction must insert a workflow event or decision record
-that includes the operator-supplied reason, previous state, next state, and
-actor/source identifier available from the existing auth layer.
+Both actions must execute the state update, audit write, stale-command
+supersession, and replay-command enqueue inside one database transaction. The
+transaction must insert a workflow event or decision record that includes the
+operator-supplied reason, previous state, next state, and actor/source
+identifier available from the existing auth layer.
 
 ### Coverage Gate Behavior
 
 After a successful operator action, the coverage gate should observe the
-updated state rather than the old stopped state. That means the next GitHub
-issue intake scan can create or continue work instead of returning
-`Covered { source: "workflow_runtime", state: "blocked" }`.
+phase-specific active state rather than the old stopped state. Because recovery
+already enqueues the replay command, the next GitHub issue intake scan should
+return `Covered` for that current active state and must not create a second
+submission beside the recovery replay.
 
 Do not make `blocked` or `failed` globally uncovered. They should remain
 covered until the operator action changes state, because automatic redispatch
@@ -178,8 +186,9 @@ the workflow into `blocked` or `failed`, derives structured stop metadata, and
 persists it in workflow instance `data` with a workflow event/decision. The
 runtime tree and operator monitor read those fields. An authenticated operator
 calls unblock or retry. The handler validates state, writes an audit event,
-updates the instance to a dispatchable state, and returns the new state. The
-next intake tick sees the updated state and can dispatch work normally.
+supersedes stale work, updates the instance to the phase-specific active state,
+and enqueues one replay command atomically. The next intake tick sees that
+active state as covered and does not duplicate the replay.
 
 ## Alternatives Considered
 
@@ -220,8 +229,9 @@ next intake tick sees the updated state and can dispatch work normally.
       structured metadata.
 - [ ] Store/action tests proving unblock is accepted only from `blocked` and
       retry is accepted only from retryable `failed` workflows.
-- [ ] Coverage-gate test proving the same issue is covered before unblock and
-      not held by the old blocked state after unblock.
+- [ ] Coverage-gate test proving the same issue is covered by the old stopped
+      state before recovery, then by the resumed active state without adding a
+      second pending command after recovery.
 - [ ] HTTP route tests for success, not found, store unavailable, wrong state,
       and non-retryable failure responses.
 - [ ] Operator monitor/runtime tree tests proving structured reason fields are

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -50,4 +50,18 @@ describe("apiFetch", () => {
 
     unauthorizedEvents.removeEventListener("unauthorized", handler);
   });
+
+  it("surfaces a structured API error message", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "workflow not in blocked state" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ) as unknown as typeof fetch;
+
+    await expect(apiFetch("/api/workflows/runtime/unblock")).rejects.toMatchObject({
+      status: 409,
+      message: "workflow not in blocked state",
+    });
+  });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -25,6 +25,26 @@ function authHeaders(): Record<string, string> {
   return tok ? { Authorization: `Bearer ${tok}` } : {};
 }
 
+async function apiErrorMessage(resp: Response, path: string): Promise<string> {
+  const fallback = `${path} → HTTP ${resp.status}`;
+  if (!resp.headers.get("Content-Type")?.toLowerCase().includes("json")) {
+    return fallback;
+  }
+
+  let payload: unknown;
+  try {
+    payload = await resp.json();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return `${fallback} (invalid JSON error response: ${detail})`;
+  }
+  if (typeof payload !== "object" || payload === null || !("error" in payload)) {
+    return fallback;
+  }
+  const detail = (payload as { error?: unknown }).error;
+  return typeof detail === "string" && detail.trim() ? detail.trim() : fallback;
+}
+
 export async function apiFetch(
   path: string,
   init: RequestInit = {},
@@ -43,7 +63,7 @@ export async function apiFetch(
     throw new ApiError(401, `${path} → 401`);
   }
   if (!resp.ok) {
-    throw new ApiError(resp.status, `${path} → HTTP ${resp.status}`);
+    throw new ApiError(resp.status, await apiErrorMessage(resp, path));
   }
   return resp;
 }

--- a/web/src/routes/overview/OperatorMonitorPanel.test.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.test.tsx
@@ -205,7 +205,7 @@ describe("<OperatorMonitorPanel>", () => {
     expect(screen.queryByText("No current operator actions.")).not.toBeInTheDocument();
   });
 
-  it("renders structured stop details and invokes only eligible recovery actions", async () => {
+  it("renders current-state stop details and invokes only eligible recovery actions", async () => {
     const monitor = makeMonitor();
     const baseAction = monitor.operator_actions[0];
     monitor.operator_actions = [
@@ -216,6 +216,9 @@ describe("<OperatorMonitorPanel>", () => {
         state: "blocked",
         blocked_reason: "Waiting for maintainer approval.",
         unblock_hint: "Post the approval comment, then unblock.",
+        failure_reason: "Stale failed reason.",
+        retry_hint: "Stale retry hint.",
+        last_stop: { state: "failed" },
         can_unblock: true,
         can_retry: false,
       },
@@ -224,8 +227,11 @@ describe("<OperatorMonitorPanel>", () => {
         kind: "failed",
         workflow_id: "workflow-retryable",
         state: "failed",
+        blocked_reason: "Stale blocked reason.",
+        unblock_hint: "Stale unblock hint.",
         failure_reason: "Runtime transport timed out.",
         retry_hint: "Retry after transport recovers.",
+        last_stop: { state: "blocked" },
         can_unblock: false,
         can_retry: true,
       },
@@ -241,8 +247,9 @@ describe("<OperatorMonitorPanel>", () => {
     ];
     monitor.stuck_workflows[0] = {
       ...monitor.stuck_workflows[0],
-      state: "blocked",
       blocked_reason: "Aged workflow still needs approval.",
+      failure_reason: "Stale aged failure.",
+      last_stop: { state: "blocked" },
     };
     mockUseOperatorMonitor.mockReturnValue({ data: monitor, isError: false });
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -251,8 +258,19 @@ describe("<OperatorMonitorPanel>", () => {
     wrap(<OperatorMonitorPanel />, queryClient);
 
     expect(screen.getByText("Waiting for maintainer approval.")).toBeInTheDocument();
+    expect(screen.getByText("Post the approval comment, then unblock.")).toBeInTheDocument();
     expect(screen.getByText("Runtime transport timed out.")).toBeInTheDocument();
+    expect(screen.getByText("Retry after transport recovers.")).toBeInTheDocument();
     expect(screen.getByText("Aged workflow still needs approval.")).toBeInTheDocument();
+    for (const staleText of [
+      "Stale failed reason.",
+      "Stale retry hint.",
+      "Stale blocked reason.",
+      "Stale unblock hint.",
+      "Stale aged failure.",
+    ]) {
+      expect(screen.queryByText(staleText)).not.toBeInTheDocument();
+    }
     expect(
       screen.queryByRole("button", { name: "Retry workflow workflow-nonretryable" }),
     ).not.toBeInTheDocument();

--- a/web/src/routes/overview/OperatorMonitorPanel.test.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.test.tsx
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { OperatorMonitorPanel } from "./OperatorMonitorPanel";
 import type { OperatorMonitorPayload } from "@/types";
 
@@ -8,12 +8,20 @@ vi.mock("@/lib/queries", () => ({
   useOperatorMonitor: vi.fn(),
 }));
 
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
 import { useOperatorMonitor } from "@/lib/queries";
+import { apiFetch } from "@/lib/api";
 
 const mockUseOperatorMonitor = useOperatorMonitor as ReturnType<typeof vi.fn>;
+const mockApiFetch = apiFetch as ReturnType<typeof vi.fn>;
 
-function wrap(ui: React.ReactElement) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function wrap(
+  ui: React.ReactElement,
+  qc = new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+) {
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
 }
 
@@ -136,6 +144,11 @@ function makeMonitor(): OperatorMonitorPayload {
 }
 
 describe("<OperatorMonitorPanel>", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiFetch.mockResolvedValue(new Response("{}", { status: 200 }));
+  });
+
   it("renders active runtime work and ready-to-merge operator actions", () => {
     mockUseOperatorMonitor.mockReturnValue({
       data: makeMonitor(),
@@ -190,5 +203,128 @@ describe("<OperatorMonitorPanel>", () => {
 
     expect(screen.getByText("Operator monitor unavailable.")).toBeInTheDocument();
     expect(screen.queryByText("No current operator actions.")).not.toBeInTheDocument();
+  });
+
+  it("renders structured stop details and invokes only eligible recovery actions", async () => {
+    const monitor = makeMonitor();
+    const baseAction = monitor.operator_actions[0];
+    monitor.operator_actions = [
+      {
+        ...baseAction,
+        kind: "blocked",
+        workflow_id: "workflow-blocked",
+        state: "blocked",
+        blocked_reason: "Waiting for maintainer approval.",
+        unblock_hint: "Post the approval comment, then unblock.",
+        can_unblock: true,
+        can_retry: false,
+      },
+      {
+        ...baseAction,
+        kind: "failed",
+        workflow_id: "workflow-retryable",
+        state: "failed",
+        failure_reason: "Runtime transport timed out.",
+        retry_hint: "Retry after transport recovers.",
+        can_unblock: false,
+        can_retry: true,
+      },
+      {
+        ...baseAction,
+        kind: "failed",
+        workflow_id: "workflow-nonretryable",
+        state: "failed",
+        failure_reason: "Runtime configuration is invalid.",
+        can_unblock: false,
+        can_retry: false,
+      },
+    ];
+    monitor.stuck_workflows[0] = {
+      ...monitor.stuck_workflows[0],
+      state: "blocked",
+      blocked_reason: "Aged workflow still needs approval.",
+    };
+    mockUseOperatorMonitor.mockReturnValue({ data: monitor, isError: false });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+    wrap(<OperatorMonitorPanel />, queryClient);
+
+    expect(screen.getByText("Waiting for maintainer approval.")).toBeInTheDocument();
+    expect(screen.getByText("Runtime transport timed out.")).toBeInTheDocument();
+    expect(screen.getByText("Aged workflow still needs approval.")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Retry workflow workflow-nonretryable" }),
+    ).not.toBeInTheDocument();
+
+    const unblockButton = screen.getByRole("button", {
+      name: "Unblock workflow workflow-blocked",
+    });
+    fireEvent.click(unblockButton);
+    expect(screen.getByText("Recovery reason is required.")).toBeInTheDocument();
+    expect(mockApiFetch).not.toHaveBeenCalled();
+    fireEvent.change(screen.getByLabelText("Recovery reason for workflow-blocked"), {
+      target: { value: "  Approval was posted  " },
+    });
+    fireEvent.click(unblockButton);
+
+    await waitFor(() =>
+      expect(mockApiFetch).toHaveBeenNthCalledWith(1, "/api/workflows/runtime/unblock", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          workflow_id: "workflow-blocked",
+          reason: "Approval was posted",
+        }),
+      }),
+    );
+    await waitFor(() => expect(unblockButton).toBeEnabled());
+
+    fireEvent.change(screen.getByLabelText("Recovery reason for workflow-retryable"), {
+      target: { value: "Transport is healthy" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry workflow workflow-retryable" }),
+    );
+
+    await waitFor(() =>
+      expect(mockApiFetch).toHaveBeenNthCalledWith(2, "/api/workflows/runtime/retry", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          workflow_id: "workflow-retryable",
+          reason: "Transport is healthy",
+        }),
+      }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["operator-monitor"] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["workflow-runtime-tree"] });
+  });
+
+  it("shows recovery failures instead of swallowing them", async () => {
+    const monitor = makeMonitor();
+    monitor.operator_actions[0] = {
+      ...monitor.operator_actions[0],
+      kind: "blocked",
+      workflow_id: "workflow-blocked",
+      state: "blocked",
+      can_unblock: true,
+    };
+    mockUseOperatorMonitor.mockReturnValue({ data: monitor, isError: false });
+    mockApiFetch.mockRejectedValueOnce(new Error("workflow not in blocked state"));
+
+    wrap(<OperatorMonitorPanel />);
+    fireEvent.change(screen.getByLabelText("Recovery reason for workflow-blocked"), {
+      target: { value: "Approval was posted" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Unblock workflow workflow-blocked" }),
+    );
+
+    expect(
+      await screen.findByText(
+        "Workflow recovery failed: workflow not in blocked state",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/routes/overview/OperatorMonitorPanel.test.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.test.tsx
@@ -297,6 +297,7 @@ describe("<OperatorMonitorPanel>", () => {
       }),
     );
     await waitFor(() => expect(unblockButton).toBeEnabled());
+    await waitFor(() => expect(unblockButton).toHaveTextContent(/^Unblock$/));
 
     fireEvent.change(screen.getByLabelText("Recovery reason for workflow-retryable"), {
       target: { value: "Transport is healthy" },
@@ -335,14 +336,17 @@ describe("<OperatorMonitorPanel>", () => {
     fireEvent.change(screen.getByLabelText("Recovery reason for workflow-blocked"), {
       target: { value: "Approval was posted" },
     });
-    fireEvent.click(
-      screen.getByRole("button", { name: "Unblock workflow workflow-blocked" }),
-    );
+    const unblockButton = screen.getByRole("button", {
+      name: "Unblock workflow workflow-blocked",
+    });
+    fireEvent.click(unblockButton);
 
     expect(
       await screen.findByText(
         "Workflow recovery failed: workflow not in blocked state",
       ),
     ).toBeInTheDocument();
+    expect(unblockButton).toBeEnabled();
+    expect(unblockButton).toHaveTextContent(/^Unblock$/);
   });
 });

--- a/web/src/routes/overview/OperatorMonitorPanel.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.tsx
@@ -42,9 +42,32 @@ function Metric({ label, value, tone = "default" }: { label: string; value: stri
   );
 }
 
-function StructuredStopDetails({ stopped }: { stopped: RuntimeStoppedState }) {
-  const reason = stopped.blocked_reason?.trim() || stopped.failure_reason?.trim();
-  const hint = stopped.unblock_hint?.trim() || stopped.retry_hint?.trim();
+function StructuredStopDetails({
+  state,
+  stopped,
+}: {
+  state: string;
+  stopped: RuntimeStoppedState;
+}) {
+  const lastStopState = stopped.last_stop?.state;
+  const displayState =
+    state === "blocked" || state === "failed"
+      ? state
+      : lastStopState === "blocked" || lastStopState === "failed"
+        ? lastStopState
+        : null;
+  const reason =
+    displayState === "blocked"
+      ? stopped.blocked_reason?.trim()
+      : displayState === "failed"
+        ? stopped.failure_reason?.trim()
+        : null;
+  const hint =
+    displayState === "blocked"
+      ? stopped.unblock_hint?.trim()
+      : displayState === "failed"
+        ? stopped.retry_hint?.trim()
+        : null;
   if (!reason && !hint) return null;
 
   return (
@@ -138,7 +161,7 @@ function ActionRow({
       </td>
       <td className="px-3 py-2 font-mono text-[11px] text-ink-2">
         <div>{action.state}</div>
-        <StructuredStopDetails stopped={action} />
+        <StructuredStopDetails state={action.state} stopped={action} />
       </td>
       <td className="px-3 py-2 font-mono text-[11px] text-ink-4">{fmtDuration(action.age_secs)}</td>
       <td className="px-3 py-2 text-right font-mono text-[11px]">
@@ -187,7 +210,7 @@ function StuckWorkflowRow({ workflow }: { workflow: StuckWorkflow }) {
     <tr className="border-b border-line last:border-b-0">
       <td className="px-3 py-2 font-mono text-[11px] text-warn">
         <div>{workflow.state.replace(/_/g, " ")}</div>
-        <StructuredStopDetails stopped={workflow} />
+        <StructuredStopDetails state={workflow.state} stopped={workflow} />
       </td>
       <td className="px-3 py-2 font-mono text-[11px] text-ink-3">{workflow.repo ?? "untracked"}</td>
       <td className="px-3 py-2 font-mono text-[11px] text-ink-3">

--- a/web/src/routes/overview/OperatorMonitorPanel.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.tsx
@@ -387,7 +387,9 @@ export function OperatorMonitorPanel() {
           data={data}
           onRecover={(input) => recovery.mutate(input)}
           recoveryDisabled={recovery.isPending}
-          recoveryPendingWorkflowId={recovery.variables?.workflowId ?? null}
+          recoveryPendingWorkflowId={
+            recovery.isPending ? (recovery.variables?.workflowId ?? null) : null
+          }
         />
       ) : (
         <p className="px-4 py-3 font-mono text-[11px] text-ink-4">Loading operator monitor.</p>

--- a/web/src/routes/overview/OperatorMonitorPanel.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.tsx
@@ -1,7 +1,25 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Panel } from "@/components/Panel";
+import { apiFetch } from "@/lib/api";
 import { useOperatorMonitor } from "@/lib/queries";
 import { fmtInt } from "@/lib/format";
-import type { FailureGroup, OperatorAction, OperatorMonitorPayload, SourceActivity, StuckWorkflow } from "@/types";
+import type {
+  FailureGroup,
+  OperatorAction,
+  OperatorMonitorPayload,
+  RuntimeStoppedState,
+  SourceActivity,
+  StuckWorkflow,
+} from "@/types";
+
+type WorkflowRecoveryAction = "unblock" | "retry";
+
+interface WorkflowRecoveryInput {
+  action: WorkflowRecoveryAction;
+  workflowId: string;
+  reason: string;
+}
 
 function fmtDuration(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
@@ -24,7 +42,92 @@ function Metric({ label, value, tone = "default" }: { label: string; value: stri
   );
 }
 
-function ActionRow({ action }: { action: OperatorAction }) {
+function StructuredStopDetails({ stopped }: { stopped: RuntimeStoppedState }) {
+  const reason = stopped.blocked_reason?.trim() || stopped.failure_reason?.trim();
+  const hint = stopped.unblock_hint?.trim() || stopped.retry_hint?.trim();
+  if (!reason && !hint) return null;
+
+  return (
+    <div className="mt-1 max-w-72 space-y-0.5 normal-case tracking-normal">
+      {reason && <div className="line-clamp-2 text-[10px] text-ink-2">{reason}</div>}
+      {hint && <div className="line-clamp-2 text-[10px] text-ink-4">{hint}</div>}
+    </div>
+  );
+}
+
+function RecoveryControl({
+  workflowId,
+  action,
+  disabled,
+  pending,
+  onRecover,
+}: {
+  workflowId: string;
+  action: WorkflowRecoveryAction;
+  disabled: boolean;
+  pending: boolean;
+  onRecover: (input: WorkflowRecoveryInput) => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const label = action === "unblock" ? "Unblock" : "Retry";
+
+  return (
+    <form
+      className="mt-2 flex min-w-52 flex-col items-end gap-1"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const trimmedReason = reason.trim();
+        if (!trimmedReason) {
+          setValidationError("Recovery reason is required.");
+          return;
+        }
+        setValidationError(null);
+        onRecover({ action, workflowId, reason: trimmedReason });
+      }}
+    >
+      <div className="flex w-full gap-1">
+        <input
+          aria-label={`Recovery reason for ${workflowId}`}
+          className="min-w-0 flex-1 border border-line bg-bg-1 px-2 py-1 text-[10px] text-ink-2 placeholder:text-ink-4 focus:border-rust focus:outline-none"
+          disabled={disabled}
+          onChange={(event) => setReason(event.target.value)}
+          placeholder="Operator reason"
+          type="text"
+          value={reason}
+        />
+        <button
+          aria-label={`${label} workflow ${workflowId}`}
+          className="border border-rust/50 px-2 py-1 text-[10px] text-rust hover:bg-rust/5 disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={disabled}
+          type="submit"
+        >
+          {pending ? `${label}ing…` : label}
+        </button>
+      </div>
+      {validationError && (
+        <span className="text-[10px] text-danger" role="alert">
+          {validationError}
+        </span>
+      )}
+    </form>
+  );
+}
+
+function ActionRow({
+  action,
+  recoveryDisabled,
+  recoveryPending,
+  onRecover,
+}: {
+  action: OperatorAction;
+  recoveryDisabled: boolean;
+  recoveryPending: boolean;
+  onRecover: (input: WorkflowRecoveryInput) => void;
+}) {
+  const recoveryAction: WorkflowRecoveryAction | null =
+    action.can_unblock === true ? "unblock" : action.can_retry === true ? "retry" : null;
+
   return (
     <tr className="border-b border-line last:border-b-0">
       <td className="px-3 py-2 font-mono text-[11px] text-ink-2">{action.kind.replace(/_/g, " ")}</td>
@@ -33,7 +136,10 @@ function ActionRow({ action }: { action: OperatorAction }) {
         {action.issue ? `#${action.issue}` : "unknown"}
         {action.pr ? ` -> PR #${action.pr}` : ""}
       </td>
-      <td className="px-3 py-2 font-mono text-[11px] text-ink-2">{action.state}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-2">
+        <div>{action.state}</div>
+        <StructuredStopDetails stopped={action} />
+      </td>
       <td className="px-3 py-2 font-mono text-[11px] text-ink-4">{fmtDuration(action.age_secs)}</td>
       <td className="px-3 py-2 text-right font-mono text-[11px]">
         {action.url ? (
@@ -46,6 +152,15 @@ function ActionRow({ action }: { action: OperatorAction }) {
           </a>
         ) : (
           <span className="text-ink-4">unlinked</span>
+        )}
+        {recoveryAction && (
+          <RecoveryControl
+            action={recoveryAction}
+            disabled={recoveryDisabled}
+            onRecover={onRecover}
+            pending={recoveryPending}
+            workflowId={action.workflow_id}
+          />
         )}
       </td>
     </tr>
@@ -70,7 +185,10 @@ function FailureRow({ failure }: { failure: FailureGroup }) {
 function StuckWorkflowRow({ workflow }: { workflow: StuckWorkflow }) {
   return (
     <tr className="border-b border-line last:border-b-0">
-      <td className="px-3 py-2 font-mono text-[11px] text-warn">{workflow.state.replace(/_/g, " ")}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-warn">
+        <div>{workflow.state.replace(/_/g, " ")}</div>
+        <StructuredStopDetails stopped={workflow} />
+      </td>
       <td className="px-3 py-2 font-mono text-[11px] text-ink-3">{workflow.repo ?? "untracked"}</td>
       <td className="px-3 py-2 font-mono text-[11px] text-ink-3">
         {workflow.issue ? `#${workflow.issue}` : workflow.workflow_id}
@@ -105,7 +223,17 @@ function SourceRow({ source }: { source: SourceActivity }) {
   );
 }
 
-function MonitorBody({ data }: { data: OperatorMonitorPayload }) {
+function MonitorBody({
+  data,
+  recoveryDisabled,
+  recoveryPendingWorkflowId,
+  onRecover,
+}: {
+  data: OperatorMonitorPayload;
+  recoveryDisabled: boolean;
+  recoveryPendingWorkflowId: string | null;
+  onRecover: (input: WorkflowRecoveryInput) => void;
+}) {
   const runtime = data.activity.runtime_workflows;
   const legacy = data.activity.legacy_queue;
   const healthTone = data.health.status === "ok" ? "ok" : "warn";
@@ -131,7 +259,17 @@ function MonitorBody({ data }: { data: OperatorMonitorPayload }) {
             <p className="border-t border-line px-4 py-3 font-mono text-[11px] text-ink-4">No current operator actions.</p>
           ) : (
             <table className="w-full border-t border-line">
-              <tbody>{data.operator_actions.map((action) => <ActionRow key={action.workflow_id} action={action} />)}</tbody>
+              <tbody>
+                {data.operator_actions.map((action) => (
+                  <ActionRow
+                    key={action.workflow_id}
+                    action={action}
+                    onRecover={onRecover}
+                    recoveryDisabled={recoveryDisabled}
+                    recoveryPending={recoveryPendingWorkflowId === action.workflow_id}
+                  />
+                ))}
+              </tbody>
             </table>
           )}
         </div>
@@ -196,13 +334,38 @@ function MonitorBody({ data }: { data: OperatorMonitorPayload }) {
 
 export function OperatorMonitorPanel() {
   const { data, isError } = useOperatorMonitor();
+  const queryClient = useQueryClient();
+  const recovery = useMutation<Response, Error, WorkflowRecoveryInput>({
+    mutationFn: ({ action, workflowId, reason }) =>
+      apiFetch(`/api/workflows/runtime/${action}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workflow_id: workflowId, reason }),
+      }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["operator-monitor"] }),
+        queryClient.invalidateQueries({ queryKey: ["workflow-runtime-tree"] }),
+      ]);
+    },
+  });
 
   return (
     <Panel title="Operator monitor" sub="runtime · actions · failures · worktrees" id="operator-monitor">
+      {recovery.error && (
+        <p className="border-b border-line px-4 py-3 font-mono text-[11px] text-danger" role="alert">
+          Workflow recovery failed: {recovery.error.message}
+        </p>
+      )}
       {isError ? (
         <p className="px-4 py-3 font-mono text-[11px] text-danger">Operator monitor unavailable.</p>
       ) : data ? (
-        <MonitorBody data={data} />
+        <MonitorBody
+          data={data}
+          onRecover={(input) => recovery.mutate(input)}
+          recoveryDisabled={recovery.isPending}
+          recoveryPendingWorkflowId={recovery.variables?.workflowId ?? null}
+        />
       ) : (
         <p className="px-4 py-3 font-mono text-[11px] text-ink-4">Loading operator monitor.</p>
       )}

--- a/web/src/types/operator_monitor.ts
+++ b/web/src/types/operator_monitor.ts
@@ -56,8 +56,19 @@ export interface SourceActivity {
   ready_to_merge: number;
 }
 
-export interface OperatorAction {
-  kind: "ready_to_merge" | "awaiting_feedback" | "blocked" | string;
+export interface RuntimeStoppedState {
+  blocked_reason?: string | null;
+  unblock_hint?: string | null;
+  failure_reason?: string | null;
+  error_kind?: string | null;
+  retry_hint?: string | null;
+  last_stop?: Record<string, unknown> | null;
+  can_unblock?: boolean;
+  can_retry?: boolean;
+}
+
+export interface OperatorAction extends RuntimeStoppedState {
+  kind: "ready_to_merge" | "awaiting_feedback" | "blocked" | "failed" | string;
   repo: string | null;
   issue: number | null;
   pr: number | null;
@@ -71,7 +82,7 @@ export interface OperatorAction {
   source: string;
 }
 
-export interface StuckWorkflow {
+export interface StuckWorkflow extends RuntimeStoppedState {
   workflow_id: string;
   definition_id: string;
   state: string;


### PR DESCRIPTION
## Summary

- Complete GH-1567 T004 by keeping phase-specific recovery states covered after the recovery transaction directly enqueues its replay command, preventing the next intake tick from adding duplicate work.
- Add operator-monitor unblock/retry controls driven only by backend eligibility, render current structured stop reasons and hints, require an operator reason, refresh runtime queries after success, and surface structured API errors.
- Document the authenticated recovery contract, supported activities/states, response classes, and the prohibition on direct database edits.
- Reconcile the GH-1567 product, technical, and task specs with phase-aware direct replay semantics.
- Stabilize the existing Codex descendant-cleanup regression test and split its configuration tests so the parent test file remains below the repository file-size ceiling.

## SP1567-T008 policy decision

SP1567-T008 is explicitly deferred to GH-1584. This PR preserves manual, authenticated recovery only; it does not add periodic rechecks or automatic recovery for blocked or failed workflows. Automatic recheck remains a separate disabled-by-default policy surface requiring reason classification, bounded attempts and backoff, durable evidence, and race-safe coordination with manual recovery.

## Duplicate-dispatch regression

Recovery already replays the stopped command atomically. A database-backed regression reproduced the old intake race as two pending commands, then verifies that recovered `replanning` and `local_review_gate` states remain covered and only the single recovery command remains pending.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-Dwarnings" cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -- --test-threads=1` (including 1656 harness-server tests and 368 harness-workflow tests)
- `cargo test -p harness-server github_coverage_gate -- --test-threads=1`
- `bun run typecheck`
- `bun run test` (31 files, 152 tests)
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1567`
- SpecRail implement route gate: allowed
- `git diff --check origin/main...HEAD`

## Review

Independent exact-head review at `c89b3e471933fa9d03e6220f6e7b05aff7becd66` found no blocking issues and recommended approval. Scope is 13 files, 953 additions, and 248 deletions.

Closes #1567