### PR TITLE
docs: GH1609 declarative workflow definitions spec packet

### DIFF
--- a/specs/GH1609/product.md
+++ b/specs/GH1609/product.md
@@ -1,0 +1,114 @@
+# GH1609 Product Spec: Declarative Workflow Definitions from WORKFLOW.md
+
+GitHub issue: `#1609`
+Depends on: GH-1608 (owned definition registry)
+
+## Goals
+
+- Make a repo's `WORKFLOW.md` sufficient to define and run a new workflow
+  shape — states, driving activities, transitions, terminal mapping,
+  required evidence — without Rust changes, on top of the existing durable
+  runtime (leases, retries, circuit breaker, audit).
+- Validate declared shapes as strictly as code: structural errors fail at
+  startup with actionable messages, never at workflow runtime.
+- Pin every workflow instance to the definition content it was created
+  under, so editing WORKFLOW.md mid-flight never mutates a running
+  instance's shape.
+- Keep the four built-in definitions and their reducers completely
+  untouched.
+
+## Non-Goals
+
+- No migration of built-in definitions (`github_issue_pr`, `pr_feedback`,
+  `quality_gate`, `prompt_task`) to declarations.
+- No child workflows, candidate fanout, or plan-issue mechanics in
+  declarative definitions v1.
+- No hot-reload of definition changes into in-flight instances.
+- No new activity execution kinds; declared activities dispatch through
+  the existing runtime profiles and activity policy map.
+
+## Users
+
+- Repo owners who want a custom flow (for example docs-review, triage, or
+  release checklists) driven by their WORKFLOW.md without forking harness.
+- The Symphony-parity operating mode: WORKFLOW.md becomes the single file
+  that defines both behavior (prompts) and shape (states/transitions).
+
+## Behavior Invariants
+
+- `B-001` A WORKFLOW.md without a `definition` block changes nothing:
+  no new registration, byte-identical config parsing for existing files.
+- `B-002` An invalid `definition` block fails config load/startup with an
+  actionable error naming the state or transition at fault; there is zero
+  partial registration (a definition registers whole or not at all).
+- `B-003` Structural validation rejects: transitions to undeclared
+  states, states unreachable from the declared initial state, missing or
+  incomplete terminal mapping (done/failed/cancelled classes), duplicate
+  state names, ids colliding with built-in or already-registered
+  definitions, and non-terminal states lacking a progress mode (a driving
+  `activity`, `progress: external_wait`, or `progress: operator_gate`) —
+  aligned with GH-1603.
+- `B-004` Valid declarations register at server startup through the
+  GH-1608 registry, before the registry freezes and before any dispatch
+  begins.
+- `B-005` `definition_version` on each instance is a content hash of the
+  canonicalized declaration. In-flight instances complete under their
+  pinned version: a changed WORKFLOW.md affects only instances created
+  after reload, and version mismatch between an instance and the loaded
+  declaration is detected, surfaced, and blocks interpretation for that
+  instance rather than silently applying the new shape.
+- `B-006` The generic interpreting reducer is reachable only for
+  registered declarative definition ids; built-in ids never enter the
+  interpreter and their reducers/validators are byte-identical in
+  behavior.
+- `B-007` Every interpreted transition into a non-terminal
+  activity-driven state carries its driving `enqueue_activity` command in
+  the same completion transaction; terminal transitions carry their
+  Mark* command — no driverless progress states (GH-1603).
+- `B-008` Signal mapping: `on_signal` entries match by signal type;
+  an unmapped signal on an otherwise successful result follows
+  `on_success`; a declared signal mapping always wins over `on_success`.
+  A result whose status is Blocked/Failed follows `on_blocked`/
+  `on_failure` when declared, and the existing generic blocked/retry
+  fallbacks when not.
+- `B-009` `evidence_required` is enforced for declared transitions: a
+  decision missing a required evidence kind is rejected with an auditable
+  reason, mirroring built-in terminal-evidence rules.
+- `B-010` Declared activity names bind to the existing `activities`
+  policy map (prompt selection, validation commands) and dispatch through
+  existing runtime profile selection; an activity declared in the
+  definition but absent from the activity policy map fails startup
+  validation (B-002 class), not runtime.
+- `B-011` An activity completion arriving for a (state, activity) pair
+  the declaration does not expect follows the existing
+  invalid-agent-output blocked fallback — never an implicit transition.
+- `B-012` The `definition` block does not deep-merge: a repo WORKFLOW.md
+  `definition` replaces the central base's declaration for that id
+  wholesale. Field-by-field merging of state machines is rejected by
+  design; the loader treats `definition` as an atomic value.
+- `B-013` Operator recovery transitions for declarative workflows
+  (blocked → an active state) are permitted only to states declared as
+  recovery targets and only through the existing operator action context,
+  mirroring built-in recovery gating.
+
+## Boundary Checklist
+
+| Category | Coverage |
+|---|---|
+| Empty input | covered: B-001 (no block = no change), B-003 (empty/incomplete declarations rejected) |
+| Failure paths | covered: B-002 (startup failure, zero partial registration), B-008 (failure/blocked routing), B-011 (unexpected completion → blocked fallback) |
+| Authorization | covered: B-013 (operator-gated recovery); definition source is the repo's own WORKFLOW.md — same trust surface as existing prompt/policy config |
+| Concurrency | covered: B-004 (registration before freeze/dispatch), B-007 (same-transaction drivers) |
+| Retry + idempotency | covered: B-010 (existing dispatch/retry machinery unchanged), B-005 (version pinning stable across restarts) |
+| Illegal transitions | covered: B-003 (structural validation), B-009 (evidence gates), B-011 (no implicit transitions) |
+| Compatibility | covered: B-001, B-006 (built-ins untouched), B-012 (atomic block, no surprise merges) |
+| Degradation / fallback | covered: B-005 (version mismatch surfaces, never silently reshapes), B-011 (blocked, not guessed) |
+| Evidence / audit | covered: B-009 (required evidence), B-007 (decisions carry commands and reasons like built-ins) |
+| Cancellation / partial | covered: terminal mapping must include cancelled (B-003); in-flight pinning under definition edits (B-005) |
+
+Cross-product boundary called out explicitly: a WORKFLOW.md edit while an
+instance is mid-flight must leave the instance on its pinned shape and
+the operator able to see both versions (B-005 + B-013), and a declaration
+that validates structurally but references an activity with no policy
+entry must die at startup, not strand a workflow at dispatch time
+(B-003 + B-010).

