### PR TITLE
fix(workflow): harden declarative runtime submissions

### DIFF
--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -380,6 +380,15 @@ impl DefaultExecutionService {
                     "definition_id must not be empty".to_string(),
                 ));
             }
+            if req
+                .prompt
+                .as_deref()
+                .is_none_or(|prompt| prompt.trim().is_empty())
+            {
+                return Err(EnqueueTaskError::BadRequest(
+                    "declarative workflow submissions require a non-empty prompt".to_string(),
+                ));
+            }
             if req.issue.is_some() || req.pr.is_some() {
                 return Err(EnqueueTaskError::BadRequest(
                     "declarative workflow submissions cannot include issue or pr".to_string(),
@@ -861,7 +870,11 @@ impl DefaultExecutionService {
                 project_root,
                 definition_id,
                 task_id: &task_id,
-                prompt: prepared.req.prompt.as_deref().unwrap_or_default(),
+                prompt: prepared.req.prompt.as_deref().ok_or_else(|| {
+                    EnqueueTaskError::BadRequest(
+                        "declarative workflow submissions require a non-empty prompt".to_string(),
+                    )
+                })?,
                 depends_on: &prepared.req.depends_on,
                 serialization_depends_on: &prepared.req.serialization_depends_on,
                 source: prepared.req.source.as_deref(),
@@ -1398,3 +1411,7 @@ mod tests;
 #[cfg(test)]
 #[path = "execution_continuation_tests.rs"]
 mod continuation_tests;
+
+#[cfg(test)]
+#[path = "execution_declarative_tests.rs"]
+mod declarative_tests;

--- a/crates/harness-server/src/services/execution_declarative_tests.rs
+++ b/crates/harness-server/src/services/execution_declarative_tests.rs
@@ -1,0 +1,18 @@
+use super::*;
+
+#[test]
+fn declarative_submission_requires_a_non_empty_prompt() {
+    for prompt in [None, Some("   ".to_string())] {
+        let request = CreateTaskRequest {
+            definition_id: Some("docs_review".to_string()),
+            prompt,
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            DefaultExecutionService::validate_request(&request),
+            Err(EnqueueTaskError::BadRequest(message))
+                if message == "declarative workflow submissions require a non-empty prompt"
+        ));
+    }
+}

--- a/crates/harness-server/src/workflow_runtime_submission.rs
+++ b/crates/harness-server/src/workflow_runtime_submission.rs
@@ -242,17 +242,41 @@ fn prompt_submission_dependency_ids(ctx: &PromptSubmissionRuntimeContext<'_>) ->
 
 async fn commit_runtime_decision(
     store: &WorkflowRuntimeStore,
-    mut instance: WorkflowInstance,
+    instance: WorkflowInstance,
     decision: WorkflowDecision,
     event_id: String,
     accepted_data: Option<serde_json::Value>,
 ) -> anyhow::Result<WorkflowInstance> {
-    let validation_context = if instance.is_terminal() {
+    let validator = decision_validator_for_instance(&instance)?;
+    commit_runtime_decision_with_validator(
+        store,
+        instance,
+        decision,
+        event_id,
+        accepted_data,
+        validator,
+        false,
+    )
+    .await
+}
+
+async fn commit_runtime_decision_with_validator(
+    store: &WorkflowRuntimeStore,
+    mut instance: WorkflowInstance,
+    decision: WorkflowDecision,
+    event_id: String,
+    accepted_data: Option<serde_json::Value>,
+    validator: DecisionValidator,
+    allow_missing_pinned_cancel: bool,
+) -> anyhow::Result<WorkflowInstance> {
+    let mut validation_context = if instance.is_terminal() {
         ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
     } else {
         ValidationContext::new("workflow-policy", chrono::Utc::now())
     };
-    let validator = decision_validator_for_instance(&instance)?;
+    if allow_missing_pinned_cancel {
+        validation_context = validation_context.allow_missing_pinned_cancel();
+    }
     if let Err(error) = validator.validate(&instance, &decision, &validation_context) {
         let reason = error.to_string();
         let record = WorkflowDecisionRecord::rejected(decision, Some(event_id), &reason);
@@ -283,7 +307,15 @@ fn decision_validator_for_instance(
     match instance.definition_id.as_str() {
         GITHUB_ISSUE_PR_DEFINITION_ID => Ok(DecisionValidator::github_issue_pr()),
         PROMPT_TASK_DEFINITION_ID => Ok(DecisionValidator::prompt_task()),
-        other => anyhow::bail!("workflow definition `{other}` cannot be committed by submission"),
+        other => harness_workflow::runtime::decision_validator_for_instance(instance)
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "workflow definition `{other}` has an invalid definition pin: {error:?}"
+                )
+            })?
+            .ok_or_else(|| {
+                anyhow::anyhow!("workflow definition `{other}` cannot be committed by submission")
+            }),
     }
 }
 
@@ -663,6 +695,9 @@ mod identity_tests;
 #[path = "workflow_runtime_submission/dependency_tests.rs"]
 mod dependency_tests;
 
+#[cfg(test)]
+#[path = "workflow_runtime_submission/declarative_cancel_tests.rs"]
+mod declarative_cancel_tests;
 #[cfg(test)]
 #[path = "workflow_runtime_submission/declarative_tests.rs"]
 mod declarative_tests;

--- a/crates/harness-server/src/workflow_runtime_submission/cancel.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/cancel.rs
@@ -1,15 +1,24 @@
+use harness_core::config::workflow::{WorkflowActivityPolicy, WorkflowDefinitionPolicy};
 use harness_workflow::runtime::{
-    WorkflowCommand, WorkflowCommandStatus, WorkflowCommandType, WorkflowDecision,
-    WorkflowInstance, WorkflowRuntimeStore, PROMPT_TASK_DEFINITION_ID,
+    build_declarative_definition, resolve_declarative_definition, DecisionValidator,
+    DeclarativeDefinitionResolution, WorkflowCommand, WorkflowCommandStatus, WorkflowCommandType,
+    WorkflowDecision, WorkflowInstance, WorkflowRuntimeStore, PROMPT_TASK_DEFINITION_ID,
 };
 use serde_json::json;
+use std::collections::BTreeMap;
 use std::fmt;
 
 use super::prompt_memory::remove_prompt_submission_prompt_durable;
 use super::{
-    commit_runtime_decision, optional_string_field, runtime_issue_task_handle, set_data_bool,
-    GITHUB_ISSUE_PR_DEFINITION_ID,
+    commit_runtime_decision, commit_runtime_decision_with_validator, optional_string_field,
+    runtime_issue_task_handle, set_data_bool, GITHUB_ISSUE_PR_DEFINITION_ID,
 };
+
+struct DeclarativeCancellation {
+    target_state: String,
+    validator: DecisionValidator,
+    missing_pin: bool,
+}
 
 #[derive(Debug, Clone)]
 pub(crate) enum RuntimeSubmissionCancelOutcome {
@@ -86,31 +95,46 @@ async fn cancel_submission_instance(
         return Ok(RuntimeSubmissionCancelOutcome::AlreadyTerminal(instance));
     }
     let is_prompt = instance.definition_id == PROMPT_TASK_DEFINITION_ID;
-    if !is_prompt && instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID {
-        return Err(RuntimeSubmissionCancelError::UnsupportedDefinition {
-            definition_id: instance.definition_id,
-        });
-    }
-    let event_type = if is_prompt {
-        "PromptSubmissionCancelled"
+    let is_issue = instance.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID;
+    let declarative = if is_prompt || is_issue {
+        None
     } else {
-        "IssueSubmissionCancelled"
+        resolve_declarative_cancellation(store, &instance).await?
     };
-    let decision_name = if is_prompt {
-        "cancel_prompt_submission"
-    } else {
-        "cancel_issue_submission"
-    };
-    let reason = if is_prompt {
-        "operator cancelled the runtime prompt submission"
-    } else {
-        "operator cancelled the runtime issue submission"
-    };
-    let command_prefix = if is_prompt {
-        "prompt-submit"
-    } else {
-        "issue-submit"
-    };
+    let (event_type, decision_name, reason, command_prefix, target_state, remove_prompt) =
+        if is_prompt {
+            (
+                "PromptSubmissionCancelled",
+                "cancel_prompt_submission",
+                "operator cancelled the runtime prompt submission",
+                "prompt-submit",
+                "cancelled".to_string(),
+                true,
+            )
+        } else if is_issue {
+            (
+                "IssueSubmissionCancelled",
+                "cancel_issue_submission",
+                "operator cancelled the runtime issue submission",
+                "issue-submit",
+                "cancelled".to_string(),
+                false,
+            )
+        } else {
+            let declarative = declarative.as_ref().ok_or_else(|| {
+                RuntimeSubmissionCancelError::UnsupportedDefinition {
+                    definition_id: instance.definition_id.clone(),
+                }
+            })?;
+            (
+                "DeclarativeSubmissionCancelled",
+                "cancel_declarative_submission",
+                "operator cancelled the runtime declarative submission",
+                "declarative-submit",
+                declarative.target_state.clone(),
+                true,
+            )
+        };
     let event = store
         .append_event(
             &instance.id,
@@ -126,7 +150,7 @@ async fn cancel_submission_instance(
         &instance.id,
         &instance.state,
         decision_name,
-        "cancelled",
+        target_state,
         reason,
     )
     .with_command(WorkflowCommand::new(
@@ -135,7 +159,20 @@ async fn cancel_submission_instance(
         json!({ "task_id": correlation_id }),
     ))
     .high_confidence();
-    let mut cancelled = commit_runtime_decision(store, instance, decision, event.id, None).await?;
+    let mut cancelled = if let Some(declarative) = declarative {
+        commit_runtime_decision_with_validator(
+            store,
+            instance,
+            decision,
+            event.id,
+            None,
+            declarative.validator,
+            declarative.missing_pin,
+        )
+        .await?
+    } else {
+        commit_runtime_decision(store, instance, decision, event.id, None).await?
+    };
     let commands = store.commands_for(&cancelled.id).await?;
     for command in commands {
         if matches!(
@@ -156,7 +193,7 @@ async fn cancel_submission_instance(
     }
     cancelled.data = set_data_bool(cancelled.data, "cancelled", true);
     store.upsert_instance(&cancelled).await?;
-    if is_prompt {
+    if remove_prompt {
         remove_prompt_submission_prompt_durable(
             store,
             optional_string_field(&cancelled.data, "prompt_ref").as_deref(),
@@ -164,4 +201,102 @@ async fn cancel_submission_instance(
         .await?;
     }
     Ok(RuntimeSubmissionCancelOutcome::Cancelled(cancelled))
+}
+
+async fn resolve_declarative_cancellation(
+    store: &WorkflowRuntimeStore,
+    instance: &WorkflowInstance,
+) -> Result<Option<DeclarativeCancellation>, RuntimeSubmissionCancelError> {
+    if let DeclarativeDefinitionResolution::Resolved(definition) =
+        resolve_declarative_definition(instance)
+    {
+        let target_state = cancelled_state(definition.policy(), instance)?;
+        return Ok(Some(DeclarativeCancellation {
+            target_state,
+            validator: DecisionValidator::new(definition.registered().allowlist.clone()),
+            missing_pin: false,
+        }));
+    }
+
+    let Some(persisted) = store
+        .get_definition(&instance.definition_id, instance.definition_version)
+        .await?
+    else {
+        return match resolve_declarative_definition(instance) {
+            DeclarativeDefinitionResolution::PinError(error) => {
+                Err(RuntimeSubmissionCancelError::Store(anyhow::anyhow!(
+                    "declarative workflow '{}' has an invalid definition pin and no persisted definition during cancellation: {error:?}",
+                    instance.id
+                )))
+            }
+            DeclarativeDefinitionResolution::NotDeclarative => Ok(None),
+            DeclarativeDefinitionResolution::Resolved(_) => unreachable!(
+                "resolved declarative cancellation returned before persisted lookup"
+            ),
+        };
+    };
+    if persisted
+        .metadata
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        != Some("declarative_workflow")
+    {
+        return Ok(None);
+    }
+    let policy: WorkflowDefinitionPolicy =
+        serde_json::from_value(persisted.metadata.get("policy").cloned().ok_or_else(|| {
+            RuntimeSubmissionCancelError::Store(anyhow::anyhow!(
+                "persisted declarative workflow '{}@{}' is missing policy metadata",
+                instance.definition_id,
+                instance.definition_version
+            ))
+        })?)
+        .map_err(anyhow::Error::from)?;
+    let activity_policies = policy
+        .states
+        .values()
+        .filter_map(|state| state.activity.as_ref())
+        .map(|activity| (activity.clone(), WorkflowActivityPolicy::default()))
+        .collect::<BTreeMap<_, _>>();
+    let definition = build_declarative_definition(&policy, &activity_policies)?;
+    let expected_hash = instance
+        .data
+        .get("definition_hash")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            RuntimeSubmissionCancelError::Store(anyhow::anyhow!(
+                "declarative workflow '{}' is missing its pinned definition hash",
+                instance.id
+            ))
+        })?;
+    if definition.definition_version() != instance.definition_version
+        || definition.definition_hash() != expected_hash
+        || persisted.definition_hash != expected_hash
+    {
+        return Err(RuntimeSubmissionCancelError::Store(anyhow::anyhow!(
+            "persisted declarative workflow '{}' does not match its pinned definition identity",
+            instance.id
+        )));
+    }
+    Ok(Some(DeclarativeCancellation {
+        target_state: cancelled_state(&policy, instance)?,
+        validator: DecisionValidator::new(definition.registered().allowlist.clone()),
+        missing_pin: true,
+    }))
+}
+
+fn cancelled_state(
+    policy: &WorkflowDefinitionPolicy,
+    instance: &WorkflowInstance,
+) -> Result<String, RuntimeSubmissionCancelError> {
+    policy
+        .terminal
+        .iter()
+        .find_map(|(state, class)| (class == "cancelled").then_some(state.clone()))
+        .ok_or_else(|| {
+            RuntimeSubmissionCancelError::Store(anyhow::anyhow!(
+                "declarative workflow '{}' has no cancelled terminal state",
+                instance.id
+            ))
+        })
 }

--- a/crates/harness-server/src/workflow_runtime_submission/declarative.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative.rs
@@ -209,7 +209,7 @@ pub(super) fn submission_instance(
     WorkflowInstance::new(
         definition.policy().id.as_str(),
         definition.definition_version(),
-        "__submission__",
+        definition.policy().initial.as_str(),
         WorkflowSubject::new("declarative", subject_key(ctx.external_id, ctx.task_id)),
     )
     .with_id(workflow_id)

--- a/crates/harness-server/src/workflow_runtime_submission/declarative_cancel_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative_cancel_tests.rs
@@ -1,0 +1,107 @@
+use super::*;
+use harness_core::{
+    config::workflow::{
+        DeclaredProgressMode, DeclaredState, WorkflowActivityPolicy, WorkflowDefinitionPolicy,
+    },
+    db::resolve_database_url,
+};
+use harness_workflow::runtime::{
+    build_declarative_definition, persisted_declarative_definition,
+    register_declarative_workflow_definitions,
+};
+use std::{collections::BTreeMap, sync::Once};
+
+const DEFINITION_ID: &str = "missing_pin_cancel_test_declarative";
+static REGISTER_CURRENT_DEFINITION: Once = Once::new();
+
+fn definition(with_stop_signal: bool) -> harness_workflow::runtime::DeclarativeWorkflowDefinition {
+    let on_signal = if with_stop_signal {
+        BTreeMap::from([("stop".to_string(), "withdrawn".to_string())])
+    } else {
+        BTreeMap::new()
+    };
+    build_declarative_definition(
+        &WorkflowDefinitionPolicy {
+            id: DEFINITION_ID.to_string(),
+            initial: "working".to_string(),
+            states: BTreeMap::from([
+                (
+                    "working".to_string(),
+                    DeclaredState {
+                        activity: Some("perform_work".to_string()),
+                        on_success: Some("completed".to_string()),
+                        on_failure: Some("failed".to_string()),
+                        on_signal,
+                        ..DeclaredState::default()
+                    },
+                ),
+                (
+                    "blocked".to_string(),
+                    DeclaredState {
+                        progress: Some(DeclaredProgressMode::OperatorGate),
+                        ..DeclaredState::default()
+                    },
+                ),
+            ]),
+            terminal: BTreeMap::from([
+                ("completed".to_string(), "succeeded".to_string()),
+                ("failed".to_string(), "failed".to_string()),
+                ("withdrawn".to_string(), "cancelled".to_string()),
+            ]),
+            evidence_required: BTreeMap::new(),
+            recovery_targets: vec!["working".to_string()],
+        },
+        &BTreeMap::from([(
+            "perform_work".to_string(),
+            WorkflowActivityPolicy::default(),
+        )]),
+    )
+    .expect("missing-pin cancellation fixture should compile")
+}
+
+#[tokio::test]
+async fn missing_registered_pin_can_use_persisted_definition_for_cancellation() -> anyhow::Result<()>
+{
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let persisted_version = definition(false);
+    REGISTER_CURRENT_DEFINITION.call_once(|| {
+        register_declarative_workflow_definitions([definition(true)])
+            .expect("current cancellation fixture should register");
+    });
+    let dir = tempfile::tempdir()?;
+    let database_url = resolve_database_url(None)?;
+    let store =
+        WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url)).await?;
+    store
+        .persist_definition_version(&persisted_declarative_definition(
+            &persisted_version,
+            Some("/repo/WORKFLOW.md"),
+        ))
+        .await?;
+    let instance = WorkflowInstance::new(
+        DEFINITION_ID,
+        persisted_version.definition_version(),
+        "working",
+        WorkflowSubject::new("declarative", "missing-pin-cancel"),
+    )
+    .with_id("missing-pin-cancel-workflow")
+    .with_data(json!({
+        "definition_hash": persisted_version.definition_hash(),
+        "prompt_ref": "missing-pin-cancel-prompt",
+    }));
+    store.upsert_instance(&instance).await?;
+
+    let outcome = cancel_submission_by_workflow_id(&store, &instance.id).await?;
+    let RuntimeSubmissionCancelOutcome::Cancelled(cancelled) = outcome else {
+        anyhow::bail!("missing-pin cancellation did not report a cancelled outcome");
+    };
+    assert_eq!(cancelled.state, "withdrawn");
+    assert_eq!(cancelled.data["cancelled"], true);
+    assert_eq!(
+        cancelled.data["last_decision"],
+        "cancel_declarative_submission"
+    );
+    Ok(())
+}

--- a/crates/harness-server/src/workflow_runtime_submission/declarative_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative_tests.rs
@@ -112,7 +112,7 @@ fn declarative_submission_decision_validates_against_the_registered_submission_r
     let instance = WorkflowInstance::new(
         TEST_DEFINITION_ID,
         definition.definition_version(),
-        "__submission__",
+        definition.policy().initial.clone(),
         WorkflowSubject::new("declarative", "task:validation"),
     )
     .with_data(json!({ "definition_hash": definition.definition_hash() }));
@@ -309,6 +309,44 @@ async fn declarative_submission_mapped_signal_reaches_terminal_state() -> anyhow
         anyhow::bail!("declarative workflow disappeared after completion");
     };
     assert_eq!(instance.state, "cancelled");
+    Ok(())
+}
+
+#[tokio::test]
+async fn declarative_submission_can_be_cancelled_by_an_operator() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    register_test_definition();
+    let dir = tempfile::tempdir()?;
+    let store = open_declarative_runtime_store(dir.path()).await?;
+    let project_root = create_test_project(dir.path())?;
+    let task_id = TaskId::from_str("declarative-operator-cancel");
+    let record = record_declarative_submission(
+        &store,
+        DeclarativeSubmissionRuntimeContext {
+            project_root: &project_root,
+            definition_id: TEST_DEFINITION_ID,
+            task_id: &task_id,
+            prompt: "cancel the declared work",
+            depends_on: &[],
+            serialization_depends_on: &[],
+            source: Some("operator-test"),
+            external_id: Some("cancel-1"),
+        },
+    )
+    .await?;
+
+    let outcome = cancel_submission_by_workflow_id(&store, &record.workflow_id).await?;
+    let RuntimeSubmissionCancelOutcome::Cancelled(instance) = outcome else {
+        anyhow::bail!("declarative submission did not report a cancelled outcome");
+    };
+    assert_eq!(instance.state, "cancelled");
+    assert_eq!(instance.data["cancelled"], true);
+    assert_eq!(
+        instance.data["last_decision"],
+        "cancel_declarative_submission"
+    );
     Ok(())
 }
 

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -127,7 +127,7 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                 &runtime_profile,
                 &workflow_document,
                 &repo_memory.records,
-            );
+            )?;
             let prompt_packet_digest = prompt_packet_digest(&prompt_packet);
             self.record_prompt_packet_prepared(&job, &prompt_packet, &prompt_packet_digest)
                 .await?;

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs
@@ -31,7 +31,7 @@ pub(super) fn build_runtime_prompt_packet(
     runtime_profile: &RuntimeProfile,
     workflow_document: &WorkflowDocument,
     repo_memory: &[RetrievedRepoMemoryRecord],
-) -> Value {
+) -> anyhow::Result<Value> {
     let mut packet = json!({
         "schema": "harness.runtime.prompt_packet.v1",
         "runtime_job": {
@@ -85,12 +85,12 @@ pub(super) fn build_runtime_prompt_packet(
     if !repo_memory.is_empty() {
         packet["repo_memory"] = repo_memory_prompt_value(repo_memory);
     }
-    apply_activity_policy(&mut packet, job, workflow, workflow_document);
+    apply_activity_policy(&mut packet, job, workflow, workflow_document)?;
     apply_candidate_submission_contract(&mut packet, job);
     if let Some(context) = prompt_continuation_context(workflow) {
         packet["continuation_context"] = context;
     }
-    packet
+    Ok(packet)
 }
 
 fn prompt_continuation_context(workflow: Option<&WorkflowInstance>) -> Option<Value> {

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/activity_policy.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/activity_policy.rs
@@ -1,11 +1,9 @@
 use super::pretty_json;
 use harness_core::config::workflow::WorkflowDocument;
 use harness_workflow::runtime::{
-    declarative_workflow_definition_for_instance, DeclarativeWorkflowDefinition, RuntimeJob,
-    WorkflowInstance,
+    resolve_declarative_definition, DeclarativeDefinitionResolution, RuntimeJob, WorkflowInstance,
 };
 use serde_json::{json, Value};
-use std::sync::Arc;
 
 use crate::workflow_runtime_worker::data_helpers::activity_name;
 
@@ -14,10 +12,10 @@ pub(super) fn apply_activity_policy(
     job: &RuntimeJob,
     workflow: Option<&WorkflowInstance>,
     workflow_document: &WorkflowDocument,
-) {
+) -> anyhow::Result<()> {
     apply_activity_policy_with_resolver(packet, job, workflow, workflow_document, |workflow| {
-        declarative_workflow_definition_for_instance(workflow)
-    });
+        resolve_declarative_definition(workflow)
+    })
 }
 
 pub(super) fn apply_activity_policy_with_resolver(
@@ -25,27 +23,60 @@ pub(super) fn apply_activity_policy_with_resolver(
     job: &RuntimeJob,
     workflow: Option<&WorkflowInstance>,
     workflow_document: &WorkflowDocument,
-    resolve_definition: impl FnOnce(&WorkflowInstance) -> Option<Arc<DeclarativeWorkflowDefinition>>,
-) {
+    resolve_definition: impl FnOnce(&WorkflowInstance) -> DeclarativeDefinitionResolution,
+) -> anyhow::Result<()> {
     let Some(workflow) = workflow else {
-        return;
+        return Ok(());
     };
-    let Some(definition) = resolve_definition(workflow) else {
-        return;
+    let definition = match resolve_definition(workflow) {
+        DeclarativeDefinitionResolution::NotDeclarative => return Ok(()),
+        DeclarativeDefinitionResolution::Resolved(definition) => definition,
+        DeclarativeDefinitionResolution::PinError(error) => anyhow::bail!(
+            "declarative workflow '{}' has an invalid definition pin while binding activity policy: {error:?}",
+            workflow.id
+        ),
     };
     let activity = activity_name(job);
-    if definition
+    let expected_activity = definition
         .policy()
         .states
         .get(&workflow.state)
-        .and_then(|state| state.activity.as_deref())
-        != Some(activity.as_str())
-    {
-        return;
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "declarative workflow '{}' cannot dispatch from non-active state '{}'",
+                workflow.id,
+                workflow.state
+            )
+        })?
+        .activity
+        .as_deref()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "declarative workflow '{}' state '{}' has no activity for runtime dispatch",
+                workflow.id,
+                workflow.state
+            )
+        })?;
+    if activity != expected_activity {
+        anyhow::bail!(
+            "declarative workflow '{}' state '{}' expects activity '{}', got '{}'",
+            workflow.id,
+            workflow.state,
+            expected_activity,
+            activity
+        );
     }
-    let Some(policy) = workflow_document.config.activities.get(&activity) else {
-        return;
-    };
+    let policy = workflow_document
+        .config
+        .activities
+        .get(expected_activity)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "declarative workflow '{}' activity '{}' is missing from WORKFLOW.md at dispatch",
+                workflow.id,
+                expected_activity
+            )
+        })?;
 
     let mut binding = json!({
         "activity": activity,
@@ -66,6 +97,7 @@ pub(super) fn apply_activity_policy_with_resolver(
         });
     }
     packet["activity_policy"] = binding;
+    Ok(())
 }
 
 pub(super) fn append_activity_policy_prompt(prompt: &mut String, prompt_packet: &Value) {

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -3,11 +3,11 @@ use harness_core::config::workflow::{
     DeclaredProgressMode, DeclaredState, WorkflowActivityPolicy, WorkflowDefinitionPolicy,
 };
 use harness_workflow::runtime::{
-    build_declarative_definition, RegisteredWorkflowDefinition, RepoMemoryKind, RepoMemoryOutcome,
-    RepoMemoryRecord, RetrievedRepoMemoryRecord, RuntimeKind, TransitionAllowlist, TransitionRule,
-    WorkflowDefinitionRegistry, WorkflowProgressMode, WorkflowRuntimeRecoveryAction,
-    WorkflowRuntimeStore, WorkflowStateDefinition, WorkflowSubject, ISSUE_PLAN_ACTIVITY,
-    ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL, PR_REPAIR_SNAPSHOT_ARTIFACT,
+    build_declarative_definition, DeclarativeDefinitionResolution, RegisteredWorkflowDefinition,
+    RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord, RetrievedRepoMemoryRecord, RuntimeKind,
+    TransitionAllowlist, TransitionRule, WorkflowDefinitionRegistry, WorkflowProgressMode,
+    WorkflowRuntimeRecoveryAction, WorkflowRuntimeStore, WorkflowStateDefinition, WorkflowSubject,
+    ISSUE_PLAN_ACTIVITY, ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL, PR_REPAIR_SNAPSHOT_ARTIFACT,
     SERVER_PR_SNAPSHOT_ARTIFACT,
 };
 use std::collections::BTreeMap;
@@ -434,7 +434,8 @@ fn runtime_prompt_packet_includes_workflow_file_contract() {
         &runtime_profile,
         &workflow_document,
         &[],
-    );
+    )
+    .expect("built-in prompt packet should build");
     assert_eq!(packet["project"]["root"], "/workspaces/job-1");
     assert_eq!(packet["project"]["source_root"], "/repo");
     assert_eq!(
@@ -485,7 +486,8 @@ fn prompt_continuation_packet_includes_attempt_context_and_signal_contract() {
         &runtime_profile,
         &WorkflowDocument::default(),
         &[],
-    );
+    )
+    .expect("continuation prompt packet should build");
 
     assert_eq!(packet["continuation_context"]["attempt"], 2);
     assert_eq!(
@@ -531,7 +533,8 @@ fn runtime_prompt_packet_describes_deferred_candidate_submission_contract() {
         &runtime_profile,
         &workflow_document,
         &[],
-    );
+    )
+    .expect("candidate prompt packet should build");
 
     assert_eq!(packet["runtime_contract"]["submission_mode"], "deferred");
     assert!(packet["runtime_contract"]["deferred_submission_contract"]
@@ -582,7 +585,8 @@ fn memory_inject_prompt_packet_includes_fenced_repo_memory_section() {
         &runtime_profile,
         &workflow_document,
         &repo_memory,
-    );
+    )
+    .expect("repo-memory prompt packet should build");
 
     assert_eq!(
         packet["repo_memory"]["schema"],
@@ -632,7 +636,8 @@ fn memory_inject_fresh_repo_gets_no_repo_memory_section() {
         &runtime_profile,
         &workflow_document,
         &[],
-    );
+    )
+    .expect("fresh-repo prompt packet should build");
 
     assert!(packet.get("repo_memory").is_none());
     let prompt = build_runtime_job_prompt(&packet, None);
@@ -684,7 +689,7 @@ fn compiled_activity_policy_definition() -> harness_workflow::runtime::Declarati
 }
 
 #[test]
