### PR TITLE
docs(specs): define GH1637 process cleanup test stability

### DIFF
--- a/artifacts/triage/issue-1637.json
+++ b/artifacts/triage/issue-1637.json
@@ -1,0 +1,21 @@
+{
+  "issue": 1637,
+  "route": "triage_issue",
+  "state": "ready_to_spec",
+  "classification": "reliability",
+  "security_private": false,
+  "duplicate": false,
+  "related_work": [
+    "GH-1635",
+    "PR-1332"
+  ],
+  "search_summary": "No active issue or pull request covers parallel macOS timeout failures among the harness-agents child and descendant lifecycle fixtures.",
+  "proposed_labels": [
+    "bug",
+    "ci",
+    "agent_generated",
+    "ready_to_spec"
+  ],
+  "decision": "allowed",
+  "human_gate_evidence": "Maintainer standing authorization recorded in the 2026-07-16 Codex goal thread."
+}

--- a/specs/GH1637/product.md
+++ b/specs/GH1637/product.md
@@ -1,0 +1,116 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1637
+
+Complexity: medium. This stabilizes timing-sensitive agent lifecycle tests
+without changing production child-process behavior or weakening workspace
+safety assertions.
+
+## User Problem
+
+The normal parallel `harness-agents` lib suite intermittently exceeds the
+five-second deadlines in Codex descendant cleanup tests on macOS. The exact
+tests pass alone, the three root-exit descendant tests pass together, and the
+complete 193-test binary passes with `--test-threads=1`. Two consecutive real
+pre-push runs nevertheless failed, blocking GH-1635 and making the local gate
+unreliable.
+
+The affected fixtures deliberately leave children or descendants alive while
+testing root exit, pipe drainage, cancellation, and drop cleanup. Running all
+of those destructive lifecycle fixtures concurrently adds process reaping and
+scheduler contention to assertions that are intended to test one cleanup
+contract at a time.
+
+## Goals
+
+1. Make the normal parallel `harness-agents` lib suite reliable on the
+   reproducing macOS environment.
+2. Coordinate only lifecycle fixtures that intentionally leave long-running
+   child or descendant processes.
+3. Preserve every bounded-return and no-late-workspace-mutation assertion.
+4. Keep all unrelated tests parallel and add no dependency.
+5. Restore the GH-1635 real DB-less pre-push gate without a global serial-test
+   flag or test skip.
+
+## Non-Goals
+
+- Changing `ManagedChild`, process-group signaling, or production agent
+  execution behavior without independent production-failure evidence.
+- Increasing the five-second root-exit deadlines as the fix.
+- Ignoring tests, weakening marker assertions, or accepting late mutation.
+- Running the whole crate or workspace with `--test-threads=1`.
+- Changing the GH-1635 database routing implementation.
+
+## User-Visible Behavior
+
+Contributors continue to run the normal parallel test command. The test binary
+internally coordinates the small set of destructive process lifecycle
+fixtures, while ordinary unit tests remain parallel. Failures in agent cleanup
+still fail the suite with the existing assertions and deadlines.
+
+## Testable Invariants
+
+1. B-001: `cargo test -p harness-agents --lib` passes repeatedly with the
+   default test-thread setting on the reproducing macOS environment.
+2. B-002: The workspace command used by pre-push passes without adding
+   `--test-threads=1`, an ignore flag, or a skip filter for agent tests.
+3. B-003: Codex and Claude lifecycle fixtures share one test-only coordination
+   primitive rather than independent module locks.
+4. B-004: Each coordinated fixture acquires the guard before spawning its
+   child and holds it through its final descendant/no-mutation assertion.
+5. B-005: Existing timeouts, descendant-start checks, parsed-output checks,
+   cancellation checks, and no-late-mutation assertions remain unchanged.
+6. B-006: The coordination primitive is async-aware and safe to hold across
+   `await`; no blocking mutex guard is held across an async suspension point.
+7. B-007: Tests that do not create long-lived child/descendant lifecycle
+   conditions remain uncoordinated and parallel.
+8. B-008: No dependency, production runtime branch, hook bypass, or global
+   environment mutation is added.
+9. B-009: Package tests, full workspace Clippy, and the deterministic GH-1635
+   hook contract test pass on the implementation head.
+10. B-010: After the fix is merged and GH-1635 is rebased, the real DB-less
+    pre-push gate passes with all selected tests enabled.
+
+## Acceptance Criteria
+
+- [ ] B-001 through B-010 have fresh evidence.
+- [ ] Three consecutive normal parallel `harness-agents` lib runs pass.
+- [ ] The existing process cleanup assertion bodies and timeout values have no
+      semantic weakening.
+- [ ] The workspace pre-push test command passes in its ordinary parallel mode.
+- [ ] GH-1635 can resume without `--no-verify`, skips, or global serialization.
+
+## Boundary Checklist
+
+| Category | Coverage |
+| --- | --- |
+| Empty / missing input | N/A: this is test-fixture scheduling, not input parsing |
+| Error and failure paths | covered: B-005 preserves cancellation, timeout, pipe, and descendant failure assertions |
+| Authorization / permission | N/A: no external authorization behavior changes |
+| Concurrency / race / ordering | covered: B-003/B-004 define one cross-adapter critical section and its lifetime |
+| Retry / repetition / idempotency | covered: B-001 requires repeated default-parallel runs |
+| Illegal state transitions | N/A: no persisted state machine changes |
+| Compatibility / migration | covered: B-008 forbids production and dependency changes |
+| Degradation / fallback | covered: B-002/B-005 forbid skips, ignores, global serialization, and timeout inflation |
+| Evidence and audit integrity | covered: B-009/B-010 require package, workspace, hook, and repeated-run evidence |
+| Cancellation / interruption / partial completion | covered: B-004/B-005 retain the cancellation/drop fixtures and hold coordination through cleanup assertions |
+
+## Edge Cases
+
+- A coordinated test panics: the async mutex releases with the guard and does
+  not poison subsequent tests.
+- Codex and Claude lifecycle tests run on different libtest worker threads:
+  they still use the same crate-level primitive.
+- A fixture fails before spawning: guard cleanup remains automatic.
+- A descendant starts but cleanup fails: the existing marker assertion still
+  fails; coordination must not convert it into success.
+- CI has fewer or more test threads than the reproducing Mac: the contract does
+  not depend on a fixed worker count.
+
+## Rollout Notes
+
+Land this repair before GH-1635 implementation readiness. No runtime rollout or
+migration is needed. Rollback reverts the implementation PR and restores the
+known flaky delivery gate.

