### PR TITLE
fix(runtime-host): add fenced lease renewal

### DIFF
--- a/crates/harness-server/src/handlers/mod.rs
+++ b/crates/harness-server/src/handlers/mod.rs
@@ -35,6 +35,9 @@ mod runtime_hosts_api_tests;
 #[cfg(test)]
 mod runtime_hosts_workflow_api_tests;
 
+#[cfg(test)]
+mod runtime_hosts_workflow_review_tests;
+
 /// Validate a project root path, returning early with an `INTERNAL_ERROR`
 /// response on failure.
 ///

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -59,6 +59,7 @@ pub async fn register_runtime_host(
     if let Err(response) = ensure_runtime_state_persistence_available(&state) {
         return response;
     }
+    let _host_operation = state.runtime_hosts.lock_operation(host_id).await;
     let host = state.runtime_hosts.register(
         host_id.to_string(),
         req.display_name.map(|v| v.trim().to_string()),
@@ -74,6 +75,7 @@ pub async fn heartbeat_runtime_host(
     State(state): State<Arc<AppState>>,
     Path(host_id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
     match state.runtime_hosts.heartbeat(&host_id) {
         Ok(host) => {
             // Heartbeat is intentionally not persisted (transient data, self-healing
@@ -104,6 +106,7 @@ pub async fn deregister_runtime_host(
     if let Err(response) = ensure_runtime_state_persistence_available(&state) {
         return response;
     }
+    let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
     if !state.runtime_hosts.hosts.contains_key(&host_id) {
         // Host already gone from memory (idempotent retry).  If a prior
         // deregister mutated memory but failed to persist, converge now.
@@ -226,6 +229,7 @@ pub async fn claim_task_for_runtime_host(
     Path(host_id): Path<String>,
     Json(req): Json<ClaimTaskRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
     if !state.runtime_hosts.hosts.contains_key(&host_id) {
         return (
             StatusCode::NOT_FOUND,
@@ -332,6 +336,7 @@ pub async fn claim_runtime_job_for_runtime_host(
             )
         }
     };
+    let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
     if !state.runtime_hosts.hosts.contains_key(&host_id) {
         return (
             StatusCode::NOT_FOUND,
@@ -461,6 +466,7 @@ pub async fn complete_runtime_job_for_runtime_host(
     Path((host_id, runtime_job_id)): Path<(String, String)>,
     Json(req): Json<CompleteRuntimeJobRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
     if !state.runtime_hosts.hosts.contains_key(&host_id) {
         return (
             StatusCode::NOT_FOUND,

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -1,10 +1,10 @@
 use crate::http::AppState;
 use axum::{
-    extract::{Path, State},
+    extract::{rejection::JsonRejection, Path, State},
     http::StatusCode,
     Json,
 };
-use chrono::{DateTime, TimeDelta, Utc};
+use chrono::{DateTime, Utc};
 use harness_workflow::runtime::{
     ActivityResult, RuntimeJobClaimDecision, RuntimeJobClaimGuard, RuntimeJobNotFoundError,
     RuntimeKind, WorkflowRuntimeStore,
@@ -12,6 +12,9 @@ use harness_workflow::runtime::{
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
+
+mod lease;
+pub use lease::renew_runtime_job_lease_for_runtime_host;
 
 #[derive(Debug, Deserialize)]
 pub struct RegisterRuntimeHostRequest {
@@ -30,6 +33,8 @@ pub struct ClaimTaskRequest {
 #[derive(Debug, Deserialize)]
 pub struct CompleteRuntimeJobRequest {
     pub lease_expires_at: DateTime<Utc>,
+    #[serde(default)]
+    pub lease_generation: Option<u64>,
     pub result: ActivityResult,
 }
 
@@ -112,6 +117,63 @@ pub async fn deregister_runtime_host(
             Json(json!({ "error": "runtime host not found" })),
         )
     } else {
+        let Some(previous_lifecycle) = state.runtime_hosts.mark_draining(&host_id) else {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "runtime host not found" })),
+            );
+        };
+        if let Err(response) = persist_runtime_state(&state).await {
+            state
+                .runtime_hosts
+                .set_lifecycle(&host_id, previous_lifecycle);
+            return response;
+        }
+
+        let store = match workflow_runtime_store(&state) {
+            Ok(store) => store,
+            Err(response) => return response,
+        };
+        if let Err(error) = store
+            .revoke_remote_host_runtime_job_leases(&host_id, Utc::now())
+            .await
+        {
+            tracing::error!(
+                host_id = %host_id,
+                error = %error,
+                "failed to revoke workflow runtime-job leases during deregistration"
+            );
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({ "error": "workflow runtime store unavailable" })),
+            );
+        }
+        match store.count_remote_host_runtime_job_leases(&host_id).await {
+            Ok(0) => {}
+            Ok(remaining) => {
+                tracing::error!(
+                    host_id = %host_id,
+                    remaining_leases = remaining,
+                    "runtime host remains draining because workflow leases remain owned"
+                );
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({ "error": "runtime host lease revocation incomplete" })),
+                );
+            }
+            Err(error) => {
+                tracing::error!(
+                    host_id = %host_id,
+                    error = %error,
+                    "failed to confirm workflow runtime-job revocation"
+                );
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({ "error": "workflow runtime store unavailable" })),
+                );
+            }
+        }
+
         match state.core.tasks.release_runtime_host_claims(&host_id).await {
             Ok(released) => {
                 if !released.is_empty() {
@@ -129,7 +191,7 @@ pub async fn deregister_runtime_host(
                     "failed to release runtime-host-owned task leases during deregistration"
                 );
                 return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
+                    StatusCode::SERVICE_UNAVAILABLE,
                     Json(json!({
                         "error": format!("failed to release task leases for runtime host: {e}")
                     })),
@@ -137,6 +199,11 @@ pub async fn deregister_runtime_host(
             }
         }
 
+        let draining_record = state
+            .runtime_hosts
+            .hosts
+            .get(&host_id)
+            .map(|host| host.clone());
         if !state.runtime_hosts.deregister(&host_id) {
             tracing::warn!(
                 host_id = %host_id,
@@ -145,6 +212,9 @@ pub async fn deregister_runtime_host(
         }
         state.runtime_project_cache.clear_host(&host_id);
         if let Err(response) = persist_runtime_state(&state).await {
+            if let Some(record) = draining_record {
+                state.runtime_hosts.hosts.insert(host_id.clone(), record);
+            }
             return response;
         }
         (StatusCode::OK, Json(json!({ "deregistered": true })))
@@ -160,6 +230,12 @@ pub async fn claim_task_for_runtime_host(
         return (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": format!("runtime host '{host_id}' is not registered") })),
+        );
+    }
+    if !state.runtime_hosts.is_active(&host_id) {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": "runtime host is draining" })),
         );
     }
 
@@ -245,12 +321,27 @@ pub async fn claim_task_for_runtime_host(
 pub async fn claim_runtime_job_for_runtime_host(
     State(state): State<Arc<AppState>>,
     Path(host_id): Path<String>,
-    Json(req): Json<ClaimTaskRequest>,
+    payload: Result<Json<lease::ClaimRuntimeJobRequest>, JsonRejection>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    let Json(req) = match payload {
+        Ok(payload) => payload,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "invalid runtime job claim request" })),
+            )
+        }
+    };
     if !state.runtime_hosts.hosts.contains_key(&host_id) {
         return (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": format!("runtime host '{host_id}' is not registered") })),
+        );
+    }
+    if !state.runtime_hosts.is_active(&host_id) {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": "runtime host is draining" })),
         );
     }
     let store = match workflow_runtime_store(&state) {
@@ -267,7 +358,7 @@ pub async fn claim_runtime_job_for_runtime_host(
             );
         }
     }
-    let lease_expires_at = match runtime_host_lease_expires_at(req.lease_secs) {
+    let lease_expires_at = match lease::runtime_host_lease_expires_at(req.lease_secs.value()) {
         Ok(value) => value,
         Err(response) => return response,
     };
@@ -351,26 +442,8 @@ pub async fn claim_runtime_job_for_runtime_host(
         }
     }
 
-    if let Err(e) = store
-        .record_runtime_event(
-            &job.id,
-            "RuntimeJobClaimed",
-            json!({
-                "owner": host_id.as_str(),
-                "lease_expires_at": lease_expires_at,
-                "claim_api": "runtime_host",
-            }),
-        )
-        .await
-    {
-        tracing::warn!(
-            runtime_job_id = %job.id,
-            error = %e,
-            "runtime host claim succeeded but runtime event recording failed"
-        );
-    }
-
     let runtime_job_id = job.id.clone();
+    let lease_generation = job.lease_generation;
     (
         StatusCode::OK,
         Json(json!({
@@ -378,6 +451,7 @@ pub async fn claim_runtime_job_for_runtime_host(
             "runtime_job": job,
             "runtime_job_id": runtime_job_id,
             "lease_expires_at": lease_expires_at,
+            "lease_generation": lease_generation,
         })),
     )
 }
@@ -392,6 +466,9 @@ pub async fn complete_runtime_job_for_runtime_host(
             StatusCode::NOT_FOUND,
             Json(json!({ "error": format!("runtime host '{host_id}' is not registered") })),
         );
+    }
+    if !state.runtime_hosts.is_active(&host_id) {
+        return lease::lease_lost_response();
     }
     let store = match workflow_runtime_store(&state) {
         Ok(store) => store,
@@ -408,10 +485,11 @@ pub async fn complete_runtime_job_for_runtime_host(
     };
 
     let completion = match store
-        .commit_runtime_activity_completion_if_owned(
+        .commit_runtime_activity_completion_if_owned_with_generation(
             &runtime_job_id,
             &host_id,
             req.lease_expires_at,
+            req.lease_generation,
             &req.result,
         )
         .await
@@ -512,47 +590,6 @@ fn workflow_runtime_store(
         (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json!({ "error": "workflow runtime store unavailable" })),
-        )
-    })
-}
-
-fn runtime_host_lease_expires_at(
-    lease_secs: Option<u64>,
-) -> Result<DateTime<Utc>, (StatusCode, Json<serde_json::Value>)> {
-    let lease_secs = match lease_secs {
-        Some(value) => match i64::try_from(value) {
-            Ok(value) => value,
-            Err(_) => {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({ "error": "lease_secs must be <= i64::MAX" })),
-                ));
-            }
-        },
-        None => crate::runtime_hosts::DEFAULT_LEASE_SECS,
-    }
-    .max(0);
-    let lease_duration = match TimeDelta::try_seconds(lease_secs) {
-        Some(value) => value,
-        None => {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(json!({
-                    "error": format!(
-                        "lease_secs value {lease_secs} is too large to compute a valid expiration timestamp"
-                    )
-                })),
-            ));
-        }
-    };
-    Utc::now().checked_add_signed(lease_duration).ok_or_else(|| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({
-                "error": format!(
-                    "lease_secs value {lease_secs} is too large to compute a valid expiration timestamp"
-                )
-            })),
         )
     })
 }

--- a/crates/harness-server/src/handlers/runtime_hosts/lease.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/lease.rs
@@ -1,0 +1,224 @@
+use crate::http::AppState;
+use axum::{
+    extract::{rejection::JsonRejection, Path, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::{DateTime, TimeDelta, Utc};
+use harness_workflow::runtime::store::runtime_job_leases::{
+    RuntimeJobLeaseRenewalOutcome, RuntimeJobLeaseRenewalRequest,
+};
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Debug, Default)]
+pub struct OptionalLeaseSecs(Option<u64>);
+
+impl OptionalLeaseSecs {
+    pub(super) fn value(&self) -> Option<u64> {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for OptionalLeaseSecs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        u64::deserialize(deserializer).map(|value| Self(Some(value)))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ClaimRuntimeJobRequest {
+    #[serde(default)]
+    pub lease_secs: OptionalLeaseSecs,
+    pub project: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RenewRuntimeJobLeaseRequest {
+    pub lease_generation: u64,
+    pub lease_expires_at: DateTime<Utc>,
+    pub renewal_id: Uuid,
+    #[serde(default)]
+    lease_secs: OptionalLeaseSecs,
+}
+
+pub async fn renew_runtime_job_lease_for_runtime_host(
+    State(state): State<Arc<AppState>>,
+    Path((host_id, runtime_job_id)): Path<(String, String)>,
+    payload: Result<Json<RenewRuntimeJobLeaseRequest>, JsonRejection>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Json(req) = match payload {
+        Ok(payload) => payload,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "invalid lease renewal request" })),
+            )
+        }
+    };
+    if !state.runtime_hosts.hosts.contains_key(&host_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "runtime host not found" })),
+        );
+    }
+    if !state.runtime_hosts.is_active(&host_id) {
+        return lease_lost_response();
+    }
+    let lease_secs = match validated_runtime_host_lease_secs(req.lease_secs.value()) {
+        Ok(value) => value,
+        Err(response) => return response,
+    };
+    let Some(store) = state.core.workflow_runtime_store.clone() else {
+        return workflow_store_unavailable_response();
+    };
+    let outcome = store
+        .renew_remote_host_runtime_job_lease(RuntimeJobLeaseRenewalRequest {
+            runtime_job_id: &runtime_job_id,
+            owner: &host_id,
+            lease_generation: req.lease_generation,
+            previous_expires_at: req.lease_expires_at,
+            renewal_id: req.renewal_id,
+            lease_secs,
+            now: Utc::now(),
+            max_lease_secs: crate::runtime_hosts::MAX_LEASE_SECS,
+            owner_active: true,
+        })
+        .await;
+    match outcome {
+        Ok(RuntimeJobLeaseRenewalOutcome::Renewed {
+            lease_generation,
+            lease_expires_at,
+            replayed,
+        }) => (
+            StatusCode::OK,
+            Json(json!({
+                "renewed": true,
+                "runtime_job_id": runtime_job_id,
+                "lease_generation": lease_generation,
+                "lease_expires_at": lease_expires_at,
+                "replayed": replayed,
+            })),
+        ),
+        Ok(RuntimeJobLeaseRenewalOutcome::LeaseLost { .. }) => lease_lost_response(),
+        Ok(RuntimeJobLeaseRenewalOutcome::NotFound) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "runtime job not found" })),
+        ),
+        Err(error) => {
+            tracing::error!(
+                host_id = %host_id,
+                runtime_job_id = %runtime_job_id,
+                error = %error,
+                "runtime host lease renewal failed"
+            );
+            workflow_store_unavailable_response()
+        }
+    }
+}
+
+pub(super) fn runtime_host_lease_expires_at(
+    lease_secs: Option<u64>,
+) -> Result<DateTime<Utc>, (StatusCode, Json<serde_json::Value>)> {
+    runtime_host_lease_expires_at_at(Utc::now(), lease_secs)
+}
+
+fn runtime_host_lease_expires_at_at(
+    now: DateTime<Utc>,
+    lease_secs: Option<u64>,
+) -> Result<DateTime<Utc>, (StatusCode, Json<serde_json::Value>)> {
+    let lease_secs = validated_runtime_host_lease_secs(lease_secs)?;
+    let duration = TimeDelta::try_seconds(lease_secs).ok_or_else(invalid_duration_response)?;
+    now.checked_add_signed(duration)
+        .ok_or_else(invalid_duration_response)
+}
+
+fn validated_runtime_host_lease_secs(
+    lease_secs: Option<u64>,
+) -> Result<i64, (StatusCode, Json<serde_json::Value>)> {
+    let value = lease_secs.unwrap_or(crate::runtime_hosts::DEFAULT_LEASE_SECS as u64);
+    if !(1..=crate::runtime_hosts::MAX_LEASE_SECS as u64).contains(&value) {
+        return Err(invalid_duration_response());
+    }
+    Ok(value as i64)
+}
+
+fn invalid_duration_response() -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({ "error": "lease_secs must be between 1 and 3600" })),
+    )
+}
+
+pub(super) fn lease_lost_response() -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::CONFLICT,
+        Json(json!({
+            "error_code": "lease_lost",
+            "must_stop": true,
+        })),
+    )
+}
+
+fn workflow_store_unavailable_response() -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({ "error": "workflow runtime store unavailable" })),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn runtime_job_lease_duration_accepts_default_and_boundaries() {
+        let now = DateTime::parse_from_rfc3339("2026-07-16T00:00:00Z")
+            .expect("fixed timestamp must parse")
+            .to_utc();
+        assert_eq!(
+            runtime_host_lease_expires_at_at(now, None).expect("default duration must be valid"),
+            now + TimeDelta::seconds(60)
+        );
+        assert_eq!(
+            runtime_host_lease_expires_at_at(now, Some(1)).expect("minimum duration must be valid"),
+            now + TimeDelta::seconds(1)
+        );
+        assert_eq!(
+            runtime_host_lease_expires_at_at(now, Some(3600))
+                .expect("maximum duration must be valid"),
+            now + TimeDelta::seconds(3600)
+        );
+    }
+
+    #[test]
+    fn runtime_job_lease_duration_rejects_zero_oversized_and_null() {
+        assert!(validated_runtime_host_lease_secs(Some(0)).is_err());
+        assert!(validated_runtime_host_lease_secs(Some(3601)).is_err());
+        assert!(validated_runtime_host_lease_secs(Some(u64::MAX)).is_err());
+
+        let request = json!({
+            "lease_generation": 1,
+            "lease_expires_at": "2026-07-16T00:00:00Z",
+            "renewal_id": Uuid::nil(),
+            "lease_secs": null,
+        });
+        assert!(serde_json::from_value::<RenewRuntimeJobLeaseRequest>(request).is_err());
+    }
+
+    #[test]
+    fn runtime_job_lease_lost_response_is_stable_and_sanitized() {
+        let (status, body) = lease_lost_response();
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(
+            body.0,
+            json!({ "error_code": "lease_lost", "must_stop": true })
+        );
+    }
+}

