### PR TITLE
fix(workflow): close driverless progress gaps

### DIFF
--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -6,6 +6,7 @@
 //! worktrees.
 
 mod activity;
+mod driverless_progress;
 mod sampling;
 
 use crate::http::AppState;
@@ -25,6 +26,8 @@ use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
+
+use driverless_progress::{list_driverless_progress, DriverlessProgressEvidence};
 
 const WORKFLOW_SAMPLE_LIMIT: i64 = 500;
 const FAILED_WORKFLOW_SAMPLE_RESERVE: usize = 100;
@@ -48,6 +51,7 @@ struct OperatorMonitorPayload {
     activity: OperatorActivity,
     operator_actions: Vec<OperatorAction>,
     stuck_workflows: Vec<StuckWorkflow>,
+    driverless_progress: Vec<DriverlessProgressEvidence>,
     failures: Vec<FailureGroup>,
     worktrees: WorktreeSummary,
 }
@@ -219,6 +223,7 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
     let by_source = source_activity(&workflows, &active_tasks);
     let operator_actions = operator_actions(&workflows, generated_at, &stopped_eligibility);
     let stuck_workflows = list_stuck_workflows(state, generated_at).await?;
+    let driverless_progress = list_driverless_progress(state).await?;
     let failures = grouped_failures(&recent_failures, &workflows);
     let capacity = state.concurrency.task_queue.global_limit() as u64;
     let local_live_worktrees = state
@@ -256,6 +261,7 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
         },
         operator_actions,
         stuck_workflows,
+        driverless_progress,
         failures,
         worktrees: WorktreeSummary {
             used: worktree_used_count(local_live_worktrees, worktree_cards.len())

--- a/crates/harness-server/src/handlers/operator_monitor/driverless_progress.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/driverless_progress.rs
@@ -1,0 +1,138 @@
+use crate::http::AppState;
+use harness_workflow::runtime::DriverlessProgressInstance;
+use serde::Serialize;
+
+use super::WORKFLOW_SAMPLE_LIMIT;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(super) struct DriverlessProgressEvidence {
+    classification: &'static str,
+    workflow_id: String,
+    definition_id: String,
+    state: String,
+    age_secs: u64,
+    provenance_status: &'static str,
+}
+
+impl From<DriverlessProgressInstance> for DriverlessProgressEvidence {
+    fn from(instance: DriverlessProgressInstance) -> Self {
+        Self {
+            classification: "driverless_progress",
+            workflow_id: instance.workflow_id,
+            definition_id: instance.definition_id,
+            state: instance.state,
+            age_secs: instance.age_secs,
+            provenance_status: instance.provenance_status.as_str(),
+        }
+    }
+}
+
+pub(super) async fn list_driverless_progress(
+    state: &AppState,
+) -> anyhow::Result<Vec<DriverlessProgressEvidence>> {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(Vec::new());
+    };
+    let workflow_cfg =
+        harness_core::config::workflow::load_workflow_config(&state.core.project_root)?;
+    let limit = i64::from(workflow_cfg.storage.workflow_watchdog_batch_size)
+        .clamp(1, WORKFLOW_SAMPLE_LIMIT);
+    Ok(store
+        .list_driverless_progress_instances(limit)
+        .await?
+        .into_iter()
+        .map(DriverlessProgressEvidence::from)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers;
+    use axum::{body::to_bytes, routing::get, Router};
+    use harness_workflow::runtime::{
+        DriverlessProgressProvenanceStatus, WorkflowInstance, WorkflowRuntimeStore,
+        WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID,
+    };
+    use serde_json::Value;
+    use std::sync::Arc;
+
+    #[test]
+    fn projection_exposes_stable_classification_and_provenance() {
+        let projection = DriverlessProgressEvidence::from(DriverlessProgressInstance {
+            workflow_id: "workflow-1".to_string(),
+            definition_id: "github_issue_pr".to_string(),
+            state: "implementing".to_string(),
+            age_secs: 42,
+            provenance_status: DriverlessProgressProvenanceStatus::MissingStateEntryProvenance,
+        });
+        let value = serde_json::to_value(projection).expect("projection should serialize");
+
+        assert_eq!(value["classification"], "driverless_progress");
+        assert_eq!(value["workflow_id"], "workflow-1");
+        assert_eq!(value["definition_id"], "github_issue_pr");
+        assert_eq!(value["state"], "implementing");
+        assert_eq!(value["age_secs"], 42);
+        assert_eq!(value["provenance_status"], "missing_state_entry_provenance");
+    }
+
+    #[tokio::test]
+    async fn operator_monitor_exposes_bounded_driverless_progress_when_watchdog_is_disabled(
+    ) -> anyhow::Result<()> {
+        let _lock = test_helpers::HOME_LOCK.lock().await;
+        let dir = test_helpers::tempdir_in_home("harness-test-driverless-progress-monitor-")?;
+        std::fs::write(
+            dir.path().join("WORKFLOW.md"),
+            "---\nstorage:\n  workflow_watchdog_enabled: false\n  workflow_watchdog_batch_size: 1\n---\nBody\n",
+        )?;
+        let mut state = test_helpers::make_test_state(dir.path()).await?;
+        let store = Arc::new(
+            WorkflowRuntimeStore::open_with_database_url(
+                &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
+                Some(&test_helpers::test_database_url()?),
+            )
+            .await?,
+        );
+        for id in ["driverless-a", "driverless-b"] {
+            store
+                .upsert_instance(
+                    &WorkflowInstance::new(
+                        GITHUB_ISSUE_PR_DEFINITION_ID,
+                        1,
+                        "implementing",
+                        WorkflowSubject::new("issue", format!("issue:{id}")),
+                    )
+                    .with_id(id.to_string()),
+                )
+                .await?;
+        }
+        state.core.workflow_runtime_store = Some(store);
+
+        let app = Router::new()
+            .route("/api/operator-monitor", get(super::super::operator_monitor))
+            .with_state(Arc::new(state));
+        let request = axum::http::Request::builder()
+            .uri("/api/operator-monitor")
+            .body(axum::body::Body::empty())?;
+        let response = tower::ServiceExt::oneshot(app, request).await?;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let body: Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await?)?;
+        let rows = body["driverless_progress"]
+            .as_array()
+            .expect("driverless progress should be an array");
+
+        assert_eq!(rows.len(), 1, "configured monitoring bound should apply");
+        assert_eq!(rows[0]["classification"], "driverless_progress");
+        assert_eq!(rows[0]["definition_id"], "github_issue_pr");
+        assert_eq!(rows[0]["state"], "implementing");
+        assert_eq!(
+            rows[0]["provenance_status"],
+            "missing_state_entry_provenance"
+        );
+        assert!(body["stuck_workflows"]
+            .as_array()
+            .is_some_and(Vec::is_empty));
+        Ok(())
+    }
+}

