### PR TITLE
fix(compression): seed NAP sampling per task

### DIFF
--- a/crates/harness-agents/src/compress_model.rs
+++ b/crates/harness-agents/src/compress_model.rs
@@ -141,6 +141,30 @@ impl CompressModel for ApiCompressModel {
 pub fn build_observation_compressor(
     config: &CompressionConfig,
 ) -> Option<Arc<dyn ObservationCompressor>> {
+    let model = configured_model(config)?;
+    Some(Arc::new(PromptCompressor::new(
+        model,
+        config.sample_rate,
+        config.min_size_bytes,
+    )))
+}
+
+/// Build a configured compressor with a stable task/request sampling phase.
+/// Each returned handle retains independent NAP counters and breaker state.
+pub fn build_seeded_observation_compressor(
+    config: &CompressionConfig,
+    seed: &str,
+) -> Option<Arc<dyn ObservationCompressor>> {
+    let model = configured_model(config)?;
+    Some(Arc::new(PromptCompressor::new_seeded(
+        model,
+        config.sample_rate,
+        config.min_size_bytes,
+        seed,
+    )))
+}
+
+fn configured_model(config: &CompressionConfig) -> Option<ApiCompressModel> {
     if !config.is_active() {
         return None;
     }
@@ -148,12 +172,11 @@ pub fn build_observation_compressor(
     if api_key.trim().is_empty() {
         return None;
     }
-    let model = ApiCompressModel::new(api_key, config.endpoint.clone(), config.model.clone());
-    Some(Arc::new(PromptCompressor::new(
-        model,
-        config.sample_rate,
-        config.min_size_bytes,
-    )))
+    Some(ApiCompressModel::new(
+        api_key,
+        config.endpoint.clone(),
+        config.model.clone(),
+    ))
 }
 
 #[cfg(test)]

--- a/crates/harness-core/src/compress.rs
+++ b/crates/harness-core/src/compress.rs
@@ -250,6 +250,47 @@ impl NapSampler for EveryN {
     }
 }
 
+/// Verifies one seed-selected position in each `n`-call window.
+///
+/// The seed is mapped with 64-bit FNV-1a, whose constants and byte-wise
+/// algorithm are fixed here to keep replay behavior stable across processes
+/// and Rust releases. This hash is only for deterministic sampling, not
+/// security. Distinct task/request IDs therefore spread short-lived handles
+/// across the configured sampling window instead of all starting at the same
+/// unsampled sequence position.
+#[derive(Debug, Clone, Copy)]
+pub struct SeededEveryN {
+    every: u64,
+    position: u64,
+}
+
+impl SeededEveryN {
+    pub fn from_rate(rate: f64, seed: &str) -> Self {
+        let every = EveryN::from_rate(rate).0;
+        let position = if every == u64::MAX {
+            0
+        } else {
+            stable_seed_hash(seed) % every
+        };
+        Self { every, position }
+    }
+}
+
+impl NapSampler for SeededEveryN {
+    fn should_verify(&self, seq: u64) -> bool {
+        self.every != u64::MAX && seq.wrapping_sub(1) % self.every == self.position
+    }
+}
+
+fn stable_seed_hash(seed: &str) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    seed.as_bytes().iter().fold(FNV_OFFSET_BASIS, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(FNV_PRIME)
+    })
+}
+
 /// Token estimate mirroring `BytesDivFourEstimator` in harness-context.
 /// Canonical core-level helper; downstream crates with private variants
 /// (harness-workflow memory_retrieval) can migrate to this.