--- a/crates/harness-server/src/handlers/runtime_hosts/lease.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/lease.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use chrono::{DateTime, TimeDelta, Utc};
 use harness_workflow::runtime::store::runtime_job_leases::{
-    RuntimeJobLeaseRenewalOutcome, RuntimeJobLeaseRenewalRequest,
+    postgres_timestamp_ceil, RuntimeJobLeaseRenewalOutcome, RuntimeJobLeaseRenewalRequest,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -138,6 +138,7 @@ fn runtime_host_lease_expires_at_at(
     let lease_secs = validated_runtime_host_lease_secs(lease_secs)?;
     let duration = TimeDelta::try_seconds(lease_secs).ok_or_else(invalid_duration_response)?;
     now.checked_add_signed(duration)
+        .and_then(postgres_timestamp_ceil)
         .ok_or_else(invalid_duration_response)
 }
 
@@ -198,6 +199,22 @@ mod tests {
                 .expect("maximum duration must be valid"),
             now + TimeDelta::seconds(3600)
         );
+    }
+
+    #[test]
+    fn runtime_job_lease_duration_ceils_submicrosecond_server_time() {
+        use chrono::Timelike;
+
+        let now = DateTime::parse_from_rfc3339("2026-07-16T00:00:00.123456789Z")
+            .expect("fixed timestamp must parse")
+            .to_utc();
+        let raw_expiry = now + TimeDelta::seconds(60);
+        let expiry = runtime_host_lease_expires_at_at(now, Some(60))
+            .expect("normalized duration must be valid");
+
+        assert!(expiry >= raw_expiry);
+        assert!(expiry - raw_expiry < TimeDelta::microseconds(1));
+        assert_eq!(expiry.nanosecond() % 1_000, 0);
     }
 
     #[test]

--- a/crates/harness-server/src/handlers/runtime_hosts/lease.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/lease.rs
@@ -1,4 +1,5 @@
 use crate::http::AppState;
+use crate::runtime_hosts::RuntimeHostLifecycle;
 use axum::{
     extract::{rejection::JsonRejection, Path, State},
     http::StatusCode,
@@ -61,15 +62,17 @@ pub async fn renew_runtime_job_lease_for_runtime_host(
             )
         }
     };
-    if !state.runtime_hosts.hosts.contains_key(&host_id) {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({ "error": "runtime host not found" })),
-        );
-    }
-    if !state.runtime_hosts.is_active(&host_id) {
-        return lease_lost_response();
-    }
+    let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
+    let owner_active = match state.runtime_hosts.lifecycle(&host_id) {
+        Some(RuntimeHostLifecycle::Active) => true,
+        Some(RuntimeHostLifecycle::Draining) => false,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "runtime host not found" })),
+            )
+        }
+    };
     let lease_secs = match validated_runtime_host_lease_secs(req.lease_secs.value()) {
         Ok(value) => value,
         Err(response) => return response,
@@ -87,7 +90,7 @@ pub async fn renew_runtime_job_lease_for_runtime_host(
             lease_secs,
             now: Utc::now(),
             max_lease_secs: crate::runtime_hosts::MAX_LEASE_SECS,
-            owner_active: true,
+            owner_active,
         })
         .await;
     match outcome {

--- a/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_api_tests.rs
@@ -5,6 +5,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use harness_workflow::runtime::WorkflowRuntimeStore;
 use std::sync::Arc;
 use tower::ServiceExt;
 
@@ -37,7 +38,16 @@ async fn make_test_state(
         return Ok(None);
     }
     match crate::test_helpers::make_test_state(dir).await {
-        Ok(state) => Ok(Some(Arc::new(state))),
+        Ok(state) => {
+            let store =
+                Arc::new(WorkflowRuntimeStore::open(&dir.join("workflow_runtime.db")).await?);
+            let mut state = Arc::new(state);
+            Arc::get_mut(&mut state)
+                .ok_or_else(|| anyhow::anyhow!("expected unique test state"))?
+                .core
+                .workflow_runtime_store = Some(store);
+            Ok(Some(state))
+        }
         Err(err) if crate::test_helpers::is_pool_timeout(&err) => Ok(None),
         Err(err) => Err(err),
     }
@@ -193,7 +203,9 @@ async fn claim_endpoint_blocks_double_claim() -> anyhow::Result<()> {
 #[tokio::test]
 async fn deregister_releases_scheduler_owned_pending_tasks() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
-    let state = Arc::new(crate::test_helpers::make_test_state(dir.path()).await?);
+    let Some(state) = make_test_state(dir.path()).await? else {
+        return Ok(());
+    };
     let mut task = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
         status: crate::task_runner::TaskStatus::Pending,
@@ -693,7 +705,9 @@ async fn claim_endpoint_rejects_overflowing_lease_ttl() -> anyhow::Result<()> {
 #[tokio::test]
 async fn deregister_keeps_host_registered_when_claim_release_fails() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
-    let state = Arc::new(crate::test_helpers::make_test_state(dir.path()).await?);
+    let Some(state) = make_test_state(dir.path()).await? else {
+        return Ok(());
+    };
     let mut task = crate::task_runner::TaskState {
         id: crate::task_runner::TaskId::new(),
         status: crate::task_runner::TaskStatus::Pending,
@@ -761,7 +775,7 @@ async fn deregister_keeps_host_registered_when_claim_release_fails() -> anyhow::
         .await?;
     assert_eq!(
         response.status(),
-        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        axum::http::StatusCode::SERVICE_UNAVAILABLE
     );
     assert!(state.runtime_hosts.hosts.contains_key("host-a"));
 

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
@@ -15,7 +15,7 @@ use harness_workflow::runtime::{
     WorkflowRuntimeStore, WorkflowSubject,
 };
 
-fn runtime_hosts_workflow_app(state: Arc<crate::http::AppState>) -> Router {
+pub(super) fn runtime_hosts_workflow_app(state: Arc<crate::http::AppState>) -> Router {
     Router::new()
         .route(
             "/api/runtime-hosts/register",
@@ -40,7 +40,7 @@ fn runtime_hosts_workflow_app(state: Arc<crate::http::AppState>) -> Router {
         .with_state(state)
 }
 
-async fn make_test_state_with_runtime_store(
+pub(super) async fn make_test_state_with_runtime_store(
     dir: &std::path::Path,
 ) -> anyhow::Result<Option<(Arc<crate::http::AppState>, Arc<WorkflowRuntimeStore>)>> {
     if !crate::test_helpers::db_tests_enabled().await {
@@ -60,7 +60,7 @@ async fn make_test_state_with_runtime_store(
     Ok(Some((state, store)))
 }
 
-async fn register_host(app: &Router, host_id: &str) -> anyhow::Result<()> {
+pub(super) async fn register_host(app: &Router, host_id: &str) -> anyhow::Result<()> {
     let response = app
         .clone()
         .oneshot(
@@ -75,7 +75,7 @@ async fn register_host(app: &Router, host_id: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn enqueue_runtime_host_test_job(
+pub(super) async fn enqueue_runtime_host_test_job(
     store: &WorkflowRuntimeStore,
     key: &str,
     runtime_kind: RuntimeKind,
@@ -101,7 +101,7 @@ async fn enqueue_runtime_host_test_job(
         .await
 }
 
-async fn post_json(
+pub(super) async fn post_json(
     app: &Router,
     uri: String,
     body: serde_json::Value,
@@ -111,7 +111,7 @@ async fn post_json(
     Ok(json)
 }
 
-async fn post_json_with_status(
+pub(super) async fn post_json_with_status(
     app: &Router,
     uri: String,
     body: serde_json::Value,

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
@@ -29,6 +29,14 @@ fn runtime_hosts_workflow_app(state: Arc<crate::http::AppState>) -> Router {
             "/api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/complete",
             post(runtime_hosts::complete_runtime_job_for_runtime_host),
         )
+        .route(
+            "/api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/lease/renew",
+            post(runtime_hosts::renew_runtime_job_lease_for_runtime_host),
+        )
+        .route(
+            "/api/runtime-hosts/{id}/deregister",
+            post(runtime_hosts::deregister_runtime_host),
+        )
         .with_state(state)
 }
 
@@ -166,6 +174,7 @@ async fn runtime_job_claim_endpoint_claims_remote_host_jobs_only() -> anyhow::Re
     .await?;
     assert_eq!(json["claimed"], true);
     assert_eq!(json["runtime_job_id"], remote_job.id);
+    assert_eq!(json["lease_generation"], 1);
     assert_eq!(json["runtime_job"]["runtime_kind"], "remote_host");
     assert_eq!(json["runtime_job"]["input"]["activity"], "remote_check");
     assert_eq!(
@@ -262,9 +271,10 @@ async fn runtime_job_claim_endpoint_defers_open_circuit_profile() -> anyhow::Res
         .not_before
         .is_some_and(|not_before| not_before > now));
     let events = store.runtime_events_for(&job.id).await?;
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].event_type, "RuntimeJobClaimDeferred");
-    assert_eq!(events[0].event["claim_api"], "runtime_host");
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event_type, "RuntimeJobClaimed");
+    assert_eq!(events[1].event_type, "RuntimeJobClaimDeferred");
+    assert_eq!(events[1].event["claim_api"], "runtime_host");
     Ok(())
 }
 
@@ -286,14 +296,15 @@ async fn runtime_job_claim_endpoint_reclaims_expired_remote_job() -> anyhow::Res
         json!({ "activity": "remote_check" }),
     )
     .await?;
-    let first = post_json(
-        &app,
-        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
-        json!({ "lease_secs": 0 }),
-    )
-    .await?;
-    assert_eq!(first["runtime_job_id"], job.id);
-    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    let first = store
+        .claim_next_runtime_job_for_runtime_kind(
+            RuntimeKind::RemoteHost,
+            "host-a",
+            Utc::now() - chrono::TimeDelta::seconds(1),
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("host-a should claim the runtime job"))?;
+    assert_eq!(first.id, job.id);
 
     let second = post_json(
         &app,
@@ -397,5 +408,175 @@ async fn runtime_job_completion_endpoint_returns_not_found_for_missing_job() -> 
 
     assert_eq!(status, StatusCode::NOT_FOUND);
     assert_eq!(body["error"], "runtime job not found: missing-job");
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_lease_renewal_is_fenced_idempotent_and_sanitized() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state);
+    register_host(&app, "host-a").await?;
+    register_host(&app, "host-b").await?;
+    let job = enqueue_runtime_host_test_job(
+        &store,
+        "renewal",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({ "activity": "remote_check" }),
+    )
+    .await?;
+    let claimed = post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+    let request = json!({
+        "lease_generation": claimed["lease_generation"],
+        "lease_expires_at": claimed["lease_expires_at"],
+        "renewal_id": uuid::Uuid::new_v4(),
+        "lease_secs": 120,
+    });
+    let uri = format!(
+        "/api/runtime-hosts/host-a/runtime-jobs/{}/lease/renew",
+        job.id
+    );
+    let renewed = post_json(&app, uri.clone(), request.clone()).await?;
+    assert_eq!(renewed["renewed"], true);
+    assert_eq!(renewed["replayed"], false);
+    assert_eq!(renewed["lease_generation"], claimed["lease_generation"]);
+
+    let replayed = post_json(&app, uri, request.clone()).await?;
+    assert_eq!(replayed["replayed"], true);
+    assert_eq!(replayed["lease_expires_at"], renewed["lease_expires_at"]);
+
+    let lease_generation = claimed["lease_generation"]
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("claim must return a numeric lease generation"))?;
+    let result = ActivityResult::failed(
+        "remote_check",
+        "Remote host reported a failed activity.",
+        "remote execution failed",
+    );
+    let (status, _) = post_json_with_status(
+        &app,
+        format!("/api/runtime-hosts/host-a/runtime-jobs/{}/complete", job.id),
+        json!({
+            "lease_generation": lease_generation + 1,
+            "lease_expires_at": renewed["lease_expires_at"],
+            "result": result,
+        }),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    let (status, lost) = post_json_with_status(
+        &app,
+        format!(
+            "/api/runtime-hosts/host-b/runtime-jobs/{}/lease/renew",
+            job.id
+        ),
+        request,
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        lost,
+        json!({ "error_code": "lease_lost", "must_stop": true })
+    );
+    assert!(!lost.to_string().contains("host-a"));
+
+    let completed = post_json(
+        &app,
+        format!("/api/runtime-hosts/host-a/runtime-jobs/{}/complete", job.id),
+        json!({
+            "lease_generation": lease_generation,
+            "lease_expires_at": renewed["lease_expires_at"],
+            "result": ActivityResult::failed(
+                "remote_check",
+                "Remote host reported a failed activity.",
+                "remote execution failed",
+            ),
+        }),
+    )
+    .await?;
+    assert_eq!(completed["completed"], true);
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_lease_renewal_rejects_invalid_duration_as_bad_request() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, _store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state);
+    register_host(&app, "host-a").await?;
+
+    for lease_secs in [json!(0), json!(3601), json!(null)] {
+        let (status, _) = post_json_with_status(
+            &app,
+            "/api/runtime-hosts/host-a/runtime-jobs/missing/lease/renew".to_string(),
+            json!({
+                "lease_generation": 1,
+                "lease_expires_at": Utc::now(),
+                "renewal_id": uuid::Uuid::new_v4(),
+                "lease_secs": lease_secs,
+            }),
+        )
+        .await?;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_host_deregister_revokes_workflow_job_before_removal() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state.clone());
+    register_host(&app, "host-a").await?;
+    let job = enqueue_runtime_host_test_job(
+        &store,
+        "deregister-revocation",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({ "activity": "remote_check" }),
+    )
+    .await?;
+    post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/deregister")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(!state.runtime_hosts.hosts.contains_key("host-a"));
+    let persisted = store
+        .get_runtime_job(&job.id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("runtime job should remain persisted"))?;
+    assert_eq!(persisted.status, RuntimeJobStatus::Pending);
+    assert!(persisted.lease.is_none());
+    let events = store.runtime_events_for(&job.id).await?;
+    assert_eq!(
+        events.last().map(|event| event.event_type.as_str()),
+        Some("RuntimeJobLeaseRevoked")
+    );
     Ok(())
 }

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_review_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_review_tests.rs
@@ -1,0 +1,242 @@
+use super::runtime_hosts_workflow_api_tests as support;
+use axum::{body::Body, http::Request};
+use chrono::Utc;
+use harness_workflow::runtime::{RuntimeJobStatus, RuntimeKind};
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::{oneshot, Barrier};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn runtime_job_lease_renewal_for_draining_host_is_audited_and_sanitized() -> anyhow::Result<()>
+{
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = support::make_test_state_with_runtime_store(dir.path()).await?
+    else {
+        return Ok(());
+    };
+    let app = support::runtime_hosts_workflow_app(state.clone());
+    support::register_host(&app, "host-a").await?;
+    let job = support::enqueue_runtime_host_test_job(
+        &store,
+        "draining-renewal",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({ "activity": "remote_check" }),
+    )
+    .await?;
+    let claimed = support::post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+    assert_eq!(
+        state.runtime_hosts.mark_draining("host-a"),
+        Some(crate::runtime_hosts::RuntimeHostLifecycle::Active)
+    );
+
+    let request = json!({
+        "lease_generation": claimed["lease_generation"],
+        "lease_expires_at": claimed["lease_expires_at"],
+        "renewal_id": uuid::Uuid::new_v4(),
+        "lease_secs": 60,
+    });
+    let (status, body) = support::post_json_with_status(
+        &app,
+        format!(
+            "/api/runtime-hosts/host-a/runtime-jobs/{}/lease/renew",
+            job.id
+        ),
+        request.clone(),
+    )
+    .await?;
+    assert_eq!(status, axum::http::StatusCode::CONFLICT);
+    assert_eq!(
+        body,
+        json!({ "error_code": "lease_lost", "must_stop": true })
+    );
+    let events = store.runtime_events_for(&job.id).await?;
+    let rejected = events.last().expect("draining rejection must be audited");
+    assert_eq!(rejected.event_type, "RuntimeJobLeaseRenewalRejected");
+    assert_eq!(rejected.event["reason"], "host_draining");
+
+    let (status, _) = support::post_json_with_status(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/missing/lease/renew".to_string(),
+        request,
+    )
+    .await?;
+    assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+    assert_eq!(store.runtime_events_for(&job.id).await?.len(), events.len());
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_lease_renew_route_requires_api_authentication() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((mut state, _store)) = support::make_test_state_with_runtime_store(dir.path()).await?
+    else {
+        return Ok(());
+    };
+    let state_mut = Arc::get_mut(&mut state).expect("test state must be uniquely owned");
+    let mut config = state_mut.core.server.config.clone();
+    config.server.api_token = Some("runtime-host-secret".to_string());
+    config.server.allow_unauthenticated = false;
+    state_mut.core.server = Arc::new(crate::server::HarnessServer::new(
+        config,
+        crate::thread_manager::ThreadManager::new(),
+        harness_agents::registry::AgentRegistry::new("test"),
+    ));
+    let app = support::runtime_hosts_workflow_app(state.clone()).layer(
+        axum::middleware::from_fn_with_state(state, crate::http::auth::api_auth_middleware),
+    );
+    let body = json!({
+        "lease_generation": 1,
+        "lease_expires_at": Utc::now(),
+        "renewal_id": uuid::Uuid::new_v4(),
+        "lease_secs": 60,
+    });
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/runtime-jobs/missing/lease/renew")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/runtime-jobs/missing/lease/renew")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer runtime-host-secret")
+                .body(Body::from(body.to_string()))?,
+        )
+        .await?;
+    assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_host_operation_boundary_orders_claim_before_deregister() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = support::make_test_state_with_runtime_store(dir.path()).await?
+    else {
+        return Ok(());
+    };
+    state
+        .runtime_hosts
+        .register("host-a".to_string(), None, vec![]);
+    let job = support::enqueue_runtime_host_test_job(
+        &store,
+        "claim-deregister-order",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({ "activity": "remote_check" }),
+    )
+    .await?;
+    let held = state.runtime_hosts.lock_operation("host-a").await;
+
+    let claim_barrier = Arc::new(Barrier::new(2));
+    let (claim_waiting_tx, claim_waiting_rx) = oneshot::channel();
+    let claim_manager = state.runtime_hosts.clone();
+    let claim_store = store.clone();
+    let claim_barrier_task = claim_barrier.clone();
+    let claim = tokio::spawn(async move {
+        claim_barrier_task.wait().await;
+        claim_waiting_tx
+            .send(())
+            .expect("claim waiter receiver must exist");
+        let _operation = claim_manager.lock_operation("host-a").await;
+        assert!(claim_manager.is_active("host-a"));
+        claim_store
+            .claim_next_runtime_job_for_runtime_kind(
+                RuntimeKind::RemoteHost,
+                "host-a",
+                Utc::now() + chrono::TimeDelta::seconds(60),
+            )
+            .await
+    });
+    claim_barrier.wait().await;
+    claim_waiting_rx.await?;
+    tokio::task::yield_now().await;
+
+    let drain_barrier = Arc::new(Barrier::new(2));
+    let drain_manager = state.runtime_hosts.clone();
+    let drain_store = store.clone();
+    let drain_barrier_task = drain_barrier.clone();
+    let drain = tokio::spawn(async move {
+        drain_barrier_task.wait().await;
+        let _operation = drain_manager.lock_operation("host-a").await;
+        assert_eq!(
+            drain_manager.mark_draining("host-a"),
+            Some(crate::runtime_hosts::RuntimeHostLifecycle::Active)
+        );
+        let revoked = drain_store
+            .revoke_remote_host_runtime_job_leases("host-a", Utc::now())
+            .await?;
+        assert_eq!(revoked, 1);
+        assert!(drain_manager.deregister("host-a"));
+        anyhow::Ok(())
+    });
+    drain_barrier.wait().await;
+    drop(held);
+
+    let claimed = claim
+        .await??
+        .expect("admitted claim must commit before draining");
+    assert_eq!(claimed.id, job.id);
+    drain.await??;
+    let persisted = store
+        .get_runtime_job(&job.id)
+        .await?
+        .expect("revoked job must remain persisted");
+    assert_eq!(persisted.status, RuntimeJobStatus::Pending);
+    assert!(persisted.lease.is_none());
+    let events = store.runtime_events_for(&job.id).await?;
+    assert_eq!(events[0].event_type, "RuntimeJobClaimed");
+    assert_eq!(events[1].event_type, "RuntimeJobLeaseRevoked");
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_host_partial_deregister_remains_draining_and_retryable() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = support::make_test_state_with_runtime_store(dir.path()).await?
+    else {
+        return Ok(());
+    };
+    let app = support::runtime_hosts_workflow_app(state.clone());
+    support::register_host(&app, "host-a").await?;
+    sqlx::query("DROP TABLE runtime_jobs CASCADE")
+        .execute(store.pool())
+        .await?;
+
+    for _ in 0..2 {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/runtime-hosts/host-a/deregister")
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            state.runtime_hosts.lifecycle("host-a"),
+            Some(crate::runtime_hosts::RuntimeHostLifecycle::Draining)
+        );
+    }
+    Ok(())
+}

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_review_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_review_tests.rs
@@ -3,18 +3,46 @@ use axum::{body::Body, http::Request};
 use chrono::Utc;
 use harness_workflow::runtime::{RuntimeJobStatus, RuntimeKind};
 use serde_json::json;
+use std::future::{poll_fn, Future};
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Poll;
 use tokio::sync::{oneshot, Barrier};
 use tower::ServiceExt;
+
+async fn poll_to_pending<F: Future>(mut future: Pin<&mut F>) {
+    poll_fn(|context| match future.as_mut().poll(context) {
+        Poll::Pending => Poll::Ready(()),
+        Poll::Ready(_) => panic!("handler unexpectedly completed before race barrier release"),
+    })
+    .await;
+}
+
+async fn required_runtime_store_state(
+    dir: &std::path::Path,
+) -> anyhow::Result<(
+    Arc<crate::http::AppState>,
+    Arc<harness_workflow::runtime::WorkflowRuntimeStore>,
+)> {
+    if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
+        anyhow::bail!(
+            "GH1602 PostgreSQL tests require HARNESS_DATABASE_URL pointing to an isolated disposable database"
+        );
+    }
+    support::make_test_state_with_runtime_store(dir)
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "GH1602 PostgreSQL test database is configured but unavailable or timed out"
+            )
+        })
+}
 
 #[tokio::test]
 async fn runtime_job_lease_renewal_for_draining_host_is_audited_and_sanitized() -> anyhow::Result<()>
 {
     let dir = tempfile::tempdir()?;
-    let Some((state, store)) = support::make_test_state_with_runtime_store(dir.path()).await?
-    else {
-        return Ok(());
-    };
+    let (state, store) = required_runtime_store_state(dir.path()).await?;
     let app = support::runtime_hosts_workflow_app(state.clone());
     support::register_host(&app, "host-a").await?;
     let job = support::enqueue_runtime_host_test_job(
@@ -75,10 +103,7 @@ async fn runtime_job_lease_renewal_for_draining_host_is_audited_and_sanitized() 
 #[tokio::test]
 async fn runtime_job_lease_renew_route_requires_api_authentication() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
-    let Some((mut state, _store)) = support::make_test_state_with_runtime_store(dir.path()).await?
-    else {
-        return Ok(());
-    };
+    let (mut state, _store) = required_runtime_store_state(dir.path()).await?;
     let state_mut = Arc::get_mut(&mut state).expect("test state must be uniquely owned");
     let mut config = state_mut.core.server.config.clone();
     config.server.api_token = Some("runtime-host-secret".to_string());
@@ -127,10 +152,7 @@ async fn runtime_job_lease_renew_route_requires_api_authentication() -> anyhow::
 #[tokio::test]
 async fn runtime_host_operation_boundary_orders_claim_before_deregister() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
-    let Some((state, store)) = support::make_test_state_with_runtime_store(dir.path()).await?
-    else {
-        return Ok(());
-    };
+    let (state, store) = required_runtime_store_state(dir.path()).await?;
     state
         .runtime_hosts
         .register("host-a".to_string(), None, vec![]);
@@ -209,10 +231,7 @@ async fn runtime_host_operation_boundary_orders_claim_before_deregister() -> any
 #[tokio::test]
 async fn runtime_host_partial_deregister_remains_draining_and_retryable() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
-    let Some((state, store)) = support::make_test_state_with_runtime_store(dir.path()).await?
-    else {
-        return Ok(());
-    };
+    let (state, store) = required_runtime_store_state(dir.path()).await?;
     let app = support::runtime_hosts_workflow_app(state.clone());
     support::register_host(&app, "host-a").await?;
     sqlx::query("DROP TABLE runtime_jobs CASCADE")
@@ -238,5 +257,91 @@ async fn runtime_host_partial_deregister_remains_draining_and_retryable() -> any
             Some(crate::runtime_hosts::RuntimeHostLifecycle::Draining)
         );
     }
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_host_handler_barrier_orders_deregister_before_renew_without_orphan(
+) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (state, store) = required_runtime_store_state(dir.path()).await?;
+    let app = support::runtime_hosts_workflow_app(state.clone());
+    support::register_host(&app, "host-a").await?;
+    let job = support::enqueue_runtime_host_test_job(
+        &store,
+        "deregister-renew-handler-race",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({ "activity": "remote_check" }),
+    )
+    .await?;
+    let claimed = support::post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+    let renewal_body = json!({
+        "lease_generation": claimed["lease_generation"],
+        "lease_expires_at": claimed["lease_expires_at"],
+        "renewal_id": uuid::Uuid::new_v4(),
+        "lease_secs": 120,
+    });
+
+    let barrier = state.runtime_hosts.lock_operation("host-a").await;
+    let mut deregister = Box::pin(
+        app.clone().oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/deregister")
+                .body(Body::empty())?,
+        ),
+    );
+    poll_to_pending(deregister.as_mut()).await;
+    let mut renew = Box::pin(
+        app.clone().oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/runtime-hosts/host-a/runtime-jobs/{}/lease/renew",
+                    job.id
+                ))
+                .header("content-type", "application/json")
+                .body(Body::from(renewal_body.to_string()))?,
+        ),
+    );
+    poll_to_pending(renew.as_mut()).await;
+    drop(barrier);
+
+    let (deregister, renew) = tokio::join!(deregister, renew);
+    assert_eq!(deregister?.status(), axum::http::StatusCode::OK);
+    assert_eq!(renew?.status(), axum::http::StatusCode::NOT_FOUND);
+    assert_eq!(state.runtime_hosts.lifecycle("host-a"), None);
+
+    let persisted = store
+        .get_runtime_job(&job.id)
+        .await?
+        .expect("deregistered job must remain reclaimable");
+    assert_eq!(persisted.status, RuntimeJobStatus::Pending);
+    assert!(persisted.lease.is_none());
+    assert_eq!(
+        store.count_remote_host_runtime_job_leases("host-a").await?,
+        0
+    );
+    let events = store.runtime_events_for(&job.id).await?;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.event_type == "RuntimeJobLeaseRevoked")
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.event_type == "RuntimeJobLeaseRenewed")
+            .count(),
+        0
+    );
     Ok(())
 }