--- a/crates/harness-server/src/http/workflow_watchdog.rs
+++ b/crates/harness-server/src/http/workflow_watchdog.rs
@@ -79,6 +79,32 @@ pub(super) fn spawn_workflow_watchdog(state: &Arc<AppState>) {
                         Err(error) => tracing::warn!("workflow watchdog tick failed: {error}"),
                     }
 
+                    match store
+                        .list_driverless_progress_instances(
+                            workflow_cfg.storage.workflow_watchdog_batch_size as i64,
+                        )
+                        .await
+                    {
+                        Ok(workflows) => {
+                            for workflow in workflows {
+                                tracing::error!(
+                                    classification = "driverless_progress",
+                                    workflow_id = %workflow.workflow_id,
+                                    definition_id = %workflow.definition_id,
+                                    state = %workflow.state,
+                                    age_secs = workflow.age_secs,
+                                    provenance_status = workflow.provenance_status.as_str(),
+                                    "workflow watchdog found driverless progress workflow"
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            tracing::error!(
+                                "workflow watchdog driverless-progress scan failed: {error}"
+                            );
+                        }
+                    }
+
                     // External alerts for stopped workflows (GH1582 T006).
                     if state.observability.alerts.is_enabled() {
                         match store

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -147,10 +147,11 @@ pub use state_registry::{
 };
 pub use status::WorkflowCommandStatus;
 pub use store::{
-    RuntimeHistoryPruneSummary, RuntimeUsageMetrics, RuntimeUsageRecord, RuntimeUsageUpsert,
-    RuntimeUsageUpsertOutcome, WorkflowDecisionTransition, WorkflowRejectedDecisionTransition,
-    WorkflowRuntimeRecoveryAction, WorkflowRuntimeRecoveryOutcome, WorkflowRuntimeRecoveryRequest,
-    WorkflowRuntimeStore, WorkflowSubmissionDecisionCommit, WorkflowSubmissionDecisionTransition,
+    DriverlessProgressInstance, DriverlessProgressProvenanceStatus, RuntimeHistoryPruneSummary,
+    RuntimeUsageMetrics, RuntimeUsageRecord, RuntimeUsageUpsert, RuntimeUsageUpsertOutcome,
+    WorkflowDecisionTransition, WorkflowRejectedDecisionTransition, WorkflowRuntimeRecoveryAction,
+    WorkflowRuntimeRecoveryOutcome, WorkflowRuntimeRecoveryRequest, WorkflowRuntimeStore,
+    WorkflowSubmissionDecisionCommit, WorkflowSubmissionDecisionTransition,
     WorkflowSubmissionPromptPayload,
 };
 pub use submission::{

--- a/crates/harness-workflow/src/runtime/store/runtime_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::runtime::model::{
     ActivityResult, ActivityStatus, WorkflowDecision, WorkflowDecisionRecord, WorkflowEvent,
-    WorkflowInstance,
+    WorkflowEvidence, WorkflowInstance,
 };
 use crate::runtime::reducer::reduce_runtime_job_completed;
 use crate::runtime::status::WorkflowCommandStatus;
@@ -93,14 +93,57 @@ async fn apply_runtime_completion_decision_for_instance_tx(
     event: &WorkflowEvent,
 ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
     let driverless_decision = driverless_structured_completion_decision(&instance, source, event)?;
-    let Some(mut decision) = reduce_runtime_job_completed(&instance, event)? else {
+    let Some(decision) = reduce_runtime_job_completed(&instance, event)? else {
         return Ok(None);
     };
     // Preserve the requested liveness rejection only when the reducer found no
     // authoritative domain outcome and would apply its generic invalid-output policy.
+    // The separate blocked policy decision remains the committed outcome, so the
+    // completed driver cannot leave the workflow in an unowned progress state.
     if is_generic_invalid_structured_fallback(&decision) {
         if let Some(driverless_decision) = driverless_decision {
-            decision = driverless_decision;
+            let rejected = persist_runtime_completion_decision_tx(
+                tx,
+                instance.clone(),
+                source,
+                event,
+                driverless_decision,
+            )
+            .await?;
+            if rejected.accepted {
+                anyhow::bail!(
+                    "driverless completion candidate unexpectedly passed progress validation"
+                );
+            }
+            let rejection_reason = rejected
+                .rejection_reason
+                .as_deref()
+                .unwrap_or("missing rejection reason");
+            let policy_decision = decision.with_evidence(WorkflowEvidence::new(
+                "rejected_workflow_decision",
+                format!(
+                    "Rejected decision record `{}` before applying blocked policy: {rejection_reason}",
+                    rejected.id
+                ),
+            ));
+            let policy = persist_runtime_completion_decision_tx(
+                tx,
+                instance,
+                source,
+                event,
+                policy_decision,
+            )
+            .await?;
+            if !policy.accepted {
+                anyhow::bail!(
+                    "blocked policy decision was rejected after driverless completion: {}",
+                    policy
+                        .rejection_reason
+                        .as_deref()
+                        .unwrap_or("missing rejection reason")
+                );
+            }
+            return Ok(Some(policy));
         }
     }
 

--- a/crates/harness-workflow/src/runtime/tests/durable_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/durable_store.rs
@@ -588,42 +588,69 @@ async fn runtime_activity_completion_fences_concurrent_driverless_replay() -> an
         "the runtime job lease must admit exactly one completion"
     );
     let winner = first.or(replay).expect("one completion should win");
-    let rejected = winner
+    let policy = winner
         .decision
         .expect("the winning completion should persist a decision");
-    assert!(!rejected.accepted);
-    assert_eq!(rejected.decision, driverless);
-    assert!(rejected
-        .rejection_reason
-        .as_deref()
-        .is_some_and(|reason| reason.starts_with("ProgressDriverMissing:")));
+    assert!(policy.accepted);
+    assert_eq!(policy.decision.decision, "block_invalid_agent_output");
+    assert_eq!(policy.decision.next_state, "blocked");
 
     let after = store
         .get_instance(&instance.id)
         .await?
         .expect("workflow instance should remain visible");
-    assert_eq!(after.state, instance.state);
-    assert_eq!(after.version, instance.version);
-    assert_eq!(after.data, instance.data);
+    assert_eq!(after.state, "blocked");
+    assert_eq!(after.version, instance.version.saturating_add(1));
+    assert_eq!(after.data["marker"], instance.data["marker"]);
     let commands = store.commands_for(&instance.id).await?;
-    assert_eq!(commands.len(), 1);
-    assert_eq!(commands[0].id, command_id);
+    assert_eq!(commands.len(), 3);
+    let completed_driver = commands
+        .iter()
+        .find(|command| command.id == command_id)
+        .expect("the completed state-entry driver should remain visible");
     assert_eq!(
-        commands[0].decision_id.as_deref(),
+        completed_driver.decision_id.as_deref(),
         Some(state_entry_record.id.as_str())
     );
-    assert_eq!(commands[0].status, WorkflowCommandStatus::Completed);
+    assert_eq!(completed_driver.status, WorkflowCommandStatus::Completed);
+    let policy_commands = commands
+        .iter()
+        .filter(|command| command.decision_id.as_deref() == Some(policy.id.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(policy_commands.len(), 2);
+    assert!(policy_commands.iter().all(|command| {
+        command.status == WorkflowCommandStatus::HandledInline
+            && matches!(
+                command.command.command_type,
+                WorkflowCommandType::MarkBlocked
+                    | WorkflowCommandType::RequestOperatorAttention
+            )
+    }));
     let jobs = store.runtime_jobs_for_command(&command_id).await?;
     assert_eq!(jobs.len(), 1);
     assert_eq!(jobs[0].status, RuntimeJobStatus::Succeeded);
     assert_eq!(store.events_for(&instance.id).await?.len(), 1);
     let decisions = store.decisions_for(&instance.id).await?;
-    assert_eq!(decisions.len(), 2);
-    assert_eq!(decisions.iter().filter(|decision| decision.accepted).count(), 1);
-    assert_eq!(
-        decisions.iter().filter(|decision| !decision.accepted).count(),
-        1
-    );
+    assert_eq!(decisions.len(), 3);
+    assert_eq!(decisions.iter().filter(|decision| decision.accepted).count(), 2);
+    let rejected = decisions
+        .iter()
+        .find(|decision| !decision.accepted)
+        .expect("the driverless candidate should remain auditable");
+    assert_eq!(rejected.decision, driverless);
+    assert!(rejected
+        .rejection_reason
+        .as_deref()
+        .is_some_and(|reason| reason.starts_with("ProgressDriverMissing:")));
+    assert_eq!(rejected.event_id, policy.event_id);
+    let rejection_link = policy
+        .decision
+        .evidence
+        .iter()
+        .find(|evidence| evidence.kind == "rejected_workflow_decision")
+        .expect("the blocked policy should link the rejected candidate");
+    assert!(rejection_link.summary.contains(&rejected.id));
+    assert!(rejection_link.summary.contains("ProgressDriverMissing:"));
     Ok(())
 }
 

--- a/docs/workflow-runtime-operations.md
+++ b/docs/workflow-runtime-operations.md
@@ -137,6 +137,12 @@ Enable `workflow_watchdog_enabled` first. It is read-only: aged `blocked` and
 `awaiting_feedback` workflow instances appear in `/api/operator-monitor` under
 `stuck_workflows` and are logged at error level.
 
+The same operator-monitor response always includes the bounded
+`driverless_progress` diagnostic, even when the watchdog is disabled. Each row
+reports its workflow, definition, state, age, and state-entry provenance without
+changing workflow state or history. Enabling the watchdog also emits these rows
+at error level; recovery remains an explicit operator action.
+
 Enable `runtime_retention_enabled` only after the stuck list is clean. Retention
 deletes terminal workflow families older than `runtime_retention_days` in
 bounded batches and relies on the Postgres runtime-store cascade constraints to

--- a/web/src/routes/Overview.test.tsx
+++ b/web/src/routes/Overview.test.tsx
@@ -147,6 +147,7 @@ function makeMonitor(): OperatorMonitorPayload {
     },
     operator_actions: [],
     stuck_workflows: [],
+    driverless_progress: [],
     failures: [],
     worktrees: {
       used: 0,

--- a/web/src/routes/overview/OperatorMonitorPanel.test.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.test.tsx
@@ -100,6 +100,16 @@ function makeMonitor(): OperatorMonitorPayload {
         source: "github",
       },
     ],
+    driverless_progress: [
+      {
+        classification: "driverless_progress",
+        workflow_id: "workflow-driverless",
+        definition_id: "github_issue_pr",
+        state: "implementing",
+        age_secs: 21_600,
+        provenance_status: "missing_state_entry_provenance",
+      },
+    ],
     failures: [
       {
         family: "github_fetch",
@@ -166,6 +176,8 @@ describe("<OperatorMonitorPanel>", () => {
     );
     expect(screen.getByText("awaiting feedback")).toBeInTheDocument();
     expect(screen.getByText("#44 -> PR #45")).toBeInTheDocument();
+    expect(screen.getByText("workflow-driverless")).toBeInTheDocument();
+    expect(screen.getByText("missing state entry provenance")).toBeInTheDocument();
   });
 
   it("renders grouped retryable GitHub fetch failures", () => {

--- a/web/src/routes/overview/OperatorMonitorPanel.tsx
+++ b/web/src/routes/overview/OperatorMonitorPanel.tsx
@@ -5,6 +5,7 @@ import { apiFetch } from "@/lib/api";
 import { useOperatorMonitor } from "@/lib/queries";
 import { fmtInt } from "@/lib/format";
 import type {
+  DriverlessProgressEvidence,
   FailureGroup,
   OperatorAction,
   OperatorMonitorPayload,
@@ -231,6 +232,18 @@ function StuckWorkflowRow({ workflow }: { workflow: StuckWorkflow }) {
   );
 }
 
+function DriverlessProgressRow({ workflow }: { workflow: DriverlessProgressEvidence }) {
+  return (
+    <tr className="border-b border-line last:border-b-0">
+      <td className="px-3 py-2 font-mono text-[11px] text-danger">{workflow.state.replace(/_/g, " ")}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">{workflow.definition_id}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-3">{workflow.workflow_id}</td>
+      <td className="px-3 py-2 font-mono text-[11px] text-ink-4">{fmtDuration(workflow.age_secs)}</td>
+      <td className="px-3 py-2 text-right font-mono text-[11px] text-warn">{workflow.provenance_status.replace(/_/g, " ")}</td>
+    </tr>
+  );
+}
+
 function SourceRow({ source }: { source: SourceActivity }) {
   return (
     <tr className="border-b border-line last:border-b-0">
@@ -318,6 +331,16 @@ function MonitorBody({
             ) : (
               <table className="w-full border-t border-line">
                 <tbody>{data.stuck_workflows.map((workflow) => <StuckWorkflowRow key={workflow.workflow_id} workflow={workflow} />)}</tbody>
+              </table>
+            )}
+          </div>
+          <div className="border-b border-line">
+            <div className="px-4 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-ink-3">Driverless progress</div>
+            {data.driverless_progress.length === 0 ? (
+              <p className="border-t border-line px-4 py-3 font-mono text-[11px] text-ink-4">No driverless progress workflows.</p>
+            ) : (
+              <table className="w-full border-t border-line">
+                <tbody>{data.driverless_progress.map((workflow) => <DriverlessProgressRow key={workflow.workflow_id} workflow={workflow} />)}</tbody>
               </table>
             )}
           </div>

--- a/web/src/types/operator_monitor.ts
+++ b/web/src/types/operator_monitor.ts
@@ -5,6 +5,7 @@ export interface OperatorMonitorPayload {
   activity: OperatorActivity;
   operator_actions: OperatorAction[];
   stuck_workflows: StuckWorkflow[];
+  driverless_progress: DriverlessProgressEvidence[];
   failures: FailureGroup[];
   worktrees: OperatorWorktreeSummary;
 }
@@ -93,6 +94,18 @@ export interface StuckWorkflow extends RuntimeStoppedState {
   updated_at: string;
   url: string | null;
   source: string;
+}
+
+export interface DriverlessProgressEvidence {
+  classification: "driverless_progress";
+  workflow_id: string;
+  definition_id: string;
+  state: string;
+  age_secs: number;
+  provenance_status:
+    | "established"
+    | "missing_state_entry_provenance"
+    | "ambiguous_state_entry_provenance";
 }
 
 export interface GitHubTokenDispatchCounter {


### PR DESCRIPTION
## Summary

- persist the rejected driverless candidate and the distinct accepted blocked policy atomically
- expose bounded driverless-progress classification and provenance through watchdog logs, operator API, and UI
- add workflow, server, and web regressions for the remaining GH1603 acceptance criteria

## Verification

- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- focused workflow state-registry, validator, recovery, provenance, and stale-work tests
- focused server projection test
- web typecheck, focused UI tests, and production build
- SpecRail GH1603 and repository checks

PostgreSQL-backed driverless tests compile locally but require the CI disposable database profile for execution; the configured local database is not safe for destructive test isolation.

Closes #1603