--- a/specs/GH1637/tasks.md
+++ b/specs/GH1637/tasks.md
@@ -1,0 +1,115 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1637
+
+## Spec Packet
+
+- Product: `specs/GH1637/product.md`
+- Tech: `specs/GH1637/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1637-T1` Owner: Codex | Done when: the failing parallel, passing exact, and passing serial baselines are recorded on a fresh `origin/main` branch | Verify: ordinary workspace test, exact filters, and the 193-test binary with `--test-threads=1`
+- [ ] `SP1637-T2` Owner: Codex | Done when: one crate-level async test-only coordination helper is used by the seven scoped lifecycle fixtures with all existing assertions unchanged | Verify: targeted diff review and `cargo test -p harness-agents --lib`
+- [ ] `SP1637-T3` Owner: Codex | Done when: three consecutive default-parallel package runs and the ordinary workspace command pass without skips or thread overrides | Verify: repeated package command plus `cargo test --workspace --exclude harness-server --exclude harness-workflow --lib`
+- [ ] `SP1637-T4` Owner: Codex | Done when: local readiness, exact-head CI/review evidence, SpecRail PR gate, and authorized merge readiness are complete | Verify: full Clippy, workflow checks, PR evidence, and PR gate
+
+### SP1637-T1 — Preserve and classify the baseline
+
+- Owner: Codex implementation agent.
+- Dependencies: merged GH-1637 spec PR; fresh branch from current
+  `origin/main`.
+- Covers: B-001, B-002, B-005, B-007, B-010.
+- Work:
+  - retain both full-suite timeout outputs and exact passing outputs;
+  - confirm the full binary passes serially;
+  - inventory every long-lived lifecycle fixture before editing.
+- Done when:
+  - evidence distinguishes full-suite fixture contention from a deterministic
+    single-cleanup failure;
+  - no file changed during baseline capture.
+- Verify:
+  - baseline commands listed in `tech.md`;
+  - `git diff --exit-code` before implementation.
+
+### SP1637-T2 — Add scoped async fixture coordination
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1637-T1.
+- Covers: B-003, B-004, B-005, B-006, B-007, B-008.
+- Work:
+  - add one `#[cfg(test)]` Tokio mutex helper in `harness-agents/src/lib.rs`;
+  - acquire it at the start of the seven named lifecycle fixtures;
+  - hold each guard through the final existing cleanup assertion;
+  - change no fixture script, timeout, assertion, manifest, hook, or production
+    cleanup behavior.
+- Done when:
+  - the package suite passes with default parallelism;
+  - the implementation diff contains only the helper and guard acquisitions.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo test -p harness-agents --lib`;
+  - exact semantic diff review.
+
+### SP1637-T3 — Prove repeated parallel stability
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1637-T2.
+- Covers: B-001, B-002, B-005, B-007, B-009, B-010.
+- Work:
+  - run the package suite three consecutive times without thread overrides;
+  - run the ordinary pre-push workspace test command;
+  - verify GH-1635's deterministic hook test after rebasing that branch.
+- Done when:
+  - every repeated and workspace run passes;
+  - no skip, ignore, timeout increase, or global serialization appears.
+- Verify:
+  - commands in the `tech.md` test plan.
+
+### SP1637-T4 — Complete local and remote readiness gates
+
+- Owner: Codex implementation agent; human final review remains authoritative.
+- Dependencies: SP1637-T3.
+- Covers: B-001 through B-010.
+- Work:
+  - run full workspace Clippy and SpecRail checks;
+  - compare implementation to the issue and full spec packet;
+  - open the separate implementation PR;
+  - collect exact-head CI, review-thread, merge-state, and PR-gate evidence.
+- Done when:
+  - all local and remote gates pass with no unresolved actionable feedback;
+  - authorized merge does not bypass required review evidence.
+- Verify:
+  - `cargo clippy --workspace --all-targets -- -D warnings`;
+  - `python3 checks/check_workflow.py --repo .`;
+  - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1637`;
+  - `python3 checks/github_pr_evidence.py --github-repo majiayu000/harness --pr <pr-number> --json > /tmp/pr-<pr-number>-evidence.json`;
+  - `python3 checks/pr_gate.py --repo . --evidence /tmp/pr-<pr-number>-evidence.json --json`.
+
+## Parallelization
+
+No parallel writable lanes. The shared helper and both adapter test modules are
+one concurrency contract and require a single integration owner. Independent
+review may be read-only.
+
+## Verification
+
+- [ ] Product invariant set:
+      `{B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008, B-009, B-010}`.
+- [ ] Task coverage union:
+      `{B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008, B-009, B-010}`.
+- [ ] Product and task coverage sets are equal.
+- [ ] Seven lifecycle fixtures use the same async test-only guard.
+- [ ] Existing fixture scripts, timeouts, and assertions are unchanged.
+- [ ] Repeated parallel and workspace commands pass.
+
+## Handoff Notes
+
+- Commit policy: `per_step`; helper/guard implementation is one atomic tested
+  step because neither half is useful alone.
+- GH-1635 remains paused at real-hook readiness until this repair merges.
+- Maintainer standing authorization covers issue/spec/implementation and merge
+  only after required gates; it does not waive CI, review threads, assertion
+  integrity, or SpecRail gates.

