### PR TITLE
fix(workflow): preserve static definition lookup

### DIFF
--- a/crates/harness-workflow/src/runtime/state_registry/versioning.rs
+++ b/crates/harness-workflow/src/runtime/state_registry/versioning.rs
@@ -171,6 +171,14 @@ impl WorkflowDefinitionRegistry {
         &self,
         instance: &WorkflowInstance,
     ) -> Option<Arc<RegisteredWorkflowDefinition>> {
+        if self.definitions.contains_key(&instance.definition_id)
+            && !self
+                .current_declarative_versions
+                .contains_key(&instance.definition_id)
+        {
+            return self.definition(&instance.definition_id);
+        }
+
         match instance.data.get("definition_hash") {
             Some(serde_json::Value::String(expected_hash)) if !expected_hash.trim().is_empty() => {
                 let definition = self
@@ -187,13 +195,7 @@ impl WorkflowDefinitionRegistry {
                 {
                     return Some(Arc::new(definition.registered().clone()));
                 }
-                if self
-                    .current_declarative_versions
-                    .contains_key(&instance.definition_id)
-                {
-                    return None;
-                }
-                self.definition(&instance.definition_id)
+                None
             }
         }
     }

--- a/crates/harness-workflow/src/runtime/tests/declarative_pinning.rs
+++ b/crates/harness-workflow/src/runtime/tests/declarative_pinning.rs
@@ -215,6 +215,18 @@ mod declarative_pinning {
             .state_definition_for_instance(&missing_unmarked_version, "completed")
             .is_none());
         assert!(workflow_definition_for_version(GITHUB_ISSUE_PR_DEFINITION_ID, u32::MAX).is_some());
+        let builtin_with_unrelated_hash = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            u32::MAX,
+            "done",
+            WorkflowSubject::new("issue", "1609"),
+        )
+        .with_data(json!({ "definition_hash": "unrelated-business-metadata" }));
+        assert_eq!(
+            workflow_state_definition_for_instance(&builtin_with_unrelated_hash, "done")
+                .and_then(|state| state.terminal_state),
+            Some(WorkflowTerminalState::Succeeded),
+        );
 
         let mut raw_registry = WorkflowDefinitionRegistry::new_for_tests();
         raw_registry
@@ -233,12 +245,12 @@ mod declarative_pinning {
         assert!(raw_registry
             .state_definition_for_instance(&raw_instance, "done")
             .is_some());
-        let missing_pinned_version = raw_instance
+        let raw_with_unrelated_hash = raw_instance
             .clone()
             .with_data(json!({ "definition_hash": v1.definition_hash() }));
         assert!(raw_registry
-            .state_definition_for_instance(&missing_pinned_version, "done")
-            .is_none());
+            .state_definition_for_instance(&raw_with_unrelated_hash, "done")
+            .is_some());
     }
 
     #[test]


### PR DESCRIPTION
Issue: #1609

## Summary

Follow up on #1627 by preserving built-in and raw static workflow lookup when instance data contains an unrelated `definition_hash` key. Only registered declarative definition ids interpret that field as version-pinning evidence.

This keeps current declarative and historical-only declarative definitions fail-closed while restoring B-006 compatibility for built-in workflows.

## Verification

- `cargo test -p harness-workflow registry_preserves_historical_shapes_and_fails_closed_for_missing_versions --lib`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`

Independent exact-head review: PASS with no findings.