### PR TITLE
fix(server): preserve NAP compressor state across retries

### DIFF
--- a/crates/harness-server/src/task_executor/compression.rs
+++ b/crates/harness-server/src/task_executor/compression.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub(crate) type TaskObservationCompressor = Arc<dyn ObservationCompressor>;
 
 /// Build one compressor for the full task lifecycle so sampling and breaker
-/// state accumulate across prompt-injection seams.
+/// state accumulate across prompt-injection seams and transient retries.
 ///
 /// GH-1574 still needs separate wiring for triage-to-plan, cross-review,
 /// workflow-runtime, and composer seams; this legacy path currently injects

--- a/crates/harness-server/src/task_executor/compression.rs
+++ b/crates/harness-server/src/task_executor/compression.rs
@@ -5,22 +5,36 @@
 //! next agent's prompt, so every failure path falls back to raw text.
 
 use harness_agents::compress_model::build_observation_compressor;
-use harness_core::compress::{CompressError, CompressHint, NapStatus, ObsSource};
+use harness_core::compress::{
+    CompressError, CompressHint, NapStatus, ObsSource, ObservationCompressor,
+};
 use harness_core::config::compression::CompressionConfig;
+use std::sync::Arc;
+
+pub(crate) type TaskObservationCompressor = Arc<dyn ObservationCompressor>;
+
+/// Build one compressor for the full task lifecycle so sampling and breaker
+/// state accumulate across prompt-injection seams.
+///
+/// GH-1574 still needs separate wiring for triage-to-plan, cross-review,
+/// workflow-runtime, and composer seams; this legacy path currently injects
+/// compression only at plan-to-implement (including replan retries).
+pub(crate) fn build_task_observation_compressor(
+    config: &CompressionConfig,
+) -> Option<TaskObservationCompressor> {
+    build_observation_compressor(config)
+}
 
 /// Compress a prior agent's output before injecting it into the next
 /// phase's prompt. Returns the raw text unchanged when compression is
 /// inactive, skipped, or fails.
 ///