--- a/specs/GH1637/tech.md
+++ b/specs/GH1637/tech.md
@@ -1,0 +1,147 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1637
+
+## Product Spec
+
+`specs/GH1637/product.md`
+
+## Codebase Context
+
+Verified at `origin/main` commit `7b8dc534`.
+
+| Area | Anchor | Current behavior | Relevance |
+| --- | --- | --- | --- |
+| Shared child management | `crates/harness-agents/src/lib.rs:151-357` | `ManagedChild` owns process-group cleanup for both agent adapters. | Production semantics are shared and must remain unchanged without separate failure evidence. |
+| Codex lifecycle fixtures | `crates/harness-agents/src/codex_tests.rs:291-489` | Root-exit, receiver-drop, timeout-drop, and buffered execute fixtures create long-lived children or descendants. | These fixtures compete under the full parallel test binary. |
+| Claude lifecycle fixtures | `crates/harness-agents/src/claude_tests.rs:761-928` | Equivalent stream root-exit, receiver-drop, and timeout-drop fixtures exercise the same OS lifecycle boundary. | Coordination must cross adapter modules. |
+| Existing environment locks | `codex_tests.rs:8-52`, `claude_tests.rs:352-389` | Each module has a private blocking mutex only for process-global environment mutation. | They cannot coordinate cross-adapter async lifecycle tests and must not be reused across `await`. |
+| GH-1635 hook command | `.githooks/pre-push` in the GH-1635 implementation branch | Runs the ordinary parallel non-server/non-workflow workspace lib suite. | The repair must make this real gate pass without serializing the whole workspace. |
+
+## Reproduction Evidence
+
+Two consecutive ordinary workspace test runs failed in one or both Codex
+root-exit descendant tests at their five-second outer timeout. Each exact test
+passed alone, all three root-exit descendant tests passed together, and the
+complete 193-test binary passed with `--test-threads=1` in 40.03 seconds. This
+isolates the failure to full-suite fixture concurrency rather than the GH-1635
+database environment or a deterministic single-cleanup failure.
+
+## Proposed Design
+
+### 1. Add one crate-level async test coordination primitive
+
+Under `#[cfg(test)]` in `crates/harness-agents/src/lib.rs`, add a crate-private
+async helper backed by `OnceLock<tokio::sync::Mutex<()>>`. The helper returns a
+`tokio::sync::MutexGuard<'static, ()>`.
+
+This location gives Codex and Claude tests one lock. Tokio's mutex is designed
+for guards held across `await`, avoids blocking a libtest worker, and does not
+poison after a panic. Tokio is already a workspace dependency.
+
+Do not add a public API, production branch, dependency, environment variable,
+or global test-runner setting.
+
+### 2. Coordinate only destructive lifecycle fixtures
+
+Acquire the shared guard as the first statement in these tests and retain it
+through the final cleanup/no-mutation assertion:
+
+- Codex root exit with descendant-held stderr;
+- Codex receiver-drop cancellation with a long-lived child;
+- Codex timeout/drop with a descendant;
+- Codex buffered execute with descendant-held stdout;
+- Claude root exit with descendant-held stderr;
+- Claude receiver-drop cancellation;
+- Claude timeout/drop with a descendant.
+
+Do not coordinate parser, argument, registry, ordinary short-process, or other
+unit tests. Coordination wait time occurs before each fixture's existing
+operation-specific timeout begins.
+
+### 3. Preserve the safety assertions verbatim
+
+The implementation adds guard acquisition only. It does not change fixture
+scripts, sleep durations, timeout values, output assertions, descendant-start
+markers, cancellation expectations, or final no-mutation markers.
+
+The lock prevents multiple destructive fixtures from competing for orphan
+reaping and scheduler time; it does not turn a failed cleanup into success.
+
+## Data Flow
+
+```text
+normal parallel libtest run
+  -> ordinary tests continue in parallel
+  -> lifecycle fixture awaits shared async guard
+       -> spawn child/descendant
+       -> execute existing timeout/cancellation contract
+       -> assert descendant started
+       -> assert no late workspace mutation
+       -> release guard
+  -> next lifecycle fixture proceeds
+```
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001/B-002 repeated default-parallel stability | coordinated lifecycle fixture set | three `cargo test -p harness-agents --lib` runs plus the workspace pre-push command |
+| B-003 shared cross-adapter primitive | `harness-agents/src/lib.rs` test-only helper | code review and both adapter test modules using the same helper |
+| B-004 guard lifetime | seven named fixtures | diff review confirms first-statement acquisition and final-assertion scope |
+| B-005 assertion integrity | existing Codex/Claude test bodies | semantic diff review; no timeout/script/assertion changes |
+| B-006 async safety | Tokio mutex helper | Clippy with `-D warnings`; no `std::sync::MutexGuard` across `await` |
+| B-007 scoped concurrency | all other agent tests | diff boundary and ordinary parallel suite |
+| B-008 no production/dependency change | Cargo manifests and non-test code | exact diff review |
+| B-009 local readiness | package/workspace commands | fmt, package tests, hook contract test, full Clippy |
+| B-010 GH-1635 recovery | rebased GH-1635 branch | real DB-less pre-push run after merge |
+
+## Risks
+
+- Coverage: over-broad coordination could hide unrelated races. Limit use to
+  the seven fixtures that intentionally retain long-lived processes.
+- Deadlock: a blocking mutex across async suspension could stall worker
+  threads. Use `tokio::sync::Mutex`, acquire once, and rely on guard drop.
+- False green: changing timeout or marker assertions would weaken the safety
+  contract. The implementation diff must contain guard additions only in the
+  seven test bodies.
+- Platform behavior: macOS exposed the contention, while Linux CI may not.
+  Keep ordinary default-parallel commands on both platforms.
+- Panic recovery: Tokio mutexes do not poison, so one failed test does not
+  cascade lock acquisition failures.
+
+## Alternatives Considered
+
+1. Raise five-second timeouts. Rejected: it hides contention and weakens the
+   bounded-return contract.
+2. Run the entire crate/workspace with `--test-threads=1`. Rejected: it slows
+   unrelated tests and masks broader concurrency regressions.
+3. Add `serial_test`. Rejected: a standard-library/Tokio solution already
+   exists and a new dependency is unnecessary.
+4. Reuse module environment locks. Rejected: they are blocking, adapter-local,
+   and unsafe to hold across async suspension.
+5. Change `ManagedChild` signaling or drain semantics. Rejected for this issue:
+   exact and serial runs pass, so current evidence does not justify changing a
+   workspace-safety production path.
+
+## Test Plan
+
+- [ ] Preserve the original failing outputs as baseline evidence.
+- [ ] `cargo fmt --all -- --check`.
+- [ ] Run `cargo test -p harness-agents --lib` three consecutive times with no
+      test-thread override.
+- [ ] `cargo test --workspace --exclude harness-server --exclude harness-workflow --lib`.
+- [ ] `bash scripts/test-pre-push-hook.sh` on the rebased GH-1635 branch.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] `python3 checks/check_workflow.py --repo .`.
+- [ ] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1637`.
+- [ ] Exact diff review proving no timeout, script, assertion, manifest, hook,
+      or production cleanup change.
+
+## Rollback Plan
+
+Revert the implementation PR. No production process, data, migration, or API
+rollback is needed. The original parallel-suite flake and GH-1635 gate blocker
+would return.


### PR DESCRIPTION
## Summary

- define the user-facing reliability contract for GH-1637
- specify one shared async test-only coordination primitive for seven destructive agent lifecycle fixtures
- preserve every existing timeout, process script, cancellation check, and no-late-mutation assertion
- plan repeated default-parallel package and workspace verification before implementation readiness

## Why

Two consecutive real GH-1635 DB-less pre-push runs failed in existing Codex process-group cleanup tests under the complete parallel suite. Exact tests passed, the three root-exit fixtures passed together, and the full 193-test binary passed with `--test-threads=1`. The packet routes that reproducible delivery-gate defect without broadening GH-1635 or changing production process cleanup without evidence.

## Linked Work

- Issue: #1637
- Related delivery-gate repair: #1635
- Spec packet: `specs/GH1637/`

## Plan

1. Preserve the parallel-fail/exact-pass/serial-pass baseline.
2. Add a crate-level Tokio mutex available only under `cfg(test)`.
3. Acquire it in the seven long-lived child/descendant fixtures and hold it through their final cleanup assertions.
4. Prove three default-parallel package runs, the ordinary workspace command, full Clippy, and exact diff integrity.

## Verification

- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1637`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Push gate exception

The current `origin/main` pre-push hook deterministically includes mandatory GH1602 PostgreSQL tests after unsetting their database URL. That known defect is tracked by GH-1635, so this spec-only push used `--no-verify` after the fresh checks above. The GH-1637 implementation must restore and prove the real GH-1635 hook; this exception is not implementation readiness evidence.
