### PR TITLE
fix(workflow): enforce progress drivers

### DIFF
--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -941,8 +941,8 @@ async fn persist_local_review_passed(
 ) -> anyhow::Result<()> {
     let project_id = ctx.project_root.to_string_lossy().into_owned();
     let PrRuntimeTarget {
-        mut instance,
-        mut new_instance,
+        instance,
+        new_instance,
         issue_number,
     } = load_or_pr_runtime_target(
         store,
@@ -955,26 +955,10 @@ async fn persist_local_review_passed(
         "pr_open",
     )
     .await?;
-    if instance.state == "pr_open" {
-        let workflow_id = instance.id.clone();
-        persist_completed_local_review_gate_record(
-            store,
-            instance,
-            new_instance,
-            issue_number,
-            ctx,
-        )
-        .await?;
-        let Some(loaded) = store.get_instance(&workflow_id).await? else {
-            anyhow::bail!("workflow runtime instance `{workflow_id}` was not found after local review gate record");
-        };
-        instance = loaded;
-        new_instance = false;
-    }
     if instance.state == "awaiting_feedback" {
         return Ok(());
     }
-    if instance.state != "local_review_gate" {
+    if !matches!(instance.state.as_str(), "pr_open" | "local_review_gate") {
         tracing::debug!(
             workflow_id = %instance.id,
             state = %instance.state,
@@ -1015,54 +999,6 @@ async fn persist_local_review_passed(
         new_instance,
         output.decision,
         "LocalReviewPassed",
-        "workflow_runtime_pr_feedback",
-        json!({
-            "task_id": ctx.task_id.as_str(),
-            "issue_number": issue_number,
-            "repo": ctx.repo,
-            "pr_number": ctx.pr_number,
-            "pr_url": ctx.pr_url,
-            "summary": ctx.summary,
-        }),
-        accepted_data,
-    )
-    .await?
-    .into_result()
-}
-
-async fn persist_completed_local_review_gate_record(
-    store: &WorkflowRuntimeStore,
-    instance: WorkflowInstance,
-    new_instance: bool,
-    issue_number: Option<u64>,
-    ctx: &LocalReviewPassedRuntimeContext<'_>,
-) -> anyhow::Result<()> {
-    let project_id = ctx.project_root.to_string_lossy().into_owned();
-    let accepted_data = pr_runtime_data(
-        ctx.project_root,
-        project_id,
-        ctx.repo,
-        issue_number,
-        ctx.task_id,
-        ctx.pr_number,
-        ctx.pr_url,
-        Some(ctx.summary),
-    );
-    let decision = WorkflowDecision::new(
-        &instance.id,
-        &instance.state,
-        "record_completed_local_review_gate",
-        "local_review_gate",
-        "Local review already passed; record the local review gate before remote feedback.",
-    )
-    .with_evidence(WorkflowEvidence::new("local_review", ctx.summary))
-    .high_confidence();
-    commit_runtime_decision(
-        store,
-        instance,
-        new_instance,
-        decision,
-        "LocalReviewGateRecorded",
         "workflow_runtime_pr_feedback",
         json!({
             "task_id": ctx.task_id.as_str(),

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -37,6 +37,7 @@ pub mod submission;
 pub mod terminal_state;
 pub mod tier_resolution;
 pub mod validator;
+mod validator_progress;
 pub mod worker;
 
 #[cfg(test)]

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -325,6 +325,21 @@ fn reduce_success(
     let mut workflow_decision =
         WorkflowDecision::new(&instance.id, &instance.state, decision, next_state, reason)
             .with_evidence(runtime_completion_evidence(event, result));
+    if instance.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID
+        && instance.state == "replanning"
+        && result.activity == "replan_issue"
+        && next_state == "implementing"
+    {
+        let completion_command_id =
+            event_field_string(event, "command_id").unwrap_or_else(|| event.id.clone());
+        workflow_decision = workflow_decision.with_command(WorkflowCommand::enqueue_activity(
+            "implement_issue",
+            format!(
+                "issue-replan:{}:implement:{completion_command_id}",
+                instance.id
+            ),
+        ));
+    }
     if instance.definition_id == PROMPT_TASK_DEFINITION_ID
         && instance.state == "implementing"
         && result.activity == PROMPT_TASK_IMPLEMENT_ACTIVITY

--- a/crates/harness-workflow/src/runtime/state_registry_equivalence_tests.rs
+++ b/crates/harness-workflow/src/runtime/state_registry_equivalence_tests.rs
@@ -455,6 +455,7 @@ const GITHUB_ISSUE_PR_RULES: &[ExpectedRule] = &[
     (Some("scheduled"), "pr_open", &[B, E, S, W]),
     (Some("pr_open"), "pr_open", &[B, W]),
     (Some("pr_open"), "local_review_gate", &[E, W]),
+    (Some("pr_open"), "awaiting_feedback", &[W]),
     (Some("local_review_gate"), "local_review_gate", &[E, W]),
     (Some("local_review_gate"), "awaiting_feedback", &[W]),
     (

--- a/crates/harness-workflow/src/runtime/submission.rs
+++ b/crates/harness-workflow/src/runtime/submission.rs
@@ -3,7 +3,6 @@ use super::model::{
     WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowEvidence, WorkflowInstance,
 };
 use super::plan_issue::ISSUE_PLAN_ACTIVITY;
-use super::remote_facts::remote_fact_command_dedupe_key;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -93,16 +92,7 @@ pub fn build_issue_submission_decision(
         reason,
     );
     if !input.dependencies_blocked && input.force_execute {
-        let dedupe_key = submission_command_dedupe_key(
-            "implement_issue",
-            input.remote_fact_hash,
-            format!(
-                "issue-submit:{}:issue:{}:task:{}:implement",
-                repo_key(input.repo),
-                input.issue_number,
-                input.task_id
-            ),
-        );
+        let dedupe_key = format!("{}:{}:submit", instance.id, instance.state);
         let command = WorkflowCommand::new(
             WorkflowCommandType::EnqueueActivity,
             dedupe_key,
@@ -119,16 +109,7 @@ pub fn build_issue_submission_decision(
         );
         decision = append_candidate_commands(decision, command, input.candidate_fanout.as_ref());
     } else if !input.dependencies_blocked {
-        let dedupe_key = submission_command_dedupe_key(
-            ISSUE_PLAN_ACTIVITY,
-            input.remote_fact_hash,
-            format!(
-                "issue-submit:{}:issue:{}:task:{}:plan",
-                repo_key(input.repo),
-                input.issue_number,
-                input.task_id
-            ),
-        );
+        let dedupe_key = format!("{}:{}:submit", instance.id, instance.state);
         decision = decision.with_command(WorkflowCommand::new(
             WorkflowCommandType::EnqueueActivity,
             dedupe_key,
@@ -224,14 +205,4 @@ fn depends_on_summary(depends_on: &[String]) -> String {
 
 fn repo_key(repo: Option<&str>) -> &str {
     repo.unwrap_or("<none>")
-}
-
-fn submission_command_dedupe_key(
-    activity: &str,
-    remote_fact_hash: Option<&str>,
-    fallback: String,
-) -> String {
-    remote_fact_hash
-        .map(|fact_hash| remote_fact_command_dedupe_key(activity, fact_hash))
-        .unwrap_or(fallback)
 }

--- a/crates/harness-workflow/src/runtime/tests/completion_reducer_core.rs
+++ b/crates/harness-workflow/src/runtime/tests/completion_reducer_core.rs
@@ -1,5 +1,5 @@
 #[test]
-fn runtime_completion_reducer_resumes_after_replan() {
+fn event_transition_dedupe_keys() {
     let instance = issue_instance("replanning");
     let result = ActivityResult::succeeded("replan_issue", "Replan completed.");
     let event = WorkflowEvent::new(
@@ -20,6 +20,15 @@ fn runtime_completion_reducer_resumes_after_replan() {
 
     assert_eq!(decision.decision, "resume_implementation_after_replan");
     assert_eq!(decision.next_state, "implementing");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].activity_name(),
+        Some("implement_issue")
+    );
+    assert_eq!(
+        decision.commands[0].dedupe_key,
+        format!("issue-replan:{}:implement:command-1", instance.id)
+    );
     DecisionValidator::github_issue_pr()
         .validate(
             &instance,

--- a/crates/harness-workflow/src/runtime/tests/decision_builders.rs
+++ b/crates/harness-workflow/src/runtime/tests/decision_builders.rs
@@ -1,5 +1,5 @@
 #[test]
-fn issue_submission_decision_starts_discovered_issue_planning() {
+fn submission_driver_dedupe_key() {
     let labels = vec!["bug".to_string(), "p1".to_string()];
     let instance = issue_instance("discovered");
     let output = build_issue_submission_decision(
@@ -29,7 +29,7 @@ fn issue_submission_decision_starts_discovered_issue_planning() {
     );
     assert_eq!(
         output.decision.commands[0].dedupe_key,
-        "issue-submit:owner/repo:issue:123:task:task-1:plan"
+        format!("{}:discovered:submit", instance.id)
     );
     assert_eq!(
         output.decision.commands[0].command["additional_prompt"],

--- a/crates/harness-workflow/src/runtime/tests/decision_validator.rs
+++ b/crates/harness-workflow/src/runtime/tests/decision_validator.rs
@@ -404,6 +404,323 @@ fn rejects_replan_after_replan_budget_is_exhausted() {
 }
 
 #[test]
+fn rejects_driverless_command_driven_transitions() {
+    let cases = [
+        (
+            "github_issue_pr",
+            DecisionValidator::github_issue_pr(),
+            issue_instance("implementing"),
+            "implementing",
+            "replanning",
+        ),
+        (
+            "prompt_task",
+            DecisionValidator::prompt_task(),
+            prompt_task_instance("implementing"),
+            "implementing",
+            "implementing",
+        ),
+        (
+            "quality_gate",
+            DecisionValidator::quality_gate(),
+            quality_gate_instance("pending"),
+            "pending",
+            "checking",
+        ),
+        (
+            "pr_feedback",
+            DecisionValidator::pr_feedback(),
+            WorkflowInstance::new(
+                PR_FEEDBACK_DEFINITION_ID,
+                1,
+                "pending",
+                WorkflowSubject::new("pull_request", "issue:123"),
+            ),
+            "pending",
+            "inspecting",
+        ),
+    ];
+
+    for (case_name, validator, instance, observed_state, next_state) in cases {
+        let decision = WorkflowDecision::new(
+            instance.id.clone(),
+            observed_state,
+            "driverless_transition",
+            next_state,
+            "no runtime work was created",
+        );
+        let err = validator
+            .validate(&instance, &decision, &validation_context())
+            .expect_err("command-driven targets must reject driverless decisions");
+        assert_eq!(
+            err.kind,
+            WorkflowDecisionRejectionKind::ProgressDriverMissing,
+            "failed case: {case_name}"
+        );
+    }
+}
+
+#[test]
+fn scalar_and_array_command_payloads_are_rejected() {
+    for (case_name, payload) in [("scalar", json!("wait")), ("array", json!([]))] {
+        let instance = issue_instance("discovered");
+        let decision = WorkflowDecision::new(
+            instance.id.clone(),
+            "discovered",
+            "await_dependencies",
+            "awaiting_dependencies",
+            "dependencies remain unresolved",
+        )
+        .with_command(WorkflowCommand::new(
+            WorkflowCommandType::Wait,
+            format!("invalid-payload:{case_name}"),
+            payload,
+        ));
+        let err = DecisionValidator::github_issue_pr()
+            .validate(&instance, &decision, &validation_context())
+            .expect_err("non-object command payloads must be rejected");
+        assert_eq!(
+            err.kind,
+            WorkflowDecisionRejectionKind::InvalidCommandPayload,
+            "failed case: {case_name}"
+        );
+        assert!(err.message.contains("must be a JSON object"));
+    }
+}
+
+#[test]
+fn empty_and_omitted_commands_share_progress_rejection() {
+    let instance = issue_instance("implementing");
+    let decision_json = json!({
+        "workflow_id": instance.id,
+        "observed_state": "implementing",
+        "decision": "run_replan",
+        "next_state": "replanning",
+        "reason": "replanning was requested without runtime work",
+        "confidence": "medium"
+    });
+    let omitted: WorkflowDecision =
+        serde_json::from_value(decision_json.clone()).expect("deserialize omitted commands");
+    let mut empty_json = decision_json;
+    empty_json["commands"] = json!([]);
+    let empty: WorkflowDecision =
+        serde_json::from_value(empty_json).expect("deserialize empty commands");
+
+    for decision in [&omitted, &empty] {
+        let err = DecisionValidator::github_issue_pr()
+            .validate(&instance, decision, &validation_context())
+            .expect_err("omitted and empty commands must both be rejected");
+        assert_eq!(
+            err.kind,
+            WorkflowDecisionRejectionKind::ProgressDriverMissing
+        );
+    }
+}
+
+#[test]
+fn wait_and_inline_commands_do_not_drive_progress() {
+    let validator = DecisionValidator::new(
+        super::validator::TransitionAllowlist::default().allow(
+            "implementing",
+            "implementing",
+            [
+                WorkflowCommandType::Wait,
+                WorkflowCommandType::RecordPlanConcern,
+                WorkflowCommandType::BindPr,
+                WorkflowCommandType::RequestOperatorAttention,
+            ],
+        ),
+    );
+    let cases = [
+        WorkflowCommand::wait("still waiting", "non-driver:wait"),
+        WorkflowCommand::record_plan_concern("audit concern", "non-driver:audit"),
+        WorkflowCommand::bind_pr(
+            77,
+            "https://github.com/owner/repo/pull/77",
+            "non-driver:bind-pr",
+        ),
+        WorkflowCommand::new(
+            WorkflowCommandType::RequestOperatorAttention,
+            "non-driver:operator-attention",
+            json!({ "reason": "operator review requested" }),
+        ),
+    ];
+
+    for command in cases {
+        let instance = issue_instance("implementing");
+        let decision = WorkflowDecision::new(
+            instance.id.clone(),
+            "implementing",
+            "inline_only",
+            "implementing",
+            "no runtime job-producing command was included",
+        )
+        .with_command(command);
+        let err = validator
+            .validate(&instance, &decision, &validation_context())
+            .expect_err("non-runtime commands must not drive command-driven progress");
+        assert_eq!(
+            err.kind,
+            WorkflowDecisionRejectionKind::ProgressDriverMissing
+        );
+    }
+}
+
+#[test]
+fn allows_declared_non_command_progress_modes() {
+    let external_wait = issue_instance("discovered");
+    let external_wait_decision = WorkflowDecision::new(
+        external_wait.id.clone(),
+        "discovered",
+        "await_dependencies",
+        "awaiting_dependencies",
+        "dependency observer owns the wake-up",
+    )
+    .with_command(WorkflowCommand::wait(
+        "dependencies unresolved",
+        "progress-mode:external-wait",
+    ));
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &external_wait,
+            &external_wait_decision,
+            &validation_context(),
+        )
+        .expect("external waits may remain without a runtime-job-producing command");
+
+    let operator_gate = issue_instance("implementing");
+    let operator_gate_decision = WorkflowDecision::new(
+        operator_gate.id.clone(),
+        "implementing",
+        "block",
+        "blocked",
+        "operator recovery owns resolution",
+    )
+    .with_command(WorkflowCommand::mark_blocked(
+        "operator action required",
+        "progress-mode:operator-gate",
+    ));
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &operator_gate,
+            &operator_gate_decision,
+            &validation_context(),
+        )
+        .expect("operator gates do not require runtime-job-producing commands");
+
+    let parent_handoff = issue_instance("quality_gate_pending");
+    let parent_handoff_decision = WorkflowDecision::new(
+        parent_handoff.id.clone(),
+        "quality_gate_pending",
+        "quality_passed",
+        "ready_to_merge",
+        "the child result was propagated to its parent",
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &parent_handoff,
+            &parent_handoff_decision,
+            &validation_context(),
+        )
+        .expect("parent handoffs do not require runtime-job-producing commands");
+
+    let terminal = quality_gate_instance("checking");
+    let terminal_decision = WorkflowDecision::new(
+        terminal.id.clone(),
+        "checking",
+        "quality_passed",
+        "passed",
+        "quality checks passed",
+    );
+    DecisionValidator::quality_gate()
+        .validate(&terminal, &terminal_decision, &validation_context())
+        .expect("terminal targets do not require runtime-job-producing commands");
+}
+
+#[test]
+fn runtime_recovery_requires_progress_driver() {
+    let instance = issue_instance("blocked");
+    let decision = WorkflowDecision::new(
+        instance.id.clone(),
+        "blocked",
+        "operator_runtime_unblock",
+        "implementing",
+        "operator recovery omitted runtime work",
+    );
+    let err = DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("workflow_runtime_operator_action", Utc::now()),
+        )
+        .expect_err("operator recovery cannot bypass the progress contract");
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::ProgressDriverMissing
+    );
+}
+
+#[test]
+fn stale_active_work_does_not_satisfy_progress() {
+    let instance = issue_instance("implementing");
+    let decision = WorkflowDecision::new(
+        instance.id.clone(),
+        "implementing",
+        "run_replan",
+        "replanning",
+        "the decision attempted to rely on older active work",
+    );
+    let context = validation_context().with_active_dedupe_key("stale:replan-command");
+    let err = DecisionValidator::github_issue_pr()
+        .validate(&instance, &decision, &context)
+        .expect_err("active work outside the decision must not satisfy progress");
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::ProgressDriverMissing
+    );
+}
+
+#[test]
+fn runtime_job_producing_commands_drive_progress() {
+    let enqueue_instance = issue_instance("implementing");
+    let enqueue_decision = WorkflowDecision::new(
+        enqueue_instance.id.clone(),
+        "implementing",
+        "run_replan",
+        "replanning",
+        "enqueue a replan activity",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "replan_issue",
+        "progress-driver:enqueue",
+    ));
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &enqueue_instance,
+            &enqueue_decision,
+            &validation_context(),
+        )
+        .expect("EnqueueActivity should drive command-driven progress");
+
+    let child_instance = issue_instance("awaiting_feedback");
+    let child_decision = WorkflowDecision::new(
+        child_instance.id.clone(),
+        "awaiting_feedback",
+        "address_feedback",
+        "addressing_feedback",
+        "start the feedback child workflow",
+    )
+    .with_command(WorkflowCommand::start_child_workflow(
+        PR_FEEDBACK_DEFINITION_ID,
+        "issue:123",
+        "progress-driver:child",
+    ));
+    DecisionValidator::github_issue_pr()
+        .validate(&child_instance, &child_decision, &validation_context())
+        .expect("StartChildWorkflow should drive command-driven progress");
+}
+
+#[test]
 fn runtime_job_and_activity_result_round_trip_through_json() {
     let result = ActivityResult::succeeded(
         "replan_issue",

--- a/crates/harness-workflow/src/runtime/tests/issue_planning.rs
+++ b/crates/harness-workflow/src/runtime/tests/issue_planning.rs
@@ -33,7 +33,7 @@ fn issue_submission_decision_force_execute_starts_implementation() {
     );
     assert_eq!(
         output.decision.commands[0].dedupe_key,
-        "issue-submit:owner/repo:issue:123:task:task-force:implement"
+        format!("{}:discovered:submit", instance.id)
     );
     DecisionValidator::github_issue_pr()
         .validate(
@@ -45,7 +45,7 @@ fn issue_submission_decision_force_execute_starts_implementation() {
 }
 
 #[test]
-fn issue_submission_decision_uses_remote_fact_hash_for_implementation_dedupe() {
+fn issue_submission_decision_keeps_remote_fact_hash_out_of_initial_dedupe() {
     let labels = Vec::new();
     let instance = issue_instance("discovered");
     let output = build_issue_submission_decision(
@@ -67,7 +67,7 @@ fn issue_submission_decision_uses_remote_fact_hash_for_implementation_dedupe() {
 
     assert_eq!(
         output.decision.commands[0].dedupe_key,
-        "implement_issue:sha256:abc"
+        format!("{}:discovered:submit", instance.id)
     );
     assert_eq!(
         output.decision.commands[0].command["dispatch_gate"]["reason"],
@@ -152,11 +152,11 @@ fn candidate_fanout_force_execute_starts_deferred_candidate_commands() -> anyhow
     assert_eq!(output.decision.commands.len(), 2);
     assert_eq!(
         output.decision.commands[0].dedupe_key,
-        "implement_issue:sha256:fanout:candidate:c1"
+        format!("{}:discovered:submit:candidate:c1", instance.id)
     );
     assert_eq!(
         output.decision.commands[1].dedupe_key,
-        "implement_issue:sha256:fanout:candidate:c2"
+        format!("{}:discovered:submit:candidate:c2", instance.id)
     );
     for (index, command) in output.decision.commands.iter().enumerate() {
         let candidate_index = index + 1;

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -1,4 +1,5 @@
 use super::model::{WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowInstance};
+use super::validator_progress;
 use chrono::{DateTime, Utc};
 use std::collections::BTreeSet;
 use std::fmt;
@@ -202,6 +203,7 @@ impl TransitionAllowlist {
             )
             .allow("pr_open", "pr_open", [BindPr, Wait])
             .allow("pr_open", "local_review_gate", [EnqueueActivity, Wait])
+            .allow("pr_open", "awaiting_feedback", [Wait])
             .allow(
                 "local_review_gate",
                 "local_review_gate",
@@ -390,6 +392,7 @@ pub enum WorkflowDecisionRejectionKind {
     TerminalReopenDenied,
     RequiredCommandMissing,
     InvalidCommandPayload,
+    ProgressDriverMissing,
     MissingTerminalEvidence,
 }
 
@@ -400,7 +403,7 @@ pub struct WorkflowDecisionRejection {
 }
 
 impl WorkflowDecisionRejection {
-    fn new(kind: WorkflowDecisionRejectionKind, message: impl Into<String>) -> Self {
+    pub(super) fn new(kind: WorkflowDecisionRejectionKind, message: impl Into<String>) -> Self {
         Self {
             kind,
             message: message.into(),
@@ -528,7 +531,7 @@ impl DecisionValidator {
             }
         }
 
-        if self.validate_hidden_workflow_transition(decision, context)? {
+        if self.validate_hidden_workflow_transition(instance, decision, context)? {
             return Ok(());
         }
 
@@ -546,6 +549,7 @@ impl DecisionValidator {
         };
 
         self.validate_commands(rule, decision, context)?;
+        validator_progress::validate_target_progress_contract(instance, decision)?;
         self.validate_workflow_specific_rules(decision, context)
     }
 
@@ -565,6 +569,13 @@ impl DecisionValidator {
         let mut seen_dedupe_keys = BTreeSet::new();
 
         for command in &decision.commands {
+            let Some(payload) = command.command.as_object() else {
+                return Err(WorkflowDecisionRejection::new(
+                    WorkflowDecisionRejectionKind::InvalidCommandPayload,
+                    "workflow command payload must be a JSON object",
+                ));
+            };
+
             if !rule.allowed_commands.contains(&command.command_type) {
                 return Err(WorkflowDecisionRejection::new(
                     WorkflowDecisionRejectionKind::CommandNotAllowed,
@@ -575,8 +586,8 @@ impl DecisionValidator {
                 ));
             }
 
+            self.validate_command_payload(command, payload)?;
             self.validate_dedupe(command, &mut seen_dedupe_keys, context)?;
-            self.validate_command_payload(command)?;
 
             if command.requires_runtime_job() && !context.resource_budget_available {
                 return Err(WorkflowDecisionRejection::new(
@@ -641,6 +652,7 @@ impl DecisionValidator {
 
     fn validate_hidden_workflow_transition(
         &self,
+        instance: &WorkflowInstance,
         decision: &WorkflowDecision,
         context: &ValidationContext,
     ) -> Result<bool, WorkflowDecisionRejection> {
@@ -658,6 +670,7 @@ impl DecisionValidator {
             [WorkflowCommandType::MarkDone],
         );
         self.validate_commands(&rule, decision, context)?;
+        validator_progress::validate_target_progress_contract(instance, decision)?;
         github_issue_pr_validation::validate_reconciliation_only_pr_merge_done(decision, context)?;
         Ok(true)
     }
@@ -665,13 +678,13 @@ impl DecisionValidator {
     fn validate_command_payload(
         &self,
         command: &WorkflowCommand,
+        payload: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<(), WorkflowDecisionRejection> {
         if command.command_type != WorkflowCommandType::BindPr {
             return Ok(());
         }
 
-        if command
-            .command
+        if payload
             .get("pr_number")
             .and_then(serde_json::Value::as_u64)
             .is_none()
@@ -682,8 +695,7 @@ impl DecisionValidator {
             ));
         }
 
-        if command
-            .command
+        if payload
             .get("pr_url")
             .and_then(serde_json::Value::as_str)
             .is_none_or(|value| value.trim().is_empty())

--- a/crates/harness-workflow/src/runtime/validator_progress.rs
+++ b/crates/harness-workflow/src/runtime/validator_progress.rs
@@ -1,0 +1,34 @@
+use super::model::{WorkflowDecision, WorkflowInstance};
+use super::state_registry::{self, WorkflowProgressMode};
+use super::validator::{WorkflowDecisionRejection, WorkflowDecisionRejectionKind};
+
+pub(super) fn validate_target_progress_contract(
+    instance: &WorkflowInstance,
+    decision: &WorkflowDecision,
+) -> Result<(), WorkflowDecisionRejection> {
+    if !state_registry::workflow_state_exists(&instance.definition_id, &decision.next_state) {
+        return Err(WorkflowDecisionRejection::new(
+            WorkflowDecisionRejectionKind::TransitionNotAllowed,
+            format!(
+                "target state '{}.{}' has no registered progress contract",
+                instance.definition_id, decision.next_state
+            ),
+        ));
+    }
+    let progress_mode =
+        state_registry::workflow_state_progress_mode(&instance.definition_id, &decision.next_state);
+    let has_driver = decision
+        .commands
+        .iter()
+        .any(super::model::WorkflowCommand::requires_runtime_job);
+    if progress_mode == Some(WorkflowProgressMode::CommandDriven) && !has_driver {
+        return Err(WorkflowDecisionRejection::new(
+            WorkflowDecisionRejectionKind::ProgressDriverMissing,
+            format!(
+                "command-driven target state '{}.{}' requires an allowlisted runtime-job-producing command in the same decision",
+                instance.definition_id, decision.next_state
+            ),
+        ));
+    }
+    Ok(())
+}


### PR DESCRIPTION
Refs #1603

Implements SP1603-T002 and SP1603-T003.

- reject non-object command payloads before command-specific field reads
- require same-decision runtime drivers for command-driven target states
- use stable initial-submission and event-derived transition dedupe keys
- route recovery, structured decisions, submission, and reconciliation through the shared validator
- preserve completed local-review reconciliation without queuing duplicate review work

Validation:
- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo test --workspace -- --test-threads=1 (with dedicated non-production Postgres)
- cargo clippy --workspace --all-targets -- -D warnings
- T002/T003 named SpecRail tests
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1603
- python3 checks/check_workflow.py --repo .