### PR TITLE
fix(workflow): fence non-runtime command skips

### DIFF
--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -1,5 +1,4 @@
 use super::model::{RuntimeJob, RuntimeProfile, WorkflowCommandRecord};
-use super::status::WorkflowCommandStatus;
 use super::store::{ClaimedCommandTerminalOutcome, RuntimeJobEnqueueOutcome, WorkflowRuntimeStore};
 use super::tier_resolution::{
     resolve_isolation_tier, IsolationTaskMetadata, IsolationTierResolution,
@@ -16,8 +15,6 @@ use harness_core::config::isolation::{
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use uuid::Uuid;
-
-const COMMAND_STATUS_SKIPPED: WorkflowCommandStatus = WorkflowCommandStatus::Skipped;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CommandDispatchOutcome {
@@ -214,12 +211,24 @@ impl<'a> RuntimeCommandDispatcher<'a> {
         command: WorkflowCommandRecord,
     ) -> anyhow::Result<CommandDispatchOutcome> {
         if !command.command.requires_runtime_job() {
-            self.store
-                .mark_command_status(&command.id, COMMAND_STATUS_SKIPPED)
-                .await?;
+            let reason = if self
+                .store
+                .skip_claimed_command_if_owned(
+                    &command.id,
+                    super::DispatchClaim {
+                        owner: &self.dispatcher_id,
+                        generation: command.dispatch_claim_generation,
+                    },
+                )
+                .await?
+            {
+                "command does not require runtime execution"
+            } else {
+                "dispatch claim became stale before non-runtime skip"
+            };
             return Ok(CommandDispatchOutcome::Skipped {
                 command_id: command.id,
-                reason: "command does not require runtime execution".to_string(),
+                reason: reason.to_string(),
             });
         }
 

--- a/crates/harness-workflow/src/runtime/store/commands.rs
+++ b/crates/harness-workflow/src/runtime/store/commands.rs
@@ -12,6 +12,31 @@ use sqlx::postgres::PgPool;
 use uuid::Uuid;
 
 impl WorkflowRuntimeStore {
+    pub async fn skip_claimed_command_if_owned(
+        &self,
+        command_id: &str,
+        dispatch_claim: DispatchClaim<'_>,
+    ) -> anyhow::Result<bool> {
+        let generation = i64::try_from(dispatch_claim.generation)
+            .map_err(|_| anyhow::anyhow!("dispatch claim generation exceeds PostgreSQL BIGINT"))?;
+        let result = sqlx::query(
+            "UPDATE workflow_commands
+             SET status = $2, dispatch_owner = NULL,
+                 dispatch_lease_expires_at = NULL, dispatch_not_before = NULL,
+                 dispatch_barrier = NULL, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $1 AND status = $3 AND dispatch_owner = $4
+               AND dispatch_claim_generation = $5",
+        )
+        .bind(command_id)
+        .bind(WorkflowCommandStatus::Skipped.as_str())
+        .bind(WorkflowCommandStatus::Dispatching.as_str())
+        .bind(dispatch_claim.owner)
+        .bind(generation)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
     pub async fn finish_claimed_command_for_terminal_workflow(
         &self,
         command_id: &str,

--- a/crates/harness-workflow/src/runtime/tests/deferred_dispatch_review.rs
+++ b/crates/harness-workflow/src/runtime/tests/deferred_dispatch_review.rs
@@ -69,6 +69,65 @@ async fn terminal_dispatcher_fast_path_rejects_reclaimed_generation() -> anyhow:
 }
 
 #[tokio::test]
+async fn non_runtime_dispatch_rejects_reclaimed_generation() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let workflow = project_issue_instance("/project-a", 1601, "pr_open");
+    store.upsert_instance(&workflow).await?;
+    let command = WorkflowCommand::bind_pr(
+        1617,
+        "https://github.com/majiayu000/harness/pull/1617",
+        "issue-1601-pr-1617",
+    );
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    let old_claim = store
+        .claim_pending_commands("reused-owner", Utc::now() + Duration::minutes(1), 10)
+        .await?
+        .into_iter()
+        .find(|record| record.id == command_id)
+        .expect("pending command should be claimed");
+    let current_claim = reclaim_claim_with_same_owner(&store, &command_id, "reused-owner").await?;
+    assert_eq!(
+        current_claim.dispatch_claim_generation,
+        old_claim.dispatch_claim_generation + 1
+    );
+
+    let dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc),
+    )
+    .with_dispatcher_id("reused-owner");
+    let stale_outcome = dispatcher.dispatch_command(old_claim).await?;
+    assert!(matches!(stale_outcome, CommandDispatchOutcome::Skipped { .. }));
+    let after_stale = store.get_command(&command_id).await?.expect("command exists");
+    assert_eq!(after_stale.status, WorkflowCommandStatus::Dispatching);
+    assert_eq!(
+        after_stale.dispatch_claim_generation,
+        current_claim.dispatch_claim_generation
+    );
+    assert_eq!(after_stale.dispatch_owner.as_deref(), Some("reused-owner"));
+
+    let current_outcome = dispatcher.dispatch_command(current_claim).await?;
+    assert!(matches!(
+        current_outcome,
+        CommandDispatchOutcome::Skipped { .. }
+    ));
+    assert_eq!(
+        store
+            .get_command(&command_id)
+            .await?
+            .expect("command exists")
+            .status,
+        WorkflowCommandStatus::Skipped
+    );
+    assert!(store.runtime_jobs_for_command(&command_id).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
 async fn same_owner_newer_generation_rejects_stale_deferral() -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {
         return Ok(());


### PR DESCRIPTION
## Summary

- fence non-runtime command skips by exact dispatch owner and claim generation
- keep stale dispatchers write-free after a lease is reclaimed by the same owner
- add a PostgreSQL regression covering stale and current generations

## Root cause

PR #1617 fenced runtime enqueue, deferral, and terminal-workflow paths, but the non-runtime fast path still called an ID-only status update. A stale dispatcher could therefore clear a newer claim and mark the command skipped after lease reclamation.

## Verification

- reproduced the pre-fix failure against a disposable PostgreSQL database
- `cargo test -p harness-workflow non_runtime_dispatch_rejects_reclaimed_generation`
- `cargo test -p harness-workflow` (410 passed on the pre-squash branch tree)
- `cargo test --workspace` (passed on the identical final tree)
- `cargo check -p harness-workflow --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings` (passed on the identical final tree)
- `cargo fmt --all -- --check`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1601`

Closes #1601
