### PR TITLE
feat(workflow): continue prompt tasks from external state

### DIFF
--- a/crates/harness-server/src/http/tests/runtime_worker_non_issue_replay_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_worker_non_issue_replay_tests.rs
@@ -76,6 +76,7 @@ async fn runtime_job_worker_replays_prompt_child_without_duplicate_side_effects(
             dependencies_blocked: false,
             source: Some("github_pr_feedback"),
             external_id: Some("pr-feedback:owner/repo:1120"),
+            continuation: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -371,6 +371,16 @@ impl DefaultExecutionService {
                 task_runner::MAX_TASK_PRIORITY,
             )));
         }
+        if let Some(policy) = req.continuation.as_ref() {
+            if req.issue.is_some() || req.pr.is_some() || req.prompt.is_none() {
+                return Err(EnqueueTaskError::BadRequest(
+                    "continuation is only supported for prompt-only tasks".to_string(),
+                ));
+            }
+            policy
+                .validate()
+                .map_err(|error| EnqueueTaskError::BadRequest(error.to_string()))?;
+        }
         Ok(())
     }
 
@@ -761,6 +771,7 @@ impl DefaultExecutionService {
                 dependencies_blocked,
                 source: prepared.req.source.as_deref(),
                 external_id: prepared.req.external_id.as_deref(),
+                continuation: prepared.req.continuation.as_ref(),
             },
         )
         .await
@@ -1267,3 +1278,7 @@ impl ExecutionService for DefaultExecutionService {
 #[cfg(test)]
 #[path = "execution_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "execution_continuation_tests.rs"]
+mod continuation_tests;

--- a/crates/harness-server/src/services/execution_continuation_tests.rs
+++ b/crates/harness-server/src/services/execution_continuation_tests.rs
@@ -1,0 +1,42 @@
+use super::*;
+
+#[test]
+fn validate_request_enforces_prompt_continuation_contract() {
+    let valid_policy = harness_workflow::runtime::PromptContinuationPolicy {
+        max_attempts: 4,
+        attempt_delay_secs: 30,
+        active_states: std::collections::BTreeSet::from(["In Progress".to_string()]),
+        no_progress_limit: 3,
+    };
+    let valid = CreateTaskRequest {
+        prompt: Some("Continue TEAM-123".to_string()),
+        continuation: Some(valid_policy.clone()),
+        ..Default::default()
+    };
+    assert!(DefaultExecutionService::validate_request(&valid).is_ok());
+
+    let wrong_kind = CreateTaskRequest {
+        issue: Some(123),
+        continuation: Some(valid_policy.clone()),
+        ..Default::default()
+    };
+    assert!(matches!(
+        DefaultExecutionService::validate_request(&wrong_kind),
+        Err(EnqueueTaskError::BadRequest(message))
+            if message == "continuation is only supported for prompt-only tasks"
+    ));
+
+    let invalid = CreateTaskRequest {
+        prompt: Some("Continue TEAM-123".to_string()),
+        continuation: Some(harness_workflow::runtime::PromptContinuationPolicy {
+            max_attempts: 0,
+            ..valid_policy
+        }),
+        ..Default::default()
+    };
+    assert!(matches!(
+        DefaultExecutionService::validate_request(&invalid),
+        Err(EnqueueTaskError::BadRequest(message))
+            if message.contains("max_attempts must be at least 1")
+    ));
+}

--- a/crates/harness-server/src/task_runner/request.rs
+++ b/crates/harness-server/src/task_runner/request.rs
@@ -1,3 +1,4 @@
+use harness_workflow::runtime::PromptContinuationPolicy;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -83,6 +84,9 @@ pub struct CreateTaskRequest {
     /// Higher values are served first when multiple tasks are waiting for a slot.
     #[serde(default)]
     pub priority: u8,
+    /// Optional bounded external-state loop for prompt-only workflow submissions.
+    #[serde(default)]
+    pub continuation: Option<PromptContinuationPolicy>,
     /// Restart-safe metadata for trusted system-generated prompt tasks.
     /// Never accepted from or exposed to external HTTP callers.
     #[serde(skip)]
@@ -159,6 +163,8 @@ pub struct PersistedRequestSettings {
     /// Pure prompt tasks and PR tasks leave this `None`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<PromptContinuationPolicy>,
     /// Primary prompt for prompt-only tasks (no issue or pr).
     ///
     /// Kept in memory so that `AwaitingDeps` tasks can reconstruct the original
@@ -199,6 +205,7 @@ impl PersistedRequestSettings {
             } else {
                 None
             },
+            continuation: req.continuation.clone(),
             // For prompt-only tasks (no issue/pr), store the prompt so that
             // AwaitingDeps tasks can reconstruct the original request when deps resolve.
             prompt: if req.issue.is_none() && req.pr.is_none() {
@@ -236,6 +243,7 @@ impl PersistedRequestSettings {
         if self.prompt.is_some() {
             req.prompt = self.prompt.clone();
         }
+        req.continuation = self.continuation.clone();
     }
 }
 
@@ -265,6 +273,7 @@ impl Default for CreateTaskRequest {
             depends_on: Vec::new(),
             serialization_depends_on: Vec::new(),
             priority: 0,
+            continuation: None,
             system_input: None,
         }
     }
@@ -419,6 +428,30 @@ mod tests {
         let req = CreateTaskRequest::default();
         assert!(!req.skip_triage);
         assert!(!req.force_execute);
+    }
+
+    #[test]
+    fn create_task_request_deserializes_and_persists_continuation_policy() {
+        let req: CreateTaskRequest = serde_json::from_str(
+            r#"{
+                "prompt": "Continue TEAM-123",
+                "continuation": {
+                    "max_attempts": 4,
+                    "attempt_delay_secs": 30,
+                    "active_states": ["In Progress"],
+                    "no_progress_limit": 2
+                }
+            }"#,
+        )
+        .expect("deserialize continuation request");
+        let policy = req.continuation.as_ref().expect("continuation policy");
+        assert!(policy.validate().is_ok());
+        assert!(policy.active_states.contains("In Progress"));
+
+        let settings = PersistedRequestSettings::from_req(&req);
+        let mut restored = CreateTaskRequest::default();
+        settings.apply_to_req(&mut restored);
+        assert_eq!(restored.continuation, req.continuation);
     }
 
     #[test]

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -2,10 +2,12 @@ use crate::task_runner::TaskId;
 use harness_core::config::isolation::IsolationTrustClass;
 use harness_workflow::runtime::{
     build_issue_submission_decision, build_prompt_submission_decision,
-    candidate_fanout_from_policy, candidate_fanout_from_value, CandidateFanoutRequest,
-    DecisionValidator, IssueSubmissionDecisionInput, PromptSubmissionDecisionInput, SubmissionMode,
-    ValidationContext, WorkflowDecision, WorkflowDecisionRecord, WorkflowDefinition,
-    WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject, PROMPT_TASK_DEFINITION_ID,
+    candidate_fanout_from_policy, candidate_fanout_from_value, continuation_value,
+    prompt_continuation_state_from_data, CandidateFanoutRequest, DecisionValidator,
+    IssueSubmissionDecisionInput, PromptContinuationPolicy, PromptSubmissionDecisionInput,
+    SubmissionMode, ValidationContext, WorkflowDecision, WorkflowDecisionRecord,
+    WorkflowDefinition, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    PROMPT_TASK_DEFINITION_ID,
 };
 use serde_json::json;
 use std::path::Path;
@@ -62,6 +64,7 @@ pub(crate) struct PromptSubmissionRuntimeContext<'a> {
     pub dependencies_blocked: bool,
     pub source: Option<&'a str>,
     pub external_id: Option<&'a str>,
+    pub continuation: Option<&'a PromptContinuationPolicy>,
 }
 
 pub(crate) struct IssueSubmissionRuntimeContext<'a> {
@@ -205,8 +208,9 @@ async fn persist_prompt_submission(
             external_id: ctx.external_id,
             depends_on: &depends_on_strings(&depends_on),
             dependencies_blocked: ctx.dependencies_blocked,
+            continuation: ctx.continuation,
         },
-    );
+    )?;
     apply_prompt_decision(
         store,
         instance,
@@ -436,7 +440,7 @@ fn prompt_submission_data(
     prompt_ref: &str,
     depends_on: &[TaskId],
 ) -> serde_json::Value {
-    crate::workflow_runtime_policy::merge_runtime_retry_policy(
+    let mut data = crate::workflow_runtime_policy::merge_runtime_retry_policy(
         ctx.project_root,
         json!({
             "project_id": project_id,
@@ -453,7 +457,11 @@ fn prompt_submission_data(
             "source": ctx.source,
             "external_id": ctx.external_id,
         }),
-    )
+    );
+    if let (Some(object), Some(policy)) = (data.as_object_mut(), ctx.continuation) {
+        object.insert("continuation".to_string(), continuation_value(policy));
+    }
+    data
 }
 
 fn merge_last_decision(mut data: serde_json::Value, decision: &str) -> serde_json::Value {
@@ -526,14 +534,19 @@ struct PromptSubmissionFields {
     prompt_ref: String,
     source: Option<String>,
     external_id: Option<String>,
+    continuation: Option<PromptContinuationPolicy>,
 }
 
 fn prompt_submission_fields(instance: &WorkflowInstance) -> anyhow::Result<PromptSubmissionFields> {
+    let continuation = prompt_continuation_state_from_data(&instance.data)
+        .map_err(anyhow::Error::msg)?
+        .map(|state| state.policy);
     Ok(PromptSubmissionFields {
         task_id: string_field(&instance.data, "task_id")?,
         prompt_ref: string_field(&instance.data, "prompt_ref")?,
         source: optional_string_field(&instance.data, "source"),
         external_id: optional_string_field(&instance.data, "external_id"),
+        continuation,
     })
 }
 
@@ -643,6 +656,10 @@ mod identity_tests;
 #[cfg(test)]
 #[path = "workflow_runtime_submission/dependency_tests.rs"]
 mod dependency_tests;
+
+#[cfg(test)]
+#[path = "workflow_runtime_submission/continuation_tests.rs"]
+mod continuation_tests;
 
 #[cfg(test)]
 #[path = "workflow_runtime_submission/replay_tests.rs"]

--- a/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/atomicity_tests.rs
@@ -183,6 +183,7 @@ async fn conflicted_prompt_submission_does_not_persist_prompt_payload() -> anyho
         dependencies_blocked: false,
         source: None,
         external_id: None,
+        continuation: None,
     };
     let accepted_data =
         prompt_submission_data(&ctx, &project_id, &stale_instance.data, &prompt_ref, &[]);
@@ -196,8 +197,9 @@ async fn conflicted_prompt_submission_does_not_persist_prompt_payload() -> anyho
             external_id: None,
             depends_on: &[],
             dependencies_blocked: false,
+            continuation: None,
         },
-    );
+    )?;
 
     let result = commit::apply_prompt_decision(
         &store,
@@ -239,6 +241,7 @@ async fn accepted_prompt_replay_with_new_prompt_keeps_referenced_payload() -> an
             dependencies_blocked: false,
             source: None,
             external_id: None,
+            continuation: None,
         },
     )
     .await?;
@@ -268,6 +271,7 @@ async fn accepted_prompt_replay_with_new_prompt_keeps_referenced_payload() -> an
             dependencies_blocked: false,
             source: None,
             external_id: None,
+            continuation: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_submission/commit.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/commit.rs
@@ -309,7 +309,7 @@ fn issue_submission_event_payload(ctx: &IssueSubmissionRuntimeContext<'_>) -> se
 }
 
 fn prompt_submission_event_payload(ctx: &PromptSubmissionRuntimeContext<'_>) -> serde_json::Value {
-    json!({
+    let mut payload = json!({
         "task_id": ctx.task_id.as_str(),
         "prompt_chars": ctx.prompt.chars().count(),
         "depends_on": depends_on_strings(ctx.depends_on),
@@ -318,7 +318,11 @@ fn prompt_submission_event_payload(ctx: &PromptSubmissionRuntimeContext<'_>) -> 
         "source": ctx.source,
         "external_id": ctx.external_id,
         "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
-    })
+    });
+    if let Some(policy) = ctx.continuation {
+        payload["continuation"] = json!(policy);
+    }
+    payload
 }
 
 fn accepted_submission_instance(

--- a/crates/harness-server/src/workflow_runtime_submission/continuation_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/continuation_tests.rs
@@ -185,3 +185,133 @@ async fn cancelled_prompt_continuation_does_not_enqueue_another_attempt() -> any
         .all(|command| command.status != WorkflowCommandStatus::Pending));
     Ok(())
 }
