### PR TITLE
feat: preserve NAP-Lite compressor usage

### DIFF
--- a/crates/harness-agents/src/compress_model.rs
+++ b/crates/harness-agents/src/compress_model.rs
@@ -7,9 +7,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use harness_core::agent::{AgentRequest, CodeAgent};
+use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent};
 use harness_core::compress::{
-    ActionSketch, CompressHint, CompressModel, ObservationCompressor, PromptCompressor,
+    ActionSketch, CompressHint, CompressModel, CompressModelError, CompressModelOutput,
+    CompressorCallUsage, ObservationCompressor, PromptCompressor,
 };
 use harness_core::config::compression::CompressionConfig;
 
@@ -37,7 +38,7 @@ impl ApiCompressModel {
         }
     }
 
-    async fn ask(&self, prompt: String) -> Result<String, String> {
+    async fn ask(&self, prompt: String) -> Result<CompressModelOutput<String>, CompressModelError> {
         let req = AgentRequest {
             prompt,
             model: Some(self.model.clone()),
@@ -46,8 +47,22 @@ impl ApiCompressModel {
         self.agent
             .execute(req)
             .await
-            .map(|resp| resp.output)
-            .map_err(|e| e.to_string())
+            .map(response_to_model_output)
+            .map_err(|error| CompressModelError {
+                message: error.to_string(),
+                usage: None,
+            })
+    }
+}
+
+fn response_to_model_output(response: AgentResponse) -> CompressModelOutput<String> {
+    CompressModelOutput {
+        output: response.output,
+        usage: CompressorCallUsage {
+            input_tokens: response.token_usage.input_tokens,
+            output_tokens: response.token_usage.output_tokens,
+            model: response.model,
+        },
     }
 }
 
@@ -86,15 +101,38 @@ fn parse_sketch(reply: &str) -> Result<ActionSketch, String> {
     serde_json::from_str(&reply[start..=end]).map_err(|e| e.to_string())
 }
 
+fn parse_sketch_output(
+    reply: CompressModelOutput<String>,
+) -> Result<CompressModelOutput<ActionSketch>, CompressModelError> {
+    match parse_sketch(&reply.output) {
+        Ok(output) => Ok(CompressModelOutput {
+            output,
+            usage: reply.usage,
+        }),
+        Err(message) => Err(CompressModelError {
+            message,
+            usage: Some(reply.usage),
+        }),
+    }
+}
+
 #[async_trait]
 impl CompressModel for ApiCompressModel {
-    async fn summarize(&self, raw: &str, hint: &CompressHint) -> Result<String, String> {
+    async fn summarize(
+        &self,
+        raw: &str,
+        hint: &CompressHint,
+    ) -> Result<CompressModelOutput<String>, CompressModelError> {
         self.ask(summarize_prompt(raw, hint)).await
     }
 
-    async fn sketch(&self, observation: &str, hint: &CompressHint) -> Result<ActionSketch, String> {
+    async fn sketch(
+        &self,
+        observation: &str,
+        hint: &CompressHint,
+    ) -> Result<CompressModelOutput<ActionSketch>, CompressModelError> {
         let reply = self.ask(sketch_prompt(observation, hint)).await?;
-        parse_sketch(&reply)
+        parse_sketch_output(reply)
     }
 }
 
@@ -122,11 +160,28 @@ pub fn build_observation_compressor(
 mod tests {
     use super::*;
     use harness_core::compress::ObsSource;
+    use harness_core::types::TokenUsage;
 
     fn hint() -> CompressHint {
         CompressHint {
             task_summary: "plan phase for issue #7".into(),
             source: ObsSource::AgentResult,
+        }
+    }
+
+    fn agent_response(output: &str) -> AgentResponse {
+        AgentResponse {
+            output: output.into(),
+            stderr: String::new(),
+            items: Vec::new(),
+            token_usage: TokenUsage {
+                input_tokens: 41,
+                output_tokens: 7,
+                total_tokens: 48,
+                cost_usd: 12.34,
+            },
+            model: "provider-returned-model".into(),
+            exit_code: Some(0),
         }
     }
 
@@ -152,6 +207,30 @@ mod tests {
     #[test]
     fn parse_sketch_rejects_non_json() {
         assert!(parse_sketch("no json here").is_err());
+    }
+
+    #[test]
+    fn response_mapping_uses_provider_tokens_and_actual_model() {
+        let output = response_to_model_output(agent_response("summary"));
+        assert_eq!(output.output, "summary");
+        assert_eq!(output.usage.input_tokens, 41);
+        assert_eq!(output.usage.output_tokens, 7);
+        assert_eq!(output.usage.model, "provider-returned-model");
+    }
+
+    #[test]
+    fn sketch_parse_error_retains_completed_call_usage() {
+        let reply = response_to_model_output(agent_response("not JSON"));
+        let err = parse_sketch_output(reply).unwrap_err();
+        assert!(err.message.contains("no JSON object"));
+        assert_eq!(
+            err.usage,
+            Some(CompressorCallUsage {
+                input_tokens: 41,
+                output_tokens: 7,
+                model: "provider-returned-model".into(),
+            })
+        );
     }
 
     #[test]

--- a/crates/harness-core/src/compress.rs
+++ b/crates/harness-core/src/compress.rs
@@ -339,11 +339,11 @@ impl<M: CompressModel, S: NapSampler> ObservationCompressor for PromptCompressor
             });
         }
 
-        self.nap_checked.fetch_add(1, Ordering::Relaxed);
         let raw_sketch =
             collect_model_output(self.model.sketch(obs, hint).await, &mut compressor_usage)?;
         let compressed_sketch =
             collect_model_output(self.model.sketch(&text, hint).await, &mut compressor_usage)?;
+        self.nap_checked.fetch_add(1, Ordering::Relaxed);
 
         if raw_sketch.agreement(&compressed_sketch) >= 2 {
             Ok(Compressed {
@@ -496,6 +496,7 @@ mod tests {
         assert_eq!(out.compressor_usage.calls.len(), 3);
         assert_eq!(out.compressor_usage.input_tokens(), 20);
         assert_eq!(out.compressor_usage.output_tokens(), 4);
+        assert_eq!(c.nap_checked(), 1);
     }
 
     #[tokio::test]
@@ -519,6 +520,7 @@ mod tests {
         assert_eq!(out.text, obs);
         assert_eq!(out.nap, NapStatus::Failed { fell_back: true });
         assert_eq!(out.compressor_usage.calls.len(), 3);
+        assert_eq!(c.nap_checked(), 1);
         assert_eq!(c.nap_failed(), 1);
     }
 
@@ -545,6 +547,7 @@ mod tests {
                 "compressed-sketch-model"
             ]
         );
+        assert_eq!(c.nap_checked(), 0);
     }
 
     #[tokio::test]
@@ -563,6 +566,7 @@ mod tests {
         assert_eq!(usage.input_tokens(), 16);
         assert_eq!(usage.output_tokens(), 3);
         assert_eq!(usage.models(), vec!["summary-model", "raw-sketch-model"]);
+        assert_eq!(c.nap_checked(), 0);
     }
 
     #[tokio::test]

--- a/crates/harness-core/src/compress.rs
+++ b/crates/harness-core/src/compress.rs
@@ -50,9 +50,76 @@ pub enum NapStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Compressed {
     pub text: String,
+    /// Byte-based estimate for the raw observation, not provider usage.
     pub original_tokens: u32,
+    /// Byte-based estimate for the returned text, not provider usage.
     pub compressed_tokens: u32,
+    /// Provider-reported usage for every completed compressor model call.
+    #[serde(default)]
+    pub compressor_usage: CompressorUsage,
     pub nap: NapStatus,
+}
+
+/// Provider-reported usage for one completed compressor model call.
+///
+/// Pricing is intentionally absent: the compressor does not have an approved
+/// pricing oracle, and [`crate::types::TokenUsage::cost_usd`] must not be
+/// inferred here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompressorCallUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    /// Actual model identifier returned by the provider.
+    pub model: String,
+}
+
+/// Provider-reported usage accumulated across completed compressor calls.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompressorUsage {
+    pub calls: Vec<CompressorCallUsage>,
+}
+
+impl CompressorUsage {
+    /// Sum provider-reported input tokens without wrapping on overflow.
+    pub fn input_tokens(&self) -> u64 {
+        self.calls
+            .iter()
+            .fold(0, |total, call| total.saturating_add(call.input_tokens))
+    }
+
+    /// Sum provider-reported output tokens without wrapping on overflow.
+    pub fn output_tokens(&self) -> u64 {
+        self.calls
+            .iter()
+            .fold(0, |total, call| total.saturating_add(call.output_tokens))
+    }
+
+    /// Actual provider-returned model identifier for each completed call.
+    pub fn models(&self) -> Vec<&str> {
+        self.calls.iter().map(|call| call.model.as_str()).collect()
+    }
+
+    fn push(&mut self, call: CompressorCallUsage) {
+        self.calls.push(call);
+    }
+}
+
+/// Successful compressor model output paired with provider-reported usage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompressModelOutput<T> {
+    pub output: T,
+    pub usage: CompressorCallUsage,
+}
+
+/// Compressor model failure, optionally after a provider call completed.
+///
+/// `usage` is present for post-processing failures such as invalid sketch
+/// JSON, because the provider completed and reported usage for that call.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{message}")]
+pub struct CompressModelError {
+    pub message: String,
+    pub usage: Option<CompressorCallUsage>,
 }
 
 #[derive(Debug, Error)]
@@ -65,8 +132,11 @@ pub enum CompressError {
     /// Callers must surface this at error level once per handle.
     #[error("compression bypassed: NAP failure rate {rate:.2} over {checks} checks")]
     BreakerOpen { rate: f64, checks: u64 },
-    #[error("compressor model error: {0}")]
-    Model(String),
+    #[error("compressor model error: {message}")]
+    Model {
+        message: String,
+        usage: CompressorUsage,
+    },
     /// The model returned a sketch that could not be parsed.
     #[error("unparseable next-action sketch: {0}")]
     BadSketch(String),
@@ -111,10 +181,39 @@ impl ActionSketch {
 #[async_trait]
 pub trait CompressModel: Send + Sync {
     /// Return a compressed rendition of `raw` for the given task framing.
-    async fn summarize(&self, raw: &str, hint: &CompressHint) -> Result<String, String>;
+    async fn summarize(
+        &self,
+        raw: &str,
+        hint: &CompressHint,
+    ) -> Result<CompressModelOutput<String>, CompressModelError>;
 
     /// Return a next-action sketch given an observation and task framing.
-    async fn sketch(&self, observation: &str, hint: &CompressHint) -> Result<ActionSketch, String>;
+    async fn sketch(
+        &self,
+        observation: &str,
+        hint: &CompressHint,
+    ) -> Result<CompressModelOutput<ActionSketch>, CompressModelError>;
+}
+
+fn collect_model_output<T>(
+    result: Result<CompressModelOutput<T>, CompressModelError>,
+    usage: &mut CompressorUsage,
+) -> Result<T, CompressError> {
+    match result {
+        Ok(output) => {
+            usage.push(output.usage);
+            Ok(output.output)
+        }
+        Err(error) => {
+            if let Some(call) = error.usage {
+                usage.push(call);
+            }
+            Err(CompressError::Model {
+                message: error.message,
+                usage: std::mem::take(usage),
+            })
+        }
+    }
 }
 
 /// Compression entry point used by the seams.
@@ -223,11 +322,9 @@ impl<M: CompressModel, S: NapSampler> ObservationCompressor for PromptCompressor
             return Err(CompressError::BreakerOpen { rate, checks });
         }
 
-        let text = self
-            .model
-            .summarize(obs, hint)
-            .await
-            .map_err(CompressError::Model)?;
+        let mut compressor_usage = CompressorUsage::default();
+        let text =
+            collect_model_output(self.model.summarize(obs, hint).await, &mut compressor_usage)?;
         let original_tokens = estimate_tokens(obs);
         let compressed_tokens = estimate_tokens(&text);
 
@@ -237,27 +334,23 @@ impl<M: CompressModel, S: NapSampler> ObservationCompressor for PromptCompressor
                 text,
                 original_tokens,
                 compressed_tokens,
+                compressor_usage,
                 nap: NapStatus::SkippedSample,
             });
         }
 
         self.nap_checked.fetch_add(1, Ordering::Relaxed);