--- a/specs/GH1609/tasks.md
+++ b/specs/GH1609/tasks.md
@@ -1,0 +1,47 @@
+# GH1609 Task Plan
+
+## Linked Issue
+
+GH-1609 (depends on GH-1608; related: GH-1607, GH-1603)
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1609-T001` Owner: `config-schema` | Done when: `WorkflowDefinitionPolicy` / `DeclaredState` land in `harness-core/src/config/workflow.rs` as an optional `definition` field with parse-level checks, and the deep-merge treats `definition` atomically (repo value replaces base wholesale) with a unit test proving no field-merge (B-001, B-012) | Verify: `cargo test -p harness-core config`
+- [ ] `SP1609-T002` Owner: `validation` | Done when: `runtime/declarative.rs` builds a `WorkflowDefinition` from a policy with the full structural matrix — undeclared targets, unreachability, terminal coverage, progress-mode XOR, activity-policy cross-check, id collisions — each with an actionable error and zero partial registration (B-002, B-003, B-010) | Verify: `cargo test -p harness-workflow declarative::validation`
+- [ ] `SP1609-T003` Owner: `registration-pinning` | Done when: server startup builds and registers declarative definitions before `freeze()`, `definition_version` is the truncated SHA-256 of the canonical policy JSON with the full hash in `instance.data`, the registry serves `(id, version)` lookups, and a missing pinned version blocks the instance with `definition_version_missing` (B-004, B-005) | Verify: `cargo test -p harness-workflow declarative::pinning && cargo test -p harness-server`
+- [ ] `SP1609-T004` Owner: `interpreter` | Done when: `reduce_success` delegates declarative ids to `declarative::reduce` implementing routing precedence (declared signal > on_success; on_failure/on_blocked with generic fallbacks), driver commands per progress mode in the same decision, and the unexpected-completion blocked fallback; built-in ids provably never enter the interpreter (B-006, B-007, B-008, B-011) | Verify: `cargo test -p harness-workflow declarative::interpreter reducer`
+- [ ] `SP1609-T005` Owner: `validator-evidence` | Done when: generated `TransitionAllowlist` rules drive `DecisionValidator` for declarative ids including `evidence_required` enforcement and operator-recovery gating restricted to declared targets (B-009, B-013) | Verify: `cargo test -p harness-workflow declarative::evidence declarative::recovery`
+- [ ] `SP1609-T006` Owner: `submission` | Done when: the runtime submission path accepts a registered declarative `definition_id`, creates a pinned instance in the declared initial state with its driving command, and rejects `depends_on` for declarative ids with a clear error (B-004, B-005) | Verify: `cargo test -p harness-server workflow_runtime_submission`
+- [ ] `SP1609-T007` Owner: `e2e-docs` | Done when: an end-to-end stub-runtime test drives a fixture WORKFLOW.md definition submit → mapped-signal transition → terminal state; WORKFLOW.md documentation gains a worked `definition` example (B-001..B-013 integration) | Verify: `cargo test -p harness-server workflow_runtime && python3 checks/check_workflow.py --repo . --spec-dir specs/GH1609`
+
+## Parallelization
+
+- `SP1609-T001` first; `SP1609-T002` after T001.
+- `SP1609-T003` after T002 and after GH-1608 lands (registry API).
+- `SP1609-T004` and `SP1609-T005` in parallel after T003 (disjoint:
+  reducer/declarative module vs validator wiring).
+- `SP1609-T006` after T003; `SP1609-T007` last.
+
+## Verification
+
+- `cargo check --workspace --all-targets`
+- `cargo test -p harness-core -p harness-workflow -p harness-server`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1609`
+
+## Handoff Notes
+
+Hard ordering: GH-1608 must merge first (registry `register()`/`freeze()`
+and owned types). The signal vocabulary (`signal_type` matching) is
+shared with GH-1607 — keep the parser in one place. v1 scope fences to
+respect during implementation: no child workflows, no candidate fanout,
+no dependency gating for declarative ids, no hot-reload (pinning +
+`definition_version_missing` is the contract). Process-global definition
+ids are a known v1 simplification; if multi-repo id collisions become
+real, per-project namespacing is the follow-up, not silent scoping.