+
+#[tokio::test]
+async fn prompt_continuation_exhaustion_and_malformed_signal_block_without_new_attempt(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = open_continuation_runtime_store(dir.path()).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+
+    let exhausted_task_id = TaskId::from_str("continuation-exhausted");
+    let exhausted_policy = continuation_policy(1);
+    let exhausted_submission = record_prompt_submission(
+        &store,
+        PromptSubmissionRuntimeContext {
+            project_root: &project_root,
+            task_id: &exhausted_task_id,
+            prompt: "Continue until the attempt bound is reached.",
+            depends_on: &[],
+            serialization_depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("dashboard"),
+            external_id: Some("TEAM-EXHAUSTED"),
+            continuation: Some(&exhausted_policy),
+        },
+    )
+    .await?;
+    let exhausted_initial = store
+        .commands_for(&exhausted_submission.workflow_id)
+        .await?;
+    let exhausted_result = ActivityResult::succeeded(
+        PROMPT_TASK_IMPLEMENT_ACTIVITY,
+        "The subject is still active.",
+    )
+    .with_signal(ActivitySignal::new(
+        "external_state",
+        json!({ "state": "In Progress", "subject": "TEAM-EXHAUSTED" }),
+    ));
+    let exhausted = store
+        .commit_parent_runtime_completion(
+            &exhausted_submission.workflow_id,
+            "runtime-1",
+            json!({
+                "command_id": exhausted_initial[0].id,
+                "runtime_job_id": "continuation-exhausted-job",
+                "activity_result": exhausted_result,
+            }),
+        )
+        .await?
+        .expect("attempt exhaustion should produce a blocked decision");
+    assert!(exhausted.accepted);
+    assert_eq!(exhausted.decision.decision, "prompt_continuation_exhausted");
+    assert_eq!(exhausted.decision.next_state, "blocked");
+    assert!(exhausted
+        .decision
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "external_state"));
+    let exhausted_instance = store
+        .get_instance(&exhausted_submission.workflow_id)
+        .await?
+        .expect("exhausted instance");
+    assert_eq!(exhausted_instance.state, "blocked");
+    assert!(store
+        .commands_for(&exhausted_submission.workflow_id)
+        .await?
+        .iter()
+        .all(|command| !command.command.dedupe_key.ends_with(":attempt:2")));
+
+    let malformed_task_id = TaskId::from_str("continuation-malformed");
+    let malformed_policy = continuation_policy(4);
+    let malformed_submission = record_prompt_submission(
+        &store,
+        PromptSubmissionRuntimeContext {
+            project_root: &project_root,
+            task_id: &malformed_task_id,
+            prompt: "Block if the external-state contract is missing.",
+            depends_on: &[],
+            serialization_depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("dashboard"),
+            external_id: Some("TEAM-MALFORMED"),
+            continuation: Some(&malformed_policy),
+        },
+    )
+    .await?;
+    let malformed_initial = store
+        .commands_for(&malformed_submission.workflow_id)
+        .await?;
+    let malformed_result = ActivityResult::succeeded(
+        PROMPT_TASK_IMPLEMENT_ACTIVITY,
+        "No structured external state was reported.",
+    );
+    let malformed = store
+        .commit_parent_runtime_completion(
+            &malformed_submission.workflow_id,
+            "runtime-1",
+            json!({
+                "command_id": malformed_initial[0].id,
+                "runtime_job_id": "continuation-malformed-job",
+                "activity_result": malformed_result,
+            }),
+        )
+        .await?
+        .expect("malformed signal should produce a blocked decision");
+    assert!(malformed.accepted);
+    assert_eq!(
+        malformed.decision.decision,
+        "prompt_continuation_signal_missing"
+    );
+    assert_eq!(malformed.decision.next_state, "blocked");
+    assert!(malformed
+        .decision
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "external_state"));
+    let malformed_instance = store
+        .get_instance(&malformed_submission.workflow_id)
+        .await?
+        .expect("malformed instance");
+    assert_eq!(malformed_instance.state, "blocked");
+    assert!(store
+        .commands_for(&malformed_submission.workflow_id)
+        .await?
+        .iter()
+        .all(|command| !command.command.dedupe_key.ends_with(":attempt:2")));
+    Ok(())
+}

--- a/crates/harness-server/src/workflow_runtime_submission/continuation_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/continuation_tests.rs
@@ -1,0 +1,187 @@
+use super::*;
+use harness_core::db::resolve_database_url;
+use harness_workflow::runtime::{
+    ActivityResult, ActivitySignal, PromptContinuationPolicy, ValidationRecord,
+    WorkflowCommandStatus, PROMPT_TASK_IMPLEMENT_ACTIVITY,
+};
+use serde_json::json;
+use std::collections::BTreeSet;
+
+async fn open_continuation_runtime_store(dir: &Path) -> anyhow::Result<WorkflowRuntimeStore> {
+    let database_url = resolve_database_url(None)?;
+    WorkflowRuntimeStore::open_with_database_url(dir, Some(&database_url)).await
+}
+
+fn continuation_policy(max_attempts: u32) -> PromptContinuationPolicy {
+    PromptContinuationPolicy {
+        max_attempts,
+        attempt_delay_secs: 0,
+        active_states: BTreeSet::from(["In Progress".to_string()]),
+        no_progress_limit: 3,
+    }
+}
+
+#[tokio::test]
+async fn prompt_continuation_submit_active_settled_reaches_done() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = open_continuation_runtime_store(dir.path()).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("continuation-e2e");
+    let policy = continuation_policy(4);
+    let submission = record_prompt_submission(
+        &store,
+        PromptSubmissionRuntimeContext {
+            project_root: &project_root,
+            task_id: &task_id,
+            prompt: "Continue TEAM-123 until it settles.",
+            depends_on: &[],
+            serialization_depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("dashboard"),
+            external_id: Some("TEAM-123"),
+            continuation: Some(&policy),
+        },
+    )
+    .await?;
+    assert!(submission.accepted);
+    let submitted = store
+        .get_instance(&submission.workflow_id)
+        .await?
+        .expect("submitted continuation instance");
+    assert_eq!(submitted.data["continuation"]["attempt"], 1);
+    let initial_commands = store.commands_for(&submission.workflow_id).await?;
+    assert_eq!(initial_commands.len(), 1);
+    assert_eq!(
+        initial_commands[0].command.dedupe_key,
+        format!("prompt-task:{}:attempt:1", submission.workflow_id)
+    );
+
+    let active = ActivityResult::succeeded(
+        PROMPT_TASK_IMPLEMENT_ACTIVITY,
+        "Created the implementation branch.",
+    )
+    .with_signal(ActivitySignal::new(
+        "external_state",
+        json!({ "state": "In Progress", "subject": "TEAM-123" }),
+    ));
+    let continued = store
+        .commit_parent_runtime_completion(
+            &submission.workflow_id,
+            "runtime-1",
+            json!({
+                "command_id": initial_commands[0].id,
+                "runtime_job_id": "continuation-job-1",
+                "activity_result": active,
+            }),
+        )
+        .await?
+        .expect("active state should commit a continuation");
+    assert_eq!(continued.decision.decision, "continue_prompt_task");
+    let after_active = store
+        .get_instance(&submission.workflow_id)
+        .await?
+        .expect("continued instance");
+    assert_eq!(after_active.state, "implementing");
+    assert_eq!(after_active.data["continuation"]["attempt"], 2);
+    assert_eq!(
+        after_active.data["continuation"]["last_summary"],
+        "Created the implementation branch."
+    );
+
+    let settled =
+        ActivityResult::succeeded(PROMPT_TASK_IMPLEMENT_ACTIVITY, "TEAM-123 reached Done.")
+            .with_signal(ActivitySignal::new(
+                "external_state",
+                json!({ "state": "Done", "subject": "TEAM-123" }),
+            ))
+            .with_validation(ValidationRecord::new("cargo test", "passed"));
+    let finished = store
+        .commit_parent_runtime_completion(
+            &submission.workflow_id,
+            "runtime-1",
+            json!({
+                "command_id": continued.decision.commands[0].dedupe_key,
+                "runtime_job_id": "continuation-job-2",
+                "activity_result": settled,
+            }),
+        )
+        .await?
+        .expect("settled state should finish");
+    assert_eq!(
+        finished.decision.decision,
+        "finish_prompt_task_external_settled"
+    );
+    let done = store
+        .get_instance(&submission.workflow_id)
+        .await?
+        .expect("finished continuation instance");
+    assert_eq!(done.state, "done");
+    Ok(())
+}
+
+#[tokio::test]
+async fn cancelled_prompt_continuation_does_not_enqueue_another_attempt() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = open_continuation_runtime_store(dir.path()).await?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+    let task_id = TaskId::from_str("continuation-cancel");
+    let policy = continuation_policy(4);
+    let submission = record_prompt_submission(
+        &store,
+        PromptSubmissionRuntimeContext {
+            project_root: &project_root,
+            task_id: &task_id,
+            prompt: "Continue TEAM-456 until it settles.",
+            depends_on: &[],
+            serialization_depends_on: &[],
+            dependencies_blocked: false,
+            source: Some("dashboard"),
+            external_id: Some("TEAM-456"),
+            continuation: Some(&policy),
+        },
+    )
+    .await?;
+    let before = store.commands_for(&submission.workflow_id).await?;
+    assert_eq!(before.len(), 1);
+    let cancelled = cancel_submission_by_workflow_id(&store, &submission.workflow_id).await?;
+    assert!(matches!(
+        cancelled,
+        RuntimeSubmissionCancelOutcome::Cancelled(_)
+    ));
+
+    let stale = ActivityResult::succeeded(PROMPT_TASK_IMPLEMENT_ACTIVITY, "Still active.")
+        .with_signal(ActivitySignal::new(
+            "external_state",
+            json!({ "state": "In Progress", "subject": "TEAM-456" }),
+        ));
+    let decision = store
+        .commit_parent_runtime_completion(
+            &submission.workflow_id,
+            "runtime-1",
+            json!({
+                "command_id": before[0].id,
+                "runtime_job_id": "continuation-cancelled-job",
+                "activity_result": stale,
+            }),
+        )
+        .await?;
+    assert!(decision.is_none());
+    let after = store.commands_for(&submission.workflow_id).await?;
+    assert_eq!(
+        after.len(),
+        2,
+        "only initial and cancellation commands should exist"
+    );
+    assert!(after
+        .iter()
+        .all(|command| command.status != WorkflowCommandStatus::Pending));
+    Ok(())
+}

--- a/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependencies.rs
@@ -439,8 +439,9 @@ async fn release_prompt_after_dependencies(
             external_id: fields.external_id.as_deref(),
             depends_on: &depends_on_strings(depends_on),
             dependencies_blocked: false,
+            continuation: fields.continuation.as_ref(),
         },
-    );
+    )?;
     let event = store
         .append_event(
             &instance.id,

--- a/crates/harness-server/src/workflow_runtime_submission/dependency_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/dependency_tests.rs
@@ -38,6 +38,7 @@ async fn prompt_submission_waits_for_dependencies_then_releases_runtime_command(
             dependencies_blocked: true,
             source: None,
             external_id: None,
+            continuation: None,
         },
     )
     .await?;
@@ -107,6 +108,7 @@ async fn prompt_submission_releases_after_failed_serialization_dependency() -> a
             dependencies_blocked: true,
             source: None,
             external_id: None,
+            continuation: None,
         },
     )
     .await?;
