### PR TITLE
refactor(cli): reconcile through server API

### DIFF
--- a/crates/harness-cli/src/commands/reconcile.rs
+++ b/crates/harness-cli/src/commands/reconcile.rs
@@ -5,7 +5,7 @@ use harness_server::reconciliation::ReconciliationReport;
 use std::path::PathBuf;
 use std::time::Duration;
 
-const REQUEST_TIMEOUT_SECS: u64 = 30;
+const CONNECT_TIMEOUT_SECS: u64 = 10;
 
 pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig) -> Result<()> {
     if let Some(project_root) = project {
@@ -18,7 +18,10 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
     let base_url = status::server_base_url(config, None)?;
     let token = status::resolve_api_token(config);
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        // Reconciliation deliberately sleeps between GitHub rate-limit windows.
+        // Bound connection setup, but let the synchronous admin operation return
+        // its complete report instead of timing out after partially applying work.
+        .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
         .no_proxy()
         .build()
         .context("failed to build HTTP client")?;

--- a/crates/harness-cli/src/commands/reconcile.rs
+++ b/crates/harness-cli/src/commands/reconcile.rs
@@ -1,12 +1,11 @@
+use super::status;
 use anyhow::{bail, Context as _, Result};
-use harness_core::config::dirs::default_db_path;
 use harness_core::config::HarnessConfig;
-use harness_core::db::{pg_open_pool, resolve_database_url};
-use harness_server::task_runner::TaskStore;
-use harness_workflow::issue_lifecycle::IssueWorkflowStore;
-use harness_workflow::runtime::WorkflowRuntimeStore;
+use harness_server::reconciliation::ReconciliationReport;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::time::Duration;
+
+const REQUEST_TIMEOUT_SECS: u64 = 30;
 
 pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig) -> Result<()> {
     if let Some(project_root) = project {
@@ -16,28 +15,65 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
         );
     }
 
-    let store = open_task_store(config).await?;
-    let (runtime_store, issue_workflow_store) = open_workflow_stores(config).await;
+    let base_url = status::server_base_url(config, None)?;
+    let token = status::resolve_api_token(config);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .no_proxy()
+        .build()
+        .context("failed to build HTTP client")?;
+    let report = request_report(&client, &base_url, token.as_deref(), dry_run).await?;
 
-    let report = harness_server::reconciliation::run_once_with_runtime_config(
-        &store,
-        runtime_store.as_ref(),
-        issue_workflow_store.as_ref(),
-        &config.reconciliation,
-        dry_run,
-        config.server.github_token.as_deref(),
-    )
-    .await;
+    print!("{}", render_report(&report, dry_run));
+    Ok(())
+}
 