-        let raw_sketch = self
-            .model
-            .sketch(obs, hint)
-            .await
-            .map_err(CompressError::Model)?;
-        let compressed_sketch = self
-            .model
-            .sketch(&text, hint)
-            .await
-            .map_err(CompressError::Model)?;
+        let raw_sketch =
+            collect_model_output(self.model.sketch(obs, hint).await, &mut compressor_usage)?;
+        let compressed_sketch =
+            collect_model_output(self.model.sketch(&text, hint).await, &mut compressor_usage)?;
 
         if raw_sketch.agreement(&compressed_sketch) >= 2 {
             Ok(Compressed {
                 text,
                 original_tokens,
                 compressed_tokens,
+                compressor_usage,
                 nap: NapStatus::Verified,
             })
         } else {
@@ -269,6 +362,7 @@ impl<M: CompressModel, S: NapSampler> ObservationCompressor for PromptCompressor
                 text: obs.to_string(),
                 original_tokens,
                 compressed_tokens: original_tokens,
+                compressor_usage,
                 nap: NapStatus::Failed { fell_back: true },
             })
         }
@@ -283,6 +377,7 @@ mod tests {
         summary: String,
         raw_sketch: ActionSketch,
         compressed_sketch: ActionSketch,
+        compressed_sketch_error: Option<CompressModelError>,
     }
 
     impl FakeModel {
@@ -296,6 +391,7 @@ mod tests {
                 summary: summary.into(),
                 raw_sketch: sketch.clone(),
                 compressed_sketch: sketch,
+                compressed_sketch_error: None,
             }
         }
 
