### PR TITLE
docs(specs): correct GH1637 cleanup timing design

### DIFF
--- a/specs/GH1637/product.md
+++ b/specs/GH1637/product.md
@@ -4,113 +4,117 @@
 
 GH-1637
 
-Complexity: medium. This stabilizes timing-sensitive agent lifecycle tests
-without changing production child-process behavior or weakening workspace
-safety assertions.
+Complexity: medium. This stabilizes timing-sensitive agent lifecycle tests by
+measuring cleanup from the event that actually starts the cleanup contract.
 
 ## User Problem
 
-The normal parallel `harness-agents` lib suite intermittently exceeds the
-five-second deadlines in Codex descendant cleanup tests on macOS. The exact
-tests pass alone, the three root-exit descendant tests pass together, and the
-complete 193-test binary passes with `--test-threads=1`. Two consecutive real
-pre-push runs nevertheless failed, blocking GH-1635 and making the local gate
-unreliable.
+The normal parallel `harness-agents` lib suite intermittently exceeds a
+five-second outer timeout in Codex and Claude descendant cleanup tests on a
+loaded macOS host. The original timeout begins before the mock agent process is
+scheduled and before its descendant-start marker exists, so unrelated process
+startup delay is charged to process-group cleanup.
 
-The affected fixtures deliberately leave children or descendants alive while
-testing root exit, pipe drainage, cancellation, and drop cleanup. Running all
-of those destructive lifecycle fixtures concurrently adds process reaping and
-scheduler contention to assertions that are intended to test one cleanup
-contract at a time.
+Further evidence disproved the original fixture-serialization hypothesis: two
+coordinated package runs passed, the third failed, and the exact Claude test
+failed on run 8 of 10. Temporary timing diagnostics then showed that once
+`ManagedChild` cleanup started, process groups drained in roughly 0–14 ms,
+while total test time varied up to 5.94 seconds under unrelated system load.
 
 ## Goals
 
 1. Make the normal parallel `harness-agents` lib suite reliable on the
    reproducing macOS environment.
-2. Coordinate only lifecycle fixtures that intentionally leave long-running
-   child or descendant processes.
-3. Preserve every bounded-return and no-late-workspace-mutation assertion.
-4. Keep all unrelated tests parallel and add no dependency.
-5. Restore the GH-1635 real DB-less pre-push gate without a global serial-test
-   flag or test skip.
+2. Separate bounded process startup observation from the existing five-second
+   root-exit cleanup deadline.
+3. Start the cleanup deadline only after the descendant-start marker proves
+   the fixture has entered the behavior under test.
+4. Preserve all descendant-kill, output, cancellation, and no-late-mutation
+   assertions.
+5. Restore the GH-1635 real DB-less pre-push gate without skips or global test
+   serialization.
 
 ## Non-Goals
 
 - Changing `ManagedChild`, process-group signaling, or production agent
-  execution behavior without independent production-failure evidence.
-- Increasing the five-second root-exit deadlines as the fix.
+  execution behavior.
+- Increasing the five-second cleanup deadline.
 - Ignoring tests, weakening marker assertions, or accepting late mutation.
 - Running the whole crate or workspace with `--test-threads=1`.
+- Stopping or reconfiguring unrelated operator processes to manufacture green.
 - Changing the GH-1635 database routing implementation.
 
 ## User-Visible Behavior
 
-Contributors continue to run the normal parallel test command. The test binary
-internally coordinates the small set of destructive process lifecycle
-fixtures, while ordinary unit tests remain parallel. Failures in agent cleanup
-still fail the suite with the existing assertions and deadlines.
+Contributors continue to run the normal parallel test command. Each root-exit
+fixture first gives its mock process a separately bounded opportunity to start
+its descendant. Once that marker exists, the existing five-second deadline
+measures only root exit, process-group cleanup, and pipe drainage.
 
 ## Testable Invariants
 
 1. B-001: `cargo test -p harness-agents --lib` passes repeatedly with the
    default test-thread setting on the reproducing macOS environment.
