### PR TITLE
feat(workflow): add owned definition registry

### DIFF
--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -105,12 +105,14 @@ impl HarnessServer {
 
     /// Start in stdio mode (JSON-RPC over stdin/stdout).
     pub async fn serve_stdio(self) -> anyhow::Result<()> {
+        harness_workflow::runtime::freeze_workflow_definition_registry();
         let state = crate::http::build_app_state(Arc::new(self)).await?;
         crate::stdio::serve(state).await
     }
 
     /// Start in HTTP + WebSocket mode.
     pub async fn serve_http(self: Arc<Self>, addr: SocketAddr) -> anyhow::Result<()> {
+        harness_workflow::runtime::freeze_workflow_definition_registry();
         crate::http::serve(self, addr).await
     }
 }

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -1,13 +1,14 @@
 use harness_core::config::workflow::WorkflowDocument;
 use harness_workflow::runtime::{
-    ActivityArtifact, DecisionValidator, RetrievedRepoMemoryRecord, RuntimeJob, RuntimeProfile,
-    WorkflowInstance, CANDIDATE_BRANCH_ARTIFACT, CANDIDATE_CLEANUP_ACTIVITY,
-    CANDIDATE_PROMOTION_ACTIVITY, ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL,
-    ISSUE_PLAN_ACTIVITY, ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL, ISSUE_STATE_ARTIFACT,
-    PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY, PR_FEEDBACK_SNAPSHOT_ARTIFACT, QUALITY_BLOCKED_SIGNAL,
-    QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
-    QUALITY_PASSED_SIGNAL, SCOPE_TOO_LARGE_SIGNAL, SERVER_PR_SNAPSHOT_ARTIFACT,
+    decision_validator_for_definition, ActivityArtifact, DecisionValidator,
+    RetrievedRepoMemoryRecord, RuntimeJob, RuntimeProfile, WorkflowInstance,
+    CANDIDATE_BRANCH_ARTIFACT, CANDIDATE_CLEANUP_ACTIVITY, CANDIDATE_PROMOTION_ACTIVITY,
+    ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL, ISSUE_PLAN_ACTIVITY, ISSUE_PLAN_ARTIFACT,
+    ISSUE_PLAN_READY_SIGNAL, ISSUE_STATE_ARTIFACT, PROMPT_TASK_DEFINITION_ID,
+    PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
+    PR_FEEDBACK_SNAPSHOT_ARTIFACT, QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL,
+    QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
+    SCOPE_TOO_LARGE_SIGNAL, SERVER_PR_SNAPSHOT_ARTIFACT,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -334,13 +335,20 @@ fn workflow_decision_command_examples(_workflow_definition: &str, _activity: &st
 }
 
 fn workflow_decision_contract(workflow: Option<&WorkflowInstance>) -> Value {
+    workflow_decision_contract_with_resolver(workflow, decision_validator_for_definition)
+}
+
+fn workflow_decision_contract_with_resolver(
+    workflow: Option<&WorkflowInstance>,
+    validator_for_definition: impl FnOnce(&str) -> Option<DecisionValidator>,
+) -> Value {
     let Some(workflow) = workflow else {
         return json!({
             "available": false,
             "reason": "No workflow instance was loaded for this runtime job."
         });
     };
-    let Some(validator) = decision_validator_for_definition(&workflow.definition_id) else {
+    let Some(validator) = validator_for_definition(&workflow.definition_id) else {
         return json!({
             "available": false,
             "workflow_id": workflow.id.as_str(),
@@ -371,16 +379,6 @@ fn workflow_decision_contract(workflow: Option<&WorkflowInstance>) -> Value {
         "observed_state": workflow.state.as_str(),
         "allowed_transitions": allowed_transitions,
     })
-}
-
-fn decision_validator_for_definition(definition_id: &str) -> Option<DecisionValidator> {
-    match definition_id {
-        "github_issue_pr" => Some(DecisionValidator::github_issue_pr()),
-        QUALITY_GATE_DEFINITION_ID => Some(DecisionValidator::quality_gate()),
-        PR_FEEDBACK_DEFINITION_ID => Some(DecisionValidator::pr_feedback()),
-        PROMPT_TASK_DEFINITION_ID => Some(DecisionValidator::prompt_task()),
-        _ => None,
-    }
 }
 
 fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Value {

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -1,8 +1,10 @@
 use super::*;
 use harness_workflow::runtime::{
-    RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord, RetrievedRepoMemoryRecord, RuntimeKind,
-    WorkflowSubject, ISSUE_PLAN_ACTIVITY, ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL,
-    PR_REPAIR_SNAPSHOT_ARTIFACT, SERVER_PR_SNAPSHOT_ARTIFACT,
+    RegisteredWorkflowDefinition, RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord,
+    RetrievedRepoMemoryRecord, RuntimeKind, TransitionAllowlist, TransitionRule,
+    WorkflowDefinitionRegistry, WorkflowStateDefinition, WorkflowSubject, ISSUE_PLAN_ACTIVITY,
+    ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL, PR_REPAIR_SNAPSHOT_ARTIFACT,
+    SERVER_PR_SNAPSHOT_ARTIFACT,
 };
 
 #[test]
@@ -243,6 +245,44 @@ fn activity_result_schema_describes_quality_gate_contract() {
         .expect("allowed transitions should be an array")
         .iter()
         .any(|transition| transition["next_state"] == "passed"));
+}
+
+#[test]
+fn workflow_decision_contract_uses_a_registered_non_builtin_definition() {
+    let mut registry = WorkflowDefinitionRegistry::new();
+    registry
+        .register(RegisteredWorkflowDefinition::new(
+            "custom_review",
+            vec![
+                WorkflowStateDefinition::active("custom_review", "queued"),
+                WorkflowStateDefinition::active("custom_review", "reviewing"),
+            ],
+            TransitionAllowlist::new(vec![TransitionRule::new("queued", "reviewing", [])]),
+        ))
+        .expect("custom workflow definition should register");
+    let workflow = WorkflowInstance::new(
+        "custom_review",
+        1,
+        "queued",
+        WorkflowSubject::new("review", "review:123"),
+    )
+    .with_id("custom-review-1");
+
+    let contract = workflow_decision_contract_with_resolver(Some(&workflow), |definition_id| {
+        registry.decision_validator_for_definition(definition_id)
+    });
+
+    assert_eq!(contract["available"], true);
+    assert_eq!(contract["workflow_definition"], "custom_review");
+    assert_eq!(contract["allowed_transitions"][0]["from_state"], "queued");
+    assert_eq!(
+        contract["allowed_transitions"][0]["next_state"],
+        "reviewing"
+    );
+    assert_eq!(
+        contract["allowed_transitions"][0]["allowed_commands"],
+        json!([])
+    );
 }
 #[test]
 fn activity_result_schema_describes_pr_feedback_child_contract() {

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -131,8 +131,10 @@ pub use repo_memory::{
     REPO_MEMORY_DEGRADATION_ARTIFACT,
 };
 pub use state_registry::{
-    known_workflow_definition_ids, workflow_state_definition, workflow_state_exists,
-    workflow_states_for_definition, workflow_terminal_state_names_for_definition,
+    decision_validator_for_definition, freeze_workflow_definition_registry,
+    known_workflow_definition_ids, register_workflow_definition, workflow_state_definition,
+    workflow_state_exists, workflow_states_for_definition,
+    workflow_terminal_state_names_for_definition, WorkflowDefinitionRegistry,
     WorkflowStateDefinition, WorkflowStateKey,
 };
 pub use status::WorkflowCommandStatus;

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -132,10 +132,10 @@ pub use repo_memory::{
 };
 pub use state_registry::{
     decision_validator_for_definition, freeze_workflow_definition_registry,
-    known_workflow_definition_ids, register_workflow_definition, workflow_state_definition,
-    workflow_state_exists, workflow_states_for_definition,
-    workflow_terminal_state_names_for_definition, WorkflowDefinitionRegistry,
-    WorkflowStateDefinition, WorkflowStateKey,
+    known_workflow_definition_ids, register_workflow_definition, workflow_definition,
+    workflow_state_definition, workflow_state_exists, workflow_states_for_definition,
+    workflow_terminal_state_names_for_definition, RegisteredWorkflowDefinition,
+    WorkflowDefinitionRegistry, WorkflowStateDefinition, WorkflowStateKey,
 };
 pub use status::WorkflowCommandStatus;
 pub use store::{

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -43,7 +43,8 @@ use super::model::{
 use super::pr_feedback::PR_FEEDBACK_DEFINITION_ID;
 use super::prompt_task::{PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY};
 use super::quality_gate::QUALITY_GATE_DEFINITION_ID;
-use super::validator::{DecisionValidator, ValidationContext};
+use super::state_registry::decision_validator_for_definition;
+use super::validator::ValidationContext;
 use serde_json::{json, Value};
 
 pub const RUNTIME_JOB_COMPLETED_EVENT: &str = "RuntimeJobCompleted";
@@ -452,12 +453,8 @@ fn structured_decision_validates(
         return false;
     }
 
-    let validator = match instance.definition_id.as_str() {
-        GITHUB_ISSUE_PR_DEFINITION_ID => DecisionValidator::github_issue_pr(),
-        QUALITY_GATE_DEFINITION_ID => DecisionValidator::quality_gate(),
-        PR_FEEDBACK_DEFINITION_ID => DecisionValidator::pr_feedback(),
-        PROMPT_TASK_DEFINITION_ID => DecisionValidator::prompt_task(),
-        _ => return true,
+    let Some(validator) = decision_validator_for_definition(&instance.definition_id) else {
+        return true;
     };
     validator
         .validate(

--- a/crates/harness-workflow/src/runtime/state_registry.rs
+++ b/crates/harness-workflow/src/runtime/state_registry.rs
@@ -56,13 +56,13 @@ impl WorkflowStateDefinition {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WorkflowDefinition {
+pub struct RegisteredWorkflowDefinition {
     pub id: String,
     pub states: Vec<WorkflowStateDefinition>,
     pub allowlist: TransitionAllowlist,
 }
 
-impl WorkflowDefinition {
+impl RegisteredWorkflowDefinition {
     pub fn new(
         id: impl Into<String>,
         states: Vec<WorkflowStateDefinition>,
@@ -78,18 +78,22 @@ impl WorkflowDefinition {
 
 #[derive(Debug)]
 pub struct WorkflowDefinitionRegistry {
-    definitions: HashMap<String, Arc<WorkflowDefinition>>,
+    definitions: HashMap<String, Arc<RegisteredWorkflowDefinition>>,
     definition_ids: Vec<String>,
     frozen: bool,
 }
 
 impl WorkflowDefinitionRegistry {
-    fn with_builtins() -> Self {
-        let mut registry = Self {
+    pub fn new() -> Self {
+        Self {
             definitions: HashMap::new(),
             definition_ids: Vec::new(),
             frozen: false,
-        };
+        }
+    }
+
+    fn with_builtins() -> Self {
+        let mut registry = Self::new();
         for definition in builtin_definitions() {
             registry
                 .register(definition)
@@ -100,14 +104,10 @@ impl WorkflowDefinitionRegistry {
 
     #[cfg(test)]
     pub fn new_for_tests() -> Self {
-        Self {
-            definitions: HashMap::new(),
-            definition_ids: Vec::new(),
-            frozen: false,
-        }
+        Self::new()
     }
 
-    pub fn register(&mut self, definition: WorkflowDefinition) -> anyhow::Result<()> {
+    pub fn register(&mut self, definition: RegisteredWorkflowDefinition) -> anyhow::Result<()> {
         if self.frozen {
             anyhow::bail!(
                 "workflow definition registry is frozen; cannot register '{}'",
@@ -134,12 +134,27 @@ impl WorkflowDefinitionRegistry {
         self.frozen
     }
 
-    pub fn definition(&self, definition_id: &str) -> Option<Arc<WorkflowDefinition>> {
+    pub fn definition(&self, definition_id: &str) -> Option<Arc<RegisteredWorkflowDefinition>> {
         self.definitions.get(definition_id).cloned()
+    }
+
+    pub fn decision_validator_for_definition(
+        &self,
+        definition_id: &str,
+    ) -> Option<DecisionValidator> {
+        self.definition(definition_id).map(|definition| {
+            DecisionValidator::for_definition(definition_id, definition.allowlist.clone())
+        })
     }
 
     pub fn known_definition_ids(&self) -> Vec<String> {
         self.definition_ids.clone()
+    }
+}
+
+impl Default for WorkflowDefinitionRegistry {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -149,7 +164,9 @@ fn registry() -> &'static RwLock<WorkflowDefinitionRegistry> {
     REGISTRY.get_or_init(|| RwLock::new(WorkflowDefinitionRegistry::with_builtins()))
 }
 
-pub fn register_workflow_definition(definition: WorkflowDefinition) -> anyhow::Result<()> {
+pub fn register_workflow_definition(
+    definition: RegisteredWorkflowDefinition,
+) -> anyhow::Result<()> {
     registry()
         .write()
         .expect("workflow definition registry lock poisoned")
@@ -163,7 +180,7 @@ pub fn freeze_workflow_definition_registry() {
         .freeze();
 }
 
-pub fn workflow_definition(definition_id: &str) -> Option<Arc<WorkflowDefinition>> {
+pub fn workflow_definition(definition_id: &str) -> Option<Arc<RegisteredWorkflowDefinition>> {
     registry()
         .read()
         .expect("workflow definition registry lock poisoned")
@@ -171,9 +188,10 @@ pub fn workflow_definition(definition_id: &str) -> Option<Arc<WorkflowDefinition
 }
 
 pub fn decision_validator_for_definition(definition_id: &str) -> Option<DecisionValidator> {
-    workflow_definition(definition_id).map(|definition| {
-        DecisionValidator::for_definition(definition_id, definition.allowlist.clone())
-    })
+    registry()
+        .read()
+        .expect("workflow definition registry lock poisoned")
+        .decision_validator_for_definition(definition_id)
 }
 
 pub fn known_workflow_definition_ids() -> Vec<String> {
@@ -226,7 +244,7 @@ pub fn workflow_state_terminal_state(
     workflow_state_definition(definition_id, state)?.terminal_state
 }
 
-fn builtin_definitions() -> [WorkflowDefinition; 4] {
+fn builtin_definitions() -> [RegisteredWorkflowDefinition; 4] {
     [
         github_issue_pr_definition(),
         prompt_task_definition(),
@@ -235,7 +253,7 @@ fn builtin_definitions() -> [WorkflowDefinition; 4] {
     ]
 }
 
-fn github_issue_pr_definition() -> WorkflowDefinition {
+fn github_issue_pr_definition() -> RegisteredWorkflowDefinition {
     definition(
         GITHUB_ISSUE_PR_DEFINITION_ID,
         &[
@@ -261,7 +279,7 @@ fn github_issue_pr_definition() -> WorkflowDefinition {
     )
 }
 
-fn prompt_task_definition() -> WorkflowDefinition {
+fn prompt_task_definition() -> RegisteredWorkflowDefinition {
     definition(
         PROMPT_TASK_DEFINITION_ID,
         &[
@@ -277,7 +295,7 @@ fn prompt_task_definition() -> WorkflowDefinition {
     )
 }
 
-fn quality_gate_definition() -> WorkflowDefinition {
+fn quality_gate_definition() -> RegisteredWorkflowDefinition {
     definition(
         QUALITY_GATE_DEFINITION_ID,
         &[
@@ -292,7 +310,7 @@ fn quality_gate_definition() -> WorkflowDefinition {
     )
 }
 
-fn pr_feedback_definition() -> WorkflowDefinition {
+fn pr_feedback_definition() -> RegisteredWorkflowDefinition {
     definition(
         PR_FEEDBACK_DEFINITION_ID,
         &[
@@ -314,8 +332,8 @@ fn definition(
     id: &'static str,
     states: &[(&'static str, Option<WorkflowTerminalState>)],
     allowlist: TransitionAllowlist,
-) -> WorkflowDefinition {
-    WorkflowDefinition::new(
+) -> RegisteredWorkflowDefinition {
+    RegisteredWorkflowDefinition::new(
         id,
         states
             .iter()
@@ -329,6 +347,10 @@ fn definition(
         allowlist,
     )
 }
+
+#[cfg(test)]
+#[path = "state_registry_equivalence_tests.rs"]
+mod equivalence_tests;
 
 #[cfg(test)]
 mod tests {
@@ -421,17 +443,6 @@ mod tests {
                     rule.to_state
                 );
             }
-        }
-    }
-
-    #[test]
-    fn builtins_preserve_states_terminal_mappings_and_allowlists() {
-        let expected = builtin_definitions();
-
-        for expected_definition in expected {
-            let actual = workflow_definition(&expected_definition.id)
-                .expect("built-in definition should be registered");
-            assert_eq!(actual.as_ref(), &expected_definition);
         }
     }
 

--- a/crates/harness-workflow/src/runtime/state_registry.rs
+++ b/crates/harness-workflow/src/runtime/state_registry.rs
@@ -1,8 +1,13 @@
 use super::{
-    pr_feedback::PR_FEEDBACK_DEFINITION_ID, prompt_task::PROMPT_TASK_DEFINITION_ID,
-    quality_gate::QUALITY_GATE_DEFINITION_ID, reducer::GITHUB_ISSUE_PR_DEFINITION_ID,
+    pr_feedback::PR_FEEDBACK_DEFINITION_ID,
+    prompt_task::PROMPT_TASK_DEFINITION_ID,
+    quality_gate::QUALITY_GATE_DEFINITION_ID,
+    reducer::GITHUB_ISSUE_PR_DEFINITION_ID,
+    validator::{DecisionValidator, TransitionAllowlist},
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock, RwLock};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -12,178 +17,202 @@ pub enum WorkflowTerminalState {
     Cancelled,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WorkflowStateKey {
-    pub definition_id: &'static str,
-    pub state: &'static str,
+    pub definition_id: Arc<str>,
+    pub state: Arc<str>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkflowStateDefinition {
     pub key: WorkflowStateKey,
     pub terminal_state: Option<WorkflowTerminalState>,
 }
 
 impl WorkflowStateDefinition {
-    pub const fn active(definition_id: &'static str, state: &'static str) -> Self {
+    pub fn active(definition_id: impl Into<Arc<str>>, state: impl Into<Arc<str>>) -> Self {
         Self {
             key: WorkflowStateKey {
-                definition_id,
-                state,
+                definition_id: definition_id.into(),
+                state: state.into(),
             },
             terminal_state: None,
         }
     }
 
-    pub const fn terminal(
-        definition_id: &'static str,
-        state: &'static str,
+    pub fn terminal(
+        definition_id: impl Into<Arc<str>>,
+        state: impl Into<Arc<str>>,
         terminal_state: WorkflowTerminalState,
     ) -> Self {
         Self {
             key: WorkflowStateKey {
-                definition_id,
-                state,
+                definition_id: definition_id.into(),
+                state: state.into(),
             },
             terminal_state: Some(terminal_state),
         }
     }
 }
 
-const WORKFLOW_DEFINITION_IDS: &[&str] = &[
-    GITHUB_ISSUE_PR_DEFINITION_ID,
-    PROMPT_TASK_DEFINITION_ID,
-    QUALITY_GATE_DEFINITION_ID,
-    PR_FEEDBACK_DEFINITION_ID,
-];
-
-const GITHUB_ISSUE_PR_STATES: &[WorkflowStateDefinition] = &[
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "discovered"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "awaiting_dependencies"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "scheduled"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "planning"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "implementing"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "replanning"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "pr_open"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "local_review_gate"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "awaiting_feedback"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "addressing_feedback"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "quality_gate_pending"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "ready_to_merge"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "merging"),
-    WorkflowStateDefinition::active(GITHUB_ISSUE_PR_DEFINITION_ID, "blocked"),
-    WorkflowStateDefinition::terminal(
-        GITHUB_ISSUE_PR_DEFINITION_ID,
-        "done",
-        WorkflowTerminalState::Succeeded,
-    ),
-    WorkflowStateDefinition::terminal(
-        GITHUB_ISSUE_PR_DEFINITION_ID,
-        "failed",
-        WorkflowTerminalState::Failed,
-    ),
-    WorkflowStateDefinition::terminal(
-        GITHUB_ISSUE_PR_DEFINITION_ID,
-        "cancelled",
-        WorkflowTerminalState::Cancelled,
-    ),
-];
-
-const PROMPT_TASK_STATES: &[WorkflowStateDefinition] = &[
-    WorkflowStateDefinition::active(PROMPT_TASK_DEFINITION_ID, "submitted"),
-    WorkflowStateDefinition::active(PROMPT_TASK_DEFINITION_ID, "awaiting_dependencies"),
-    WorkflowStateDefinition::active(PROMPT_TASK_DEFINITION_ID, "implementing"),
-    WorkflowStateDefinition::active(PROMPT_TASK_DEFINITION_ID, "blocked"),
-    WorkflowStateDefinition::terminal(
-        PROMPT_TASK_DEFINITION_ID,
-        "done",
-        WorkflowTerminalState::Succeeded,
-    ),
-    WorkflowStateDefinition::terminal(
-        PROMPT_TASK_DEFINITION_ID,
-        "failed",
-        WorkflowTerminalState::Failed,
-    ),
-    WorkflowStateDefinition::terminal(
-        PROMPT_TASK_DEFINITION_ID,
-        "cancelled",
-        WorkflowTerminalState::Cancelled,
-    ),
-];
-
-const QUALITY_GATE_STATES: &[WorkflowStateDefinition] = &[
-    WorkflowStateDefinition::active(QUALITY_GATE_DEFINITION_ID, "pending"),
-    WorkflowStateDefinition::active(QUALITY_GATE_DEFINITION_ID, "checking"),
-    WorkflowStateDefinition::active(QUALITY_GATE_DEFINITION_ID, "blocked"),
-    WorkflowStateDefinition::terminal(
-        QUALITY_GATE_DEFINITION_ID,
-        "passed",
-        WorkflowTerminalState::Succeeded,
-    ),
-    WorkflowStateDefinition::terminal(
-        QUALITY_GATE_DEFINITION_ID,
-        "failed",
-        WorkflowTerminalState::Failed,
-    ),
-    WorkflowStateDefinition::terminal(
-        QUALITY_GATE_DEFINITION_ID,
-        "cancelled",
-        WorkflowTerminalState::Cancelled,
-    ),
-];
-
-const PR_FEEDBACK_STATES: &[WorkflowStateDefinition] = &[
-    WorkflowStateDefinition::active(PR_FEEDBACK_DEFINITION_ID, "pending"),
-    WorkflowStateDefinition::active(PR_FEEDBACK_DEFINITION_ID, "inspecting"),
-    WorkflowStateDefinition::active(PR_FEEDBACK_DEFINITION_ID, "feedback_found"),
-    WorkflowStateDefinition::active(PR_FEEDBACK_DEFINITION_ID, "no_actionable_feedback"),
-    WorkflowStateDefinition::active(PR_FEEDBACK_DEFINITION_ID, "ready_to_merge"),
-    WorkflowStateDefinition::active(PR_FEEDBACK_DEFINITION_ID, "blocked"),
-    WorkflowStateDefinition::terminal(
-        PR_FEEDBACK_DEFINITION_ID,
-        "done",
-        WorkflowTerminalState::Succeeded,
-    ),
-    WorkflowStateDefinition::terminal(
-        PR_FEEDBACK_DEFINITION_ID,
-        "failed",
-        WorkflowTerminalState::Failed,
-    ),
-    WorkflowStateDefinition::terminal(
-        PR_FEEDBACK_DEFINITION_ID,
-        "cancelled",
-        WorkflowTerminalState::Cancelled,
-    ),
-];
-
-pub fn known_workflow_definition_ids() -> &'static [&'static str] {
-    WORKFLOW_DEFINITION_IDS
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowDefinition {
+    pub id: String,
+    pub states: Vec<WorkflowStateDefinition>,
+    pub allowlist: TransitionAllowlist,
 }
 
-pub fn workflow_states_for_definition(definition_id: &str) -> &'static [WorkflowStateDefinition] {
-    match definition_id {
-        GITHUB_ISSUE_PR_DEFINITION_ID => GITHUB_ISSUE_PR_STATES,
-        PROMPT_TASK_DEFINITION_ID => PROMPT_TASK_STATES,
-        QUALITY_GATE_DEFINITION_ID => QUALITY_GATE_STATES,
-        PR_FEEDBACK_DEFINITION_ID => PR_FEEDBACK_STATES,
-        _ => &[],
+impl WorkflowDefinition {
+    pub fn new(
+        id: impl Into<String>,
+        states: Vec<WorkflowStateDefinition>,
+        allowlist: TransitionAllowlist,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            states,
+            allowlist,
+        }
     }
 }
 
-pub fn workflow_terminal_state_names_for_definition(definition_id: &str) -> Vec<&'static str> {
-    workflow_states_for_definition(definition_id)
-        .iter()
-        .filter_map(|definition| definition.terminal_state.map(|_| definition.key.state))
-        .collect()
+#[derive(Debug)]
+pub struct WorkflowDefinitionRegistry {
+    definitions: HashMap<String, Arc<WorkflowDefinition>>,
+    definition_ids: Vec<String>,
+    frozen: bool,
+}
+
+impl WorkflowDefinitionRegistry {
+    fn with_builtins() -> Self {
+        let mut registry = Self {
+            definitions: HashMap::new(),
+            definition_ids: Vec::new(),
+            frozen: false,
+        };
+        for definition in builtin_definitions() {
+            registry
+                .register(definition)
+                .expect("built-in workflow definitions must be unique");
+        }
+        registry
+    }
+
+    #[cfg(test)]
+    pub fn new_for_tests() -> Self {
+        Self {
+            definitions: HashMap::new(),
+            definition_ids: Vec::new(),
+            frozen: false,
+        }
+    }
+
+    pub fn register(&mut self, definition: WorkflowDefinition) -> anyhow::Result<()> {
+        if self.frozen {
+            anyhow::bail!(
+                "workflow definition registry is frozen; cannot register '{}'",
+                definition.id
+            );
+        }
+        if self.definitions.contains_key(&definition.id) {
+            anyhow::bail!(
+                "workflow definition '{}' is already registered",
+                definition.id
+            );
+        }
+        self.definition_ids.push(definition.id.clone());
+        self.definitions
+            .insert(definition.id.clone(), Arc::new(definition));
+        Ok(())
+    }
+
+    pub fn freeze(&mut self) {
+        self.frozen = true;
+    }
+
+    pub fn is_frozen(&self) -> bool {
+        self.frozen
+    }
+
+    pub fn definition(&self, definition_id: &str) -> Option<Arc<WorkflowDefinition>> {
+        self.definitions.get(definition_id).cloned()
+    }
+
+    pub fn known_definition_ids(&self) -> Vec<String> {
+        self.definition_ids.clone()
+    }
+}
+
+static REGISTRY: OnceLock<RwLock<WorkflowDefinitionRegistry>> = OnceLock::new();
+
+fn registry() -> &'static RwLock<WorkflowDefinitionRegistry> {
+    REGISTRY.get_or_init(|| RwLock::new(WorkflowDefinitionRegistry::with_builtins()))
+}
+
+pub fn register_workflow_definition(definition: WorkflowDefinition) -> anyhow::Result<()> {
+    registry()
+        .write()
+        .expect("workflow definition registry lock poisoned")
+        .register(definition)
+}
+
+pub fn freeze_workflow_definition_registry() {
+    registry()
+        .write()
+        .expect("workflow definition registry lock poisoned")
+        .freeze();
+}
+
+pub fn workflow_definition(definition_id: &str) -> Option<Arc<WorkflowDefinition>> {
+    registry()
+        .read()
+        .expect("workflow definition registry lock poisoned")
+        .definition(definition_id)
+}
+
+pub fn decision_validator_for_definition(definition_id: &str) -> Option<DecisionValidator> {
+    workflow_definition(definition_id).map(|definition| {
+        DecisionValidator::for_definition(definition_id, definition.allowlist.clone())
+    })
+}
+
+pub fn known_workflow_definition_ids() -> Vec<String> {
+    registry()
+        .read()
+        .expect("workflow definition registry lock poisoned")
+        .known_definition_ids()
+}
+
+pub fn workflow_states_for_definition(definition_id: &str) -> Vec<WorkflowStateDefinition> {
+    workflow_definition(definition_id)
+        .map(|definition| definition.states.clone())
+        .unwrap_or_default()
+}
+
+pub fn workflow_terminal_state_names_for_definition(definition_id: &str) -> Vec<String> {
+    workflow_definition(definition_id)
+        .map(|definition| {
+            definition
+                .states
+                .iter()
+                .filter(|state| state.terminal_state.is_some())
+                .map(|state| state.key.state.to_string())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 pub fn workflow_state_definition(
     definition_id: &str,
     state: &str,
-) -> Option<&'static WorkflowStateDefinition> {
-    workflow_states_for_definition(definition_id)
-        .iter()
-        .find(|definition| definition.key.state == state)
+) -> Option<WorkflowStateDefinition> {
+    workflow_definition(definition_id).and_then(|definition| {
+        definition
+            .states
+            .iter()
+            .find(|definition| definition.key.state.as_ref() == state)
+            .cloned()
+    })
 }
 
 pub fn workflow_state_exists(definition_id: &str, state: &str) -> bool {
@@ -195,6 +224,110 @@ pub fn workflow_state_terminal_state(
     state: &str,
 ) -> Option<WorkflowTerminalState> {
     workflow_state_definition(definition_id, state)?.terminal_state
+}
+
+fn builtin_definitions() -> [WorkflowDefinition; 4] {
+    [
+        github_issue_pr_definition(),
+        prompt_task_definition(),
+        quality_gate_definition(),
+        pr_feedback_definition(),
+    ]
+}
+
+fn github_issue_pr_definition() -> WorkflowDefinition {
+    definition(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        &[
+            ("discovered", None),
+            ("awaiting_dependencies", None),
+            ("scheduled", None),
+            ("planning", None),
+            ("implementing", None),
+            ("replanning", None),
+            ("pr_open", None),
+            ("local_review_gate", None),
+            ("awaiting_feedback", None),
+            ("addressing_feedback", None),
+            ("quality_gate_pending", None),
+            ("ready_to_merge", None),
+            ("merging", None),
+            ("blocked", None),
+            ("done", Some(WorkflowTerminalState::Succeeded)),
+            ("failed", Some(WorkflowTerminalState::Failed)),
+            ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+        ],
+        TransitionAllowlist::github_issue_pr_defaults(),
+    )
+}
+
+fn prompt_task_definition() -> WorkflowDefinition {
+    definition(
+        PROMPT_TASK_DEFINITION_ID,
+        &[
+            ("submitted", None),
+            ("awaiting_dependencies", None),
+            ("implementing", None),
+            ("blocked", None),
+            ("done", Some(WorkflowTerminalState::Succeeded)),
+            ("failed", Some(WorkflowTerminalState::Failed)),
+            ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+        ],
+        TransitionAllowlist::prompt_task_defaults(),
+    )
+}
+
+fn quality_gate_definition() -> WorkflowDefinition {
+    definition(
+        QUALITY_GATE_DEFINITION_ID,
+        &[
+            ("pending", None),
+            ("checking", None),
+            ("blocked", None),
+            ("passed", Some(WorkflowTerminalState::Succeeded)),
+            ("failed", Some(WorkflowTerminalState::Failed)),
+            ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+        ],
+        TransitionAllowlist::quality_gate_defaults(),
+    )
+}
+
+fn pr_feedback_definition() -> WorkflowDefinition {
+    definition(
+        PR_FEEDBACK_DEFINITION_ID,
+        &[
+            ("pending", None),
+            ("inspecting", None),
+            ("feedback_found", None),
+            ("no_actionable_feedback", None),
+            ("ready_to_merge", None),
+            ("blocked", None),
+            ("done", Some(WorkflowTerminalState::Succeeded)),
+            ("failed", Some(WorkflowTerminalState::Failed)),
+            ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+        ],
+        TransitionAllowlist::pr_feedback_defaults(),
+    )
+}
+
+fn definition(
+    id: &'static str,
+    states: &[(&'static str, Option<WorkflowTerminalState>)],
+    allowlist: TransitionAllowlist,
+) -> WorkflowDefinition {
+    WorkflowDefinition::new(
+        id,
+        states
+            .iter()
+            .map(|(state, terminal_state)| match terminal_state {
+                Some(terminal_state) => {
+                    WorkflowStateDefinition::terminal(id, *state, *terminal_state)
+                }
+                None => WorkflowStateDefinition::active(id, *state),
+            })
+            .collect(),
+        allowlist,
+    )
 }
 
 #[cfg(test)]
@@ -220,7 +353,15 @@ mod tests {
 
     #[test]
     fn registry_lists_only_known_definition_states() {
-        assert!(known_workflow_definition_ids().contains(&GITHUB_ISSUE_PR_DEFINITION_ID));
+        assert_eq!(
+            known_workflow_definition_ids(),
+            vec![
+                GITHUB_ISSUE_PR_DEFINITION_ID,
+                PROMPT_TASK_DEFINITION_ID,
+                QUALITY_GATE_DEFINITION_ID,
+                PR_FEEDBACK_DEFINITION_ID,
+            ]
+        );
         assert!(workflow_states_for_definition("unknown_workflow").is_empty());
         assert!(workflow_state_exists(
             GITHUB_ISSUE_PR_DEFINITION_ID,
@@ -281,5 +422,72 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn builtins_preserve_states_terminal_mappings_and_allowlists() {
+        let expected = builtin_definitions();
+
+        for expected_definition in expected {
+            let actual = workflow_definition(&expected_definition.id)
+                .expect("built-in definition should be registered");
+            assert_eq!(actual.as_ref(), &expected_definition);
+        }
+    }
+
+    #[test]
+    fn state_key_clones_reuse_owned_string_allocations() {
+        let state = workflow_state_definition(PROMPT_TASK_DEFINITION_ID, "implementing")
+            .expect("prompt task implementing state should exist");
+        let cloned = state.key.clone();
+
+        assert!(Arc::ptr_eq(&state.key.definition_id, &cloned.definition_id));
+        assert!(Arc::ptr_eq(&state.key.state, &cloned.state));
+    }
+
+    #[test]
+    fn duplicate_registration_fails_without_replacing_the_first_definition() {
+        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+        let first = definition(
+            "fixture",
+            &[("pending", None)],
+            TransitionAllowlist::default(),
+        );
+        let duplicate = definition(
+            "fixture",
+            &[("other", None)],
+            TransitionAllowlist::default(),
+        );
+
+        registry
+            .register(first)
+            .expect("first registration should pass");
+        let error = registry
+            .register(duplicate)
+            .expect_err("duplicate registration should fail");
+
+        assert!(error.to_string().contains("already registered"));
+        assert!(registry
+            .definition("fixture")
+            .is_some_and(|definition| definition.states[0].key.state.as_ref() == "pending"));
+    }
+
+    #[test]
+    fn freeze_is_idempotent_and_rejects_late_registration() {
+        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+        registry.freeze();
+        registry.freeze();
+
+        let error = registry
+            .register(definition(
+                "late",
+                &[("pending", None)],
+                TransitionAllowlist::default(),
+            ))
+            .expect_err("post-freeze registration should fail");
+
+        assert!(registry.is_frozen());
+        assert!(error.to_string().contains("is frozen"));
+        assert!(registry.definition("late").is_none());
     }
 }

--- a/crates/harness-workflow/src/runtime/state_registry_equivalence_tests.rs
+++ b/crates/harness-workflow/src/runtime/state_registry_equivalence_tests.rs
@@ -1,0 +1,250 @@
+use super::*;
+use std::collections::BTreeSet;
+
+type ExpectedRule = (Option<&'static str>, &'static str, &'static [&'static str]);
+
+struct ExpectedDefinition {
+    id: &'static str,
+    states: &'static [(&'static str, Option<WorkflowTerminalState>)],
+    rules: &'static [ExpectedRule],
+}
+
+#[test]
+fn builtins_preserve_literal_states_terminal_mappings_and_transition_rules() {
+    let expected = [
+        ExpectedDefinition {
+            id: "github_issue_pr",
+            states: &[
+                ("discovered", None),
+                ("awaiting_dependencies", None),
+                ("scheduled", None),
+                ("planning", None),
+                ("implementing", None),
+                ("replanning", None),
+                ("pr_open", None),
+                ("local_review_gate", None),
+                ("awaiting_feedback", None),
+                ("addressing_feedback", None),
+                ("quality_gate_pending", None),
+                ("ready_to_merge", None),
+                ("merging", None),
+                ("blocked", None),
+                ("done", Some(WorkflowTerminalState::Succeeded)),
+                ("failed", Some(WorkflowTerminalState::Failed)),
+                ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+            ],
+            rules: GITHUB_ISSUE_PR_RULES,
+        },
+        ExpectedDefinition {
+            id: "prompt_task",
+            states: &[
+                ("submitted", None),
+                ("awaiting_dependencies", None),
+                ("implementing", None),
+                ("blocked", None),
+                ("done", Some(WorkflowTerminalState::Succeeded)),
+                ("failed", Some(WorkflowTerminalState::Failed)),
+                ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+            ],
+            rules: PROMPT_TASK_RULES,
+        },
+        ExpectedDefinition {
+            id: "quality_gate",
+            states: &[
+                ("pending", None),
+                ("checking", None),
+                ("blocked", None),
+                ("passed", Some(WorkflowTerminalState::Succeeded)),
+                ("failed", Some(WorkflowTerminalState::Failed)),
+                ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+            ],
+            rules: QUALITY_GATE_RULES,
+        },
+        ExpectedDefinition {
+            id: "pr_feedback",
+            states: &[
+                ("pending", None),
+                ("inspecting", None),
+                ("feedback_found", None),
+                ("no_actionable_feedback", None),
+                ("ready_to_merge", None),
+                ("blocked", None),
+                ("done", Some(WorkflowTerminalState::Succeeded)),
+                ("failed", Some(WorkflowTerminalState::Failed)),
+                ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+            ],
+            rules: PR_FEEDBACK_RULES,
+        },
+    ];
+
+    assert_eq!(
+        known_workflow_definition_ids(),
+        expected
+            .iter()
+            .map(|definition| definition.id.to_string())
+            .collect::<Vec<_>>()
+    );
+
+    for expected_definition in expected {
+        let actual = workflow_definition(expected_definition.id)
+            .expect("literal built-in definition should be registered");
+        assert_eq!(actual.id, expected_definition.id);
+        assert_eq!(actual.states.len(), expected_definition.states.len());
+        for (actual_state, (expected_state, expected_terminal)) in
+            actual.states.iter().zip(expected_definition.states)
+        {
+            assert_eq!(
+                actual_state.key.definition_id.as_ref(),
+                expected_definition.id
+            );
+            assert_eq!(actual_state.key.state.as_ref(), *expected_state);
+            assert_eq!(actual_state.terminal_state, *expected_terminal);
+        }
+
+        let actual_rules = actual.allowlist.rules().collect::<Vec<_>>();
+        assert_eq!(actual_rules.len(), expected_definition.rules.len());
+        for (actual_rule, (expected_from, expected_to, expected_commands)) in
+            actual_rules.iter().zip(expected_definition.rules)
+        {
+            assert_eq!(actual_rule.from_state.as_deref(), *expected_from);
+            assert_eq!(actual_rule.to_state, *expected_to);
+            assert_eq!(
+                actual_rule
+                    .allowed_commands
+                    .iter()
+                    .map(|command| command.as_str())
+                    .collect::<BTreeSet<_>>(),
+                expected_commands.iter().copied().collect::<BTreeSet<_>>()
+            );
+        }
+    }
+}
+
+const E: &str = "enqueue_activity";
+const S: &str = "start_child_workflow";
+const B: &str = "bind_pr";
+const P: &str = "record_plan_concern";
+const W: &str = "wait";
+const MB: &str = "mark_blocked";
+const MD: &str = "mark_done";
+const MF: &str = "mark_failed";
+const MC: &str = "mark_cancelled";
+const O: &str = "request_operator_attention";
+
+const GITHUB_ISSUE_PR_RULES: &[ExpectedRule] = &[
+    (Some("discovered"), "awaiting_dependencies", &[W]),
+    (Some("failed"), "awaiting_dependencies", &[W]),
+    (Some("cancelled"), "awaiting_dependencies", &[W]),
+    (Some("awaiting_dependencies"), "awaiting_dependencies", &[W]),
+    (Some("awaiting_dependencies"), "scheduled", &[E, W]),
+    (Some("awaiting_dependencies"), "planning", &[E, W]),
+    (Some("awaiting_dependencies"), "implementing", &[E, W]),
+    (Some("discovered"), "scheduled", &[E, W]),
+    (Some("discovered"), "planning", &[E, W]),
+    (Some("discovered"), "implementing", &[E, W]),
+    (Some("scheduled"), "scheduled", &[E, W]),
+    (Some("failed"), "scheduled", &[E, W]),
+    (Some("failed"), "planning", &[E, W]),
+    (Some("failed"), "implementing", &[E, W]),
+    (Some("failed"), "replanning", &[E, W]),
+    (Some("failed"), "local_review_gate", &[E, W]),
+    (Some("failed"), "awaiting_feedback", &[E, S, W]),
+    (Some("failed"), "addressing_feedback", &[E, S, W]),
+    (Some("failed"), "merging", &[E]),
+    (Some("blocked"), "implementing", &[E, W]),
+    (Some("blocked"), "replanning", &[E, W]),
+    (Some("blocked"), "local_review_gate", &[E, W]),
+    (Some("blocked"), "awaiting_feedback", &[E, S, W]),
+    (Some("blocked"), "addressing_feedback", &[E, S, W]),
+    (Some("blocked"), "merging", &[E]),
+    (Some("cancelled"), "scheduled", &[E, W]),
+    (Some("cancelled"), "planning", &[E, W]),
+    (Some("cancelled"), "implementing", &[E, W]),
+    (Some("scheduled"), "planning", &[E, W]),
+    (Some("scheduled"), "implementing", &[E, P, W]),
+    (Some("scheduled"), "replanning", &[E, P, MB, W]),
+    (Some("planning"), "implementing", &[E, MB]),
+    (Some("planning"), "planning", &[E, W]),
+    (Some("implementing"), "implementing", &[E, P, W]),
+    (Some("implementing"), "replanning", &[E, P, MB, W]),
+    (Some("replanning"), "implementing", &[E, P, MB, W]),
+    (Some("implementing"), "pr_open", &[B, E, S, W]),
+    (Some("implementing"), "done", &[MD]),
+    (Some("scheduled"), "pr_open", &[B, E, S, W]),
+    (Some("pr_open"), "pr_open", &[B, W]),
+    (Some("pr_open"), "local_review_gate", &[E, W]),
+    (Some("local_review_gate"), "local_review_gate", &[E, W]),
+    (Some("local_review_gate"), "awaiting_feedback", &[W]),
+    (
+        Some("local_review_gate"),
+        "addressing_feedback",
+        &[E, MB, W],
+    ),
+    (Some("pr_open"), "done", &[MD]),
+    (Some("awaiting_feedback"), "awaiting_feedback", &[E, S, W]),
+    (
+        Some("awaiting_feedback"),
+        "addressing_feedback",
+        &[E, S, MB, W],
+    ),
+    (
+        Some("addressing_feedback"),
+        "addressing_feedback",
+        &[E, S, MB, W],
+    ),
+    (Some("addressing_feedback"), "local_review_gate", &[E, S, W]),
+    (Some("awaiting_feedback"), "quality_gate_pending", &[S, W]),
+    (Some("quality_gate_pending"), "ready_to_merge", &[]),
+    (Some("awaiting_feedback"), "done", &[MD]),
+    (Some("addressing_feedback"), "done", &[MD]),
+    (Some("quality_gate_pending"), "done", &[MD]),
+    (Some("quality_gate_pending"), "quality_gate_pending", &[W]),
+    (Some("ready_to_merge"), "ready_to_merge", &[W]),
+    (Some("ready_to_merge"), "merging", &[E]),
+    (Some("merging"), "done", &[MD]),
+    (Some("ready_to_merge"), "done", &[MD]),
+    (None, "blocked", &[MB, O, W]),
+    (None, "failed", &[MF]),
+    (None, "cancelled", &[MC]),
+];
+
+const PROMPT_TASK_RULES: &[ExpectedRule] = &[
+    (Some("submitted"), "awaiting_dependencies", &[W]),
+    (Some("failed"), "awaiting_dependencies", &[W]),
+    (Some("cancelled"), "awaiting_dependencies", &[W]),
+    (Some("awaiting_dependencies"), "awaiting_dependencies", &[W]),
+    (Some("awaiting_dependencies"), "implementing", &[E, W]),
+    (Some("submitted"), "implementing", &[E, W]),
+    (Some("failed"), "implementing", &[E, W]),
+    (Some("cancelled"), "implementing", &[E, W]),
+    (Some("implementing"), "implementing", &[E, W]),
+    (Some("blocked"), "awaiting_dependencies", &[W]),
+    (Some("blocked"), "implementing", &[E, W]),
+    (Some("implementing"), "done", &[MD]),
+    (None, "blocked", &[MB, O, W]),
+    (None, "failed", &[MF]),
+    (None, "cancelled", &[MC]),
+];
+
+const QUALITY_GATE_RULES: &[ExpectedRule] = &[
+    (Some("pending"), "checking", &[E, W]),
+    (Some("checking"), "checking", &[E, W]),
+    (Some("checking"), "passed", &[]),
+    (None, "blocked", &[MB, O, W]),
+    (None, "failed", &[MF]),
+    (None, "cancelled", &[MC]),
+];
+
+const PR_FEEDBACK_RULES: &[ExpectedRule] = &[
+    (Some("pending"), "inspecting", &[E, W]),
+    (Some("inspecting"), "inspecting", &[E, W]),
+    (Some("inspecting"), "feedback_found", &[]),
+    (Some("inspecting"), "no_actionable_feedback", &[]),
+    (Some("inspecting"), "ready_to_merge", &[]),
+    (Some("feedback_found"), "done", &[W]),
+    (Some("no_actionable_feedback"), "done", &[W]),
+    (Some("ready_to_merge"), "done", &[W]),
+    (None, "blocked", &[MB, O, W]),
+    (None, "failed", &[MF]),
+    (None, "cancelled", &[MC]),
+];

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -4,10 +4,6 @@ use super::model::{
     WorkflowCommand, WorkflowCommandRecord, WorkflowCommandType, WorkflowDecision,
     WorkflowDecisionRecord, WorkflowDefinition, WorkflowEvent, WorkflowInstance, WorkflowLease,
 };
-use super::pr_feedback::PR_FEEDBACK_DEFINITION_ID;
-use super::prompt_task::PROMPT_TASK_DEFINITION_ID;
-use super::quality_gate::QUALITY_GATE_DEFINITION_ID;
-use super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID;
 use super::status::WorkflowCommandStatus;
 use super::store_migrations::WORKFLOW_RUNTIME_MIGRATIONS;
 use super::validator::DecisionValidator;
@@ -22,6 +18,8 @@ use std::path::Path;
 
 #[path = "store/commands.rs"]
 mod command_store;
+#[path = "store/instance_helpers.rs"]
+mod instance_helpers;
 #[path = "store/instances.rs"]
 mod instances;
 #[path = "store/recovery.rs"]
@@ -2275,11 +2273,5 @@ fn command_status_for_activity(status: ActivityStatus) -> WorkflowCommandStatus 
 }
 
 fn validator_for_definition(definition_id: &str) -> Option<DecisionValidator> {
-    match definition_id {
-        GITHUB_ISSUE_PR_DEFINITION_ID => Some(DecisionValidator::github_issue_pr()),
-        QUALITY_GATE_DEFINITION_ID => Some(DecisionValidator::quality_gate()),
-        PR_FEEDBACK_DEFINITION_ID => Some(DecisionValidator::pr_feedback()),
-        PROMPT_TASK_DEFINITION_ID => Some(DecisionValidator::prompt_task()),
-        _ => None,
-    }
+    super::state_registry::decision_validator_for_definition(definition_id)
 }

--- a/crates/harness-workflow/src/runtime/store/instance_helpers.rs
+++ b/crates/harness-workflow/src/runtime/store/instance_helpers.rs
@@ -1,0 +1,25 @@
+use crate::runtime::state_registry::{
+    known_workflow_definition_ids, workflow_terminal_state_names_for_definition,
+};
+use crate::runtime::WorkflowOtelTraceContext;
+
+pub(super) fn otel_trace_context_from_data(
+    data: &serde_json::Value,
+) -> Option<WorkflowOtelTraceContext> {
+    let context =
+        serde_json::from_value::<WorkflowOtelTraceContext>(data.get("otel_trace_context")?.clone())
+            .ok()?;
+    context.has_valid_trace_ids().then_some(context)
+}
+
+pub(super) fn terminal_state_pairs() -> (Vec<String>, Vec<String>) {
+    let mut definition_ids = Vec::new();
+    let mut states = Vec::new();
+    for definition_id in known_workflow_definition_ids() {
+        for state in workflow_terminal_state_names_for_definition(&definition_id) {
+            definition_ids.push(definition_id.clone());
+            states.push(state);
+        }
+    }
+    (definition_ids, states)
+}

--- a/crates/harness-workflow/src/runtime/store/instances.rs
+++ b/crates/harness-workflow/src/runtime/store/instances.rs
@@ -1,24 +1,16 @@
 use super::{
     command_store, insert_decision_record_tx, insert_event_tx, insert_instance_if_absent_tx,
+    instance_helpers::{otel_trace_context_from_data, terminal_state_pairs},
     load_or_insert_initial_instance_tx, select_instance_for_update_tx, to_jsonb_string,
     upsert_instance_tx, workflow_instance_from_row, RuntimeHistoryPruneSummary,
     WorkflowDecisionTransition, WorkflowInstancePage, WorkflowRejectedDecisionTransition,
     WorkflowRuntimeStore,
 };
 use crate::runtime::model::{WorkflowDecisionRecord, WorkflowInstance};
-use crate::runtime::state_registry::{
-    known_workflow_definition_ids, workflow_terminal_state_names_for_definition,
-};
+use crate::runtime::state_registry::workflow_terminal_state_names_for_definition;
 use crate::runtime::status::WorkflowCommandStatus;
 use crate::runtime::WorkflowOtelTraceContext;
 use chrono::{DateTime, Utc};
-
-fn otel_trace_context_from_data(data: &serde_json::Value) -> Option<WorkflowOtelTraceContext> {
-    let context =
-        serde_json::from_value::<WorkflowOtelTraceContext>(data.get("otel_trace_context")?.clone())
-            .ok()?;
-    context.has_valid_trace_ids().then_some(context)
-}
 
 impl WorkflowRuntimeStore {
     pub async fn insert_instance_if_absent(
@@ -805,16 +797,4 @@ impl WorkflowRuntimeStore {
             .map(|(data, updated_at)| workflow_instance_from_row(data, updated_at))
             .collect()
     }
-}
-
-fn terminal_state_pairs() -> (Vec<&'static str>, Vec<&'static str>) {
-    let mut definition_ids = Vec::new();
-    let mut states = Vec::new();
-    for definition_id in known_workflow_definition_ids() {
-        for state in workflow_terminal_state_names_for_definition(definition_id) {
-            definition_ids.push(*definition_id);
-            states.push(state);
-        }
-    }
-    (definition_ids, states)
 }

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -437,22 +437,40 @@ impl DecisionValidator {
     }
 
     pub fn github_issue_pr() -> Self {
-        Self {
-            allowlist: TransitionAllowlist::github_issue_pr_defaults(),
-            kind: DecisionValidatorKind::GithubIssuePr,
-        }
+        super::state_registry::decision_validator_for_definition(
+            super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID,
+        )
+        .expect("built-in github_issue_pr workflow definition must be registered")
     }
 
     pub fn quality_gate() -> Self {
-        Self::new(TransitionAllowlist::quality_gate_defaults())
+        super::state_registry::decision_validator_for_definition(
+            super::quality_gate::QUALITY_GATE_DEFINITION_ID,
+        )
+        .expect("built-in quality_gate workflow definition must be registered")
     }
 
     pub fn pr_feedback() -> Self {
-        Self::new(TransitionAllowlist::pr_feedback_defaults())
+        super::state_registry::decision_validator_for_definition(
+            super::pr_feedback::PR_FEEDBACK_DEFINITION_ID,
+        )
+        .expect("built-in pr_feedback workflow definition must be registered")
     }
 
     pub fn prompt_task() -> Self {
-        Self::new(TransitionAllowlist::prompt_task_defaults())
+        super::state_registry::decision_validator_for_definition(
+            super::prompt_task::PROMPT_TASK_DEFINITION_ID,
+        )
+        .expect("built-in prompt_task workflow definition must be registered")
+    }
+
+    pub(crate) fn for_definition(definition_id: &str, allowlist: TransitionAllowlist) -> Self {
+        let kind = if definition_id == super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID {
+            DecisionValidatorKind::GithubIssuePr
+        } else {
+            DecisionValidatorKind::Generic
+        };
+        Self { allowlist, kind }
     }
 
     pub fn validate(

--- a/crates/harness-workflow/tests/state_registry_public_api.rs
+++ b/crates/harness-workflow/tests/state_registry_public_api.rs
@@ -1,0 +1,29 @@
+use harness_workflow::runtime::{
+    register_workflow_definition, workflow_definition, RegisteredWorkflowDefinition,
+    TransitionAllowlist, TransitionRule, WorkflowDefinition as PersistedWorkflowDefinition,
+    WorkflowStateDefinition,
+};
+
+#[test]
+fn downstream_crate_can_construct_and_register_a_runtime_definition() {
+    let definition_id = "downstream_registry_api_fixture";
+    let definition = RegisteredWorkflowDefinition::new(
+        definition_id,
+        vec![
+            WorkflowStateDefinition::active(definition_id, "pending"),
+            WorkflowStateDefinition::active(definition_id, "running"),
+        ],
+        TransitionAllowlist::new(vec![TransitionRule::new("pending", "running", [])]),
+    );
+
+    register_workflow_definition(definition)
+        .expect("downstream runtime definition should register through the public API");
+
+    let registered = workflow_definition(definition_id)
+        .expect("downstream runtime definition should be available after registration");
+    assert_eq!(registered.id, definition_id);
+    assert_eq!(registered.states.len(), 2);
+
+    let persisted = PersistedWorkflowDefinition::new(definition_id, 1, "Downstream fixture");
+    assert_eq!(persisted.id, registered.id);
+}


### PR DESCRIPTION
## Summary
- replace static workflow state tables with an owned, process-wide definition registry
- route runtime decision validation, terminal-state lookups, and prompt transition contracts through registered definitions
- freeze the registry at server startup and preserve built-in behavior with independent literal equivalence fixtures
- expose `RegisteredWorkflowDefinition` through the public runtime API without colliding with the persisted model type

## Independent review remediation
- added a downstream construction and registration integration test
- removed the hardcoded prompt validator match and covered a registered non-built-in definition
- replaced the self-referential preservation test with literal built-in states, terminal mappings, and transition rules

## Verification
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p harness-workflow state_registry` (8 passed)
- `cargo test -p harness-workflow --test state_registry_public_api` (1 passed)
- `cargo test -p harness-server workflow_runtime_worker::prompt_packet::tests::` (10 passed)
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1608`
- formatting and diff checks passed

## Remaining merge gates
- current-head CI
- exact-head independent re-review
- resolved review threads and PR gate

Closes #1608