--- a/crates/harness-server/src/handlers/runtime_project_cache.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache.rs
@@ -1,5 +1,6 @@
 use crate::http::AppState;
 use crate::project_registry::{check_allowed_roots, validate_project_root};
+use crate::runtime_hosts::RuntimeHostLifecycle;
 use crate::runtime_project_cache::WatchedProjectInput;
 use axum::{
     extract::{Path, State},
@@ -47,18 +48,11 @@ pub async fn sync_runtime_host_projects(
     if let Err(response) = ensure_runtime_state_persistence_available(&state) {
         return response;
     }
-    let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
-    if !host_exists(&state, &host_id) {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "runtime host not found"})),
-        );
-    }
-    if !state.runtime_hosts.is_active(&host_id) {
-        return (
-            StatusCode::CONFLICT,
-            Json(json!({"error": "runtime host is draining"})),
-        );
+    {
+        let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
+        if let Err(response) = ensure_active_host(&state, &host_id) {
+            return response;
+        }
     }
 
     let mut inputs: Vec<WatchedProjectInput> = Vec::with_capacity(req.projects.len());
@@ -83,6 +77,10 @@ pub async fn sync_runtime_host_projects(
         });
     }
 
+    let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
+    if let Err(response) = ensure_active_host(&state, &host_id) {
+        return response;
+    }
     let snapshot = state
         .runtime_project_cache
         .sync_host_projects(&host_id, inputs);
@@ -94,6 +92,23 @@ pub async fn sync_runtime_host_projects(
 
 fn host_exists(state: &AppState, host_id: &str) -> bool {
     state.runtime_hosts.hosts.contains_key(host_id)
+}
+
+fn ensure_active_host(
+    state: &AppState,
+    host_id: &str,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    match state.runtime_hosts.lifecycle(host_id) {
+        Some(RuntimeHostLifecycle::Active) => Ok(()),
+        Some(RuntimeHostLifecycle::Draining) => Err((
+            StatusCode::CONFLICT,
+            Json(json!({"error": "runtime host is draining"})),
+        )),
+        None => Err((
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "runtime host not found"})),
+        )),
+    }
 }
 
 async fn resolve_project_token(

--- a/crates/harness-server/src/handlers/runtime_project_cache.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache.rs
@@ -48,12 +48,13 @@ pub async fn sync_runtime_host_projects(
     if let Err(response) = ensure_runtime_state_persistence_available(&state) {
         return response;
     }
-    {
+    let registration_id = {
         let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
-        if let Err(response) = ensure_active_host(&state, &host_id) {
-            return response;
+        match active_host_registration_id(&state, &host_id) {
+            Ok(registration_id) => registration_id,
+            Err(response) => return response,
         }
-    }
+    };
 
     let mut inputs: Vec<WatchedProjectInput> = Vec::with_capacity(req.projects.len());
     for item in req.projects {
@@ -78,8 +79,15 @@ pub async fn sync_runtime_host_projects(
     }
 
     let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
-    if let Err(response) = ensure_active_host(&state, &host_id) {
-        return response;
+    match active_host_registration_id(&state, &host_id) {
+        Ok(current_registration_id) if current_registration_id == registration_id => {}
+        Ok(_) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({"error": "runtime host registration changed during project sync"})),
+            )
+        }
+        Err(response) => return response,
     }
     let snapshot = state
         .runtime_project_cache
@@ -109,6 +117,22 @@ fn ensure_active_host(
             Json(json!({"error": "runtime host not found"})),
         )),
     }
+}
+
+fn active_host_registration_id(
+    state: &AppState,
+    host_id: &str,
+) -> Result<uuid::Uuid, (StatusCode, Json<serde_json::Value>)> {
+    ensure_active_host(state, host_id)?;
+    state
+        .runtime_hosts
+        .active_registration_id(host_id)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "runtime host not found"})),
+            )
+        })
 }
 
 async fn resolve_project_token(

--- a/crates/harness-server/src/handlers/runtime_project_cache.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache.rs
@@ -47,10 +47,17 @@ pub async fn sync_runtime_host_projects(
     if let Err(response) = ensure_runtime_state_persistence_available(&state) {
         return response;
     }
+    let _host_operation = state.runtime_hosts.lock_operation(&host_id).await;
     if !host_exists(&state, &host_id) {
         return (
             StatusCode::NOT_FOUND,
             Json(json!({"error": "runtime host not found"})),
+        );
+    }
+    if !state.runtime_hosts.is_active(&host_id) {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({"error": "runtime host is draining"})),
         );
     }
 
@@ -76,14 +83,6 @@ pub async fn sync_runtime_host_projects(
         });
     }
 
-    // Keep a read guard while writing cache to prevent concurrent deregister()
-    // from deleting the host between validation and cache sync.
-    let Some(_host_guard) = state.runtime_hosts.hosts.get(&host_id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "runtime host not found"})),
-        );
-    };
     let snapshot = state
         .runtime_project_cache
         .sync_host_projects(&host_id, inputs);

--- a/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
@@ -323,3 +323,74 @@ async fn sync_after_deregister_does_not_recreate_cache() -> anyhow::Result<()> {
         .is_none());
     Ok(())
 }
+
+#[tokio::test]
+async fn draining_host_cannot_repopulate_cache_after_partial_deregister() -> anyhow::Result<()> {
+    let data_dir = tempfile::tempdir()?;
+    let project_dir = tempfile::tempdir()?;
+    std::fs::create_dir_all(project_dir.path().join(".git"))?;
+
+    let Some((state, runtime_store)) =
+        super::runtime_hosts_workflow_api_tests::make_test_state_with_runtime_store(
+            data_dir.path(),
+        )
+        .await?
+    else {
+        return Ok(());
+    };
+    let app = runtime_project_cache_app(state.clone());
+
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({"host_id": "host-a"}).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(register.status(), StatusCode::OK);
+
+    sqlx::query("DROP TABLE runtime_jobs CASCADE")
+        .execute(runtime_store.pool())
+        .await?;
+    let deregister = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/deregister")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(deregister.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        state.runtime_hosts.lifecycle("host-a"),
+        Some(crate::runtime_hosts::RuntimeHostLifecycle::Draining)
+    );
+
+    state.runtime_project_cache.clear_host("host-a");
+    let stale_sync = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/projects/sync")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "projects": [{"project": project_dir.path().to_string_lossy()}]
+                    })
+                    .to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(stale_sync.status(), StatusCode::CONFLICT);
+    assert!(state
+        .runtime_project_cache
+        .get_host_cache("host-a")
+        .is_none());
+    Ok(())
+}

--- a/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
@@ -1,12 +1,60 @@
 use super::{runtime_hosts, runtime_project_cache};
+use crate::project_registry::Project;
+use crate::services::project::ProjectService;
+use async_trait::async_trait;
 use axum::{
     body::Body,
     http::{Request, StatusCode},
     routing::{get, post},
     Router,
 };
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Barrier;
 use tower::ServiceExt;
+
+struct BlockingResolveProjectService {
+    root: PathBuf,
+    entered: Arc<Barrier>,
+    release: Arc<Barrier>,
+}
+
+#[async_trait]
+impl ProjectService for BlockingResolveProjectService {
+    async fn register(&self, _project: Project) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn get(&self, _id: &str) -> anyhow::Result<Option<Project>> {
+        Ok(None)
+    }
+
+    async fn get_by_name(&self, _name: &str) -> anyhow::Result<Option<Project>> {
+        Ok(None)
+    }
+
+    async fn list(&self) -> anyhow::Result<Vec<Project>> {
+        Ok(Vec::new())
+    }
+
+    async fn remove(&self, _id: &str) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+
+    async fn resolve_path(&self, id: &str) -> anyhow::Result<Option<PathBuf>> {
+        if id != "slow-project" {
+            return Ok(None);
+        }
+        self.entered.wait().await;
+        self.release.wait().await;
+        Ok(Some(self.root.clone()))
+    }
+
+    fn default_root(&self) -> &Path {
+        &self.root
+    }
+}
 
 fn runtime_project_cache_app(state: Arc<crate::http::AppState>) -> Router {
     Router::new()
@@ -388,6 +436,86 @@ async fn draining_host_cannot_repopulate_cache_after_partial_deregister() -> any
         )
         .await?;
     assert_eq!(stale_sync.status(), StatusCode::CONFLICT);