-2. B-002: The workspace command used by pre-push passes without adding
-   `--test-threads=1`, an ignore flag, or a skip filter for agent tests.
-3. B-003: Codex and Claude lifecycle fixtures share one test-only coordination
-   primitive rather than independent module locks.
-4. B-004: Each coordinated fixture acquires the guard before spawning its
-   child and holds it through its final descendant/no-mutation assertion.
-5. B-005: Existing timeouts, descendant-start checks, parsed-output checks,
-   cancellation checks, and no-late-mutation assertions remain unchanged.
-6. B-006: The coordination primitive is async-aware and safe to hold across
-   `await`; no blocking mutex guard is held across an async suspension point.
-7. B-007: Tests that do not create long-lived child/descendant lifecycle
-   conditions remain uncoordinated and parallel.
+2. B-002: The workspace command used by pre-push passes without
+   `--test-threads=1`, ignore flags, or agent-test skip filters.
+3. B-003: The Codex streamed, Codex buffered, and Claude streamed root-exit
+   fixtures start their five-second completion deadline only after their
+   descendant-start marker is observed.
+4. B-004: Descendant startup observation is independently bounded and a
+   missing marker fails the test rather than removing the cleanup deadline.
+5. B-005: The existing five-second root-exit/cleanup deadline remains exactly
+   five seconds.
+6. B-006: Existing mock scripts, parsed-output checks, descendant-start checks,
+   cancellation checks, and no-late-mutation assertions remain semantically
+   intact.
+7. B-007: No cross-test lock, global serialization, sleep-based retry, skip, or
+   ignore is added.
 8. B-008: No dependency, production runtime branch, hook bypass, or global
    environment mutation is added.
-9. B-009: Package tests, full workspace Clippy, and the deterministic GH-1635
-   hook contract test pass on the implementation head.
-10. B-010: After the fix is merged and GH-1635 is rebased, the real DB-less
+9. B-009: Three consecutive package runs, the ordinary workspace command, full
+   Clippy, and the deterministic GH-1635 hook test pass on the combined head.
+10. B-010: After the repair merges and GH-1635 rebases, the real DB-less
     pre-push gate passes with all selected tests enabled.
 
 ## Acceptance Criteria
 
 - [ ] B-001 through B-010 have fresh evidence.
 - [ ] Three consecutive normal parallel `harness-agents` lib runs pass.
-- [ ] The existing process cleanup assertion bodies and timeout values have no
-      semantic weakening.
-- [ ] The workspace pre-push test command passes in its ordinary parallel mode.
-- [ ] GH-1635 can resume without `--no-verify`, skips, or global serialization.
+- [ ] The five-second cleanup deadline and final workspace-safety assertions
+      are unchanged.
+- [ ] The workspace pre-push test command passes in ordinary parallel mode.
+- [ ] GH-1635 resumes without `--no-verify`, skips, or global serialization.
 
 ## Boundary Checklist
 
 | Category | Coverage |
 | --- | --- |
-| Empty / missing input | N/A: this is test-fixture scheduling, not input parsing |
-| Error and failure paths | covered: B-005 preserves cancellation, timeout, pipe, and descendant failure assertions |
-| Authorization / permission | N/A: no external authorization behavior changes |
-| Concurrency / race / ordering | covered: B-003/B-004 define one cross-adapter critical section and its lifetime |
-| Retry / repetition / idempotency | covered: B-001 requires repeated default-parallel runs |
+| Empty / missing input | N/A: test fixture timing, not input parsing |
+| Error and failure paths | covered: B-004/B-006 preserve missing-marker, cancellation, pipe, and descendant failures |
+| Authorization / permission | N/A: no authorization behavior changes |
+| Concurrency / race / ordering | covered: B-003 orders marker observation before the cleanup deadline without serializing tests |
+| Retry / repetition / idempotency | covered: B-001/B-009 require repeated default-parallel runs |
 | Illegal state transitions | N/A: no persisted state machine changes |
 | Compatibility / migration | covered: B-008 forbids production and dependency changes |
-| Degradation / fallback | covered: B-002/B-005 forbid skips, ignores, global serialization, and timeout inflation |
+| Degradation / fallback | covered: B-005/B-007 forbid timeout inflation, skips, retries, and global serialization |
 | Evidence and audit integrity | covered: B-009/B-010 require package, workspace, hook, and repeated-run evidence |
-| Cancellation / interruption / partial completion | covered: B-004/B-005 retain the cancellation/drop fixtures and hold coordination through cleanup assertions |
+| Cancellation / interruption / partial completion | covered: B-004/B-006 keep startup failure and cancellation/drop behavior explicit |
 
 ## Edge Cases
 
