### PR TITLE
feat(eval): add private NAP replay evidence tooling

### DIFF
--- a/scripts/evaluate_nap_replay.py
+++ b/scripts/evaluate_nap_replay.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python3
+"""Build a private NAP replay manifest and summarize GH1574 gate evidence.
+
+The tool has no network or subprocess client. ``build-manifest`` reads local
+Codex JSONL and writes pseudonymous metadata only. ``summarize-evidence``
+accepts already-produced A/B measurements and writes an aggregate-only report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import math
+import os
+import re
+import stat
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from nap_replay_safety import (
+    MAX_JSONL_LINE_BYTES,
+    MAX_METRIC_VALUE,
+    MAX_RECORDS_PER_SESSION,
+    ReplayValidationError,
+    _assert_no_leaks,
+    _json_loads,
+    _load_salt,
+    _strict_json_load,
+    _validate_salt,
+    secure_write_json,
+)
+
+
+SCHEMA_VERSION = 1
+PHASE1_EXPECTED_SESSIONS = 40
+DEFAULT_SALT_ENV = "HARNESS_NAP_REPLAY_SALT"
+MAX_TOP_N = 1_000
+MAX_CANDIDATE_FILES = 100_000
+MAX_SESSION_BYTES = 1024 * 1024 * 1024
+MAX_TOTAL_SCAN_BYTES = 16 * 1024 * 1024 * 1024
+
+SESSION_KEY_RE = re.compile(r"session_[0-9a-f]{32}\Z")
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+ROLLOUT_DATE_RE = re.compile(r"rollout-(\d{4}-\d{2}-\d{2})T")
+OBSERVATION_FIELDS = {
+    "function_call_output": ("output",),
+    "custom_tool_call_output": ("output",),
+    "tool_call_output": ("output",),
+    "tool_output": ("output", "content", "result"),
+    "tool_search_output": ("execution", "tools"),
+    "mcp_tool_call_end": ("result",),
+    "patch_apply_end": ("stdout", "stderr", "changes"),
+}
+
+MANIFEST_KEYS = {
+    "schema_version",
+    "manifest_id",
+    "corpus_kind",
+    "selection",
+    "sessions",
+    "aggregate",
+}
+SELECTION_KEYS = {
+    "candidate_sessions",
+    "expected_sessions",
+    "selected_sessions",
+    "since_date",
+    "through_date",
+    "order",
+}
+MANIFEST_SESSION_KEYS = {
+    "session_key",
+    "source_hmac_sha256",
+    "bytes",
+    "records",
+    "observation_records",
+    "observation_bytes",
+}
+AGGREGATE_KEYS = {"bytes", "records", "observation_records", "observation_bytes"}
+EVIDENCE_KEYS = {
+    "schema_version",
+    "manifest_id",
+    "expected_sessions",
+    "pricing",
+    "sessions",
+}
+PRICING_KEYS = {
+    "compressor_input_usd_per_million",
+    "compressor_output_usd_per_million",
+    "saved_input_usd_per_million",
+}
+EVIDENCE_SESSION_KEYS = {
+    "session_key",
+    "baseline_tokens",
+    "compressed_tokens",
+    "fallback_raw_tokens",
+    "untouched_raw_tokens",
+    "nap_checked",
+    "nap_failed",
+    "baseline_success",
+    "candidate_success",
+    "compressor_input_tokens",
+    "compressor_output_tokens",
+}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    path: Path
+    relative_path: str
+    size: int
+    session_key: str
+    device: int
+    inode: int
+    modified_ns: int
+    changed_ns: int
+
+
+def _require_object(value: Any, label: str, keys: set[str]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ReplayValidationError(f"{label} must be an object")
+    actual = set(value)
+    if actual != keys:
+        raise ReplayValidationError(
+            f"{label} schema mismatch; missing={sorted(keys - actual)}, "
+            f"extra={sorted(actual - keys)}"
+        )
+    return value
+
+
+def _require_int(value: Any, label: str, *, positive: bool = False) -> int:
+    minimum = 1 if positive else 0
+    if type(value) is not int or not minimum <= value <= MAX_METRIC_VALUE:
+        qualifier = "positive" if positive else "non-negative"
+        raise ReplayValidationError(f"{label} must be a bounded {qualifier} integer")
+    return value
+
+
+def _require_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ReplayValidationError(f"{label} must be a non-negative number")
+    result = float(value)
+    if not math.isfinite(result) or not 0 <= result <= MAX_METRIC_VALUE:
+        raise ReplayValidationError(f"{label} must be a bounded non-negative number")
+    return result
+
+
+def _require_bool(value: Any, label: str) -> bool:
+    if type(value) is not bool:
+        raise ReplayValidationError(f"{label} must be a boolean")
+    return value
+
+
+def _require_session_key(value: Any, label: str) -> str:
+    if not isinstance(value, str) or SESSION_KEY_RE.fullmatch(value) is None:
+        raise ReplayValidationError(f"{label} must be a pseudonymous session key")
+    return value
+
+
+def _pseudonym(relative_path: str, salt: bytes) -> str:
+    message = b"harness.nap-replay.session.v1\0" + relative_path.encode("utf-8")
+    digest = hmac.new(salt, message, hashlib.sha256).hexdigest()
+    return f"session_{digest[:32]}"
+
+
+def _parse_date(raw: str) -> date:
+    try:
+        return date.fromisoformat(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("date must use YYYY-MM-DD") from exc
+
+
+def _session_date(relative_path: str) -> date:
+    parts = Path(relative_path).parts
+    if len(parts) >= 3:
+        try:
+            parsed = date(int(parts[0]), int(parts[1]), int(parts[2]))
+        except (TypeError, ValueError):
+            parsed = None
+        if parsed is not None:
+            return parsed
+    match = ROLLOUT_DATE_RE.search(Path(relative_path).name)
+    if match is None:
+        raise ReplayValidationError("session candidate has no parseable rollout date")
+    try:
+        return date.fromisoformat(match.group(1))
+    except ValueError as exc:
+        raise ReplayValidationError("session candidate has an invalid rollout date") from exc
+
+
+def _walk_jsonl(
+    root: Path,
+    salt: bytes,
+    since_date: date | None,
+    through_date: date | None,
+) -> list[Candidate]:
+    if root.is_symlink() or not root.is_dir():
+        raise ReplayValidationError("sessions root must be a real directory")
+    if since_date and through_date and since_date > through_date:
+        raise ReplayValidationError("since_date must not be after through_date")
+    root = root.resolve()
+    candidates: list[Candidate] = []
+    seen_files: set[tuple[int, int]] = set()
+    visited_entries = 0
+
+    def walk_error(_: OSError) -> None:
+        raise ReplayValidationError("failed to traverse the sessions root")
+
+    for current, directories, files in os.walk(
+        root, followlinks=False, onerror=walk_error
+    ):
+        current_path = Path(current)
+        visited_entries += len(directories) + len(files)
+        if visited_entries > MAX_CANDIDATE_FILES:
+            raise ReplayValidationError("sessions root exceeds the visited-entry limit")
+        if any((current_path / item).is_symlink() for item in directories):
+            raise ReplayValidationError("sessions root contains a directory symlink")
+        for filename in files:
+            if not filename.endswith(".jsonl"):
+                continue
+            path = current_path / filename
+            try:
+                info = path.lstat()
+            except OSError as exc:
+                raise ReplayValidationError("failed to stat a session file") from exc
+            if path.is_symlink() or not stat.S_ISREG(info.st_mode):
+                raise ReplayValidationError("session candidate must be a regular file")
+            if info.st_nlink != 1 or info.st_size > MAX_SESSION_BYTES:
+                raise ReplayValidationError("session candidate violates link or size limits")
+            relative = path.relative_to(root).as_posix()
+            observed_date = _session_date(relative)
+            if since_date and observed_date < since_date:
+                continue
+            if through_date and observed_date > through_date:
+                continue
+            identity = (info.st_dev, info.st_ino)
+            if identity in seen_files:
+                raise ReplayValidationError("sessions root contains duplicate hard-linked files")
+            seen_files.add(identity)
+            candidates.append(
+                Candidate(
+                    path,
+                    relative,
+                    info.st_size,
+                    _pseudonym(relative, salt),
+                    info.st_dev,
+                    info.st_ino,
+                    info.st_mtime_ns,
+                    info.st_ctime_ns,
+                )
+            )
+    return candidates
+
+
+def _content_bytes(value: Any) -> int:
+    if isinstance(value, str):
+        return len(value.encode("utf-8"))
+    if isinstance(value, (list, dict)):
+        encoded = json.dumps(
+            value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        )
+        return len(encoded.encode("utf-8"))
+    if value is None:
+        return 0
+    raise ReplayValidationError("observation content has an unsupported JSON type")
+
+
+def _observation_bytes(record: dict[str, Any]) -> int | None:
+    outer_type = record.get("type")
+    if not isinstance(outer_type, str) or not outer_type:
+        raise ReplayValidationError("every JSONL record must have a string type")
+    observation = record
+    observation_type = outer_type
+    if outer_type in {"response_item", "event_msg"}:
+        observation = record.get("payload")
+        if not isinstance(observation, dict):
+            raise ReplayValidationError(f"{outer_type} payload must be an object")
+        observation_type = observation.get("type")
+    fields = OBSERVATION_FIELDS.get(observation_type)
+    if fields is None:
+        return None
+    present = [observation[field] for field in fields if field in observation]
+    if not present:
+        raise ReplayValidationError("observation record has no supported content field")
+    return sum(_content_bytes(value) for value in present)
+
+
+def _scan_candidate(candidate: Candidate, salt: bytes) -> dict[str, Any]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(candidate.path, flags)
+    except OSError as exc:
+        raise ReplayValidationError("failed to open a selected session safely") from exc
+    records = observation_records = observation_bytes = 0
+    digest_key = hmac.new(
+        salt, b"harness.nap-replay.source-content.v1", hashlib.sha256
+    ).digest()
+    digest = hmac.new(digest_key, digestmod=hashlib.sha256)
+    try:
+        with os.fdopen(descriptor, "rb") as handle:
+            before = os.fstat(handle.fileno())
+            expected = (
+                candidate.device,
+                candidate.inode,
+                candidate.size,
+                candidate.modified_ns,
+                candidate.changed_ns,
+            )
+            observed = (
+                before.st_dev,
+                before.st_ino,
+                before.st_size,
+                before.st_mtime_ns,
+                before.st_ctime_ns,
+            )
+            if observed != expected:
+                raise ReplayValidationError("session changed after candidate discovery")
+            while True:
+                raw_line = handle.readline(MAX_JSONL_LINE_BYTES + 1)
+                if not raw_line:
+                    break
+                records += 1
+                if records > MAX_RECORDS_PER_SESSION:
+                    raise ReplayValidationError("session exceeds the record-count limit")
+                if not raw_line.strip() or len(raw_line) > MAX_JSONL_LINE_BYTES:
+                    raise ReplayValidationError("session contains an invalid-size record")
+                digest.update(raw_line)
+                try:
+                    record = _json_loads(raw_line.decode("utf-8"))
+                except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+                    raise ReplayValidationError("session contains invalid JSONL") from exc
+                if not isinstance(record, dict):
+                    raise ReplayValidationError("every JSONL record must be an object")
+                size = _observation_bytes(record)
+                if size is not None:
+                    observation_records += 1
+                    observation_bytes += size
+            after = os.fstat(handle.fileno())
+            stable = (
+                after.st_dev,
+                after.st_ino,
+                after.st_size,
+                after.st_mtime_ns,
+                after.st_ctime_ns,
+            )
+            if stable != expected:
+                raise ReplayValidationError("session changed while it was scanned")
+    except ReplayValidationError:
+        raise
+    except OSError as exc:
+        raise ReplayValidationError("failed while scanning a selected session") from exc
+    return {
+        "session_key": candidate.session_key,
+        "source_hmac_sha256": digest.hexdigest(),
+        "bytes": candidate.size,
+        "records": records,
+        "observation_records": observation_records,
+        "observation_bytes": observation_bytes,
+    }
+
+
+def _manifest_id(manifest: dict[str, Any]) -> str:
+    body = {key: value for key, value in manifest.items() if key != "manifest_id"}
+    encoded = json.dumps(body, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def build_manifest(
+    sessions_root: Path,
+    salt: bytes,
+    top_n: int = PHASE1_EXPECTED_SESSIONS,
+    since_date: date | None = None,
+    through_date: date | None = None,
+) -> dict[str, Any]:
+    _validate_salt(salt)
+    if not 1 <= top_n <= MAX_TOP_N:
+        raise ReplayValidationError(f"top_n must be between 1 and {MAX_TOP_N}")
+    candidates = _walk_jsonl(sessions_root, salt, since_date, through_date)
+    if len(candidates) < top_n:
+        raise ReplayValidationError(
+            f"insufficient session evidence: expected {top_n}, found {len(candidates)}"
+        )
+    if sum(candidate.size for candidate in candidates) > MAX_TOTAL_SCAN_BYTES:
+        raise ReplayValidationError("filtered corpus exceeds the total scan-byte limit")
+    scanned = [_scan_candidate(candidate, salt) for candidate in candidates]
+    scanned.sort(
+        key=lambda item: (
+            -item["observation_bytes"],
+            -item["bytes"],
+            item["session_key"],
+        )
+    )
+    sessions = scanned[:top_n]
+    aggregate = {
+        field: sum(session[field] for session in sessions) for field in AGGREGATE_KEYS
+    }
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "manifest_id": "",
+        "corpus_kind": "codex_jsonl",
+        "selection": {
+            "candidate_sessions": len(candidates),
+            "expected_sessions": top_n,
+            "selected_sessions": len(sessions),
+            "since_date": since_date.isoformat() if since_date else None,
+            "through_date": through_date.isoformat() if through_date else None,
+            "order": "observation_bytes_desc_then_total_bytes_then_session_key",
+        },
+        "sessions": sessions,
+        "aggregate": aggregate,
+    }
+    manifest["manifest_id"] = _manifest_id(manifest)
+    forbidden = [part for item in candidates for part in (item.relative_path, item.path.name)]
+    _validate_manifest(manifest)
+    _assert_no_leaks(manifest, forbidden)
+    return manifest
+
+
+def _validate_manifest(value: Any) -> dict[str, Any]:
+    manifest = _require_object(value, "manifest", MANIFEST_KEYS)
+    if manifest["schema_version"] != SCHEMA_VERSION:
+        raise ReplayValidationError("unsupported manifest schema_version")
+    if manifest["corpus_kind"] != "codex_jsonl":
+        raise ReplayValidationError("manifest corpus_kind must be codex_jsonl")
+    if not isinstance(manifest["manifest_id"], str) or not SHA256_RE.fullmatch(
+        manifest["manifest_id"]
+    ):
+        raise ReplayValidationError("manifest_id must be a SHA-256 digest")
+    if not hmac.compare_digest(manifest["manifest_id"], _manifest_id(manifest)):
+        raise ReplayValidationError("manifest_id does not match the manifest content")
+    selection = _require_object(manifest["selection"], "manifest.selection", SELECTION_KEYS)
+    candidates = _require_int(
+        selection["candidate_sessions"], "manifest candidate_sessions", positive=True
+    )
+    expected = _require_int(
+        selection["expected_sessions"], "manifest expected_sessions", positive=True
+    )
+    selected = _require_int(
+        selection["selected_sessions"], "manifest selected_sessions", positive=True
+    )
+    if candidates < expected or selected != expected:
+        raise ReplayValidationError("manifest lacks the expected session evidence")
+    if selection["order"] != "observation_bytes_desc_then_total_bytes_then_session_key":
+        raise ReplayValidationError("manifest selection order is unsupported")
+    for field in ("since_date", "through_date"):
+        raw = selection[field]
+        if raw is not None:
+            if not isinstance(raw, str):
+                raise ReplayValidationError(f"manifest {field} must be an ISO date or null")
+            try:
+                date.fromisoformat(raw)
+            except ValueError as exc:
+                raise ReplayValidationError(f"manifest {field} is invalid") from exc
+    sessions = manifest["sessions"]
+    if not isinstance(sessions, list) or len(sessions) != expected:
+        raise ReplayValidationError("manifest session count does not match expected_sessions")
+    keys: set[str] = set()
+    totals = {field: 0 for field in AGGREGATE_KEYS}
+    previous_order: tuple[int, int, str] | None = None
+    for index, raw_session in enumerate(sessions):
+        session = _require_object(
+            raw_session, f"manifest.sessions[{index}]", MANIFEST_SESSION_KEYS
+        )
+        key = _require_session_key(session["session_key"], "manifest session_key")
+        if key in keys:
+            raise ReplayValidationError("manifest contains duplicate session keys")
+        keys.add(key)
+        if not isinstance(session["source_hmac_sha256"], str) or not SHA256_RE.fullmatch(
+            session["source_hmac_sha256"]
+        ):
+            raise ReplayValidationError("manifest source_hmac_sha256 is invalid")
+        for field in AGGREGATE_KEYS:
+            totals[field] += _require_int(
+                session[field], f"manifest.sessions[{index}].{field}"
+            )
+        order = (-session["observation_bytes"], -session["bytes"], key)
+        if previous_order is not None and order < previous_order:
+            raise ReplayValidationError("manifest sessions are not in canonical order")
+        previous_order = order
+    aggregate = _require_object(manifest["aggregate"], "manifest.aggregate", AGGREGATE_KEYS)
+    for field, total in totals.items():
+        if _require_int(aggregate[field], f"manifest.aggregate.{field}") != total:
+            raise ReplayValidationError(f"manifest aggregate {field} does not match sessions")
+    _assert_no_leaks(manifest)
+    return manifest
+
+
+def _validate_evidence(value: Any, manifest: dict[str, Any]) -> dict[str, Any]:
+    evidence = _require_object(value, "evidence", EVIDENCE_KEYS)
+    if evidence["schema_version"] != SCHEMA_VERSION:
+        raise ReplayValidationError("unsupported evidence schema_version")
+    if not isinstance(evidence["manifest_id"], str) or not hmac.compare_digest(
+        evidence["manifest_id"], manifest["manifest_id"]
+    ):
+        raise ReplayValidationError("evidence manifest_id does not match the manifest")
+    expected = _require_int(
+        evidence["expected_sessions"], "evidence expected_sessions", positive=True
+    )
+    if expected != manifest["selection"]["expected_sessions"]:
+        raise ReplayValidationError("evidence expected_sessions does not match manifest")
+    pricing = _require_object(evidence["pricing"], "evidence.pricing", PRICING_KEYS)
+    for field in PRICING_KEYS:
+        _require_number(pricing[field], f"evidence.pricing.{field}")
+    if float(pricing["saved_input_usd_per_million"]) <= 0:
+        raise ReplayValidationError("saved_input_usd_per_million must be positive")
+    sessions = evidence["sessions"]
+    if not isinstance(sessions, list) or len(sessions) != expected:
+        raise ReplayValidationError("evidence does not contain exactly expected_sessions")
+    manifest_sessions = {item["session_key"]: item for item in manifest["sessions"]}
+    evidence_keys: set[str] = set()
+    for index, raw_session in enumerate(sessions):
+        session = _require_object(
+            raw_session, f"evidence.sessions[{index}]", EVIDENCE_SESSION_KEYS
+        )
+        key = _require_session_key(session["session_key"], "evidence session_key")
+        if key in evidence_keys or key not in manifest_sessions:
+            raise ReplayValidationError("evidence contains duplicate or unknown session keys")
+        evidence_keys.add(key)
+        for field in EVIDENCE_SESSION_KEYS - {
+            "session_key",
+            "baseline_success",
+            "candidate_success",
+        }:
+            _require_int(session[field], f"evidence.sessions[{index}].{field}")
+        _require_bool(session["baseline_success"], "evidence baseline_success")
+        _require_bool(session["candidate_success"], "evidence candidate_success")
+        if session["baseline_tokens"] == 0:
+            raise ReplayValidationError("each baseline token count must be positive")
+        effective = sum(
+            session[field]
+            for field in ("compressed_tokens", "fallback_raw_tokens", "untouched_raw_tokens")
+        )
+        if effective == 0:
+            raise ReplayValidationError("each effective candidate token count must be positive")
+        if session["nap_failed"] > session["nap_checked"]:
+            raise ReplayValidationError("nap_failed cannot exceed nap_checked")
+        if session["nap_checked"] > manifest_sessions[key]["observation_records"]:
+            raise ReplayValidationError("nap_checked exceeds manifest observation records")
+    if evidence_keys != set(manifest_sessions):
+        raise ReplayValidationError("evidence session keys do not match the manifest")
+    _assert_no_leaks(evidence)
+    return evidence
+
+
+def summarize_evidence(manifest_value: Any, evidence_value: Any) -> dict[str, Any]:
+    manifest = _validate_manifest(manifest_value)
+    if manifest["selection"]["expected_sessions"] != PHASE1_EXPECTED_SESSIONS:
+        raise ReplayValidationError("GH1574 Phase 1 requires exactly 40 sessions")
+    if not manifest["selection"]["since_date"] or not manifest["selection"]["through_date"]:
+        raise ReplayValidationError("GH1574 Phase 1 requires an explicit corpus date window")
+    evidence = _validate_evidence(evidence_value, manifest)
+    sessions = evidence["sessions"]
+    expected = evidence["expected_sessions"]
+
+    baseline_tokens = sum(item["baseline_tokens"] for item in sessions)
+    compressed_tokens = sum(item["compressed_tokens"] for item in sessions)
+    fallback_raw_tokens = sum(item["fallback_raw_tokens"] for item in sessions)
+    untouched_raw_tokens = sum(item["untouched_raw_tokens"] for item in sessions)
+    effective_tokens = compressed_tokens + fallback_raw_tokens + untouched_raw_tokens
+    saved_tokens = baseline_tokens - effective_tokens
+    token_saving = saved_tokens / baseline_tokens
+
+    nap_checked = sum(item["nap_checked"] for item in sessions)
+    nap_failed = sum(item["nap_failed"] for item in sessions)
+    nap_mismatch = nap_failed / nap_checked if nap_checked else None
+
+    baseline_successes = sum(item["baseline_success"] for item in sessions)
+    candidate_successes = sum(item["candidate_success"] for item in sessions)
+    regressions = sum(
+        item["baseline_success"] and not item["candidate_success"] for item in sessions
+    )
+    improvements = sum(
+        not item["baseline_success"] and item["candidate_success"] for item in sessions
+    )
+    baseline_success_rate = baseline_successes / expected
+    candidate_success_rate = candidate_successes / expected
+
+    compressor_input_tokens = sum(item["compressor_input_tokens"] for item in sessions)
+    compressor_output_tokens = sum(item["compressor_output_tokens"] for item in sessions)
+    pricing = evidence["pricing"]
+    compression_cost = (
+        compressor_input_tokens * float(pricing["compressor_input_usd_per_million"])
+        + compressor_output_tokens * float(pricing["compressor_output_usd_per_million"])
+    ) / 1_000_000
+    saved_value = saved_tokens * float(pricing["saved_input_usd_per_million"]) / 1_000_000
+    cost_ratio = compression_cost / saved_value if saved_value > 0 else None
+
+    decisions = {
+        "token_saving": token_saving >= 0.20,
+        "nap_mismatch": nap_mismatch is not None and nap_mismatch < 0.05,
+        "success_parity": regressions == 0,
+        "cost_ratio": cost_ratio is not None and cost_ratio < 0.20,
+    }
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "manifest_id": manifest["manifest_id"],
+        "gate": "gh1574_phase1",
+        "corpus_window": {
+            "since_date": manifest["selection"]["since_date"],
+            "through_date": manifest["selection"]["through_date"],
+        },
+        "expected_sessions": expected,
+        "observed_sessions": len(sessions),
+        "denominators": {
+            "baseline_tokens": baseline_tokens,
+            "nap_checked": nap_checked,
+            "success_sessions": expected,
+            "saved_token_value_usd": saved_value,
+        },
+        "metrics": {
+            "effective_candidate_tokens": effective_tokens,
+            "compressed_tokens": compressed_tokens,
+            "fallback_raw_tokens": fallback_raw_tokens,
+            "untouched_raw_tokens": untouched_raw_tokens,
+            "saved_tokens": saved_tokens,
+            "effective_token_saving": token_saving,
+            "nap_failed": nap_failed,
+            "nap_mismatch_rate": nap_mismatch,
+            "baseline_successes": baseline_successes,
+            "candidate_successes": candidate_successes,
+            "baseline_success_rate": baseline_success_rate,
+            "candidate_success_rate": candidate_success_rate,
+            "success_rate_delta": candidate_success_rate - baseline_success_rate,
+            "paired_success_regressions": regressions,
+            "paired_success_improvements": improvements,
+            "compressor_input_tokens": compressor_input_tokens,
+            "compressor_output_tokens": compressor_output_tokens,
+            "compression_cost_usd": compression_cost,
+            "compression_cost_saved_value_ratio": cost_ratio,
+        },
+        "pricing": dict(pricing),
+        "thresholds": {
+            "effective_token_saving_min_inclusive": 0.20,
+            "nap_mismatch_max_exclusive": 0.05,
+            "paired_success_regressions_max_inclusive": 0,
+            "compression_cost_saved_value_ratio_max_exclusive": 0.20,
+        },
+        "decisions": decisions,
+        "overall_pass": all(decisions.values()),
+    }
+    _assert_no_leaks(report)
+    return report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    manifest = subparsers.add_parser("build-manifest", help="build private corpus metadata")
+    manifest.add_argument("--sessions-root", required=True, type=Path)
+    manifest.add_argument("--output", required=True, type=Path)
+    manifest.add_argument("--top-n", type=int, default=PHASE1_EXPECTED_SESSIONS)
+    manifest.add_argument("--since-date", type=_parse_date)
+    manifest.add_argument("--through-date", type=_parse_date)
+    manifest.add_argument("--salt-env", default=DEFAULT_SALT_ENV)
+    summarize = subparsers.add_parser(
+        "summarize-evidence", help="evaluate aggregate evidence against GH1574 gates"
+    )
+    summarize.add_argument("--manifest", required=True, type=Path)
+    summarize.add_argument("--evidence", required=True, type=Path)
+    summarize.add_argument("--output", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "build-manifest":
+            manifest = build_manifest(
+                args.sessions_root,
+                _load_salt(args.salt_env),
+                args.top_n,
+                args.since_date,
+                args.through_date,
+            )
+            secure_write_json(args.output, manifest)
+            return 0
+        manifest = _strict_json_load(args.manifest)
+        evidence = _strict_json_load(args.evidence)
+        report = summarize_evidence(manifest, evidence)
+        secure_write_json(args.output, report)
+        return 0 if report["overall_pass"] else 3
+    except ReplayValidationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except (OSError, UnicodeError, RecursionError, OverflowError, MemoryError, ValueError):
+        print("error: unsafe or invalid replay input", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/evaluate_nap_replay.py
+++ b/scripts/evaluate_nap_replay.py
@@ -127,8 +127,8 @@ def _require_object(value: Any, label: str, keys: set[str]) -> dict[str, Any]:
     actual = set(value)
     if actual != keys:
         raise ReplayValidationError(
-            f"{label} schema mismatch; missing={sorted(keys - actual)}, "
-            f"extra={sorted(actual - keys)}"
+            f"{label} schema mismatch; missing_count={len(keys - actual)}, "
+            f"extra_count={len(actual - keys)}"
         )
     return value
 

--- a/scripts/evaluate_nap_replay.py
+++ b/scripts/evaluate_nap_replay.py
@@ -177,9 +177,9 @@ def _parse_date(raw: str) -> date:
 
 def _session_date(relative_path: str) -> date:
     parts = Path(relative_path).parts
-    if len(parts) >= 3:
+    if len(parts) >= 4:
         try:
-            parsed = date(int(parts[0]), int(parts[1]), int(parts[2]))
+            parsed = date(int(parts[-4]), int(parts[-3]), int(parts[-2]))
         except (TypeError, ValueError):
             parsed = None
         if parsed is not None:
@@ -260,10 +260,19 @@ def _walk_jsonl(
 def _content_bytes(value: Any) -> int:
     if isinstance(value, str):
         return len(value.encode("utf-8"))
-    if isinstance(value, (list, dict)):
-        encoded = json.dumps(
-            value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
-        )
+    if isinstance(value, (list, dict, bool, int, float)):
+        try:
+            encoded = json.dumps(
+                value,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+                allow_nan=False,
+            )
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ReplayValidationError(
+                "observation content has an unsupported JSON type"
+            ) from exc
         return len(encoded.encode("utf-8"))
     if value is None:
         return 0

--- a/scripts/nap_replay_safety.py
+++ b/scripts/nap_replay_safety.py
@@ -1,0 +1,206 @@
+"""Bounded private-file I/O for the local GH1574 replay evaluator."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any, Iterable
+
+
+MAX_JSON_INPUT_BYTES = 64 * 1024 * 1024
+MAX_JSONL_LINE_BYTES = 256 * 1024 * 1024
+MAX_RECORDS_PER_SESSION = 5_000_000
+MAX_METRIC_VALUE = 10**15
+
+WINDOWS_ABSOLUTE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+WINDOWS_UNC_RE = re.compile(r"^\\\\[^\\]+\\[^\\]+")
+EMBEDDED_POSIX_PATH_RE = re.compile(r"(?:^|[\s\"'=])/(?:Users|home|private|tmp|var|etc)/")
+SECRET_RE = re.compile(
+    r"(?:ghp_|github_pat_|sk-[A-Za-z0-9]|AKIA[0-9A-Z]{12}|"
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----|"
+    r"(?:api[_-]?key|token|authorization)\s*[:=])",
+    re.IGNORECASE,
+)
+
+
+class ReplayValidationError(ValueError):
+    """Input cannot safely or completely support the requested report."""
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ReplayValidationError("JSON input contains a duplicate object key")
+        result[key] = value
+    return result
+
+
+def _bounded_json_int(raw: str) -> int:
+    value = int(raw)
+    if abs(value) > MAX_METRIC_VALUE:
+        raise ReplayValidationError("JSON integer exceeds the supported range")
+    return value
+
+
+def _json_loads(text: str) -> Any:
+    return json.loads(
+        text,
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_int=_bounded_json_int,
+        parse_constant=lambda value: (_ for _ in ()).throw(
+            ReplayValidationError(f"non-finite JSON number: {value}")
+        ),
+    )
+
+
+def _open_directory(path: Path, *, private: bool) -> int:
+    resolved = path.resolve(strict=True)
+    expected = resolved.stat()
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(resolved, flags)
+    observed = os.fstat(descriptor)
+    identity = (expected.st_dev, expected.st_ino, expected.st_uid, stat.S_IMODE(expected.st_mode))
+    opened = (observed.st_dev, observed.st_ino, observed.st_uid, stat.S_IMODE(observed.st_mode))
+    if identity != opened or not stat.S_ISDIR(observed.st_mode):
+        os.close(descriptor)
+        raise ReplayValidationError("directory identity changed during secure open")
+    if private and (observed.st_uid != os.geteuid() or stat.S_IMODE(observed.st_mode) & 0o077):
+        os.close(descriptor)
+        raise ReplayValidationError("output parent must be owner-only mode 0700")
+    return descriptor
+
+
+def _strict_json_load(path: Path) -> Any:
+    directory_fd: int | None = None
+    descriptor: int | None = None
+    try:
+        if path.parent.is_symlink() or path.name in {"", ".", ".."}:
+            raise ReplayValidationError("JSON input path is unsafe")
+        directory_fd = _open_directory(path.parent, private=False)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path.name, flags, dir_fd=directory_fd)
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_size > MAX_JSON_INPUT_BYTES:
+            raise ReplayValidationError("JSON input is not a bounded regular file")
+        chunks: list[bytes] = []
+        remaining = MAX_JSON_INPUT_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        if remaining == 0 and os.read(descriptor, 1):
+            raise ReplayValidationError("JSON input exceeds the size limit")
+        after = os.fstat(descriptor)
+        if (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, before.st_ctime_ns) != (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_ctime_ns,
+        ):
+            raise ReplayValidationError("JSON input changed while it was read")
+        return _json_loads(b"".join(chunks).decode("utf-8"))
+    except ReplayValidationError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError, RecursionError, ValueError) as exc:
+        raise ReplayValidationError("failed to read valid bounded UTF-8 JSON input") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if directory_fd is not None:
+            os.close(directory_fd)
+
+
+def _assert_no_leaks(value: Any, forbidden_tokens: Iterable[str] = ()) -> None:
+    forbidden = tuple(token for token in forbidden_tokens if token)
+
+    def unsafe(text: str) -> bool:
+        normalized = text.strip()
+        return (
+            normalized.startswith("/")
+            or normalized.casefold().startswith("file://")
+            or WINDOWS_ABSOLUTE_RE.match(normalized) is not None
+            or WINDOWS_UNC_RE.match(normalized) is not None
+            or EMBEDDED_POSIX_PATH_RE.search(text) is not None
+            or SECRET_RE.search(text) is not None
+            or any(token in text for token in forbidden)
+            or any(ord(char) < 32 for char in text)
+        )
+
+    def visit(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, child in node.items():
+                if not isinstance(key, str) or unsafe(key):
+                    raise ReplayValidationError("output contains unsafe key material")
+                visit(child)
+        elif isinstance(node, list):
+            for child in node:
+                visit(child)
+        elif isinstance(node, str) and unsafe(node):
+            raise ReplayValidationError("output contains private or secret-like material")
+
+    visit(value)
+
+
+def _validate_salt(salt: bytes) -> None:
+    if len(salt) != 32 or len(set(salt)) < 8:
+        raise ReplayValidationError("operator salt must contain 32 CSPRNG-generated bytes")
+
+
+def _load_salt(env_name: str) -> bytes:
+    try:
+        salt = bytes.fromhex(os.environ.get(env_name, ""))
+    except ValueError as exc:
+        raise ReplayValidationError(
+            f"operator salt in {env_name} must be 64 hexadecimal characters"
+        ) from exc
+    _validate_salt(salt)
+    return salt
+
+
+def secure_write_json(path: Path, value: Any) -> None:
+    """Create one mode-0600 JSON file inside a stable private directory FD."""
+    encoded = (json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n").encode()
+    descriptor: int | None = None
+    directory_fd: int | None = None
+    created = False
+    try:
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if path.parent.is_symlink() or path.name in {"", ".", ".."}:
+            raise ReplayValidationError("output path is unsafe")
+        directory_fd = _open_directory(path.parent, private=True)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path.name, flags, 0o600, dir_fd=directory_fd)
+        created = True
+        os.fchmod(descriptor, 0o600)
+        view = memoryview(encoded)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise ReplayValidationError("secure output write made no progress")
+            view = view[written:]
+        os.fsync(descriptor)
+        if stat.S_IMODE(os.fstat(descriptor).st_mode) != 0o600:
+            raise ReplayValidationError("output file mode is not 0600")
+    except ReplayValidationError:
+        if created and directory_fd is not None:
+            os.unlink(path.name, dir_fd=directory_fd)
+        raise
+    except OSError as exc:
+        if created and directory_fd is not None:
+            try:
+                os.unlink(path.name, dir_fd=directory_fd)
+            except OSError as cleanup_exc:
+                raise ReplayValidationError("failed to clean partial output") from cleanup_exc
+        raise ReplayValidationError("failed to write secure output") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if directory_fd is not None:
+            os.close(directory_fd)

--- a/scripts/nap_replay_safety.py
+++ b/scripts/nap_replay_safety.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import stat
@@ -46,11 +47,19 @@ def _bounded_json_int(raw: str) -> int:
     return value
 
 
+def _bounded_json_float(raw: str) -> float:
+    value = float(raw)
+    if not math.isfinite(value) or abs(value) > MAX_METRIC_VALUE:
+        raise ReplayValidationError("JSON float exceeds the supported range")
+    return value
+
+
 def _json_loads(text: str) -> Any:
     return json.loads(
         text,
         object_pairs_hook=_reject_duplicate_keys,
         parse_int=_bounded_json_int,
+        parse_float=_bounded_json_float,
         parse_constant=lambda value: (_ for _ in ()).throw(
             ReplayValidationError(f"non-finite JSON number: {value}")
         ),

--- a/scripts/nap_replay_safety.py
+++ b/scripts/nap_replay_safety.py
@@ -54,15 +54,17 @@ def _bounded_json_float(raw: str) -> float:
     return value
 
 
+def _reject_non_finite_constant(value: str) -> None:
+    raise ReplayValidationError(f"non-finite JSON number: {value}")
+
+
 def _json_loads(text: str) -> Any:
     return json.loads(
         text,
         object_pairs_hook=_reject_duplicate_keys,
         parse_int=_bounded_json_int,
         parse_float=_bounded_json_float,
-        parse_constant=lambda value: (_ for _ in ()).throw(
-            ReplayValidationError(f"non-finite JSON number: {value}")
-        ),
+        parse_constant=_reject_non_finite_constant,
     )
 
 
@@ -166,8 +168,13 @@ def _validate_salt(salt: bytes) -> None:
 
 
 def _load_salt(env_name: str) -> bytes:
+    raw = os.environ.get(env_name)
+    if not raw:
+        raise ReplayValidationError(
+            f"operator salt environment variable {env_name} is missing or empty"
+        )
     try:
-        salt = bytes.fromhex(os.environ.get(env_name, ""))
+        salt = bytes.fromhex(raw)
     except ValueError as exc:
         raise ReplayValidationError(
             f"operator salt in {env_name} must be 64 hexadecimal characters"

--- a/scripts/nap_replay_safety.py
+++ b/scripts/nap_replay_safety.py
@@ -58,7 +58,10 @@ def _json_loads(text: str) -> Any:
 
 
 def _open_directory(path: Path, *, private: bool) -> int:
-    resolved = path.resolve(strict=True)
+    try:
+        resolved = path.resolve(strict=True)
+    except RuntimeError as exc:
+        raise ReplayValidationError("directory path cannot be resolved safely") from exc
     expected = resolved.stat()
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
     descriptor = os.open(resolved, flags)

--- a/scripts/test_evaluate_nap_replay.py
+++ b/scripts/test_evaluate_nap_replay.py
@@ -470,6 +470,32 @@ class OutputAndCliTests(unittest.TestCase):
         self.assertIn("error:", stderr.getvalue())
         self.assertNotIn("/missing/private/path", stderr.getvalue())
 
+    def test_cli_intermediate_symlink_loop_is_sanitized(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = root / "first"
+            second = root / "second"
+            os.symlink("second", first)
+            os.symlink("first", second)
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                result = NAP.main(
+                    [
+                        "summarize-evidence",
+                        "--manifest",
+                        str(first / "nested" / "manifest.json"),
+                        "--evidence",
+                        str(first / "nested" / "evidence.json"),
+                        "--output",
+                        str(root / "report.json"),
+                    ]
+                )
+
+        self.assertEqual(result, 2)
+        self.assertIn("error:", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+        self.assertNotIn(str(root), stderr.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_evaluate_nap_replay.py
+++ b/scripts/test_evaluate_nap_replay.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Synthetic-only tests for the GH1574 local NAP replay tooling."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).parent
+SPEC = importlib.util.spec_from_file_location(
+    "evaluate_nap_replay", SCRIPT_DIR / "evaluate_nap_replay.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+NAP = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = NAP
+SPEC.loader.exec_module(NAP)
+
+SALT = hashlib.sha256(b"synthetic-only-gh1574-test-salt").digest()
+SALT_HEX = SALT.hex()
+SINCE = date(2026, 6, 1)
+THROUGH = date(2026, 7, 12)
+
+
+def write_session(
+    path: Path,
+    observation: str,
+    *,
+    include_variants: bool = False,
+    padding: int = 0,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    records: list[dict] = [
+        {"type": "session_meta", "payload": {"id": path.stem}},
+        {
+            "type": "response_item",
+            "payload": {"type": "function_call_output", "output": observation},
+        },
+    ]
+    if include_variants:
+        records.extend(
+            [
+                {
+                    "type": "response_item",
+                    "payload": {
+                        "type": "custom_tool_call_output",
+                        "output": "custom",
+                    },
+                },
+                {
+                    "type": "response_item",
+                    "payload": {
+                        "type": "tool_search_output",
+                        "execution": "search",
+                        "tools": [{"name": "fixture"}],
+                    },
+                },
+                {
+                    "type": "event_msg",
+                    "payload": {"type": "mcp_tool_call_end", "result": "mcp"},
+                },
+                {
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "patch_apply_end",
+                        "stdout": "out",
+                        "stderr": "err",
+                        "changes": ["file"],
+                    },
+                },
+            ]
+        )
+    records.append({"type": "event_msg", "payload": {"message": "x" * padding}})
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records), encoding="utf-8"
+    )
+
+
+def build_corpus(root: Path, count: int = 40) -> dict:
+    for index in range(count):
+        day = 1 + index % 28
+        path = root / "2026" / "06" / f"{day:02d}" / f"rollout-{index:02d}.jsonl"
+        write_session(path, f"observation-{index}-" + "z" * (index + 1))
+    return NAP.build_manifest(root, SALT, count, SINCE, THROUGH)
+
+
+def evidence_for(manifest: dict, overrides: dict[int, dict] | None = None) -> dict:
+    overrides = overrides or {}
+    sessions = []
+    for index, item in enumerate(manifest["sessions"]):
+        session = {
+            "session_key": item["session_key"],
+            "baseline_tokens": 1_000,
+            "compressed_tokens": 500,
+            "fallback_raw_tokens": 200,
+            "untouched_raw_tokens": 100,
+            "nap_checked": 1,
+            "nap_failed": 0,
+            "baseline_success": True,
+            "candidate_success": True,
+            "compressor_input_tokens": 100,
+            "compressor_output_tokens": 25,
+        }
+        session.update(overrides.get(index, {}))
+        sessions.append(session)
+    return {
+        "schema_version": 1,
+        "manifest_id": manifest["manifest_id"],
+        "expected_sessions": len(sessions),
+        "pricing": {
+            "compressor_input_usd_per_million": 1.0,
+            "compressor_output_usd_per_million": 2.0,
+            "saved_input_usd_per_million": 5.0,
+        },
+        "sessions": sessions,
+    }
+
+
+class ManifestTests(unittest.TestCase):
+    def test_date_filter_ranks_by_observation_bytes_and_emits_no_identifiers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            write_session(
+                root / "2026/05/31/rollout-old.jsonl", "old" + "x" * 1_000
+            )
+            write_session(root / "2026/06/01/rollout-small.jsonl", "small", padding=5_000)
+            write_session(root / "2026/06/02/rollout-large.jsonl", "large" + "y" * 100)
+            manifest = NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+
+            self.assertEqual(manifest["selection"]["candidate_sessions"], 2)
+            self.assertEqual(manifest["sessions"][0]["observation_bytes"], 105)
+            self.assertRegex(
+                manifest["sessions"][0]["source_hmac_sha256"], r"^[0-9a-f]{64}$"
+            )
+            rendered = json.dumps(manifest, sort_keys=True)
+            self.assertNotIn("rollout-large", rendered)
+            self.assertNotIn(str(root), rendered)
+            self.assertNotIn("large", rendered)
+            self.assertEqual(manifest["manifest_id"], NAP._manifest_id(manifest))
+
+    def test_event_and_response_observation_variants_are_counted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            write_session(
+                root / "2026/06/01/rollout-variants.jsonl",
+                "base",
+                include_variants=True,
+            )
+            manifest = NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+            self.assertEqual(manifest["sessions"][0]["observation_records"], 5)
+            self.assertGreater(manifest["sessions"][0]["observation_bytes"], 20)
+
+    def test_manifest_changes_when_same_path_content_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            path = root / "2026/06/01/rollout-same.jsonl"
+            write_session(path, "first")
+            first = NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+            write_session(path, "second")
+            second = NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+            self.assertEqual(
+                first["sessions"][0]["session_key"], second["sessions"][0]["session_key"]
+            )
+            self.assertNotEqual(first["manifest_id"], second["manifest_id"])
+            self.assertNotEqual(
+                first["sessions"][0]["source_hmac_sha256"],
+                second["sessions"][0]["source_hmac_sha256"],
+            )
+
+    def test_symlink_hardlink_malformed_and_duplicate_keys_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            root.mkdir()
+            target = root / "rollout-2026-06-01T00.jsonl"
+            write_session(target, "one")
+            os.link(target, root / "rollout-2026-06-02T00.jsonl")
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "link or size"):
+                NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            root.mkdir()
+            (root / "rollout-2026-06-01T00.jsonl").write_text(
+                '{"type":"x","type":"y"}\n', encoding="utf-8"
+            )
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "duplicate"):
+                NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            root.mkdir()
+            target = Path(tmp) / "rollout-2026-06-01T00.jsonl"
+            write_session(target, "one")
+            os.symlink(target, root / "rollout-2026-06-01T01.jsonl")
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "regular file"):
+                NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+
+    def test_invalid_window_salt_limits_and_insufficient_evidence_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            write_session(root / "2026/06/01/one.jsonl", "one")
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "after"):
+                NAP.build_manifest(root, SALT, 1, THROUGH, SINCE)
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "insufficient"):
+                NAP.build_manifest(root, SALT, 2, SINCE, THROUGH)
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "top_n"):
+                NAP.build_manifest(root, SALT, NAP.MAX_TOP_N + 1, SINCE, THROUGH)
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "CSPRNG"):
+                NAP.build_manifest(root, b"x" * 32, 1, SINCE, THROUGH)
+
+    def test_resource_limits_reject_large_sessions_lines_corpora_and_integers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            path = root / "2026/06/01/huge.jsonl"
+            path.parent.mkdir(parents=True)
+            with path.open("wb") as handle:
+                handle.truncate(NAP.MAX_SESSION_BYTES + 1)
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "link or size"):
+                NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            write_session(root / "2026/06/01/line.jsonl", "x" * 64)
+            with mock.patch.object(NAP, "MAX_JSONL_LINE_BYTES", 32):
+                with self.assertRaisesRegex(NAP.ReplayValidationError, "invalid-size"):
+                    NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            write_session(root / "2026/06/01/total.jsonl", "value")
+            with mock.patch.object(NAP, "MAX_TOTAL_SCAN_BYTES", 1):
+                with self.assertRaisesRegex(NAP.ReplayValidationError, "scan-byte"):
+                    NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+
+        with self.assertRaisesRegex(NAP.ReplayValidationError, "integer"):
+            NAP._json_loads('{"value":10000000000000000}')
+
+
+class EvidenceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temp = tempfile.TemporaryDirectory()
+        cls.manifest = build_corpus(Path(cls.temp.name) / "sessions")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temp.cleanup()
+
+    def test_metric_math_counts_fallback_as_raw(self) -> None:
+        report = NAP.summarize_evidence(self.manifest, evidence_for(self.manifest))
+        metrics = report["metrics"]
+        self.assertEqual(metrics["effective_candidate_tokens"], 32_000)
+        self.assertEqual(metrics["fallback_raw_tokens"], 8_000)
+        self.assertEqual(metrics["saved_tokens"], 8_000)
+        self.assertAlmostEqual(metrics["effective_token_saving"], 0.20)
+        self.assertEqual(report["manifest_id"], self.manifest["manifest_id"])
+        self.assertTrue(report["overall_pass"])
+
+    def test_strict_mismatch_and_cost_thresholds_fail(self) -> None:
+        mismatch = evidence_for(
+            self.manifest,
+            {0: {"nap_failed": 1}, 1: {"nap_failed": 1}},
+        )
+        mismatch_report = NAP.summarize_evidence(self.manifest, mismatch)
+        self.assertAlmostEqual(mismatch_report["metrics"]["nap_mismatch_rate"], 0.05)
+        self.assertFalse(mismatch_report["decisions"]["nap_mismatch"])
+
+        exact_cost = evidence_for(self.manifest)
+        exact_cost["pricing"] = {
+            "compressor_input_usd_per_million": 1.0,
+            "compressor_output_usd_per_million": 4.0,
+            "saved_input_usd_per_million": 5.0,
+        }
+        cost_report = NAP.summarize_evidence(self.manifest, exact_cost)
+        self.assertAlmostEqual(
+            cost_report["metrics"]["compression_cost_saved_value_ratio"], 0.20
+        )
+        self.assertFalse(cost_report["decisions"]["cost_ratio"])
+
+    def test_paired_regression_fails_non_regression_parity(self) -> None:
+        evidence = evidence_for(
+            self.manifest,
+            {
+                0: {"baseline_success": True, "candidate_success": False},
+                1: {"baseline_success": False, "candidate_success": True},
+            },
+        )
+        report = NAP.summarize_evidence(self.manifest, evidence)
+        self.assertEqual(report["metrics"]["success_rate_delta"], 0.0)
+        self.assertEqual(report["metrics"]["paired_success_regressions"], 1)
+        self.assertFalse(report["decisions"]["success_parity"])
+
+    def test_zero_or_negative_savings_and_zero_nap_are_reported_as_failures(self) -> None:
+        no_savings = evidence_for(self.manifest)
+        for session in no_savings["sessions"]:
+            session.update(
+                compressed_tokens=900,
+                fallback_raw_tokens=200,
+                untouched_raw_tokens=100,
+                nap_checked=0,
+            )
+        report = NAP.summarize_evidence(self.manifest, no_savings)
+        self.assertLess(report["metrics"]["effective_token_saving"], 0)
+        self.assertIsNone(report["metrics"]["nap_mismatch_rate"])
+        self.assertIsNone(report["metrics"]["compression_cost_saved_value_ratio"])
+        self.assertFalse(report["overall_pass"])
+
+    def test_manifest_binding_fixed_40_and_accounting_are_enforced(self) -> None:
+        evidence = evidence_for(self.manifest)
+        evidence["manifest_id"] = "0" * 64
+        with self.assertRaisesRegex(NAP.ReplayValidationError, "manifest_id"):
+            NAP.summarize_evidence(self.manifest, evidence)
+
+        small = dict(self.manifest)
+        small["selection"] = dict(
+            self.manifest["selection"], expected_sessions=39, selected_sessions=39
+        )
+        small["sessions"] = self.manifest["sessions"][:39]
+        small["aggregate"] = {
+            field: sum(item[field] for item in small["sessions"])
+            for field in NAP.AGGREGATE_KEYS
+        }
+        small["manifest_id"] = NAP._manifest_id(small)
+        with self.assertRaisesRegex(NAP.ReplayValidationError, "40 sessions"):
+            NAP.summarize_evidence(small, evidence_for(small))
+
+        excessive = evidence_for(self.manifest)
+        excessive["sessions"][0]["nap_checked"] = 2
+        with self.assertRaisesRegex(NAP.ReplayValidationError, "observation records"):
+            NAP.summarize_evidence(self.manifest, excessive)
+
+    def test_incomplete_unknown_or_unsafe_evidence_is_rejected(self) -> None:
+        evidence = evidence_for(self.manifest)
+        evidence["sessions"].pop()
+        with self.assertRaisesRegex(NAP.ReplayValidationError, "exactly"):
+            NAP.summarize_evidence(self.manifest, evidence)
+
+        evidence = evidence_for(self.manifest)
+        evidence["sessions"][0]["raw_observation"] = "/private/source/path"
+        with self.assertRaisesRegex(NAP.ReplayValidationError, "schema mismatch"):
+            NAP.summarize_evidence(self.manifest, evidence)
+
+        with self.assertRaisesRegex(NAP.ReplayValidationError, "secret-like"):
+            NAP._assert_no_leaks({"value": "github_pat_private"})
+
+
+class OutputAndCliTests(unittest.TestCase):
+    def test_secure_output_requires_private_parent_and_refuses_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            private = Path(tmp) / "private"
+            private.mkdir(mode=0o700)
+            output = private / "report.json"
+            NAP.secure_write_json(output, {"safe": True})
+            self.assertEqual(stat.S_IMODE(output.stat().st_mode), 0o600)
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "write secure output"):
+                NAP.secure_write_json(output, {"safe": False})
+
+            public = Path(tmp) / "public"
+            public.mkdir(mode=0o755)
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "owner-only"):
+                NAP.secure_write_json(public / "report.json", {"safe": True})
+
+            real = Path(tmp) / "real"
+            real.mkdir(mode=0o700)
+            linked = Path(tmp) / "linked"
+            os.symlink(real, linked)
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "unsafe"):
+                NAP.secure_write_json(linked / "report.json", {"safe": True})
+
+    def test_hex_salt_and_duplicate_json_validation(self) -> None:
+        with mock.patch.dict(os.environ, {NAP.DEFAULT_SALT_ENV: SALT_HEX}, clear=False):
+            self.assertEqual(NAP._load_salt(NAP.DEFAULT_SALT_ENV), SALT)
+        with mock.patch.dict(os.environ, {NAP.DEFAULT_SALT_ENV: "not-hex"}, clear=False):
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "hexadecimal"):
+                NAP._load_salt(NAP.DEFAULT_SALT_ENV)
+        with self.assertRaisesRegex(NAP.ReplayValidationError, "duplicate"):
+            NAP._json_loads('{"a":1,"a":2}')
+
+    def test_cli_build_and_summarize_returns_zero_or_three(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sessions_root = root / "sessions"
+            manifest_value = build_corpus(sessions_root)
+            private = root / "private"
+            private.mkdir(mode=0o700)
+            built_path = private / "built.json"
+            with mock.patch.dict(os.environ, {NAP.DEFAULT_SALT_ENV: SALT_HEX}, clear=False):
+                result = NAP.main(
+                    [
+                        "build-manifest",
+                        "--sessions-root",
+                        str(sessions_root),
+                        "--output",
+                        str(built_path),
+                        "--since-date",
+                        "2026-06-01",
+                        "--through-date",
+                        "2026-07-12",
+                    ]
+                )
+            self.assertEqual(result, 0)
+            built = json.loads(built_path.read_text())
+            self.assertEqual(built["manifest_id"], manifest_value["manifest_id"])
+
+            manifest_path = private / "manifest-input.json"
+            evidence_path = private / "evidence-input.json"
+            manifest_path.write_text(json.dumps(built), encoding="utf-8")
+            evidence_path.write_text(json.dumps(evidence_for(built)), encoding="utf-8")
+            report_path = private / "pass-report.json"
+            self.assertEqual(
+                NAP.main(
+                    [
+                        "summarize-evidence",
+                        "--manifest",
+                        str(manifest_path),
+                        "--evidence",
+                        str(evidence_path),
+                        "--output",
+                        str(report_path),
+                    ]
+                ),
+                0,
+            )
+
+            failing = evidence_for(built)
+            failing["sessions"][0]["candidate_success"] = False
+            failing_path = private / "failing-input.json"
+            failing_path.write_text(json.dumps(failing), encoding="utf-8")
+            fail_report = private / "fail-report.json"
+            self.assertEqual(
+                NAP.main(
+                    [
+                        "summarize-evidence",
+                        "--manifest",
+                        str(manifest_path),
+                        "--evidence",
+                        str(failing_path),
+                        "--output",
+                        str(fail_report),
+                    ]
+                ),
+                3,
+            )
+            self.assertFalse(json.loads(fail_report.read_text())["overall_pass"])
+
+    def test_cli_validation_error_is_sanitized(self) -> None:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            result = NAP.main(
+                [
+                    "build-manifest",
+                    "--sessions-root",
+                    "/missing/private/path",
+                    "--output",
+                    "/missing/output.json",
+                ]
+            )
+        self.assertEqual(result, 2)
+        self.assertIn("error:", stderr.getvalue())
+        self.assertNotIn("/missing/private/path", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_evaluate_nap_replay.py
+++ b/scripts/test_evaluate_nap_replay.py
@@ -161,6 +161,58 @@ class ManifestTests(unittest.TestCase):
             self.assertEqual(manifest["sessions"][0]["observation_records"], 5)
             self.assertGreater(manifest["sessions"][0]["observation_bytes"], 20)
 
+    def test_finite_json_primitive_observations_are_counted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            path = root / "2026/06/01/rollout-primitives.jsonl"
+            path.parent.mkdir(parents=True)
+            values = [True, 7, 1.25]
+            records = [
+                {
+                    "type": "response_item",
+                    "payload": {"type": "function_call_output", "output": value},
+                }
+                for value in values
+            ]
+            path.write_text(
+                "".join(json.dumps(record) + "\n" for record in records),
+                encoding="utf-8",
+            )
+
+            manifest = NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+
+            expected_bytes = sum(
+                len(
+                    json.dumps(
+                        value,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                        ensure_ascii=False,
+                        allow_nan=False,
+                    ).encode("utf-8")
+                )
+                for value in values
+            )
+            self.assertEqual(manifest["sessions"][0]["observation_records"], 3)
+            self.assertEqual(
+                manifest["sessions"][0]["observation_bytes"], expected_bytes
+            )
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "unsupported JSON"):
+                NAP._content_bytes(float("nan"))
+
+    def test_nested_date_directories_are_parsed_from_the_path_suffix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            write_session(
+                root / "tenant/archive/2026/06/03/session.jsonl",
+                "nested-date",
+            )
+
+            manifest = NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+
+            self.assertEqual(manifest["selection"]["candidate_sessions"], 1)
+            self.assertEqual(manifest["sessions"][0]["observation_bytes"], 11)
+
     def test_manifest_changes_when_same_path_content_changes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "sessions"
@@ -245,6 +297,8 @@ class ManifestTests(unittest.TestCase):
 
         with self.assertRaisesRegex(NAP.ReplayValidationError, "integer"):
             NAP._json_loads('{"value":10000000000000000}')
+        with self.assertRaisesRegex(NAP.ReplayValidationError, "non-finite"):
+            NAP._json_loads('{"value":NaN}')
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "sessions"
@@ -402,6 +456,19 @@ class OutputAndCliTests(unittest.TestCase):
                 NAP._load_salt(NAP.DEFAULT_SALT_ENV)
         with self.assertRaisesRegex(NAP.ReplayValidationError, "duplicate"):
             NAP._json_loads('{"a":1,"a":2}')
+
+    def test_missing_or_empty_salt_environment_variable_is_reported(self) -> None:
+        expected = (
+            f"operator salt environment variable {NAP.DEFAULT_SALT_ENV} "
+            "is missing or empty"
+        )
+        for environment in ({}, {NAP.DEFAULT_SALT_ENV: ""}):
+            with self.subTest(environment=environment):
+                with mock.patch.dict(os.environ, environment, clear=True):
+                    with self.assertRaisesRegex(
+                        NAP.ReplayValidationError, f"^{expected}$"
+                    ):
+                        NAP._load_salt(NAP.DEFAULT_SALT_ENV)
 
     def test_cli_build_and_summarize_returns_zero_or_three(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_evaluate_nap_replay.py
+++ b/scripts/test_evaluate_nap_replay.py
@@ -246,6 +246,18 @@ class ManifestTests(unittest.TestCase):
         with self.assertRaisesRegex(NAP.ReplayValidationError, "integer"):
             NAP._json_loads('{"value":10000000000000000}')
 
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "sessions"
+            path = root / "2026/06/01/overflow.jsonl"
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                '{"type":"response_item","payload":{"type":"tool_search_output",'
+                '"execution":"search","tools":[{"score":1e10000}]}}\n',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(NAP.ReplayValidationError, "float"):
+                NAP.build_manifest(root, SALT, 1, SINCE, THROUGH)
+
 
 class EvidenceTests(unittest.TestCase):
     @classmethod
@@ -347,9 +359,13 @@ class EvidenceTests(unittest.TestCase):
             NAP.summarize_evidence(self.manifest, evidence)
 
         evidence = evidence_for(self.manifest)
-        evidence["sessions"][0]["raw_observation"] = "/private/source/path"
-        with self.assertRaisesRegex(NAP.ReplayValidationError, "schema mismatch"):
+        unsafe_key = "/private/source/path"
+        evidence["sessions"][0][unsafe_key] = True
+        with self.assertRaisesRegex(
+            NAP.ReplayValidationError, "schema mismatch"
+        ) as captured:
             NAP.summarize_evidence(self.manifest, evidence)
+        self.assertNotIn(unsafe_key, str(captured.exception))
 
         with self.assertRaisesRegex(NAP.ReplayValidationError, "secret-like"):
             NAP._assert_no_leaks({"value": "github_pat_private"})


### PR DESCRIPTION
## Summary

- add a local-only manifest builder for pseudonymous Codex session metadata
- bind submitted A/B evidence to the exact 40-session manifest
- report token savings, NAP mismatch rate, paired success parity, and cost ratio
- fail closed on unsafe paths, changing inputs, unbounded records, duplicate JSON keys, secret-like output, and intermediate symlink loops
- cover the new tooling with 17 unit tests and 85% combined line coverage

## Scope

This is a partial delivery for T006. It does not execute an external model replay, export private session content, mark T006 complete, or enable the feature by default.

Related: #1574

## Validation

- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts -p test_evaluate_nap_replay.py
- coverage: 85% combined line coverage
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1574
- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- private manifest dry run: 40 sessions selected from 1,155 candidates for 2026-06-01 through 2026-07-11; only pseudonymous aggregate metadata was produced
- independent correctness review: approved on current head
- independent security review: approved

## Remaining T006 gates

- run the isolated A/B replay under an approved budget without sending private sessions to an external model
- make compressor sampling and circuit-breaker state persist across requests
- define and capture actual compressor usage, the success oracle, and approved pricing
- evaluate the thresholds and keep the feature disabled if any threshold fails