@@ -275,6 +316,18 @@ pub struct PromptCompressor<M: CompressModel, S: NapSampler = EveryN> {
 impl<M: CompressModel> PromptCompressor<M, EveryN> {
     pub fn new(model: M, sample_rate: f64, min_size_bytes: usize) -> Self {
         Self::with_sampler(model, EveryN::from_rate(sample_rate), min_size_bytes)
+    }
+}
+
+impl<M: CompressModel> PromptCompressor<M, SeededEveryN> {
+    /// Construct a compressor whose deterministic verification phase is
+    /// derived from a stable task/request identifier.
+    pub fn new_seeded(model: M, sample_rate: f64, min_size_bytes: usize, seed: &str) -> Self {
+        Self::with_sampler(
+            model,
+            SeededEveryN::from_rate(sample_rate, seed),
+            min_size_bytes,
+        )
     }
 }
 
@@ -510,6 +563,33 @@ mod tests {
         let second = c.compress(&raw_obs(), &hint()).await.unwrap();
         assert_eq!(second.nap, NapStatus::Verified);
         assert_eq!(second.compressor_usage.calls.len(), 3);
+    }
+
+    #[test]
+    fn seeded_sampler_is_stable_and_distributes_first_calls() {
+        let decisions: Vec<bool> = (0..1_000)
+            .map(|seed| SeededEveryN::from_rate(0.1, &format!("task-{seed}")).should_verify(1))
+            .collect();
+        let repeated: Vec<bool> = (0..1_000)
+            .map(|seed| SeededEveryN::from_rate(0.1, &format!("task-{seed}")).should_verify(1))
+            .collect();
+        let selected = decisions.iter().filter(|decision| **decision).count();
+
+        assert_eq!(decisions, repeated);
+        assert!(
+            (80..=120).contains(&selected),
+            "expected about 100 sampled task seeds, got {selected}"
+        );
+    }
+
+    #[test]
+    fn seeded_sampler_verifies_once_per_window() {
+        let sampler = SeededEveryN::from_rate(0.1, "task-1574");
+        assert_eq!(
+            (1..=20).filter(|seq| sampler.should_verify(*seq)).count(),
+            2
+        );
+        assert!(!SeededEveryN::from_rate(0.0, "task-1574").should_verify(1));
     }
 
     #[tokio::test]

--- a/crates/harness-core/src/compress.rs
+++ b/crates/harness-core/src/compress.rs
@@ -306,8 +306,8 @@ fn stable_seed_hash(seed: &str) -> u64 {
     const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
     const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
-    seed.as_bytes().iter().fold(FNV_OFFSET_BASIS, |hash, byte| {
-        (hash ^ u64::from(*byte)).wrapping_mul(FNV_PRIME)
+    seed.bytes().fold(FNV_OFFSET_BASIS, |hash, byte| {
+        (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME)
     })
 }
 

--- a/crates/harness-core/src/compress.rs
+++ b/crates/harness-core/src/compress.rs
@@ -250,35 +250,55 @@ impl NapSampler for EveryN {
     }
 }
 
-/// Verifies one seed-selected position in each `n`-call window.
+/// Applies the configured verification rate with a seed-selected phase.
 ///
 /// The seed is mapped with 64-bit FNV-1a, whose constants and byte-wise
 /// algorithm are fixed here to keep replay behavior stable across processes
 /// and Rust releases. This hash is only for deterministic sampling, not
-/// security. Distinct task/request IDs therefore spread short-lived handles
-/// across the configured sampling window instead of all starting at the same
-/// unsampled sequence position.
+/// security. The phase gives each call the configured selection probability
+/// across distinct task/request IDs while systematic sampling keeps the
+/// long-run rate close to the configured value for each handle.
 #[derive(Debug, Clone, Copy)]
-pub struct SeededEveryN {
-    every: u64,
-    position: u64,
+pub struct SeededRateSampler {
+    rate_units: u64,
+    phase_units: u64,
 }
 
-impl SeededEveryN {
+const SAMPLING_UNITS: u64 = 1_u64 << 53;
+
+impl SeededRateSampler {
     pub fn from_rate(rate: f64, seed: &str) -> Self {
-        let every = EveryN::from_rate(rate).0;
-        let position = if every == u64::MAX {
-            0
+        let rate = if rate.is_nan() {
+            0.0
         } else {
-            stable_seed_hash(seed) % every
+            rate.clamp(0.0, 1.0)
         };
-        Self { every, position }
+        // Use 53-bit fixed-point units so arbitrary f64 rates retain their
+        // configured precision without floating-point sequence drift.
+        let rate_units = (rate * SAMPLING_UNITS as f64).round() as u64;
+        let phase_units = stable_seed_hash(seed) >> 11;
+        Self {
+            rate_units,
+            phase_units,
+        }
     }
 }
 
-impl NapSampler for SeededEveryN {
+impl NapSampler for SeededRateSampler {
     fn should_verify(&self, seq: u64) -> bool {
-        self.every != u64::MAX && seq.wrapping_sub(1) % self.every == self.position
+        if seq == 0 || self.rate_units == 0 {
+            return false;
+        }
+        if self.rate_units >= SAMPLING_UNITS {
+            return true;
+        }
+
+        let scale = u128::from(SAMPLING_UNITS);
+        let rate = u128::from(self.rate_units);
+        let phase = u128::from(self.phase_units);
+        let current = (u128::from(seq) * rate + phase) / scale;
+        let previous = (u128::from(seq - 1) * rate + phase) / scale;
+        current > previous
     }
 }
 
@@ -319,13 +339,13 @@ impl<M: CompressModel> PromptCompressor<M, EveryN> {
     }
 }
 
-impl<M: CompressModel> PromptCompressor<M, SeededEveryN> {
+impl<M: CompressModel> PromptCompressor<M, SeededRateSampler> {
     /// Construct a compressor whose deterministic verification phase is
     /// derived from a stable task/request identifier.
     pub fn new_seeded(model: M, sample_rate: f64, min_size_bytes: usize, seed: &str) -> Self {
         Self::with_sampler(
             model,
-            SeededEveryN::from_rate(sample_rate, seed),
+            SeededRateSampler::from_rate(sample_rate, seed),
             min_size_bytes,
         )
     }
@@ -568,10 +588,10 @@ mod tests {
     #[test]
     fn seeded_sampler_is_stable_and_distributes_first_calls() {
         let decisions: Vec<bool> = (0..1_000)
-            .map(|seed| SeededEveryN::from_rate(0.1, &format!("task-{seed}")).should_verify(1))
+            .map(|seed| SeededRateSampler::from_rate(0.1, &format!("task-{seed}")).should_verify(1))
             .collect();
         let repeated: Vec<bool> = (0..1_000)
-            .map(|seed| SeededEveryN::from_rate(0.1, &format!("task-{seed}")).should_verify(1))
+            .map(|seed| SeededRateSampler::from_rate(0.1, &format!("task-{seed}")).should_verify(1))
             .collect();
         let selected = decisions.iter().filter(|decision| **decision).count();
 
@@ -583,13 +603,19 @@ mod tests {
     }
 
     #[test]
-    fn seeded_sampler_verifies_once_per_window() {
-        let sampler = SeededEveryN::from_rate(0.1, "task-1574");
-        assert_eq!(
-            (1..=20).filter(|seq| sampler.should_verify(*seq)).count(),
-            2
-        );
-        assert!(!SeededEveryN::from_rate(0.0, "task-1574").should_verify(1));
+    fn seeded_sampler_honors_arbitrary_rates() {
+        for rate in [0.1, 0.6, 0.75] {
+            let sampler = SeededRateSampler::from_rate(rate, "task-1574");
+            let selected = (1..=10_000)
+                .filter(|seq| sampler.should_verify(*seq))
+                .count();
+            let expected = (10_000.0 * rate) as usize;
+            assert!(selected.abs_diff(expected) <= 1, "rate={rate}");
+        }
+
+        assert!(!SeededRateSampler::from_rate(0.0, "task-1574").should_verify(1));
+        assert!(SeededRateSampler::from_rate(2.0, "task-1574").should_verify(1));
+        assert!(!SeededRateSampler::from_rate(f64::NAN, "task-1574").should_verify(1));
     }
 
     #[tokio::test]

--- a/crates/harness-server/src/task_executor/compression.rs
+++ b/crates/harness-server/src/task_executor/compression.rs
@@ -4,12 +4,16 @@
 //! `state.plan_output`); compression only affects what is injected into the
 //! next agent's prompt, so every failure path falls back to raw text.
 
+#[cfg(test)]
 use harness_agents::compress_model::build_observation_compressor;
+use harness_agents::compress_model::build_seeded_observation_compressor;
 use harness_core::compress::{
     CompressError, CompressHint, NapStatus, ObsSource, ObservationCompressor,
 };
 use harness_core::config::compression::CompressionConfig;
 use std::sync::Arc;
+
+use crate::task_runner::TaskId;
 
 pub(crate) type TaskObservationCompressor = Arc<dyn ObservationCompressor>;
 
@@ -21,8 +25,9 @@ pub(crate) type TaskObservationCompressor = Arc<dyn ObservationCompressor>;
 /// compression only at plan-to-implement (including replan retries).
 pub(crate) fn build_task_observation_compressor(
     config: &CompressionConfig,
+    task_id: &TaskId,
 ) -> Option<TaskObservationCompressor> {
-    build_observation_compressor(config)
+    build_seeded_observation_compressor(config, task_id.as_str())
 }
 
 /// Compress a prior agent's output before injecting it into the next

--- a/crates/harness-server/src/task_runner/spawn.rs
+++ b/crates/harness-server/src/task_runner/spawn.rs
@@ -560,6 +560,7 @@ where
         let observation_compressor =
             crate::task_executor::compression::build_task_observation_compressor(
                 &server_config.context.compression,
+                &id,
             );
         let mut transient_attempts = 0u32;
         // Track total turns used across all transient-retry attempts so the


### PR DESCRIPTION
## Summary

- add deterministic task/request-seeded NAP sampling using a stable FNV-1a phase
- preserve independent per-task verification counters and circuit breakers
- seed production task compressors from `TaskId` so short-lived tasks collectively honor the configured sample rate

## Why

A fresh `EveryN(10)` compressor always started at sequence 1, so separate short-lived task handles never ran the default 10% NAP verification. Sharing one global handle would mix breaker state across tasks. This prerequisite fixes sampling without weakening task isolation.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p harness-core compress::tests`
- `cargo test -p harness-agents compress_model::tests`
- `cargo test -p harness-server task_executor::compression::tests`
- `cargo check -p harness-core -p harness-agents -p harness-server --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --exclude harness-server`
- `git diff --check`

Full `cargo test --workspace` additionally ran 1,698 harness-server library tests: 1,390 passed and 308 database-backed tests failed because `HARNESS_DATABASE_URL` is not configured, matching the repository pre-push environment rule. GitHub CI subsequently passed the full database-backed server profile.

This is a prerequisite for the remaining cross-review agent-result seam and does not close the acceptance issue.

Related: #1574