@@ -308,23 +404,66 @@ mod tests {
             };
             this
         }
+
+        fn failing_after_summary_and_raw_sketch(summary: &str) -> Self {
+            let mut this = Self::agreeing(summary);
+            this.compressed_sketch_error = Some(CompressModelError {
+                message: "invalid sketch JSON".into(),
+                usage: Some(call_usage(4, 1, "compressed-sketch-model")),
+            });
+            this
+        }
+
+        fn request_failing_after_summary_and_raw_sketch(summary: &str) -> Self {
+            let mut this = Self::agreeing(summary);
+            this.compressed_sketch_error = Some(CompressModelError {
+                message: "provider request failed".into(),
+                usage: None,
+            });
+            this
+        }
+    }
+
+    fn call_usage(input_tokens: u64, output_tokens: u64, model: &str) -> CompressorCallUsage {
+        CompressorCallUsage {
+            input_tokens,
+            output_tokens,
+            model: model.into(),
+        }
     }
 
     #[async_trait]
     impl CompressModel for FakeModel {
-        async fn summarize(&self, _raw: &str, _hint: &CompressHint) -> Result<String, String> {
-            Ok(self.summary.clone())
+        async fn summarize(
+            &self,
+            _raw: &str,
+            _hint: &CompressHint,
+        ) -> Result<CompressModelOutput<String>, CompressModelError> {
+            Ok(CompressModelOutput {
+                output: self.summary.clone(),
+                usage: call_usage(10, 2, "summary-model"),
+            })
         }
 
         async fn sketch(
             &self,
             observation: &str,
             _hint: &CompressHint,
-        ) -> Result<ActionSketch, String> {
+        ) -> Result<CompressModelOutput<ActionSketch>, CompressModelError> {
             if observation == self.summary {
-                Ok(self.compressed_sketch.clone())
+                let usage = call_usage(4, 1, "compressed-sketch-model");
+                if let Some(error) = &self.compressed_sketch_error {
+                    return Err(error.clone());
+                }
+                Ok(CompressModelOutput {
+                    output: self.compressed_sketch.clone(),
+                    usage,
+                })
             } else {
-                Ok(self.raw_sketch.clone())
+                Ok(CompressModelOutput {
+                    output: self.raw_sketch.clone(),
+                    usage: call_usage(6, 1, "raw-sketch-model"),
+                })
             }
         }
     }
@@ -354,6 +493,9 @@ mod tests {
         assert_eq!(out.text, "summary text");
         assert_eq!(out.nap, NapStatus::Verified);
         assert!(out.compressed_tokens < out.original_tokens);
+        assert_eq!(out.compressor_usage.calls.len(), 3);
+        assert_eq!(out.compressor_usage.input_tokens(), 20);
+        assert_eq!(out.compressor_usage.output_tokens(), 4);
     }
 
     #[tokio::test]
@@ -362,8 +504,11 @@ mod tests {
         let c = PromptCompressor::with_sampler(FakeModel::agreeing("summary text"), EveryN(2), 16);
         let first = c.compress(&raw_obs(), &hint()).await.unwrap();
         assert_eq!(first.nap, NapStatus::SkippedSample);
+        assert_eq!(first.compressor_usage.calls.len(), 1);
+        assert_eq!(first.compressor_usage.models(), vec!["summary-model"]);
         let second = c.compress(&raw_obs(), &hint()).await.unwrap();
         assert_eq!(second.nap, NapStatus::Verified);
+        assert_eq!(second.compressor_usage.calls.len(), 3);
     }
 
     #[tokio::test]
@@ -373,7 +518,51 @@ mod tests {
         let out = c.compress(&obs, &hint()).await.unwrap();
         assert_eq!(out.text, obs);
         assert_eq!(out.nap, NapStatus::Failed { fell_back: true });
+        assert_eq!(out.compressor_usage.calls.len(), 3);
         assert_eq!(c.nap_failed(), 1);
+    }
+
+    #[tokio::test]
+    async fn later_post_processing_failure_retains_completed_and_failed_call_usage() {
+        let c = PromptCompressor::new(
+            FakeModel::failing_after_summary_and_raw_sketch("summary text"),
+            1.0,
+            16,
+        );
+        let err = c.compress(&raw_obs(), &hint()).await.unwrap_err();
+        let CompressError::Model { message, usage } = err else {
+            panic!("expected model error");
+        };
+        assert_eq!(message, "invalid sketch JSON");
+        assert_eq!(usage.calls.len(), 3);
+        assert_eq!(usage.input_tokens(), 20);
+        assert_eq!(usage.output_tokens(), 4);
+        assert_eq!(
+            usage.models(),
+            vec![
+                "summary-model",
+                "raw-sketch-model",
+                "compressed-sketch-model"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn later_request_failure_retains_only_completed_call_usage() {
+        let c = PromptCompressor::new(
+            FakeModel::request_failing_after_summary_and_raw_sketch("summary text"),
+            1.0,
+            16,
+        );
+        let err = c.compress(&raw_obs(), &hint()).await.unwrap_err();
+        let CompressError::Model { message, usage } = err else {
+            panic!("expected model error");
+        };
+        assert_eq!(message, "provider request failed");
+        assert_eq!(usage.calls.len(), 2);
+        assert_eq!(usage.input_tokens(), 16);
+        assert_eq!(usage.output_tokens(), 3);
+        assert_eq!(usage.models(), vec!["summary-model", "raw-sketch-model"]);
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/task_executor/compression.rs
+++ b/crates/harness-server/src/task_executor/compression.rs
@@ -29,18 +29,15 @@ pub(crate) async fn compress_observation_for_prompt(
     };
     match compressor.compress(raw, &hint).await {
         Ok(compressed) => {
-            let compressor_provider_input_tokens = compressed.compressor_usage.input_tokens();
-            let compressor_provider_output_tokens = compressed.compressor_usage.output_tokens();
-            let compressor_models = compressed.compressor_usage.models();
             match compressed.nap {
                 NapStatus::Failed { .. } => {
                     // Compressed.text already carries the raw fallback.
                     tracing::warn!(
                         task_summary,
                         original_tokens = compressed.original_tokens,
-                        compressor_provider_input_tokens,
-                        compressor_provider_output_tokens,
-                        compressor_models = ?compressor_models,
+                        compressor_provider_input_tokens = compressed.compressor_usage.input_tokens(),
+                        compressor_provider_output_tokens = compressed.compressor_usage.output_tokens(),
+                        compressor_models = ?compressed.compressor_usage.models(),
                         "NAP verification failed; using raw observation"
                     );
                 }
@@ -49,9 +46,9 @@ pub(crate) async fn compress_observation_for_prompt(
                         task_summary,
                         original_tokens = compressed.original_tokens,
                         compressed_tokens = compressed.compressed_tokens,
-                        compressor_provider_input_tokens,
-                        compressor_provider_output_tokens,
-                        compressor_models = ?compressor_models,
+                        compressor_provider_input_tokens = compressed.compressor_usage.input_tokens(),
+                        compressor_provider_output_tokens = compressed.compressor_usage.output_tokens(),
+                        compressor_models = ?compressed.compressor_usage.models(),
                         nap = ?nap,
                         "observation compressed for prompt injection"
                     );
@@ -65,15 +62,12 @@ pub(crate) async fn compress_observation_for_prompt(
             raw.to_string()
         }
         Err(CompressError::Model { message, usage }) => {
-            let compressor_provider_input_tokens = usage.input_tokens();
-            let compressor_provider_output_tokens = usage.output_tokens();
-            let compressor_models = usage.models();
             tracing::warn!(
                 error = %message,
                 task_summary,
-                compressor_provider_input_tokens,
-                compressor_provider_output_tokens,
-                compressor_models = ?compressor_models,
+                compressor_provider_input_tokens = usage.input_tokens(),
+                compressor_provider_output_tokens = usage.output_tokens(),
+                compressor_models = ?usage.models(),
                 "compressor model failed; using raw observation"
             );
             raw.to_string()

--- a/crates/harness-server/src/task_executor/compression.rs
+++ b/crates/harness-server/src/task_executor/compression.rs
@@ -29,12 +29,18 @@ pub(crate) async fn compress_observation_for_prompt(
     };
     match compressor.compress(raw, &hint).await {
         Ok(compressed) => {
+            let compressor_provider_input_tokens = compressed.compressor_usage.input_tokens();
+            let compressor_provider_output_tokens = compressed.compressor_usage.output_tokens();
+            let compressor_models = compressed.compressor_usage.models();
             match compressed.nap {
                 NapStatus::Failed { .. } => {
                     // Compressed.text already carries the raw fallback.
                     tracing::warn!(
                         task_summary,
                         original_tokens = compressed.original_tokens,
+                        compressor_provider_input_tokens,
+                        compressor_provider_output_tokens,
+                        compressor_models = ?compressor_models,
                         "NAP verification failed; using raw observation"
                     );
                 }
@@ -43,6 +49,9 @@ pub(crate) async fn compress_observation_for_prompt(
                         task_summary,
                         original_tokens = compressed.original_tokens,
                         compressed_tokens = compressed.compressed_tokens,
+                        compressor_provider_input_tokens,
+                        compressor_provider_output_tokens,
+                        compressor_models = ?compressor_models,
                         nap = ?nap,
                         "observation compressed for prompt injection"
                     );
@@ -53,6 +62,20 @@ pub(crate) async fn compress_observation_for_prompt(
         Err(CompressError::TooSmall { .. }) => raw.to_string(),
         Err(err @ CompressError::BreakerOpen { .. }) => {
             tracing::error!(%err, task_summary, "compression bypassed by circuit breaker");
+            raw.to_string()
+        }
+        Err(CompressError::Model { message, usage }) => {
+            let compressor_provider_input_tokens = usage.input_tokens();
+            let compressor_provider_output_tokens = usage.output_tokens();
+            let compressor_models = usage.models();
+            tracing::warn!(
+                error = %message,
+                task_summary,
+                compressor_provider_input_tokens,
+                compressor_provider_output_tokens,
+                compressor_models = ?compressor_models,
+                "compressor model failed; using raw observation"
+            );
             raw.to_string()
         }
         Err(err) => {


### PR DESCRIPTION
## What

- Carry provider-reported compressor input/output tokens and the actual response model through the core compression contract.
- Aggregate one summary call plus both sampled NAP sketch calls.
- Preserve completed-call usage when a later provider request or sketch post-processing step fails.
- Surface structured compressor usage in server logs while keeping the existing bytes/4 observation estimates separate.
- Cover unsampled, sampled-pass, NAP-mismatch, post-processing-failure, request-failure, and response-model mapping paths.

Related: #1574

This is a prerequisite slice for `SP1574-T006`. T006 remains incomplete, and issue #1574 remains open. No private-session replay or external model call was performed.

## Why

PR #1589 added privacy-safe manifest and aggregate-evidence tooling, but the evaluator fields for compressor input/output tokens had no production source because `ApiCompressModel` discarded `AgentResponse.token_usage` and `AgentResponse.model`. This change preserves those exact provider values without inferring cost. Pricing, success-oracle, provider/privacy approval, persistent per-task state, and the controlled A/B replay remain separate gates.

## Test Plan

- [x] `cargo test -p harness-core compress` (12 passed)
- [x] `cargo test -p harness-agents compress_model` (7 passed)
- [x] `cargo test -p harness-server task_executor::compression` (2 passed)
- [x] `cargo check --workspace --all-targets --quiet`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1574`
- [x] `python3 checks/check_workflow.py --repo .`
- [x] Independent native review: APPROVE after one test-coverage finding was fixed
- [ ] Live provider/replay test (intentionally not run; requires approved provider, privacy, budget, pricing, success oracle, and a frozen corpus)