--- a/specs/GH1609/tech.md
+++ b/specs/GH1609/tech.md
@@ -1,0 +1,225 @@
+# GH1609 Tech Spec: Declarative Workflow Definitions
+
+Product spec: `specs/GH1609/product.md`
+GitHub issue: `#1609`
+Depends on: GH-1608 (registry). Related: GH-1607 (shared signal
+vocabulary), GH-1603 (progress ownership).
+
+## Codebase Context (verified anchors)
+
+- WORKFLOW.md loading and deep-merge:
+  `crates/harness-core/src/config/workflow.rs:516-612` (per-repo file
+  deep-merged field-by-field over the central base registered at startup,
+  `crates/harness-cli/src/commands.rs:752-765`).
+- Config shape: `config/workflow.rs:235-266` (`WorkflowConfig`,
+  `activities: BTreeMap<String, WorkflowActivityPolicy>`).
+- Hardcoded success-transition table:
+  `crates/harness-workflow/src/runtime/reducer.rs:287-322`; blocked
+  fallback for unexpected completions `reducer.rs:313-321`
+  (`invalid_agent_output_blocked_decision`); validator selection
+  `reducer.rs:459`.
+- Generic transition engine:
+  `crates/harness-workflow/src/runtime/validator.rs:59-104`
+  (`TransitionAllowlist`, `TransitionRule`), evidence-gated terminal
+  rules exemplar `validator_github_issue_pr.rs:57-80` (reconciliation
+  done requires `github_pr` evidence).
+- Structured result contract:
+  `crates/harness-workflow/src/runtime/model.rs:679-683`
+  (`ActivitySignal`), `model.rs:718-732` (`ActivityResult`), commands
+  `model.rs:197-254`, instance pinning field `model.rs:78-79`
+  (`definition_version: u32`).
+- Dispatch profile selection (already string-keyed):
+  `crates/harness-workflow/src/runtime/dispatcher.rs:85`
+  (`select(definition_id, activity)`).
+- Submission seam: `crates/harness-server/src/workflow_runtime_submission.rs`
+  (prompt path at `:198`; declarative path added alongside).
+- Registry (from GH-1608): `runtime/state_registry.rs` —
+  `WorkflowDefinition { id, states, allowlist }`, `register()`,
+  `freeze()`.
+
+## Proposed Design
+
+### Config schema (harness-core, `config/workflow.rs`)
+
+```rust
+pub struct WorkflowDefinitionPolicy {
+    pub id: String,
+    pub initial: String,
+    pub states: BTreeMap<String, DeclaredState>,
+    pub terminal: BTreeMap<String, String>, // state -> succeeded|failed|cancelled
+    pub evidence_required: BTreeMap<String, Vec<String>>, // state -> evidence kinds
+    pub recovery_targets: Vec<String>,      // states operators may unblock into
+}
+
+pub struct DeclaredState {
+    pub activity: Option<String>,
+    pub progress: Option<DeclaredProgressMode>, // external_wait | operator_gate
+    pub on_success: Option<String>,
+    pub on_failure: Option<String>,
+    pub on_blocked: Option<String>,
+    pub on_signal: BTreeMap<String, String>,   // signal_type -> next state
+}
+```
+
+- New `WorkflowConfig` field: `definition: Option<WorkflowDefinitionPolicy>`
+  (`#[serde(default)]`, B-001).
+- Merge semantics: in the deep-merge at `workflow.rs:591-612`, `definition`
+  is treated atomically — a repo-level value replaces the base value
+  wholesale; there is no per-field merge of the block (B-012). This is an
+  explicit carve-out in the merge function with a unit test.
+- Parse-level checks only in harness-core (serde + non-empty fields);
+  graph validation lives in harness-workflow (dependency direction:
+  harness-workflow already depends on harness-core, not vice versa).
+
+### Structural validation + registration (harness-workflow, new `runtime/declarative.rs`)
+
+`build_declarative_definition(policy, activity_policies) -> anyhow::Result<WorkflowDefinition>`:
+
+1. Every transition target (`on_success`/`on_failure`/`on_blocked`/
+   `on_signal` values, `initial`, `recovery_targets`) names a declared
+   state (B-003).
+2. Reachability from `initial` covers every declared state (B-003).
+3. Terminal coverage: at least one state maps to `succeeded` and one to
+   `cancelled`; every terminal class referenced by any routing edge must
+   be mapped; terminal states appear in `terminal` only and carry no
+   outgoing edges (B-003).
+4. Non-terminal states declare exactly one progress mode: `activity`
+   XOR `progress` (B-003, GH-1603).
+5. Declared activities exist in the `activities` policy map (B-010).
+6. Id does not collide with built-ins or prior registrations (B-003;
+   double-checked by `register()`).
+7. Output: `WorkflowDefinition` whose `TransitionAllowlist` is generated
+   from the declared edges — one `TransitionRule` per edge, plus
+   evidence requirements from `evidence_required` (B-009) and
+   operator-recovery rules from `recovery_targets` restricted to the
+   operator action context (B-013).
+
+Server startup: after config load, for each managed project's resolved
+WORKFLOW.md, build + `register()` declarative definitions, then
+`freeze()` (B-004). Any error aborts startup (B-002).
+
+### Content-hash pinning
+
+- `definition_version: u32` = truncated (lower 32 bits) SHA-256 of the
+  canonical JSON serialization of `WorkflowDefinitionPolicy`; the full
+  hex hash is stored in `instance.data["definition_hash"]` at creation
+  for collision-proof auditing (B-005).
+- The registry keeps `(id, version) -> Arc<WorkflowDefinition>` for every
+  version seen at startup. Interpretation looks up the instance's pinned
+  version; a missing version (WORKFLOW.md edited between restarts while
+  the instance was in flight) transitions the instance to `blocked` with
+  decision `definition_version_missing` — surfaced, never silently
+  reinterpreted under the new shape (B-005). Operators resolve by
+  reverting the definition or cancelling the instance.
+
+### Generic interpreting reducer (`runtime/reducer.rs`)
+
+At the top of `reduce_success` (before the hardcoded match at
+`reducer.rs:287`): if `instance.definition_id` resolves to a declarative
+definition, delegate to `declarative::reduce(definition, instance, event,
+result)`:
+
+- Status Succeeded: check `on_signal` matches from `result.signals`
+  (declared mapping wins, B-008); else `on_success`; missing route for an
+  observed completion → `invalid_agent_output_blocked_decision`
+  (B-011).
+- Status Blocked/Failed: `on_blocked`/`on_failure` when declared; else
+  fall through to the existing generic blocked/retry decisions
+  (`runtime_failure.rs` paths) unchanged (B-008).
+- Emitted decision: next state + driving command derived from the target
+  state's progress mode — `enqueue_activity` for activity states (dedupe
+  key `"{id}:{state}:{event.id}"`), `Wait` for `external_wait`,
+  `RequestOperatorAttention` for `operator_gate`, `Mark*` for terminal
+  states — always in the same decision (B-007).
+- Built-in ids never resolve as declarative (registry namespaces are
+  disjoint by B-003 collision check), so the hardcoded paths are
+  untouched (B-006).
+
+### Validator
+
+No new engine: the generated `TransitionAllowlist` from GH-1608's
+registry drives `DecisionValidator` for declarative ids (selection seam
+`reducer.rs:459`). Evidence enforcement reuses the rule shape used by
+`validator_github_issue_pr.rs` terminal-evidence checks, generalized to
+"transition into state S requires evidence kinds [...]" (B-009).
+
+### Submission (harness-server)
+
+`workflow_runtime_submission.rs` gains a declarative path: a submission
+naming a registered declarative `definition_id` creates an instance in
+the declaration's `initial` state (pinned version/hash) and emits the
+initial state's driving command, following the prompt-task submission
+shape at `:198`. Dependencies (`depends_on`) reuse the existing
+`awaiting_dependencies` handling only if declared; v1 keeps dependency
+gating out of declarative definitions (submission rejects `depends_on`
+for declarative ids with a clear error).
+
+## Edge Cases
+
+- Declaration valid at startup, activity policy removed in a later
+  restart: startup validation re-runs on every boot; the boot fails
+  (B-002/B-010) instead of stranding dispatch.
+- Signal type declared both in `on_signal` and produced alongside
+  success: declared mapping wins deterministically; multiple mapped
+  signals on one result → the first in declaration order wins and the
+  decision reason records the tie (deterministic, auditable).
+- Two repos declare the same definition id: second registration fails
+  startup (B-003) — ids are process-global in v1; the error message
+  tells operators to namespace ids per repo.
+- WORKFLOW.md edited and server restarted mid-flight: old-version
+  instances hit `definition_version_missing` → blocked with operator
+  guidance (B-005); new instances run the new shape.
+
+## Migration / Compatibility
+
+- `WorkflowConfig.definition` is `#[serde(default)]` optional: existing
+  WORKFLOW.md files parse unchanged (B-001).
+- No schema migration: pinning reuses `definition_version` and
+  `instance.data`.
+- Registry freeze ordering depends on GH-1608 landing first.
+
+## Verification Plan
+
+- harness-core: parse + atomic-merge tests (`definition` never
+  field-merges, B-012); optional-field compat (B-001).
+- harness-workflow unit: structural validation matrix — undeclared
+  target, unreachable state, missing terminal class, dual/missing
+  progress mode, unknown activity, id collision (B-002/B-003/B-010);
+  interpreter branches — success route, signal precedence, failure/
+  blocked routes, unexpected completion fallback (B-008, B-011); driver
+  command per progress mode (B-007); evidence rejection (B-009);
+  recovery gating (B-013).
+- Pinning: version lookup across simulated definition change;
+  `definition_version_missing` → blocked (B-005).
+- harness-server: declarative submission e2e through the stub runtime —
+  submit → activity completes with mapped signal → terminal state, with
+  built-in suites untouched as the B-006 gate.
+- Full gates: `cargo check --workspace --all-targets`,
+  `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo fmt --all -- --check`.
+
+## Rollback Plan
+
+Feature is inert without a `definition` block (B-001). Rollback = remove
+the block; in-flight declarative instances finish under pinned versions
+or are cancelled by operators. Code revert removes the config field,
+`declarative.rs`, and the reducer delegation line; built-in paths are
+untouched throughout (B-006).
+
+## Product-to-Test Mapping
+
+| Invariant | Implementation area | Verification |
+|---|---|---|
+| B-001 | optional config field | `cargo test -p harness-core config::workflow` (existing files parse) |
+| B-002 | startup build+register abort | `cargo test -p harness-workflow declarative::validation` + server boot test |
+| B-003 | structural validation matrix | `cargo test -p harness-workflow declarative::validation` |
+| B-004 | startup registration before freeze | `cargo test -p harness-server` boot ordering test |
+| B-005 | content hash + version lookup | `cargo test -p harness-workflow declarative::pinning` |
+| B-006 | delegation guard on declarative ids | full built-in suites green + interpreter unreachable-for-builtin test |
+| B-007 | driver command per progress mode | `cargo test -p harness-workflow declarative::interpreter` |
+| B-008 | routing precedence | `cargo test -p harness-workflow declarative::interpreter` |
+| B-009 | generated evidence rules | `cargo test -p harness-workflow declarative::evidence` |
+| B-010 | activity-policy cross-check | `cargo test -p harness-workflow declarative::validation` |
+| B-011 | unexpected completion fallback | `cargo test -p harness-workflow declarative::interpreter` |
+| B-012 | atomic merge carve-out | `cargo test -p harness-core config::workflow::definition_merge` |
+| B-013 | recovery target gating | `cargo test -p harness-workflow declarative::recovery` |