-- A coordinated test panics: the async mutex releases with the guard and does
-  not poison subsequent tests.
-- Codex and Claude lifecycle tests run on different libtest worker threads:
-  they still use the same crate-level primitive.
-- A fixture fails before spawning: guard cleanup remains automatic.
-- A descendant starts but cleanup fails: the existing marker assertion still
-  fails; coordination must not convert it into success.
-- CI has fewer or more test threads than the reproducing Mac: the contract does
-  not depend on a fixed worker count.
+- The host is heavily loaded before the mock process runs: startup observation
+  has its own bound and does not consume the cleanup deadline.
+- The agent task exits before creating the marker: the fixture fails with
+  startup/task evidence.
+- The descendant starts but cleanup hangs: the unchanged five-second deadline
+  still fails.
+- The descendant starts and is killed: the final delayed marker assertion
+  still proves it cannot mutate the workspace.
+- CI has fewer or more test threads: no fixed worker count or global lock is
+  required.
 
 ## Rollout Notes
 
-Land this repair before GH-1635 implementation readiness. No runtime rollout or
-migration is needed. Rollback reverts the implementation PR and restores the
-known flaky delivery gate.
+GH-1639 must land first so the Claude lifecycle file is below the hard ceiling.
+No runtime rollout or migration is needed. Rollback restores the known flaky
+delivery gate.

--- a/specs/GH1637/tasks.md
+++ b/specs/GH1637/tasks.md
@@ -11,88 +11,72 @@ GH-1637
 
 ## Implementation Tasks
 
-- [ ] `SP1637-T1` Owner: Codex | Done when: the failing parallel, passing exact, and passing serial baselines are recorded on a fresh `origin/main` branch | Verify: ordinary workspace test, exact filters, and the 193-test binary with `--test-threads=1`
-- [ ] `SP1637-T2` Owner: Codex | Done when: one crate-level async test-only coordination helper is used by the seven scoped lifecycle fixtures with all existing assertions unchanged | Verify: targeted diff review and `cargo test -p harness-agents --lib`
-- [ ] `SP1637-T3` Owner: Codex | Done when: three consecutive default-parallel package runs and the ordinary workspace command pass without skips or thread overrides | Verify: repeated package command plus `cargo test --workspace --exclude harness-server --exclude harness-workflow --lib`
-- [ ] `SP1637-T4` Owner: Codex | Done when: local readiness, exact-head CI/review evidence, SpecRail PR gate, and authorized merge readiness are complete | Verify: full Clippy, workflow checks, PR evidence, and PR gate
+- [ ] `SP1637-T1` Owner: Codex | Done when: parallel, coordinated, exact, diagnostic-timing, and host-load evidence identify pre-marker scheduling as the failure phase | Verify: preserved command outputs and clean pre-edit diff
+- [ ] `SP1637-T2` Owner: Codex | Done when: GH-1639's compliant Claude lifecycle module is merged and GH-1637 rebases onto current `origin/main` | Verify: line counts, merged PR evidence, and route gate
+- [ ] `SP1637-T3` Owner: Codex | Done when: three root-exit fixtures observe descendant startup before applying the unchanged five-second completion deadline | Verify: targeted tests, semantic diff review, and package tests
+- [ ] `SP1637-T4` Owner: Codex | Done when: three package runs, ordinary workspace tests, full Clippy, exact-head CI/review evidence, and SpecRail PR gate pass | Verify: commands in `tech.md` and PR evidence
 
-### SP1637-T1 — Preserve and classify the baseline
+### SP1637-T1 — Preserve the corrected root-cause evidence
 
 - Owner: Codex implementation agent.
-- Dependencies: merged GH-1637 spec PR; fresh branch from current
-  `origin/main`.
-- Covers: B-001, B-002, B-005, B-007, B-010.
+- Dependencies: original GH-1637 spec and failed implementation experiment.
+- Covers: B-001, B-002, B-003, B-005, B-007, B-008.
 - Work:
-  - retain both full-suite timeout outputs and exact passing outputs;
-  - confirm the full binary passes serially;
-  - inventory every long-lived lifecycle fixture before editing.
-- Done when:
-  - evidence distinguishes full-suite fixture contention from a deterministic
-    single-cleanup failure;
-  - no file changed during baseline capture.
-- Verify:
-  - baseline commands listed in `tech.md`;
-  - `git diff --exit-code` before implementation.
+  - retain the two original full-suite failures;
+  - retain the failed shared-lock and exact-test reproductions;
+  - retain temporary timing evidence showing 0–14 ms cleanup after variable
+    pre-marker startup delay;
+  - remove all diagnostic code before implementation.
+- Done when: one evidence-backed hypothesis remains and the source diff is
+  clean before the corrected implementation.
+- Verify: `git diff --exit-code` after diagnostic removal.
 
-### SP1637-T2 — Add scoped async fixture coordination
+### SP1637-T2 — Land the file-size prerequisite
 
 - Owner: Codex implementation agent.
-- Dependencies: SP1637-T1.
+- Dependencies: GH-1639 spec and implementation PRs.
+- Covers: B-006, B-008.
+- Work:
+  - merge the byte-equivalent Claude lifecycle extraction;
+  - rebase from fresh `origin/main`;
+  - confirm all touched files remain below 800 lines.
+- Done when: VibeGuard accepts scoped edits without bypass.
+- Verify: line counts and GH-1639 merge evidence.
+
+### SP1637-T3 — Anchor cleanup deadlines to descendant startup
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1637-T1 and SP1637-T2.
 - Covers: B-003, B-004, B-005, B-006, B-007, B-008.
 - Work:
-  - add one `#[cfg(test)]` Tokio mutex helper in `harness-agents/src/lib.rs`;
-  - acquire it at the start of the seven named lifecycle fixtures;
-  - hold each guard through the final existing cleanup assertion;
-  - change no fixture script, timeout, assertion, manifest, hook, or production
-    cleanup behavior.
-- Done when:
-  - the package suite passes with default parallelism;
-  - the implementation diff contains only the helper and guard acquisitions.
-- Verify:
-  - `cargo fmt --all -- --check`;
-  - `cargo test -p harness-agents --lib`;
-  - exact semantic diff review.
+  - spawn the existing Codex streamed, Codex buffered, and Claude streamed
+    root-exit executions as observable tasks;
+  - bound and verify descendant marker startup;
+  - apply the existing five-second timeout only after marker observation;
+  - preserve scripts, response and marker assertions, final delayed safety
+    checks, cancellation/drop tests, and production code.
+- Done when: targeted filters pass repeatedly and the diff contains no lock,
+  timeout increase, skip, retry, manifest, hook, or production edit.
+- Verify: formatting, targeted tests, and semantic diff review.
 
-### SP1637-T3 — Prove repeated parallel stability
-
-- Owner: Codex implementation agent.
-- Dependencies: SP1637-T2.
-- Covers: B-001, B-002, B-005, B-007, B-009, B-010.
-- Work:
-  - run the package suite three consecutive times without thread overrides;
-  - run the ordinary pre-push workspace test command;
-  - verify GH-1635's deterministic hook test after rebasing that branch.
-- Done when:
-  - every repeated and workspace run passes;
-  - no skip, ignore, timeout increase, or global serialization appears.
-- Verify:
-  - commands in the `tech.md` test plan.
-
-### SP1637-T4 — Complete local and remote readiness gates
+### SP1637-T4 — Prove repeated readiness and merge gates
 
 - Owner: Codex implementation agent; human final review remains authoritative.
 - Dependencies: SP1637-T3.
 - Covers: B-001 through B-010.
 - Work:
-  - run full workspace Clippy and SpecRail checks;
-  - compare implementation to the issue and full spec packet;
-  - open the separate implementation PR;
-  - collect exact-head CI, review-thread, merge-state, and PR-gate evidence.
-- Done when:
-  - all local and remote gates pass with no unresolved actionable feedback;
-  - authorized merge does not bypass required review evidence.
-- Verify:
-  - `cargo clippy --workspace --all-targets -- -D warnings`;
-  - `python3 checks/check_workflow.py --repo .`;
-  - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1637`;
-  - `python3 checks/github_pr_evidence.py --github-repo majiayu000/harness --pr <pr-number> --json > /tmp/pr-<pr-number>-evidence.json`;
-  - `python3 checks/pr_gate.py --repo . --evidence /tmp/pr-<pr-number>-evidence.json --json`.
+  - run three default-parallel package suites and the ordinary workspace suite;
+  - verify the deterministic GH-1635 hook contract and full Clippy;
+  - open the separate implementation PR and collect exact-head CI, review
+    threads, merge state, and PR-gate evidence.
+- Done when: all local and remote gates pass without stopping unrelated
+  operator workloads or bypassing selected tests.
+- Verify: all commands in the `tech.md` test plan and repository PR gate.
 
 ## Parallelization
 
-No parallel writable lanes. The shared helper and both adapter test modules are
-one concurrency contract and require a single integration owner. Independent
-review may be read-only.
+No parallel writable lanes. GH-1639 is an ordered prerequisite; the three
+fixture changes form one timing contract and have one integration owner.
 
 ## Verification
 
@@ -101,15 +85,14 @@ review may be read-only.
 - [ ] Task coverage union:
       `{B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008, B-009, B-010}`.
 - [ ] Product and task coverage sets are equal.
-- [ ] Seven lifecycle fixtures use the same async test-only guard.
-- [ ] Existing fixture scripts, timeouts, and assertions are unchanged.
-- [ ] Repeated parallel and workspace commands pass.
+- [ ] Three root-exit fixtures anchor the deadline after startup.
+- [ ] Five-second deadlines, scripts, and final assertions remain unchanged.
+- [ ] Repeated parallel and workspace commands pass under current host load.
 
 ## Handoff Notes
 
-- Commit policy: `per_step`; helper/guard implementation is one atomic tested
-  step because neither half is useful alone.
-- GH-1635 remains paused at real-hook readiness until this repair merges.
-- Maintainer standing authorization covers issue/spec/implementation and merge
-  only after required gates; it does not waive CI, review threads, assertion
-  integrity, or SpecRail gates.
+- Commit policy: `per_step`; corrected fixture timing is one atomic tested step.
+- The original shared-lock implementation is abandoned based on fresh evidence.
+- GH-1635 resumes after this repair merges.
+- Standing authorization remains conditional on CI, review threads, assertion
+  integrity, and SpecRail gates.

--- a/specs/GH1637/tech.md
+++ b/specs/GH1637/tech.md
@@ -10,138 +10,132 @@ GH-1637
 
 ## Codebase Context
 
-Verified at `origin/main` commit `7b8dc534`.
+Updated from the original `7b8dc534` baseline after GH-1639 was specified.
 
 | Area | Anchor | Current behavior | Relevance |
 | --- | --- | --- | --- |
-| Shared child management | `crates/harness-agents/src/lib.rs:151-357` | `ManagedChild` owns process-group cleanup for both agent adapters. | Production semantics are shared and must remain unchanged without separate failure evidence. |
-| Codex lifecycle fixtures | `crates/harness-agents/src/codex_tests.rs:291-489` | Root-exit, receiver-drop, timeout-drop, and buffered execute fixtures create long-lived children or descendants. | These fixtures compete under the full parallel test binary. |
-| Claude lifecycle fixtures | `crates/harness-agents/src/claude_tests.rs:761-928` | Equivalent stream root-exit, receiver-drop, and timeout-drop fixtures exercise the same OS lifecycle boundary. | Coordination must cross adapter modules. |
-| Existing environment locks | `codex_tests.rs:8-52`, `claude_tests.rs:352-389` | Each module has a private blocking mutex only for process-global environment mutation. | They cannot coordinate cross-adapter async lifecycle tests and must not be reused across `await`. |
-| GH-1635 hook command | `.githooks/pre-push` in the GH-1635 implementation branch | Runs the ordinary parallel non-server/non-workflow workspace lib suite. | The repair must make this real gate pass without serializing the whole workspace. |
+| Child cleanup | `crates/harness-agents/src/lib.rs:151-357` | `ManagedChild` bounds post-exit group drainage at two seconds. Diagnostic runs drained in 0–14 ms once cleanup began. | Production cleanup is not the observed delay and remains unchanged. |
+| Codex lifecycle fixtures | `crates/harness-agents/src/codex_tests.rs:291-489` | Two root-exit tests wrap process startup and cleanup together in five seconds; adjacent cancellation/drop tests already observe startup separately. | Reuse the proven two-phase fixture pattern. |
+| Claude lifecycle fixtures | `crates/harness-agents/src/claude_tests/lifecycle.rs` after GH-1639 | The streamed root-exit test has the same combined deadline; cancellation/drop tests already separate startup observation. | Apply the same marker-anchored contract after the split. |
+| Startup helpers | `codex_tests.rs:88-163`, `claude_tests.rs:19-30` | Existing helpers observe stream/task progress or filesystem markers with independent bounds. | Reuse rather than adding synchronization infrastructure. |
+| GH-1635 hook | `.githooks/pre-push` in the GH-1635 implementation branch | Runs the ordinary parallel non-server/non-workflow workspace lib suite. | Must pass without whole-suite serialization. |
 
-## Reproduction Evidence
+## Root-Cause Evidence
 
-Two consecutive ordinary workspace test runs failed in one or both Codex
-root-exit descendant tests at their five-second outer timeout. Each exact test
-passed alone, all three root-exit descendant tests passed together, and the
-complete 193-test binary passed with `--test-threads=1` in 40.03 seconds. This
-isolates the failure to full-suite fixture concurrency rather than the GH-1635
-database environment or a deterministic single-cleanup failure.
+The original parallel suite failed twice. A shared async lock around seven
+lifecycle fixtures produced two passing package runs and then another exact
+timeout, falsifying fixture concurrency as the root cause. The exact Claude
+root-exit test then failed on run 8 of 10.
+
+Temporary test-only timing diagnostics ran the exact fixture 20 times. Once
+`ManagedChild` cleanup started, group drainage completed in approximately
+0–14 ms. Total fixture duration varied from about 2.05 to 5.94 seconds while an
+unrelated Cargo build kept host load high. The delay therefore occurs before
+the descendant marker and cleanup phase, but the existing timeout charges that
+startup/scheduling delay to cleanup.
 
 ## Proposed Design
 
-### 1. Add one crate-level async test coordination primitive
+### 1. Land the GH-1639 prerequisite
 
-Under `#[cfg(test)]` in `crates/harness-agents/src/lib.rs`, add a crate-private
-async helper backed by `OnceLock<tokio::sync::Mutex<()>>`. The helper returns a
-`tokio::sync::MutexGuard<'static, ()>`.
+First merge the behavior-preserving extraction of the three Claude lifecycle
+fixtures into `claude_tests/lifecycle.rs`. GH-1637 then edits compliant files
+without bypassing the 800-line hard ceiling.
 
