### PR TITLE
feat(workflow): add declarative definition foundation

### DIFF
--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -84,6 +84,64 @@ pub struct WorkflowActivityPolicy {
     pub validation: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeclaredProgressMode {
+    ExternalWait,
+    OperatorGate,
+}
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct DeclaredState {
+    pub activity: Option<String>,
+    pub progress: Option<DeclaredProgressMode>,
+    pub on_success: Option<String>,
+    pub on_failure: Option<String>,
+    pub on_blocked: Option<String>,
+    pub on_signal: BTreeMap<String, String>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowDefinitionPolicy {
+    pub id: String,
+    pub initial: String,
+    #[serde(default)]
+    pub states: BTreeMap<String, DeclaredState>,
+    #[serde(default)]
+    pub terminal: BTreeMap<String, String>,
+    #[serde(default)]
+    pub evidence_required: BTreeMap<String, Vec<String>>,
+    #[serde(default)]
+    pub recovery_targets: Vec<String>,
+}
+impl WorkflowDefinitionPolicy {
+    fn validate_identifiers(&self) -> anyhow::Result<()> {
+        if self.id.trim().is_empty() {
+            anyhow::bail!("definition id must not be empty");
+        }
+        if self.initial.trim().is_empty() {
+            anyhow::bail!("definition initial state must not be empty");
+        }
+        for (name, state) in &self.states {
+            if name.trim().is_empty() {
+                anyhow::bail!("definition state name must not be empty");
+            }
+            if state
+                .activity
+                .as_deref()
+                .is_some_and(|value| value.trim().is_empty())
+            {
+                anyhow::bail!("definition state `{name}` activity must not be empty");
+            }
+            for signal_type in state.on_signal.keys() {
+                if signal_type.trim().is_empty() {
+                    anyhow::bail!("definition state `{name}` signal type must not be empty");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IssueWorkflowPolicy {
     #[serde(default = "default_force_execute_label")]
@@ -237,6 +295,8 @@ pub struct WorkflowMemoryPolicy {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct WorkflowConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub definition: Option<WorkflowDefinitionPolicy>,
     #[serde(default)]
     pub workflow: WorkflowIdentityPolicy,
     #[serde(default)]
@@ -576,18 +636,26 @@ fn read_workflow_file(path: &Path) -> anyhow::Result<Option<(serde_yaml::Value, 
     Ok(Some((value, body.trim().to_string())))
 }
 
-/// Recursively merge `over` onto `base`. Mappings are merged key-by-key
-/// (recursing into nested mappings); a YAML `null` override keeps the base
-/// value; every other scalar/sequence override replaces the base value. This
-/// gives field-level override semantics for nested workflow policy.
+/// Recursively merge `over` onto `base`, except for an atomic root-level
+/// `definition`. A YAML `null` keeps the base; other non-mappings replace it.
 fn deep_merge_yaml(base: serde_yaml::Value, over: serde_yaml::Value) -> serde_yaml::Value {
+    deep_merge_yaml_at(base, over, true)
+}
+
+fn deep_merge_yaml_at(
+    base: serde_yaml::Value,
+    over: serde_yaml::Value,
+    root: bool,
+) -> serde_yaml::Value {
     use serde_yaml::Value;
     match (base, over) {
         (Value::Mapping(mut base_map), Value::Mapping(over_map)) => {
             for (key, over_value) in over_map {
-                let merged = match base_map.remove(&key) {
-                    Some(base_value) => deep_merge_yaml(base_value, over_value),
-                    None => over_value,
+                let atomic = root && key.as_str() == Some("definition") && !over_value.is_null();
+                let merged = match (atomic, base_map.remove(&key)) {
+                    (true, _) => over_value,
+                    (false, Some(base_value)) => deep_merge_yaml_at(base_value, over_value, false),
+                    (false, None) => over_value,
                 };
                 base_map.insert(key, merged);
             }
@@ -657,6 +725,9 @@ fn load_workflow_document_with_base(
             anyhow::anyhow!("failed to parse merged workflow front matter ({source_path}): {e}")
         })?,
     };
+    if let Some(definition) = &config.definition {
+        definition.validate_identifiers()?;
+    }
     config.runtime_dispatch.apply_default_activity_profiles();
     let defer_floor = config.runtime_dispatch.defer_backoff_secs;
     let defer_ceiling = config.runtime_dispatch.defer_backoff_max_secs;

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -80,6 +80,7 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert_eq!(cfg.storage.task_retention_interval_secs, 3600);
     assert!(!cfg.issue_workflow.require_human_gate_before_merge);
     assert!(cfg.activities.is_empty());
+    assert!(cfg.definition.is_none());
     Ok(())
 }
 
@@ -596,6 +597,112 @@ fn deep_merge_yaml_null_override_keeps_base() {
     let over: serde_yaml::Value = serde_yaml::from_str("a: ~\n").unwrap();
     let merged = deep_merge_yaml(base, over);
     assert_eq!(merged["a"].as_u64(), Some(1));
+}
+
+#[test]
+fn load_workflow_document_parses_and_atomically_replaces_definition() -> anyhow::Result<()> {
+    let base_dir = tempfile::tempdir()?;
+    let base_path = base_dir.path().join("WORKFLOW.md");
+    std::fs::write(
+        &base_path,
+        "---\ndefinition:\n  id: base\n  initial: base_start\n  states:\n    base_start: {}\n  recovery_targets: [base_start]\n---\n",
+    )?;
+    let repo_dir = tempfile::tempdir()?;
+    std::fs::write(
+        repo_dir.path().join("WORKFLOW.md"),
+        r#"---
+definition:
+  id: docs_review
+  initial: review
+  states:
+    review:
+      activity: inspect_docs
+      on_success: approval
+      on_failure: failed
+      on_blocked: approval
+      on_signal:
+        changes_requested: review
+    approval:
+      progress: operator_gate
+    external_input:
+      progress: external_wait
+    done: {}
+    failed: {}
+    cancelled: {}
+  terminal:
+    done: succeeded
+    failed: failed
+    cancelled: cancelled
+  evidence_required:
+    done: [validation_report]
+  recovery_targets: [review]
+---
+"#,
+    )?;
+
+    let definition = load_workflow_document_with_base(repo_dir.path(), Some(&base_path))?
+        .config
+        .definition
+        .expect("repo definition should parse");
+    assert_eq!(definition.id, "docs_review");
+    assert_eq!(definition.initial, "review");
+    assert_eq!(
+        definition.states["review"].activity.as_deref(),
+        Some("inspect_docs")
+    );
+    assert_eq!(
+        definition.states["approval"].progress,
+        Some(DeclaredProgressMode::OperatorGate)
+    );
+    assert_eq!(
+        definition.states["external_input"].progress,
+        Some(DeclaredProgressMode::ExternalWait)
+    );
+    assert_eq!(
+        definition.states["review"].on_signal["changes_requested"],
+        "review"
+    );
+    assert_eq!(definition.terminal["done"], "succeeded");
+    assert_eq!(definition.evidence_required["done"], ["validation_report"]);
+    assert_eq!(definition.recovery_targets, ["review"]);
+    assert!(!definition.states.contains_key("base_start"));
+    Ok(())
+}
+
+#[test]
+fn load_workflow_document_rejects_empty_definition_identifiers() -> anyhow::Result<()> {
+    let cases = [
+        ("  id: ' '\n  initial: start\n  states: {start: {}}", "id"),
+        (
+            "  id: docs\n  initial: ' '\n  states: {start: {}}",
+            "initial state",
+        ),
+        (
+            "  id: docs\n  initial: start\n  states: {' ': {}}",
+            "state name",
+        ),
+        (
+            "  id: docs\n  initial: start\n  states:\n    start: {activity: ' '}",
+            "activity",
+        ),
+        (
+            "  id: docs\n  initial: start\n  states:\n    start:\n      on_signal: {' ': done}",
+            "signal type",
+        ),
+    ];
+    for (definition, expected) in cases {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(
+            dir.path().join("WORKFLOW.md"),
+            format!("---\ndefinition:\n{definition}\n---\n"),
+        )?;
+        let error = load_workflow_document(dir.path()).expect_err("empty identifier must fail");
+        assert!(
+            format!("{error:#}").contains(expected),
+            "unexpected error: {error:#}"
+        );
+    }
+    Ok(())
 }
 
 #[test]

--- a/crates/harness-workflow/src/runtime/declarative.rs
+++ b/crates/harness-workflow/src/runtime/declarative.rs
@@ -1,0 +1,735 @@
+use super::{
+    model::WorkflowCommandType,
+    pr_feedback::PR_FEEDBACK_DEFINITION_ID,
+    prompt_task::PROMPT_TASK_DEFINITION_ID,
+    quality_gate::QUALITY_GATE_DEFINITION_ID,
+    reducer::GITHUB_ISSUE_PR_DEFINITION_ID,
+    state_registry::{
+        RegisteredWorkflowDefinition, WorkflowProgressMode, WorkflowStateDefinition,
+        WorkflowTerminalState,
+    },
+    validator::{TransitionAllowlist, TransitionRule},
+};
+use harness_core::config::workflow::{
+    DeclaredProgressMode, DeclaredState, WorkflowActivityPolicy, WorkflowDefinitionPolicy,
+};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+/// A structurally validated declaration and the registry definition compiled from it.
+///
+/// The policy remains attached because the generic interpreter needs routing, evidence,
+/// activity, and recovery metadata that `RegisteredWorkflowDefinition` does not retain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclarativeWorkflowDefinition {
+    pub registered: RegisteredWorkflowDefinition,
+    pub policy: WorkflowDefinitionPolicy,
+}
+
+impl DeclarativeWorkflowDefinition {
+    pub fn into_registered(self) -> RegisteredWorkflowDefinition {
+        self.registered
+    }
+}
+
+/// Validates and compiles a declarative workflow without registering it.
+pub fn build_declarative_definition(
+    policy: &WorkflowDefinitionPolicy,
+    activity_policies: &BTreeMap<String, WorkflowActivityPolicy>,
+) -> anyhow::Result<DeclarativeWorkflowDefinition> {
+    validate_top_level(policy)?;
+
+    let terminal_states = parse_terminal_states(policy)?;
+    validate_active_states(policy, activity_policies)?;
+    validate_targets(policy, &terminal_states)?;
+    validate_reachability(policy, &terminal_states)?;
+
+    let states = compile_states(policy, &terminal_states);
+    let allowlist = compile_allowlist(policy, &terminal_states);
+
+    Ok(DeclarativeWorkflowDefinition {
+        registered: RegisteredWorkflowDefinition::new(&policy.id, states, allowlist),
+        policy: policy.clone(),
+    })
+}
+
+fn validate_top_level(policy: &WorkflowDefinitionPolicy) -> anyhow::Result<()> {
+    if policy.id.trim().is_empty() {
+        anyhow::bail!("declarative workflow definition id must not be empty");
+    }
+    if [
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        PROMPT_TASK_DEFINITION_ID,
+        QUALITY_GATE_DEFINITION_ID,
+        PR_FEEDBACK_DEFINITION_ID,
+    ]
+    .contains(&policy.id.as_str())
+    {
+        anyhow::bail!(
+            "declarative workflow definition id '{}' collides with a built-in definition",
+            policy.id
+        );
+    }
+    if policy.states.is_empty() {
+        anyhow::bail!(
+            "declarative workflow definition '{}' must declare at least one active state",
+            policy.id
+        );
+    }
+    if policy.terminal.is_empty() {
+        anyhow::bail!(
+            "declarative workflow definition '{}' must declare terminal states",
+            policy.id
+        );
+    }
+    if policy.initial.trim().is_empty() {
+        anyhow::bail!(
+            "declarative workflow definition '{}' initial state must not be empty",
+            policy.id
+        );
+    }
+    if policy.terminal.contains_key(&policy.initial) {
+        anyhow::bail!(
+            "declarative workflow definition '{}' initial state '{}' must be active, not terminal",
+            policy.id,
+            policy.initial
+        );
+    }
+    if !policy.states.contains_key(&policy.initial) {
+        anyhow::bail!(
+            "declarative workflow definition '{}' initial state '{}' is not declared as an active state",
+            policy.id,
+            policy.initial
+        );
+    }
+
+    if let Some(overlap) = policy
+        .states
+        .keys()
+        .find(|state| policy.terminal.contains_key(*state))
+    {
+        anyhow::bail!(
+            "declarative workflow definition '{}' state '{}' is declared in both active and terminal namespaces",
+            policy.id,
+            overlap
+        );
+    }
+
+    let blocked = policy.states.get("blocked").ok_or_else(|| {
+        anyhow::anyhow!(
+            "declarative workflow definition '{}' must declare active state 'blocked' with progress 'operator_gate' for runtime fallbacks",
+            policy.id
+        )
+    })?;
+    if blocked.activity.is_some() || blocked.progress != Some(DeclaredProgressMode::OperatorGate) {
+        anyhow::bail!(
+            "declarative workflow definition '{}' state 'blocked' must declare exactly progress 'operator_gate' and no activity",
+            policy.id
+        );
+    }
+
+    Ok(())
+}
+
+fn parse_terminal_states(
+    policy: &WorkflowDefinitionPolicy,
+) -> anyhow::Result<BTreeMap<String, WorkflowTerminalState>> {
+    let mut parsed = BTreeMap::new();
+    let mut owners = BTreeMap::<&str, String>::new();
+
+    for (state, class) in &policy.terminal {
+        if state.trim().is_empty() {
+            anyhow::bail!(
+                "declarative workflow definition '{}' has an empty terminal state name",
+                policy.id
+            );
+        }
+        let (class_name, terminal_state) = match class.as_str() {
+            "succeeded" => ("succeeded", WorkflowTerminalState::Succeeded),
+            "failed" => ("failed", WorkflowTerminalState::Failed),
+            "cancelled" => ("cancelled", WorkflowTerminalState::Cancelled),
+            _ => {
+                anyhow::bail!(
+                    "declarative workflow definition '{}' terminal state '{}' has unknown class '{}'; expected succeeded, failed, or cancelled",
+                    policy.id,
+                    state,
+                    class
+                )
+            }
+        };
+        if let Some(existing) = owners.insert(class_name, state.clone()) {
+            anyhow::bail!(
+                "declarative workflow definition '{}' terminal class '{}' is assigned to both '{}' and '{}'; exactly one state is required",
+                policy.id,
+                class,
+                existing,
+                state
+            );
+        }
+        parsed.insert(state.clone(), terminal_state);
+    }
+
+    for class in ["succeeded", "failed", "cancelled"] {
+        if !owners.contains_key(class) {
+            anyhow::bail!(
+                "declarative workflow definition '{}' is missing terminal class '{}'; exactly one state is required",
+                policy.id,
+                class
+            );
+        }
+    }
+
+    Ok(parsed)
+}
+
+fn validate_active_states(
+    policy: &WorkflowDefinitionPolicy,
+    activity_policies: &BTreeMap<String, WorkflowActivityPolicy>,
+) -> anyhow::Result<()> {
+    for (state_name, state) in &policy.states {
+        if state_name.trim().is_empty() {
+            anyhow::bail!(
+                "declarative workflow definition '{}' has an empty active state name",
+                policy.id
+            );
+        }
+        if state.activity.is_some() == state.progress.is_some() {
+            anyhow::bail!(
+                "declarative workflow definition '{}' active state '{}' must declare exactly one of activity or progress",
+                policy.id,
+                state_name
+            );
+        }
+        if let Some(activity) = state.activity.as_deref() {
+            if activity.trim().is_empty() {
+                anyhow::bail!(
+                    "declarative workflow definition '{}' active state '{}' has an empty activity name",
+                    policy.id,
+                    state_name
+                );
+            }
+            if !activity_policies.contains_key(activity) {
+                anyhow::bail!(
+                    "declarative workflow definition '{}' active state '{}' references activity '{}' absent from the workflow activities policy map",
+                    policy.id,
+                    state_name,
+                    activity
+                );
+            }
+        }
+        if let Some(signal_type) = state
+            .on_signal
+            .keys()
+            .find(|signal_type| signal_type.trim().is_empty())
+        {
+            anyhow::bail!(
+                "declarative workflow definition '{}' active state '{}' has an empty signal type '{}', which is not deterministic",
+                policy.id,
+                state_name,
+                signal_type
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_targets(
+    policy: &WorkflowDefinitionPolicy,
+    terminal_states: &BTreeMap<String, WorkflowTerminalState>,
+) -> anyhow::Result<()> {
+    let is_declared =
+        |state: &str| policy.states.contains_key(state) || terminal_states.contains_key(state);
+
+    for (state_name, state) in &policy.states {
+        for (route, target) in transition_targets(state) {
+            if !is_declared(target) {
+                anyhow::bail!(
+                    "declarative workflow definition '{}' active state '{}' {} target '{}' is undeclared",
+                    policy.id,
+                    state_name,
+                    route,
+                    target
+                );
+            }
+        }
+    }
+
+    for evidence_target in policy.evidence_required.keys() {
+        if !is_declared(evidence_target) {
+            anyhow::bail!(
+                "declarative workflow definition '{}' evidence requirement target '{}' is undeclared",
+                policy.id,
+                evidence_target
+            );
+        }
+    }
+
+    let mut recovery_targets = BTreeSet::new();
+    for target in &policy.recovery_targets {
+        if !recovery_targets.insert(target) {
+            anyhow::bail!(
+                "declarative workflow definition '{}' recovery target '{}' is declared more than once",
+                policy.id,
+                target
+            );
+        }
+        if !policy.states.contains_key(target) {
+            let kind = if terminal_states.contains_key(target) {
+                "terminal"
+            } else {
+                "undeclared"
+            };
+            anyhow::bail!(
+                "declarative workflow definition '{}' recovery target '{}' must name an active state, but it is {}",
+                policy.id,
+                target,
+                kind
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_reachability(
+    policy: &WorkflowDefinitionPolicy,
+    terminal_states: &BTreeMap<String, WorkflowTerminalState>,
+) -> anyhow::Result<()> {
+    let mut reachable = BTreeSet::new();
+    let mut pending = VecDeque::from([policy.initial.as_str()]);
+
+    while let Some(state_name) = pending.pop_front() {
+        if !reachable.insert(state_name) {
+            continue;
+        }
+        let Some(state) = policy.states.get(state_name) else {
+            continue;
+        };
+        for (_, target) in transition_targets(state) {
+            pending.push_back(target);
+        }
+        // Any active state can enter the runtime's invalid-output blocked fallback.
+        pending.push_back("blocked");
+        if state_name == "blocked" {
+            pending.extend(policy.recovery_targets.iter().map(String::as_str));
+        }
+    }
+
+    let unreachable = policy
+        .states
+        .keys()
+        .chain(terminal_states.keys())
+        .filter(|state| !reachable.contains(state.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !unreachable.is_empty() {
+        anyhow::bail!(
+            "declarative workflow definition '{}' has states unreachable from initial state '{}': {}",
+            policy.id,
+            policy.initial,
+            unreachable.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+fn compile_states(
+    policy: &WorkflowDefinitionPolicy,
+    terminal_states: &BTreeMap<String, WorkflowTerminalState>,
+) -> Vec<WorkflowStateDefinition> {
+    let mut states = policy
+        .states
+        .iter()
+        .map(|(name, state)| {
+            let progress_mode = match state.progress {
+                Some(DeclaredProgressMode::ExternalWait) => WorkflowProgressMode::ExternalWait,
+                Some(DeclaredProgressMode::OperatorGate) => WorkflowProgressMode::OperatorGate,
+                None => WorkflowProgressMode::CommandDriven,
+            };
+            WorkflowStateDefinition::active(policy.id.as_str(), name.as_str(), progress_mode)
+        })
+        .collect::<Vec<_>>();
+    states.extend(terminal_states.iter().map(|(name, terminal_state)| {
+        WorkflowStateDefinition::terminal(policy.id.as_str(), name.as_str(), *terminal_state)
+    }));
+    states
+}
+
+fn compile_allowlist(
+    policy: &WorkflowDefinitionPolicy,
+    terminal_states: &BTreeMap<String, WorkflowTerminalState>,
+) -> TransitionAllowlist {
+    let mut edges = BTreeSet::new();
+    for (source, state) in &policy.states {
+        for (_, target) in transition_targets(state) {
+            edges.insert((source.as_str(), target));
+        }
+    }
+
+    let mut rules = edges
+        .into_iter()
+        .map(|(source, target)| {
+            TransitionRule::new(
+                source,
+                target,
+                allowed_commands_for_target(policy, terminal_states, target),
+            )
+        })
+        .collect::<Vec<_>>();
+    rules.push(TransitionRule::from_any(
+        "blocked",
+        [
+            WorkflowCommandType::MarkBlocked,
+            WorkflowCommandType::RequestOperatorAttention,
+            WorkflowCommandType::Wait,
+        ],
+    ));
+    TransitionAllowlist::new(rules)
+}
+
+fn allowed_commands_for_target(
+    policy: &WorkflowDefinitionPolicy,
+    terminal_states: &BTreeMap<String, WorkflowTerminalState>,
+    target: &str,
+) -> Vec<WorkflowCommandType> {
+    if target == "blocked" {
+        return vec![
+            WorkflowCommandType::MarkBlocked,
+            WorkflowCommandType::RequestOperatorAttention,
+            WorkflowCommandType::Wait,
+        ];
+    }
+    if let Some(terminal_state) = terminal_states.get(target) {
+        return vec![match terminal_state {
+            WorkflowTerminalState::Succeeded => WorkflowCommandType::MarkDone,
+            WorkflowTerminalState::Failed => WorkflowCommandType::MarkFailed,
+            WorkflowTerminalState::Cancelled => WorkflowCommandType::MarkCancelled,
+        }];
+    }
+
+    let state = &policy.states[target];
+    if state.activity.is_some() {
+        vec![WorkflowCommandType::EnqueueActivity]
+    } else {
+        match state.progress {
+            Some(DeclaredProgressMode::ExternalWait) => vec![WorkflowCommandType::Wait],
+            Some(DeclaredProgressMode::OperatorGate) => {
+                vec![WorkflowCommandType::RequestOperatorAttention]
+            }
+            None => unreachable!("active-state progress contract was validated"),
+        }
+    }
+}
+
+fn transition_targets(state: &DeclaredState) -> Vec<(&str, &str)> {
+    let mut targets = Vec::new();
+    if let Some(target) = state.on_success.as_deref() {
+        targets.push(("on_success", target));
+    }
+    if let Some(target) = state.on_failure.as_deref() {
+        targets.push(("on_failure", target));
+    }
+    if let Some(target) = state.on_blocked.as_deref() {
+        targets.push(("on_blocked", target));
+    }
+    targets.extend(
+        state
+            .on_signal
+            .iter()
+            .map(|(signal, target)| (signal.as_str(), target.as_str())),
+    );
+    targets
+}
+
+#[cfg(test)]
+mod validation {
+    use super::*;
+
+    fn activity_state(on_success: impl Into<String>) -> DeclaredState {
+        DeclaredState {
+            activity: Some("implement".to_string()),
+            on_success: Some(on_success.into()),
+            on_failure: Some("failed".to_string()),
+            on_signal: BTreeMap::from([("cancel".to_string(), "cancelled".to_string())]),
+            ..DeclaredState::default()
+        }
+    }
+
+    fn valid_policy() -> WorkflowDefinitionPolicy {
+        WorkflowDefinitionPolicy {
+            id: "docs_review".to_string(),
+            initial: "reviewing".to_string(),
+            states: BTreeMap::from([
+                (
+                    "blocked".to_string(),
+                    DeclaredState {
+                        progress: Some(DeclaredProgressMode::OperatorGate),
+                        ..DeclaredState::default()
+                    },
+                ),
+                ("reviewing".to_string(), activity_state("done")),
+            ]),
+            terminal: BTreeMap::from([
+                ("cancelled".to_string(), "cancelled".to_string()),
+                ("done".to_string(), "succeeded".to_string()),
+                ("failed".to_string(), "failed".to_string()),
+            ]),
+            evidence_required: BTreeMap::from([(
+                "done".to_string(),
+                vec!["review_report".to_string()],
+            )]),
+            recovery_targets: vec!["reviewing".to_string()],
+        }
+    }
+
+    fn activity_policies() -> BTreeMap<String, WorkflowActivityPolicy> {
+        BTreeMap::from([("implement".to_string(), WorkflowActivityPolicy::default())])
+    }
+
+    fn error_for(policy: &WorkflowDefinitionPolicy) -> String {
+        build_declarative_definition(policy, &activity_policies())
+            .expect_err("declaration should be invalid")
+            .to_string()
+    }
+
+    #[test]
+    fn compiles_valid_definition_without_registration_side_effects() {
+        let policy = valid_policy();
+        let compiled = build_declarative_definition(&policy, &activity_policies())
+            .expect("valid declaration should compile");
+
+        assert_eq!(compiled.registered.id, "docs_review");
+        assert_eq!(compiled.policy, policy);
+        assert_eq!(compiled.registered.states.len(), 5);
+        assert_eq!(
+            compiled
+                .registered
+                .allowlist
+                .rule_for("reviewing", "done")
+                .expect("declared transition should be compiled")
+                .allowed_commands,
+            BTreeSet::from([WorkflowCommandType::MarkDone])
+        );
+        assert_eq!(
+            compiled
+                .registered
+                .allowlist
+                .rule_for("reviewing", "blocked")
+                .expect("blocked fallback should be compiled")
+                .allowed_commands,
+            BTreeSet::from([
+                WorkflowCommandType::MarkBlocked,
+                WorkflowCommandType::Wait,
+                WorkflowCommandType::RequestOperatorAttention,
+            ])
+        );
+        assert!(super::super::state_registry::workflow_definition("docs_review").is_none());
+    }
+
+    #[test]
+    fn rejects_builtin_id_collision() {
+        let mut policy = valid_policy();
+        policy.id = PROMPT_TASK_DEFINITION_ID.to_string();
+        assert!(error_for(&policy).contains("collides with a built-in definition"));
+    }
+
+    #[test]
+    fn rejects_empty_declarations_and_invalid_initial_state() {
+        let mut empty_active = valid_policy();
+        empty_active.states.clear();
+        assert!(error_for(&empty_active).contains("at least one active state"));
+
+        let mut empty_terminal = valid_policy();
+        empty_terminal.terminal.clear();
+        assert!(error_for(&empty_terminal).contains("must declare terminal states"));
+
+        let mut missing_initial = valid_policy();
+        missing_initial.initial = "missing".to_string();
+        assert!(error_for(&missing_initial).contains("is not declared as an active state"));
+
+        let mut terminal_initial = valid_policy();
+        terminal_initial.initial = "done".to_string();
+        assert!(error_for(&terminal_initial).contains("must be active, not terminal"));
+    }
+
+    #[test]
+    fn rejects_namespace_overlap_and_invalid_blocked_state() {
+        let mut overlap = valid_policy();
+        overlap
+            .terminal
+            .insert("blocked".to_string(), "succeeded".to_string());
+        overlap
+            .terminal
+            .insert("done".to_string(), "failed".to_string());
+        overlap
+            .terminal
+            .insert("failed".to_string(), "cancelled".to_string());
+        overlap.terminal.remove("cancelled");
+        assert!(error_for(&overlap).contains("both active and terminal namespaces"));
+
+        let mut missing_blocked = valid_policy();
+        missing_blocked.states.remove("blocked");
+        assert!(error_for(&missing_blocked).contains("must declare active state 'blocked'"));
+
+        let mut wrong_blocked = valid_policy();
+        wrong_blocked.states.insert(
+            "blocked".to_string(),
+            DeclaredState {
+                progress: Some(DeclaredProgressMode::ExternalWait),
+                ..DeclaredState::default()
+            },
+        );
+        assert!(error_for(&wrong_blocked).contains("progress 'operator_gate'"));
+    }
+
+    #[test]
+    fn rejects_incomplete_or_duplicate_terminal_mapping() {
+        let mut missing = valid_policy();
+        missing.terminal.remove("failed");
+        assert!(error_for(&missing).contains("missing terminal class 'failed'"));
+
+        let mut duplicate = valid_policy();
+        duplicate
+            .terminal
+            .insert("also_done".to_string(), "succeeded".to_string());
+        assert!(error_for(&duplicate).contains("terminal class 'succeeded' is assigned to both"));
+
+        let mut unknown = valid_policy();
+        unknown
+            .terminal
+            .insert("failed".to_string(), "aborted".to_string());
+        assert!(error_for(&unknown).contains("unknown class 'aborted'"));
+    }
+
+    #[test]
+    fn rejects_missing_or_dual_progress_mode_and_unknown_activity() {
+        let mut missing = valid_policy();
+        missing
+            .states
+            .insert("reviewing".to_string(), DeclaredState::default());
+        assert!(error_for(&missing).contains("exactly one of activity or progress"));
+
+        let mut dual = valid_policy();
+        dual.states.get_mut("reviewing").unwrap().progress =
+            Some(DeclaredProgressMode::ExternalWait);
+        assert!(error_for(&dual).contains("exactly one of activity or progress"));
+
+        let mut unknown_activity = valid_policy();
+        unknown_activity
+            .states
+            .get_mut("reviewing")
+            .unwrap()
+            .activity = Some("missing_policy".to_string());
+        assert!(
+            error_for(&unknown_activity).contains("absent from the workflow activities policy map")
+        );
+    }
+
+    #[test]
+    fn rejects_undeclared_transition_and_evidence_targets() {
+        let mut transition = valid_policy();
+        transition.states.get_mut("reviewing").unwrap().on_failure = Some("missing".to_string());
+        let error = error_for(&transition);
+        assert!(
+            error.contains("active state 'reviewing' on_failure target 'missing' is undeclared")
+        );
+
+        let mut evidence = valid_policy();
+        evidence
+            .evidence_required
+            .insert("missing".to_string(), vec!["report".to_string()]);
+        assert!(
+            error_for(&evidence).contains("evidence requirement target 'missing' is undeclared")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_recovery_targets() {
+        let mut terminal = valid_policy();
+        terminal.recovery_targets = vec!["done".to_string()];
+        assert!(error_for(&terminal).contains("must name an active state, but it is terminal"));
+
+        let mut missing = valid_policy();
+        missing.recovery_targets = vec!["missing".to_string()];
+        assert!(error_for(&missing).contains("must name an active state, but it is undeclared"));
+
+        let mut duplicate = valid_policy();
+        duplicate.recovery_targets = vec!["reviewing".to_string(), "reviewing".to_string()];
+        assert!(error_for(&duplicate).contains("is declared more than once"));
+    }
+
+    #[test]
+    fn rejects_unreachable_active_and_terminal_states() {
+        let mut active = valid_policy();
+        active.states.insert(
+            "orphan".to_string(),
+            DeclaredState {
+                progress: Some(DeclaredProgressMode::ExternalWait),
+                ..DeclaredState::default()
+            },
+        );
+        assert!(error_for(&active)
+            .contains("states unreachable from initial state 'reviewing': orphan"));
+
+        let mut terminal = valid_policy();
+        terminal
+            .terminal
+            .insert("unused".to_string(), "succeeded".to_string());
+        terminal.terminal.remove("done");
+        terminal.states.get_mut("reviewing").unwrap().on_success = Some("failed".to_string());
+        terminal.evidence_required =
+            BTreeMap::from([("unused".to_string(), vec!["review_report".to_string()])]);
+        let error = error_for(&terminal);
+        assert!(
+            error.contains("states unreachable from initial state 'reviewing': unused"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn compiles_deterministic_signal_edges_and_target_driver_commands() {
+        let mut policy = valid_policy();
+        policy.states.insert(
+            "waiting".to_string(),
+            DeclaredState {
+                progress: Some(DeclaredProgressMode::ExternalWait),
+                on_success: Some("failed".to_string()),
+                ..DeclaredState::default()
+            },
+        );
+        let reviewing = policy.states.get_mut("reviewing").unwrap();
+        reviewing.on_success = Some("waiting".to_string());
+        reviewing.on_blocked = Some("blocked".to_string());
+        reviewing
+            .on_signal
+            .insert("approved".to_string(), "done".to_string());
+
+        let compiled = build_declarative_definition(&policy, &activity_policies()).unwrap();
+        let allowlist = &compiled.registered.allowlist;
+        assert_eq!(
+            allowlist
+                .rule_for("reviewing", "waiting")
+                .unwrap()
+                .allowed_commands,
+            BTreeSet::from([WorkflowCommandType::Wait])
+        );
+        assert_eq!(
+            allowlist
+                .rule_for("reviewing", "done")
+                .unwrap()
+                .allowed_commands,
+            BTreeSet::from([WorkflowCommandType::MarkDone])
+        );
+        assert_eq!(
+            allowlist
+                .rule_for("reviewing", "blocked")
+                .unwrap()
+                .allowed_commands,
+            BTreeSet::from([
+                WorkflowCommandType::MarkBlocked,
+                WorkflowCommandType::RequestOperatorAttention,
+                WorkflowCommandType::Wait,
+            ])
+        );
+    }
+}

--- a/crates/harness-workflow/src/runtime/declarative.rs
+++ b/crates/harness-workflow/src/runtime/declarative.rs
@@ -1,4 +1,5 @@
 use super::{
+    declarative_pinning::declarative_definition_identity,
     model::WorkflowCommandType,
     pr_feedback::PR_FEEDBACK_DEFINITION_ID,
     prompt_task::PROMPT_TASK_DEFINITION_ID,
@@ -19,13 +20,47 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 ///
 /// The policy remains attached because the generic interpreter needs routing, evidence,
 /// activity, and recovery metadata that `RegisteredWorkflowDefinition` does not retain.
+///
+/// ```compile_fail
+/// use harness_workflow::runtime::DeclarativeWorkflowDefinition;
+///
+/// fn mutate_compiled_states(definition: &mut DeclarativeWorkflowDefinition) {
+///     definition.registered.states.clear();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use harness_workflow::runtime::DeclarativeWorkflowDefinition;
+///
+/// fn forge_identity(definition: &mut DeclarativeWorkflowDefinition) {
+///     definition.definition_hash = "sha256:forged".to_string();
+/// }
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeclarativeWorkflowDefinition {
-    pub registered: RegisteredWorkflowDefinition,
-    pub policy: WorkflowDefinitionPolicy,
+    registered: RegisteredWorkflowDefinition,
+    policy: WorkflowDefinitionPolicy,
+    definition_version: u32,
+    definition_hash: String,
 }
 
 impl DeclarativeWorkflowDefinition {
+    pub fn registered(&self) -> &RegisteredWorkflowDefinition {
+        &self.registered
+    }
+
+    pub fn policy(&self) -> &WorkflowDefinitionPolicy {
+        &self.policy
+    }
+
+    pub fn definition_version(&self) -> u32 {
+        self.definition_version
+    }
+
+    pub fn definition_hash(&self) -> &str {
+        &self.definition_hash
+    }
+
     pub fn into_registered(self) -> RegisteredWorkflowDefinition {
         self.registered
     }
@@ -45,10 +80,13 @@ pub fn build_declarative_definition(
 
     let states = compile_states(policy, &terminal_states);
     let allowlist = compile_allowlist(policy, &terminal_states);
+    let (definition_version, definition_hash) = declarative_definition_identity(policy)?;
 
     Ok(DeclarativeWorkflowDefinition {
         registered: RegisteredWorkflowDefinition::new(&policy.id, states, allowlist),
         policy: policy.clone(),
+        definition_version,
+        definition_hash,
     })
 }
 
@@ -439,297 +477,4 @@ fn transition_targets(state: &DeclaredState) -> Vec<(&str, &str)> {
             .map(|(signal, target)| (signal.as_str(), target.as_str())),
     );
     targets
-}
-
-#[cfg(test)]
-mod validation {
-    use super::*;
-
-    fn activity_state(on_success: impl Into<String>) -> DeclaredState {
-        DeclaredState {
-            activity: Some("implement".to_string()),
-            on_success: Some(on_success.into()),
-            on_failure: Some("failed".to_string()),
-            on_signal: BTreeMap::from([("cancel".to_string(), "cancelled".to_string())]),
-            ..DeclaredState::default()
-        }
-    }
-
-    fn valid_policy() -> WorkflowDefinitionPolicy {
-        WorkflowDefinitionPolicy {
-            id: "docs_review".to_string(),
-            initial: "reviewing".to_string(),
-            states: BTreeMap::from([
-                (
-                    "blocked".to_string(),
-                    DeclaredState {
-                        progress: Some(DeclaredProgressMode::OperatorGate),
-                        ..DeclaredState::default()
-                    },
-                ),
-                ("reviewing".to_string(), activity_state("done")),
-            ]),
-            terminal: BTreeMap::from([
-                ("cancelled".to_string(), "cancelled".to_string()),
-                ("done".to_string(), "succeeded".to_string()),
-                ("failed".to_string(), "failed".to_string()),
-            ]),
-            evidence_required: BTreeMap::from([(
-                "done".to_string(),
-                vec!["review_report".to_string()],
-            )]),
-            recovery_targets: vec!["reviewing".to_string()],
-        }
-    }
-
-    fn activity_policies() -> BTreeMap<String, WorkflowActivityPolicy> {
-        BTreeMap::from([("implement".to_string(), WorkflowActivityPolicy::default())])
-    }
-
-    fn error_for(policy: &WorkflowDefinitionPolicy) -> String {
-        build_declarative_definition(policy, &activity_policies())
-            .expect_err("declaration should be invalid")
-            .to_string()
-    }
-
-    #[test]
-    fn compiles_valid_definition_without_registration_side_effects() {
-        let policy = valid_policy();
-        let compiled = build_declarative_definition(&policy, &activity_policies())
-            .expect("valid declaration should compile");
-
-        assert_eq!(compiled.registered.id, "docs_review");
-        assert_eq!(compiled.policy, policy);
-        assert_eq!(compiled.registered.states.len(), 5);
-        assert_eq!(
-            compiled
-                .registered
-                .allowlist
-                .rule_for("reviewing", "done")
-                .expect("declared transition should be compiled")
-                .allowed_commands,
-            BTreeSet::from([WorkflowCommandType::MarkDone])
-        );
-        assert_eq!(
-            compiled
-                .registered
-                .allowlist
-                .rule_for("reviewing", "blocked")
-                .expect("blocked fallback should be compiled")
-                .allowed_commands,
-            BTreeSet::from([
-                WorkflowCommandType::MarkBlocked,
-                WorkflowCommandType::Wait,
-                WorkflowCommandType::RequestOperatorAttention,
-            ])
-        );
-        assert!(super::super::state_registry::workflow_definition("docs_review").is_none());
-    }
-
-    #[test]
-    fn rejects_builtin_id_collision() {
-        let mut policy = valid_policy();
-        policy.id = PROMPT_TASK_DEFINITION_ID.to_string();
-        assert!(error_for(&policy).contains("collides with a built-in definition"));
-    }
-
-    #[test]
-    fn rejects_empty_declarations_and_invalid_initial_state() {
-        let mut empty_active = valid_policy();
-        empty_active.states.clear();
-        assert!(error_for(&empty_active).contains("at least one active state"));
-
-        let mut empty_terminal = valid_policy();
-        empty_terminal.terminal.clear();
-        assert!(error_for(&empty_terminal).contains("must declare terminal states"));
-
-        let mut missing_initial = valid_policy();
-        missing_initial.initial = "missing".to_string();
-        assert!(error_for(&missing_initial).contains("is not declared as an active state"));
-
-        let mut terminal_initial = valid_policy();
-        terminal_initial.initial = "done".to_string();
-        assert!(error_for(&terminal_initial).contains("must be active, not terminal"));
-    }
-
-    #[test]
-    fn rejects_namespace_overlap_and_invalid_blocked_state() {
-        let mut overlap = valid_policy();
-        overlap
-            .terminal
-            .insert("blocked".to_string(), "succeeded".to_string());
-        overlap
-            .terminal
-            .insert("done".to_string(), "failed".to_string());
-        overlap
-            .terminal
-            .insert("failed".to_string(), "cancelled".to_string());
-        overlap.terminal.remove("cancelled");
-        assert!(error_for(&overlap).contains("both active and terminal namespaces"));
-
-        let mut missing_blocked = valid_policy();
-        missing_blocked.states.remove("blocked");
-        assert!(error_for(&missing_blocked).contains("must declare active state 'blocked'"));
-
-        let mut wrong_blocked = valid_policy();
-        wrong_blocked.states.insert(
-            "blocked".to_string(),
-            DeclaredState {
-                progress: Some(DeclaredProgressMode::ExternalWait),
-                ..DeclaredState::default()
-            },
-        );
-        assert!(error_for(&wrong_blocked).contains("progress 'operator_gate'"));
-    }
-
-    #[test]
-    fn rejects_incomplete_or_duplicate_terminal_mapping() {
-        let mut missing = valid_policy();
-        missing.terminal.remove("failed");
-        assert!(error_for(&missing).contains("missing terminal class 'failed'"));
-
-        let mut duplicate = valid_policy();
-        duplicate
-            .terminal
-            .insert("also_done".to_string(), "succeeded".to_string());
-        assert!(error_for(&duplicate).contains("terminal class 'succeeded' is assigned to both"));
-
-        let mut unknown = valid_policy();
-        unknown
-            .terminal
-            .insert("failed".to_string(), "aborted".to_string());
-        assert!(error_for(&unknown).contains("unknown class 'aborted'"));
-    }
-
-    #[test]
-    fn rejects_missing_or_dual_progress_mode_and_unknown_activity() {
-        let mut missing = valid_policy();
-        missing
-            .states
-            .insert("reviewing".to_string(), DeclaredState::default());
-        assert!(error_for(&missing).contains("exactly one of activity or progress"));
-
-        let mut dual = valid_policy();
-        dual.states.get_mut("reviewing").unwrap().progress =
-            Some(DeclaredProgressMode::ExternalWait);
-        assert!(error_for(&dual).contains("exactly one of activity or progress"));
-
-        let mut unknown_activity = valid_policy();
-        unknown_activity
-            .states
-            .get_mut("reviewing")
-            .unwrap()
-            .activity = Some("missing_policy".to_string());
-        assert!(
-            error_for(&unknown_activity).contains("absent from the workflow activities policy map")
-        );
-    }
-
-    #[test]
-    fn rejects_undeclared_transition_and_evidence_targets() {
-        let mut transition = valid_policy();
-        transition.states.get_mut("reviewing").unwrap().on_failure = Some("missing".to_string());
-        let error = error_for(&transition);
-        assert!(
-            error.contains("active state 'reviewing' on_failure target 'missing' is undeclared")
-        );
-
-        let mut evidence = valid_policy();
-        evidence
-            .evidence_required
-            .insert("missing".to_string(), vec!["report".to_string()]);
-        assert!(
-            error_for(&evidence).contains("evidence requirement target 'missing' is undeclared")
-        );
-    }
-
-    #[test]
-    fn rejects_invalid_recovery_targets() {
-        let mut terminal = valid_policy();
-        terminal.recovery_targets = vec!["done".to_string()];
-        assert!(error_for(&terminal).contains("must name an active state, but it is terminal"));
-
-        let mut missing = valid_policy();
-        missing.recovery_targets = vec!["missing".to_string()];
-        assert!(error_for(&missing).contains("must name an active state, but it is undeclared"));
-
-        let mut duplicate = valid_policy();
-        duplicate.recovery_targets = vec!["reviewing".to_string(), "reviewing".to_string()];
-        assert!(error_for(&duplicate).contains("is declared more than once"));
-    }
-
-    #[test]
-    fn rejects_unreachable_active_and_terminal_states() {
-        let mut active = valid_policy();
-        active.states.insert(
-            "orphan".to_string(),
-            DeclaredState {
-                progress: Some(DeclaredProgressMode::ExternalWait),
-                ..DeclaredState::default()
-            },
-        );
-        assert!(error_for(&active)
-            .contains("states unreachable from initial state 'reviewing': orphan"));
-
-        let mut terminal = valid_policy();
-        terminal
-            .terminal
-            .insert("unused".to_string(), "succeeded".to_string());
-        terminal.terminal.remove("done");
-        terminal.states.get_mut("reviewing").unwrap().on_success = Some("failed".to_string());
-        terminal.evidence_required =
-            BTreeMap::from([("unused".to_string(), vec!["review_report".to_string()])]);
-        let error = error_for(&terminal);
-        assert!(
-            error.contains("states unreachable from initial state 'reviewing': unused"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[test]
-    fn compiles_deterministic_signal_edges_and_target_driver_commands() {
-        let mut policy = valid_policy();
-        policy.states.insert(
-            "waiting".to_string(),
-            DeclaredState {
-                progress: Some(DeclaredProgressMode::ExternalWait),
-                on_success: Some("failed".to_string()),
-                ..DeclaredState::default()
-            },
-        );
-        let reviewing = policy.states.get_mut("reviewing").unwrap();
-        reviewing.on_success = Some("waiting".to_string());
-        reviewing.on_blocked = Some("blocked".to_string());
-        reviewing
-            .on_signal
-            .insert("approved".to_string(), "done".to_string());
-
-        let compiled = build_declarative_definition(&policy, &activity_policies()).unwrap();
-        let allowlist = &compiled.registered.allowlist;
-        assert_eq!(
-            allowlist
-                .rule_for("reviewing", "waiting")
-                .unwrap()
-                .allowed_commands,
-            BTreeSet::from([WorkflowCommandType::Wait])
-        );
-        assert_eq!(
-            allowlist
-                .rule_for("reviewing", "done")
-                .unwrap()
-                .allowed_commands,
-            BTreeSet::from([WorkflowCommandType::MarkDone])
-        );
-        assert_eq!(
-            allowlist
-                .rule_for("reviewing", "blocked")
-                .unwrap()
-                .allowed_commands,
-            BTreeSet::from([
-                WorkflowCommandType::MarkBlocked,
-                WorkflowCommandType::RequestOperatorAttention,
-                WorkflowCommandType::Wait,
-            ])
-        );
-    }
 }

--- a/crates/harness-workflow/src/runtime/declarative_pinning.rs
+++ b/crates/harness-workflow/src/runtime/declarative_pinning.rs
@@ -1,0 +1,115 @@
+use super::{
+    declarative::{build_declarative_definition, DeclarativeWorkflowDefinition},
+    model::WorkflowDefinition as DurableWorkflowDefinition,
+    remote_facts::stable_remote_fact_hash,
+};
+use harness_core::config::workflow::{WorkflowActivityPolicy, WorkflowDefinitionPolicy};
+use std::collections::BTreeMap;
+
+pub(super) const DECLARATIVE_DEFINITION_METADATA_KIND: &str = "declarative_workflow";
+const METADATA_SCHEMA_VERSION: u64 = 1;
+
+pub fn declarative_definition_identity(
+    policy: &WorkflowDefinitionPolicy,
+) -> anyhow::Result<(u32, String)> {
+    let policy_json = serde_json::to_value(policy)?;
+    let definition_hash = stable_remote_fact_hash(&policy_json);
+    let version_hex = definition_hash
+        .get(definition_hash.len().saturating_sub(8)..)
+        .ok_or_else(|| anyhow::anyhow!("declarative definition hash is too short"))?;
+    let definition_version = u32::from_str_radix(version_hex, 16).map_err(|error| {
+        anyhow::anyhow!(
+            "declarative definition hash '{}' has an invalid version suffix: {error}",
+            definition_hash
+        )
+    })?;
+    Ok((definition_version, definition_hash))
+}
+
+pub fn persisted_declarative_definition(
+    definition: &DeclarativeWorkflowDefinition,
+    source_path: Option<&str>,
+) -> DurableWorkflowDefinition {
+    let mut persisted = DurableWorkflowDefinition::new(
+        definition.policy().id.clone(),
+        definition.definition_version(),
+        definition.policy().id.clone(),
+    )
+    .with_definition_hash(definition.definition_hash())
+    .with_metadata(serde_json::json!({
+        "kind": DECLARATIVE_DEFINITION_METADATA_KIND,
+        "schema_version": METADATA_SCHEMA_VERSION,
+        "policy": definition.policy(),
+    }));
+    if let Some(source_path) = source_path {
+        persisted = persisted.with_source_path(source_path);
+    }
+    persisted
+}
+
+pub fn hydrate_declarative_definition(
+    definition: &DurableWorkflowDefinition,
+    activity_policies: &BTreeMap<String, WorkflowActivityPolicy>,
+) -> anyhow::Result<DeclarativeWorkflowDefinition> {
+    let metadata = definition.metadata.as_object().ok_or_else(|| {
+        anyhow::anyhow!(
+            "persisted workflow definition '{}@{}' metadata must be an object",
+            definition.id,
+            definition.version
+        )
+    })?;
+    if metadata.get("kind").and_then(serde_json::Value::as_str)
+        != Some(DECLARATIVE_DEFINITION_METADATA_KIND)
+    {
+        anyhow::bail!(
+            "persisted workflow definition '{}@{}' is not a declarative workflow definition",
+            definition.id,
+            definition.version
+        );
+    }
+    if metadata
+        .get("schema_version")
+        .and_then(serde_json::Value::as_u64)
+        != Some(METADATA_SCHEMA_VERSION)
+    {
+        anyhow::bail!(
+            "persisted declarative workflow definition '{}@{}' has an unsupported metadata schema",
+            definition.id,
+            definition.version
+        );
+    }
+    let policy_value = metadata.get("policy").ok_or_else(|| {
+        anyhow::anyhow!(
+            "persisted declarative workflow definition '{}@{}' is missing policy metadata",
+            definition.id,
+            definition.version
+        )
+    })?;
+    let policy: WorkflowDefinitionPolicy = serde_json::from_value(policy_value.clone())?;
+    let hydrated = build_declarative_definition(&policy, activity_policies)?;
+    if hydrated.policy().id != definition.id {
+        anyhow::bail!(
+            "persisted declarative workflow definition id '{}' does not match policy id '{}'",
+            definition.id,
+            hydrated.policy().id
+        );
+    }
+    if hydrated.definition_version() != definition.version {
+        anyhow::bail!(
+            "persisted declarative workflow definition '{}@{}' version does not match canonical policy version {}",
+            definition.id,
+            definition.version,
+            hydrated.definition_version()
+        );
+    }
+    if hydrated.definition_hash() != definition.definition_hash {
+        anyhow::bail!(
+            "persisted declarative workflow definition '{}@{}' hash '{}' does not match canonical policy hash '{}'",
+            definition.id,
+            definition.version,
+            definition.definition_hash,
+            hydrated.definition_hash()
+        );
+    }
+    Ok(hydrated)
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -10,6 +10,7 @@ mod candidate_promotion;
 mod candidate_selection;
 mod candidate_terminal;
 mod command_record;
+pub mod declarative;
 mod dispatch_barrier;
 pub mod dispatcher;
 pub mod errors;
@@ -62,6 +63,7 @@ pub use candidate_selection::{
     CandidateOutcome, CandidatePromotionRecord, CandidateRankingRecord, CandidateSelectionInput,
     CandidateSelectionRecord, CANDIDATE_SELECTION_RECORD_TYPE, CANDIDATE_SELECTION_SCHEMA,
 };
+pub use declarative::{build_declarative_definition, DeclarativeWorkflowDefinition};
 pub use dispatch_barrier::{
     DeferClaimedCommandOutcome, DispatchBackoffPolicy, DispatchBarrier, DispatchBarrierInput,
     DispatchBarrierReasonCode, DispatchClaim,

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -11,6 +11,7 @@ mod candidate_selection;
 mod candidate_terminal;
 mod command_record;
 pub mod declarative;
+mod declarative_pinning;
 mod dispatch_barrier;
 pub mod dispatcher;
 pub mod errors;
@@ -64,6 +65,10 @@ pub use candidate_selection::{
     CandidateSelectionRecord, CANDIDATE_SELECTION_RECORD_TYPE, CANDIDATE_SELECTION_SCHEMA,
 };
 pub use declarative::{build_declarative_definition, DeclarativeWorkflowDefinition};
+pub use declarative_pinning::{
+    declarative_definition_identity, hydrate_declarative_definition,
+    persisted_declarative_definition,
+};
 pub use dispatch_barrier::{
     DeferClaimedCommandOutcome, DispatchBackoffPolicy, DispatchBarrier, DispatchBarrierInput,
     DispatchBarrierReasonCode, DispatchClaim,
@@ -144,8 +149,12 @@ pub use repo_memory::{
 };
 pub use state_registry::{
     decision_validator_for_definition, freeze_workflow_definition_registry,
-    known_workflow_definition_ids, register_workflow_definition, workflow_definition,
-    workflow_state_definition, workflow_state_exists, workflow_state_progress_mode,
+    known_workflow_definition_ids, register_declarative_workflow_definitions,
+    register_historical_declarative_workflow_definitions, register_workflow_definition,
+    workflow_declarative_definition, workflow_definition, workflow_definition_for_version,
+    workflow_state_definition, workflow_state_definition_for_instance,
+    workflow_state_definition_for_version, workflow_state_exists, workflow_state_progress_mode,
+    workflow_state_progress_mode_for_version, workflow_state_terminal_state_for_version,
     workflow_states_for_definition, workflow_terminal_state_names_for_definition,
     RegisteredWorkflowDefinition, WorkflowDefinitionRegistry, WorkflowProgressMode,
     WorkflowStateDefinition, WorkflowStateKey,
@@ -163,7 +172,10 @@ pub use submission::{
     build_issue_submission_decision, IssueSubmissionDecisionInput, IssueSubmissionDecisionOutput,
     IssueSubmissionWorkflowAction, SubmissionMode,
 };
-pub use terminal_state::{workflow_terminal_state, WorkflowTerminalState};
+pub use terminal_state::{
+    workflow_terminal_state, workflow_terminal_state_for_instance,
+    workflow_terminal_state_for_version, WorkflowTerminalState,
+};
 pub use tier_resolution::{resolve_isolation_tier, IsolationTaskMetadata, IsolationTierResolution};
 pub use validator::{
     DecisionValidator, TransitionAllowlist, TransitionRule, ValidationContext,

--- a/crates/harness-workflow/src/runtime/model.rs
+++ b/crates/harness-workflow/src/runtime/model.rs
@@ -1,4 +1,4 @@
-use super::terminal_state::{workflow_terminal_state, WorkflowTerminalState};
+use super::terminal_state::{workflow_terminal_state_for_instance, WorkflowTerminalState};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -119,7 +119,7 @@ impl WorkflowInstance {
     }
 
     pub fn terminal_state(&self) -> Option<WorkflowTerminalState> {
-        workflow_terminal_state(&self.definition_id, &self.state)
+        workflow_terminal_state_for_instance(self)
     }
 
     pub fn with_id(mut self, id: impl Into<String>) -> Self {

--- a/crates/harness-workflow/src/runtime/state_registry.rs
+++ b/crates/harness-workflow/src/runtime/state_registry.rs
@@ -1,4 +1,6 @@
 use super::{
+    declarative::DeclarativeWorkflowDefinition,
+    model::WorkflowInstance,
     pr_feedback::PR_FEEDBACK_DEFINITION_ID,
     prompt_task::PROMPT_TASK_DEFINITION_ID,
     quality_gate::QUALITY_GATE_DEFINITION_ID,
@@ -8,6 +10,8 @@ use super::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock};
+
+mod versioning;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -96,9 +100,11 @@ impl RegisteredWorkflowDefinition {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WorkflowDefinitionRegistry {
     definitions: HashMap<String, Arc<RegisteredWorkflowDefinition>>,
+    declarative_versions: HashMap<(String, u32), Arc<DeclarativeWorkflowDefinition>>,
+    current_declarative_versions: HashMap<String, u32>,
     definition_ids: Vec<String>,
     frozen: bool,
 }
@@ -107,6 +113,8 @@ impl WorkflowDefinitionRegistry {
     pub fn new() -> Self {
         Self {
             definitions: HashMap::new(),
+            declarative_versions: HashMap::new(),
+            current_declarative_versions: HashMap::new(),
             definition_ids: Vec::new(),
             frozen: false,
         }
@@ -128,18 +136,55 @@ impl WorkflowDefinitionRegistry {
     }
 
     pub fn register(&mut self, definition: RegisteredWorkflowDefinition) -> anyhow::Result<()> {
-        if self.frozen {
-            anyhow::bail!(
-                "workflow definition registry is frozen; cannot register '{}'",
-                definition.id
-            );
-        }
+        self.ensure_mutable(&definition.id)?;
         if self.definitions.contains_key(&definition.id) {
             anyhow::bail!(
                 "workflow definition '{}' is already registered",
                 definition.id
             );
         }
+        if self
+            .declarative_versions
+            .keys()
+            .any(|(definition_id, _)| definition_id == &definition.id)
+        {
+            anyhow::bail!(
+                "workflow definition '{}' has registered declarative history",
+                definition.id
+            );
+        }
+        Self::validate_registered_definition(&definition)?;
+        self.definition_ids.push(definition.id.clone());
+        self.definitions
+            .insert(definition.id.clone(), Arc::new(definition));
+        Ok(())
+    }
+
+    pub fn register_batch(
+        &mut self,
+        definitions: impl IntoIterator<Item = RegisteredWorkflowDefinition>,
+    ) -> anyhow::Result<()> {
+        let mut staged = self.clone();
+        for definition in definitions {
+            staged.register(definition)?;
+        }
+        *self = staged;
+        Ok(())
+    }
+
+    fn ensure_mutable(&self, definition_id: &str) -> anyhow::Result<()> {
+        if self.frozen {
+            anyhow::bail!(
+                "workflow definition registry is frozen; cannot register '{}'",
+                definition_id
+            );
+        }
+        Ok(())
+    }
+
+    fn validate_registered_definition(
+        definition: &RegisteredWorkflowDefinition,
+    ) -> anyhow::Result<()> {
         if let Some(state) = definition
             .states
             .iter()
@@ -151,9 +196,6 @@ impl WorkflowDefinitionRegistry {
                 state.key.state
             );
         }
-        self.definition_ids.push(definition.id.clone());
-        self.definitions
-            .insert(definition.id.clone(), Arc::new(definition));
         Ok(())
     }
 
@@ -204,6 +246,24 @@ pub fn register_workflow_definition(
         .register(definition)
 }
 
+pub fn register_declarative_workflow_definitions(
+    definitions: impl IntoIterator<Item = DeclarativeWorkflowDefinition>,
+) -> anyhow::Result<()> {
+    registry()
+        .write()
+        .expect("workflow definition registry lock poisoned")
+        .register_declarative_current_batch(definitions)
+}
+
+pub fn register_historical_declarative_workflow_definitions(
+    definitions: impl IntoIterator<Item = DeclarativeWorkflowDefinition>,
+) -> anyhow::Result<()> {
+    registry()
+        .write()
+        .expect("workflow definition registry lock poisoned")
+        .register_declarative_historical_batch(definitions)
+}
+
 pub fn freeze_workflow_definition_registry() {
     registry()
         .write()
@@ -216,6 +276,26 @@ pub fn workflow_definition(definition_id: &str) -> Option<Arc<RegisteredWorkflow
         .read()
         .expect("workflow definition registry lock poisoned")
         .definition(definition_id)
+}
+
+pub fn workflow_declarative_definition(
+    definition_id: &str,
+    definition_version: u32,
+) -> Option<Arc<DeclarativeWorkflowDefinition>> {
+    registry()
+        .read()
+        .expect("workflow definition registry lock poisoned")
+        .declarative_definition(definition_id, definition_version)
+}
+
+pub fn workflow_definition_for_version(
+    definition_id: &str,
+    definition_version: u32,
+) -> Option<Arc<RegisteredWorkflowDefinition>> {
+    registry()
+        .read()
+        .expect("workflow definition registry lock poisoned")
+        .definition_for_version(definition_id, definition_version)
 }
 
 pub fn decision_validator_for_definition(definition_id: &str) -> Option<DecisionValidator> {
@@ -264,6 +344,27 @@ pub fn workflow_state_definition(
     })
 }
 
+pub fn workflow_state_definition_for_version(
+    definition_id: &str,
+    definition_version: u32,
+    state: &str,
+) -> Option<WorkflowStateDefinition> {
+    registry()
+        .read()
+        .expect("workflow definition registry lock poisoned")
+        .state_definition_for_version(definition_id, definition_version, state)
+}
+
+pub fn workflow_state_definition_for_instance(
+    instance: &WorkflowInstance,
+    state: &str,
+) -> Option<WorkflowStateDefinition> {
+    registry()
+        .read()
+        .expect("workflow definition registry lock poisoned")
+        .state_definition_for_instance(instance, state)
+}
+
 pub fn workflow_state_exists(definition_id: &str, state: &str) -> bool {
     workflow_state_definition(definition_id, state).is_some()
 }
@@ -280,6 +381,22 @@ pub fn workflow_state_progress_mode(
     state: &str,
 ) -> Option<WorkflowProgressMode> {
     workflow_state_definition(definition_id, state)?.progress_mode
+}
+
+pub fn workflow_state_progress_mode_for_version(
+    definition_id: &str,
+    definition_version: u32,
+    state: &str,
+) -> Option<WorkflowProgressMode> {
+    workflow_state_definition_for_version(definition_id, definition_version, state)?.progress_mode
+}
+
+pub fn workflow_state_terminal_state_for_version(
+    definition_id: &str,
+    definition_version: u32,
+    state: &str,
+) -> Option<WorkflowTerminalState> {
+    workflow_state_definition_for_version(definition_id, definition_version, state)?.terminal_state
 }
 
 fn builtin_definitions() -> [RegisteredWorkflowDefinition; 4] {
@@ -481,232 +598,3 @@ fn terminal(
 #[cfg(test)]
 #[path = "state_registry_equivalence_tests.rs"]
 mod equivalence_tests;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::runtime::validator::TransitionAllowlist;
-
-    #[test]
-    fn registry_scopes_success_states_to_workflow_definitions() {
-        assert_eq!(
-            workflow_state_terminal_state(QUALITY_GATE_DEFINITION_ID, "passed"),
-            Some(WorkflowTerminalState::Succeeded)
-        );
-        assert_eq!(
-            workflow_state_terminal_state(GITHUB_ISSUE_PR_DEFINITION_ID, "passed"),
-            None
-        );
-        assert_eq!(
-            workflow_state_terminal_state(QUALITY_GATE_DEFINITION_ID, "done"),
-            None
-        );
-    }
-
-    #[test]
-    fn registry_lists_only_known_definition_states() {
-        assert_eq!(
-            known_workflow_definition_ids(),
-            vec![
-                GITHUB_ISSUE_PR_DEFINITION_ID,
-                PROMPT_TASK_DEFINITION_ID,
-                QUALITY_GATE_DEFINITION_ID,
-                PR_FEEDBACK_DEFINITION_ID,
-            ]
-        );
-        assert!(workflow_states_for_definition("unknown_workflow").is_empty());
-        assert!(workflow_state_exists(
-            GITHUB_ISSUE_PR_DEFINITION_ID,
-            "awaiting_feedback"
-        ));
-        assert!(!workflow_state_exists(
-            GITHUB_ISSUE_PR_DEFINITION_ID,
-            "inspecting"
-        ));
-    }
-
-    #[test]
-    fn registry_lists_terminal_state_names_by_definition() {
-        assert_eq!(
-            workflow_terminal_state_names_for_definition(GITHUB_ISSUE_PR_DEFINITION_ID),
-            vec!["done", "failed", "cancelled"]
-        );
-        assert_eq!(
-            workflow_terminal_state_names_for_definition(QUALITY_GATE_DEFINITION_ID),
-            vec!["passed", "failed", "cancelled"]
-        );
-        assert!(workflow_terminal_state_names_for_definition("unknown_workflow").is_empty());
-    }
-
-    #[test]
-    fn registry_covers_validator_transition_states() {
-        let allowlists = [
-            (
-                GITHUB_ISSUE_PR_DEFINITION_ID,
-                TransitionAllowlist::github_issue_pr_defaults(),
-            ),
-            (
-                PROMPT_TASK_DEFINITION_ID,
-                TransitionAllowlist::prompt_task_defaults(),
-            ),
-            (
-                QUALITY_GATE_DEFINITION_ID,
-                TransitionAllowlist::quality_gate_defaults(),
-            ),
-            (
-                PR_FEEDBACK_DEFINITION_ID,
-                TransitionAllowlist::pr_feedback_defaults(),
-            ),
-        ];
-
-        for (definition_id, allowlist) in allowlists {
-            let definition = workflow_definition(definition_id)
-                .expect("built-in workflow definition should be registered");
-            for state in &definition.states {
-                assert!(
-                    state.has_complete_progress_contract(),
-                    "{definition_id}.{} must declare exactly one progress or terminal contract",
-                    state.key.state
-                );
-            }
-            for rule in allowlist.rules() {
-                if let Some(from_state) = rule.from_state.as_deref() {
-                    assert!(
-                        workflow_state_exists(definition_id, from_state),
-                        "{definition_id} missing from_state {from_state}"
-                    );
-                }
-                assert!(
-                    workflow_state_definition(definition_id, &rule.to_state)
-                        .is_some_and(|state| state.has_complete_progress_contract()),
-                    "{definition_id} to_state {} is missing a complete contract",
-                    rule.to_state,
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn progress_mode_lookup_fails_closed_for_terminal_and_unknown_states() {
-        assert_eq!(
-            workflow_state_progress_mode(GITHUB_ISSUE_PR_DEFINITION_ID, "implementing"),
-            Some(WorkflowProgressMode::CommandDriven)
-        );
-        assert_eq!(
-            workflow_state_progress_mode(GITHUB_ISSUE_PR_DEFINITION_ID, "done"),
-            None
-        );
-        assert_eq!(
-            workflow_state_progress_mode(GITHUB_ISSUE_PR_DEFINITION_ID, "unknown"),
-            None
-        );
-        assert_eq!(
-            workflow_state_progress_mode("unknown_definition", "implementing"),
-            None
-        );
-    }
-
-    #[test]
-    fn state_key_clones_reuse_owned_string_allocations() {
-        let state = workflow_state_definition(PROMPT_TASK_DEFINITION_ID, "implementing")
-            .expect("prompt task implementing state should exist");
-        let cloned = state.key.clone();
-
-        assert!(Arc::ptr_eq(&state.key.definition_id, &cloned.definition_id));
-        assert!(Arc::ptr_eq(&state.key.state, &cloned.state));
-    }
-
-    #[test]
-    fn duplicate_registration_fails_without_replacing_the_first_definition() {
-        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
-        let first = definition(
-            "fixture",
-            vec![active(
-                "fixture",
-                "pending",
-                WorkflowProgressMode::ExternalWait,
-            )],
-            TransitionAllowlist::default(),
-        );
-        let duplicate = definition(
-            "fixture",
-            vec![active(
-                "fixture",
-                "other",
-                WorkflowProgressMode::ExternalWait,
-            )],
-            TransitionAllowlist::default(),
-        );
-
-        registry
-            .register(first)
-            .expect("first registration should pass");
-        let error = registry
-            .register(duplicate)
-            .expect_err("duplicate registration should fail");
-
-        assert!(error.to_string().contains("already registered"));
-        assert!(registry
-            .definition("fixture")
-            .is_some_and(|definition| definition.states[0].key.state.as_ref() == "pending"));
-    }
-
-    #[test]
-    fn freeze_is_idempotent_and_rejects_late_registration() {
-        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
-        registry.freeze();
-        registry.freeze();
-
-        let error = registry
-            .register(definition(
-                "late",
-                vec![active(
-                    "late",
-                    "pending",
-                    WorkflowProgressMode::ExternalWait,
-                )],
-                TransitionAllowlist::default(),
-            ))
-            .expect_err("post-freeze registration should fail");
-
-        assert!(registry.is_frozen());
-        assert!(error.to_string().contains("is frozen"));
-        assert!(registry.definition("late").is_none());
-    }
-
-    #[test]
-    fn registration_rejects_incomplete_or_conflicting_progress_contracts() {
-        let invalid_states = [
-            WorkflowStateDefinition {
-                key: WorkflowStateKey {
-                    definition_id: Arc::from("fixture"),
-                    state: Arc::from("missing"),
-                },
-                progress_mode: None,
-                terminal_state: None,
-            },
-            WorkflowStateDefinition {
-                key: WorkflowStateKey {
-                    definition_id: Arc::from("fixture"),
-                    state: Arc::from("conflicting"),
-                },
-                progress_mode: Some(WorkflowProgressMode::OperatorGate),
-                terminal_state: Some(WorkflowTerminalState::Failed),
-            },
-        ];
-
-        for state in invalid_states {
-            let mut registry = WorkflowDefinitionRegistry::new_for_tests();
-            let error = registry
-                .register(RegisteredWorkflowDefinition::new(
-                    "fixture",
-                    vec![state],
-                    TransitionAllowlist::default(),
-                ))
-                .expect_err("invalid state contract should fail registration");
-
-            assert!(error.to_string().contains("exactly one"));
-            assert!(registry.definition("fixture").is_none());
-        }
-    }
-}

--- a/crates/harness-workflow/src/runtime/state_registry/versioning.rs
+++ b/crates/harness-workflow/src/runtime/state_registry/versioning.rs
@@ -1,0 +1,241 @@
+use super::{
+    DeclarativeWorkflowDefinition, RegisteredWorkflowDefinition, WorkflowDefinitionRegistry,
+    WorkflowStateDefinition, GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID,
+    PR_FEEDBACK_DEFINITION_ID, QUALITY_GATE_DEFINITION_ID,
+};
+use crate::runtime::declarative_pinning::declarative_definition_identity;
+use crate::runtime::model::WorkflowInstance;
+use std::sync::Arc;
+
+impl WorkflowDefinitionRegistry {
+    pub fn register_declarative_current(
+        &mut self,
+        definition: DeclarativeWorkflowDefinition,
+    ) -> anyhow::Result<()> {
+        self.ensure_mutable(&definition.policy().id)?;
+        if self.definitions.contains_key(&definition.policy().id) {
+            anyhow::bail!(
+                "workflow definition '{}' is already registered as current",
+                definition.policy().id
+            );
+        }
+        let version_key = (
+            definition.policy().id.clone(),
+            definition.definition_version(),
+        );
+        let versioned = self.checked_version_entry(version_key.clone(), definition)?;
+        self.validate_declarative_definition(&versioned)?;
+        self.definition_ids.push(version_key.0.clone());
+        self.definitions.insert(
+            version_key.0.clone(),
+            Arc::new(versioned.registered().clone()),
+        );
+        self.current_declarative_versions
+            .insert(version_key.0.clone(), version_key.1);
+        self.declarative_versions.insert(version_key, versioned);
+        Ok(())
+    }
+
+    pub fn register_declarative_current_batch(
+        &mut self,
+        definitions: impl IntoIterator<Item = DeclarativeWorkflowDefinition>,
+    ) -> anyhow::Result<()> {
+        let mut staged = self.clone();
+        for definition in definitions {
+            staged.register_declarative_current(definition)?;
+        }
+        *self = staged;
+        Ok(())
+    }
+
+    pub fn register_declarative_historical(
+        &mut self,
+        definition: DeclarativeWorkflowDefinition,
+    ) -> anyhow::Result<()> {
+        self.ensure_mutable(&definition.policy().id)?;
+        if self.definitions.contains_key(&definition.policy().id)
+            && !self
+                .current_declarative_versions
+                .contains_key(&definition.policy().id)
+        {
+            anyhow::bail!(
+                "historical declarative definition '{}' collides with a non-declarative current definition",
+                definition.policy().id
+            );
+        }
+        let version_key = (
+            definition.policy().id.clone(),
+            definition.definition_version(),
+        );
+        let versioned = self.checked_version_entry(version_key.clone(), definition)?;
+        self.validate_declarative_definition(&versioned)?;
+        self.declarative_versions.insert(version_key, versioned);
+        Ok(())
+    }
+
+    pub fn register_declarative_historical_batch(
+        &mut self,
+        definitions: impl IntoIterator<Item = DeclarativeWorkflowDefinition>,
+    ) -> anyhow::Result<()> {
+        let mut staged = self.clone();
+        for definition in definitions {
+            staged.register_declarative_historical(definition)?;
+        }
+        *self = staged;
+        Ok(())
+    }
+
+    fn validate_declarative_definition(
+        &self,
+        definition: &DeclarativeWorkflowDefinition,
+    ) -> anyhow::Result<()> {
+        Self::validate_registered_definition(definition.registered())?;
+        if definition.registered().id != definition.policy().id {
+            anyhow::bail!(
+                "declarative workflow registry definition id '{}' does not match policy id '{}'",
+                definition.registered().id,
+                definition.policy().id
+            );
+        }
+        let (expected_version, expected_hash) =
+            declarative_definition_identity(definition.policy())?;
+        if definition.definition_version() != expected_version
+            || definition.definition_hash() != expected_hash
+        {
+            anyhow::bail!(
+                "declarative workflow definition '{}' identity does not match its canonical policy",
+                definition.policy().id
+            );
+        }
+        Ok(())
+    }
+
+    fn checked_version_entry(
+        &self,
+        version_key: (String, u32),
+        definition: DeclarativeWorkflowDefinition,
+    ) -> anyhow::Result<Arc<DeclarativeWorkflowDefinition>> {
+        let Some(existing) = self.declarative_versions.get(&version_key) else {
+            return Ok(Arc::new(definition));
+        };
+        if existing.definition_hash() != definition.definition_hash() {
+            anyhow::bail!(
+                "declarative workflow definition '{}@{}' version collision between hashes '{}' and '{}'",
+                version_key.0,
+                version_key.1,
+                existing.definition_hash(),
+                definition.definition_hash()
+            );
+        }
+        if existing.as_ref() != &definition {
+            anyhow::bail!(
+                "declarative workflow definition '{}@{}' full hash collision for '{}'",
+                version_key.0,
+                version_key.1,
+                definition.definition_hash()
+            );
+        }
+        Ok(existing.clone())
+    }
+
+    pub fn current_declarative_definition(
+        &self,
+        definition_id: &str,
+    ) -> Option<Arc<DeclarativeWorkflowDefinition>> {
+        let version = *self.current_declarative_versions.get(definition_id)?;
+        self.declarative_definition(definition_id, version)
+    }
+
+    pub fn declarative_definition(
+        &self,
+        definition_id: &str,
+        definition_version: u32,
+    ) -> Option<Arc<DeclarativeWorkflowDefinition>> {
+        self.declarative_versions
+            .get(&(definition_id.to_string(), definition_version))
+            .cloned()
+    }
+
+    pub fn definition_for_version(
+        &self,
+        definition_id: &str,
+        definition_version: u32,
+    ) -> Option<Arc<RegisteredWorkflowDefinition>> {
+        if let Some(definition) = self.declarative_definition(definition_id, definition_version) {
+            return Some(Arc::new(definition.registered().clone()));
+        }
+        is_builtin_definition_id(definition_id).then(|| self.definition(definition_id))?
+    }
+
+    pub fn definition_for_instance(
+        &self,
+        instance: &WorkflowInstance,
+    ) -> Option<Arc<RegisteredWorkflowDefinition>> {
+        match instance.data.get("definition_hash") {
+            Some(serde_json::Value::String(expected_hash)) if !expected_hash.trim().is_empty() => {
+                let definition = self
+                    .declarative_definition(&instance.definition_id, instance.definition_version)?;
+                if definition.definition_hash() != expected_hash {
+                    return None;
+                }
+                Some(Arc::new(definition.registered().clone()))
+            }
+            Some(_) => None,
+            None => {
+                if let Some(definition) = self
+                    .declarative_definition(&instance.definition_id, instance.definition_version)
+                {
+                    return Some(Arc::new(definition.registered().clone()));
+                }
+                if self
+                    .current_declarative_versions
+                    .contains_key(&instance.definition_id)
+                {
+                    return None;
+                }
+                self.definition(&instance.definition_id)
+            }
+        }
+    }
+
+    pub fn state_definition_for_version(
+        &self,
+        definition_id: &str,
+        definition_version: u32,
+        state: &str,
+    ) -> Option<WorkflowStateDefinition> {
+        state_definition(
+            self.definition_for_version(definition_id, definition_version)?,
+            state,
+        )
+    }
+
+    pub fn state_definition_for_instance(
+        &self,
+        instance: &WorkflowInstance,
+        state: &str,
+    ) -> Option<WorkflowStateDefinition> {
+        state_definition(self.definition_for_instance(instance)?, state)
+    }
+}
+
+fn state_definition(
+    definition: Arc<RegisteredWorkflowDefinition>,
+    state: &str,
+) -> Option<WorkflowStateDefinition> {
+    definition
+        .states
+        .iter()
+        .find(|definition| definition.key.state.as_ref() == state)
+        .cloned()
+}
+
+fn is_builtin_definition_id(definition_id: &str) -> bool {
+    [
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        PROMPT_TASK_DEFINITION_ID,
+        QUALITY_GATE_DEFINITION_ID,
+        PR_FEEDBACK_DEFINITION_ID,
+    ]
+    .contains(&definition_id)
+}

--- a/crates/harness-workflow/src/runtime/state_registry_equivalence_tests.rs
+++ b/crates/harness-workflow/src/runtime/state_registry_equivalence_tests.rs
@@ -402,6 +402,229 @@ fn progress_mode_semantics_match_authoritative_ownership_matrix() {
     }
 }
 
+#[test]
+fn registry_scopes_success_states_to_workflow_definitions() {
+    assert_eq!(
+        workflow_state_terminal_state(QUALITY_GATE_DEFINITION_ID, "passed"),
+        Some(WorkflowTerminalState::Succeeded)
+    );
+    assert_eq!(
+        workflow_state_terminal_state(GITHUB_ISSUE_PR_DEFINITION_ID, "passed"),
+        None
+    );
+    assert_eq!(
+        workflow_state_terminal_state(QUALITY_GATE_DEFINITION_ID, "done"),
+        None
+    );
+}
+
+#[test]
+fn registry_lists_only_known_definition_states() {
+    assert_eq!(
+        known_workflow_definition_ids(),
+        vec![
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            PROMPT_TASK_DEFINITION_ID,
+            QUALITY_GATE_DEFINITION_ID,
+            PR_FEEDBACK_DEFINITION_ID,
+        ]
+    );
+    assert!(workflow_states_for_definition("unknown_workflow").is_empty());
+    assert!(workflow_state_exists(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        "awaiting_feedback"
+    ));
+    assert!(!workflow_state_exists(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        "inspecting"
+    ));
+}
+
+#[test]
+fn registry_lists_terminal_state_names_by_definition() {
+    assert_eq!(
+        workflow_terminal_state_names_for_definition(GITHUB_ISSUE_PR_DEFINITION_ID),
+        vec!["done", "failed", "cancelled"]
+    );
+    assert_eq!(
+        workflow_terminal_state_names_for_definition(QUALITY_GATE_DEFINITION_ID),
+        vec!["passed", "failed", "cancelled"]
+    );
+    assert!(workflow_terminal_state_names_for_definition("unknown_workflow").is_empty());
+}
+
+#[test]
+fn registry_covers_validator_transition_states() {
+    let allowlists = [
+        (
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            TransitionAllowlist::github_issue_pr_defaults(),
+        ),
+        (
+            PROMPT_TASK_DEFINITION_ID,
+            TransitionAllowlist::prompt_task_defaults(),
+        ),
+        (
+            QUALITY_GATE_DEFINITION_ID,
+            TransitionAllowlist::quality_gate_defaults(),
+        ),
+        (
+            PR_FEEDBACK_DEFINITION_ID,
+            TransitionAllowlist::pr_feedback_defaults(),
+        ),
+    ];
+
+    for (definition_id, allowlist) in allowlists {
+        let definition = workflow_definition(definition_id)
+            .expect("built-in workflow definition should be registered");
+        for state in &definition.states {
+            assert!(
+                state.has_complete_progress_contract(),
+                "{definition_id}.{} must declare exactly one progress or terminal contract",
+                state.key.state
+            );
+        }
+        for rule in allowlist.rules() {
+            if let Some(from_state) = rule.from_state.as_deref() {
+                assert!(
+                    workflow_state_exists(definition_id, from_state),
+                    "{definition_id} missing from_state {from_state}"
+                );
+            }
+            assert!(
+                workflow_state_definition(definition_id, &rule.to_state)
+                    .is_some_and(|state| state.has_complete_progress_contract()),
+                "{definition_id} to_state {} is missing a complete contract",
+                rule.to_state,
+            );
+        }
+    }
+}
+
+#[test]
+fn progress_mode_lookup_fails_closed_for_terminal_and_unknown_states() {
+    assert_eq!(
+        workflow_state_progress_mode(GITHUB_ISSUE_PR_DEFINITION_ID, "implementing"),
+        Some(WorkflowProgressMode::CommandDriven)
+    );
+    assert_eq!(
+        workflow_state_progress_mode(GITHUB_ISSUE_PR_DEFINITION_ID, "done"),
+        None
+    );
+    assert_eq!(
+        workflow_state_progress_mode(GITHUB_ISSUE_PR_DEFINITION_ID, "unknown"),
+        None
+    );
+    assert_eq!(
+        workflow_state_progress_mode("unknown_definition", "implementing"),
+        None
+    );
+}
+
+#[test]
+fn state_key_clones_reuse_owned_string_allocations() {
+    let state = workflow_state_definition(PROMPT_TASK_DEFINITION_ID, "implementing")
+        .expect("prompt task implementing state should exist");
+    let cloned = state.key.clone();
+
+    assert!(Arc::ptr_eq(&state.key.definition_id, &cloned.definition_id));
+    assert!(Arc::ptr_eq(&state.key.state, &cloned.state));
+}
+
+#[test]
+fn duplicate_registration_fails_without_replacing_the_first_definition() {
+    let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+    let first = definition(
+        "fixture",
+        vec![active(
+            "fixture",
+            "pending",
+            WorkflowProgressMode::ExternalWait,
+        )],
+        TransitionAllowlist::default(),
+    );
+    let duplicate = definition(
+        "fixture",
+        vec![active(
+            "fixture",
+            "other",
+            WorkflowProgressMode::ExternalWait,
+        )],
+        TransitionAllowlist::default(),
+    );
+
+    registry
+        .register(first)
+        .expect("first registration should pass");
+    let error = registry
+        .register(duplicate)
+        .expect_err("duplicate registration should fail");
+
+    assert!(error.to_string().contains("already registered"));
+    assert!(registry
+        .definition("fixture")
+        .is_some_and(|definition| definition.states[0].key.state.as_ref() == "pending"));
+}
+
+#[test]
+fn freeze_is_idempotent_and_rejects_late_registration() {
+    let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+    registry.freeze();
+    registry.freeze();
+
+    let error = registry
+        .register(definition(
+            "late",
+            vec![active(
+                "late",
+                "pending",
+                WorkflowProgressMode::ExternalWait,
+            )],
+            TransitionAllowlist::default(),
+        ))
+        .expect_err("post-freeze registration should fail");
+
+    assert!(registry.is_frozen());
+    assert!(error.to_string().contains("is frozen"));
+    assert!(registry.definition("late").is_none());
+}
+
+#[test]
+fn registration_rejects_incomplete_or_conflicting_progress_contracts() {
+    let invalid_states = [
+        WorkflowStateDefinition {
+            key: WorkflowStateKey {
+                definition_id: Arc::from("fixture"),
+                state: Arc::from("missing"),
+            },
+            progress_mode: None,
+            terminal_state: None,
+        },
+        WorkflowStateDefinition {
+            key: WorkflowStateKey {
+                definition_id: Arc::from("fixture"),
+                state: Arc::from("conflicting"),
+            },
+            progress_mode: Some(WorkflowProgressMode::OperatorGate),
+            terminal_state: Some(WorkflowTerminalState::Failed),
+        },
+    ];
+
+    for state in invalid_states {
+        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+        let error = registry
+            .register(RegisteredWorkflowDefinition::new(
+                "fixture",
+                vec![state],
+                TransitionAllowlist::default(),
+            ))
+            .expect_err("invalid state contract should fail registration");
+
+        assert!(error.to_string().contains("exactly one"));
+        assert!(registry.definition("fixture").is_none());
+    }
+}
+
 const E: &str = "enqueue_activity";
 const S: &str = "start_child_workflow";
 const B: &str = "bind_pr";

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -5,7 +5,7 @@ use super::errors::RuntimeJobNotFoundError;
 use super::model::{
     ActivityResult, ActivityStatus, RuntimeEvent, RuntimeJob, RuntimeJobStatus, RuntimeKind,
     WorkflowCommand, WorkflowCommandRecord, WorkflowCommandType, WorkflowDecision,
-    WorkflowDecisionRecord, WorkflowDefinition, WorkflowEvent, WorkflowInstance, WorkflowLease,
+    WorkflowDecisionRecord, WorkflowEvent, WorkflowInstance, WorkflowLease,
 };
 use super::status::WorkflowCommandStatus;
 use super::store_migrations::WORKFLOW_RUNTIME_MIGRATIONS;
@@ -21,6 +21,8 @@ use std::path::Path;
 
 #[path = "store/commands.rs"]
 mod command_store;
+#[path = "store/definitions.rs"]
+mod definitions;
 #[path = "store/driverless_progress.rs"]
 mod driverless_progress;
 #[path = "store/instance_helpers.rs"]
@@ -246,42 +248,6 @@ impl WorkflowRuntimeStore {
     }
     pub fn pool(&self) -> &PgPool {
         &self.pool
-    }
-    pub async fn upsert_definition(&self, definition: &WorkflowDefinition) -> anyhow::Result<()> {
-        let data = to_jsonb_string(definition)?;
-        sqlx::query(
-            "INSERT INTO workflow_definitions (id, version, data, active)
-             VALUES ($1, $2, $3::jsonb, $4)
-             ON CONFLICT (id, version) DO UPDATE SET
-                data = EXCLUDED.data,
-                active = EXCLUDED.active,
-                updated_at = CURRENT_TIMESTAMP",
-        )
-        .bind(&definition.id)
-        .bind(definition.version as i64)
-        .bind(&data)
-        .bind(definition.active)
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
-    pub async fn get_definition(
-        &self,
-        id: &str,
-        version: u32,
-    ) -> anyhow::Result<Option<WorkflowDefinition>> {
-        let row: Option<(String,)> = sqlx::query_as(
-            "SELECT data::text FROM workflow_definitions
-             WHERE id = $1 AND version = $2",
-        )
-        .bind(id)
-        .bind(version as i64)
-        .fetch_optional(&self.pool)
-        .await?;
-        row.map(|(data,)| serde_json::from_str(&data))
-            .transpose()
-            .map_err(Into::into)
     }
     pub async fn upsert_prompt_payload(
         &self,

--- a/crates/harness-workflow/src/runtime/store/definitions.rs
+++ b/crates/harness-workflow/src/runtime/store/definitions.rs
@@ -1,0 +1,122 @@
+use super::{to_jsonb_string, WorkflowRuntimeStore};
+use crate::runtime::declarative_pinning::DECLARATIVE_DEFINITION_METADATA_KIND;
+use crate::runtime::model::WorkflowDefinition;
+
+impl WorkflowRuntimeStore {
+    pub async fn upsert_definition(&self, definition: &WorkflowDefinition) -> anyhow::Result<()> {
+        if is_declarative_definition(definition) {
+            return self.persist_definition_version(definition).await;
+        }
+        let data = to_jsonb_string(definition)?;
+        let upserted = sqlx::query(
+            "INSERT INTO workflow_definitions (id, version, data, active)
+             VALUES ($1, $2, $3::jsonb, $4)
+             ON CONFLICT (id, version) DO UPDATE SET
+                data = EXCLUDED.data,
+                active = EXCLUDED.active,
+                updated_at = CURRENT_TIMESTAMP
+             WHERE workflow_definitions.data->'metadata'->>'kind' IS DISTINCT FROM $5",
+        )
+        .bind(&definition.id)
+        .bind(definition.version as i64)
+        .bind(&data)
+        .bind(definition.active)
+        .bind(DECLARATIVE_DEFINITION_METADATA_KIND)
+        .execute(&self.pool)
+        .await?;
+        if upserted.rows_affected() == 0 {
+            anyhow::bail!(
+                "workflow definition '{}@{}' is an immutable declarative version and cannot be overwritten through upsert_definition",
+                definition.id,
+                definition.version
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn get_definition(
+        &self,
+        id: &str,
+        version: u32,
+    ) -> anyhow::Result<Option<WorkflowDefinition>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT data::text FROM workflow_definitions
+             WHERE id = $1 AND version = $2",
+        )
+        .bind(id)
+        .bind(version as i64)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|(data,)| serde_json::from_str(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub async fn persist_definition_version(
+        &self,
+        definition: &WorkflowDefinition,
+    ) -> anyhow::Result<()> {
+        let data = to_jsonb_string(definition)?;
+        let inserted = sqlx::query(
+            "INSERT INTO workflow_definitions (id, version, data, active)
+             VALUES ($1, $2, $3::jsonb, $4)
+             ON CONFLICT (id, version) DO NOTHING",
+        )
+        .bind(&definition.id)
+        .bind(definition.version as i64)
+        .bind(&data)
+        .bind(definition.active)
+        .execute(&self.pool)
+        .await?;
+        if inserted.rows_affected() == 1 {
+            return Ok(());
+        }
+
+        let existing = self
+            .get_definition(&definition.id, definition.version)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "workflow definition '{}@{}' conflicted but could not be reloaded",
+                    definition.id,
+                    definition.version
+                )
+            })?;
+        if existing.definition_hash != definition.definition_hash {
+            anyhow::bail!(
+                "workflow definition '{}@{}' version collision between hashes '{}' and '{}'",
+                definition.id,
+                definition.version,
+                existing.definition_hash,
+                definition.definition_hash
+            );
+        }
+        if existing != *definition {
+            anyhow::bail!(
+                "workflow definition '{}@{}' immutable payload conflicts with the persisted declarative version",
+                definition.id,
+                definition.version
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn list_definitions(&self) -> anyhow::Result<Vec<WorkflowDefinition>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT data::text FROM workflow_definitions ORDER BY id ASC, version ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|(data,)| serde_json::from_str(&data).map_err(Into::into))
+            .collect()
+    }
+}
+
+fn is_declarative_definition(definition: &WorkflowDefinition) -> bool {
+    definition
+        .metadata
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        == Some(DECLARATIVE_DEFINITION_METADATA_KIND)
+}

--- a/crates/harness-workflow/src/runtime/terminal_state.rs
+++ b/crates/harness-workflow/src/runtime/terminal_state.rs
@@ -4,6 +4,25 @@ pub fn workflow_terminal_state(definition_id: &str, state: &str) -> Option<Workf
     super::state_registry::workflow_state_terminal_state(definition_id, state)
 }
 
+pub fn workflow_terminal_state_for_version(
+    definition_id: &str,
+    definition_version: u32,
+    state: &str,
+) -> Option<WorkflowTerminalState> {
+    super::state_registry::workflow_state_terminal_state_for_version(
+        definition_id,
+        definition_version,
+        state,
+    )
+}
+
+pub fn workflow_terminal_state_for_instance(
+    instance: &super::model::WorkflowInstance,
+) -> Option<WorkflowTerminalState> {
+    super::state_registry::workflow_state_definition_for_instance(instance, &instance.state)?
+        .terminal_state
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -51,6 +51,8 @@ include!("tests/command_dispatcher.rs");
 include!("tests/command_store.rs");
 include!("tests/deferred_dispatch.rs");
 include!("tests/deferred_dispatch_review.rs");
+include!("tests/declarative_pinning.rs");
+include!("tests/declarative_validation.rs");
 include!("tests/driverless_progress.rs");
 
 mod issue_planning;

--- a/crates/harness-workflow/src/runtime/tests/declarative_pinning.rs
+++ b/crates/harness-workflow/src/runtime/tests/declarative_pinning.rs
@@ -1,0 +1,360 @@
+mod declarative_pinning {
+    use super::super::*;
+    use harness_core::config::workflow::{
+        DeclaredProgressMode, DeclaredState, WorkflowActivityPolicy, WorkflowDefinitionPolicy,
+    };
+    use harness_core::db::resolve_database_url;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn activity_policies() -> BTreeMap<String, WorkflowActivityPolicy> {
+        BTreeMap::from([("review".to_string(), WorkflowActivityPolicy::default())])
+    }
+
+    fn policy_v1() -> WorkflowDefinitionPolicy {
+        WorkflowDefinitionPolicy {
+            id: "docs_review".to_string(),
+            initial: "reviewing".to_string(),
+            states: BTreeMap::from([
+                (
+                    "blocked".to_string(),
+                    DeclaredState {
+                        progress: Some(DeclaredProgressMode::OperatorGate),
+                        ..DeclaredState::default()
+                    },
+                ),
+                (
+                    "reviewing".to_string(),
+                    DeclaredState {
+                        activity: Some("review".to_string()),
+                        on_success: Some("done".to_string()),
+                        on_failure: Some("failed".to_string()),
+                        on_signal: BTreeMap::from([(
+                            "cancel".to_string(),
+                            "cancelled".to_string(),
+                        )]),
+                        ..DeclaredState::default()
+                    },
+                ),
+            ]),
+            terminal: BTreeMap::from([
+                ("cancelled".to_string(), "cancelled".to_string()),
+                ("done".to_string(), "succeeded".to_string()),
+                ("failed".to_string(), "failed".to_string()),
+            ]),
+            evidence_required: BTreeMap::from([(
+                "done".to_string(),
+                vec!["review_report".to_string()],
+            )]),
+            recovery_targets: vec!["reviewing".to_string()],
+        }
+    }
+
+    fn policy_v2() -> WorkflowDefinitionPolicy {
+        let mut policy = policy_v1();
+        policy
+            .states
+            .get_mut("reviewing")
+            .expect("fixture reviewing state should exist")
+            .on_success = Some("completed".to_string());
+        let reviewing = policy
+            .states
+            .get_mut("reviewing")
+            .expect("fixture reviewing state should exist");
+        reviewing.activity = None;
+        reviewing.progress = Some(DeclaredProgressMode::ExternalWait);
+        policy.terminal.remove("done");
+        policy
+            .terminal
+            .insert("completed".to_string(), "succeeded".to_string());
+        policy.evidence_required.remove("done");
+        policy.evidence_required.insert(
+            "completed".to_string(),
+            vec!["review_report".to_string()],
+        );
+        policy
+    }
+
+    fn compiled(policy: &WorkflowDefinitionPolicy) -> DeclarativeWorkflowDefinition {
+        build_declarative_definition(policy, &activity_policies())
+            .expect("fixture declaration should compile")
+    }
+
+    #[test]
+    fn canonical_identity_uses_lower_sha256_bits_and_roundtrips_strictly() {
+        let definition = compiled(&policy_v1());
+        let suffix = definition
+            .definition_hash()
+            .get(definition.definition_hash().len() - 8..)
+            .expect("sha256 hash should have an eight-character suffix");
+        assert_eq!(
+            definition.definition_version(),
+            u32::from_str_radix(suffix, 16).expect("hash suffix should be hexadecimal")
+        );
+
+        let persisted = persisted_declarative_definition(&definition, Some("/repo/WORKFLOW.md"));
+        assert_eq!(persisted.source_path.as_deref(), Some("/repo/WORKFLOW.md"));
+        assert_eq!(persisted.definition_hash, definition.definition_hash());
+        assert_eq!(
+            hydrate_declarative_definition(&persisted, &activity_policies())
+                .expect("canonical persisted declaration should hydrate"),
+            definition
+        );
+
+        let mut wrong_hash = persisted.clone();
+        wrong_hash.definition_hash = "sha256:wrong".to_string();
+        assert!(hydrate_declarative_definition(&wrong_hash, &activity_policies())
+            .expect_err("hash mismatch must fail closed")
+            .to_string()
+            .contains("does not match canonical policy hash"));
+
+        let mut wrong_version = persisted;
+        wrong_version.version ^= 1;
+        assert!(hydrate_declarative_definition(&wrong_version, &activity_policies())
+            .expect_err("version mismatch must fail closed")
+            .to_string()
+            .contains("does not match canonical policy version"));
+    }
+
+    #[test]
+    fn registry_preserves_historical_shapes_and_fails_closed_for_missing_versions() {
+        let v1 = compiled(&policy_v1());
+        let v2 = compiled(&policy_v2());
+        assert_ne!(v1.definition_version(), v2.definition_version());
+
+        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+        registry
+            .register_declarative_historical(v1.clone())
+            .expect("v1 history should register");
+        registry
+            .register_declarative_current(v2.clone())
+            .expect("v2 current should register");
+
+        assert_eq!(
+            registry
+                .state_definition_for_version("docs_review", v1.definition_version(), "done")
+                .and_then(|state| state.terminal_state),
+            Some(WorkflowTerminalState::Succeeded)
+        );
+        assert_eq!(
+            registry
+                .state_definition_for_version(
+                    "docs_review",
+                    v1.definition_version(),
+                    "reviewing",
+                )
+                .and_then(|state| state.progress_mode),
+            Some(WorkflowProgressMode::CommandDriven)
+        );
+        assert_eq!(
+            registry
+                .state_definition_for_version(
+                    "docs_review",
+                    v2.definition_version(),
+                    "reviewing",
+                )
+                .and_then(|state| state.progress_mode),
+            Some(WorkflowProgressMode::ExternalWait)
+        );
+        let v1_instance = WorkflowInstance::new(
+            "docs_review",
+            v1.definition_version(),
+            "done",
+            WorkflowSubject::new("document", "one"),
+        )
+        .with_data(json!({ "definition_hash": v1.definition_hash() }));
+        let v2_instance = WorkflowInstance::new(
+            "docs_review",
+            v2.definition_version(),
+            "done",
+            WorkflowSubject::new("document", "two"),
+        )
+        .with_data(json!({ "definition_hash": v2.definition_hash() }));
+        assert_eq!(
+            registry
+                .state_definition_for_instance(&v1_instance, "done")
+                .and_then(|state| state.terminal_state),
+            Some(WorkflowTerminalState::Succeeded),
+        );
+        assert!(registry
+            .state_definition_for_instance(&v2_instance, "done")
+            .is_none());
+        let mismatched_hash = WorkflowInstance::new(
+            "docs_review",
+            v1.definition_version(),
+            "done",
+            WorkflowSubject::new("document", "mismatch"),
+        )
+        .with_data(json!({ "definition_hash": v2.definition_hash() }));
+        assert!(registry
+            .state_definition_for_instance(&mismatched_hash, "done")
+            .is_none());
+        assert!(registry
+            .state_definition_for_version("docs_review", v2.definition_version(), "done")
+            .is_none());
+        assert_eq!(
+            registry
+                .state_definition_for_version(
+                    "docs_review",
+                    v2.definition_version(),
+                    "completed",
+                )
+                .and_then(|state| state.terminal_state),
+            Some(WorkflowTerminalState::Succeeded)
+        );
+        assert!(registry
+            .definition_for_version("docs_review", u32::MAX)
+            .is_none());
+        let missing_unmarked_version = WorkflowInstance::new(
+            "docs_review",
+            u32::MAX,
+            "completed",
+            WorkflowSubject::new("document", "missing-unmarked"),
+        );
+        assert!(registry
+            .state_definition_for_instance(&missing_unmarked_version, "completed")
+            .is_none());
+        assert!(workflow_definition_for_version(GITHUB_ISSUE_PR_DEFINITION_ID, u32::MAX).is_some());
+
+        let mut raw_registry = WorkflowDefinitionRegistry::new_for_tests();
+        raw_registry
+            .register(RegisteredWorkflowDefinition::new(
+                "docs_review",
+                v1.registered().states.clone(),
+                v1.registered().allowlist.clone(),
+            ))
+            .expect("raw compatibility definition should register");
+        let raw_instance = WorkflowInstance::new(
+            "docs_review",
+            u32::MAX,
+            "done",
+            WorkflowSubject::new("document", "raw"),
+        );
+        assert!(raw_registry
+            .state_definition_for_instance(&raw_instance, "done")
+            .is_some());
+        let missing_pinned_version = raw_instance
+            .clone()
+            .with_data(json!({ "definition_hash": v1.definition_hash() }));
+        assert!(raw_registry
+            .state_definition_for_instance(&missing_pinned_version, "done")
+            .is_none());
+    }
+
+    #[test]
+    fn registry_batch_failure_and_namespace_collision_leave_state_unchanged() {
+        let v1 = compiled(&policy_v1());
+        let v2 = compiled(&policy_v2());
+        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+        let error = registry
+            .register_declarative_current_batch([v1.clone(), v2.clone()])
+            .expect_err("duplicate current ids in one batch must fail");
+        assert!(error.to_string().contains("already registered as current"));
+        assert!(registry.definition("docs_review").is_none());
+        assert!(registry
+            .declarative_definition("docs_review", v1.definition_version())
+            .is_none());
+
+        registry
+            .register_declarative_historical(v1.clone())
+            .expect("first historical version should register");
+        let raw_collision = RegisteredWorkflowDefinition::new(
+            "docs_review",
+            v1.registered().states.clone(),
+            v1.registered().allowlist.clone(),
+        );
+        assert!(registry
+            .register(raw_collision)
+            .expect_err("raw current registration must not shadow declarative history")
+            .to_string()
+            .contains("registered declarative history"));
+        assert_eq!(
+            registry
+                .declarative_definition("docs_review", v1.definition_version())
+                .expect("original historical version should remain")
+                .definition_hash(),
+            v1.definition_hash()
+        );
+    }
+
+    #[tokio::test]
+    async fn durable_versions_roundtrip_and_reject_hash_collisions() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&dir.path().join("declarative-pinning.db")).await?;
+        let v1 = compiled(&policy_v1());
+        let v2 = compiled(&policy_v2());
+        let mut persisted_v1 = persisted_declarative_definition(&v1, Some("/repo/v1/WORKFLOW.md"));
+        persisted_v1.active = false;
+        let persisted_v2 = persisted_declarative_definition(&v2, Some("/repo/WORKFLOW.md"));
+        store.persist_definition_version(&persisted_v1).await?;
+        store.persist_definition_version(&persisted_v2).await?;
+
+        let persisted = store.list_definitions().await?;
+        assert_eq!(persisted.len(), 2);
+        let loaded_v1 = persisted
+            .iter()
+            .find(|definition| definition.version == v1.definition_version())
+            .expect("persisted v1 should be listed");
+        let loaded_v2 = persisted
+            .iter()
+            .find(|definition| definition.version == v2.definition_version())
+            .expect("persisted v2 should be listed");
+        let hydrated_v1 = hydrate_declarative_definition(loaded_v1, &activity_policies())?;
+        let hydrated_v2 = hydrate_declarative_definition(loaded_v2, &activity_policies())?;
+        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+        registry.register_declarative_historical(hydrated_v1)?;
+        registry.register_declarative_current(hydrated_v2)?;
+        assert!(registry
+            .declarative_definition("docs_review", v1.definition_version())
+            .is_some());
+        assert_eq!(
+            registry
+                .current_declarative_definition("docs_review")
+                .expect("v2 should remain current")
+                .definition_version(),
+            v2.definition_version()
+        );
+
+        let mut same_hash_different_metadata = persisted_v1.clone();
+        same_hash_different_metadata
+            .metadata
+            .as_object_mut()
+            .expect("declarative metadata should be an object")
+            .insert("tampered".to_string(), json!(true));
+        let error = store
+            .persist_definition_version(&same_hash_different_metadata)
+            .await
+            .expect_err("same hash with different metadata must remain immutable");
+        assert!(error.to_string().contains("immutable payload conflicts"));
+
+        let mut mutable_upsert = persisted_v1.clone();
+        mutable_upsert.name = "Mutable overwrite".to_string();
+        mutable_upsert.metadata = json!({ "kind": "generic" });
+        let error = store
+            .upsert_definition(&mutable_upsert)
+            .await
+            .expect_err("generic upsert must not overwrite a declarative row");
+        assert!(error.to_string().contains("cannot be overwritten"));
+
+        let mut collision = persisted_v1.clone();
+        collision.definition_hash = "sha256:different".to_string();
+        let error = store
+            .persist_definition_version(&collision)
+            .await
+            .expect_err("durable version collision must fail");
+        assert!(error.to_string().contains("version collision"));
+        assert_eq!(
+            store
+                .get_definition("docs_review", v1.definition_version())
+                .await?
+                .expect("original durable version should remain")
+                .definition_hash,
+            persisted_v1.definition_hash
+        );
+        Ok(())
+    }
+}

--- a/crates/harness-workflow/src/runtime/tests/declarative_validation.rs
+++ b/crates/harness-workflow/src/runtime/tests/declarative_validation.rs
@@ -1,0 +1,295 @@
+mod declarative_validation {
+    use super::super::*;
+    use harness_core::config::workflow::{
+        DeclaredProgressMode, DeclaredState, WorkflowActivityPolicy, WorkflowDefinitionPolicy,
+    };
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn activity_state(on_success: impl Into<String>) -> DeclaredState {
+        DeclaredState {
+            activity: Some("implement".to_string()),
+            on_success: Some(on_success.into()),
+            on_failure: Some("failed".to_string()),
+            on_signal: BTreeMap::from([("cancel".to_string(), "cancelled".to_string())]),
+            ..DeclaredState::default()
+        }
+    }
+
+    fn valid_policy() -> WorkflowDefinitionPolicy {
+        WorkflowDefinitionPolicy {
+            id: "docs_review".to_string(),
+            initial: "reviewing".to_string(),
+            states: BTreeMap::from([
+                (
+                    "blocked".to_string(),
+                    DeclaredState {
+                        progress: Some(DeclaredProgressMode::OperatorGate),
+                        ..DeclaredState::default()
+                    },
+                ),
+                ("reviewing".to_string(), activity_state("done")),
+            ]),
+            terminal: BTreeMap::from([
+                ("cancelled".to_string(), "cancelled".to_string()),
+                ("done".to_string(), "succeeded".to_string()),
+                ("failed".to_string(), "failed".to_string()),
+            ]),
+            evidence_required: BTreeMap::from([(
+                "done".to_string(),
+                vec!["review_report".to_string()],
+            )]),
+            recovery_targets: vec!["reviewing".to_string()],
+        }
+    }
+
+    fn activity_policies() -> BTreeMap<String, WorkflowActivityPolicy> {
+        BTreeMap::from([("implement".to_string(), WorkflowActivityPolicy::default())])
+    }
+
+    fn error_for(policy: &WorkflowDefinitionPolicy) -> String {
+        build_declarative_definition(policy, &activity_policies())
+            .expect_err("declaration should be invalid")
+            .to_string()
+    }
+
+    #[test]
+    fn compiles_valid_definition_without_registration_side_effects() {
+        let policy = valid_policy();
+        let compiled = build_declarative_definition(&policy, &activity_policies())
+            .expect("valid declaration should compile");
+
+        assert_eq!(compiled.registered().id, "docs_review");
+        assert_eq!(compiled.policy(), &policy);
+        assert_eq!(compiled.registered().states.len(), 5);
+        assert_eq!(
+            compiled
+                .registered()
+                .allowlist
+                .rule_for("reviewing", "done")
+                .expect("declared transition should be compiled")
+                .allowed_commands,
+            BTreeSet::from([WorkflowCommandType::MarkDone])
+        );
+        assert_eq!(
+            compiled
+                .registered()
+                .allowlist
+                .rule_for("reviewing", "blocked")
+                .expect("blocked fallback should be compiled")
+                .allowed_commands,
+            BTreeSet::from([
+                WorkflowCommandType::MarkBlocked,
+                WorkflowCommandType::Wait,
+                WorkflowCommandType::RequestOperatorAttention,
+            ])
+        );
+        assert!(workflow_definition("docs_review").is_none());
+    }
+
+    #[test]
+    fn rejects_builtin_id_collision() {
+        let mut policy = valid_policy();
+        policy.id = PROMPT_TASK_DEFINITION_ID.to_string();
+        assert!(error_for(&policy).contains("collides with a built-in definition"));
+    }
+
+    #[test]
+    fn rejects_empty_declarations_and_invalid_initial_state() {
+        let mut empty_active = valid_policy();
+        empty_active.states.clear();
+        assert!(error_for(&empty_active).contains("at least one active state"));
+
+        let mut empty_terminal = valid_policy();
+        empty_terminal.terminal.clear();
+        assert!(error_for(&empty_terminal).contains("must declare terminal states"));
+
+        let mut missing_initial = valid_policy();
+        missing_initial.initial = "missing".to_string();
+        assert!(error_for(&missing_initial).contains("is not declared as an active state"));
+
+        let mut terminal_initial = valid_policy();
+        terminal_initial.initial = "done".to_string();
+        assert!(error_for(&terminal_initial).contains("must be active, not terminal"));
+    }
+
+    #[test]
+    fn rejects_namespace_overlap_and_invalid_blocked_state() {
+        let mut overlap = valid_policy();
+        overlap
+            .terminal
+            .insert("blocked".to_string(), "succeeded".to_string());
+        overlap
+            .terminal
+            .insert("done".to_string(), "failed".to_string());
+        overlap
+            .terminal
+            .insert("failed".to_string(), "cancelled".to_string());
+        overlap.terminal.remove("cancelled");
+        assert!(error_for(&overlap).contains("both active and terminal namespaces"));
+
+        let mut missing_blocked = valid_policy();
+        missing_blocked.states.remove("blocked");
+        assert!(error_for(&missing_blocked).contains("must declare active state 'blocked'"));
+
+        let mut wrong_blocked = valid_policy();
+        wrong_blocked.states.insert(
+            "blocked".to_string(),
+            DeclaredState {
+                progress: Some(DeclaredProgressMode::ExternalWait),
+                ..DeclaredState::default()
+            },
+        );
+        assert!(error_for(&wrong_blocked).contains("progress 'operator_gate'"));
+    }
+
+    #[test]
+    fn rejects_incomplete_or_duplicate_terminal_mapping() {
+        let mut missing = valid_policy();
+        missing.terminal.remove("failed");
+        assert!(error_for(&missing).contains("missing terminal class 'failed'"));
+
+        let mut duplicate = valid_policy();
+        duplicate
+            .terminal
+            .insert("also_done".to_string(), "succeeded".to_string());
+        assert!(error_for(&duplicate).contains("terminal class 'succeeded' is assigned to both"));
+
+        let mut unknown = valid_policy();
+        unknown
+            .terminal
+            .insert("failed".to_string(), "aborted".to_string());
+        assert!(error_for(&unknown).contains("unknown class 'aborted'"));
+    }
+
+    #[test]
+    fn rejects_missing_or_dual_progress_mode_and_unknown_activity() {
+        let mut missing = valid_policy();
+        missing
+            .states
+            .insert("reviewing".to_string(), DeclaredState::default());
+        assert!(error_for(&missing).contains("exactly one of activity or progress"));
+
+        let mut dual = valid_policy();
+        dual.states.get_mut("reviewing").unwrap().progress =
+            Some(DeclaredProgressMode::ExternalWait);
+        assert!(error_for(&dual).contains("exactly one of activity or progress"));
+
+        let mut unknown_activity = valid_policy();
+        unknown_activity
+            .states
+            .get_mut("reviewing")
+            .unwrap()
+            .activity = Some("missing_policy".to_string());
+        assert!(
+            error_for(&unknown_activity).contains("absent from the workflow activities policy map")
+        );
+    }
+
+    #[test]
+    fn rejects_undeclared_transition_and_evidence_targets() {
+        let mut transition = valid_policy();
+        transition.states.get_mut("reviewing").unwrap().on_failure = Some("missing".to_string());
+        let error = error_for(&transition);
+        assert!(
+            error.contains("active state 'reviewing' on_failure target 'missing' is undeclared")
+        );
+
+        let mut evidence = valid_policy();
+        evidence
+            .evidence_required
+            .insert("missing".to_string(), vec!["report".to_string()]);
+        assert!(
+            error_for(&evidence).contains("evidence requirement target 'missing' is undeclared")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_recovery_targets() {
+        let mut terminal = valid_policy();
+        terminal.recovery_targets = vec!["done".to_string()];
+        assert!(error_for(&terminal).contains("must name an active state, but it is terminal"));
+
+        let mut missing = valid_policy();
+        missing.recovery_targets = vec!["missing".to_string()];
+        assert!(error_for(&missing).contains("must name an active state, but it is undeclared"));
+
+        let mut duplicate = valid_policy();
+        duplicate.recovery_targets = vec!["reviewing".to_string(), "reviewing".to_string()];
+        assert!(error_for(&duplicate).contains("is declared more than once"));
+    }
+
+    #[test]
+    fn rejects_unreachable_active_and_terminal_states() {
+        let mut active = valid_policy();
+        active.states.insert(
+            "orphan".to_string(),
+            DeclaredState {
+                progress: Some(DeclaredProgressMode::ExternalWait),
+                ..DeclaredState::default()
+            },
+        );
+        assert!(error_for(&active)
+            .contains("states unreachable from initial state 'reviewing': orphan"));
+
+        let mut terminal = valid_policy();
+        terminal
+            .terminal
+            .insert("unused".to_string(), "succeeded".to_string());
+        terminal.terminal.remove("done");
+        terminal.states.get_mut("reviewing").unwrap().on_success = Some("failed".to_string());
+        terminal.evidence_required =
+            BTreeMap::from([("unused".to_string(), vec!["review_report".to_string()])]);
+        let error = error_for(&terminal);
+        assert!(
+            error.contains("states unreachable from initial state 'reviewing': unused"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn compiles_deterministic_signal_edges_and_target_driver_commands() {
+        let mut policy = valid_policy();
+        policy.states.insert(
+            "waiting".to_string(),
+            DeclaredState {
+                progress: Some(DeclaredProgressMode::ExternalWait),
+                on_success: Some("failed".to_string()),
+                ..DeclaredState::default()
+            },
+        );
+        let reviewing = policy.states.get_mut("reviewing").unwrap();
+        reviewing.on_success = Some("waiting".to_string());
+        reviewing.on_blocked = Some("blocked".to_string());
+        reviewing
+            .on_signal
+            .insert("approved".to_string(), "done".to_string());
+
+        let compiled = build_declarative_definition(&policy, &activity_policies()).unwrap();
+        let allowlist = &compiled.registered().allowlist;
+        assert_eq!(
+            allowlist
+                .rule_for("reviewing", "waiting")
+                .unwrap()
+                .allowed_commands,
+            BTreeSet::from([WorkflowCommandType::Wait])
+        );
+        assert_eq!(
+            allowlist
+                .rule_for("reviewing", "done")
+                .unwrap()
+                .allowed_commands,
+            BTreeSet::from([WorkflowCommandType::MarkDone])
+        );
+        assert_eq!(
+            allowlist
+                .rule_for("reviewing", "blocked")
+                .unwrap()
+                .allowed_commands,
+            BTreeSet::from([
+                WorkflowCommandType::MarkBlocked,
+                WorkflowCommandType::RequestOperatorAttention,
+                WorkflowCommandType::Wait,
+            ])
+        );
+    }
+}

--- a/crates/harness-workflow/src/runtime/validator_progress.rs
+++ b/crates/harness-workflow/src/runtime/validator_progress.rs
@@ -6,7 +6,9 @@ pub(super) fn validate_target_progress_contract(
     instance: &WorkflowInstance,
     decision: &WorkflowDecision,
 ) -> Result<(), WorkflowDecisionRejection> {
-    if !state_registry::workflow_state_exists(&instance.definition_id, &decision.next_state) {
+    if state_registry::workflow_state_definition_for_instance(instance, &decision.next_state)
+        .is_none()
+    {
         return Err(WorkflowDecisionRejection::new(
             WorkflowDecisionRejectionKind::TransitionNotAllowed,
             format!(
@@ -16,7 +18,8 @@ pub(super) fn validate_target_progress_contract(
         ));
     }
     let progress_mode =
-        state_registry::workflow_state_progress_mode(&instance.definition_id, &decision.next_state);
+        state_registry::workflow_state_definition_for_instance(instance, &decision.next_state)
+            .and_then(|state| state.progress_mode);
     let has_driver = decision
         .commands
         .iter()


### PR DESCRIPTION
Refs #1609

## Summary

Land the inert foundation for WORKFLOW.md declarative workflow definitions (SP1609-T001, T002, and the version/persistence half of T003).

- parse an optional atomic `definition` block without changing existing WORKFLOW.md behavior
- validate/compile state graphs, terminal classes, progress ownership, activities, recovery targets, reachability, and deterministic signal routes
- derive canonical SHA-256 identity with a lower-32-bit `definition_version`
- retain current and historical versions in the registry with atomic batch registration and collision guards
- persist/hydrate immutable historical declarations with strict full-hash and payload checks
- resolve terminal/progress state through the instance's pinned version/full hash while preserving built-in/static compatibility

This PR intentionally does not register declarations at server startup, expose submission, or enable the interpreter. Those remain unreachable until the follow-up runtime and server slices.

## Verification

- `cargo test --workspace -- --test-threads=1`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1609`
- `python3 checks/check_workflow.py --repo .`

Independent exact-head review: PASS with no findings after resolving opaque-compiler, durable-immutability, and fail-closed lookup findings.
