### PR TITLE
docs: GH1608 owned workflow definition registry spec packet

### DIFF
--- a/specs/GH1608/product.md
+++ b/specs/GH1608/product.md
@@ -1,0 +1,74 @@
+# GH1608 Product Spec: Runtime-Registered Workflow Definition Registry
+
+GitHub issue: `#1608`
+
+## Goals
+
+- Replace the compile-time static workflow state tables with a registry of
+  owned definitions populated at startup, so a later feature (GH-1609) can
+  register configuration-defined workflow definitions without Rust edits.
+- Register each definition's state table and its transition allowlist
+  together, giving one lookup source for "what states exist" and "what
+  transitions are legal".
+- Preserve observable behavior exactly: the four built-in definitions,
+  their states, terminal mappings, and transition rules do not change.
+
+## Non-Goals
+
+- No new definition sources: no WORKFLOW.md parsing, no config schema
+  (GH-1609 owns that).
+- No reducer generalization; hardcoded completion logic stays as-is.
+- No persisted-schema, wire-format, or dispatch changes.
+
+## Users
+
+- GH-1609 (declarative definitions), which needs a registration API.
+- Harness developers adding future built-in definitions with less
+  boilerplate and a single registration point.
+
+## Behavior Invariants
+
+- `B-001` Behavior-preserving: every existing `harness-workflow` and
+  `harness-server` test passes unchanged; an equivalence test asserts the
+  registered built-in state sets, terminal mappings, and transition
+  allowlists are identical to the previous static tables.
+- `B-002` Registry entry types own their strings; no `&'static str`
+  remains in `WorkflowStateKey` / `WorkflowStateDefinition` or the
+  registration API.
+- `B-003` The four built-in definitions are seeded exactly once during
+  registry initialization, before any dispatcher, worker, or store
+  consumer can perform a lookup.
+- `B-004` Registering a definition id that already exists fails loudly
+  (error, not warning); there is no silent replacement.
+- `B-005` Lookups for unknown definition ids behave exactly as today:
+  empty state slice, `None` terminal state, no panic.
+- `B-006` Registry reads take no lock across await points and add no
+  measurable overhead to the dispatch/completion hot path (read-only
+  after initialization or read-locked with short critical sections).
+- `B-007` The registry freezes after startup registration completes;
+  attempts to register once workflow processing has started are rejected
+  with an error, so the set of definitions is stable for the lifetime of
+  the process.
+- `B-008` Each registered definition carries its transition allowlist;
+  validator selection resolves through the registry rather than a
+  hardcoded match, with rule content unchanged for built-ins.
+
+## Boundary Checklist
+
+| Category | Coverage |
+|---|---|
+| Empty input | covered: B-005 (unknown id lookups keep today's empty/None semantics) |
+| Failure paths | covered: B-004 (duplicate registration errors), B-007 (late registration rejected) |
+| Authorization | N/A — in-process API only; no new external surface |
+| Concurrency | covered: B-006 (no lock across await, short read sections), B-003/B-007 (registration ordered before consumers) |
+| Retry + idempotency | covered: B-004 (re-registration is an explicit error, not an implicit upsert) |
+| Illegal transitions | covered: B-008 (allowlists preserved verbatim for built-ins) |
+| Compatibility | covered: B-001 (full-suite equivalence gate), B-002 (API shape change is compile-time only) |
+| Degradation / fallback | covered: B-004/B-007 (loud failure, never silent partial registry) |
+| Evidence / audit | covered: B-001 (equivalence test is the recorded proof of preservation) |
+| Cancellation / partial | covered: B-007 (freeze point makes partially-registered states impossible to observe) |
+
+Cross-product boundary called out explicitly: initialization order — the
+registry must be complete and frozen before the first store lookup, and a
+failed built-in registration must abort startup rather than start a
+server with a partial registry (B-003 + B-004 + B-007).

--- a/specs/GH1608/tasks.md
+++ b/specs/GH1608/tasks.md
@@ -1,0 +1,44 @@
+# GH1608 Task Plan
+
+## Linked Issue
+
+GH-1608 (prerequisite for GH-1609; related: GH-1603)
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1608-T001` Owner: `types` | Done when: `WorkflowStateKey` / `WorkflowStateDefinition` own their strings, const constructors are replaced by owned builders, and the four built-in tables become `*_definition()` functions returning `WorkflowDefinition { id, states, allowlist }` (B-002, B-008) | Verify: `cargo check -p harness-workflow`
+- [ ] `SP1608-T002` Owner: `registry` | Done when: `WorkflowDefinitionRegistry` exists behind a `OnceLock<RwLock<..>>` whose initializer seeds the four built-ins; `register()` errors on duplicate id and post-freeze; `freeze()` is idempotent; a test-only fresh-registry constructor exists (B-003, B-004, B-007) | Verify: `cargo test -p harness-workflow state_registry`
+- [ ] `SP1608-T003` Owner: `api-migration` | Done when: the free-function API reads through the registry with owned/`Arc` return types and all in-repo consumers (`runtime/mod.rs`, `runtime/model.rs`, `runtime/store/instances.rs`, `runtime/terminal_state.rs`) compile against it with unchanged semantics for unknown ids (B-005, B-006) | Verify: `cargo test -p harness-workflow`
+- [ ] `SP1608-T004` Owner: `validator-selection` | Done when: `DecisionValidator` selection at `reducer.rs:459` resolves the allowlist via the registry; the `*_defaults()` constructors remain the single source of built-in rule content, called once at seeding (B-008) | Verify: `cargo test -p harness-workflow validator reducer`
+- [ ] `SP1608-T005` Owner: `equivalence-gate` | Done when: an equivalence test hardcodes the pre-refactor ids, state sets, terminal mappings, and per-definition transition rules and asserts registry output matches exactly; server startup calls `freeze()` after registration (B-001, B-003, B-007) | Verify: `cargo test -p harness-workflow state_registry::equivalence && cargo test -p harness-server`
+
+## Parallelization
+
+- `SP1608-T001` first; `SP1608-T002` after T001.
+- `SP1608-T003` and `SP1608-T004` in parallel after T002 (disjoint files:
+  registry consumers vs validator selection).
+- `SP1608-T005` last as the preservation gate.
+
+## Verification
+
+- `cargo check --workspace --all-targets`
+- `cargo test -p harness-workflow -p harness-server`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1608`
+
+## Handoff Notes
+
+Strictly an enabling refactor: zero observable behavior change is the
+acceptance bar, enforced by the equivalence test plus the full existing
+suites. GH-1609 consumes `register()`/`freeze()`; GH-1603's progress
+contracts should attach per-state metadata to `WorkflowStateDefinition`
+once both land — keep the struct open for an additive field. The
+equivalence test's hardcoded expectations must be copied from the current
+const tables before they are deleted, in the same PR, so the source of
+truth never disappears between commits.

--- a/specs/GH1608/tech.md
+++ b/specs/GH1608/tech.md
@@ -1,0 +1,159 @@
+# GH1608 Tech Spec: Owned Workflow Definition Registry
+
+Product spec: `specs/GH1608/product.md`
+GitHub issue: `#1608`
+Related: GH-1609 (consumer of the registration API), GH-1603 (progress
+contracts will attach per-state metadata to registry entries)
+
+## Codebase Context (verified anchors)
+
+- Static tables: `crates/harness-workflow/src/runtime/state_registry.rs:53-58`
+  (`WORKFLOW_DEFINITION_IDS`), `:60-157` (four `const` state tables built
+  from `WorkflowStateDefinition::active/terminal`).
+- `&'static str` types: `state_registry.rs:15-25` (`WorkflowStateKey`,
+  `WorkflowStateDefinition` with `definition_id: &'static str`,
+  `state: &'static str`), const constructors `:27-51`.
+- Free-function API: `state_registry.rs:159-196`
+  (`known_workflow_definition_ids`, `workflow_states_for_definition`,
+  `workflow_terminal_state_names_for_definition`,
+  `workflow_state_definition`, `workflow_state_exists`,
+  `workflow_state_terminal_state`).
+- Consumers of that API: `runtime/mod.rs`, `runtime/model.rs`
+  (`WorkflowInstance::terminal_state` at `model.rs:120-122`),
+  `runtime/store/instances.rs`, `runtime/terminal_state.rs`.
+- Validator allowlists (generic engine, hardcoded defaults):
+  `crates/harness-workflow/src/runtime/validator.rs:59-104`
+  (`TransitionAllowlist`), per-definition constructors `:105`
+  (`github_issue_pr_defaults`), `:260` (`quality_gate_defaults`), `:278`
+  (`pr_feedback_defaults`), `:297` (`prompt_task_defaults`), selection
+  constructors `:439-456`, hardcoded selection in the reducer at
+  `runtime/reducer.rs:459`.
+- Definition-id constants: `runtime/reducer.rs:50`
+  (`GITHUB_ISSUE_PR_DEFINITION_ID`), `runtime/prompt_task.rs:3`,
+  `runtime/quality_gate.rs` and `runtime/pr_feedback.rs` equivalents
+  (imported at `state_registry.rs:1-4`).
+
+## Proposed Design
+
+### Owned types
+
+```rust
+// state_registry.rs
+pub struct WorkflowStateKey {
+    pub definition_id: String,
+    pub state: String,
+}
+
+pub struct WorkflowStateDefinition {
+    pub key: WorkflowStateKey,
+    pub terminal_state: Option<WorkflowTerminalState>,
+}
+
+pub struct WorkflowDefinition {
+    pub id: String,
+    pub states: Vec<WorkflowStateDefinition>,
+    pub allowlist: TransitionAllowlist,
+}
+```
+
+Const constructors go away; built-in tables become functions returning
+owned `WorkflowDefinition`s (`github_issue_pr_definition()`, ...), each
+pairing the existing state list with the existing
+`DecisionValidator::*_defaults()` allowlist (B-002, B-008).
+
+### Registry
+
+```rust
+pub struct WorkflowDefinitionRegistry {
+    definitions: HashMap<String, Arc<WorkflowDefinition>>,
+    frozen: bool,
+}
+```
+
+- Process-wide handle: `static REGISTRY: OnceLock<RwLock<WorkflowDefinitionRegistry>>`,
+  initialized on first access with the four built-ins already seeded
+  (B-003) — seeding inside the `OnceLock` initializer makes "empty
+  registry observed" unrepresentable.
+- `register(def: WorkflowDefinition) -> anyhow::Result<()>`: errors on
+  duplicate id (B-004) or when frozen (B-007).
+- `freeze()`: called by server startup after config-driven registration
+  (GH-1609) and by test harnesses; post-freeze `register` errors.
+- Reads clone `Arc<WorkflowDefinition>` out of a short read-lock; no lock
+  is held across await points (B-006). The existing free functions keep
+  their signatures where possible; the two returning `&'static` slices
+  change to owned/`Arc` returns:
+  - `workflow_states_for_definition(&str) -> Arc<[WorkflowStateDefinition]>`
+    (or `Vec` clone; states are small),
+  - `known_workflow_definition_ids() -> Vec<String>`.
+  Callers are updated mechanically (~5 files).
+
+### Validator selection through the registry
+
+`DecisionValidator` selection at `reducer.rs:459` switches from a
+hardcoded match to `registry.allowlist_for(definition_id)`, falling back
+to today's behavior for unknown ids. The four `*_defaults()`
+constructors remain the single source of built-in rule content — they are
+called once at seeding, not deleted (B-001, B-008).
+
+### What does NOT change
+
+- `WorkflowInstance` (already owns `definition_id: String`,
+  `model.rs:76-91`).
+- Reducer completion logic, dispatcher, store schemas, worker.
+- Public behavior for unknown definition ids (B-005): empty state list,
+  `None` terminal lookups.
+
+## Edge Cases
+
+- Two subsystems racing first access of the `OnceLock`: initializer runs
+  once; both observe the fully-seeded registry (B-003).
+- A test registering a fixture definition twice: second call errors;
+  tests needing re-registration use a fresh registry via a test-only
+  constructor (`WorkflowDefinitionRegistry::new_for_tests()`), not the
+  global (B-004).
+- Freeze ordering in binaries that never load config definitions (CLI
+  tools, tests using the store directly): freeze is idempotent and the
+  built-ins are always present pre-freeze, so consumers that never call
+  `freeze()` still see a correct (just unfrozen) registry; only
+  registration attempts after processing starts are a bug this catches
+  opportunistically (B-007 is enforced at the server startup seam).
+
+## Migration / Compatibility
+
+- Compile-time only: no persisted data, wire format, or config change.
+- `&'static` → owned return types are source-breaking inside the
+  workspace only; all consumers are in-repo (~5 files).
+- Equivalence test snapshots the old tables (hardcoded expectation in the
+  test, copied from the current consts) against registry output so drift
+  during the refactor is caught mechanically (B-001).
+
+## Verification Plan
+
+- `cargo test -p harness-workflow state_registry` — equivalence test:
+  ids, state sets, terminal mappings, and allowlist rules for all four
+  built-ins match the pre-refactor tables exactly (B-001, B-008).
+- `cargo test -p harness-workflow` + `cargo test -p harness-server` —
+  full behavior-preservation gate (B-001).
+- New unit tests: duplicate registration errors (B-004), post-freeze
+  registration errors (B-007), unknown-id lookups (B-005).
+- `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo fmt --all -- --check`, `cargo check --workspace --all-targets`.
+
+## Rollback Plan
+
+No persisted or wire surface: revert the commits and the static tables
+return. GH-1609 must not merge before this lands (dependency ordering is
+one-way).
+
+## Product-to-Test Mapping
+
+| Invariant | Implementation area | Verification |
+|---|---|---|
+| B-001 | whole refactor | full `harness-workflow` + `harness-server` suites + equivalence test |
+| B-002 | owned types in `state_registry.rs` | compile-time; grep gate: no `&'static str` in registry types |
+| B-003 | `OnceLock` initializer seeds built-ins | `cargo test -p harness-workflow state_registry` (first-access test) |
+| B-004 | `register()` duplicate check | `cargo test -p harness-workflow state_registry::duplicate` |
+| B-005 | lookup fallbacks | `cargo test -p harness-workflow state_registry::unknown_id` |
+| B-006 | short read-lock reads | review gate + no `.await` inside lock scope (clippy `await_holding_lock`) |
+| B-007 | `freeze()` semantics | `cargo test -p harness-workflow state_registry::freeze` |
+| B-008 | allowlist registered with states | equivalence test compares `rules()` output per definition |

--- a/specs/GH1608/tech.md
+++ b/specs/GH1608/tech.md
@@ -40,8 +40,8 @@ contracts will attach per-state metadata to registry entries)
 ```rust
 // state_registry.rs
 pub struct WorkflowStateKey {
-    pub definition_id: String,
-    pub state: String,
+    pub definition_id: Arc<str>, // cheap clone on hot-path lookups (B-006)
+    pub state: Arc<str>,
 }
 
 pub struct WorkflowStateDefinition {


### PR DESCRIPTION
## Summary

Spec packet (product/tech/tasks) for GH-1608: replace the compile-time static workflow state tables (`state_registry.rs` const tables, `&'static str` keys, hardcoded validator selection) with a `WorkflowDefinitionRegistry` of owned definitions, seeded with the four built-ins inside the `OnceLock` initializer and frozen after startup registration.

Key design points:
- Behavior-preserving: equivalence test hardcodes the pre-refactor ids/states/terminal mappings/transition rules and asserts registry output matches exactly; full existing suites are the gate.
- Each definition registers its state table together with its `TransitionAllowlist`, giving one lookup source; `DecisionValidator` selection resolves through the registry.
- Duplicate and post-freeze registration fail loudly; unknown-id lookups keep today's empty/None semantics.
- Prerequisite for GH-1609 (declarative definitions from WORKFLOW.md).

## Linked Issue

Refs #1608 (spec packet only; no implementation in this PR)

## Test Plan

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1608` — SpecRail check passed
- Docs-only change; no code surface