+    assert!(state
+        .runtime_project_cache
+        .get_host_cache("host-a")
+        .is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn project_resolution_releases_host_lock_and_rechecks_draining() -> anyhow::Result<()> {
+    let data_dir = tempfile::tempdir()?;
+    let project_dir = tempfile::tempdir()?;
+    std::fs::create_dir_all(project_dir.path().join(".git"))?;
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+
+    let Some((mut state, _runtime_store)) =
+        super::runtime_hosts_workflow_api_tests::make_test_state_with_runtime_store(
+            data_dir.path(),
+        )
+        .await?
+    else {
+        return Ok(());
+    };
+    Arc::get_mut(&mut state)
+        .ok_or_else(|| anyhow::anyhow!("expected unique test state"))?
+        .project_svc = Arc::new(BlockingResolveProjectService {
+        root: project_dir.path().to_path_buf(),
+        entered: entered.clone(),
+        release: release.clone(),
+    });
+    let app = runtime_project_cache_app(state.clone());
+
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({"host_id": "host-a"}).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(register.status(), StatusCode::OK);
+
+    let sync_app = app.clone();
+    let sync_request = Request::builder()
+        .method("POST")
+        .uri("/api/runtime-hosts/host-a/projects/sync")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::json!({"projects": [{"project": "slow-project"}]}).to_string(),
+        ))?;
+    let sync = tokio::spawn(async move { sync_app.oneshot(sync_request).await });
+    entered.wait().await;
+
+    let host_lock_available = match tokio::time::timeout(
+        Duration::from_millis(250),
+        state.runtime_hosts.lock_operation("host-a"),
+    )
+    .await
+    {
+        Ok(_host_operation) => {
+            assert_eq!(
+                state.runtime_hosts.mark_draining("host-a"),
+                Some(crate::runtime_hosts::RuntimeHostLifecycle::Active)
+            );
+            true
+        }
+        Err(_) => false,
+    };
+    release.wait().await;
+    let response = sync.await??;
+
+    assert!(
+        host_lock_available,
+        "project resolution must not hold the host operation lock"
+    );
+    assert_eq!(response.status(), StatusCode::CONFLICT);
     assert!(state
         .runtime_project_cache
         .get_host_cache("host-a")

--- a/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
@@ -246,7 +246,12 @@ async fn sync_after_deregister_does_not_recreate_cache() -> anyhow::Result<()> {
     let project_dir = tempfile::tempdir()?;
     std::fs::create_dir_all(project_dir.path().join(".git"))?;
 
-    let Some(state) = make_test_state(data_dir.path()).await? else {
+    let Some((state, _runtime_store)) =
+        super::runtime_hosts_workflow_api_tests::make_test_state_with_runtime_store(
+            data_dir.path(),
+        )
+        .await?
+    else {
         return Ok(());
     };
     let app = runtime_project_cache_app(state.clone());

--- a/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_project_cache_api_tests.rs
@@ -522,3 +522,116 @@ async fn project_resolution_releases_host_lock_and_rechecks_draining() -> anyhow
         .is_none());
     Ok(())
 }
+
+#[tokio::test]
+async fn project_resolution_rejects_same_id_reregistration_aba() -> anyhow::Result<()> {
+    let data_dir = tempfile::tempdir()?;
+    let project_dir = tempfile::tempdir()?;
+    std::fs::create_dir_all(project_dir.path().join(".git"))?;
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+
+    let Some((mut state, _runtime_store)) =
+        super::runtime_hosts_workflow_api_tests::make_test_state_with_runtime_store(
+            data_dir.path(),
+        )
+        .await?
+    else {
+        return Ok(());
+    };
+    Arc::get_mut(&mut state)
+        .ok_or_else(|| anyhow::anyhow!("expected unique test state"))?
+        .project_svc = Arc::new(BlockingResolveProjectService {
+        root: project_dir.path().to_path_buf(),
+        entered: entered.clone(),
+        release: release.clone(),
+    });
+    let app = runtime_project_cache_app(state.clone());
+
+    let register = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({"host_id": "host-a"}).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(register.status(), StatusCode::OK);
+    let original_registration = state
+        .runtime_hosts
+        .active_registration_id("host-a")
+        .expect("registered host must have an identity");
+
+    let sync_app = app.clone();
+    let sync = tokio::spawn(async move {
+        sync_app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/runtime-hosts/host-a/projects/sync")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "projects": [{"project": "slow-project"}]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("sync request must build"),
+            )
+            .await
+    });
+    entered.wait().await;
+
+    let deregister = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/host-a/deregister")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(deregister.status(), StatusCode::OK);
+    let reregister = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runtime-hosts/register")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({"host_id": "host-a"}).to_string(),
+                ))?,
+        )
+        .await?;
+    assert_eq!(reregister.status(), StatusCode::OK);
+    let replacement_registration = state
+        .runtime_hosts
+        .active_registration_id("host-a")
+        .expect("replacement host must have an identity");
+    assert_ne!(replacement_registration, original_registration);
+    assert!(state
+        .runtime_project_cache
+        .get_host_cache("host-a")
+        .is_none());
+
+    release.wait().await;
+    let response = sync.await??;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let body = http_body_util::BodyExt::collect(response.into_body())
+        .await?
+        .to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body)?;
+    assert_eq!(
+        json["error"],
+        "runtime host registration changed during project sync"
+    );
+    assert!(state
+        .runtime_project_cache
+        .get_host_cache("host-a")
+        .is_none());
+    Ok(())
+}

--- a/crates/harness-server/src/http/http_router.rs
+++ b/crates/harness-server/src/http/http_router.rs
@@ -134,6 +134,10 @@ pub(super) fn build_router(state: Arc<AppState>) -> Router {
             post(crate::handlers::runtime_hosts::complete_runtime_job_for_runtime_host),
         )
         .route(
+            "/api/runtime-hosts/{host_id}/runtime-jobs/{runtime_job_id}/lease/renew",
+            post(crate::handlers::runtime_hosts::renew_runtime_job_lease_for_runtime_host),
+        )
+        .route(
             "/api/runtime-hosts/{host_id}/projects",
             get(crate::handlers::runtime_project_cache::list_runtime_host_projects),
         )

--- a/crates/harness-server/src/runtime_hosts.rs
+++ b/crates/harness-server/src/runtime_hosts.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
 pub const DEFAULT_HEARTBEAT_TIMEOUT_SECS: i64 = 60;