+async fn request_report(
+    client: &reqwest::Client,
+    base_url: &str,
+    token: Option<&str>,
+    dry_run: bool,
+) -> Result<ReconciliationReport> {
+    let path = format!("/reconcile?dry_run={dry_run}");
+    let url = format!("{base_url}{path}");
+    let mut request = client.post(&url);
+    if let Some(token) = token {
+        request = request.bearer_auth(token);
+    }
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("failed to connect to harness server at {url}"))?;
+    let response_status = response.status();
+    if response_status == reqwest::StatusCode::UNAUTHORIZED {
+        bail!(
+            "server rejected {path} with 401; set server.api_token in config or HARNESS_API_TOKEN"
+        );
+    }
+    if !response_status.is_success() {
+        let body = response
+            .text()
+            .await
+            .with_context(|| format!("failed to read error response for {path}"))?;
+        bail!("server returned {response_status} for {path}: {body}");
+    }
+    response
+        .json::<ReconciliationReport>()
+        .await
+        .with_context(|| format!("server returned invalid JSON for {path}"))
+}
+
+fn render_report(report: &ReconciliationReport, dry_run: bool) -> String {
+    let mut output = String::new();
     if dry_run {
-        println!(
-            "Reconciliation dry-run: {} candidate(s), {} terminal skipped, {} task transition(s), {} workflow transition(s), {} workflow alert(s)",
+        output.push_str(&format!(
+            "Reconciliation dry-run: {} candidate(s), {} terminal skipped, {} task transition(s), {} workflow transition(s), {} workflow alert(s)\n",
             report.candidates,
             report.skipped_terminal,
             report.transitions.len(),
             report.workflow_transitions.len(),
             report.workflow_alerts.len()
-        );
+        ));
     } else {
         let applied = report.transitions.iter().filter(|t| t.applied).count()
             + report
@@ -45,27 +81,44 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
                 .iter()
                 .filter(|t| t.applied)
                 .count();
-        println!(
-            "Reconciliation: {} candidate(s), {} terminal skipped, {} transition(s) applied, {} workflow alert(s)",
+        output.push_str(&format!(
+            "Reconciliation: {} candidate(s), {} terminal skipped, {} transition(s) applied, {} workflow alert(s)\n",
             report.candidates,
             report.skipped_terminal,
             applied,
             report.workflow_alerts.len()
-        );
+        ));
     }
 
-    for t in &report.transitions {
-        let applied = if t.applied { "applied" } else { "dry-run" };
-        println!("  {} → {} ({}) [{}]", t.from, t.to, t.reason, applied);
+    for transition in &report.transitions {
+        let applied = if transition.applied {
+            "applied"
+        } else {
+            "dry-run"
+        };
+        output.push_str(&format!(
+            "  {} → {} ({}) [{}]\n",
+            transition.from, transition.to, transition.reason, applied
+        ));
     }
 
-    for t in &report.workflow_transitions {
-        let applied = if t.applied { "applied" } else { "dry-run" };
-        let repo = t.repo.as_deref().unwrap_or("<unknown>");
-        println!(
-            "  workflow {} {}#{}: {} → {} ({}) [{}]",
-            t.workflow_id, repo, t.pr_number, t.from, t.to, t.reason, applied
-        );
+    for transition in &report.workflow_transitions {
+        let applied = if transition.applied {
+            "applied"
+        } else {
+            "dry-run"
+        };
+        let repo = transition.repo.as_deref().unwrap_or("<unknown>");
+        output.push_str(&format!(
+            "  workflow {} {}#{}: {} → {} ({}) [{}]\n",
+            transition.workflow_id,
+            repo,
+            transition.pr_number,
+            transition.from,
+            transition.to,
+            transition.reason,
+            applied
+        ));
     }
 
     for alert in &report.workflow_alerts {
@@ -75,8 +128,8 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
             .map(|number| number.to_string())
             .unwrap_or_else(|| "<unknown>".to_string());
         let pr_url = alert.pr_url.as_deref().unwrap_or("<unknown>");
-        println!(
-            "  workflow alert {} repo={} issue=#{} pr=#{} state={} age_secs={} ttl_secs={} reason={} url={}",
+        output.push_str(&format!(
+            "  workflow alert {} repo={} issue=#{} pr=#{} state={} age_secs={} ttl_secs={} reason={} url={}\n",
             alert.workflow_id,
             repo,
             issue_number,
@@ -86,200 +139,166 @@ pub async fn run(dry_run: bool, project: Option<PathBuf>, config: &HarnessConfig
             alert.ttl_secs,
             alert.reason,
             pr_url
-        );
+        ));
     }
 
-    Ok(())
-}
-
-async fn open_task_store(config: &HarnessConfig) -> Result<Arc<TaskStore>> {
-    std::fs::create_dir_all(&config.server.data_dir).with_context(|| {
-        format!(
-            "failed to create data_dir {}",
-            config.server.data_dir.display()
-        )
-    })?;
-    let data_dir = config.server.data_dir.canonicalize().with_context(|| {
-        format!(
-            "failed to canonicalize data_dir {}",
-            config.server.data_dir.display()
-        )
-    })?;
-    let db_path = default_db_path(&data_dir, "tasks");
-    let database_url = resolve_database_url(config.server.database_url.as_deref())?;
-    let setup_pool = pg_open_pool(&database_url).await?;
-    let task_context = harness_server::task_db::TaskDb::shared_schema_context(Some(&database_url))?;
-    TaskStore::open_shared_for_reconciliation_with_data_dir(
-        &db_path,
-        &task_context,
-        &setup_pool,
-        &data_dir,
-        Some(&database_url),
-    )
-    .await
-}
-
-async fn open_workflow_stores(
-    config: &HarnessConfig,
-) -> (Option<WorkflowRuntimeStore>, Option<IssueWorkflowStore>) {
-    let workflow_config =
-        harness_core::config::workflow::load_workflow_config(&config.server.project_root)
-            .unwrap_or_default();
-    let workflow_ns = workflow_config.storage.schema_namespace;
-    let runtime_schema = format!("{workflow_ns}_runtime");
-    let issue_schema = format!("{workflow_ns}_issue");
-    let database_url = config.server.database_url.as_deref();
-
-    let runtime_store = match WorkflowRuntimeStore::open_with_database_url_and_schema(
-        database_url,
-        &runtime_schema,
-    )
-    .await
-    {
-        Ok(store) => Some(store),
-        Err(error) => {
-            tracing::warn!(
-                schema = %runtime_schema,
-                "workflow runtime store unavailable during reconciliation: {error}"
-            );
-            None
-        }
-    };
-    let issue_workflow_store =
-        match IssueWorkflowStore::open_with_database_url_and_schema(database_url, &issue_schema)
-            .await
-        {
-            Ok(store) => Some(store),
-            Err(error) => {
-                tracing::warn!(
-                    schema = %issue_schema,
-                    "issue workflow store unavailable during reconciliation: {error}"
-                );
-                None
-            }
-        };
-
-    (runtime_store, issue_workflow_store)
+    output
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harness_core::types::TaskId;
-    use harness_server::task_db::TaskDb;
-    use harness_server::task_runner::{
-        TaskKind, TaskPhase, TaskSchedulerState, TaskState, TaskStatus,
+    use harness_server::reconciliation::{
+        ReconciliationTransition, WorkflowReconciliationAlert, WorkflowReconciliationTransition,
     };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     #[tokio::test]
-    async fn open_task_store_reads_shared_schema_scoped_to_data_dir() -> Result<()> {
-        let database_url = match resolve_database_url(None) {
-            Ok(database_url) => database_url,
-            Err(_) => return Ok(()),
-        };
-        let setup_pool = match pg_open_pool(&database_url).await {
-            Ok(pool) => pool,
-            Err(_) => return Ok(()),
-        };
-        let sandbox = tempfile::tempdir()?;
-        let target_data_dir = sandbox.path().join("target-data");
-        let other_data_dir = sandbox.path().join("other-data");
-        std::fs::create_dir_all(&target_data_dir)?;
-        std::fs::create_dir_all(&other_data_dir)?;
+    async fn request_report_posts_dry_run_with_bearer_token() -> Result<()> {
+        let body = r#"{"candidates":2,"skipped_terminal":1,"transitions":[],"workflow_transitions":[],"workflow_alerts":[]}"#;
+        let (base_url, request) = spawn_response("200 OK", body).await?;
+        let client = reqwest::Client::builder().no_proxy().build()?;
 
-        let task_context =
-            harness_server::task_db::TaskDb::shared_schema_context(Some(&database_url))?;
-        let target_db =
-            TaskDb::open_shared_with_data_dir(&task_context, &setup_pool, &target_data_dir).await?;
-        let other_db =
-            TaskDb::open_shared_with_data_dir(&task_context, &setup_pool, &other_data_dir).await?;
-        let target_id = TaskId("reconcile-shared-target".to_string());
-        let other_id = TaskId("reconcile-shared-other".to_string());
-        let running_id = TaskId("reconcile-shared-running".to_string());
-        target_db
-            .insert(&task_state(
-                &target_id,
-                &target_data_dir,
-                TaskStatus::Pending,
-            ))
-            .await?;
-        other_db
-            .insert(&task_state(&other_id, &other_data_dir, TaskStatus::Pending))
-            .await?;
-        target_db
-            .insert(&task_state(
-                &running_id,
-                &target_data_dir,
-                TaskStatus::Implementing,
-            ))
-            .await?;
+        let report = request_report(&client, &base_url, Some("test-token"), true).await?;
+        let request = request.await?;
 
-        let mut config = HarnessConfig::default();
-        config.server.data_dir = target_data_dir;
-        config.server.database_url = Some(database_url);
-
-        let store = open_task_store(&config).await?;
-        assert!(
-            store.get_with_db_fallback(&target_id).await?.is_some(),
-            "reconcile task store should see tasks from its configured data_dir"
-        );
-        assert!(
-            store.get_with_db_fallback(&other_id).await?.is_none(),
-            "reconcile task store must not see tasks from another data_dir"
-        );
-        let running_task = store
-            .get_with_db_fallback(&running_id)
-            .await?
-            .expect("reconcile task store should load active running tasks");
-        assert_eq!(
-            running_task.status,
-            TaskStatus::Implementing,
-            "reconcile task store must not run startup recovery side effects"
-        );
-        let persisted_running = target_db
-            .get(running_id.as_str())
-            .await?
-            .expect("running task should remain persisted");
-        assert_eq!(
-            persisted_running.status,
-            TaskStatus::Implementing,
-            "opening reconcile task store must not fail running tasks in storage"
-        );
-
+        assert_eq!(report.candidates, 2);
+        assert!(request.starts_with("POST /reconcile?dry_run=true HTTP/1.1\r\n"));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer test-token\r\n"));
         Ok(())
     }
 
-    fn task_state(id: &TaskId, project_root: &std::path::Path, status: TaskStatus) -> TaskState {
-        TaskState {
-            id: id.clone(),
-            task_kind: TaskKind::Prompt,
-            status,
-            failure_kind: None,
-            turn: 0,
-            pr_url: None,
-            rounds: Vec::new(),
-            error: None,
-            source: Some("test".to_string()),
-            external_id: None,
-            parent_id: None,
-            depends_on: Vec::new(),
-            subtask_ids: Vec::new(),
-            project_root: Some(project_root.to_path_buf()),
-            workspace_path: None,
-            workspace_owner: None,
-            run_generation: 0,
-            issue: None,
-            repo: None,
-            description: Some("reconcile shared schema test task".to_string()),
-            created_at: None,
-            updated_at: None,
-            priority: 0,
-            phase: TaskPhase::Implement,
-            triage_output: None,
-            plan_output: None,
-            request_settings: None,
-            scheduler: TaskSchedulerState::queued(),
-            version: 0,
+    #[tokio::test]
+    async fn request_report_rejects_unauthorized_response() -> Result<()> {
+        let (base_url, request) = spawn_response("401 Unauthorized", "denied").await?;
+        let client = reqwest::Client::builder().no_proxy().build()?;
+
+        let error = request_report(&client, &base_url, None, false)
+            .await
+            .expect_err("401 must fail");
+        request.await?;
+
+        assert!(error.to_string().contains("server rejected"));
+        assert!(error.to_string().contains("HARNESS_API_TOKEN"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn request_report_rejects_non_success_and_invalid_json() -> Result<()> {
+        let client = reqwest::Client::builder().no_proxy().build()?;
+        let (base_url, request) = spawn_response("500 Internal Server Error", "broken").await?;
+        let error = request_report(&client, &base_url, None, false)
+            .await
+            .expect_err("500 must fail");
+        request.await?;
+        assert!(error.to_string().contains("500 Internal Server Error"));
+        assert!(error.to_string().contains("broken"));
+
+        let (base_url, request) = spawn_response("200 OK", "not-json").await?;
+        let error = request_report(&client, &base_url, None, false)
+            .await
+            .expect_err("invalid JSON must fail");
+        request.await?;
+        assert!(error.to_string().contains("invalid JSON"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn deprecated_project_is_rejected_before_connecting() {
+        let error = run(
+            false,
+            Some(PathBuf::from("legacy-project")),
+            &HarnessConfig::default(),
+        )
+        .await
+        .expect_err("--project must remain rejected");
+
+        assert!(error.to_string().contains("no longer supported"));
+    }
+
+    #[test]
+    fn render_report_preserves_apply_and_dry_run_details() {
+        let report = sample_report();
+
+        let applied = render_report(&report, false);
+        assert!(applied.contains("1 transition(s) applied"));
+        assert!(applied.contains("pending → completed (merged) [applied]"));
+        assert!(applied.contains("workflow workflow-1 owner/repo#42"));
+        assert!(applied.contains("workflow alert workflow-2"));
+
+        let dry_run = render_report(&report, true);
+        assert!(dry_run.contains("1 task transition(s), 1 workflow transition(s)"));
+    }
+
+    fn sample_report() -> ReconciliationReport {
+        ReconciliationReport {
+            candidates: 2,
+            skipped_terminal: 1,
+            transitions: vec![ReconciliationTransition {
+                task_id: "task-1".to_string(),
+                from: "pending".to_string(),
+                to: "completed".to_string(),
+                reason: "merged".to_string(),
+                applied: true,
+            }],
+            workflow_transitions: vec![WorkflowReconciliationTransition {
+                workflow_id: "workflow-1".to_string(),
+                from: "review".to_string(),
+                to: "done".to_string(),
+                reason: "merged".to_string(),
+                applied: false,
+                repo: Some("owner/repo".to_string()),
+                issue_number: Some(41),
+                pr_number: 42,
+                pr_url: Some("https://example.test/pr/42".to_string()),
+            }],
+            workflow_alerts: vec![WorkflowReconciliationAlert {
+                workflow_id: "workflow-2".to_string(),
+                state: "review".to_string(),
+                reason: "stale".to_string(),
+                age_secs: 120,
+                ttl_secs: 60,
+                repo: Some("owner/repo".to_string()),
+                issue_number: None,
+                pr_number: 43,
+                pr_url: None,
+            }],
         }
+    }
+
+    async fn spawn_response(
+        status: &'static str,
+        body: &'static str,
+    ) -> Result<(String, tokio::task::JoinHandle<String>)> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("mock request");
+            let mut request = Vec::new();
+            loop {
+                let mut buffer = [0_u8; 1024];
+                let read = stream.read(&mut buffer).await.expect("read mock request");
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write mock response");
+            String::from_utf8(request).expect("HTTP request is UTF-8")
+        });
+        Ok((format!("http://{address}"), task))
     }
 }


### PR DESCRIPTION
## Summary

- route `harness reconcile` through the existing authenticated `POST /reconcile` server endpoint
- remove the CLI direct dependency on legacy task and workflow stores
- preserve apply/dry-run rendering and deprecated `--project` rejection
- fail explicitly on connection, authentication, HTTP, and JSON errors

This is a non-deletion SP1434-T006 consumer-migration slice. Probe, archive, and deletion gates remain unchanged.

Refs #1434

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p harness-cli --all-targets`
- `cargo test -p harness-cli reconcile`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1434`
- `git diff --check`