-fn declarative_activity_policy_binds_prompt_and_validation_to_the_pinned_activity() {
+fn declarative_activity_policy_binds_exactly_and_missing_policy_fails_closed() {
     let definition = Arc::new(compiled_activity_policy_definition());
     let workflow = WorkflowInstance::new(
         definition.policy().id.clone(),
@@ -718,8 +723,9 @@ fn declarative_activity_policy_binds_prompt_and_validation_to_the_pinned_activit
         &job,
         Some(&workflow),
         &workflow_document,
-        |_| Some(definition.clone()),
-    );
+        |_| DeclarativeDefinitionResolution::Resolved(definition.clone()),
+    )
+    .expect("exact declarative activity policy should bind");
 
     assert_eq!(
         packet["activity_policy"]["prompt"],
@@ -733,6 +739,20 @@ fn declarative_activity_policy_binds_prompt_and_validation_to_the_pinned_activit
     assert!(prompt.contains("Activity policy instructions:"));
     assert!(prompt.contains("Inspect only the declared repository surface."));
     assert!(prompt.contains("cargo check -p harness-server --all-targets"));
+
+    workflow_document.config.activities.clear();
+    let error = super::activity_policy::apply_activity_policy_with_resolver(
+        &mut json!({
+            "activity_result_schema": {},
+            "required_structured_output": {},
+        }),
+        &job,
+        Some(&workflow),
+        &workflow_document,
+        |_| DeclarativeDefinitionResolution::Resolved(definition.clone()),
+    )
+    .expect_err("a missing declared activity policy must fail closed");
+    assert!(error.to_string().contains("missing from WORKFLOW.md"));
 }
 
 #[test]
@@ -767,8 +787,9 @@ fn built_in_or_unmatched_activity_does_not_bind_declarative_activity_policy() {
         &job,
         Some(&workflow),
         &workflow_document,
-        |_| None,
-    );
+        |_| DeclarativeDefinitionResolution::NotDeclarative,
+    )
+    .expect("built-in workflows should not bind declarative activity policy");
 
     assert!(packet.get("activity_policy").is_none());
     assert!(packet["activity_result_schema"]

--- a/crates/harness-server/src/workflow_runtime_worker_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker_tests.rs
@@ -309,7 +309,8 @@ fn runtime_prompt_packet_includes_workflow_file_contract() {
         &runtime_profile,
         &workflow_document,
         &[],
-    );
+    )
+    .expect("workflow-file prompt packet should build");
     assert_eq!(packet["project"]["root"], "/workspaces/job-1");
     assert_eq!(packet["project"]["source_root"], "/repo");
     assert_eq!(

--- a/crates/harness-workflow/src/runtime/declarative.rs
+++ b/crates/harness-workflow/src/runtime/declarative.rs
@@ -469,7 +469,7 @@ fn compile_allowlist(
         for (_, target) in transition_targets(state) {
             edges.insert((source.as_str(), target));
         }
-        if state.activity.is_some() {
+        if source == &policy.initial || state.activity.is_some() {
             edges.insert((source.as_str(), source.as_str()));
         }
     }
@@ -484,12 +484,6 @@ fn compile_allowlist(
         .into_iter()
         .map(|(source, target)| transition_rule_for_target(policy, terminal_states, source, target))
         .collect::<Vec<_>>();
-    rules.push(transition_rule_for_target(
-        policy,
-        terminal_states,
-        "__submission__",
-        &policy.initial,
-    ));
     for source in policy.states.keys() {
         for class in ["failed", "cancelled"] {
             let target = terminal_state_for_class(policy, class);

--- a/crates/harness-workflow/src/runtime/declarative_interpreter.rs
+++ b/crates/harness-workflow/src/runtime/declarative_interpreter.rs
@@ -9,9 +9,15 @@ pub fn build_declarative_submission_decision(
     definition: &DeclarativeWorkflowDefinition,
     instance: &WorkflowInstance,
 ) -> anyhow::Result<WorkflowDecision> {
+    let initial = definition.policy().initial.as_str();
     if instance.definition_id != definition.policy().id
         || instance.definition_version != definition.definition_version()
-        || instance.state != "__submission__"
+        || instance.state != initial
+        || instance
+            .data
+            .get("definition_hash")
+            .and_then(serde_json::Value::as_str)
+            != Some(definition.definition_hash())
     {
         anyhow::bail!(
             "declarative submission instance does not match definition '{}@{}'",
@@ -19,18 +25,17 @@ pub fn build_declarative_submission_decision(
             definition.definition_version()
         );
     }
-    let target = definition.policy().initial.as_str();
     let commands = commands_for_target(
         definition,
-        target,
-        format!("{}:{}:submit", instance.id, target),
+        initial,
+        format!("{}:{}:submit", instance.id, initial),
     )?;
     let mut decision = WorkflowDecision::new(
         &instance.id,
-        "__submission__",
+        initial,
         DECLARATIVE_SUBMISSION_DECISION,
-        target,
-        format!("declarative workflow entered initial state '{target}'"),
+        initial,
+        format!("declarative workflow entered initial state '{initial}'"),
     )
     .high_confidence();
     decision.commands = commands;
@@ -146,12 +151,14 @@ mod tests {
         let instance = WorkflowInstance::new(
             definition.policy().id.clone(),
             definition.definition_version(),
-            "__submission__",
+            definition.policy().initial.clone(),
             WorkflowSubject::new("test", "submission"),
-        );
+        )
+        .with_data(json!({ "definition_hash": definition.definition_hash() }));
 
         let decision = build_declarative_submission_decision(&definition, &instance)?;
         assert_eq!(decision.decision, DECLARATIVE_SUBMISSION_DECISION);
+        assert_eq!(decision.observed_state, "working");
         assert_eq!(decision.next_state, "working");
         assert_eq!(
             decision.commands[0].command_type,
@@ -170,9 +177,10 @@ mod tests {
         let instance = WorkflowInstance::new(
             "wrong_definition",
             definition.definition_version(),
-            "__submission__",
+            definition.policy().initial.clone(),
             WorkflowSubject::new("test", "submission-mismatch"),
-        );
+        )
+        .with_data(json!({ "definition_hash": definition.definition_hash() }));
 
         assert!(build_declarative_submission_decision(&definition, &instance).is_err());
     }

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -8,6 +8,8 @@ use std::fmt;
 mod github_issue_pr_validation;
 #[path = "validator_prompt_task.rs"]
 mod prompt_task_validation;
+#[path = "validator_context.rs"]
+mod validation_context;
 
 #[cfg(test)]
 #[path = "validator_tests.rs"]
@@ -344,46 +346,8 @@ pub struct ValidationContext {
     pub replan_available: bool,
     pub wait_available: bool,
     pub allow_terminal_reopen: bool,
+    pub allow_missing_pinned_cancel: bool,
     pub active_dedupe_keys: BTreeSet<String>,
-}
-
-impl ValidationContext {
-    pub fn new(actor: impl Into<String>, now: DateTime<Utc>) -> Self {
-        Self {
-            actor: actor.into(),
-            now,
-            resource_budget_available: true,
-            replan_available: true,
-            wait_available: true,
-            allow_terminal_reopen: false,
-            active_dedupe_keys: BTreeSet::new(),
-        }
-    }
-
-    pub fn without_resource_budget(mut self) -> Self {
-        self.resource_budget_available = false;
-        self
-    }
-
-    pub fn with_replan_exhausted(mut self) -> Self {
-        self.replan_available = false;
-        self
-    }
-
-    pub fn with_wait_exhausted(mut self) -> Self {
-        self.wait_available = false;
-        self
-    }
-
-    pub fn with_active_dedupe_key(mut self, dedupe_key: impl Into<String>) -> Self {
-        self.active_dedupe_keys.insert(dedupe_key.into());
-        self
-    }
-
-    pub fn allow_terminal_reopen(mut self) -> Self {
-        self.allow_terminal_reopen = true;
-        self
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -572,7 +536,11 @@ impl DecisionValidator {
             prompt_task_validation::validate_decision(decision)?;
         }
         self.validate_commands(rule, decision, context)?;
-        validator_progress::validate_target_progress_contract(instance, decision)?;
+        validator_progress::validate_target_progress_contract_with_override(
+            instance,
+            decision,
+            context.allow_missing_pinned_cancel,
+        )?;
         self.validate_workflow_specific_rules(decision, context)
     }
 

--- a/crates/harness-workflow/src/runtime/validator_context.rs
+++ b/crates/harness-workflow/src/runtime/validator_context.rs
@@ -1,0 +1,48 @@
+use super::ValidationContext;
+use chrono::{DateTime, Utc};
+use std::collections::BTreeSet;
+
+impl ValidationContext {
+    pub fn new(actor: impl Into<String>, now: DateTime<Utc>) -> Self {
+        Self {
+            actor: actor.into(),
+            now,
+            resource_budget_available: true,
+            replan_available: true,
+            wait_available: true,
+            allow_terminal_reopen: false,
+            allow_missing_pinned_cancel: false,
+            active_dedupe_keys: BTreeSet::new(),
+        }
+    }
+
+    pub fn without_resource_budget(mut self) -> Self {
+        self.resource_budget_available = false;
+        self
+    }
+
+    pub fn with_replan_exhausted(mut self) -> Self {
+        self.replan_available = false;
+        self
+    }
+
+    pub fn with_wait_exhausted(mut self) -> Self {
+        self.wait_available = false;
+        self
+    }
+
+    pub fn with_active_dedupe_key(mut self, dedupe_key: impl Into<String>) -> Self {
+        self.active_dedupe_keys.insert(dedupe_key.into());
+        self
+    }
+
+    pub fn allow_terminal_reopen(mut self) -> Self {
+        self.allow_terminal_reopen = true;
+        self
+    }
+
+    pub fn allow_missing_pinned_cancel(mut self) -> Self {
+        self.allow_missing_pinned_cancel = true;
+        self
+    }
+}

--- a/crates/harness-workflow/src/runtime/validator_progress.rs
+++ b/crates/harness-workflow/src/runtime/validator_progress.rs
@@ -71,9 +71,25 @@ pub(super) fn validate_target_progress_contract(
     instance: &WorkflowInstance,
     decision: &WorkflowDecision,
 ) -> Result<(), WorkflowDecisionRejection> {
-    if state_registry::workflow_state_definition_for_instance(instance, &decision.next_state)
-        .is_none()
+    validate_target_progress_contract_with_override(instance, decision, false)
+}
+
+pub(super) fn validate_target_progress_contract_with_override(
+    instance: &WorkflowInstance,
+    decision: &WorkflowDecision,
+    allow_missing_pinned_cancel: bool,
+) -> Result<(), WorkflowDecisionRejection> {
+    let state =
+        state_registry::workflow_state_definition_for_instance(instance, &decision.next_state);
+    if state.is_none()
+        && allow_missing_pinned_cancel
+        && decision.decision == "cancel_declarative_submission"
+        && decision.commands.len() == 1
+        && decision.commands[0].command_type == super::model::WorkflowCommandType::MarkCancelled
     {
+        return Ok(());
+    }
+    if state.is_none() {
         return Err(WorkflowDecisionRejection::new(
             WorkflowDecisionRejectionKind::TransitionNotAllowed,
             format!(
@@ -82,9 +98,7 @@ pub(super) fn validate_target_progress_contract(
             ),
         ));
     }
-    let progress_mode =
-        state_registry::workflow_state_definition_for_instance(instance, &decision.next_state)
-            .and_then(|state| state.progress_mode);
+    let progress_mode = state.and_then(|state| state.progress_mode);
     let has_driver = decision
         .commands
         .iter()


### PR DESCRIPTION
Closes #1609

Follow-up to #1630.

- require a non-empty prompt and start declarative instances directly in their declared initial state
- fail closed when an exact pinned activity cannot bind its WORKFLOW.md policy
- support operator cancellation into each definition's declared cancelled terminal state
- recover missing pinned versions from identity-verified persisted definitions for cancellation
- preserve built-in workflow behavior and cover the full runtime job chain, dedupe, fallback, and cancellation paths

Validation:
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1
- cargo fmt --all -- --check
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1609