@@ -45,8 +45,31 @@ pub(crate) struct RuntimeHostRecord {
 
 pub struct RuntimeHostManager {
     pub(crate) hosts: DashMap<String, RuntimeHostRecord>,
-    operation_locks: DashMap<String, Arc<Mutex<()>>>,
+    operation_locks: Arc<DashMap<String, Weak<Mutex<()>>>>,
     pub(crate) heartbeat_timeout_secs: i64,
+}
+
+pub struct RuntimeHostOperationGuard {
+    guard: Option<OwnedMutexGuard<()>>,
+    operation_locks: Arc<DashMap<String, Weak<Mutex<()>>>>,
+    host_id: String,
+    operation_lock: Weak<Mutex<()>>,
+}
+
+impl Drop for RuntimeHostOperationGuard {
+    fn drop(&mut self) {
+        drop(self.guard.take());
+        if self.operation_lock.strong_count() != 0 {
+            return;
+        }
+        if let dashmap::mapref::entry::Entry::Occupied(entry) =
+            self.operation_locks.entry(self.host_id.clone())
+        {
+            if Weak::ptr_eq(entry.get(), &self.operation_lock) && entry.get().strong_count() == 0 {
+                entry.remove();
+            }
+        }
+    }
 }
 
 impl RuntimeHostManager {
@@ -57,7 +80,7 @@ impl RuntimeHostManager {
     pub fn with_heartbeat_timeout(heartbeat_timeout_secs: i64) -> Self {
         Self {
             hosts: DashMap::new(),
-            operation_locks: DashMap::new(),
+            operation_locks: Arc::new(DashMap::new()),
             heartbeat_timeout_secs,
         }
     }
@@ -67,15 +90,31 @@ impl RuntimeHostManager {
     /// The lock entry intentionally outlives deregistration. Reusing a host ID
     /// must retain the same ordering boundary as requests that were queued
     /// before the previous registration was removed.
-    pub async fn lock_operation(&self, host_id: &str) -> OwnedMutexGuard<()> {
-        self.operation_lock(host_id).lock_owned().await
+    pub async fn lock_operation(&self, host_id: &str) -> RuntimeHostOperationGuard {
+        let operation_lock = self.operation_lock(host_id);
+        let operation_lock_weak = Arc::downgrade(&operation_lock);
+        let guard = operation_lock.lock_owned().await;
+        RuntimeHostOperationGuard {
+            guard: Some(guard),
+            operation_locks: self.operation_locks.clone(),
+            host_id: host_id.to_string(),
+            operation_lock: operation_lock_weak,
+        }
     }
 
-    pub(crate) fn operation_lock(&self, host_id: &str) -> Arc<Mutex<()>> {
-        self.operation_locks
-            .entry(host_id.to_string())
-            .or_insert_with(|| Arc::new(Mutex::new(())))
-            .clone()
+    fn operation_lock(&self, host_id: &str) -> Arc<Mutex<()>> {
+        let mut entry = self.operation_locks.entry(host_id.to_string()).or_default();
+        if let Some(operation_lock) = entry.upgrade() {
+            return operation_lock;
+        }
+        let operation_lock = Arc::new(Mutex::new(()));
+        *entry = Arc::downgrade(&operation_lock);
+        operation_lock
+    }
+
+    #[cfg(test)]
+    pub(crate) fn operation_lock_count(&self) -> usize {
+        self.operation_locks.len()
     }
 
     pub fn register(

--- a/crates/harness-server/src/runtime_hosts.rs
+++ b/crates/harness-server/src/runtime_hosts.rs
@@ -1,9 +1,18 @@
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_HEARTBEAT_TIMEOUT_SECS: i64 = 60;
 pub const DEFAULT_LEASE_SECS: i64 = 60;
+pub const MAX_LEASE_SECS: i64 = 3600;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeHostLifecycle {
+    #[default]
+    Active,
+    Draining,
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RuntimeHostInfo {
@@ -13,6 +22,7 @@ pub struct RuntimeHostInfo {
     pub registered_at: String,
     pub last_heartbeat_at: String,
     pub online: bool,
+    pub lifecycle: RuntimeHostLifecycle,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -28,6 +38,7 @@ pub(crate) struct RuntimeHostRecord {
     pub(crate) capabilities: Vec<String>,
     pub(crate) registered_at: DateTime<Utc>,
     pub(crate) last_heartbeat_at: DateTime<Utc>,
+    pub(crate) lifecycle: RuntimeHostLifecycle,
 }
 
 pub struct RuntimeHostManager {
@@ -54,12 +65,18 @@ impl RuntimeHostManager {
         capabilities: Vec<String>,
     ) -> RuntimeHostInfo {
         let now = Utc::now();
+        let lifecycle = self
+            .hosts
+            .get(&host_id)
+            .map(|record| record.lifecycle)
+            .unwrap_or_default();
         let record = RuntimeHostRecord {
             id: host_id.clone(),
             display_name: display_name.unwrap_or_else(|| host_id.clone()),
             capabilities,
             registered_at: now,
             last_heartbeat_at: now,
+            lifecycle,
         };
         self.hosts.insert(host_id, record.clone());
         self.to_info(&record, now)
@@ -77,6 +94,27 @@ impl RuntimeHostManager {
 
     pub fn deregister(&self, host_id: &str) -> bool {
         self.hosts.remove(host_id).is_some()
+    }
+
+    pub fn mark_draining(&self, host_id: &str) -> Option<RuntimeHostLifecycle> {
+        let mut host = self.hosts.get_mut(host_id)?;
+        let previous = host.lifecycle;
+        host.lifecycle = RuntimeHostLifecycle::Draining;
+        Some(previous)
+    }
+
+    pub fn set_lifecycle(&self, host_id: &str, lifecycle: RuntimeHostLifecycle) -> bool {
+        let Some(mut host) = self.hosts.get_mut(host_id) else {
+            return false;
+        };
+        host.lifecycle = lifecycle;
+        true
+    }
+
+    pub fn is_active(&self, host_id: &str) -> bool {
+        self.hosts
+            .get(host_id)
+            .is_some_and(|host| host.lifecycle == RuntimeHostLifecycle::Active)
     }
 
     pub fn list_hosts(&self) -> Vec<RuntimeHostInfo> {
@@ -99,6 +137,7 @@ impl RuntimeHostManager {
             registered_at: record.registered_at.to_rfc3339(),
             last_heartbeat_at: record.last_heartbeat_at.to_rfc3339(),
             online,
+            lifecycle: record.lifecycle,
         }
     }
 }

--- a/crates/harness-server/src/runtime_hosts.rs
+++ b/crates/harness-server/src/runtime_hosts.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 
 pub const DEFAULT_HEARTBEAT_TIMEOUT_SECS: i64 = 60;
 pub const DEFAULT_LEASE_SECS: i64 = 60;
@@ -43,6 +45,7 @@ pub(crate) struct RuntimeHostRecord {
 
 pub struct RuntimeHostManager {
     pub(crate) hosts: DashMap<String, RuntimeHostRecord>,
+    operation_locks: DashMap<String, Arc<Mutex<()>>>,
     pub(crate) heartbeat_timeout_secs: i64,
 }
 
@@ -54,8 +57,25 @@ impl RuntimeHostManager {
     pub fn with_heartbeat_timeout(heartbeat_timeout_secs: i64) -> Self {
         Self {
             hosts: DashMap::new(),
+            operation_locks: DashMap::new(),
             heartbeat_timeout_secs,
         }
+    }
+
+    /// Serializes lifecycle validation with every host-owned durable operation.
+    ///
+    /// The lock entry intentionally outlives deregistration. Reusing a host ID
+    /// must retain the same ordering boundary as requests that were queued
+    /// before the previous registration was removed.
+    pub async fn lock_operation(&self, host_id: &str) -> OwnedMutexGuard<()> {
+        self.operation_lock(host_id).lock_owned().await
+    }
+
+    pub(crate) fn operation_lock(&self, host_id: &str) -> Arc<Mutex<()>> {
+        self.operation_locks
+            .entry(host_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
     }
 
     pub fn register(
@@ -115,6 +135,10 @@ impl RuntimeHostManager {
         self.hosts
             .get(host_id)
             .is_some_and(|host| host.lifecycle == RuntimeHostLifecycle::Active)
+    }
+
+    pub fn lifecycle(&self, host_id: &str) -> Option<RuntimeHostLifecycle> {
+        self.hosts.get(host_id).map(|host| host.lifecycle)
     }
 
     pub fn list_hosts(&self) -> Vec<RuntimeHostInfo> {

--- a/crates/harness-server/src/runtime_hosts.rs
+++ b/crates/harness-server/src/runtime_hosts.rs
@@ -3,6 +3,7 @@ use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Weak};
 use tokio::sync::{Mutex, OwnedMutexGuard};
+use uuid::Uuid;
 
 pub const DEFAULT_HEARTBEAT_TIMEOUT_SECS: i64 = 60;
 pub const DEFAULT_LEASE_SECS: i64 = 60;
@@ -36,6 +37,7 @@ pub struct TaskClaimResult {
 #[derive(Debug, Clone)]
 pub(crate) struct RuntimeHostRecord {
     pub(crate) id: String,
+    pub(crate) registration_id: Uuid,
     pub(crate) display_name: String,
     pub(crate) capabilities: Vec<String>,
     pub(crate) registered_at: DateTime<Utc>,
@@ -131,6 +133,7 @@ impl RuntimeHostManager {
             .unwrap_or_default();
         let record = RuntimeHostRecord {
             id: host_id.clone(),
+            registration_id: Uuid::new_v4(),
             display_name: display_name.unwrap_or_else(|| host_id.clone()),
             capabilities,
             registered_at: now,
@@ -178,6 +181,12 @@ impl RuntimeHostManager {
 
     pub fn lifecycle(&self, host_id: &str) -> Option<RuntimeHostLifecycle> {
         self.hosts.get(host_id).map(|host| host.lifecycle)
+    }
+
+    pub fn active_registration_id(&self, host_id: &str) -> Option<Uuid> {
+        self.hosts.get(host_id).and_then(|host| {
+            (host.lifecycle == RuntimeHostLifecycle::Active).then_some(host.registration_id)
+        })
     }
 
     pub fn list_hosts(&self) -> Vec<RuntimeHostInfo> {

--- a/crates/harness-server/src/runtime_hosts_state.rs
+++ b/crates/harness-server/src/runtime_hosts_state.rs
@@ -39,6 +39,7 @@ impl RuntimeHostManager {
                 host.id.clone(),
                 RuntimeHostRecord {
                     id: host.id,
+                    registration_id: uuid::Uuid::new_v4(),
                     display_name: host.display_name,
                     capabilities: host.capabilities,
                     registered_at: host.registered_at,

--- a/crates/harness-server/src/runtime_hosts_state.rs
+++ b/crates/harness-server/src/runtime_hosts_state.rs
@@ -1,4 +1,4 @@
-use crate::runtime_hosts::{RuntimeHostManager, RuntimeHostRecord};
+use crate::runtime_hosts::{RuntimeHostLifecycle, RuntimeHostManager, RuntimeHostRecord};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +9,8 @@ pub struct PersistedRuntimeHost {
     pub capabilities: Vec<String>,
     pub registered_at: DateTime<Utc>,
     pub last_heartbeat_at: DateTime<Utc>,
+    #[serde(default)]
+    pub lifecycle: RuntimeHostLifecycle,
 }
 
 impl RuntimeHostManager {
@@ -23,6 +25,7 @@ impl RuntimeHostManager {
                     capabilities: host.capabilities.clone(),
                     registered_at: host.registered_at,
                     last_heartbeat_at: host.last_heartbeat_at,
+                    lifecycle: host.lifecycle,
                 }
             })
             .collect()
@@ -40,6 +43,7 @@ impl RuntimeHostManager {
                     capabilities: host.capabilities,
                     registered_at: host.registered_at,
                     last_heartbeat_at: host.last_heartbeat_at,
+                    lifecycle: host.lifecycle,
                 },
             );
         }

--- a/crates/harness-server/src/runtime_hosts_tests.rs
+++ b/crates/harness-server/src/runtime_hosts_tests.rs
@@ -1,4 +1,4 @@
-use crate::runtime_hosts::RuntimeHostManager;
+use crate::runtime_hosts::{RuntimeHostLifecycle, RuntimeHostManager};
 use chrono::{TimeDelta, Utc};
 
 #[test]
@@ -81,4 +81,37 @@ fn deregister_removes_host_only() {
     assert!(manager.deregister("host-a"));
     assert!(!manager.deregister("host-a"));
     assert!(manager.list_hosts().is_empty());
+}
+
+#[test]
+fn draining_host_cannot_be_reactivated_by_registration() {
+    let manager = RuntimeHostManager::with_heartbeat_timeout(60);
+    manager.register("host-a".to_string(), None, vec![]);
+
+    assert_eq!(
+        manager.mark_draining("host-a"),
+        Some(RuntimeHostLifecycle::Active)
+    );
+    let updated = manager.register(
+        "host-a".to_string(),
+        Some("Updated host".to_string()),
+        vec!["rust".to_string()],
+    );
+
+    assert_eq!(updated.lifecycle, RuntimeHostLifecycle::Draining);
+    assert!(!manager.is_active("host-a"));
+}
+
+#[test]
+fn persisted_legacy_host_defaults_to_active() {
+    let value = serde_json::json!({
+        "id": "host-a",
+        "display_name": "Host A",
+        "capabilities": [],
+        "registered_at": "2026-07-16T00:00:00Z",
+        "last_heartbeat_at": "2026-07-16T00:00:00Z"
+    });
+    let host: crate::runtime_hosts_state::PersistedRuntimeHost =
+        serde_json::from_value(value).expect("legacy host record must deserialize");
+    assert_eq!(host.lifecycle, RuntimeHostLifecycle::Active);
 }

--- a/crates/harness-server/src/runtime_hosts_tests.rs
+++ b/crates/harness-server/src/runtime_hosts_tests.rs
@@ -1,6 +1,7 @@
 use crate::runtime_hosts::{RuntimeHostLifecycle, RuntimeHostManager};
 use chrono::{TimeDelta, Utc};
-use std::sync::Arc;
+use std::future::{poll_fn, Future};
+use std::task::Poll;
 
 #[test]
 fn register_upserts_host_metadata() {
@@ -117,29 +118,45 @@ fn persisted_legacy_host_defaults_to_active() {
     assert_eq!(host.lifecycle, RuntimeHostLifecycle::Active);
 }
 
-#[test]
-fn operation_lock_is_stable_across_deregistration_and_host_id_reuse() {
-    let manager = RuntimeHostManager::with_heartbeat_timeout(60);
-    manager.register("host-a".to_string(), None, vec![]);
-
-    let before = manager.operation_lock("host-a");
-    assert!(manager.deregister("host-a"));
-    manager.register("host-a".to_string(), None, vec![]);
-    let after = manager.operation_lock("host-a");
-    let other = manager.operation_lock("host-b");
-
-    assert!(Arc::ptr_eq(&before, &after));
-    assert!(!Arc::ptr_eq(&before, &other));
-}
-
 #[tokio::test]
 async fn operation_lock_serializes_same_host_without_blocking_other_hosts() {
     let manager = RuntimeHostManager::with_heartbeat_timeout(60);
     let first = manager.lock_operation("host-a").await;
-
-    assert!(manager.operation_lock("host-a").try_lock().is_err());
-    assert!(manager.operation_lock("host-b").try_lock().is_ok());
-
+    let other = manager.lock_operation("host-b").await;
+    assert_eq!(manager.operation_lock_count(), 2);
+    drop(other);
+    assert_eq!(manager.operation_lock_count(), 1);
     drop(first);
-    assert!(manager.operation_lock("host-a").try_lock().is_ok());
+    assert_eq!(manager.operation_lock_count(), 0);
+}
+
+#[tokio::test]
+async fn operation_lock_preserves_queued_order_across_deregister_and_reuse() {
+    let manager = std::sync::Arc::new(RuntimeHostManager::with_heartbeat_timeout(60));
+    manager.register("host-a".to_string(), None, vec![]);
+    let first = manager.lock_operation("host-a").await;
+    assert!(manager.deregister("host-a"));
+    manager.register("host-a".to_string(), None, vec![]);
+
+    let mut queued = Box::pin(manager.lock_operation("host-a"));
+    poll_fn(|context| match queued.as_mut().poll(context) {
+        Poll::Pending => Poll::Ready(()),
+        Poll::Ready(_) => panic!("queued operation acquired the held lock"),
+    })
+    .await;
+    drop(first);
+    let second = queued.await;
+    assert_eq!(manager.operation_lock_count(), 1);
+    drop(second);
+    assert_eq!(manager.operation_lock_count(), 0);
+}
+
+#[tokio::test]
+async fn operation_lock_unknown_host_churn_does_not_accumulate_entries() {
+    let manager = RuntimeHostManager::with_heartbeat_timeout(60);
+    for index in 0..1_000 {
+        let guard = manager.lock_operation(&format!("unknown-{index}")).await;
+        drop(guard);
+    }
+    assert_eq!(manager.operation_lock_count(), 0);
 }

--- a/crates/harness-server/src/runtime_hosts_tests.rs
+++ b/crates/harness-server/src/runtime_hosts_tests.rs
@@ -1,5 +1,6 @@
 use crate::runtime_hosts::{RuntimeHostLifecycle, RuntimeHostManager};
 use chrono::{TimeDelta, Utc};
+use std::sync::Arc;
 
 #[test]
 fn register_upserts_host_metadata() {
@@ -114,4 +115,31 @@ fn persisted_legacy_host_defaults_to_active() {
     let host: crate::runtime_hosts_state::PersistedRuntimeHost =
         serde_json::from_value(value).expect("legacy host record must deserialize");
     assert_eq!(host.lifecycle, RuntimeHostLifecycle::Active);
+}
+
+#[test]
+fn operation_lock_is_stable_across_deregistration_and_host_id_reuse() {
+    let manager = RuntimeHostManager::with_heartbeat_timeout(60);
+    manager.register("host-a".to_string(), None, vec![]);
+
+    let before = manager.operation_lock("host-a");
+    assert!(manager.deregister("host-a"));
+    manager.register("host-a".to_string(), None, vec![]);
+    let after = manager.operation_lock("host-a");
+    let other = manager.operation_lock("host-b");
+
+    assert!(Arc::ptr_eq(&before, &after));
+    assert!(!Arc::ptr_eq(&before, &other));
+}
+
+#[tokio::test]
+async fn operation_lock_serializes_same_host_without_blocking_other_hosts() {
+    let manager = RuntimeHostManager::with_heartbeat_timeout(60);
+    let first = manager.lock_operation("host-a").await;
+
+    assert!(manager.operation_lock("host-a").try_lock().is_err());
+    assert!(manager.operation_lock("host-b").try_lock().is_ok());
+
+    drop(first);
+    assert!(manager.operation_lock("host-a").try_lock().is_ok());
 }

--- a/crates/harness-server/src/runtime_hosts_tests.rs
+++ b/crates/harness-server/src/runtime_hosts_tests.rs
@@ -105,6 +105,23 @@ fn draining_host_cannot_be_reactivated_by_registration() {
 }
 
 #[test]
+fn registration_identity_changes_on_same_id_reregistration() {
+    let manager = RuntimeHostManager::with_heartbeat_timeout(60);
+    manager.register("host-a".to_string(), None, vec![]);
+    let first = manager
+        .active_registration_id("host-a")
+        .expect("first registration must have an identity");
+
+    assert!(manager.deregister("host-a"));
+    manager.register("host-a".to_string(), None, vec![]);
+    let second = manager
+        .active_registration_id("host-a")
+        .expect("replacement registration must have an identity");
+
+    assert_ne!(first, second);
+}
+
+#[test]
 fn persisted_legacy_host_defaults_to_active() {
     let value = serde_json::json!({
         "id": "host-a",

--- a/crates/harness-server/src/runtime_state_store_tests.rs
+++ b/crates/harness-server/src/runtime_state_store_tests.rs
@@ -247,5 +247,6 @@ fn make_host(id: &str) -> crate::runtime_hosts_state::PersistedRuntimeHost {
         capabilities: vec!["codex".to_string()],
         registered_at: Utc::now(),
         last_heartbeat_at: Utc::now(),
+        lifecycle: crate::runtime_hosts::RuntimeHostLifecycle::Active,
     }
 }

--- a/crates/harness-workflow/src/runtime/job_claim.rs
+++ b/crates/harness-workflow/src/runtime/job_claim.rs
@@ -1,3 +1,6 @@
+use super::store::runtime_job_leases::{
+    append_runtime_event_tx, delete_all_runtime_job_lease_receipts_tx,
+};
 use super::store::{enum_str, to_jsonb_string};
 use super::{RuntimeJob, RuntimeKind, WorkflowRuntimeStore};
 use chrono::{DateTime, Utc};
@@ -30,6 +33,7 @@ impl WorkflowRuntimeStore {
         owner: &str,
         expires_at: DateTime<Utc>,
     ) -> anyhow::Result<Option<RuntimeJob>> {
+        let records_remote_host_audit = only_runtime_kind == Some(RuntimeKind::RemoteHost);
         let only_runtime_kind = only_runtime_kind
             .map(|runtime_kind| enum_str(&runtime_kind))
             .transpose()?;
@@ -80,6 +84,7 @@ impl WorkflowRuntimeStore {
         };
 
         let mut job: RuntimeJob = serde_json::from_str(&data)?;
+        let reclaimed = job.status == super::RuntimeJobStatus::Running;
         job.claim(owner, expires_at);
         let updated = to_jsonb_string(&job)?;
         let status = enum_str(&job.status)?;
@@ -94,6 +99,25 @@ impl WorkflowRuntimeStore {
         .bind(&id)
         .execute(&mut *tx)
         .await?;
+        if records_remote_host_audit {
+            delete_all_runtime_job_lease_receipts_tx(&mut tx, &id).await?;
+            append_runtime_event_tx(
+                &mut tx,
+                &id,
+                if reclaimed {
+                    "RuntimeJobReclaimed"
+                } else {
+                    "RuntimeJobClaimed"
+                },
+                serde_json::json!({
+                    "owner": owner,
+                    "lease_generation": job.lease_generation,
+                    "lease_expires_at": expires_at,
+                    "claim_api": "runtime_host",
+                }),
+            )
+            .await?;
+        }
         tx.commit().await?;
         Ok(Some(job))
     }

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -29,6 +29,8 @@ mod instances;
 mod recovery;
 #[path = "store/runtime_completion.rs"]
 mod runtime_completion;
+#[path = "store/runtime_job_leases.rs"]
+pub mod runtime_job_leases;
 #[path = "store/runtime_usage.rs"]
 mod runtime_usage;
 #[path = "store/submission_commit.rs"]
@@ -1028,29 +1030,12 @@ impl WorkflowRuntimeStore {
         payload: Value,
     ) -> anyhow::Result<RuntimeEvent> {
         let mut tx = self.pool.begin().await?;
-        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
-            .bind(format!("runtime_events:{runtime_job_id}"))
-            .execute(&mut *tx)
-            .await?;
-        let (next_sequence,): (i64,) = sqlx::query_as(
-            "SELECT COALESCE(MAX(sequence), 0) + 1 FROM runtime_events WHERE runtime_job_id = $1",
+        let event = runtime_job_leases::append_runtime_event_tx(
+            &mut tx,
+            runtime_job_id,
+            event_type,
+            payload,
         )
-        .bind(runtime_job_id)
-        .fetch_one(&mut *tx)
-        .await?;
-        let event = RuntimeEvent::new(runtime_job_id, next_sequence as u64, event_type, payload);
-        let data = to_jsonb_string(&event)?;
-        sqlx::query(
-            "INSERT INTO runtime_events
-                (id, runtime_job_id, sequence, event_type, data)
-             VALUES ($1, $2, $3, $4, $5::jsonb)",
-        )
-        .bind(&event.id)
-        .bind(&event.runtime_job_id)
-        .bind(event.sequence as i64)
-        .bind(&event.event_type)
-        .bind(&data)
-        .execute(&mut *tx)
         .await?;
         tx.commit().await?;
         Ok(event)
@@ -1215,6 +1200,12 @@ impl WorkflowRuntimeStore {
         .bind(runtime_job_id)
         .execute(&mut *tx)
         .await?;
+        runtime_job_leases::delete_runtime_job_lease_receipts_tx(
+            &mut tx,
+            runtime_job_id,
+            job.lease_generation,
+        )
+        .await?;
         tx.commit().await?;
         Ok(Some(job))
     }
@@ -1224,6 +1215,24 @@ impl WorkflowRuntimeStore {
         runtime_job_id: &str,
         owner: &str,
         lease_expires_at: DateTime<Utc>,
+        result: &ActivityResult,
+    ) -> anyhow::Result<Option<RuntimeActivityCompletion>> {
+        self.commit_runtime_activity_completion_if_owned_with_generation(
+            runtime_job_id,
+            owner,
+            lease_expires_at,
+            None,
+            result,
+        )
+        .await
+    }
+
+    pub async fn commit_runtime_activity_completion_if_owned_with_generation(
+        &self,
+        runtime_job_id: &str,
+        owner: &str,
+        lease_expires_at: DateTime<Utc>,
+        lease_generation: Option<u64>,
         result: &ActivityResult,
     ) -> anyhow::Result<Option<RuntimeActivityCompletion>> {
         let mut tx = self.pool.begin().await?;
@@ -1257,10 +1266,12 @@ impl WorkflowRuntimeStore {
         };
         let mut job: RuntimeJob = serde_json::from_str(&data)?;
         let is_current_lease = job.status == RuntimeJobStatus::Running
-            && job
-                .lease
-                .as_ref()
-                .is_some_and(|lease| lease.owner == owner && lease.expires_at == lease_expires_at);
+            && lease_generation.is_none_or(|generation| generation == job.lease_generation)
+            && job.lease.as_ref().is_some_and(|lease| {
+                lease.owner == owner
+                    && lease.expires_at == lease_expires_at
+                    && lease.expires_at > Utc::now()
+            });
         if !is_current_lease {
             tx.commit().await?;
             return Ok(None);
@@ -1279,6 +1290,12 @@ impl WorkflowRuntimeStore {
         .bind(&updated)
         .bind(runtime_job_id)
         .execute(&mut *tx)
+        .await?;
+        runtime_job_leases::delete_runtime_job_lease_receipts_tx(
+            &mut tx,
+            runtime_job_id,
+            job.lease_generation,
+        )
         .await?;
         let Some(command_row) = command_row else {
             tx.commit().await?;
@@ -1494,6 +1511,12 @@ impl WorkflowRuntimeStore {
         .bind(runtime_job_id)
         .execute(&mut *tx)
         .await?;
+        runtime_job_leases::delete_runtime_job_lease_receipts_tx(
+            &mut tx,
+            runtime_job_id,
+            job.lease_generation,
+        )
+        .await?;
         tx.commit().await?;
         Ok(Some(job))
     }
@@ -1659,6 +1682,12 @@ impl WorkflowRuntimeStore {
             .bind(&updated)
             .bind(&id)
             .execute(&mut *tx)
+            .await?;
+            runtime_job_leases::delete_runtime_job_lease_receipts_tx(
+                &mut tx,
+                &id,
+                job.lease_generation,
+            )
             .await?;
             cancelled += 1;
         }

--- a/crates/harness-workflow/src/runtime/store/recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery.rs
@@ -1,3 +1,4 @@
+use super::runtime_job_leases::delete_runtime_job_lease_receipts_tx;
 use super::{
     command_store, enum_str, insert_decision_record_tx, insert_event_tx,
     select_instance_for_update_tx, to_jsonb_string, upsert_instance_tx, validator_for_definition,
@@ -459,6 +460,7 @@ async fn cancel_unfinished_runtime_jobs_tx(
         .bind(job_id)
         .execute(&mut **tx)
         .await?;
+        delete_runtime_job_lease_receipts_tx(tx, job_id, job.lease_generation).await?;
     }
 
     Ok(rows.len() as u64)

--- a/crates/harness-workflow/src/runtime/store/runtime_job_leases.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_job_leases.rs
@@ -1,0 +1,445 @@
+use super::{enum_str, to_jsonb_string, WorkflowRuntimeStore};
+use crate::runtime::model::{RuntimeEvent, RuntimeJob, RuntimeJobStatus, RuntimeKind};
+use chrono::{DateTime, TimeDelta, Utc};
+use serde_json::{json, Value};
+use sqlx::{Postgres, Transaction};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeJobLeaseRenewalRejection {
+    Expired,
+    HostDraining,
+    InvalidDuration,
+    InvariantViolation,
+    RenewalIdConflict,
+    Revoked,
+    StaleExpiry,
+    WrongGeneration,
+    WrongOwner,
+    WrongRuntimeKind,
+    WrongState,
+}
+
+impl RuntimeJobLeaseRenewalRejection {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Expired => "expired",
+            Self::HostDraining => "host_draining",
+            Self::InvalidDuration => "invalid_duration",
+            Self::InvariantViolation => "invariant_violation",
+            Self::RenewalIdConflict => "renewal_id_conflict",
+            Self::Revoked => "revoked",
+            Self::StaleExpiry => "stale_expiry",
+            Self::WrongGeneration => "wrong_generation",
+            Self::WrongOwner => "wrong_owner",
+            Self::WrongRuntimeKind => "wrong_runtime_kind",
+            Self::WrongState => "wrong_state",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RuntimeJobLeaseRenewalOutcome {
+    Renewed {
+        lease_generation: u64,
+        lease_expires_at: DateTime<Utc>,
+        replayed: bool,
+    },
+    LeaseLost {
+        reason: RuntimeJobLeaseRenewalRejection,
+    },
+    NotFound,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeJobLeaseRenewalRequest<'a> {
+    pub runtime_job_id: &'a str,
+    pub owner: &'a str,
+    pub lease_generation: u64,
+    pub previous_expires_at: DateTime<Utc>,
+    pub renewal_id: Uuid,
+    pub lease_secs: i64,
+    pub now: DateTime<Utc>,
+    pub max_lease_secs: i64,
+    pub owner_active: bool,
+}
+
+type ReceiptRow = (String, DateTime<Utc>, DateTime<Utc>, i64);
+
+impl WorkflowRuntimeStore {
+    pub async fn renew_remote_host_runtime_job_lease(
+        &self,
+        request: RuntimeJobLeaseRenewalRequest<'_>,
+    ) -> anyhow::Result<RuntimeJobLeaseRenewalOutcome> {
+        let mut tx = self.pool.begin().await?;
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data::text FROM runtime_jobs WHERE id = $1 FOR UPDATE")
+                .bind(request.runtime_job_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        let Some((data,)) = row else {
+            tx.commit().await?;
+            return Ok(RuntimeJobLeaseRenewalOutcome::NotFound);
+        };
+        let mut job: RuntimeJob = serde_json::from_str(&data)?;
+
+        sqlx::query(
+            "DELETE FROM runtime_job_lease_renewal_receipts
+             WHERE runtime_job_id = $1 AND renewed_expires_at <= $2",
+        )
+        .bind(request.runtime_job_id)
+        .bind(request.now)
+        .execute(&mut *tx)
+        .await?;
+
+        let rejection = if !request.owner_active {
+            Some(RuntimeJobLeaseRenewalRejection::HostDraining)
+        } else if job.status != RuntimeJobStatus::Running {
+            Some(RuntimeJobLeaseRenewalRejection::WrongState)
+        } else if job.runtime_kind != RuntimeKind::RemoteHost {
+            Some(RuntimeJobLeaseRenewalRejection::WrongRuntimeKind)
+        } else if job.lease_generation != request.lease_generation {
+            Some(RuntimeJobLeaseRenewalRejection::WrongGeneration)
+        } else {
+            match job.lease.as_ref() {
+                None => Some(RuntimeJobLeaseRenewalRejection::Revoked),
+                Some(lease) if lease.expires_at <= request.now => {
+                    Some(RuntimeJobLeaseRenewalRejection::Expired)
+                }
+                Some(lease) if lease.owner != request.owner => {
+                    Some(RuntimeJobLeaseRenewalRejection::WrongOwner)
+                }
+                Some(_) => None,
+            }
+        };
+        if let Some(reason) = rejection {
+            return reject_renewal_tx(tx, &request, reason).await;
+        }
+
+        let generation = match i64::try_from(request.lease_generation) {
+            Ok(generation) => generation,
+            Err(_) => {
+                return reject_renewal_tx(
+                    tx,
+                    &request,
+                    RuntimeJobLeaseRenewalRejection::InvariantViolation,
+                )
+                .await;
+            }
+        };
+        let receipt: Option<ReceiptRow> = sqlx::query_as(
+            "SELECT owner, previous_expires_at, renewed_expires_at, lease_secs
+             FROM runtime_job_lease_renewal_receipts
+             WHERE runtime_job_id = $1 AND lease_generation = $2 AND renewal_id = $3",
+        )
+        .bind(request.runtime_job_id)
+        .bind(generation)
+        .bind(request.renewal_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if let Some((owner, previous_expires_at, renewed_expires_at, lease_secs)) = receipt {
+            if owner != request.owner
+                || previous_expires_at != request.previous_expires_at
+                || lease_secs != request.lease_secs
+            {
+                return reject_renewal_tx(
+                    tx,
+                    &request,
+                    RuntimeJobLeaseRenewalRejection::RenewalIdConflict,
+                )
+                .await;
+            }
+            tx.commit().await?;
+            return Ok(RuntimeJobLeaseRenewalOutcome::Renewed {
+                lease_generation: job.lease_generation,
+                lease_expires_at: renewed_expires_at,
+                replayed: true,
+            });
+        }
+
+        let Some(current_expires_at) = job.lease.as_ref().map(|lease| lease.expires_at) else {
+            return reject_renewal_tx(tx, &request, RuntimeJobLeaseRenewalRejection::Revoked).await;
+        };
+        if current_expires_at != request.previous_expires_at {
+            return reject_renewal_tx(tx, &request, RuntimeJobLeaseRenewalRejection::StaleExpiry)
+                .await;
+        }
+        if request.lease_secs <= 0 || request.lease_secs > request.max_lease_secs {
+            return reject_renewal_tx(
+                tx,
+                &request,
+                RuntimeJobLeaseRenewalRejection::InvalidDuration,
+            )
+            .await;
+        }
+        let Some(max_duration) = TimeDelta::try_seconds(request.max_lease_secs) else {
+            return reject_renewal_tx(
+                tx,
+                &request,
+                RuntimeJobLeaseRenewalRejection::InvariantViolation,
+            )
+            .await;
+        };
+        let Some(max_expires_at) = request.now.checked_add_signed(max_duration) else {
+            return reject_renewal_tx(
+                tx,
+                &request,
+                RuntimeJobLeaseRenewalRejection::InvariantViolation,
+            )
+            .await;
+        };
+        if current_expires_at > max_expires_at {
+            return reject_renewal_tx(
+                tx,
+                &request,
+                RuntimeJobLeaseRenewalRejection::InvariantViolation,
+            )
+            .await;
+        }
+        let Some(target_duration) = TimeDelta::try_seconds(request.lease_secs) else {
+            return reject_renewal_tx(
+                tx,
+                &request,
+                RuntimeJobLeaseRenewalRejection::InvalidDuration,
+            )
+            .await;
+        };
+        let Some(target_expires_at) = request.now.checked_add_signed(target_duration) else {
+            return reject_renewal_tx(
+                tx,
+                &request,
+                RuntimeJobLeaseRenewalRejection::InvalidDuration,
+            )
+            .await;
+        };
+        let renewed_expires_at = current_expires_at.max(target_expires_at);
+        job.renew_lease(request.owner, renewed_expires_at);
+        job.updated_at = request.now;
+        let updated = to_jsonb_string(&job)?;
+        let status = enum_str(&job.status)?;
+        sqlx::query(
+            "UPDATE runtime_jobs
+             SET status = $1, not_before = $2, data = $3::jsonb, updated_at = $4
+             WHERE id = $5",
+        )
+        .bind(&status)
+        .bind(job.not_before)
+        .bind(&updated)
+        .bind(request.now)
+        .bind(request.runtime_job_id)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "INSERT INTO runtime_job_lease_renewal_receipts
+                (runtime_job_id, renewal_id, owner, lease_generation,
+                 previous_expires_at, renewed_expires_at, lease_secs, created_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        )
+        .bind(request.runtime_job_id)
+        .bind(request.renewal_id)
+        .bind(request.owner)
+        .bind(generation)
+        .bind(request.previous_expires_at)
+        .bind(renewed_expires_at)
+        .bind(request.lease_secs)
+        .bind(request.now)
+        .execute(&mut *tx)
+        .await?;
+        append_runtime_event_tx(
+            &mut tx,
+            request.runtime_job_id,
+            "RuntimeJobLeaseRenewed",
+            json!({
+                "owner": request.owner,
+                "lease_generation": request.lease_generation,
+                "previous_expires_at": request.previous_expires_at,
+                "lease_expires_at": renewed_expires_at,
+                "lease_secs": request.lease_secs,
+                "renewal_id": request.renewal_id,
+                "source": "runtime_host",
+            }),
+        )
+        .await?;
+        tx.commit().await?;
+        Ok(RuntimeJobLeaseRenewalOutcome::Renewed {
+            lease_generation: job.lease_generation,
+            lease_expires_at: renewed_expires_at,
+            replayed: false,
+        })
+    }
+
+    pub async fn revoke_remote_host_runtime_job_leases(
+        &self,
+        owner: &str,
+        now: DateTime<Utc>,
+    ) -> anyhow::Result<usize> {
+        let mut tx = self.pool.begin().await?;
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT id, data::text FROM runtime_jobs
+             WHERE status = 'running'
+               AND runtime_kind = 'remote_host'
+               AND data #>> '{lease,owner}' = $1
+             ORDER BY id
+             FOR UPDATE",
+        )
+        .bind(owner)
+        .fetch_all(&mut *tx)
+        .await?;
+        for (runtime_job_id, data) in &rows {
+            let mut job: RuntimeJob = serde_json::from_str(data)?;
+            let previous_expires_at = job.lease.as_ref().map(|lease| lease.expires_at);
+            job.status = RuntimeJobStatus::Pending;
+            job.lease = None;
+            job.not_before = None;
+            job.updated_at = now;
+            let updated = to_jsonb_string(&job)?;
+            sqlx::query(
+                "UPDATE runtime_jobs
+                 SET status = 'pending', not_before = NULL, data = $1::jsonb, updated_at = $2
+                 WHERE id = $3",
+            )
+            .bind(&updated)
+            .bind(now)
+            .bind(runtime_job_id)
+            .execute(&mut *tx)
+            .await?;
+            delete_runtime_job_lease_receipts_tx(&mut tx, runtime_job_id, job.lease_generation)
+                .await?;
+            append_runtime_event_tx(
+                &mut tx,
+                runtime_job_id,
+                "RuntimeJobLeaseRevoked",
+                json!({
+                    "owner": owner,
+                    "lease_generation": job.lease_generation,
+                    "previous_expires_at": previous_expires_at,
+                    "reason": "host_deregistered",
+                    "source": "runtime_host_deregister",
+                }),
+            )
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(rows.len())
+    }
+
+    pub async fn count_remote_host_runtime_job_leases(&self, owner: &str) -> anyhow::Result<i64> {
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM runtime_jobs
+             WHERE status = 'running'
+               AND runtime_kind = 'remote_host'
+               AND data #>> '{lease,owner}' = $1",
+        )
+        .bind(owner)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(count)
+    }
+}
+
+async fn reject_renewal_tx(
+    mut tx: Transaction<'_, Postgres>,
+    request: &RuntimeJobLeaseRenewalRequest<'_>,
+    reason: RuntimeJobLeaseRenewalRejection,
+) -> anyhow::Result<RuntimeJobLeaseRenewalOutcome> {
+    append_runtime_event_tx(
+        &mut tx,
+        request.runtime_job_id,
+        "RuntimeJobLeaseRenewalRejected",
+        json!({
+            "requested_lease_generation": request.lease_generation,
+            "renewal_id": request.renewal_id,
+            "reason": reason.as_str(),
+            "source": "runtime_host",
+        }),
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(RuntimeJobLeaseRenewalOutcome::LeaseLost { reason })
+}
+
+pub(crate) async fn append_runtime_event_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    runtime_job_id: &str,
+    event_type: &str,
+    payload: Value,
+) -> anyhow::Result<RuntimeEvent> {
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(format!("runtime_events:{runtime_job_id}"))
+        .execute(&mut **tx)
+        .await?;
+    let (next_sequence,): (i64,) = sqlx::query_as(
+        "SELECT COALESCE(MAX(sequence), 0) + 1 FROM runtime_events WHERE runtime_job_id = $1",
+    )
+    .bind(runtime_job_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    let event = RuntimeEvent::new(runtime_job_id, next_sequence as u64, event_type, payload);
+    let data = to_jsonb_string(&event)?;
+    sqlx::query(
+        "INSERT INTO runtime_events (id, runtime_job_id, sequence, event_type, data)
+         VALUES ($1, $2, $3, $4, $5::jsonb)",
+    )
+    .bind(&event.id)
+    .bind(&event.runtime_job_id)
+    .bind(event.sequence as i64)
+    .bind(&event.event_type)
+    .bind(&data)
+    .execute(&mut **tx)
+    .await?;
+    Ok(event)
+}
+
+pub(crate) async fn delete_runtime_job_lease_receipts_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    runtime_job_id: &str,
+    lease_generation: u64,
+) -> anyhow::Result<()> {
+    let generation = i64::try_from(lease_generation)
+        .map_err(|_| anyhow::anyhow!("lease generation exceeds PostgreSQL BIGINT range"))?;
+    sqlx::query(
+        "DELETE FROM runtime_job_lease_renewal_receipts
+         WHERE runtime_job_id = $1 AND lease_generation = $2",
+    )
+    .bind(runtime_job_id)
+    .bind(generation)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+pub(crate) async fn delete_all_runtime_job_lease_receipts_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    runtime_job_id: &str,
+) -> anyhow::Result<()> {
+    sqlx::query("DELETE FROM runtime_job_lease_renewal_receipts WHERE runtime_job_id = $1")
+        .bind(runtime_job_id)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RuntimeJobLeaseRenewalRejection;
+
+    #[test]
+    fn runtime_store_remote_host_lease_rejection_codes_are_closed_and_sanitized() {
+        let reasons = [
+            RuntimeJobLeaseRenewalRejection::Expired,
+            RuntimeJobLeaseRenewalRejection::HostDraining,
+            RuntimeJobLeaseRenewalRejection::InvalidDuration,
+            RuntimeJobLeaseRenewalRejection::InvariantViolation,
+            RuntimeJobLeaseRenewalRejection::RenewalIdConflict,
+            RuntimeJobLeaseRenewalRejection::Revoked,
+            RuntimeJobLeaseRenewalRejection::StaleExpiry,
+            RuntimeJobLeaseRenewalRejection::WrongGeneration,
+            RuntimeJobLeaseRenewalRejection::WrongOwner,
+            RuntimeJobLeaseRenewalRejection::WrongRuntimeKind,
+            RuntimeJobLeaseRenewalRejection::WrongState,
+        ];
+        let codes: Vec<&str> = reasons.into_iter().map(|reason| reason.as_str()).collect();
+        assert_eq!(codes.len(), 11);
+        assert!(codes.iter().all(|code| !code.contains("host-")));
+    }
+}

--- a/crates/harness-workflow/src/runtime/store/runtime_job_leases.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_job_leases.rs
@@ -1,6 +1,6 @@
 use super::{enum_str, to_jsonb_string, WorkflowRuntimeStore};
 use crate::runtime::model::{RuntimeEvent, RuntimeJob, RuntimeJobStatus, RuntimeKind};
-use chrono::{DateTime, TimeDelta, Utc};
+use chrono::{DateTime, TimeDelta, Timelike, Utc};
 use serde_json::{json, Value};
 use sqlx::{Postgres, Transaction};
 use uuid::Uuid;
@@ -66,6 +66,21 @@ pub struct RuntimeJobLeaseRenewalRequest<'a> {
 
 type ReceiptRow = (String, DateTime<Utc>, DateTime<Utc>, i64);
 
+pub fn postgres_timestamp_floor(value: DateTime<Utc>) -> DateTime<Utc> {
+    let microsecond_nanos = value.nanosecond() / 1_000 * 1_000;
+    value.with_nanosecond(microsecond_nanos).unwrap_or(value)
+}
+
+pub fn postgres_timestamp_ceil(value: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    let remainder = value.nanosecond() % 1_000;
+    if remainder == 0 {
+        return Some(value);
+    }
+    value
+        .checked_add_signed(TimeDelta::nanoseconds(i64::from(1_000 - remainder)))
+        .map(postgres_timestamp_floor)
+}
+
 impl WorkflowRuntimeStore {
     pub async fn renew_remote_host_runtime_job_lease(
         &self,
@@ -82,6 +97,7 @@ impl WorkflowRuntimeStore {
             return Ok(RuntimeJobLeaseRenewalOutcome::NotFound);
         };
         let mut job: RuntimeJob = serde_json::from_str(&data)?;
+        let request_previous_expires_at = postgres_timestamp_floor(request.previous_expires_at);
 
         sqlx::query(
             "DELETE FROM runtime_job_lease_renewal_receipts
@@ -139,7 +155,7 @@ impl WorkflowRuntimeStore {
         .await?;
         if let Some((owner, previous_expires_at, renewed_expires_at, lease_secs)) = receipt {
             if owner != request.owner
-                || previous_expires_at != request.previous_expires_at
+                || previous_expires_at != request_previous_expires_at
                 || lease_secs != request.lease_secs
             {
                 return reject_renewal_tx(
@@ -160,7 +176,7 @@ impl WorkflowRuntimeStore {
         let Some(current_expires_at) = job.lease.as_ref().map(|lease| lease.expires_at) else {
             return reject_renewal_tx(tx, &request, RuntimeJobLeaseRenewalRejection::Revoked).await;
         };
-        if current_expires_at != request.previous_expires_at {
+        if postgres_timestamp_floor(current_expires_at) != request_previous_expires_at {
             return reject_renewal_tx(tx, &request, RuntimeJobLeaseRenewalRejection::StaleExpiry)
                 .await;
         }
@@ -180,7 +196,11 @@ impl WorkflowRuntimeStore {
             )
             .await;
         };
-        let Some(max_expires_at) = request.now.checked_add_signed(max_duration) else {
+        let Some(max_expires_at) = request
+            .now
+            .checked_add_signed(max_duration)
+            .and_then(postgres_timestamp_ceil)
+        else {
             return reject_renewal_tx(
                 tx,
                 &request,
@@ -188,7 +208,16 @@ impl WorkflowRuntimeStore {
             )
             .await;
         };
-        if current_expires_at > max_expires_at {
+        let Some(normalized_current_expires_at) = postgres_timestamp_ceil(current_expires_at)
+        else {
+            return reject_renewal_tx(
+                tx,
+                &request,
+                RuntimeJobLeaseRenewalRejection::InvariantViolation,
+            )
+            .await;
+        };
+        if normalized_current_expires_at > max_expires_at {
             return reject_renewal_tx(
                 tx,
                 &request,
@@ -204,7 +233,11 @@ impl WorkflowRuntimeStore {
             )
             .await;
         };
-        let Some(target_expires_at) = request.now.checked_add_signed(target_duration) else {
+        let Some(target_expires_at) = request
+            .now
+            .checked_add_signed(target_duration)
+            .and_then(postgres_timestamp_ceil)
+        else {
             return reject_renewal_tx(
                 tx,
                 &request,
@@ -212,7 +245,7 @@ impl WorkflowRuntimeStore {
             )
             .await;
         };
-        let renewed_expires_at = current_expires_at.max(target_expires_at);
+        let renewed_expires_at = normalized_current_expires_at.max(target_expires_at);
         job.renew_lease(request.owner, renewed_expires_at);
         job.updated_at = request.now;
         let updated = to_jsonb_string(&job)?;
@@ -239,7 +272,7 @@ impl WorkflowRuntimeStore {
         .bind(request.renewal_id)
         .bind(request.owner)
         .bind(generation)
-        .bind(request.previous_expires_at)
+        .bind(request_previous_expires_at)
         .bind(renewed_expires_at)
         .bind(request.lease_secs)
         .bind(request.now)
@@ -252,7 +285,7 @@ impl WorkflowRuntimeStore {
             json!({
                 "owner": request.owner,
                 "lease_generation": request.lease_generation,
-                "previous_expires_at": request.previous_expires_at,
+                "previous_expires_at": request_previous_expires_at,
                 "lease_expires_at": renewed_expires_at,
                 "lease_secs": request.lease_secs,
                 "renewal_id": request.renewal_id,

--- a/crates/harness-workflow/src/runtime/store_migrations.rs
+++ b/crates/harness-workflow/src/runtime/store_migrations.rs
@@ -508,4 +508,29 @@ pub(super) static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
               )
               WHERE status IN ('pending', 'dispatching', 'deferred')",
     },
+    Migration {
+        version: 20,
+        description: "create runtime job lease renewal receipts",
+        sql: "CREATE TABLE IF NOT EXISTS runtime_job_lease_renewal_receipts (
+            runtime_job_id       TEXT NOT NULL,
+            renewal_id           UUID NOT NULL,
+            owner                TEXT NOT NULL,
+            lease_generation     BIGINT NOT NULL,
+            previous_expires_at  TIMESTAMPTZ NOT NULL,
+            renewed_expires_at   TIMESTAMPTZ NOT NULL,
+            lease_secs           BIGINT NOT NULL,
+            created_at           TIMESTAMPTZ NOT NULL,
+            PRIMARY KEY (runtime_job_id, lease_generation, renewal_id),
+            CONSTRAINT runtime_job_lease_renewal_receipts_job_fkey
+                FOREIGN KEY (runtime_job_id)
+                REFERENCES runtime_jobs(id)
+                ON DELETE CASCADE,
+            CONSTRAINT runtime_job_lease_renewal_receipts_generation_nonnegative
+                CHECK (lease_generation >= 0),
+            CONSTRAINT runtime_job_lease_renewal_receipts_lease_secs_positive
+                CHECK (lease_secs > 0)
+        );
+        CREATE INDEX IF NOT EXISTS idx_runtime_job_lease_receipts_expiry
+          ON runtime_job_lease_renewal_receipts (runtime_job_id, renewed_expires_at)",
+    },
 ];

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -53,6 +53,7 @@ mod local_review;
 mod otel_spans;
 mod p1_followups;
 mod pr_repair_evidence;
+mod remote_host_lease;
 mod replay_determinism;
 mod retry;
 mod runtime_store;

--- a/crates/harness-workflow/src/runtime/tests/remote_host_lease.rs
+++ b/crates/harness-workflow/src/runtime/tests/remote_host_lease.rs
@@ -7,14 +7,14 @@ use uuid::Uuid;
 
 static REMOTE_LEASE_DB_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-async fn remote_lease_store() -> anyhow::Result<Option<WorkflowRuntimeStore>> {
+async fn remote_lease_store() -> anyhow::Result<WorkflowRuntimeStore> {
     if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
-        return Ok(None);
+        anyhow::bail!(
+            "GH1602 PostgreSQL tests require HARNESS_DATABASE_URL pointing to an isolated disposable database"
+        );
     }
     let dir = tempfile::tempdir()?;
-    Ok(Some(
-        WorkflowRuntimeStore::open(&dir.path().join("remote-host-lease.db")).await?,
-    ))
+    WorkflowRuntimeStore::open(&dir.path().join("remote-host-lease.db")).await
 }
 
 async fn enqueue_remote_lease_job(
@@ -111,9 +111,7 @@ fn assert_rejected(
 #[tokio::test]
 async fn runtime_store_remote_host_lease_ttl_receipts_and_fences() -> anyhow::Result<()> {
     let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
-    let Some(store) = remote_lease_store().await? else {
-        return Ok(());
-    };
+    let store = remote_lease_store().await?;
     let now = Utc::now();
     let original_expiry = now + Duration::seconds(60);
     let pending = enqueue_remote_lease_job(&store, "ttl-receipts").await?;
@@ -250,9 +248,7 @@ async fn runtime_store_remote_host_lease_ttl_receipts_and_fences() -> anyhow::Re
 async fn runtime_store_remote_host_lease_reclaim_cleans_receipts_and_fences_generation(
 ) -> anyhow::Result<()> {
     let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
-    let Some(store) = remote_lease_store().await? else {
-        return Ok(());
-    };
+    let store = remote_lease_store().await?;
     let now = Utc::now();
     let expiry = now + Duration::seconds(60);
     let pending = enqueue_remote_lease_job(&store, "same-host-reclaim").await?;
@@ -340,9 +336,7 @@ async fn runtime_store_remote_host_lease_reclaim_cleans_receipts_and_fences_gene
 async fn runtime_store_remote_host_lease_concurrent_renew_and_complete_have_one_winner(
 ) -> anyhow::Result<()> {
     let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
-    let Some(store) = remote_lease_store().await? else {
-        return Ok(());
-    };
+    let store = remote_lease_store().await?;
     let store = Arc::new(store);
     let now = Utc::now();
     let expiry = now + Duration::seconds(60);
@@ -408,12 +402,94 @@ async fn runtime_store_remote_host_lease_concurrent_renew_and_complete_have_one_
 }
 
 #[tokio::test]
+async fn runtime_store_remote_host_lease_concurrent_renew_and_reclaim_have_one_mutation_winner(
+) -> anyhow::Result<()> {
+    let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
+    let store = Arc::new(remote_lease_store().await?);
+    let now = Utc::now();
+    let expired_at = now - Duration::seconds(1);
+    enqueue_remote_lease_job(&store, "renew-reclaim-race").await?;
+    let claimed = store
+        .claim_next_runtime_job_for_runtime_kind(RuntimeKind::RemoteHost, "host-a", expired_at)
+        .await?
+        .expect("job should be initially claimed");
+
+    let barrier = Arc::new(Barrier::new(3));
+    let renew_store = store.clone();
+    let renew_barrier = barrier.clone();
+    let renew_job = claimed.clone();
+    let renew = tokio::spawn(async move {
+        renew_barrier.wait().await;
+        renew_store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &renew_job,
+                "host-a",
+                expired_at,
+                Uuid::new_v4(),
+                60,
+                now,
+            ))
+            .await
+    });
+    let reclaim_store = store.clone();
+    let reclaim_barrier = barrier.clone();
+    let reclaim = tokio::spawn(async move {
+        reclaim_barrier.wait().await;
+        reclaim_store
+            .claim_next_runtime_job_for_runtime_kind(
+                RuntimeKind::RemoteHost,
+                "host-b",
+                now + Duration::seconds(60),
+            )
+            .await
+    });
+    barrier.wait().await;
+
+    let renewal_outcome = renew.await??;
+    assert!(matches!(
+        renewal_outcome,
+        RuntimeJobLeaseRenewalOutcome::LeaseLost {
+            reason: RuntimeJobLeaseRenewalRejection::Expired
+                | RuntimeJobLeaseRenewalRejection::WrongGeneration
+                | RuntimeJobLeaseRenewalRejection::WrongOwner
+        }
+    ));
+    let reclaimed = reclaim.await??.expect("expired job must be reclaimed");
+    assert_eq!(reclaimed.lease_generation, claimed.lease_generation + 1);
+    assert_eq!(
+        reclaimed.lease.as_ref().map(|lease| lease.owner.as_str()),
+        Some("host-b")
+    );
+
+    let persisted = store
+        .get_runtime_job(&claimed.id)
+        .await?
+        .expect("reclaimed job must remain readable");
+    assert_eq!(persisted.lease_generation, reclaimed.lease_generation);
+    assert_eq!(persisted.lease, reclaimed.lease);
+    let events = store.runtime_events_for(&claimed.id).await?;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.event_type == "RuntimeJobReclaimed")
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.event_type == "RuntimeJobLeaseRenewalRejected")
+            .count(),
+        1
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_store_remote_host_lease_expired_receipt_is_cleaned_before_rejection(
 ) -> anyhow::Result<()> {
     let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
-    let Some(store) = remote_lease_store().await? else {
-        return Ok(());
-    };
+    let store = remote_lease_store().await?;
     let now = Utc::now();
     let expiry = now + Duration::seconds(1);
     enqueue_remote_lease_job(&store, "receipt-expiry").await?;
@@ -495,9 +571,7 @@ impl FenceCase {
 async fn runtime_store_remote_host_lease_full_state_and_horizon_fence_matrix() -> anyhow::Result<()>
 {
     let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
-    let Some(store) = remote_lease_store().await? else {
-        return Ok(());
-    };
+    let store = remote_lease_store().await?;
     let now = Utc::now();
     let cases = [
         FenceCase::Draining,

--- a/crates/harness-workflow/src/runtime/tests/remote_host_lease.rs
+++ b/crates/harness-workflow/src/runtime/tests/remote_host_lease.rs
@@ -268,7 +268,7 @@ async fn runtime_store_remote_host_lease_ttl_receipts_and_fences() -> anyhow::Re
             .iter()
             .filter(|event| event.event_type == "RuntimeJobLeaseRenewalRejected")
             .count(),
-        3
+        4
     );
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/tests/remote_host_lease.rs
+++ b/crates/harness-workflow/src/runtime/tests/remote_host_lease.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::runtime::store::runtime_job_leases::{
-    RuntimeJobLeaseRenewalOutcome, RuntimeJobLeaseRenewalRejection, RuntimeJobLeaseRenewalRequest,
+    postgres_timestamp_ceil, RuntimeJobLeaseRenewalOutcome, RuntimeJobLeaseRenewalRejection,
+    RuntimeJobLeaseRenewalRequest,
 };
 use tokio::sync::Barrier;
 use uuid::Uuid;
@@ -112,7 +113,9 @@ fn assert_rejected(
 async fn runtime_store_remote_host_lease_ttl_receipts_and_fences() -> anyhow::Result<()> {
     let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
     let store = remote_lease_store().await?;
-    let now = Utc::now();
+    let now = Utc::now()
+        .with_nanosecond(123_456_789)
+        .expect("fixed nanosecond component must be valid");
     let original_expiry = now + Duration::seconds(60);
     let pending = enqueue_remote_lease_job(&store, "ttl-receipts").await?;
     let claimed = store
@@ -143,7 +146,8 @@ async fn runtime_store_remote_host_lease_ttl_receipts_and_fences() -> anyhow::Re
             ))
             .await?,
     );
-    assert_eq!(short_target_expiry, original_expiry);
+    assert!(short_target_expiry >= original_expiry);
+    assert_eq!(short_target_expiry.nanosecond() % 1_000, 0);
     assert!(!replayed);
 
     let (replayed_expiry, replayed) = renewed_expiry(
@@ -158,7 +162,29 @@ async fn runtime_store_remote_host_lease_ttl_receipts_and_fences() -> anyhow::Re
             ))
             .await?,
     );
-    assert_eq!(replayed_expiry, original_expiry);
+    assert_eq!(replayed_expiry, short_target_expiry);
+    assert_eq!(
+        serde_json::to_string(&replayed_expiry)?,
+        serde_json::to_string(&short_target_expiry)?
+    );
+    assert!(replayed);
+
+    let same_microsecond_expiry = original_expiry
+        .with_nanosecond(original_expiry.nanosecond() / 1_000 * 1_000 + 1)
+        .expect("same-microsecond timestamp must be valid");
+    let (precision_replay_expiry, replayed) = renewed_expiry(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &claimed,
+                "host-a",
+                same_microsecond_expiry,
+                renewal_id,
+                1,
+                now,
+            ))
+            .await?,
+    );
+    assert_eq!(precision_replay_expiry, short_target_expiry);
     assert!(replayed);
 
     assert_rejected(
@@ -188,7 +214,10 @@ async fn runtime_store_remote_host_lease_ttl_receipts_and_fences() -> anyhow::Re
             ))
             .await?,
     );
-    assert_eq!(extended_expiry, now + Duration::seconds(120));
+    assert_eq!(
+        Some(extended_expiry),
+        postgres_timestamp_ceil(now + Duration::seconds(120))
+    );
 
     let mut wrong_generation =
         renewal(&claimed, "host-a", extended_expiry, Uuid::new_v4(), 60, now);
@@ -391,9 +420,10 @@ async fn runtime_store_remote_host_lease_concurrent_renew_and_complete_have_one_
         .expect("job should remain readable");
     if renewed {
         assert_eq!(persisted.status, RuntimeJobStatus::Running);
-        assert!(persisted
-            .lease
-            .is_some_and(|lease| lease.expires_at == now + Duration::seconds(120)));
+        assert_eq!(
+            persisted.lease.map(|lease| lease.expires_at),
+            postgres_timestamp_ceil(now + Duration::seconds(120))
+        );
     } else {
         assert_eq!(persisted.status, RuntimeJobStatus::Succeeded);
         assert!(persisted.lease.is_none());
@@ -506,10 +536,17 @@ async fn runtime_store_remote_host_lease_expired_receipt_is_cleaned_before_rejec
             .await?,
     );
 
+    let normalized_expiry = postgres_timestamp_ceil(expiry)
+        .expect("ordinary test timestamp must normalize to PostgreSQL precision");
     assert_rejected(
         store
             .renew_remote_host_runtime_job_lease(renewal(
-                &claimed, "host-a", expiry, renewal_id, 1, expiry,
+                &claimed,
+                "host-a",
+                expiry,
+                renewal_id,
+                1,
+                normalized_expiry,
             ))
             .await?,
         RuntimeJobLeaseRenewalRejection::Expired,
@@ -664,6 +701,9 @@ async fn runtime_store_remote_host_lease_full_state_and_horizon_fence_matrix() -
             ))
             .await?,
     );
-    assert_eq!(maximum_expiry, now + Duration::seconds(3_600));
+    assert_eq!(
+        Some(maximum_expiry),
+        postgres_timestamp_ceil(now + Duration::seconds(3_600))
+    );
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/tests/remote_host_lease.rs
+++ b/crates/harness-workflow/src/runtime/tests/remote_host_lease.rs
@@ -1,0 +1,595 @@
+use super::*;
+use crate::runtime::store::runtime_job_leases::{
+    RuntimeJobLeaseRenewalOutcome, RuntimeJobLeaseRenewalRejection, RuntimeJobLeaseRenewalRequest,
+};
+use tokio::sync::Barrier;
+use uuid::Uuid;
+
+static REMOTE_LEASE_DB_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn remote_lease_store() -> anyhow::Result<Option<WorkflowRuntimeStore>> {
+    if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
+        return Ok(None);
+    }
+    let dir = tempfile::tempdir()?;
+    Ok(Some(
+        WorkflowRuntimeStore::open(&dir.path().join("remote-host-lease.db")).await?,
+    ))
+}
+
+async fn enqueue_remote_lease_job(
+    store: &WorkflowRuntimeStore,
+    key: &str,
+) -> anyhow::Result<RuntimeJob> {
+    let workflow = WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        WorkflowSubject::new("issue", format!("issue:{key}")),
+    )
+    .with_id(format!("remote-lease-{key}"));
+    store.upsert_instance(&workflow).await?;
+    let command = WorkflowCommand::enqueue_activity("remote_check", format!("remote-{key}"));
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({ "activity": "remote_check" }),
+        )
+        .await
+}
+
+async fn persist_runtime_job(store: &WorkflowRuntimeStore, job: &RuntimeJob) -> anyhow::Result<()> {
+    let status = serde_json::to_value(job.status)?
+        .as_str()
+        .expect("runtime job status must serialize as a string")
+        .to_string();
+    let runtime_kind = serde_json::to_value(job.runtime_kind)?
+        .as_str()
+        .expect("runtime kind must serialize as a string")
+        .to_string();
+    sqlx::query(
+        "UPDATE runtime_jobs
+         SET status = $1, runtime_kind = $2, not_before = $3, data = $4::jsonb, updated_at = $5
+         WHERE id = $6",
+    )
+    .bind(status)
+    .bind(runtime_kind)
+    .bind(job.not_before)
+    .bind(serde_json::to_string(job)?)
+    .bind(job.updated_at)
+    .bind(&job.id)
+    .execute(store.pool())
+    .await?;
+    Ok(())
+}
+
+fn renewal<'a>(
+    job: &'a RuntimeJob,
+    owner: &'a str,
+    previous_expires_at: DateTime<Utc>,
+    renewal_id: Uuid,
+    lease_secs: i64,
+    now: DateTime<Utc>,
+) -> RuntimeJobLeaseRenewalRequest<'a> {
+    RuntimeJobLeaseRenewalRequest {
+        runtime_job_id: &job.id,
+        owner,
+        lease_generation: job.lease_generation,
+        previous_expires_at,
+        renewal_id,
+        lease_secs,
+        now,
+        max_lease_secs: 3_600,
+        owner_active: true,
+    }
+}
+
+fn renewed_expiry(outcome: RuntimeJobLeaseRenewalOutcome) -> (DateTime<Utc>, bool) {
+    match outcome {
+        RuntimeJobLeaseRenewalOutcome::Renewed {
+            lease_expires_at,
+            replayed,
+            ..
+        } => (lease_expires_at, replayed),
+        other => panic!("expected successful renewal, got {other:?}"),
+    }
+}
+
+fn assert_rejected(
+    outcome: RuntimeJobLeaseRenewalOutcome,
+    expected: RuntimeJobLeaseRenewalRejection,
+) {
+    assert_eq!(
+        outcome,
+        RuntimeJobLeaseRenewalOutcome::LeaseLost { reason: expected }
+    );
+}
+
+#[tokio::test]
+async fn runtime_store_remote_host_lease_ttl_receipts_and_fences() -> anyhow::Result<()> {
+    let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
+    let Some(store) = remote_lease_store().await? else {
+        return Ok(());
+    };
+    let now = Utc::now();
+    let original_expiry = now + Duration::seconds(60);
+    let pending = enqueue_remote_lease_job(&store, "ttl-receipts").await?;
+    let claimed = store
+        .claim_next_runtime_job_for_runtime_kind(RuntimeKind::RemoteHost, "host-a", original_expiry)
+        .await?
+        .expect("remote job should be claimed");
+    assert_eq!(claimed.id, pending.id);
+
+    assert!(store
+        .claim_next_runtime_job_for_runtime_kind(
+            RuntimeKind::RemoteHost,
+            "host-b",
+            now + Duration::seconds(90),
+        )
+        .await?
+        .is_none());
+
+    let renewal_id = Uuid::new_v4();
+    let (short_target_expiry, replayed) = renewed_expiry(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &claimed,
+                "host-a",
+                original_expiry,
+                renewal_id,
+                1,
+                now,
+            ))
+            .await?,
+    );
+    assert_eq!(short_target_expiry, original_expiry);
+    assert!(!replayed);
+
+    let (replayed_expiry, replayed) = renewed_expiry(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &claimed,
+                "host-a",
+                original_expiry,
+                renewal_id,
+                1,
+                now,
+            ))
+            .await?,
+    );
+    assert_eq!(replayed_expiry, original_expiry);
+    assert!(replayed);
+
+    assert_rejected(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &claimed,
+                "host-a",
+                original_expiry,
+                renewal_id,
+                2,
+                now,
+            ))
+            .await?,
+        RuntimeJobLeaseRenewalRejection::RenewalIdConflict,
+    );
+
+    let extended_id = Uuid::new_v4();
+    let (extended_expiry, _) = renewed_expiry(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &claimed,
+                "host-a",
+                original_expiry,
+                extended_id,
+                120,
+                now,
+            ))
+            .await?,
+    );
+    assert_eq!(extended_expiry, now + Duration::seconds(120));
+
+    let mut wrong_generation =
+        renewal(&claimed, "host-a", extended_expiry, Uuid::new_v4(), 60, now);
+    wrong_generation.lease_generation += 1;
+    assert_rejected(
+        store
+            .renew_remote_host_runtime_job_lease(wrong_generation)
+            .await?,
+        RuntimeJobLeaseRenewalRejection::WrongGeneration,
+    );
+    assert_rejected(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &claimed,
+                "host-b",
+                extended_expiry,
+                Uuid::new_v4(),
+                60,
+                now,
+            ))
+            .await?,
+        RuntimeJobLeaseRenewalRejection::WrongOwner,
+    );
+    assert_rejected(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &claimed,
+                "host-a",
+                original_expiry,
+                Uuid::new_v4(),
+                60,
+                now,
+            ))
+            .await?,
+        RuntimeJobLeaseRenewalRejection::StaleExpiry,
+    );
+
+    let events = store.runtime_events_for(&claimed.id).await?;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.event_type == "RuntimeJobLeaseRenewed")
+            .count(),
+        2
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.event_type == "RuntimeJobLeaseRenewalRejected")
+            .count(),
+        3
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_store_remote_host_lease_reclaim_cleans_receipts_and_fences_generation(
+) -> anyhow::Result<()> {
+    let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
+    let Some(store) = remote_lease_store().await? else {
+        return Ok(());
+    };
+    let now = Utc::now();
+    let expiry = now + Duration::seconds(60);
+    let pending = enqueue_remote_lease_job(&store, "same-host-reclaim").await?;
+    let first = store
+        .claim_next_runtime_job_for_runtime_kind(RuntimeKind::RemoteHost, "host-a", expiry)
+        .await?
+        .expect("first claim should succeed");
+    let renewal_id = Uuid::new_v4();
+    renewed_expiry(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &first, "host-a", expiry, renewal_id, 120, now,
+            ))
+            .await?,
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM runtime_job_lease_renewal_receipts WHERE runtime_job_id = $1",
+        )
+        .bind(&pending.id)
+        .fetch_one(store.pool())
+        .await?,
+        1
+    );
+
+    assert_eq!(
+        store
+            .revoke_remote_host_runtime_job_leases("host-a", now)
+            .await?,
+        1
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM runtime_job_lease_renewal_receipts WHERE runtime_job_id = $1",
+        )
+        .bind(&pending.id)
+        .fetch_one(store.pool())
+        .await?,
+        0
+    );
+
+    let second_expiry = now + Duration::seconds(180);
+    let second = store
+        .claim_next_runtime_job_for_runtime_kind(RuntimeKind::RemoteHost, "host-a", second_expiry)
+        .await?
+        .expect("same host should reclaim revoked job");
+    assert_eq!(second.lease_generation, first.lease_generation + 1);
+
+    assert_rejected(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &first,
+                "host-a",
+                expiry,
+                Uuid::new_v4(),
+                60,
+                now,
+            ))
+            .await?,
+        RuntimeJobLeaseRenewalRejection::WrongGeneration,
+    );
+    let stale_completion = store
+        .commit_runtime_activity_completion_if_owned_with_generation(
+            &first.id,
+            "host-a",
+            expiry,
+            Some(first.lease_generation),
+            &ActivityResult::succeeded("remote_check", "done"),
+        )
+        .await?;
+    assert!(stale_completion.is_none());
+
+    let events = store.runtime_events_for(&first.id).await?;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.event_type == "RuntimeJobLeaseRevoked")
+            .count(),
+        1
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_store_remote_host_lease_concurrent_renew_and_complete_have_one_winner(
+) -> anyhow::Result<()> {
+    let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
+    let Some(store) = remote_lease_store().await? else {
+        return Ok(());
+    };
+    let store = Arc::new(store);
+    let now = Utc::now();
+    let expiry = now + Duration::seconds(60);
+    let pending = enqueue_remote_lease_job(&store, "renew-complete-race").await?;
+    let claimed = store
+        .claim_next_runtime_job_for_runtime_kind(RuntimeKind::RemoteHost, "host-a", expiry)
+        .await?
+        .expect("job should be claimed");
+    assert_eq!(claimed.id, pending.id);
+
+    let barrier = Arc::new(Barrier::new(3));
+    let renew_store = store.clone();
+    let renew_barrier = barrier.clone();
+    let renew_job = claimed.clone();
+    let renew = tokio::spawn(async move {
+        renew_barrier.wait().await;
+        renew_store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &renew_job,
+                "host-a",
+                expiry,
+                Uuid::new_v4(),
+                120,
+                now,
+            ))
+            .await
+    });
+    let complete_store = store.clone();
+    let complete_barrier = barrier.clone();
+    let complete_job = claimed.clone();
+    let complete = tokio::spawn(async move {
+        complete_barrier.wait().await;
+        complete_store
+            .commit_runtime_activity_completion_if_owned_with_generation(
+                &complete_job.id,
+                "host-a",
+                expiry,
+                Some(complete_job.lease_generation),
+                &ActivityResult::succeeded("remote_check", "done"),
+            )
+            .await
+    });
+    barrier.wait().await;
+
+    let renewed = matches!(renew.await??, RuntimeJobLeaseRenewalOutcome::Renewed { .. });
+    let completed = complete.await??.is_some();
+    assert_ne!(renewed, completed, "exactly one fenced operation must win");
+
+    let persisted = store
+        .get_runtime_job(&claimed.id)
+        .await?
+        .expect("job should remain readable");
+    if renewed {
+        assert_eq!(persisted.status, RuntimeJobStatus::Running);
+        assert!(persisted
+            .lease
+            .is_some_and(|lease| lease.expires_at == now + Duration::seconds(120)));
+    } else {
+        assert_eq!(persisted.status, RuntimeJobStatus::Succeeded);
+        assert!(persisted.lease.is_none());
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_store_remote_host_lease_expired_receipt_is_cleaned_before_rejection(
+) -> anyhow::Result<()> {
+    let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
+    let Some(store) = remote_lease_store().await? else {
+        return Ok(());
+    };
+    let now = Utc::now();
+    let expiry = now + Duration::seconds(1);
+    enqueue_remote_lease_job(&store, "receipt-expiry").await?;
+    let claimed = store
+        .claim_next_runtime_job_for_runtime_kind(RuntimeKind::RemoteHost, "host-a", expiry)
+        .await?
+        .expect("job should be claimed");
+    let renewal_id = Uuid::new_v4();
+    renewed_expiry(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &claimed, "host-a", expiry, renewal_id, 1, now,
+            ))
+            .await?,
+    );
+
+    assert_rejected(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &claimed, "host-a", expiry, renewal_id, 1, expiry,
+            ))
+            .await?,
+        RuntimeJobLeaseRenewalRejection::Expired,
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM runtime_job_lease_renewal_receipts WHERE runtime_job_id = $1",
+        )
+        .bind(&claimed.id)
+        .fetch_one(store.pool())
+        .await?,
+        0
+    );
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum FenceCase {
+    Draining,
+    Expired,
+    Revoked,
+    WrongRuntimeKind,
+    WrongState,
+    InvalidZeroDuration,
+    InvalidOversizedDuration,
+    OverHorizon,
+}
+
+impl FenceCase {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Draining => "draining",
+            Self::Expired => "expired",
+            Self::Revoked => "revoked",
+            Self::WrongRuntimeKind => "wrong-runtime-kind",
+            Self::WrongState => "wrong-state",
+            Self::InvalidZeroDuration => "invalid-zero-duration",
+            Self::InvalidOversizedDuration => "invalid-oversized-duration",
+            Self::OverHorizon => "over-horizon",
+        }
+    }
+
+    fn rejection(self) -> RuntimeJobLeaseRenewalRejection {
+        match self {
+            Self::Draining => RuntimeJobLeaseRenewalRejection::HostDraining,
+            Self::Expired => RuntimeJobLeaseRenewalRejection::Expired,
+            Self::Revoked => RuntimeJobLeaseRenewalRejection::Revoked,
+            Self::WrongRuntimeKind => RuntimeJobLeaseRenewalRejection::WrongRuntimeKind,
+            Self::WrongState => RuntimeJobLeaseRenewalRejection::WrongState,
+            Self::InvalidZeroDuration | Self::InvalidOversizedDuration => {
+                RuntimeJobLeaseRenewalRejection::InvalidDuration
+            }
+            Self::OverHorizon => RuntimeJobLeaseRenewalRejection::InvariantViolation,
+        }
+    }
+}
+
+#[tokio::test]
+async fn runtime_store_remote_host_lease_full_state_and_horizon_fence_matrix() -> anyhow::Result<()>
+{
+    let _db_guard = REMOTE_LEASE_DB_TEST_LOCK.lock().await;
+    let Some(store) = remote_lease_store().await? else {
+        return Ok(());
+    };
+    let now = Utc::now();
+    let cases = [
+        FenceCase::Draining,
+        FenceCase::Expired,
+        FenceCase::Revoked,
+        FenceCase::WrongRuntimeKind,
+        FenceCase::WrongState,
+        FenceCase::InvalidZeroDuration,
+        FenceCase::InvalidOversizedDuration,
+        FenceCase::OverHorizon,
+    ];
+
+    for case in cases {
+        let initial_expiry = match case {
+            FenceCase::Expired => now - Duration::seconds(1),
+            FenceCase::OverHorizon => now + Duration::seconds(3_601),
+            _ => now + Duration::seconds(60),
+        };
+        enqueue_remote_lease_job(&store, case.name()).await?;
+        let mut claimed = store
+            .claim_next_runtime_job_for_runtime_kind(
+                RuntimeKind::RemoteHost,
+                "host-a",
+                initial_expiry,
+            )
+            .await?
+            .expect("matrix job should be claimed");
+        match case {
+            FenceCase::Revoked => claimed.lease = None,
+            FenceCase::WrongRuntimeKind => claimed.runtime_kind = RuntimeKind::CodexJsonrpc,
+            FenceCase::WrongState => claimed.status = RuntimeJobStatus::Succeeded,
+            _ => {}
+        }
+        if matches!(
+            case,
+            FenceCase::Revoked | FenceCase::WrongRuntimeKind | FenceCase::WrongState
+        ) {
+            persist_runtime_job(&store, &claimed).await?;
+        }
+
+        let lease_secs = match case {
+            FenceCase::InvalidZeroDuration => 0,
+            FenceCase::InvalidOversizedDuration => 3_601,
+            _ => 60,
+        };
+        let mut request = renewal(
+            &claimed,
+            "host-a",
+            initial_expiry,
+            Uuid::new_v4(),
+            lease_secs,
+            now,
+        );
+        request.owner_active = !matches!(case, FenceCase::Draining);
+        assert_rejected(
+            store.renew_remote_host_runtime_job_lease(request).await?,
+            case.rejection(),
+        );
+
+        let persisted = store
+            .get_runtime_job(&claimed.id)
+            .await?
+            .expect("rejected matrix job must remain readable");
+        assert_eq!(persisted.status, claimed.status);
+        assert_eq!(persisted.runtime_kind, claimed.runtime_kind);
+        assert_eq!(persisted.lease, claimed.lease);
+        let events = store.runtime_events_for(&claimed.id).await?;
+        let rejection = events
+            .last()
+            .expect("known-job rejection must append an event");
+        assert_eq!(rejection.event_type, "RuntimeJobLeaseRenewalRejected");
+        assert_eq!(rejection.event["reason"], case.rejection().as_str());
+    }
+
+    enqueue_remote_lease_job(&store, "maximum-ttl").await?;
+    let expiry = now + Duration::seconds(60);
+    let claimed = store
+        .claim_next_runtime_job_for_runtime_kind(RuntimeKind::RemoteHost, "host-a", expiry)
+        .await?
+        .expect("maximum-TTL job should be claimed");
+    let (maximum_expiry, _) = renewed_expiry(
+        store
+            .renew_remote_host_runtime_job_lease(renewal(
+                &claimed,
+                "host-a",
+                expiry,
+                Uuid::new_v4(),
+                3_600,
+                now,
+            ))
+            .await?,
+    );
+    assert_eq!(maximum_expiry, now + Duration::seconds(3_600));
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/tests/remote_host_lease.rs
+++ b/crates/harness-workflow/src/runtime/tests/remote_host_lease.rs
@@ -207,7 +207,7 @@ async fn runtime_store_remote_host_lease_ttl_receipts_and_fences() -> anyhow::Re
             .renew_remote_host_runtime_job_lease(renewal(
                 &claimed,
                 "host-a",
-                original_expiry,
+                short_target_expiry,
                 extended_id,
                 120,
                 now,

--- a/docs/runtime-host-model-spec.md
+++ b/docs/runtime-host-model-spec.md
@@ -27,6 +27,7 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 - `POST /api/runtime-hosts/{id}/tasks/claim`
 4. Workflow runtime job HTTP API endpoints:
 - `POST /api/runtime-hosts/{id}/runtime-jobs/claim`
+- `POST /api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/lease/renew`
 - `POST /api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/complete`
 5. Tests for lease correctness, heartbeat-driven status, runtime job claim ownership, and terminal callback ownership.
 
@@ -44,6 +45,7 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 - `capabilities: Vec<String>`
 - `registered_at: DateTime<Utc>`
 - `last_heartbeat_at: DateTime<Utc>`
+- `lifecycle: active | draining` (legacy records default to `active`)
 
 `TaskScheduler` runtime-host lease fields
 - `runtime_host_id: Option<String>`
@@ -60,18 +62,20 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 
 1. `register` is idempotent by `host_id` (upsert metadata and refresh heartbeat).
 2. `heartbeat` on unknown host returns error.
-3. `deregister` removes host state and releases any pending task claims owned by that host.
+3. `deregister` first persists `draining`, revokes every owned workflow runtime-job lease, releases pending task claims, and removes the host only after no workflow leases remain. A failed or interrupted cleanup leaves the host visibly draining and retryable.
 4. Legacy task `claim` selects only tasks in `pending` status.
 5. A non-expired lease blocks claims by other hosts.
 6. Expired leases are reclaimable by any host.
 7. Workflow runtime-job claims select only `runtime_kind = remote_host` jobs.
 8. In-process runtime workers do not claim `remote_host` jobs.
-9. Runtime-job completion requires the host id and exact lease expiration timestamp from the claim response.
+9. Runtime-job completion requires the host id and exact lease expiration timestamp from the claim response. Upgraded clients also send the additive lease generation; legacy clients may omit it.
+10. Runtime-job claim and renewal lease durations default to 60 seconds and accept only `1..=3600` seconds.
+11. A draining host cannot claim or renew work. Heartbeat only updates host liveness and never extends a job lease.
 
-## API Response Shape (V1)
+## API Response Shape
 
 `GET /api/runtime-hosts`
-- `hosts: [{ id, display_name, capabilities, registered_at, last_heartbeat_at, online }]`
+- `hosts: [{ id, display_name, capabilities, registered_at, last_heartbeat_at, online, lifecycle }]`
 - `online` is computed as `now - last_heartbeat_at <= heartbeat_timeout_secs`
 
 `POST /api/runtime-hosts/{id}/tasks/claim`
@@ -80,15 +84,36 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 
 `POST /api/runtime-hosts/{id}/runtime-jobs/claim`
 - request: `{ lease_secs?: number }`
-- success: `{ claimed: true, runtime_job_id, lease_expires_at, runtime_job }`
+- success: `{ claimed: true, runtime_job_id, lease_generation, lease_expires_at, runtime_job }`
 - none available: `{ claimed: false }`
 - `runtime_job.input` carries the activity payload and runtime profile manifest needed by the external host.
+- `lease_secs` is a target TTL from server time, defaults to `60`, and must be an integer in `1..=3600`; `null`, zero, and larger values are rejected.
+
+`POST /api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/lease/renew`
+- request: `{ lease_generation, lease_expires_at, renewal_id, lease_secs?: number }`
+- success: `{ renewed: true, runtime_job_id, lease_generation, lease_expires_at, replayed }`
+- the server computes `max(current_expiry, server_now + lease_secs)`, so renewal never shortens a lease and never extends beyond the 3600-second server-time horizon.
+- retry an ambiguous transport result with the same `renewal_id` and identical inputs; a live replay returns the original expiry with `replayed: true` and creates no second renewal event.
+- stale, expired, revoked, reclaimed, wrong-host, wrong-generation, or draining ownership returns HTTP `409` with `{ error_code: "lease_lost", must_stop: true }`; the response never exposes another owner's identity or lease evidence.
+- unknown host or job returns `404`, invalid input returns `400`, and unavailable durable storage returns `503`.
 
 `POST /api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/complete`
-- request: `{ lease_expires_at, result }`
+- request: `{ lease_expires_at, lease_generation?, result }`
 - `result` is the workflow `ActivityResult` payload and may report `succeeded`, `failed`, `blocked`, or `cancelled`.
 - success: `{ completed: true, runtime_job, workflow_event, decision }`
 - stale or wrong lease: HTTP `409` with `{ completed: false, error }`
+
+## Remote Executor Renewal Protocol
+
+1. Schedule renewal at approximately one third of the confirmed TTL and keep at most one renewal request in flight per runtime job.
+2. Treat heartbeat and per-job renewal as independent protocols. Heartbeat proves host liveness only; renewal of one job does not renew any other job.
+3. On an ambiguous transport failure, retry only with the same `renewal_id`, generation, prior expiry, and duration.
+4. On `404`, `409`, `must_stop: true`, or inability to confirm renewal before the last confirmed expiry, cancel local execution and suppress completion.
+5. Deregistration is draining cleanup: do not claim or renew after draining begins, and retry deregistration until it succeeds or returns an operational failure.
+
+## Rollback
+
+Stop remote clients from calling renewal before disabling the renew route. The additive generation, lifecycle, and receipt data remain compatible with legacy claim and completion clients. Before removing draining/revocation behavior, verify that no host is draining and no runtime job depends on a renewed expiry.
 
 ## Risks
 


### PR DESCRIPTION
Closes #1602

## Summary
- add bounded, idempotent RemoteHost runtime-job lease renewal with owner/generation/expiry fencing and durable audit receipts
- serialize host lifecycle operations so draining, renewal, completion, claim, project-cache sync, and deregistration have one ordering boundary
- release the host operation lock during slow project resolution, then recheck lifecycle and registration identity under lock before cache mutation
- revoke workflow runtime-job leases before host removal and preserve retryable draining state
- normalize PostgreSQL lease timestamps before receipt replay comparisons
- document the remote executor stop contract and add deterministic fence, replay, cleanup, authentication, and race tests

## Verification
- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p harness-workflow (432 passed plus public API)
- cargo test -p harness-server -- --test-threads=4 (1729 passed plus integration tests)
- runtime_store_remote_host_lease_ttl_receipts_and_fences passed 5 consecutive runs against an isolated PostgreSQL test database
- cargo test -p harness-server runtime_hosts_workflow_api_tests (9 passed)
- cargo test -p harness-server runtime_hosts_workflow_review_tests (5 passed)
- cargo test -p harness-server runtime_project_cache_api_tests (8 passed)
- cargo test -p harness-server runtime_hosts_tests (12 passed)
- cargo test -p harness-server project_resolution_rejects_same_id_reregistration_aba (1 passed)
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1602
- python3 checks/check_workflow.py --repo .