@@ -167,6 +169,7 @@ async fn prompt_submission_recovers_release_when_in_memory_prompt_is_missing() -
             dependencies_blocked: true,
             source: None,
             external_id: None,
+            continuation: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_submission/identity_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/identity_tests.rs
@@ -94,6 +94,7 @@ async fn prompt_submission_records_explicit_submission_id() -> anyhow::Result<()
             dependencies_blocked: false,
             source: Some("dashboard"),
             external_id: Some("manual:prompt:1129"),
+            continuation: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_submission/replay_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/replay_tests.rs
@@ -117,6 +117,7 @@ async fn prompt_resubmission_after_completed_command_creates_fresh_attempt() -> 
             dependencies_blocked: false,
             source: Some("dashboard"),
             external_id: Some(external_id),
+            continuation: None,
         },
     )
     .await?;
@@ -140,6 +141,7 @@ async fn prompt_resubmission_after_completed_command_creates_fresh_attempt() -> 
             dependencies_blocked: false,
             source: Some("dashboard"),
             external_id: Some(external_id),
+            continuation: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_submission_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission_tests.rs
@@ -118,6 +118,7 @@ async fn prompt_submission_records_pending_runtime_implementation_command() -> a
             dependencies_blocked: false,
             source: Some("dashboard"),
             external_id: Some("manual:prompt:1"),
+            continuation: None,
         },
     )
     .await?;
@@ -164,9 +165,11 @@ async fn prompt_submission_records_pending_runtime_implementation_command() -> a
     );
 
     let events = store.events_for(&workflow_id).await?;
-    assert!(events
+    let submitted_event = events
         .iter()
-        .any(|event| event.event_type == "PromptSubmitted"));
+        .find(|event| event.event_type == "PromptSubmitted")
+        .expect("prompt submission event");
+    assert!(submitted_event.event.get("continuation").is_none());
 
     let commands = store.commands_for(&workflow_id).await?;
     assert_eq!(commands.len(), 1);
@@ -251,6 +254,7 @@ async fn prompt_resubmission_removes_previous_cached_prompt() -> anyhow::Result<
             dependencies_blocked: false,
             source: Some("dashboard"),
             external_id: Some(external_id),
+            continuation: None,
         },
     )
     .await?;
@@ -580,6 +584,7 @@ async fn cancel_prompt_submission_cancels_dispatched_runtime_jobs() -> anyhow::R
             dependencies_blocked: false,
             source: None,
             external_id: None,
+            continuation: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_worker/child_workflow_non_issue.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/child_workflow_non_issue.rs
@@ -65,6 +65,7 @@ pub(super) async fn execute_start_prompt_task_child_workflow(
             dependencies_blocked: false,
             source: Some(source.as_str()),
             external_id: Some(external_id.as_str()),
+            continuation: None,
         },
     )
     .await?;

--- a/crates/harness-server/src/workflow_runtime_worker/data_helpers.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/data_helpers.rs
@@ -454,6 +454,7 @@ mod tests {
                 dependencies_blocked: false,
                 source: Some("test"),
                 external_id: Some("manual:restart-safe"),
+                continuation: None,
             },
         )
         .await?;

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -82,7 +82,23 @@ pub(super) fn build_runtime_prompt_packet(
         packet["repo_memory"] = repo_memory_prompt_value(repo_memory);
     }
     apply_candidate_submission_contract(&mut packet, job);
+    if let Some(context) = prompt_continuation_context(workflow) {
+        packet["continuation_context"] = context;
+    }
     packet