-/// The compressor handle is built per call, so the NAP circuit breaker
-/// only aggregates within one call site invocation; a shared per-task
-/// handle arrives with the triage-seam wiring (tasks.md handoff).
 pub(crate) async fn compress_observation_for_prompt(
-    config: &CompressionConfig,
+    compressor: Option<&dyn ObservationCompressor>,
     raw: &str,
     task_summary: &str,
 ) -> String {
-    let Some(compressor) = build_observation_compressor(config) else {
+    let Some(compressor) = compressor else {
         return raw.to_string();
     };
     let hint = CompressHint {
@@ -82,12 +96,17 @@ pub(crate) async fn compress_observation_for_prompt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use harness_core::compress::{
+        ActionSketch, CompressModel, CompressModelError, CompressModelOutput, CompressorCallUsage,
+        PromptCompressor,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[tokio::test]
-    async fn inactive_config_returns_raw_unchanged() {
+    async fn missing_compressor_returns_raw_unchanged() {
         let raw = "x".repeat(4096);
-        let out =
-            compress_observation_for_prompt(&CompressionConfig::default(), &raw, "test").await;
+        let out = compress_observation_for_prompt(None, &raw, "test").await;
         assert_eq!(out, raw);
     }
 
@@ -103,5 +122,74 @@ mod tests {
         if std::env::var("ANTHROPIC_API_KEY").is_err() {
             assert!(build_observation_compressor(&config).is_none());
         }
+    }
+
+    struct DisagreeingModel {
+        summaries: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl CompressModel for DisagreeingModel {
+        async fn summarize(
+            &self,
+            _obs: &str,
+            _hint: &CompressHint,
+        ) -> Result<CompressModelOutput<String>, CompressModelError> {
+            self.summaries.fetch_add(1, Ordering::Relaxed);
+            Ok(CompressModelOutput {
+                output: "compressed observation".to_string(),
+                usage: CompressorCallUsage {
+                    input_tokens: 10,
+                    output_tokens: 2,
+                    model: "test-compressor".to_string(),
+                },
+            })
+        }
+
+        async fn sketch(
+            &self,
+            observation: &str,
+            _hint: &CompressHint,
+        ) -> Result<CompressModelOutput<ActionSketch>, CompressModelError> {
+            let compressed = observation == "compressed observation";
+            Ok(CompressModelOutput {
+                output: ActionSketch {
+                    intent: if compressed { "stop" } else { "continue" }.to_string(),
+                    target_files: vec![if compressed { "b.rs" } else { "a.rs" }.to_string()],
+                    command_class: if compressed { "none" } else { "cargo_test" }.to_string(),
+                },
+                usage: CompressorCallUsage {
+                    input_tokens: 5,
+                    output_tokens: 1,
+                    model: "test-compressor".to_string(),
+                },
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn shared_handle_accumulates_nap_failures_and_opens_breaker() {
+        let summaries = Arc::new(AtomicUsize::new(0));
+        let compressor = Arc::new(PromptCompressor::new(
+            DisagreeingModel {
+                summaries: Arc::clone(&summaries),
+            },
+            1.0,
+            0,
+        ));
+        let raw = "raw observation";
+
+        for _ in 0..5 {
+            let output =
+                compress_observation_for_prompt(Some(compressor.as_ref()), raw, "task").await;
+            assert_eq!(output, raw);
+        }
+        let after_breaker =
+            compress_observation_for_prompt(Some(compressor.as_ref()), raw, "task").await;
+
+        assert_eq!(after_breaker, raw);
+        assert_eq!(compressor.nap_checked(), 5);
+        assert_eq!(compressor.nap_failed(), 5);
+        assert_eq!(summaries.load(Ordering::Relaxed), 5);
     }
 }

--- a/crates/harness-server/src/task_executor/implement_pipeline/flow.rs
+++ b/crates/harness-server/src/task_executor/implement_pipeline/flow.rs
@@ -10,6 +10,7 @@ use crate::task_runner::{
 };
 use anyhow::Context;
 use harness_core::agent::CodeAgent;
+use harness_core::compress::ObservationCompressor;
 use harness_core::types::{Decision, Event, SessionId};
 use harness_core::{lang_detect, prompts};
 use std::collections::HashMap;
@@ -40,6 +41,7 @@ pub(crate) async fn run_implement_phase(
     repo_slug: &str,
     project: &Path,
     project_root: &Path,
+    observation_compressor: Option<&dyn ObservationCompressor>,
     plan_output: Option<String>,
     resumed_pr_url: Option<String>,
     resumed_review_prep: Option<prompts::PrReviewPrepOutcome>,
@@ -73,7 +75,7 @@ pub(crate) async fn run_implement_phase(
                 let plan_for_prompt = match plan_output.as_deref() {
                     Some(raw) => Some(
                         super::super::compression::compress_observation_for_prompt(
-                            &server_config.context.compression,
+                            observation_compressor,
                             raw,
                             &format!("implementation phase for issue #{issue} in {repo_slug}"),
                         )

--- a/crates/harness-server/src/task_executor/mod.rs
+++ b/crates/harness-server/src/task_executor/mod.rs
@@ -70,6 +70,7 @@ pub(crate) async fn run_task(
     server_config: &harness_core::config::HarnessConfig,
     issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     workflow_runtime_store: Option<Arc<harness_workflow::runtime::WorkflowRuntimeStore>>,
+    observation_compressor: Option<&dyn harness_core::compress::ObservationCompressor>,
     turns_used_acc: &mut u32,
 ) -> anyhow::Result<()> {
     harness_core::usage_probe::record_usage(
@@ -89,6 +90,7 @@ pub(crate) async fn run_task(
         server_config,
         issue_workflow_store,
         workflow_runtime_store,
+        observation_compressor,
         turns_used_acc,
     )
     .await

--- a/crates/harness-server/src/task_executor/run_task.rs
+++ b/crates/harness-server/src/task_executor/run_task.rs
@@ -11,8 +11,8 @@ pub(super) use super::run_policy::{
     should_run_issue_triage,
 };
 use super::{
-    agent_review, agent_review_provider_gate, compression, gates, implement_pipeline,
-    non_implementation, review_loop, triage_pipeline,
+    agent_review, agent_review_provider_gate, gates, implement_pipeline, non_implementation,
+    review_loop, triage_pipeline,
 };
 use crate::task_executor::SharedTurnInterceptors;
 use crate::task_runner::{
@@ -63,6 +63,7 @@ pub(crate) async fn run_task(
     server_config: &harness_core::config::HarnessConfig,
     issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     workflow_runtime_store: Option<Arc<harness_workflow::runtime::WorkflowRuntimeStore>>,
+    observation_compressor: Option<&dyn harness_core::compress::ObservationCompressor>,
     // Accumulated turn count from previous transient-retry attempts.
     // Ensures the max_turns budget is global across the full task lifecycle,
     // not reset on each retry (fix for budget-reset-on-retry bug).
@@ -98,8 +99,6 @@ pub(crate) async fn run_task(
         )
     })?;
     let resolved = harness_core::config::resolve::resolve_config(server_config, &project_config);
-    let observation_compressor =
-        compression::build_task_observation_compressor(&server_config.context.compression);
     let git = Some(&project_config.git);
     let repo_slug = detect_repo_slug(&project)
         .await
@@ -342,7 +341,7 @@ pub(crate) async fn run_task(
             &repo_slug,
             &project,
             &project_root,
-            observation_compressor.as_deref(),
+            observation_compressor,
             current_plan_output.clone(),
             resumed_pr_url.clone(),
             resumed_review_prep.clone(),

--- a/crates/harness-server/src/task_executor/run_task.rs
+++ b/crates/harness-server/src/task_executor/run_task.rs
@@ -11,8 +11,8 @@ pub(super) use super::run_policy::{
     should_run_issue_triage,
 };
 use super::{
-    agent_review, agent_review_provider_gate, gates, implement_pipeline, non_implementation,
-    review_loop, triage_pipeline,
+    agent_review, agent_review_provider_gate, compression, gates, implement_pipeline,
+    non_implementation, review_loop, triage_pipeline,
 };
 use crate::task_executor::SharedTurnInterceptors;
 use crate::task_runner::{
@@ -98,6 +98,8 @@ pub(crate) async fn run_task(
         )
     })?;
     let resolved = harness_core::config::resolve::resolve_config(server_config, &project_config);
+    let observation_compressor =
+        compression::build_task_observation_compressor(&server_config.context.compression);
     let git = Some(&project_config.git);
     let repo_slug = detect_repo_slug(&project)
         .await
@@ -340,6 +342,7 @@ pub(crate) async fn run_task(
             &repo_slug,
             &project,
             &project_root,
+            observation_compressor.as_deref(),
             current_plan_output.clone(),
             resumed_pr_url.clone(),
             resumed_review_prep.clone(),

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -555,6 +555,12 @@ where
 
         // Retry loop: on transient errors, back off and retry up to MAX_TRANSIENT_RETRIES.
         // Retrying inside the spawn means the stream stays open and the task actually re-runs.
+        // Keep the observation compressor outside the retry loop so NAP sampling and
+        // breaker state span the complete task lifecycle rather than one attempt.
+        let observation_compressor =
+            crate::task_executor::compression::build_task_observation_compressor(
+                &server_config.context.compression,
+            );
         let mut transient_attempts = 0u32;
         // Track total turns used across all transient-retry attempts so the
         // max_turns budget is enforced globally over the full task lifecycle.
@@ -594,6 +600,7 @@ where
                 server_config.as_ref(),
                 issue_workflow_store.clone(),
                 workflow_runtime_store.clone(),
+                observation_compressor.as_deref(),
                 &mut total_turns_used,
             )
             .await;


### PR DESCRIPTION
## Summary

- build one observation compressor per legacy task run
- reuse its sampling and breaker state across plan-to-implement and replan retries
- preserve raw fallback and checkpoint behavior
- add a regression test proving NAP failures accumulate and open the breaker

This is a partial GH-1574 slice. Triage-to-plan, cross-review, workflow-runtime, composer degradation, and A/B replay evidence remain open.

Refs #1574

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p harness-server --all-targets`
- `cargo test -p harness-server task_executor::compression::tests --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1574`
- `git diff --check`