### PR TITLE
feat(workflow): add progress ownership contract

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -2,7 +2,8 @@ use super::*;
 use harness_workflow::runtime::{
     RegisteredWorkflowDefinition, RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord,
     RetrievedRepoMemoryRecord, RuntimeKind, TransitionAllowlist, TransitionRule,
-    WorkflowDefinitionRegistry, WorkflowStateDefinition, WorkflowSubject, ISSUE_PLAN_ACTIVITY,
+    WorkflowDefinitionRegistry, WorkflowProgressMode, WorkflowRuntimeRecoveryAction,
+    WorkflowRuntimeStore, WorkflowStateDefinition, WorkflowSubject, ISSUE_PLAN_ACTIVITY,
     ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL, PR_REPAIR_SNAPSHOT_ARTIFACT,
     SERVER_PR_SNAPSHOT_ARTIFACT,
 };
@@ -254,8 +255,16 @@ fn workflow_decision_contract_uses_a_registered_non_builtin_definition() {
         .register(RegisteredWorkflowDefinition::new(
             "custom_review",
             vec![
-                WorkflowStateDefinition::active("custom_review", "queued"),
-                WorkflowStateDefinition::active("custom_review", "reviewing"),
+                WorkflowStateDefinition::active(
+                    "custom_review",
+                    "queued",
+                    WorkflowProgressMode::ExternalWait,
+                ),
+                WorkflowStateDefinition::active(
+                    "custom_review",
+                    "reviewing",
+                    WorkflowProgressMode::OperatorGate,
+                ),
             ],
             TransitionAllowlist::new(vec![TransitionRule::new("queued", "reviewing", [])]),
         ))
@@ -282,6 +291,38 @@ fn workflow_decision_contract_uses_a_registered_non_builtin_definition() {
     assert_eq!(
         contract["allowed_transitions"][0]["allowed_commands"],
         json!([])
+    );
+}
+
+#[test]
+fn progress_wake_paths_are_callable_for_non_command_modes() {
+    let config = harness_core::config::workflow::WorkflowConfig::default();
+    assert!(config.pr_feedback.enabled);
+    assert!(config.runtime_dispatch.enabled);
+    assert!(config.runtime_worker.enabled);
+
+    let _issue_dependency_observer =
+        crate::workflow_runtime_submission::release_ready_issue_dependencies;
+    let _prompt_dependency_observer =
+        crate::workflow_runtime_submission::release_ready_prompt_dependencies;
+    let _local_review_selector = crate::workflow_runtime_pr_feedback::request_local_review;
+    let _feedback_selector = crate::workflow_runtime_pr_feedback::request_pr_feedback_sweep;
+    let _merge_approval = crate::workflow_runtime_pr_feedback::approve_runtime_merge_by_workflow_id;
+    let _recovery_action = WorkflowRuntimeStore::recover_stopped_instance;
+    let _parent_propagation = WorkflowRuntimeStore::commit_parent_runtime_completion;
+
+    assert_eq!(WorkflowRuntimeRecoveryAction::Unblock.as_str(), "unblock");
+    assert_eq!(WorkflowRuntimeRecoveryAction::Retry.as_str(), "retry");
+    let child = WorkflowInstance::new(
+        PR_FEEDBACK_DEFINITION_ID,
+        1,
+        "feedback_found",
+        WorkflowSubject::new("pr", "pr:77"),
+    )
+    .with_parent("github-issue-parent");
+    assert_eq!(
+        child.parent_workflow_id.as_deref(),
+        Some("github-issue-parent")
     );
 }
 #[test]

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -139,9 +139,10 @@ pub use repo_memory::{
 pub use state_registry::{
     decision_validator_for_definition, freeze_workflow_definition_registry,
     known_workflow_definition_ids, register_workflow_definition, workflow_definition,
-    workflow_state_definition, workflow_state_exists, workflow_states_for_definition,
-    workflow_terminal_state_names_for_definition, RegisteredWorkflowDefinition,
-    WorkflowDefinitionRegistry, WorkflowStateDefinition, WorkflowStateKey,
+    workflow_state_definition, workflow_state_exists, workflow_state_progress_mode,
+    workflow_states_for_definition, workflow_terminal_state_names_for_definition,
+    RegisteredWorkflowDefinition, WorkflowDefinitionRegistry, WorkflowProgressMode,
+    WorkflowStateDefinition, WorkflowStateKey,
 };
 pub use status::WorkflowCommandStatus;
 pub use store::{

--- a/crates/harness-workflow/src/runtime/state_registry.rs
+++ b/crates/harness-workflow/src/runtime/state_registry.rs
@@ -17,6 +17,15 @@ pub enum WorkflowTerminalState {
     Cancelled,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowProgressMode {
+    CommandDriven,
+    ExternalWait,
+    OperatorGate,
+    ParentHandoff,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WorkflowStateKey {
     pub definition_id: Arc<str>,
@@ -26,16 +35,22 @@ pub struct WorkflowStateKey {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkflowStateDefinition {
     pub key: WorkflowStateKey,
+    pub progress_mode: Option<WorkflowProgressMode>,
     pub terminal_state: Option<WorkflowTerminalState>,
 }
 
 impl WorkflowStateDefinition {
-    pub fn active(definition_id: impl Into<Arc<str>>, state: impl Into<Arc<str>>) -> Self {
+    pub fn active(
+        definition_id: impl Into<Arc<str>>,
+        state: impl Into<Arc<str>>,
+        progress_mode: WorkflowProgressMode,
+    ) -> Self {
         Self {
             key: WorkflowStateKey {
                 definition_id: definition_id.into(),
                 state: state.into(),
             },
+            progress_mode: Some(progress_mode),
             terminal_state: None,
         }
     }
@@ -50,8 +65,13 @@ impl WorkflowStateDefinition {
                 definition_id: definition_id.into(),
                 state: state.into(),
             },
+            progress_mode: None,
             terminal_state: Some(terminal_state),
         }
+    }
+
+    fn has_complete_progress_contract(&self) -> bool {
+        self.progress_mode.is_some() != self.terminal_state.is_some()
     }
 }
 
@@ -118,6 +138,17 @@ impl WorkflowDefinitionRegistry {
             anyhow::bail!(
                 "workflow definition '{}' is already registered",
                 definition.id
+            );
+        }
+        if let Some(state) = definition
+            .states
+            .iter()
+            .find(|state| !state.has_complete_progress_contract())
+        {
+            anyhow::bail!(
+                "workflow definition '{}' state '{}' must declare exactly one of progress_mode or terminal_state",
+                definition.id,
+                state.key.state
             );
         }
         self.definition_ids.push(definition.id.clone());
@@ -244,6 +275,13 @@ pub fn workflow_state_terminal_state(
     workflow_state_definition(definition_id, state)?.terminal_state
 }
 
+pub fn workflow_state_progress_mode(
+    definition_id: &str,
+    state: &str,
+) -> Option<WorkflowProgressMode> {
+    workflow_state_definition(definition_id, state)?.progress_mode
+}
+
 fn builtin_definitions() -> [RegisteredWorkflowDefinition; 4] {
     [
         github_issue_pr_definition(),
@@ -254,75 +292,163 @@ fn builtin_definitions() -> [RegisteredWorkflowDefinition; 4] {
 }
 
 fn github_issue_pr_definition() -> RegisteredWorkflowDefinition {
+    use WorkflowProgressMode::{CommandDriven, ExternalWait, OperatorGate, ParentHandoff};
+
     definition(
         GITHUB_ISSUE_PR_DEFINITION_ID,
-        &[
-            ("discovered", None),
-            ("awaiting_dependencies", None),
-            ("scheduled", None),
-            ("planning", None),
-            ("implementing", None),
-            ("replanning", None),
-            ("pr_open", None),
-            ("local_review_gate", None),
-            ("awaiting_feedback", None),
-            ("addressing_feedback", None),
-            ("quality_gate_pending", None),
-            ("ready_to_merge", None),
-            ("merging", None),
-            ("blocked", None),
-            ("done", Some(WorkflowTerminalState::Succeeded)),
-            ("failed", Some(WorkflowTerminalState::Failed)),
-            ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+        vec![
+            active(GITHUB_ISSUE_PR_DEFINITION_ID, "discovered", CommandDriven),
+            active(
+                GITHUB_ISSUE_PR_DEFINITION_ID,
+                "awaiting_dependencies",
+                ExternalWait,
+            ),
+            active(GITHUB_ISSUE_PR_DEFINITION_ID, "scheduled", CommandDriven),
+            active(GITHUB_ISSUE_PR_DEFINITION_ID, "planning", CommandDriven),
+            active(GITHUB_ISSUE_PR_DEFINITION_ID, "implementing", CommandDriven),
+            active(GITHUB_ISSUE_PR_DEFINITION_ID, "replanning", CommandDriven),
+            active(GITHUB_ISSUE_PR_DEFINITION_ID, "pr_open", ExternalWait),
+            active(
+                GITHUB_ISSUE_PR_DEFINITION_ID,
+                "local_review_gate",
+                CommandDriven,
+            ),
+            active(
+                GITHUB_ISSUE_PR_DEFINITION_ID,
+                "awaiting_feedback",
+                ExternalWait,
+            ),
+            active(
+                GITHUB_ISSUE_PR_DEFINITION_ID,
+                "addressing_feedback",
+                CommandDriven,
+            ),
+            active(
+                GITHUB_ISSUE_PR_DEFINITION_ID,
+                "quality_gate_pending",
+                ParentHandoff,
+            ),
+            active(
+                GITHUB_ISSUE_PR_DEFINITION_ID,
+                "ready_to_merge",
+                OperatorGate,
+            ),
+            active(GITHUB_ISSUE_PR_DEFINITION_ID, "merging", CommandDriven),
+            active(GITHUB_ISSUE_PR_DEFINITION_ID, "blocked", OperatorGate),
+            terminal(
+                GITHUB_ISSUE_PR_DEFINITION_ID,
+                "done",
+                WorkflowTerminalState::Succeeded,
+            ),
+            terminal(
+                GITHUB_ISSUE_PR_DEFINITION_ID,
+                "failed",
+                WorkflowTerminalState::Failed,
+            ),
+            terminal(
+                GITHUB_ISSUE_PR_DEFINITION_ID,
+                "cancelled",
+                WorkflowTerminalState::Cancelled,
+            ),
         ],
         TransitionAllowlist::github_issue_pr_defaults(),
     )
 }
 
 fn prompt_task_definition() -> RegisteredWorkflowDefinition {
+    use WorkflowProgressMode::{CommandDriven, ExternalWait, OperatorGate};
+
     definition(
         PROMPT_TASK_DEFINITION_ID,
-        &[
-            ("submitted", None),
-            ("awaiting_dependencies", None),
-            ("implementing", None),
-            ("blocked", None),
-            ("done", Some(WorkflowTerminalState::Succeeded)),
-            ("failed", Some(WorkflowTerminalState::Failed)),
-            ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+        vec![
+            active(PROMPT_TASK_DEFINITION_ID, "submitted", CommandDriven),
+            active(
+                PROMPT_TASK_DEFINITION_ID,
+                "awaiting_dependencies",
+                ExternalWait,
+            ),
+            active(PROMPT_TASK_DEFINITION_ID, "implementing", CommandDriven),
+            active(PROMPT_TASK_DEFINITION_ID, "blocked", OperatorGate),
+            terminal(
+                PROMPT_TASK_DEFINITION_ID,
+                "done",
+                WorkflowTerminalState::Succeeded,
+            ),
+            terminal(
+                PROMPT_TASK_DEFINITION_ID,
+                "failed",
+                WorkflowTerminalState::Failed,
+            ),
+            terminal(
+                PROMPT_TASK_DEFINITION_ID,
+                "cancelled",
+                WorkflowTerminalState::Cancelled,
+            ),
         ],
         TransitionAllowlist::prompt_task_defaults(),
     )
 }
 
 fn quality_gate_definition() -> RegisteredWorkflowDefinition {
+    use WorkflowProgressMode::{CommandDriven, OperatorGate};
+
     definition(
         QUALITY_GATE_DEFINITION_ID,
-        &[
-            ("pending", None),
-            ("checking", None),
-            ("blocked", None),
-            ("passed", Some(WorkflowTerminalState::Succeeded)),
-            ("failed", Some(WorkflowTerminalState::Failed)),
-            ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+        vec![
+            active(QUALITY_GATE_DEFINITION_ID, "pending", CommandDriven),
+            active(QUALITY_GATE_DEFINITION_ID, "checking", CommandDriven),
+            active(QUALITY_GATE_DEFINITION_ID, "blocked", OperatorGate),
+            terminal(
+                QUALITY_GATE_DEFINITION_ID,
+                "passed",
+                WorkflowTerminalState::Succeeded,
+            ),
+            terminal(
+                QUALITY_GATE_DEFINITION_ID,
+                "failed",
+                WorkflowTerminalState::Failed,
+            ),
+            terminal(
+                QUALITY_GATE_DEFINITION_ID,
+                "cancelled",
+                WorkflowTerminalState::Cancelled,
+            ),
         ],
         TransitionAllowlist::quality_gate_defaults(),
     )
 }
 
 fn pr_feedback_definition() -> RegisteredWorkflowDefinition {
+    use WorkflowProgressMode::{CommandDriven, OperatorGate, ParentHandoff};
+
     definition(
         PR_FEEDBACK_DEFINITION_ID,
-        &[
-            ("pending", None),
-            ("inspecting", None),
-            ("feedback_found", None),
-            ("no_actionable_feedback", None),
-            ("ready_to_merge", None),
-            ("blocked", None),
-            ("done", Some(WorkflowTerminalState::Succeeded)),
-            ("failed", Some(WorkflowTerminalState::Failed)),
-            ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+        vec![
+            active(PR_FEEDBACK_DEFINITION_ID, "pending", CommandDriven),
+            active(PR_FEEDBACK_DEFINITION_ID, "inspecting", CommandDriven),
+            active(PR_FEEDBACK_DEFINITION_ID, "feedback_found", ParentHandoff),
+            active(
+                PR_FEEDBACK_DEFINITION_ID,
+                "no_actionable_feedback",
+                ParentHandoff,
+            ),
+            active(PR_FEEDBACK_DEFINITION_ID, "ready_to_merge", ParentHandoff),
+            active(PR_FEEDBACK_DEFINITION_ID, "blocked", OperatorGate),
+            terminal(
+                PR_FEEDBACK_DEFINITION_ID,
+                "done",
+                WorkflowTerminalState::Succeeded,
+            ),
+            terminal(
+                PR_FEEDBACK_DEFINITION_ID,
+                "failed",
+                WorkflowTerminalState::Failed,
+            ),
+            terminal(
+                PR_FEEDBACK_DEFINITION_ID,
+                "cancelled",
+                WorkflowTerminalState::Cancelled,
+            ),
         ],
         TransitionAllowlist::pr_feedback_defaults(),
     )
@@ -330,22 +456,26 @@ fn pr_feedback_definition() -> RegisteredWorkflowDefinition {
 
 fn definition(
     id: &'static str,
-    states: &[(&'static str, Option<WorkflowTerminalState>)],
+    states: Vec<WorkflowStateDefinition>,
     allowlist: TransitionAllowlist,
 ) -> RegisteredWorkflowDefinition {
-    RegisteredWorkflowDefinition::new(
-        id,
-        states
-            .iter()
-            .map(|(state, terminal_state)| match terminal_state {
-                Some(terminal_state) => {
-                    WorkflowStateDefinition::terminal(id, *state, *terminal_state)
-                }
-                None => WorkflowStateDefinition::active(id, *state),
-            })
-            .collect(),
-        allowlist,
-    )
+    RegisteredWorkflowDefinition::new(id, states, allowlist)
+}
+
+fn active(
+    definition_id: &'static str,
+    state: &'static str,
+    progress_mode: WorkflowProgressMode,
+) -> WorkflowStateDefinition {
+    WorkflowStateDefinition::active(definition_id, state, progress_mode)
+}
+
+fn terminal(
+    definition_id: &'static str,
+    state: &'static str,
+    terminal_state: WorkflowTerminalState,
+) -> WorkflowStateDefinition {
+    WorkflowStateDefinition::terminal(definition_id, state, terminal_state)
 }
 
 #[cfg(test)]
@@ -430,6 +560,15 @@ mod tests {
         ];
 
         for (definition_id, allowlist) in allowlists {
+            let definition = workflow_definition(definition_id)
+                .expect("built-in workflow definition should be registered");
+            for state in &definition.states {
+                assert!(
+                    state.has_complete_progress_contract(),
+                    "{definition_id}.{} must declare exactly one progress or terminal contract",
+                    state.key.state
+                );
+            }
             for rule in allowlist.rules() {
                 if let Some(from_state) = rule.from_state.as_deref() {
                     assert!(
@@ -438,12 +577,33 @@ mod tests {
                     );
                 }
                 assert!(
-                    workflow_state_exists(definition_id, &rule.to_state),
-                    "{definition_id} missing to_state {}",
-                    rule.to_state
+                    workflow_state_definition(definition_id, &rule.to_state)
+                        .is_some_and(|state| state.has_complete_progress_contract()),
+                    "{definition_id} to_state {} is missing a complete contract",
+                    rule.to_state,
                 );
             }
         }
+    }
+
+    #[test]
+    fn progress_mode_lookup_fails_closed_for_terminal_and_unknown_states() {
+        assert_eq!(
+            workflow_state_progress_mode(GITHUB_ISSUE_PR_DEFINITION_ID, "implementing"),
+            Some(WorkflowProgressMode::CommandDriven)
+        );
+        assert_eq!(
+            workflow_state_progress_mode(GITHUB_ISSUE_PR_DEFINITION_ID, "done"),
+            None
+        );
+        assert_eq!(
+            workflow_state_progress_mode(GITHUB_ISSUE_PR_DEFINITION_ID, "unknown"),
+            None
+        );
+        assert_eq!(
+            workflow_state_progress_mode("unknown_definition", "implementing"),
+            None
+        );
     }
 
     #[test]
@@ -461,12 +621,20 @@ mod tests {
         let mut registry = WorkflowDefinitionRegistry::new_for_tests();
         let first = definition(
             "fixture",
-            &[("pending", None)],
+            vec![active(
+                "fixture",
+                "pending",
+                WorkflowProgressMode::ExternalWait,
+            )],
             TransitionAllowlist::default(),
         );
         let duplicate = definition(
             "fixture",
-            &[("other", None)],
+            vec![active(
+                "fixture",
+                "other",
+                WorkflowProgressMode::ExternalWait,
+            )],
             TransitionAllowlist::default(),
         );
 
@@ -492,7 +660,11 @@ mod tests {
         let error = registry
             .register(definition(
                 "late",
-                &[("pending", None)],
+                vec![active(
+                    "late",
+                    "pending",
+                    WorkflowProgressMode::ExternalWait,
+                )],
                 TransitionAllowlist::default(),
             ))
             .expect_err("post-freeze registration should fail");
@@ -500,5 +672,41 @@ mod tests {
         assert!(registry.is_frozen());
         assert!(error.to_string().contains("is frozen"));
         assert!(registry.definition("late").is_none());
+    }
+
+    #[test]
+    fn registration_rejects_incomplete_or_conflicting_progress_contracts() {
+        let invalid_states = [
+            WorkflowStateDefinition {
+                key: WorkflowStateKey {
+                    definition_id: Arc::from("fixture"),
+                    state: Arc::from("missing"),
+                },
+                progress_mode: None,
+                terminal_state: None,
+            },
+            WorkflowStateDefinition {
+                key: WorkflowStateKey {
+                    definition_id: Arc::from("fixture"),
+                    state: Arc::from("conflicting"),
+                },
+                progress_mode: Some(WorkflowProgressMode::OperatorGate),
+                terminal_state: Some(WorkflowTerminalState::Failed),
+            },
+        ];
+
+        for state in invalid_states {
+            let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+            let error = registry
+                .register(RegisteredWorkflowDefinition::new(
+                    "fixture",
+                    vec![state],
+                    TransitionAllowlist::default(),
+                ))
+                .expect_err("invalid state contract should fail registration");
+
+            assert!(error.to_string().contains("exactly one"));
+            assert!(registry.definition("fixture").is_none());
+        }
     }
 }

--- a/crates/harness-workflow/src/runtime/state_registry_equivalence_tests.rs
+++ b/crates/harness-workflow/src/runtime/state_registry_equivalence_tests.rs
@@ -1,12 +1,69 @@
 use super::*;
+use crate::runtime::{WorkflowCommand, WorkflowCommandType};
+use serde_json::json;
 use std::collections::BTreeSet;
 
 type ExpectedRule = (Option<&'static str>, &'static str, &'static [&'static str]);
 
-struct ExpectedDefinition {
+struct ExpectedDefinition<'a> {
     id: &'static str,
-    states: &'static [(&'static str, Option<WorkflowTerminalState>)],
+    states: &'a [(
+        &'static str,
+        Option<WorkflowProgressMode>,
+        Option<WorkflowTerminalState>,
+    )],
     rules: &'static [ExpectedRule],
+}
+
+const fn command_driven(
+    state: &'static str,
+) -> (
+    &'static str,
+    Option<WorkflowProgressMode>,
+    Option<WorkflowTerminalState>,
+) {
+    (state, Some(WorkflowProgressMode::CommandDriven), None)
+}
+
+const fn external_wait(
+    state: &'static str,
+) -> (
+    &'static str,
+    Option<WorkflowProgressMode>,
+    Option<WorkflowTerminalState>,
+) {
+    (state, Some(WorkflowProgressMode::ExternalWait), None)
+}
+
+const fn operator_gate(
+    state: &'static str,
+) -> (
+    &'static str,
+    Option<WorkflowProgressMode>,
+    Option<WorkflowTerminalState>,
+) {
+    (state, Some(WorkflowProgressMode::OperatorGate), None)
+}
+
+const fn parent_handoff(
+    state: &'static str,
+) -> (
+    &'static str,
+    Option<WorkflowProgressMode>,
+    Option<WorkflowTerminalState>,
+) {
+    (state, Some(WorkflowProgressMode::ParentHandoff), None)
+}
+
+const fn terminal_state(
+    state: &'static str,
+    terminal_state: WorkflowTerminalState,
+) -> (
+    &'static str,
+    Option<WorkflowProgressMode>,
+    Option<WorkflowTerminalState>,
+) {
+    (state, None, Some(terminal_state))
 }
 
 #[test]
@@ -15,63 +72,63 @@ fn builtins_preserve_literal_states_terminal_mappings_and_transition_rules() {
         ExpectedDefinition {
             id: "github_issue_pr",
             states: &[
-                ("discovered", None),
-                ("awaiting_dependencies", None),
-                ("scheduled", None),
-                ("planning", None),
-                ("implementing", None),
-                ("replanning", None),
-                ("pr_open", None),
-                ("local_review_gate", None),
-                ("awaiting_feedback", None),
-                ("addressing_feedback", None),
-                ("quality_gate_pending", None),
-                ("ready_to_merge", None),
-                ("merging", None),
-                ("blocked", None),
-                ("done", Some(WorkflowTerminalState::Succeeded)),
-                ("failed", Some(WorkflowTerminalState::Failed)),
-                ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+                command_driven("discovered"),
+                external_wait("awaiting_dependencies"),
+                command_driven("scheduled"),
+                command_driven("planning"),
+                command_driven("implementing"),
+                command_driven("replanning"),
+                external_wait("pr_open"),
+                command_driven("local_review_gate"),
+                external_wait("awaiting_feedback"),
+                command_driven("addressing_feedback"),
+                parent_handoff("quality_gate_pending"),
+                operator_gate("ready_to_merge"),
+                command_driven("merging"),
+                operator_gate("blocked"),
+                terminal_state("done", WorkflowTerminalState::Succeeded),
+                terminal_state("failed", WorkflowTerminalState::Failed),
+                terminal_state("cancelled", WorkflowTerminalState::Cancelled),
             ],
             rules: GITHUB_ISSUE_PR_RULES,
         },
         ExpectedDefinition {
             id: "prompt_task",
             states: &[
-                ("submitted", None),
-                ("awaiting_dependencies", None),
-                ("implementing", None),
-                ("blocked", None),
-                ("done", Some(WorkflowTerminalState::Succeeded)),
-                ("failed", Some(WorkflowTerminalState::Failed)),
-                ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+                command_driven("submitted"),
+                external_wait("awaiting_dependencies"),
+                command_driven("implementing"),
+                operator_gate("blocked"),
+                terminal_state("done", WorkflowTerminalState::Succeeded),
+                terminal_state("failed", WorkflowTerminalState::Failed),
+                terminal_state("cancelled", WorkflowTerminalState::Cancelled),
             ],
             rules: PROMPT_TASK_RULES,
         },
         ExpectedDefinition {
             id: "quality_gate",
             states: &[
-                ("pending", None),
-                ("checking", None),
-                ("blocked", None),
-                ("passed", Some(WorkflowTerminalState::Succeeded)),
-                ("failed", Some(WorkflowTerminalState::Failed)),
-                ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+                command_driven("pending"),
+                command_driven("checking"),
+                operator_gate("blocked"),
+                terminal_state("passed", WorkflowTerminalState::Succeeded),
+                terminal_state("failed", WorkflowTerminalState::Failed),
+                terminal_state("cancelled", WorkflowTerminalState::Cancelled),
             ],
             rules: QUALITY_GATE_RULES,
         },
         ExpectedDefinition {
             id: "pr_feedback",
             states: &[
-                ("pending", None),
-                ("inspecting", None),
-                ("feedback_found", None),
-                ("no_actionable_feedback", None),
-                ("ready_to_merge", None),
-                ("blocked", None),
-                ("done", Some(WorkflowTerminalState::Succeeded)),
-                ("failed", Some(WorkflowTerminalState::Failed)),
-                ("cancelled", Some(WorkflowTerminalState::Cancelled)),
+                command_driven("pending"),
+                command_driven("inspecting"),
+                parent_handoff("feedback_found"),
+                parent_handoff("no_actionable_feedback"),
+                parent_handoff("ready_to_merge"),
+                operator_gate("blocked"),
+                terminal_state("done", WorkflowTerminalState::Succeeded),
+                terminal_state("failed", WorkflowTerminalState::Failed),
+                terminal_state("cancelled", WorkflowTerminalState::Cancelled),
             ],
             rules: PR_FEEDBACK_RULES,
         },
@@ -90,7 +147,7 @@ fn builtins_preserve_literal_states_terminal_mappings_and_transition_rules() {
             .expect("literal built-in definition should be registered");
         assert_eq!(actual.id, expected_definition.id);
         assert_eq!(actual.states.len(), expected_definition.states.len());
-        for (actual_state, (expected_state, expected_terminal)) in
+        for (actual_state, (expected_state, expected_progress, expected_terminal)) in
             actual.states.iter().zip(expected_definition.states)
         {
             assert_eq!(
@@ -98,6 +155,7 @@ fn builtins_preserve_literal_states_terminal_mappings_and_transition_rules() {
                 expected_definition.id
             );
             assert_eq!(actual_state.key.state.as_ref(), *expected_state);
+            assert_eq!(actual_state.progress_mode, *expected_progress);
             assert_eq!(actual_state.terminal_state, *expected_terminal);
         }
 
@@ -116,6 +174,230 @@ fn builtins_preserve_literal_states_terminal_mappings_and_transition_rules() {
                     .collect::<BTreeSet<_>>(),
                 expected_commands.iter().copied().collect::<BTreeSet<_>>()
             );
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ProgressOwner {
+    RuntimeJobDriver(WorkflowCommandType),
+    ExternalObserver(&'static str),
+    OperatorAction(&'static str),
+    ParentPropagation(&'static str),
+}
+
+#[test]
+fn progress_mode_semantics_match_authoritative_ownership_matrix() {
+    use WorkflowCommandType::{EnqueueActivity, StartChildWorkflow};
+    use WorkflowProgressMode::{CommandDriven, ExternalWait, OperatorGate, ParentHandoff};
+
+    let expected = [
+        (
+            "github_issue_pr",
+            "discovered",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "github_issue_pr",
+            "awaiting_dependencies",
+            ExternalWait,
+            ProgressOwner::ExternalObserver("runtime_dependency_release_observer"),
+        ),
+        (
+            "github_issue_pr",
+            "scheduled",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "github_issue_pr",
+            "planning",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "github_issue_pr",
+            "implementing",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "github_issue_pr",
+            "replanning",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "github_issue_pr",
+            "pr_open",
+            ExternalWait,
+            ProgressOwner::ExternalObserver("pr_feedback_sweeper_local_review_selector"),
+        ),
+        (
+            "github_issue_pr",
+            "local_review_gate",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "github_issue_pr",
+            "awaiting_feedback",
+            ExternalWait,
+            ProgressOwner::ExternalObserver("pr_feedback_sweeper_feedback_selector"),
+        ),
+        (
+            "github_issue_pr",
+            "addressing_feedback",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(StartChildWorkflow),
+        ),
+        (
+            "github_issue_pr",
+            "quality_gate_pending",
+            ParentHandoff,
+            ProgressOwner::ParentPropagation("quality_gate_child_completion"),
+        ),
+        (
+            "github_issue_pr",
+            "ready_to_merge",
+            OperatorGate,
+            ProgressOwner::OperatorAction("merge_approval"),
+        ),
+        (
+            "github_issue_pr",
+            "merging",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "github_issue_pr",
+            "blocked",
+            OperatorGate,
+            ProgressOwner::OperatorAction("authorized_recovery"),
+        ),
+        (
+            "prompt_task",
+            "submitted",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "prompt_task",
+            "awaiting_dependencies",
+            ExternalWait,
+            ProgressOwner::ExternalObserver("runtime_dependency_release_observer"),
+        ),
+        (
+            "prompt_task",
+            "implementing",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "prompt_task",
+            "blocked",
+            OperatorGate,
+            ProgressOwner::OperatorAction("authorized_recovery"),
+        ),
+        (
+            "quality_gate",
+            "pending",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "quality_gate",
+            "checking",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "quality_gate",
+            "blocked",
+            OperatorGate,
+            ProgressOwner::OperatorAction("authorized_recovery"),
+        ),
+        (
+            "pr_feedback",
+            "pending",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "pr_feedback",
+            "inspecting",
+            CommandDriven,
+            ProgressOwner::RuntimeJobDriver(EnqueueActivity),
+        ),
+        (
+            "pr_feedback",
+            "feedback_found",
+            ParentHandoff,
+            ProgressOwner::ParentPropagation("pr_feedback_child_completion"),
+        ),
+        (
+            "pr_feedback",
+            "no_actionable_feedback",
+            ParentHandoff,
+            ProgressOwner::ParentPropagation("pr_feedback_child_completion"),
+        ),
+        (
+            "pr_feedback",
+            "ready_to_merge",
+            ParentHandoff,
+            ProgressOwner::ParentPropagation("pr_feedback_child_completion"),
+        ),
+        (
+            "pr_feedback",
+            "blocked",
+            OperatorGate,
+            ProgressOwner::OperatorAction("authorized_recovery"),
+        ),
+    ];
+
+    let actual = known_workflow_definition_ids()
+        .into_iter()
+        .flat_map(|definition_id| {
+            workflow_states_for_definition(&definition_id)
+                .into_iter()
+                .filter_map(move |state| {
+                    state
+                        .progress_mode
+                        .map(|mode| (definition_id.clone(), state.key.state.to_string(), mode))
+                })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(actual.len(), expected.len());
+
+    for ((definition_id, state, mode, owner), (actual_definition, actual_state, actual_mode)) in
+        expected.iter().zip(&actual)
+    {
+        assert_eq!(actual_definition, definition_id);
+        assert_eq!(actual_state, state);
+        assert_eq!(actual_mode, mode);
+        match (mode, owner) {
+            (CommandDriven, ProgressOwner::RuntimeJobDriver(command_type)) => {
+                let command = WorkflowCommand::new(*command_type, "semantic-fixture", json!({}));
+                assert!(
+                    command.requires_runtime_job(),
+                    "{definition_id}.{state} must name a runtime-job-producing driver"
+                );
+            }
+            (ExternalWait, ProgressOwner::ExternalObserver(observer)) => assert!(matches!(
+                *observer,
+                "runtime_dependency_release_observer"
+                    | "pr_feedback_sweeper_local_review_selector"
+                    | "pr_feedback_sweeper_feedback_selector"
+            )),
+            (OperatorGate, ProgressOwner::OperatorAction(action)) => {
+                assert!(matches!(*action, "merge_approval" | "authorized_recovery"))
+            }
+            (ParentHandoff, ProgressOwner::ParentPropagation(hook)) => assert!(matches!(
+                *hook,
+                "quality_gate_child_completion" | "pr_feedback_child_completion"
+            )),
+            _ => panic!("{definition_id}.{state} has a mode/owner category mismatch"),
         }
     }
 }

--- a/crates/harness-workflow/tests/state_registry_public_api.rs
+++ b/crates/harness-workflow/tests/state_registry_public_api.rs
@@ -1,7 +1,7 @@
 use harness_workflow::runtime::{
     register_workflow_definition, workflow_definition, RegisteredWorkflowDefinition,
     TransitionAllowlist, TransitionRule, WorkflowDefinition as PersistedWorkflowDefinition,
-    WorkflowStateDefinition,
+    WorkflowProgressMode, WorkflowStateDefinition,
 };
 
 #[test]
@@ -10,8 +10,16 @@ fn downstream_crate_can_construct_and_register_a_runtime_definition() {
     let definition = RegisteredWorkflowDefinition::new(
         definition_id,
         vec![
-            WorkflowStateDefinition::active(definition_id, "pending"),
-            WorkflowStateDefinition::active(definition_id, "running"),
+            WorkflowStateDefinition::active(
+                definition_id,
+                "pending",
+                WorkflowProgressMode::ExternalWait,
+            ),
+            WorkflowStateDefinition::active(
+                definition_id,
+                "running",
+                WorkflowProgressMode::OperatorGate,
+            ),
         ],
         TransitionAllowlist::new(vec![TransitionRule::new("pending", "running", [])]),
     );
@@ -23,6 +31,10 @@ fn downstream_crate_can_construct_and_register_a_runtime_definition() {
         .expect("downstream runtime definition should be available after registration");
     assert_eq!(registered.id, definition_id);
     assert_eq!(registered.states.len(), 2);
+    assert_eq!(
+        registered.states[1].progress_mode,
+        Some(WorkflowProgressMode::OperatorGate)
+    );
 
     let persisted = PersistedWorkflowDefinition::new(definition_id, 1, "Downstream fixture");
     assert_eq!(persisted.id, registered.id);


### PR DESCRIPTION
## Summary

- add a closed `WorkflowProgressMode` contract for every nonterminal registered state
- encode the authoritative progress ownership matrix for all four built-in workflow definitions
- reject registry entries that declare neither or both progress and terminal metadata
- add exhaustive matrix, semantic owner, unknown-state, downstream API, and callable wake-path tests

## Scope

This is the partial `SP1603-T001` foundation only. Decision enforcement, persistence rejection, historical diagnostics, and operator projection remain in later slices.

## Verification

- `cargo test -p harness-workflow state_registry -- --nocapture` (11 passed)
- `cargo test -p harness-workflow registry_covers_validator_transition_states -- --nocapture`
- `cargo test -p harness-workflow progress_mode_semantics -- --nocapture`
- `cargo test -p harness-server progress_wake_paths -- --nocapture`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1603`

Refs #1603