--- a/specs/GH1609/tech.md
+++ b/specs/GH1609/tech.md
@@ -51,9 +51,16 @@ pub struct WorkflowDefinitionPolicy {
     pub recovery_targets: Vec<String>,      // states operators may unblock into
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeclaredProgressMode {
+    ExternalWait,
+    OperatorGate,
+}
+
 pub struct DeclaredState {
     pub activity: Option<String>,
-    pub progress: Option<DeclaredProgressMode>, // external_wait | operator_gate
+    pub progress: Option<DeclaredProgressMode>,
     pub on_success: Option<String>,
     pub on_failure: Option<String>,
     pub on_blocked: Option<String>,
@@ -104,6 +111,14 @@ WORKFLOW.md, build + `register()` declarative definitions, then
   canonical JSON serialization of `WorkflowDefinitionPolicy`; the full
   hex hash is stored in `instance.data["definition_hash"]` at creation
   for collision-proof auditing (B-005).
+- Truncation-collision guard: at startup, if two distinct declarations
+  for the same `id` (full SHA-256 differs) truncate to the same u32
+  `definition_version`, startup aborts with an actionable error naming
+  both hashes — a collision must never make version lookup ambiguous or
+  silently reinterpret a pinned instance (B-005). Interpretation
+  cross-checks the full hash in `instance.data["definition_hash"]` when
+  present, so even an undetected collision fails closed to
+  `definition_version_missing`.
 - The registry keeps `(id, version) -> Arc<WorkflowDefinition>` for every
   version seen at startup. Interpretation looks up the instance's pinned
   version; a missing version (WORKFLOW.md edited between restarts while
@@ -129,8 +144,11 @@ result)`:
 - Emitted decision: next state + driving command derived from the target
   state's progress mode — `enqueue_activity` for activity states (dedupe
   key `"{id}:{state}:{event.id}"`), `Wait` for `external_wait`,
-  `RequestOperatorAttention` for `operator_gate`, `Mark*` for terminal
-  states — always in the same decision (B-007).
+  `RequestOperatorAttention` for `operator_gate`, and for terminal
+  states the existing command per terminal class — `succeeded` →
+  `MarkDone` (there is no `MarkSucceeded`; see
+  `WorkflowCommandType`, `model.rs:197-208`), `failed` → `MarkFailed`,
+  `cancelled` → `MarkCancelled` — always in the same decision (B-007).
 - Built-in ids never resolve as declarative (registry namespaces are
   disjoint by B-003 collision check), so the hardcoded paths are
   untouched (B-006).
@@ -149,7 +167,11 @@ registry drives `DecisionValidator` for declarative ids (selection seam
 naming a registered declarative `definition_id` creates an instance in
 the declaration's `initial` state (pinned version/hash) and emits the
 initial state's driving command, following the prompt-task submission
-shape at `:198`. Dependencies (`depends_on`) reuse the existing
+shape at `:198`. The initial command has no completion event, so its
+dedupe key uses the submission form `"{workflow_id}:{initial_state}:submit"`
+— unique per instance, stable across submission retries for the same
+instance id (the `{event.id}` form applies only to completion-driven
+transitions). Dependencies (`depends_on`) reuse the existing
 `awaiting_dependencies` handling only if declared; v1 keeps dependency
 gating out of declarative definitions (submission rejects `depends_on`
 for declarative ids with a clear error).
@@ -161,8 +183,10 @@ for declarative ids with a clear error).
   (B-002/B-010) instead of stranding dispatch.
 - Signal type declared both in `on_signal` and produced alongside
   success: declared mapping wins deterministically; multiple mapped
-  signals on one result → the first in declaration order wins and the
-  decision reason records the tie (deterministic, auditable).
+  signals on one result → the lexicographically smallest mapped
+  `signal_type` wins (matching `BTreeMap` iteration order, so precedence
+  needs no extra dependency and cannot drift from the data structure) and
+  the decision reason records the tie (deterministic, auditable).
 - Two repos declare the same definition id: second registration fails
   startup (B-003) — ids are process-global in v1; the error message
   tells operators to namespace ids per repo.


### PR DESCRIPTION
## Summary

Spec packet (product/tech/tasks) for GH-1609: a `definition` block in WORKFLOW.md frontmatter that declares workflow shape — states, driving activities, transitions (success/failure/blocked/signal routing), terminal mapping, required evidence, and operator recovery targets — interpreted by a generic reducer on top of the existing durable runtime. This is the doc-defined-behavior half of the Symphony-parity design.

Key design points:
- Structural validation at startup (undeclared targets, unreachability, terminal coverage, progress-mode XOR per GH-1603, activity-policy cross-check, id collisions) with zero partial registration.
- Instances pin a content hash via `definition_version`; mid-flight WORKFLOW.md edits never reshape running instances — a missing pinned version blocks with `definition_version_missing`, never silently reinterprets.
- Generic interpreter reachable only for declarative ids; the four built-in workflows and their reducers are untouched.
- `definition` merges atomically (repo replaces base wholesale) — state machines are never field-merged.
- Transition legality and evidence requirements ride the existing `TransitionAllowlist` engine, generated from the declaration.

## Dependencies

Depends on #1608 (owned definition registry) landing first.

## Linked Issue

Refs #1609 (spec packet only; no implementation in this PR)

## Test Plan

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1609` — SpecRail check passed
- Docs-only change; no code surface