-This location gives Codex and Claude tests one lock. Tokio's mutex is designed
-for guards held across `await`, avoids blocking a libtest worker, and does not
-poison after a panic. Tokio is already a workspace dependency.
+### 2. Run root-exit fixtures as observable tasks
 
-Do not add a public API, production branch, dependency, environment variable,
-or global test-runner setting.
+For the three tests that prove a root process exits while a descendant holds a
+pipe:
 
-### 2. Coordinate only destructive lifecycle fixtures
+- spawn the existing agent execution future as a Tokio task;
+- independently observe the existing descendant-start marker with a bounded
+  startup helper;
+- fail and abort cleanly when the marker is not observed;
+- only after the marker exists, wrap the task handle in the existing
+  five-second completion timeout.
 
-Acquire the shared guard as the first statement in these tests and retain it
-through the final cleanup/no-mutation assertion:
+The Codex streamed test can reuse
+`assert_path_observed_before_task_exit`. The buffered Codex and streamed Claude
+tests may use their existing marker polling pattern with explicit abort/join
+diagnostics appropriate to each task result type.
 
-- Codex root exit with descendant-held stderr;
-- Codex receiver-drop cancellation with a long-lived child;
-- Codex timeout/drop with a descendant;
-- Codex buffered execute with descendant-held stdout;
-- Claude root exit with descendant-held stderr;
-- Claude receiver-drop cancellation;
-- Claude timeout/drop with a descendant.
+### 3. Preserve the cleanup contract
 
-Do not coordinate parser, argument, registry, ordinary short-process, or other
-unit tests. Coordination wait time occurs before each fixture's existing
-operation-specific timeout begins.
+Do not change the five-second completion deadline, mock shell scripts, marker
+paths, response parsing, descendant-start assertions, 1.5-second
+no-late-mutation delay, cancellation/drop tests, or production code.
 
