### PR TITLE
feat(workflow): report driverless progress

### DIFF
--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -21,6 +21,8 @@ use std::path::Path;
 
 #[path = "store/commands.rs"]
 mod command_store;
+#[path = "store/driverless_progress.rs"]
+mod driverless_progress;
 #[path = "store/instance_helpers.rs"]
 mod instance_helpers;
 #[path = "store/instances.rs"]
@@ -33,6 +35,7 @@ mod runtime_completion;
 mod runtime_usage;
 #[path = "store/submission_commit.rs"]
 mod submission_commit;
+pub use driverless_progress::{DriverlessProgressInstance, DriverlessProgressProvenanceStatus};
 pub use recovery::{
     WorkflowRuntimeRecoveryAction, WorkflowRuntimeRecoveryOutcome, WorkflowRuntimeRecoveryRequest,
 };

--- a/crates/harness-workflow/src/runtime/store/driverless_progress.rs
+++ b/crates/harness-workflow/src/runtime/store/driverless_progress.rs
@@ -1,0 +1,193 @@
+use super::WorkflowRuntimeStore;
+use crate::runtime::state_registry::{
+    known_workflow_definition_ids, workflow_states_for_definition, WorkflowProgressMode,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriverlessProgressProvenanceStatus {
+    Established,
+    MissingStateEntryProvenance,
+    AmbiguousStateEntryProvenance,
+}
+
+impl DriverlessProgressProvenanceStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Established => "established",
+            Self::MissingStateEntryProvenance => "missing_state_entry_provenance",
+            Self::AmbiguousStateEntryProvenance => "ambiguous_state_entry_provenance",
+        }
+    }
+}
+
+impl TryFrom<&str> for DriverlessProgressProvenanceStatus {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "established" => Ok(Self::Established),
+            "missing_state_entry_provenance" => Ok(Self::MissingStateEntryProvenance),
+            "ambiguous_state_entry_provenance" => Ok(Self::AmbiguousStateEntryProvenance),
+            other => anyhow::bail!("unknown driverless progress provenance status: {other}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriverlessProgressInstance {
+    pub workflow_id: String,
+    pub definition_id: String,
+    pub state: String,
+    pub age_secs: u64,
+    pub provenance_status: DriverlessProgressProvenanceStatus,
+}
+
+impl WorkflowRuntimeStore {
+    pub async fn list_driverless_progress_instances(
+        &self,
+        limit: i64,
+    ) -> anyhow::Result<Vec<DriverlessProgressInstance>> {
+        let (definition_ids, states) = command_driven_state_pairs();
+        if definition_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let limit = limit.clamp(1, 500);
+        let rows: Vec<(String, String, String, i64, String)> = sqlx::query_as(
+            "WITH command_driven_states(definition_id, state) AS (
+                 SELECT * FROM unnest($1::text[], $2::text[])
+             ),
+             candidates AS (
+                 SELECT instance.id,
+                        instance.definition_id,
+                        instance.state,
+                        instance.updated_at
+                 FROM workflow_instances AS instance
+                 JOIN command_driven_states AS registered
+                   ON registered.definition_id = instance.definition_id
+                  AND registered.state = instance.state
+             ),
+             accepted_with_sequence AS (
+                 SELECT decision.id AS decision_id,
+                        decision.workflow_id,
+                        event.sequence,
+                        decision.data->'decision'->>'next_state' AS next_state,
+                        dense_rank() OVER (
+                            PARTITION BY decision.workflow_id
+                            ORDER BY event.sequence DESC
+                        ) AS sequence_rank
+                 FROM workflow_decisions AS decision
+                 JOIN workflow_events AS event
+                   ON event.id = decision.event_id
+                  AND event.workflow_id = decision.workflow_id
+                 JOIN candidates AS candidate
+                   ON candidate.id = decision.workflow_id
+                 WHERE decision.accepted = TRUE
+             ),
+             accepted_without_sequence AS (
+                 SELECT decision.workflow_id, COUNT(*) AS count
+                 FROM workflow_decisions AS decision
+                 JOIN candidates AS candidate
+                   ON candidate.id = decision.workflow_id
+                 LEFT JOIN workflow_events AS event
+                   ON event.id = decision.event_id
+                  AND event.workflow_id = decision.workflow_id
+                 WHERE decision.accepted = TRUE
+                   AND event.id IS NULL
+                 GROUP BY decision.workflow_id
+             ),
+             newest AS (
+                 SELECT workflow_id,
+                        COUNT(*) AS decision_count,
+                        CASE WHEN COUNT(*) = 1
+                            THEN (ARRAY_AGG(decision_id))[1]
+                        END AS decision_id,
+                        CASE WHEN COUNT(*) = 1
+                            THEN (ARRAY_AGG(next_state))[1]
+                        END AS next_state
+                 FROM accepted_with_sequence
+                 WHERE sequence_rank = 1
+                 GROUP BY workflow_id
+             ),
+             classified AS (
+                 SELECT candidate.*,
+                        newest.decision_id,
+                        CASE
+                            WHEN COALESCE(unsequenced.count, 0) > 0
+                              OR COALESCE(newest.decision_count, 0) > 1
+                                THEN 'ambiguous_state_entry_provenance'
+                            WHEN newest.decision_id IS NULL
+                              OR newest.next_state IS DISTINCT FROM candidate.state
+                                THEN 'missing_state_entry_provenance'
+                            ELSE 'established'
+                        END AS provenance_status
+                 FROM candidates AS candidate
+                 LEFT JOIN newest ON newest.workflow_id = candidate.id
+                 LEFT JOIN accepted_without_sequence AS unsequenced
+                   ON unsequenced.workflow_id = candidate.id
+             )
+             SELECT classified.id,
+                    classified.definition_id,
+                    classified.state,
+                    GREATEST(
+                        0,
+                        FLOOR(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - classified.updated_at)))
+                    )::bigint AS age_secs,
+                    classified.provenance_status
+             FROM classified
+             WHERE classified.provenance_status <> 'established'
+                OR NOT EXISTS (
+                    SELECT 1
+                    FROM workflow_commands AS command
+                    WHERE command.workflow_id = classified.id
+                      AND command.decision_id = classified.decision_id
+                      AND command.command_type IN ('enqueue_activity', 'start_child_workflow')
+                      AND (
+                          command.status IN ('pending', 'dispatching', 'deferred', 'dispatched')
+                          OR EXISTS (
+                              SELECT 1
+                              FROM runtime_jobs AS job
+                              WHERE job.command_id = command.id
+                                AND job.status IN ('pending', 'running')
+                          )
+                      )
+                )
+             ORDER BY classified.updated_at ASC, classified.id ASC
+             LIMIT $3",
+        )
+        .bind(&definition_ids)
+        .bind(&states)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(
+                |(workflow_id, definition_id, state, age_secs, provenance_status)| {
+                    Ok(DriverlessProgressInstance {
+                        workflow_id,
+                        definition_id,
+                        state,
+                        age_secs: u64::try_from(age_secs).map_err(|_| {
+                            anyhow::anyhow!("driverless progress age must be non-negative")
+                        })?,
+                        provenance_status: provenance_status.as_str().try_into()?,
+                    })
+                },
+            )
+            .collect()
+    }
+}
+
+fn command_driven_state_pairs() -> (Vec<String>, Vec<String>) {
+    let pairs: Vec<(String, String)> = known_workflow_definition_ids()
+        .into_iter()
+        .flat_map(|definition_id| {
+            workflow_states_for_definition(&definition_id)
+                .into_iter()
+                .filter(|state| state.progress_mode == Some(WorkflowProgressMode::CommandDriven))
+                .map(move |state| (definition_id.clone(), state.key.state.to_string()))
+        })
+        .collect();
+    pairs.into_iter().unzip()
+}

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -47,6 +47,7 @@ include!("tests/command_dispatcher.rs");
 include!("tests/command_store.rs");
 include!("tests/deferred_dispatch.rs");
 include!("tests/deferred_dispatch_review.rs");