+}
+
+fn prompt_continuation_context(workflow: Option<&WorkflowInstance>) -> Option<Value> {
+    let continuation = workflow?.data.get("continuation")?;
+    let attempt = continuation.get("attempt")?.as_u64()?;
+    if attempt <= 1 {
+        return None;
+    }
+    Some(json!({
+        "attempt": attempt,
+        "previous_external_state": continuation.get("last_external_state").cloned().unwrap_or(Value::Null),
+        "previous_summary": continuation.get("last_summary").cloned().unwrap_or(Value::Null),
+    }))
 }
 
 fn apply_candidate_submission_contract(packet: &mut Value, job: &RuntimeJob) {
@@ -177,6 +193,20 @@ pub(super) fn build_runtime_job_prompt(
          Activity: {activity}\n\n\
          Prompt packet:\n{prompt_packet_json}\n",
     );
+    if let Some(context) = prompt_packet.get("continuation_context") {
+        let attempt = context.get("attempt").and_then(Value::as_u64).unwrap_or(0);
+        let previous_state = context
+            .get("previous_external_state")
+            .and_then(Value::as_str)
+            .unwrap_or("<none>");
+        let previous_summary = context
+            .get("previous_summary")
+            .and_then(Value::as_str)
+            .unwrap_or("<none>");
+        prompt.push_str(&format!(
+            "\nContinuation context:\n- Attempt: {attempt}\n- Previous external state: {previous_state}\n- Previous attempt summary: {previous_summary}\n"
+        ));
+    }
     if let Some(repo_memory_section) = repo_memory_prompt_section(prompt_packet) {
         prompt.push_str(&repo_memory_section);
     }
@@ -252,7 +282,7 @@ pub(super) fn activity_result_schema(
     let summary_contract = agent_summary_contract(workflow_definition, &activity);
     let decision_contract = workflow_decision_contract(workflow);
     let command_examples = workflow_decision_command_examples(workflow_definition, &activity);
-    json!({
+    let mut schema = json!({
         "schema": "harness.runtime.activity_result.v1",
         "activity": activity,
         "workflow_definition": workflow_definition,
@@ -318,7 +348,36 @@ pub(super) fn activity_result_schema(
                 "Omit `artifacts`, `signals`, or `validation` entirely if there is nothing to report — empty arrays or missing fields are both fine."
             ]
         },
-    })
+    });
+    if workflow
+        .and_then(|workflow| workflow.data.get("continuation"))
+        .is_some()
+        && workflow_definition == PROMPT_TASK_DEFINITION_ID
+        && activity == PROMPT_TASK_IMPLEMENT_ACTIVITY
+    {
+        schema["continuation_signal_contract"] = json!({
+            "required_signal_type": "external_state",
+            "exact_count": 1,
+            "payload": {
+                "type": "object",
+                "required_fields": { "state": "non-empty string" },
+                "optional_fields": ["subject"]
+            },
+            "decision_owner": "Harness runtime; the agent reports state and must not emit a continuation workflow_decision"
+        });
+        schema["transition_contract"]["on_succeeded"] = json!({
+            "reducer_next_state": "implementing_when_external_state_is_active_else_done; malformed_or_missing_signal_blocks",
+            "accepted_signals": ["external_state"],
+            "success_requires": "Exactly one external_state signal with an object payload containing a non-empty string state. Active states continue within the configured attempt and no-progress bounds. Settled states still require validation evidence before done."
+        });
+        schema["activity_contract"]["accepted_signals"] = json!(["external_state"]);
+        schema["activity_contract"]["success_requires"] = json!(
+            "exactly_one_external_state_signal; settled external states also require validation evidence"
+        );
+        schema["agent_summary_contract"]["artifacts"]["validation_report"]["required_when"] =
+            json!("The reported external_state is settled and no validation records are present.");
+    }
+    schema
 }
 
 fn workflow_decision_command_examples(_workflow_definition: &str, _activity: &str) -> Value {

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -443,6 +443,62 @@ fn runtime_prompt_packet_includes_workflow_file_contract() {
 }
 
 #[test]
+fn prompt_continuation_packet_includes_attempt_context_and_signal_contract() {
+    let job = RuntimeJob::pending(
+        "command-continue",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY }),
+    );
+    let workflow = WorkflowInstance::new(
+        PROMPT_TASK_DEFINITION_ID,
+        1,
+        "implementing",
+        WorkflowSubject::new("prompt", "TEAM-123"),
+    )
+    .with_id("prompt-workflow-1")
+    .with_data(json!({
+        "continuation": {
+            "policy": {
+                "max_attempts": 4,
+                "attempt_delay_secs": 30,
+                "active_states": ["In Progress"],
+                "no_progress_limit": 3
+            },
+            "attempt": 2,
+            "last_external_state": "In Progress",
+            "last_summary": "Created the implementation branch.",
+            "same_state_count": 0
+        }
+    }));
+    let runtime_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
+    let packet = build_runtime_prompt_packet(
+        &job,
+        Some(&workflow),
+        Path::new("/workspaces/job-continue"),
+        Path::new("/repo"),
+        &runtime_profile,
+        &WorkflowDocument::default(),
+        &[],
+    );
+
+    assert_eq!(packet["continuation_context"]["attempt"], 2);
+    assert_eq!(
+        packet["continuation_context"]["previous_external_state"],
+        "In Progress"
+    );
+    assert_eq!(
+        packet["activity_result_schema"]["continuation_signal_contract"]["required_signal_type"],
+        "external_state"
+    );
+    let prompt = build_runtime_job_prompt(&packet, Some("Continue TEAM-123."));
+    assert!(prompt.contains("Continuation context:"));
+    assert!(prompt.contains("Attempt: 2"));
+    assert!(prompt.contains("Previous external state: In Progress"));
+    assert!(prompt.contains("Previous attempt summary: Created the implementation branch."));
+}
+
+#[test]
 fn runtime_prompt_packet_describes_deferred_candidate_submission_contract() {
     let job = RuntimeJob::pending(
         "command-1",

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -108,9 +108,12 @@ pub use pr_feedback::{
     PR_FEEDBACK_SNAPSHOT_ARTIFACT, PR_REPAIR_SNAPSHOT_ARTIFACT, SERVER_PR_SNAPSHOT_ARTIFACT,
 };
 pub use prompt_task::{
-    build_prompt_submission_decision, PromptSubmissionDecisionInput,
-    PromptSubmissionDecisionOutput, PromptTaskWorkflowAction, PROMPT_TASK_DEFINITION_ID,
-    PROMPT_TASK_IMPLEMENT_ACTIVITY,
+    build_prompt_submission_decision, continuation_value, parse_external_state_signal,
+    prompt_continuation_state_from_data, ExternalStateSignal, PromptContinuationPolicy,
+    PromptContinuationPolicyError, PromptContinuationState, PromptSubmissionDecisionInput,
+    PromptSubmissionDecisionOutput, PromptTaskWorkflowAction,
+    PROMPT_CONTINUATION_DEFAULT_NO_PROGRESS_LIMIT, PROMPT_CONTINUATION_MAX_ATTEMPTS,
+    PROMPT_CONTINUATION_MAX_DELAY_SECS, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
 };
 pub use quality_gate::{
     build_quality_gate_run_decision, quality_gate_workflow_id, QualityGateDecisionInput,

--- a/crates/harness-workflow/src/runtime/prompt_task.rs
+++ b/crates/harness-workflow/src/runtime/prompt_task.rs
@@ -1,7 +1,182 @@
-use super::model::{WorkflowCommand, WorkflowDecision, WorkflowEvidence, WorkflowInstance};
+use super::model::{
+    ActivityResult, WorkflowCommand, WorkflowDecision, WorkflowEvidence, WorkflowInstance,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+use std::fmt;
 
 pub const PROMPT_TASK_DEFINITION_ID: &str = "prompt_task";
 pub const PROMPT_TASK_IMPLEMENT_ACTIVITY: &str = "implement_prompt";
+pub const PROMPT_CONTINUATION_MAX_ATTEMPTS: u32 = 20;
+pub const PROMPT_CONTINUATION_MAX_DELAY_SECS: u64 = 3_600;
+pub const PROMPT_CONTINUATION_DEFAULT_NO_PROGRESS_LIMIT: u32 = 3;
+
+fn default_no_progress_limit() -> u32 {
+    PROMPT_CONTINUATION_DEFAULT_NO_PROGRESS_LIMIT
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptContinuationPolicy {
+    pub max_attempts: u32,
+    pub attempt_delay_secs: u64,
+    pub active_states: BTreeSet<String>,
+    #[serde(default = "default_no_progress_limit")]
+    pub no_progress_limit: u32,
+}
+
+impl PromptContinuationPolicy {
+    pub fn validate(&self) -> Result<(), PromptContinuationPolicyError> {
+        if self.max_attempts == 0 {
+            return Err(PromptContinuationPolicyError::new(
+                "continuation.max_attempts must be at least 1",
+            ));
+        }
+        if self.max_attempts > PROMPT_CONTINUATION_MAX_ATTEMPTS {
+            return Err(PromptContinuationPolicyError::new(format!(
+                "continuation.max_attempts must not exceed {PROMPT_CONTINUATION_MAX_ATTEMPTS}"
+            )));
+        }
+        if self.attempt_delay_secs > PROMPT_CONTINUATION_MAX_DELAY_SECS {
+            return Err(PromptContinuationPolicyError::new(format!(
+                "continuation.attempt_delay_secs must not exceed {PROMPT_CONTINUATION_MAX_DELAY_SECS}"
+            )));
+        }
+        if self.active_states.is_empty() {
+            return Err(PromptContinuationPolicyError::new(
+                "continuation.active_states must contain at least one state",
+            ));
+        }
+        if self
+            .active_states
+            .iter()
+            .any(|state| state.trim().is_empty())
+        {
+            return Err(PromptContinuationPolicyError::new(
+                "continuation.active_states must not contain an empty state",
+            ));
+        }
+        if self.no_progress_limit == 0 {
+            return Err(PromptContinuationPolicyError::new(
+                "continuation.no_progress_limit must be at least 1",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptContinuationPolicyError {
+    message: String,
+}
+
+impl PromptContinuationPolicyError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for PromptContinuationPolicyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for PromptContinuationPolicyError {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptContinuationState {
+    pub policy: PromptContinuationPolicy,
+    pub attempt: u32,
+    pub last_external_state: Option<String>,
+    pub last_summary: Option<String>,
+    pub same_state_count: u32,
+}
+
+impl PromptContinuationState {
+    pub fn initial(policy: &PromptContinuationPolicy) -> Self {
+        Self {
+            policy: policy.clone(),
+            attempt: 1,
+            last_external_state: None,
+            last_summary: None,
+            same_state_count: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExternalStateSignal {
+    pub state: String,
+    pub payload: Value,
+}
+
+impl ExternalStateSignal {
+    pub fn evidence(&self) -> WorkflowEvidence {
+        WorkflowEvidence::new("external_state", self.payload.to_string())
+    }
+}
+
+pub fn prompt_continuation_state_from_data(
+    data: &Value,
+) -> Result<Option<PromptContinuationState>, String> {
+    let Some(value) = data.get("continuation") else {
+        return Ok(None);
+    };
+    let state: PromptContinuationState = serde_json::from_value(value.clone())
+        .map_err(|error| format!("persisted continuation state is invalid: {error}"))?;
+    state
+        .policy
+        .validate()
+        .map_err(|error| format!("persisted continuation policy is invalid: {error}"))?;
+    if state.attempt == 0 || state.attempt > state.policy.max_attempts {
+        return Err(format!(
+            "persisted continuation attempt {} is outside 1..={}",
+            state.attempt, state.policy.max_attempts
+        ));
+    }
+    Ok(Some(state))
+}
+
+pub fn parse_external_state_signal(result: &ActivityResult) -> Result<ExternalStateSignal, String> {
+    let mut signals = result
+        .signals
+        .iter()
+        .filter(|signal| signal.signal_type == "external_state");
+    let Some(signal) = signals.next() else {
+        return Err(
+            "implement_prompt result must contain exactly one external_state signal".into(),
+        );
+    };
+    if signals.next().is_some() {
+        return Err("implement_prompt result contains multiple external_state signals".into());
+    }
+    let Some(payload) = signal.signal.as_object() else {
+        return Err("external_state signal payload must be a JSON object".into());
+    };
+    let Some(state) = payload.get("state").and_then(Value::as_str) else {
+        return Err("external_state signal payload must contain a string state field".into());
+    };
+    if state.trim().is_empty() {
+        return Err("external_state signal state must not be empty".into());
+    }
+    Ok(ExternalStateSignal {
+        state: state.to_string(),
+        payload: signal.signal.clone(),
+    })
+}
+
+pub fn continuation_value(policy: &PromptContinuationPolicy) -> Value {
+    json!({
+        "policy": policy,
+        "attempt": 1,
+        "last_external_state": null,
+        "last_summary": null,
+        "same_state_count": 0,
+    })
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromptTaskWorkflowAction {
@@ -17,6 +192,7 @@ pub struct PromptSubmissionDecisionInput<'a> {
     pub external_id: Option<&'a str>,
     pub depends_on: &'a [String],
     pub dependencies_blocked: bool,
+    pub continuation: Option<&'a PromptContinuationPolicy>,
 }
 
 #[derive(Debug, Clone)]
@@ -28,7 +204,10 @@ pub struct PromptSubmissionDecisionOutput {
 pub fn build_prompt_submission_decision(
     instance: &WorkflowInstance,
     input: PromptSubmissionDecisionInput<'_>,
-) -> PromptSubmissionDecisionOutput {
+) -> Result<PromptSubmissionDecisionOutput, PromptContinuationPolicyError> {
+    if let Some(policy) = input.continuation {
+        policy.validate()?;
+    }
     let next_state = if input.dependencies_blocked {
         "awaiting_dependencies"
     } else {
@@ -47,13 +226,18 @@ pub fn build_prompt_submission_decision(
         reason,
     );
     if !input.dependencies_blocked {
-        decision = decision.with_command(WorkflowCommand::new(
-            super::model::WorkflowCommandType::EnqueueActivity,
+        let dedupe_key = if input.continuation.is_some() {
+            format!("prompt-task:{}:attempt:1", instance.id)
+        } else {
             format!(
                 "prompt-submit:{}:task:{}:implement",
                 subject_key(input),
                 input.task_id
-            ),
+            )
+        };
+        decision = decision.with_command(WorkflowCommand::new(
+            super::model::WorkflowCommandType::EnqueueActivity,
+            dedupe_key,
             serde_json::json!({
                 "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY,
                 "prompt_ref": input.prompt_ref,
@@ -79,10 +263,10 @@ pub fn build_prompt_submission_decision(
         ))
         .high_confidence();
 
-    PromptSubmissionDecisionOutput {
+    Ok(PromptSubmissionDecisionOutput {
         action: PromptTaskWorkflowAction::RunImplementation,
         decision,
-    }
+    })
 }
 
 fn subject_key(input: PromptSubmissionDecisionInput<'_>) -> &str {
@@ -94,4 +278,75 @@ fn depends_on_summary(depends_on: &[String]) -> String {
         return "<none>".to_string();
     }
     depends_on.join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy() -> PromptContinuationPolicy {
+        PromptContinuationPolicy {
+            max_attempts: 4,
+            attempt_delay_secs: 30,
+            active_states: BTreeSet::from(["In Progress".to_string()]),
+            no_progress_limit: 3,
+        }
+    }
+
+    #[test]
+    fn prompt_continuation_policy_enforces_bounds() {
+        assert!(policy().validate().is_ok());
+        for invalid in [
+            PromptContinuationPolicy {
+                max_attempts: 0,
+                ..policy()
+            },
+            PromptContinuationPolicy {
+                max_attempts: PROMPT_CONTINUATION_MAX_ATTEMPTS + 1,
+                ..policy()
+            },
+            PromptContinuationPolicy {
+                attempt_delay_secs: PROMPT_CONTINUATION_MAX_DELAY_SECS + 1,
+                ..policy()
+            },
+            PromptContinuationPolicy {
+                active_states: BTreeSet::new(),
+                ..policy()
+            },
+            PromptContinuationPolicy {
+                no_progress_limit: 0,
+                ..policy()
+            },
+        ] {
+            assert!(invalid.validate().is_err());
+        }
+    }
+
+    #[test]
+    fn external_state_signal_parser_is_strict() {
+        let valid = ActivityResult::succeeded(PROMPT_TASK_IMPLEMENT_ACTIVITY, "active")
+            .with_signal(super::super::model::ActivitySignal::new(
+                "external_state",
+                json!({ "state": "In Progress", "subject": "TEAM-123" }),
+            ));
+        assert_eq!(
+            parse_external_state_signal(&valid)
+                .expect("valid signal")
+                .state,
+            "In Progress"
+        );
+
+        let non_object =
+            ActivityResult::succeeded(PROMPT_TASK_IMPLEMENT_ACTIVITY, "bad").with_signal(
+                super::super::model::ActivitySignal::new("external_state", json!("In Progress")),
+            );
+        assert!(parse_external_state_signal(&non_object).is_err());
+        let ambiguous = valid
+            .clone()
+            .with_signal(super::super::model::ActivitySignal::new(
+                "external_state",
+                json!({ "state": "Done" }),
+            ));
+        assert!(parse_external_state_signal(&ambiguous).is_err());
+    }
 }

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -448,10 +448,9 @@ fn structured_decision_validates(
     result: &ActivityResult,
     decision: &WorkflowDecision,
 ) -> bool {
-    if prompt_task_activity_matches(instance, result)
-        && (instance.data.get("continuation").is_some()
-            || decision.decision == "continue_prompt_task")
-    {
+    if prompt_task_activity_matches(instance, result) {
+        // Prompt-task outcomes are derived from the persisted policy and activity evidence.
+        // Agent-provided decisions must not override or bootstrap that runtime-owned state.
         return false;
     }
     if instance.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -1,6 +1,7 @@
 mod github_issue_completion;
 mod plan_issue_completion;
 mod pr_feedback_completion;
+mod prompt_task_completion;
 mod quality_gate_completion;
 mod runtime_failure;
 mod support;
@@ -18,6 +19,7 @@ use self::pr_feedback_completion::{
     pr_feedback_child_decision_from_activity_result, pr_feedback_success_contract_error,
     pr_feedback_sweep_decision_from_activity_result,
 };
+use self::prompt_task_completion::prompt_task_success_decision;
 use self::quality_gate_completion::{
     parent_quality_gate_pass_decision, quality_gate_activity_matches,
     quality_gate_success_contract_error, quality_gate_success_decision,
@@ -41,7 +43,10 @@ use super::model::{
     WorkflowEvent, WorkflowInstance,
 };
 use super::pr_feedback::PR_FEEDBACK_DEFINITION_ID;
-use super::prompt_task::{PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY};
+use super::prompt_task::{
+    parse_external_state_signal, prompt_continuation_state_from_data, PROMPT_TASK_DEFINITION_ID,
+    PROMPT_TASK_IMPLEMENT_ACTIVITY,
+};
 use super::quality_gate::QUALITY_GATE_DEFINITION_ID;
 use super::state_registry::decision_validator_for_definition;
 use super::validator::ValidationContext;
@@ -225,11 +230,12 @@ fn reduce_success(
     }
 
     if prompt_task_activity_matches(instance, result) {
-        if let Some(reason) = prompt_task_success_contract_error(result) {
+        if let Some(reason) = prompt_task_success_contract_error(instance, result) {
             return Some(invalid_agent_output_blocked_decision(
                 instance, event, result, reason,
             ));
         }
+        return prompt_task_success_decision(instance, event, result);
     }
 
     if let Some(decision) = bind_pr_from_activity_result(instance, event, result) {
@@ -304,11 +310,6 @@ fn reduce_success(
             "passed",
             "quality_passed",
             "quality gate activity completed successfully",
-        ),
-        (PROMPT_TASK_DEFINITION_ID, "implementing", PROMPT_TASK_IMPLEMENT_ACTIVITY) => (
-            "done",
-            "finish_prompt_task",
-            "prompt implementation activity completed successfully",
         ),
         _ if known_success_without_decision(instance, event, result) => return None,
         _ => {
@@ -447,6 +448,10 @@ fn structured_decision_validates(
     result: &ActivityResult,
     decision: &WorkflowDecision,
 ) -> bool {
+    if prompt_task_activity_matches(instance, result) && instance.data.get("continuation").is_some()
+    {
+        return false;
+    }
     if instance.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID
         && instance.state == "implementing"
         && result.activity == "implement_issue"
@@ -463,7 +468,7 @@ fn structured_decision_validates(
     }
     if prompt_task_activity_matches(instance, result)
         && decision.next_state == "done"
-        && prompt_task_success_contract_error(result).is_some()
+        && prompt_task_success_contract_error(instance, result).is_some()
     {
         return false;
     }
@@ -492,11 +497,21 @@ fn prompt_task_activity_matches(instance: &WorkflowInstance, result: &ActivityRe
     )
 }
 
-fn prompt_task_success_contract_error(result: &ActivityResult) -> Option<&'static str> {
+fn prompt_task_success_contract_error(
+    instance: &WorkflowInstance,
+    result: &ActivityResult,
+) -> Option<&'static str> {
     if prompt_task_has_validation_evidence(result) {
-        None
-    } else {
-        Some("implement_prompt succeeded without validation evidence")
+        return None;
+    }
+    match prompt_continuation_state_from_data(&instance.data) {
+        Ok(Some(continuation)) => match parse_external_state_signal(result) {
+            Ok(signal) if continuation.policy.active_states.contains(&signal.state) => None,
+            Err(_) => None,
+            _ => Some("implement_prompt succeeded without validation evidence"),
+        },
+        Ok(None) => Some("implement_prompt succeeded without validation evidence"),
+        Err(_) => None,
     }
 }
 

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -448,7 +448,9 @@ fn structured_decision_validates(
     result: &ActivityResult,
     decision: &WorkflowDecision,
 ) -> bool {
-    if prompt_task_activity_matches(instance, result) && instance.data.get("continuation").is_some()
+    if prompt_task_activity_matches(instance, result)
+        && (instance.data.get("continuation").is_some()
+            || decision.decision == "continue_prompt_task")
     {
         return false;
     }

--- a/crates/harness-workflow/src/runtime/reducer/prompt_task_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/prompt_task_completion.rs
@@ -1,0 +1,397 @@
+use super::support::{runtime_blocked_command, runtime_completion_evidence};
+use crate::runtime::model::{
+    ActivityResult, WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowEvent,
+    WorkflowEvidence, WorkflowInstance,
+};
+use crate::runtime::prompt_task::{
+    parse_external_state_signal, prompt_continuation_state_from_data, ExternalStateSignal,
+    PromptContinuationState, PROMPT_TASK_IMPLEMENT_ACTIVITY,
+};
+use chrono::Duration;
+use serde_json::{json, Value};
+
+pub(super) fn prompt_task_success_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    let continuation = match prompt_continuation_state_from_data(&instance.data) {
+        Ok(Some(continuation)) => continuation,
+        Ok(None) => return Some(single_shot_done_decision(instance, event, result)),
+        Err(reason) => {
+            return Some(blocked_decision(
+                instance,
+                event,
+                result,
+                "prompt_continuation_signal_missing",
+                &reason,
+                None,
+            ));
+        }
+    };
+    let signal = match parse_external_state_signal(result) {
+        Ok(signal) => signal,
+        Err(reason) => {
+            return Some(blocked_decision(
+                instance,
+                event,
+                result,
+                "prompt_continuation_signal_missing",
+                &reason,
+                None,
+            ));
+        }
+    };
+    let observed = observed_state(&continuation, result, &signal);
+    if !continuation.policy.active_states.contains(&signal.state) {
+        return Some(settled_done_decision(
+            instance, event, result, &signal, &observed,
+        ));
+    }
+    if continuation.attempt >= continuation.policy.max_attempts {
+        let reason = format!(
+            "prompt continuation exhausted max_attempts={} while external state remained `{}`",
+            continuation.policy.max_attempts, signal.state
+        );
+        return Some(blocked_decision(
+            instance,
+            event,
+            result,
+            "prompt_continuation_exhausted",
+            &reason,
+            Some((&signal, &observed)),
+        ));
+    }
+    if observed.same_state_count >= continuation.policy.no_progress_limit {
+        let reason = format!(
+            "prompt continuation made no progress for {} consecutive attempts in external state `{}`",
+            observed.same_state_count, signal.state
+        );
+        return Some(blocked_decision(
+            instance,
+            event,
+            result,
+            "prompt_continuation_no_progress",
+            &reason,
+            Some((&signal, &observed)),
+        ));
+    }
+    Some(continue_decision(
+        instance, event, result, &signal, observed,
+    ))
+}
+
+fn single_shot_done_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> WorkflowDecision {
+    WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "finish_prompt_task",
+        "done",
+        "prompt implementation activity completed successfully",
+    )
+    .with_command(mark_done_command(instance, result, None))
+    .with_evidence(runtime_completion_evidence(event, result))
+    .high_confidence()
+}
+
+fn settled_done_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+    signal: &ExternalStateSignal,
+    continuation: &PromptContinuationState,
+) -> WorkflowDecision {
+    WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "finish_prompt_task_external_settled",
+        "done",
+        format!(
+            "external state `{}` is outside the configured active states",
+            signal.state
+        ),
+    )
+    .with_command(mark_done_command(instance, result, Some(continuation)))
+    .with_evidence(runtime_completion_evidence(event, result))
+    .with_evidence(signal.evidence())
+    .high_confidence()
+}
+
+fn continue_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+    signal: &ExternalStateSignal,
+    mut continuation: PromptContinuationState,
+) -> WorkflowDecision {
+    continuation.attempt = continuation.attempt.saturating_add(1);
+    let mut command = json!({
+        "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY,
+        "continuation": &continuation,
+    });
+    if continuation.policy.attempt_delay_secs > 0 {
+        let delay = Duration::seconds(continuation.policy.attempt_delay_secs as i64);
+        command["retry_not_before"] = json!((event.created_at + delay).to_rfc3339());
+    }
+    WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "continue_prompt_task",
+        "implementing",
+        format!(
+            "external state `{}` remains active; enqueue attempt {}",
+            signal.state, continuation.attempt
+        ),
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::EnqueueActivity,
+        format!(
+            "prompt-task:{}:attempt:{}",
+            instance.id, continuation.attempt
+        ),
+        command,
+    ))
+    .with_evidence(runtime_completion_evidence(event, result))
+    .with_evidence(signal.evidence())
+    .high_confidence()
+}
+
+fn blocked_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+    decision_id: &str,
+    reason: &str,
+    signal_and_state: Option<(&ExternalStateSignal, &PromptContinuationState)>,
+) -> WorkflowDecision {
+    let mut block = runtime_blocked_command(
+        reason,
+        None,
+        format!("runtime-completion:{}:{decision_id}:block", event.id),
+        event,
+        result,
+    );
+    if let Some((_, continuation)) = signal_and_state {
+        block.command["continuation"] = json!(continuation);
+    }
+    let mut decision = WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        decision_id,
+        "blocked",
+        reason,
+    )
+    .with_command(block)
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::RequestOperatorAttention,
+        format!("runtime-completion:{}:{decision_id}:operator", event.id),
+        json!({
+            "reason": reason,
+            "activity": result.activity,
+        }),
+    ))
+    .with_evidence(runtime_completion_evidence(event, result));
+    decision = match signal_and_state {
+        Some((signal, _)) => decision.with_evidence(signal.evidence()),
+        None => decision.with_evidence(WorkflowEvidence::new(
+            "external_state",
+            external_state_evidence_summary(result),
+        )),
+    };
+    decision.high_confidence()
+}
+
+fn observed_state(
+    previous: &PromptContinuationState,
+    result: &ActivityResult,
+    signal: &ExternalStateSignal,
+) -> PromptContinuationState {
+    let no_progress = previous.last_external_state.as_deref() == Some(signal.state.as_str())
+        && result.artifacts.is_empty()
+        && result.validation.is_empty();
+    PromptContinuationState {
+        policy: previous.policy.clone(),
+        attempt: previous.attempt,
+        last_external_state: Some(signal.state.clone()),
+        last_summary: Some(result.summary.clone()),
+        same_state_count: if no_progress {
+            previous.same_state_count.saturating_add(1)
+        } else {
+            0
+        },
+    }
+}
+
+fn mark_done_command(
+    instance: &WorkflowInstance,
+    result: &ActivityResult,
+    continuation: Option<&PromptContinuationState>,
+) -> WorkflowCommand {
+    let mut payload = json!({
+        "activity": result.activity,
+        "workflow_id": instance.id,
+    });
+    if let Some(continuation) = continuation {
+        payload["continuation"] = json!(continuation);
+    }
+    WorkflowCommand::new(
+        WorkflowCommandType::MarkDone,
+        format!("prompt-task:{}:done", instance.id),
+        payload,
+    )
+}
+
+fn external_state_evidence_summary(result: &ActivityResult) -> String {
+    let values = result
+        .signals
+        .iter()
+        .filter(|signal| signal.signal_type == "external_state")
+        .map(|signal| signal.signal.clone())
+        .collect::<Vec<Value>>();
+    json!({ "signals": values }).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::model::{ActivitySignal, ValidationRecord, WorkflowSubject};
+    use crate::runtime::prompt_task::PromptContinuationPolicy;
+    use std::collections::BTreeSet;
+
+    fn policy(max_attempts: u32, no_progress_limit: u32) -> PromptContinuationPolicy {
+        PromptContinuationPolicy {
+            max_attempts,
+            attempt_delay_secs: 30,
+            active_states: BTreeSet::from(["In Progress".to_string()]),
+            no_progress_limit,
+        }
+    }
+
+    fn instance(continuation: Option<PromptContinuationState>) -> WorkflowInstance {
+        let mut data = json!({});
+        if let Some(continuation) = continuation {
+            data["continuation"] = json!(continuation);
+        }
+        WorkflowInstance::new(
+            "prompt_task",
+            1,
+            "implementing",
+            WorkflowSubject::new("prompt", "task-1"),
+        )
+        .with_id("workflow-1")
+        .with_data(data)
+    }
+
+    fn event(result: &ActivityResult) -> WorkflowEvent {
+        WorkflowEvent::new("workflow-1", 1, "RuntimeJobCompleted", "runtime-1").with_payload(
+            json!({
+                "command_id": "command-1",
+                "runtime_job_id": "job-1",
+                "activity_result": result,
+            }),
+        )
+    }
+
+    fn result(state: Option<&str>) -> ActivityResult {
+        let result = ActivityResult::succeeded(PROMPT_TASK_IMPLEMENT_ACTIVITY, "attempt summary");
+        match state {
+            Some(state) => result.with_signal(ActivitySignal::new(
+                "external_state",
+                json!({ "state": state, "subject": "TEAM-123" }),
+            )),
+            None => result,
+        }
+    }
+
+    #[test]
+    fn prompt_continuation_preserves_single_shot_and_settled_done_paths() {
+        let validated = result(None).with_validation(ValidationRecord::new("cargo test", "passed"));
+        let decision =
+            prompt_task_success_decision(&instance(None), &event(&validated), &validated)
+                .expect("single shot decision");
+        assert_eq!(decision.decision, "finish_prompt_task");
+        assert_eq!(decision.next_state, "done");
+
+        let continuation = PromptContinuationState::initial(&policy(4, 3));
+        let settled =
+            result(Some("Done")).with_validation(ValidationRecord::new("cargo test", "passed"));
+        let decision =
+            prompt_task_success_decision(&instance(Some(continuation)), &event(&settled), &settled)
+                .expect("settled decision");
+        assert_eq!(decision.decision, "finish_prompt_task_external_settled");
+        assert_eq!(decision.next_state, "done");
+        assert!(decision.evidence.iter().any(|e| e.kind == "external_state"));
+    }
+
+    #[test]
+    fn prompt_continuation_active_state_enqueues_next_attempt_with_context_and_delay() {
+        let continuation = PromptContinuationState::initial(&policy(4, 3));
+        let active = result(Some("In Progress"));
+        let completion = event(&active);
+        let expected_not_before = (completion.created_at + Duration::seconds(30)).to_rfc3339();
+        let decision =
+            prompt_task_success_decision(&instance(Some(continuation)), &completion, &active)
+                .expect("continue decision");
+        assert_eq!(decision.decision, "continue_prompt_task");
+        assert_eq!(decision.next_state, "implementing");
+        assert_eq!(decision.commands.len(), 1);
+        assert_eq!(
+            decision.commands[0].dedupe_key,
+            "prompt-task:workflow-1:attempt:2"
+        );
+        assert_eq!(decision.commands[0].command["continuation"]["attempt"], 2);
+        assert_eq!(
+            decision.commands[0].command["continuation"]["last_summary"],
+            "attempt summary"
+        );
+        assert_eq!(
+            decision.commands[0].command["retry_not_before"],
+            expected_not_before
+        );
+    }
+
+    #[test]
+    fn prompt_continuation_blocks_malformed_exhausted_and_no_progress_results() {
+        let malformed = result(None);
+        let malformed_decision = prompt_task_success_decision(
+            &instance(Some(PromptContinuationState::initial(&policy(4, 3)))),
+            &event(&malformed),
+            &malformed,
+        )
+        .expect("malformed decision");
+        assert_eq!(
+            malformed_decision.decision,
+            "prompt_continuation_signal_missing"
+        );
+        assert_eq!(malformed_decision.next_state, "blocked");
+
+        let exhausted = PromptContinuationState {
+            attempt: 2,
+            ..PromptContinuationState::initial(&policy(2, 3))
+        };
+        let active = result(Some("In Progress"));
+        let exhausted_decision =
+            prompt_task_success_decision(&instance(Some(exhausted)), &event(&active), &active)
+                .expect("exhausted decision");
+        assert_eq!(exhausted_decision.decision, "prompt_continuation_exhausted");
+
+        let stalled = PromptContinuationState {
+            attempt: 2,
+            last_external_state: Some("In Progress".to_string()),
+            same_state_count: 1,
+            ..PromptContinuationState::initial(&policy(4, 2))
+        };
+        let stalled_decision =
+            prompt_task_success_decision(&instance(Some(stalled)), &event(&active), &active)
+                .expect("stalled decision");
+        assert_eq!(stalled_decision.decision, "prompt_continuation_no_progress");
+        assert_eq!(
+            stalled_decision.commands[0].command["continuation"]["same_state_count"],
+            2
+        );
+    }
+}

--- a/crates/harness-workflow/src/runtime/state_registry_equivalence_tests.rs
+++ b/crates/harness-workflow/src/runtime/state_registry_equivalence_tests.rs
@@ -500,7 +500,7 @@ const PROMPT_TASK_RULES: &[ExpectedRule] = &[
     (Some("submitted"), "implementing", &[E, W]),
     (Some("failed"), "implementing", &[E, W]),
     (Some("cancelled"), "implementing", &[E, W]),
-    (Some("implementing"), "implementing", &[E, W]),
+    (Some("implementing"), "implementing", &[E]),
     (Some("blocked"), "awaiting_dependencies", &[W]),
     (Some("blocked"), "implementing", &[E, W]),
     (Some("implementing"), "done", &[MD]),

--- a/crates/harness-workflow/src/runtime/store/runtime_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion.rs
@@ -7,6 +7,7 @@ use crate::runtime::model::{
     ActivityResult, ActivityStatus, WorkflowDecision, WorkflowDecisionRecord, WorkflowEvent,
     WorkflowEvidence, WorkflowInstance,
 };
+use crate::runtime::prompt_task::{PromptContinuationState, PROMPT_TASK_DEFINITION_ID};
 use crate::runtime::reducer::reduce_runtime_job_completed;
 use crate::runtime::status::WorkflowCommandStatus;
 use crate::runtime::validator::{ValidationContext, WorkflowDecisionRejectionKind};
@@ -226,6 +227,7 @@ async fn persist_runtime_completion_decision_tx(
     insert_decision_record_tx(tx, &record).await?;
 
     if record.accepted {
+        apply_prompt_continuation_side_effect(&mut instance, &record.decision)?;
         for followup in &record.decision.commands {
             let status = if followup.requires_runtime_job() {
                 WorkflowCommandStatus::Pending
@@ -243,4 +245,51 @@ async fn persist_runtime_completion_decision_tx(
     }
 
     Ok(record)
+}
+
+fn apply_prompt_continuation_side_effect(
+    instance: &mut WorkflowInstance,
+    decision: &WorkflowDecision,
+) -> anyhow::Result<()> {
+    if instance.definition_id != PROMPT_TASK_DEFINITION_ID
+        || !matches!(
+            decision.decision.as_str(),
+            "continue_prompt_task"
+                | "finish_prompt_task_external_settled"
+                | "prompt_continuation_exhausted"
+                | "prompt_continuation_no_progress"
+        )
+    {
+        return Ok(());
+    }
+    let continuation_values = decision
+        .commands
+        .iter()
+        .filter_map(|command| command.command.get("continuation"))
+        .collect::<Vec<_>>();
+    if continuation_values.len() != 1 {
+        anyhow::bail!(
+            "prompt continuation decision `{}` must persist exactly one continuation state",
+            decision.decision
+        );
+    }
+    let continuation: PromptContinuationState =
+        serde_json::from_value(continuation_values[0].clone())?;
+    continuation.policy.validate()?;
+    if continuation.attempt == 0 || continuation.attempt > continuation.policy.max_attempts {
+        anyhow::bail!(
+            "prompt continuation decision `{}` has invalid attempt {}",
+            decision.decision,
+            continuation.attempt
+        );
+    }
+    let data = instance
+        .data
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("prompt task instance data must be a JSON object"))?;
+    data.insert(
+        "continuation".to_string(),
+        serde_json::to_value(continuation)?,
+    );
+    Ok(())
 }

--- a/crates/harness-workflow/src/runtime/store/runtime_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion.rs
@@ -7,7 +7,9 @@ use crate::runtime::model::{
     ActivityResult, ActivityStatus, WorkflowDecision, WorkflowDecisionRecord, WorkflowEvent,
     WorkflowEvidence, WorkflowInstance,
 };
-use crate::runtime::prompt_task::{PromptContinuationState, PROMPT_TASK_DEFINITION_ID};
+use crate::runtime::prompt_task::{
+    prompt_continuation_state_from_data, PromptContinuationState, PROMPT_TASK_DEFINITION_ID,
+};
 use crate::runtime::reducer::reduce_runtime_job_completed;
 use crate::runtime::status::WorkflowCommandStatus;
 use crate::runtime::validator::{ValidationContext, WorkflowDecisionRejectionKind};
@@ -262,6 +264,14 @@ fn apply_prompt_continuation_side_effect(
     {
         return Ok(());
     }
+    let previous = prompt_continuation_state_from_data(&instance.data)
+        .map_err(anyhow::Error::msg)?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "prompt continuation decision `{}` requires authoritative persisted continuation state",
+                decision.decision
+            )
+        })?;
     let continuation_values = decision
         .commands
         .iter()
@@ -276,6 +286,27 @@ fn apply_prompt_continuation_side_effect(
     let continuation: PromptContinuationState =
         serde_json::from_value(continuation_values[0].clone())?;
     continuation.policy.validate()?;
+    if continuation.policy != previous.policy {
+        anyhow::bail!(
+            "prompt continuation decision `{}` cannot replace the persisted policy",
+            decision.decision
+        );
+    }
+    let expected_attempt = if decision.decision == "continue_prompt_task" {
+        previous.attempt.checked_add(1).ok_or_else(|| {
+            anyhow::anyhow!("prompt continuation attempt overflowed the persisted counter")
+        })?
+    } else {
+        previous.attempt
+    };
+    if continuation.attempt != expected_attempt {
+        anyhow::bail!(
+            "prompt continuation decision `{}` expected attempt {}, got {}",
+            decision.decision,
+            expected_attempt,
+            continuation.attempt
+        );
+    }
     if continuation.attempt == 0 || continuation.attempt > continuation.policy.max_attempts {
         anyhow::bail!(
             "prompt continuation decision `{}` has invalid attempt {}",

--- a/crates/harness-workflow/src/runtime/store/runtime_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion.rs
@@ -4,8 +4,8 @@ use super::{
     WorkflowRuntimeStore,
 };
 use crate::runtime::model::{
-    ActivityResult, ActivityStatus, WorkflowDecision, WorkflowDecisionRecord, WorkflowEvent,
-    WorkflowEvidence, WorkflowInstance,
+    ActivityResult, ActivityStatus, WorkflowCommand, WorkflowDecision, WorkflowDecisionRecord,
+    WorkflowEvent, WorkflowEvidence, WorkflowInstance,
 };
 use crate::runtime::prompt_task::{
     prompt_continuation_state_from_data, PromptContinuationState, PROMPT_TASK_DEFINITION_ID,
@@ -229,7 +229,11 @@ async fn persist_runtime_completion_decision_tx(
     insert_decision_record_tx(tx, &record).await?;
 
     if record.accepted {
-        apply_prompt_continuation_side_effect(&mut instance, &record.decision)?;
+        if apply_prompt_continuation_side_effect(tx, &mut instance, &record.decision).await?
+            == PromptContinuationSideEffect::DurableReplay
+        {
+            return Ok(record);
+        }
         for followup in &record.decision.commands {
             let status = if followup.requires_runtime_job() {
                 WorkflowCommandStatus::Pending
@@ -249,10 +253,17 @@ async fn persist_runtime_completion_decision_tx(
     Ok(record)
 }
 
-fn apply_prompt_continuation_side_effect(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromptContinuationSideEffect {
+    Applied,
+    DurableReplay,
+}
+
+async fn apply_prompt_continuation_side_effect(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     instance: &mut WorkflowInstance,
     decision: &WorkflowDecision,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PromptContinuationSideEffect> {
     if instance.definition_id != PROMPT_TASK_DEFINITION_ID
         || !matches!(
             decision.decision.as_str(),
@@ -262,7 +273,7 @@ fn apply_prompt_continuation_side_effect(
                 | "prompt_continuation_no_progress"
         )
     {
-        return Ok(());
+        return Ok(PromptContinuationSideEffect::Applied);
     }
     let previous = prompt_continuation_state_from_data(&instance.data)
         .map_err(anyhow::Error::msg)?
@@ -291,6 +302,10 @@ fn apply_prompt_continuation_side_effect(
             "prompt continuation decision `{}` cannot replace the persisted policy",
             decision.decision
         );
+    }
+    if decision.decision == "continue_prompt_task" && continuation == previous {
+        require_durable_continuation_replay(tx, instance, decision).await?;
+        return Ok(PromptContinuationSideEffect::DurableReplay);
     }
     let expected_attempt = if decision.decision == "continue_prompt_task" {
         previous.attempt.checked_add(1).ok_or_else(|| {
@@ -322,5 +337,37 @@ fn apply_prompt_continuation_side_effect(
         "continuation".to_string(),
         serde_json::to_value(continuation)?,
     );
+    Ok(PromptContinuationSideEffect::Applied)
+}
+
+async fn require_durable_continuation_replay(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    instance: &WorkflowInstance,
+    decision: &WorkflowDecision,
+) -> anyhow::Result<()> {
+    let command = decision.commands.first().ok_or_else(|| {
+        anyhow::anyhow!("prompt continuation replay requires its attempt-scoped command")
+    })?;
+    let existing: Option<(String,)> = sqlx::query_as(
+        "SELECT data::text FROM workflow_commands
+         WHERE workflow_id = $1 AND dedupe_key = $2",
+    )
+    .bind(&instance.id)
+    .bind(&command.dedupe_key)
+    .fetch_optional(&mut **tx)
+    .await?;
+    let Some((data,)) = existing else {
+        anyhow::bail!(
+            "prompt continuation replay is missing durable command `{}`",
+            command.dedupe_key
+        );
+    };
+    let existing_command: WorkflowCommand = serde_json::from_str(&data)?;
+    if existing_command != *command {
+        anyhow::bail!(
+            "prompt continuation replay command `{}` does not match durable state",
+            command.dedupe_key
+        );
+    }
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -14,14 +14,15 @@ use super::{
     DispatchBarrierInput, DispatchBarrierReasonCode, DispatchClaim, InMemoryWorkflowBus,
     IssueSubmissionDecisionInput, IssueSubmissionWorkflowAction, PlanIssueDecisionInput,
     PlanIssueWorkflowAction, PrDetectedDecisionInput, PrFeedbackDecisionInput, PrFeedbackOutcome,
-    PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, PromptSubmissionDecisionInput,
-    QualityGateDecisionInput, QualityGateWorkflowAction, RuntimeCommandDispatcher,
-    RuntimeJobExecutor, RuntimeProfileSelector, RuntimeWorker, SubmissionMode,
-    WorkflowCommandStatus, WorkflowDecisionTransition, WorkflowRuntimeStore,
-    GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY, PROMPT_TASK_DEFINITION_ID,
-    PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
-    QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
-    QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL, SCOPE_TOO_LARGE_SIGNAL,
+    PrFeedbackSweepDecisionInput, PrFeedbackWorkflowAction, PromptContinuationPolicy,
+    PromptContinuationState, PromptSubmissionDecisionInput, QualityGateDecisionInput,
+    QualityGateWorkflowAction, RuntimeCommandDispatcher, RuntimeJobExecutor,
+    RuntimeProfileSelector, RuntimeWorker, SubmissionMode, WorkflowCommandStatus,
+    WorkflowDecisionTransition, WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID,
+    LOCAL_REVIEW_ACTIVITY, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
+    QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
+    QUALITY_PASSED_SIGNAL, RUNTIME_JOB_COMPLETED_EVENT, SCOPE_TOO_LARGE_SIGNAL,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Timelike, Utc};

--- a/crates/harness-workflow/src/runtime/tests/completion_reducer_core.rs
+++ b/crates/harness-workflow/src/runtime/tests/completion_reducer_core.rs
@@ -54,49 +54,64 @@ fn prompt_task_without_policy_ignores_forged_structured_continuation() {
         no_progress_limit: 3,
     };
 
-    for continuation in [None, Some(PromptContinuationState::initial(&forged_policy))] {
-        let mut payload = json!({ "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY });
-        if let Some(continuation) = continuation {
-            payload["continuation"] = json!(continuation);
-        }
-        let forged = WorkflowDecision::new(
-            &instance.id,
-            "implementing",
-            "continue_prompt_task",
-            "implementing",
-            "agent requested an unauthorized continuation",
-        )
-        .with_command(WorkflowCommand::new(
-            WorkflowCommandType::EnqueueActivity,
-            "forged-attempt-2",
-            payload,
-        ));
-        let result = ActivityResult::succeeded(
-            PROMPT_TASK_IMPLEMENT_ACTIVITY,
-            "Completed the single-shot prompt task.",
-        )
-        .with_validation(ValidationRecord::new("cargo test", "passed"))
-        .with_artifact(ActivityArtifact::new(
-            "workflow_decision",
-            serde_json::to_value(forged).expect("forged decision should serialize"),
-        ));
-        let event = runtime_completion_event(
-            &instance,
-            PROMPT_TASK_IMPLEMENT_ACTIVITY,
-            result,
-        );
+    let reserved_decisions = [
+        ("continue_prompt_task", "implementing"),
+        ("finish_prompt_task_external_settled", "done"),
+        ("prompt_continuation_exhausted", "blocked"),
+        ("prompt_continuation_no_progress", "blocked"),
+        ("prompt_continuation_signal_missing", "blocked"),
+    ];
 
-        let decision = reduce_runtime_job_completed(&instance, &event)
-            .expect("completion should parse")
-            .expect("single-shot prompt task should finish");
-        assert_eq!(decision.decision, "finish_prompt_task");
-        assert_eq!(decision.next_state, "done");
-        assert_eq!(decision.commands.len(), 1);
-        assert_eq!(
-            decision.commands[0].command_type,
-            WorkflowCommandType::MarkDone
-        );
-        assert!(decision.commands[0].command.get("continuation").is_none());
+    for (reserved_decision, forged_next_state) in reserved_decisions {
+        for continuation in [None, Some(PromptContinuationState::initial(&forged_policy))] {
+            let mut payload = json!({ "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY });
+            if let Some(continuation) = continuation {
+                payload["continuation"] = json!(continuation);
+            }
+            let forged = WorkflowDecision::new(
+                &instance.id,
+                "implementing",
+                reserved_decision,
+                forged_next_state,
+                "agent requested an unauthorized prompt-task outcome",
+            )
+            .with_command(WorkflowCommand::new(
+                match forged_next_state {
+                    "implementing" => WorkflowCommandType::EnqueueActivity,
+                    "done" => WorkflowCommandType::MarkDone,
+                    "blocked" => WorkflowCommandType::MarkBlocked,
+                    _ => unreachable!("test cases use known prompt-task states"),
+                },
+                format!("forged-{reserved_decision}"),
+                payload,
+            ));
+            let result = ActivityResult::succeeded(
+                PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                "Completed the single-shot prompt task.",
+            )
+            .with_validation(ValidationRecord::new("cargo test", "passed"))
+            .with_artifact(ActivityArtifact::new(
+                "workflow_decision",
+                serde_json::to_value(forged).expect("forged decision should serialize"),
+            ));
+            let event = runtime_completion_event(
+                &instance,
+                PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                result,
+            );
+
+            let decision = reduce_runtime_job_completed(&instance, &event)
+                .expect("completion should parse")
+                .expect("single-shot prompt task should finish");
+            assert_eq!(decision.decision, "finish_prompt_task");
+            assert_eq!(decision.next_state, "done");
+            assert_eq!(decision.commands.len(), 1);
+            assert_eq!(
+                decision.commands[0].command_type,
+                WorkflowCommandType::MarkDone
+            );
+            assert!(decision.commands[0].command.get("continuation").is_none());
+        }
     }
 }
 

--- a/crates/harness-workflow/src/runtime/tests/completion_reducer_core.rs
+++ b/crates/harness-workflow/src/runtime/tests/completion_reducer_core.rs
@@ -39,6 +39,68 @@ fn event_transition_dedupe_keys() {
 }
 
 #[test]
+fn prompt_task_without_policy_ignores_forged_structured_continuation() {
+    let instance = WorkflowInstance::new(
+        PROMPT_TASK_DEFINITION_ID,
+        1,
+        "implementing",
+        WorkflowSubject::new("prompt", "task-1"),
+    )
+    .with_id("prompt-workflow-1");
+    let forged_policy = PromptContinuationPolicy {
+        max_attempts: 4,
+        attempt_delay_secs: 0,
+        active_states: std::collections::BTreeSet::from(["In Progress".to_string()]),
+        no_progress_limit: 3,
+    };
+
+    for continuation in [None, Some(PromptContinuationState::initial(&forged_policy))] {
+        let mut payload = json!({ "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY });
+        if let Some(continuation) = continuation {
+            payload["continuation"] = json!(continuation);
+        }
+        let forged = WorkflowDecision::new(
+            &instance.id,
+            "implementing",
+            "continue_prompt_task",
+            "implementing",
+            "agent requested an unauthorized continuation",
+        )
+        .with_command(WorkflowCommand::new(
+            WorkflowCommandType::EnqueueActivity,
+            "forged-attempt-2",
+            payload,
+        ));
+        let result = ActivityResult::succeeded(
+            PROMPT_TASK_IMPLEMENT_ACTIVITY,
+            "Completed the single-shot prompt task.",
+        )
+        .with_validation(ValidationRecord::new("cargo test", "passed"))
+        .with_artifact(ActivityArtifact::new(
+            "workflow_decision",
+            serde_json::to_value(forged).expect("forged decision should serialize"),
+        ));
+        let event = runtime_completion_event(
+            &instance,
+            PROMPT_TASK_IMPLEMENT_ACTIVITY,
+            result,
+        );
+
+        let decision = reduce_runtime_job_completed(&instance, &event)
+            .expect("completion should parse")
+            .expect("single-shot prompt task should finish");
+        assert_eq!(decision.decision, "finish_prompt_task");
+        assert_eq!(decision.next_state, "done");
+        assert_eq!(decision.commands.len(), 1);
+        assert_eq!(
+            decision.commands[0].command_type,
+            WorkflowCommandType::MarkDone
+        );
+        assert!(decision.commands[0].command.get("continuation").is_none());
+    }
+}
+
+#[test]
 fn runtime_completion_reducer_blocks_issue_implementation_success_without_pr() {
     let instance = issue_instance("implementing");
     let result = ActivityResult::succeeded("implement_issue", "Implementation completed.");

--- a/crates/harness-workflow/src/runtime/tests/decision_builders.rs
+++ b/crates/harness-workflow/src/runtime/tests/decision_builders.rs
@@ -198,8 +198,10 @@ fn prompt_submission_decision_starts_runtime_implementation() {
             external_id: Some("manual-prompt-1"),
             depends_on: &[],
             dependencies_blocked: false,
+            continuation: None,
         },
-    );
+    )
+    .expect("valid prompt submission policy");
 
     assert_eq!(output.decision.decision, "submit_prompt");
     assert_eq!(output.decision.next_state, "implementing");
@@ -240,8 +242,10 @@ fn prompt_submission_decision_waits_for_dependencies_without_runtime_command() {
             external_id: None,
             depends_on: &depends_on,
             dependencies_blocked: true,
+            continuation: None,
         },
-    );
+    )
+    .expect("valid prompt submission policy");
 
     assert_eq!(output.decision.next_state, "awaiting_dependencies");
     assert!(output.decision.commands.is_empty());
@@ -267,8 +271,10 @@ fn prompt_submission_decision_reopens_blocked_prompt_task() {
             external_id: Some("manual-prompt-retry"),
             depends_on: &[],
             dependencies_blocked: false,
+            continuation: None,
         },
-    );
+    )
+    .expect("valid prompt submission policy");
 
     assert_eq!(output.decision.next_state, "implementing");
     assert_eq!(output.decision.commands.len(), 1);

--- a/crates/harness-workflow/src/runtime/tests/decision_validator.rs
+++ b/crates/harness-workflow/src/runtime/tests/decision_validator.rs
@@ -412,6 +412,7 @@ fn rejects_driverless_command_driven_transitions() {
             issue_instance("implementing"),
             "implementing",
             "replanning",
+            WorkflowDecisionRejectionKind::ProgressDriverMissing,
         ),
         (
             "prompt_task",
@@ -419,6 +420,7 @@ fn rejects_driverless_command_driven_transitions() {
             prompt_task_instance("implementing"),
             "implementing",
             "implementing",
+            WorkflowDecisionRejectionKind::InvalidDecisionContract,
         ),
         (
             "quality_gate",
@@ -426,6 +428,7 @@ fn rejects_driverless_command_driven_transitions() {
             quality_gate_instance("pending"),
             "pending",
             "checking",
+            WorkflowDecisionRejectionKind::ProgressDriverMissing,
         ),
         (
             "pr_feedback",
@@ -438,10 +441,11 @@ fn rejects_driverless_command_driven_transitions() {
             ),
             "pending",
             "inspecting",
+            WorkflowDecisionRejectionKind::ProgressDriverMissing,
         ),
     ];
 
-    for (case_name, validator, instance, observed_state, next_state) in cases {
+    for (case_name, validator, instance, observed_state, next_state, expected_kind) in cases {
         let decision = WorkflowDecision::new(
             instance.id.clone(),
             observed_state,
@@ -454,7 +458,7 @@ fn rejects_driverless_command_driven_transitions() {
             .expect_err("command-driven targets must reject driverless decisions");
         assert_eq!(
             err.kind,
-            WorkflowDecisionRejectionKind::ProgressDriverMissing,
+            expected_kind,
             "failed case: {case_name}"
         );
     }

--- a/crates/harness-workflow/src/runtime/tests/durable_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/durable_store.rs
@@ -125,6 +125,94 @@ async fn durable_store_persists_workflow_runtime_bus_contract() -> anyhow::Resul
 }
 
 #[tokio::test]
+async fn prompt_continuation_completion_persists_context_and_dedupes_attempt_command(
+) -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let policy = PromptContinuationPolicy {
+        max_attempts: 4,
+        attempt_delay_secs: 0,
+        active_states: std::collections::BTreeSet::from(["In Progress".to_string()]),
+        no_progress_limit: 3,
+    };
+    let instance = WorkflowInstance::new(
+        PROMPT_TASK_DEFINITION_ID,
+        1,
+        "implementing",
+        WorkflowSubject::new("prompt", "TEAM-123"),
+    )
+    .with_id("prompt-continuation-store")
+    .with_data(json!({
+        "continuation": PromptContinuationState::initial(&policy),
+    }));
+    store.upsert_instance(&instance).await?;
+    let result = ActivityResult::succeeded(
+        PROMPT_TASK_IMPLEMENT_ACTIVITY,
+        "Created the implementation branch.",
+    )
+    .with_signal(ActivitySignal::new(
+        "external_state",
+        json!({ "state": "In Progress", "subject": "TEAM-123" }),
+    ));
+    let payload = json!({
+        "command_id": "attempt-1-command",
+        "runtime_job_id": "attempt-1-job",
+        "activity_result": result,
+    });
+    let event = WorkflowEvent::new(
+        &instance.id,
+        1,
+        RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-1",
+    )
+    .with_payload(payload.clone());
+    let decision = reduce_runtime_job_completed(&instance, &event)?
+        .expect("active continuation should produce a decision");
+
+    let first = store
+        .commit_runtime_completion_decision_for_test(
+            &instance.id,
+            "runtime-1",
+            payload.clone(),
+            &decision,
+        )
+        .await?
+        .expect("first completion should commit");
+    assert!(first.accepted);
+    let after = store
+        .get_instance(&instance.id)
+        .await?
+        .expect("continuation instance should reload");
+    assert_eq!(after.data["continuation"]["attempt"], 2);
+    assert_eq!(
+        after.data["continuation"]["last_summary"],
+        "Created the implementation branch."
+    );
+
+    let replay = store
+        .commit_runtime_completion_decision_for_test(
+            &instance.id,
+            "runtime-1",
+            payload,
+            &decision,
+        )
+        .await?
+        .expect("replayed completion should remain idempotent");
+    assert!(replay.accepted);
+    let commands = store.commands_for(&instance.id).await?;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(
+        commands[0].command.dedupe_key,
+        "prompt-task:prompt-continuation-store:attempt:2"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn durable_store_apply_decision_transition_can_create_initial_instance() -> anyhow::Result<()>
 {
     if resolve_database_url(None).is_err() {

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -6,6 +6,8 @@ use std::fmt;
 
 #[path = "validator_github_issue_pr.rs"]
 mod github_issue_pr_validation;
+#[path = "validator_prompt_task.rs"]
+mod prompt_task_validation;
 
 #[cfg(test)]
 #[path = "validator_tests.rs"]
@@ -315,7 +317,7 @@ impl TransitionAllowlist {
             .allow("submitted", "implementing", [EnqueueActivity, Wait])
             .allow("failed", "implementing", [EnqueueActivity, Wait])
             .allow("cancelled", "implementing", [EnqueueActivity, Wait])
-            .allow("implementing", "implementing", [EnqueueActivity, Wait])
+            .allow("implementing", "implementing", [EnqueueActivity])
             .allow("blocked", "awaiting_dependencies", [Wait])
             .allow("blocked", "implementing", [EnqueueActivity, Wait])
             .allow("implementing", "done", [MarkDone])
@@ -392,6 +394,7 @@ pub enum WorkflowDecisionRejectionKind {
     TerminalReopenDenied,
     RequiredCommandMissing,
     InvalidCommandPayload,
+    InvalidDecisionContract,
     ProgressDriverMissing,
     MissingTerminalEvidence,
 }
@@ -429,6 +432,7 @@ pub struct DecisionValidator {
 enum DecisionValidatorKind {
     Generic,
     GithubIssuePr,
+    PromptTask,
 }
 
 impl DecisionValidator {
@@ -468,10 +472,10 @@ impl DecisionValidator {
     }
 
     pub(crate) fn for_definition(definition_id: &str, allowlist: TransitionAllowlist) -> Self {
-        let kind = if definition_id == super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID {
-            DecisionValidatorKind::GithubIssuePr
-        } else {
-            DecisionValidatorKind::Generic
+        let kind = match definition_id {
+            super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID => DecisionValidatorKind::GithubIssuePr,
+            super::prompt_task::PROMPT_TASK_DEFINITION_ID => DecisionValidatorKind::PromptTask,
+            _ => DecisionValidatorKind::Generic,
         };
         Self { allowlist, kind }
     }
@@ -548,6 +552,12 @@ impl DecisionValidator {
             ));
         };
 
+        if self.kind == DecisionValidatorKind::PromptTask
+            && decision.observed_state == "implementing"
+            && decision.next_state == "implementing"
+        {
+            prompt_task_validation::validate_decision(decision)?;
+        }
         self.validate_commands(rule, decision, context)?;
         validator_progress::validate_target_progress_contract(instance, decision)?;
         self.validate_workflow_specific_rules(decision, context)
@@ -646,6 +656,11 @@ impl DecisionValidator {
     ) -> Result<(), WorkflowDecisionRejection> {
         if self.kind == DecisionValidatorKind::GithubIssuePr {
             github_issue_pr_validation::validate_decision(decision, context)?;
+        }
+        if self.kind == DecisionValidatorKind::PromptTask
+            && !(decision.observed_state == "implementing" && decision.next_state == "implementing")
+        {
+            prompt_task_validation::validate_decision(decision)?;
         }
         Ok(())
     }

--- a/crates/harness-workflow/src/runtime/validator_prompt_task.rs
+++ b/crates/harness-workflow/src/runtime/validator_prompt_task.rs
@@ -1,0 +1,171 @@
+use super::{WorkflowDecisionRejection, WorkflowDecisionRejectionKind};
+use crate::runtime::model::{WorkflowCommandType, WorkflowDecision};
+use crate::runtime::prompt_task::PROMPT_TASK_IMPLEMENT_ACTIVITY;
+
+pub(super) fn validate_decision(
+    decision: &WorkflowDecision,
+) -> Result<(), WorkflowDecisionRejection> {
+    if decision.observed_state != "implementing" || decision.next_state != "implementing" {
+        return Ok(());
+    }
+    if decision.decision != "continue_prompt_task" {
+        return Err(invalid_contract(
+            "prompt_task implementing self-transitions require decision continue_prompt_task",
+        ));
+    }
+    let enqueue_commands = decision
+        .commands
+        .iter()
+        .filter(|command| command.command_type == WorkflowCommandType::EnqueueActivity)
+        .collect::<Vec<_>>();
+    if enqueue_commands.len() != 1 || decision.commands.len() != 1 {
+        return Err(invalid_contract(
+            "continue_prompt_task requires exactly one EnqueueActivity command",
+        ));
+    }
+    if enqueue_commands[0].activity_name() != Some(PROMPT_TASK_IMPLEMENT_ACTIVITY) {
+        return Err(invalid_contract(
+            "continue_prompt_task must enqueue implement_prompt",
+        ));
+    }
+    Ok(())
+}
+
+fn invalid_contract(message: &str) -> WorkflowDecisionRejection {
+    WorkflowDecisionRejection::new(
+        WorkflowDecisionRejectionKind::InvalidDecisionContract,
+        message,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::model::{
+        WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowInstance, WorkflowSubject,
+    };
+    use crate::runtime::validator::{DecisionValidator, ValidationContext};
+    use chrono::Utc;
+    use serde_json::json;
+
+    fn instance() -> WorkflowInstance {
+        WorkflowInstance::new(
+            "prompt_task",
+            1,
+            "implementing",
+            WorkflowSubject::new("prompt", "task-1"),
+        )
+    }
+
+    #[test]
+    fn prompt_task_validator_accepts_exact_continuation_contract() {
+        let instance = instance();
+        let decision = WorkflowDecision::new(
+            &instance.id,
+            "implementing",
+            "continue_prompt_task",
+            "implementing",
+            "continue",
+        )
+        .with_command(WorkflowCommand::enqueue_activity(
+            PROMPT_TASK_IMPLEMENT_ACTIVITY,
+            "prompt-task:task-1:attempt:2",
+        ));
+        DecisionValidator::prompt_task()
+            .validate(
+                &instance,
+                &decision,
+                &ValidationContext::new("runtime", Utc::now()),
+            )
+            .expect("valid continuation should pass");
+    }
+
+    #[test]
+    fn prompt_task_validator_rejects_arbitrary_self_transition() {
+        let instance = instance();
+        let decision = WorkflowDecision::new(
+            &instance.id,
+            "implementing",
+            "wait_somehow",
+            "implementing",
+            "continue",
+        )
+        .with_command(WorkflowCommand::enqueue_activity(
+            PROMPT_TASK_IMPLEMENT_ACTIVITY,
+            "prompt-task:task-1:attempt:2",
+        ));
+        let error = DecisionValidator::prompt_task()
+            .validate(
+                &instance,
+                &decision,
+                &ValidationContext::new("runtime", Utc::now()),
+            )
+            .expect_err("arbitrary self-transition must fail");
+        assert_eq!(
+            error.kind,
+            WorkflowDecisionRejectionKind::InvalidDecisionContract
+        );
+    }
+
+    #[test]
+    fn prompt_task_validator_rejects_missing_wait_wrong_and_multiple_commands() {
+        let instance = instance();
+        let cases = [
+            WorkflowDecision::new(
+                &instance.id,
+                "implementing",
+                "continue_prompt_task",
+                "implementing",
+                "continue",
+            ),
+            WorkflowDecision::new(
+                &instance.id,
+                "implementing",
+                "continue_prompt_task",
+                "implementing",
+                "continue",
+            )
+            .with_command(WorkflowCommand::wait("wait", "wait-1")),
+            WorkflowDecision::new(
+                &instance.id,
+                "implementing",
+                "continue_prompt_task",
+                "implementing",
+                "continue",
+            )
+            .with_command(WorkflowCommand::enqueue_activity(
+                "wrong_activity",
+                "wrong-1",
+            )),
+            WorkflowDecision::new(
+                &instance.id,
+                "implementing",
+                "continue_prompt_task",
+                "implementing",
+                "continue",
+            )
+            .with_command(WorkflowCommand::enqueue_activity(
+                PROMPT_TASK_IMPLEMENT_ACTIVITY,
+                "implement-1",
+            ))
+            .with_command(WorkflowCommand::new(
+                WorkflowCommandType::EnqueueActivity,
+                "implement-2",
+                json!({ "activity": PROMPT_TASK_IMPLEMENT_ACTIVITY }),
+            )),
+        ];
+        for decision in cases {
+            let error = DecisionValidator::prompt_task()
+                .validate(
+                    &instance,
+                    &decision,
+                    &ValidationContext::new("runtime", Utc::now()),
+                )
+                .expect_err("invalid continuation contract must fail closed");
+            assert_eq!(
+                error.kind,
+                WorkflowDecisionRejectionKind::InvalidDecisionContract
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add an optional validated continuation policy to prompt task submission
- persist attempt state and atomically enqueue bounded follow-up attempts from agent-reported external state
- inject prior state and summary context into continuation prompts
- fail closed on malformed signals, exhaustion, no progress, cancellation, and forged prompt-task workflow decisions

## Verification

- cargo fmt --all -- --check
- cargo test -p harness-workflow prompt_task_without_policy_ignores_forged_structured_continuation -- --nocapture
- cargo test -p harness-workflow prompt_continuation -- --nocapture (4 non-database tests passed; the Postgres-backed test reached the local bootstrap timeout and must execute in CI)
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1607
- python3 checks/check_workflow.py --repo .
- independent exact-head review PASS at b214b81340b4fb99c6fa68e693a6dd4a3d4b22de

Closes #1607