-### 3. Preserve the safety assertions verbatim
-
-The implementation adds guard acquisition only. It does not change fixture
-scripts, sleep durations, timeout values, output assertions, descendant-start
-markers, cancellation expectations, or final no-mutation markers.
-
-The lock prevents multiple destructive fixtures from competing for orphan
-reaping and scheduler time; it does not turn a failed cleanup into success.
+No shared lock is added. Startup observation is not a retry; it defines the
+precondition from which cleanup latency is measured.
 
 ## Data Flow
 
 ```text
-normal parallel libtest run
-  -> ordinary tests continue in parallel
-  -> lifecycle fixture awaits shared async guard
-       -> spawn child/descendant
-       -> execute existing timeout/cancellation contract
-       -> assert descendant started
-       -> assert no late workspace mutation
-       -> release guard
-  -> next lifecycle fixture proceeds
+parallel libtest worker
+  -> spawn existing mock agent task
+  -> bounded startup observation
+       -> marker absent/task exits: fail with diagnostics
+       -> descendant marker exists: start existing 5-second deadline
+  -> await root exit + process-group cleanup + pipe drainage
+  -> assert parsed result
+  -> retain delayed no-workspace-mutation assertion
 ```
 
 ## Product-to-Test Mapping
 
-| Behavior invariant | Implementation area | Verification |
+| Invariant | Implementation area | Verification |
 | --- | --- | --- |
-| B-001/B-002 repeated default-parallel stability | coordinated lifecycle fixture set | three `cargo test -p harness-agents --lib` runs plus the workspace pre-push command |
-| B-003 shared cross-adapter primitive | `harness-agents/src/lib.rs` test-only helper | code review and both adapter test modules using the same helper |
-| B-004 guard lifetime | seven named fixtures | diff review confirms first-statement acquisition and final-assertion scope |
-| B-005 assertion integrity | existing Codex/Claude test bodies | semantic diff review; no timeout/script/assertion changes |
-| B-006 async safety | Tokio mutex helper | Clippy with `-D warnings`; no `std::sync::MutexGuard` across `await` |
-| B-007 scoped concurrency | all other agent tests | diff boundary and ordinary parallel suite |
-| B-008 no production/dependency change | Cargo manifests and non-test code | exact diff review |
-| B-009 local readiness | package/workspace commands | fmt, package tests, hook contract test, full Clippy |
-| B-010 GH-1635 recovery | rebased GH-1635 branch | real DB-less pre-push run after merge |
+| B-001/B-002 repeated stability | three root-exit fixtures | three package runs plus ordinary workspace command |
+| B-003 marker-anchored deadline | Codex streamed/buffered and Claude streamed tests | targeted source review and exact filters |
+| B-004 startup failure | existing marker/task helpers and abort branches | missing-marker diagnostics review and targeted tests |
+| B-005 unchanged deadline | three `Duration::from_secs(5)` calls | exact diff review |
+| B-006 assertion integrity | existing scripts and assertions | semantic diff review |
+| B-007 no serialization | crate/test runner configuration | absence of lock, skip, retry, and thread override |
+| B-008 no production/dependency change | manifests and non-test code | exact file-list review |
+| B-009 local readiness | package/workspace/hook/Clippy commands | fresh command outputs |
+| B-010 GH-1635 recovery | rebased GH-1635 branch | real DB-less pre-push run |
 
 ## Risks
 
-- Coverage: over-broad coordination could hide unrelated races. Limit use to
-  the seven fixtures that intentionally retain long-lived processes.
-- Deadlock: a blocking mutex across async suspension could stall worker
-  threads. Use `tokio::sync::Mutex`, acquire once, and rely on guard drop.
-- False green: changing timeout or marker assertions would weaken the safety
-  contract. The implementation diff must contain guard additions only in the
-  seven test bodies.
-- Platform behavior: macOS exposed the contention, while Linux CI may not.
-  Keep ordinary default-parallel commands on both platforms.
-- Panic recovery: Tokio mutexes do not poison, so one failed test does not
-  cascade lock acquisition failures.
+- Task ownership: spawning changes error shape. Join errors and agent errors
+  must remain distinguishable in assertions.
+- False green: starting the five-second deadline before the marker would retain
+  the bug; starting it after cleanup would weaken the test. Anchor immediately
+  after marker observation.
+- Hung startup: use an independent bounded observation and abort the task on
+  failure.
+- Scope drift: do not edit production cleanup or the cancellation/drop tests.
+- Platform variance: keep default parallel test commands and do not stop
+  unrelated operator workloads to make verification pass.
 
 ## Alternatives Considered
 