+include!("tests/driverless_progress.rs");
 
 mod issue_planning;
 mod local_review;

--- a/crates/harness-workflow/src/runtime/tests/driverless_progress.rs
+++ b/crates/harness-workflow/src/runtime/tests/driverless_progress.rs
@@ -1,0 +1,411 @@
+#[tokio::test]
+async fn driverless_progress_reports_only_unowned_command_driven_instances() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let driverless = driverless_progress_instance(&store, "driverless", "implementing").await?;
+    let driverless_decision = accepted_state_entry(&store, &driverless, "implementing").await?;
+
+    let active = driverless_progress_instance(&store, "active", "implementing").await?;
+    let active_decision = accepted_state_entry(&store, &active, "implementing").await?;
+    let child_driver = WorkflowCommand::start_child_workflow(
+        PR_FEEDBACK_DEFINITION_ID,
+        "issue:123:pr-feedback",
+        "active-child-driver",
+    );
+    store
+        .enqueue_command_with_status(
+            &active.id,
+            Some(&active_decision.id),
+            &child_driver,
+            WorkflowCommandStatus::Dispatching,
+        )
+        .await?;
+
+    let deferred = driverless_progress_instance(&store, "deferred", "implementing").await?;
+    let deferred_decision = accepted_state_entry(&store, &deferred, "implementing").await?;
+    insert_driver_command(
+        &store,
+        &deferred.id,
+        Some(&deferred_decision.id),
+        "deferred-driver",
+        WorkflowCommandStatus::Deferred,
+    )
+    .await?;
+
+    let unfinished_job =
+        driverless_progress_instance(&store, "unfinished-job", "implementing").await?;
+    let unfinished_decision =
+        accepted_state_entry(&store, &unfinished_job, "implementing").await?;
+    let unfinished_command = insert_driver_command(
+        &store,
+        &unfinished_job.id,
+        Some(&unfinished_decision.id),
+        "unfinished-job-driver",
+        WorkflowCommandStatus::Pending,
+    )
+    .await?;
+    store
+        .enqueue_runtime_job(
+            &unfinished_command,
+            RuntimeKind::CodexExec,
+            "default",
+            json!({ "activity": "implement_issue" }),
+        )
+        .await?;
+    sqlx::query("UPDATE workflow_commands SET status = 'completed' WHERE id = $1")
+        .bind(&unfinished_command)
+        .execute(store.pool())
+        .await?;
+
+    let stale = driverless_progress_instance(&store, "stale", "implementing").await?;
+    let stale_decision =
+        accepted_state_entry_with_id(&store, &stale, "planning", "zzzz-older-decision").await?;
+    insert_driver_command(
+        &store,
+        &stale.id,
+        Some(&stale_decision.id),
+        "stale-driver",
+        WorkflowCommandStatus::Pending,
+    )
+    .await?;
+    let stale_current =
+        accepted_state_entry_with_id(&store, &stale, "implementing", "aaaa-newer-decision").await?;
+
+    let dedupe_collision =
+        driverless_progress_instance(&store, "dedupe-collision", "implementing").await?;
+    let dedupe_older = accepted_state_entry(&store, &dedupe_collision, "planning").await?;
+    insert_driver_command(
+        &store,
+        &dedupe_collision.id,
+        Some(&dedupe_older.id),
+        "shared-transition-dedupe-key",
+        WorkflowCommandStatus::Pending,
+    )
+    .await?;
+    accepted_state_entry(&store, &dedupe_collision, "implementing").await?;
+
+    let unrelated =
+        driverless_progress_instance(&store, "unrelated-decision", "implementing").await?;
+    accepted_state_entry(&store, &unrelated, "implementing").await?;
+    insert_driver_command(
+        &store,
+        &unrelated.id,
+        Some(&active_decision.id),
+        "unrelated-decision-driver",
+        WorkflowCommandStatus::Pending,
+    )
+    .await?;
+
+    let terminal_work =
+        driverless_progress_instance(&store, "terminal-work", "implementing").await?;
+    let terminal_decision =
+        accepted_state_entry(&store, &terminal_work, "implementing").await?;
+    let terminal_command = insert_driver_command(
+        &store,
+        &terminal_work.id,
+        Some(&terminal_decision.id),
+        "terminal-driver",
+        WorkflowCommandStatus::Pending,
+    )
+    .await?;
+    let terminal_job = store
+        .enqueue_runtime_job(
+            &terminal_command,
+            RuntimeKind::CodexExec,
+            "default",
+            json!({ "activity": "implement_issue" }),
+        )
+        .await?;
+    sqlx::query("UPDATE workflow_commands SET status = 'completed' WHERE id = $1")
+        .bind(&terminal_command)
+        .execute(store.pool())
+        .await?;
+    sqlx::query("UPDATE runtime_jobs SET status = 'succeeded' WHERE id = $1")
+        .bind(&terminal_job.id)
+        .execute(store.pool())
+        .await?;
+
+    let null_provenance =
+        driverless_progress_instance(&store, "null-provenance", "implementing").await?;
+    accepted_state_entry(&store, &null_provenance, "implementing").await?;
+    insert_driver_command(
+        &store,
+        &null_provenance.id,
+        None,
+        "null-driver",
+        WorkflowCommandStatus::Pending,
+    )
+    .await?;
+
+    let rejected = driverless_progress_instance(&store, "rejected", "implementing").await?;
+    let rejected_event = store
+        .append_event(&rejected.id, "test", "test", json!({}))
+        .await?;
+    let rejected_record = WorkflowDecisionRecord::rejected(
+        WorkflowDecision::new(
+            &rejected.id,
+            "planning",
+            "reject",
+            "implementing",
+            "test rejection",
+        ),
+        Some(rejected_event.id),
+        "test rejection",
+    );
+    store.record_decision(&rejected_record).await?;
+    insert_driver_command(
+        &store,
+        &rejected.id,
+        Some(&rejected_record.id),
+        "rejected-driver",
+        WorkflowCommandStatus::Pending,
+    )
+    .await?;
+
+    let non_command =
+        driverless_progress_instance(&store, "external-wait", "awaiting_dependencies").await?;
+    let terminal = driverless_progress_instance(&store, "terminal", "done").await?;
+
+    let before_counts = runtime_history_counts(&store).await?;
+    let rows = store.list_driverless_progress_instances(500).await?;
+    let after_counts = runtime_history_counts(&store).await?;
+    assert_eq!(before_counts, after_counts, "diagnostic must be read-only");
+
+    let by_id: std::collections::HashMap<_, _> = rows
+        .iter()
+        .map(|row| (row.workflow_id.as_str(), row))
+        .collect();
+    assert_eq!(
+        by_id[driverless.id.as_str()].provenance_status,
+        super::store::DriverlessProgressProvenanceStatus::Established
+    );
+    assert_eq!(
+        by_id[stale.id.as_str()].provenance_status,
+        super::store::DriverlessProgressProvenanceStatus::Established
+    );
+    assert_eq!(
+        by_id[dedupe_collision.id.as_str()].provenance_status,
+        super::store::DriverlessProgressProvenanceStatus::Established
+    );
+    assert_eq!(
+        by_id[unrelated.id.as_str()].provenance_status,
+        super::store::DriverlessProgressProvenanceStatus::Established
+    );
+    assert_eq!(
+        by_id[terminal_work.id.as_str()].provenance_status,
+        super::store::DriverlessProgressProvenanceStatus::Established
+    );
+    assert_eq!(
+        by_id[null_provenance.id.as_str()].provenance_status,
+        super::store::DriverlessProgressProvenanceStatus::Established
+    );
+    assert_eq!(
+        by_id[rejected.id.as_str()].provenance_status,
+        super::store::DriverlessProgressProvenanceStatus::MissingStateEntryProvenance
+    );
+    assert!(!by_id.contains_key(active.id.as_str()));
+    assert!(!by_id.contains_key(deferred.id.as_str()));
+    assert!(!by_id.contains_key(unfinished_job.id.as_str()));
+    assert!(!by_id.contains_key(non_command.id.as_str()));
+    assert!(!by_id.contains_key(terminal.id.as_str()));
+    assert_eq!(driverless_decision.workflow_id, driverless.id);
+    assert_eq!(stale_current.workflow_id, stale.id);
+    assert!(rows.iter().all(|row| row.age_secs < 60));
+    Ok(())
+}
+
+#[tokio::test]
+async fn driverless_progress_classifies_missing_and_ambiguous_provenance() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let missing = driverless_progress_instance(&store, "missing", "implementing").await?;
+    let mismatched = driverless_progress_instance(&store, "mismatched", "implementing").await?;
+    accepted_state_entry(&store, &mismatched, "planning").await?;
+
+    let equal = driverless_progress_instance(&store, "equal", "implementing").await?;
+    let equal_event = store
+        .append_event(&equal.id, "test", "test", json!({}))
+        .await?;
+    for decision_name in ["equal-a", "equal-b"] {
+        let mut record = WorkflowDecisionRecord::accepted(
+            WorkflowDecision::new(
+                &equal.id,
+                "planning",
+                decision_name,
+                "implementing",
+                "equal sequence fixture",
+            ),
+            Some(equal_event.id.clone()),
+        );
+        record.id = format!("{decision_name}-decision");
+        store.record_decision(&record).await?;
+    }
+
+    let unsequenced =
+        driverless_progress_instance(&store, "unsequenced", "implementing").await?;
+    accepted_state_entry(&store, &unsequenced, "implementing").await?;
+    let mut unsequenced_record = WorkflowDecisionRecord::accepted(
+        WorkflowDecision::new(
+            &unsequenced.id,
+            "planning",
+            "unsequenced",
+            "implementing",
+            "missing event sequence fixture",
+        ),
+        None,
+    );
+    unsequenced_record.id = "unsequenced-decision".to_string();
+    store.record_decision(&unsequenced_record).await?;
+
+    let rows = store.list_driverless_progress_instances(500).await?;
+    let by_id: std::collections::HashMap<_, _> = rows
+        .iter()
+        .map(|row| (row.workflow_id.as_str(), row))
+        .collect();
+    for workflow_id in [&missing.id, &mismatched.id] {
+        assert_eq!(
+            by_id[workflow_id.as_str()].provenance_status,
+            super::store::DriverlessProgressProvenanceStatus::MissingStateEntryProvenance
+        );
+    }
+    for workflow_id in [&equal.id, &unsequenced.id] {
+        assert_eq!(
+            by_id[workflow_id.as_str()].provenance_status,
+            super::store::DriverlessProgressProvenanceStatus::AmbiguousStateEntryProvenance
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn driverless_progress_is_bounded_and_ordered_by_age_then_id() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let older_b = driverless_progress_instance(&store, "older-b", "implementing").await?;
+    let older_a = driverless_progress_instance(&store, "older-a", "implementing").await?;
+    let newer = driverless_progress_instance(&store, "newer", "implementing").await?;
+    for instance in [&older_b, &older_a, &newer] {
+        accepted_state_entry(&store, instance, "implementing").await?;
+    }
+    let older_at = Utc::now() - Duration::hours(2);
+    sqlx::query("UPDATE workflow_instances SET updated_at = $1 WHERE id = ANY($2::text[])")
+        .bind(older_at)
+        .bind(vec![older_b.id.clone(), older_a.id.clone()])
+        .execute(store.pool())
+        .await?;
+
+    let rows = store.list_driverless_progress_instances(2).await?;
+    assert_eq!(rows.len(), 2);
+    let mut expected = vec![older_a.id, older_b.id];
+    expected.sort();
+    assert_eq!(
+        rows.iter()
+            .map(|row| row.workflow_id.clone())
+            .collect::<Vec<_>>(),
+        expected
+    );
+    assert!(rows.iter().all(|row| row.age_secs >= 7_000));
+    Ok(())
+}
+
+async fn driverless_progress_instance(
+    store: &WorkflowRuntimeStore,
+    id: &str,
+    state: &str,
+) -> anyhow::Result<WorkflowInstance> {
+    let instance = issue_instance(state).with_id(format!("driverless-progress-{id}"));
+    store.upsert_instance(&instance).await?;
+    Ok(instance)
+}
+
+async fn accepted_state_entry(
+    store: &WorkflowRuntimeStore,
+    instance: &WorkflowInstance,
+    next_state: &str,
+) -> anyhow::Result<WorkflowDecisionRecord> {
+    let event = store
+        .append_event(&instance.id, "test", "test", json!({}))
+        .await?;
+    let decision_id = format!("{}-decision-{}", instance.id, event.sequence);
+    persist_state_entry(
+        store,
+        instance,
+        next_state,
+        event.id,
+        &decision_id,
+    )
+    .await
+}
+
+async fn accepted_state_entry_with_id(
+    store: &WorkflowRuntimeStore,
+    instance: &WorkflowInstance,
+    next_state: &str,
+    decision_id: &str,
+) -> anyhow::Result<WorkflowDecisionRecord> {
+    let event = store
+        .append_event(&instance.id, "test", "test", json!({}))
+        .await?;
+    persist_state_entry(store, instance, next_state, event.id, decision_id).await
+}
+
+async fn persist_state_entry(
+    store: &WorkflowRuntimeStore,
+    instance: &WorkflowInstance,
+    next_state: &str,
+    event_id: String,
+    decision_id: &str,
+) -> anyhow::Result<WorkflowDecisionRecord> {
+    let mut record = WorkflowDecisionRecord::accepted(
+        WorkflowDecision::new(
+            &instance.id,
+            "planning",
+            format!("enter-{next_state}"),
+            next_state,
+            "state entry fixture",
+        ),
+        Some(event_id),
+    );
+    record.id = decision_id.to_string();
+    store.record_decision(&record).await?;
+    Ok(record)
+}
+
+async fn insert_driver_command(
+    store: &WorkflowRuntimeStore,
+    workflow_id: &str,
+    decision_id: Option<&str>,
+    dedupe_key: &str,
+    status: WorkflowCommandStatus,
+) -> anyhow::Result<String> {
+    let command = WorkflowCommand::enqueue_activity("implement_issue", dedupe_key);
+    store
+        .enqueue_command_with_status(workflow_id, decision_id, &command, status)
+        .await
+}
+
+async fn runtime_history_counts(
+    store: &WorkflowRuntimeStore,
+) -> anyhow::Result<(i64, i64, i64, i64, i64)> {
+    Ok(sqlx::query_as(
+        "SELECT
+            (SELECT COUNT(*) FROM workflow_instances),
+            (SELECT COUNT(*) FROM workflow_events),
+            (SELECT COUNT(*) FROM workflow_decisions),
+            (SELECT COUNT(*) FROM workflow_commands),
+            (SELECT COUNT(*) FROM runtime_jobs)",
+    )
+    .fetch_one(store.pool())
+    .await?)
+}


### PR DESCRIPTION
Refs #1603

Implements SP1603-T005.

- add one bounded read-only PostgreSQL snapshot query for registered command-driven states
- derive current-state-entry provenance from workflow event sequence, never UUID ordering
- classify missing and ambiguous provenance conservatively
- require exact decision_id ownership by a runtime-producing command or unfinished job
- exclude stale, rejected, null, unrelated, dedupe-colliding, and terminal evidence
- treat deferred commands as active to match the #1601 mainline recovery contract (the older tech text listed only pending/dispatching/dispatched)

Validation:
- cargo fmt --all -- --check
- cargo check -p harness-workflow --all-targets
- cargo test -p harness-workflow driverless_progress -- --nocapture
- cargo test -p harness-workflow
- cargo clippy --workspace --all-targets -- -D warnings