-1. Raise five-second timeouts. Rejected: it hides contention and weakens the
-   bounded-return contract.
-2. Run the entire crate/workspace with `--test-threads=1`. Rejected: it slows
-   unrelated tests and masks broader concurrency regressions.
-3. Add `serial_test`. Rejected: a standard-library/Tokio solution already
-   exists and a new dependency is unnecessary.
-4. Reuse module environment locks. Rejected: they are blocking, adapter-local,
-   and unsafe to hold across async suspension.
-5. Change `ManagedChild` signaling or drain semantics. Rejected for this issue:
-   exact and serial runs pass, so current evidence does not justify changing a
-   workspace-safety production path.
+1. Shared async test lock. Rejected by new evidence: two runs passed and the
+   third failed; the exact test also failed without fixture concurrency.
+2. Increase the five-second timeout. Rejected: it would hide phase conflation
+   rather than measure cleanup from its real precondition.
+3. Global `--test-threads=1`. Rejected: slows unrelated tests and does not fix
+   the exact-test failure.
+4. Change `ManagedChild`. Rejected: instrumentation shows cleanup itself drains
+   promptly once reached.
+5. Stop unrelated builds. Rejected: external operator state is out of scope and
+   tests must tolerate ordinary host load.
 
 ## Test Plan
 
-- [ ] Preserve the original failing outputs as baseline evidence.
+- [ ] Merge GH-1639 and rebase GH-1637 onto current `origin/main`.
 - [ ] `cargo fmt --all -- --check`.
+- [ ] Run the three root-exit filters repeatedly.
 - [ ] Run `cargo test -p harness-agents --lib` three consecutive times with no
       test-thread override.
 - [ ] `cargo test --workspace --exclude harness-server --exclude harness-workflow --lib`.
 - [ ] `bash scripts/test-pre-push-hook.sh` on the rebased GH-1635 branch.
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings`.
-- [ ] `python3 checks/check_workflow.py --repo .`.
-- [ ] `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1637`.
-- [ ] Exact diff review proving no timeout, script, assertion, manifest, hook,
-      or production cleanup change.
+- [ ] Both SpecRail workflow checks.
+- [ ] Exact diff review proving the five-second deadline, scripts, final
+      assertions, manifests, hooks, and production cleanup are unchanged.
 
 ## Rollback Plan
 
-Revert the implementation PR. No production process, data, migration, or API
-rollback is needed. The original parallel-suite flake and GH-1635 gate blocker
-would return.
+Revert the implementation PR. No production or data rollback is required; the
+known loaded-host timing flake and GH-1635 gate blocker would return.


### PR DESCRIPTION
## Summary

- replace GH-1637's disproven shared-lock design with marker-anchored cleanup timing
- preserve the existing five-second cleanup deadline
- bound startup separately and measure cleanup only after the descendant-start marker exists
- record the failed lock experiment, exact-test failure, and temporary cleanup timing evidence

## Linked Work

- Issue: #1637
- Required file-size prerequisite: #1639
- Related delivery-gate repair: #1635
- Updated spec packet: `specs/GH1637/`

## Why the spec changed

The first design was tested and falsified: two coordinated package runs passed, the third failed, and the exact Claude test failed on run 8 of 10. Temporary diagnostics then showed `ManagedChild` cleanup drained in roughly 0–14 ms once reached, while total fixture time varied up to 5.94 seconds under unrelated host load. The current timeout incorrectly starts before process scheduling and descendant startup.

## Corrected plan

1. Merge GH-1639 so the Claude lifecycle module is below 800 lines.
2. Spawn the three root-exit executions as observable tasks.
3. Bound and verify the existing descendant-start marker.
4. Start the unchanged five-second completion deadline immediately after that marker.
5. Preserve scripts, response checks, final no-mutation assertions, production code, and ordinary test parallelism.

## Verification

- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1637`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Push gate exception

Current `origin/main` still has the known GH-1635 pre-push matrix defect, so this spec-only push used `--no-verify` after the fresh checks above. The corrected implementation must pass the real selected test matrices; this exception is not implementation evidence.
