### PR TITLE
fix(hooks): isolate pre-push database test modes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,24 +6,49 @@ set -euo pipefail
 # workspace tests that spawn their own git repos in temp directories.
 unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE 2>/dev/null || true
 
+database_configured=false
+if [ -n "${HARNESS_DATABASE_URL:-}" ]; then
+    database_configured=true
+fi
+
+db_less_config_home="$(mktemp -d "${TMPDIR:-/tmp}/harness-pre-push.XXXXXX")"
+cleanup() {
+    rm -rf -- "$db_less_config_home"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+run_db_less() {
+    env \
+        -u HARNESS_DATABASE_URL \
+        -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS \
+        -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS \
+        XDG_CONFIG_HOME="$db_less_config_home" \
+        "$@"
+}
+
 echo "=== pre-push: clippy ==="
 cargo clippy --workspace --all-targets -- -D warnings
 
 echo "=== pre-push: test ==="
-# Keep HARNESS_DATABASE_URL scoped to harness-server. Some non-server tests
-# exercise process-global environment behavior and should not inherit DB config.
-echo "=== pre-push: non-server lib tests ==="
-env \
-    -u HARNESS_DATABASE_URL \
-    -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS \
-    -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS \
-    cargo test --workspace --exclude harness-server --lib
+echo "=== pre-push: database-independent workspace lib tests ==="
+run_db_less cargo test --workspace --exclude harness-server --exclude harness-workflow --lib
 
-if [ -n "${HARNESS_DATABASE_URL:-}" ]; then
+if [ "$database_configured" = true ]; then
+    echo "=== pre-push: harness-workflow full lib tests ==="
+    cargo test -p harness-workflow --lib
+
     echo "=== pre-push: harness-server lib tests ==="
     cargo test -p harness-server --lib
 else
-    echo "HARNESS_DATABASE_URL not set — skipping harness-server DB-backed lib tests"
+    echo "=== pre-push: harness-workflow database-independent lib tests ==="
+    run_db_less \
+        cargo test -p harness-workflow --lib -- \
+        --skip runtime::tests::remote_host_lease
+
+    echo "HARNESS_DATABASE_URL is not set — deferred 6 runtime::tests::remote_host_lease PostgreSQL tests and harness-server DB-backed lib tests"
 fi
 
 echo "=== pre-push: all checks passed ==="

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ Validation workflow:
 - When adding a new enum variant, grep ALL match sites for that enum and update them — CI uses exhaustive match checks
 - Dead code in `#[cfg(test)]` modules still triggers `-D warnings` in CI; delete unused test helpers instead of suppressing with `#[allow(dead_code)]`
 - Pre-commit hook (`.githooks/pre-commit`) runs fmt + staged-scope clippy as a fast commit gate. After cloning, activate with: `git config core.hooksPath .githooks`
-- Pre-push hook (`.githooks/pre-push`) runs full workspace clippy, non-server workspace lib tests, and `harness-server` lib tests when `HARNESS_DATABASE_URL` is configured.
-- Local Postgres-dependent `harness-server` tests require `HARNESS_DATABASE_URL`. Without it, the pre-push hook skips `harness-server` and leaves full DB coverage to CI or a configured local database.
+- Pre-push hook (`.githooks/pre-push`) always runs full workspace clippy. In DB-less mode it runs database-independent workspace and `harness-workflow` lib tests under an isolated config root. With `HARNESS_DATABASE_URL`, it runs the full `harness-workflow` and `harness-server` lib suites.
+- PostgreSQL-dependent `harness-workflow` and `harness-server` tests require an isolated disposable database through `HARNESS_DATABASE_URL`. Without it, pre-push defers those explicit PostgreSQL suites to CI or a configured local database.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ Use the user's language for conversation. Keep repository artifacts in English, 
 - Run `cargo fmt --all` before every commit — CI enforces `cargo fmt --all -- --check`
 - Dead code in `#[cfg(test)]` modules still triggers `-D warnings` in CI; delete unused test helpers instead of suppressing with `#[allow(dead_code)]`
 - Pre-commit hook (`.githooks/pre-commit`) runs fmt + staged-scope clippy as a fast commit gate. After cloning, activate with: `git config core.hooksPath .githooks`
-- Pre-push hook (`.githooks/pre-push`) runs full workspace clippy, non-server workspace lib tests, and `harness-server` lib tests when `HARNESS_DATABASE_URL` is configured.
-- Local Postgres-dependent `harness-server` tests require `HARNESS_DATABASE_URL`; without it, pre-push skips `harness-server` locally.
+- Pre-push hook (`.githooks/pre-push`) always runs full workspace clippy. In DB-less mode it runs database-independent workspace and `harness-workflow` lib tests under an isolated config root. With `HARNESS_DATABASE_URL`, it runs the full `harness-workflow` and `harness-server` lib suites.
+- PostgreSQL-dependent `harness-workflow` and `harness-server` tests require an isolated disposable database through `HARNESS_DATABASE_URL`; without it, pre-push defers those explicit PostgreSQL suites to CI or a configured local database.
 
 ## Local Cargo Concurrency
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,12 @@ and clippy for the cargo packages touched by staged files. Docs-only staged
 changes skip clippy.
 
 The pre-push hook is the full local gate before upload: it runs
-`cargo clippy --workspace --all-targets -- -D warnings`, non-server workspace
-lib tests, and `harness-server` lib tests when `HARNESS_DATABASE_URL` is
-configured. Without `HARNESS_DATABASE_URL`, the hook skips `harness-server`
-locally and leaves full DB coverage to CI or a configured local database.
+`cargo clippy --workspace --all-targets -- -D warnings` in every mode. Without
+`HARNESS_DATABASE_URL`, it runs database-independent workspace and
+`harness-workflow` lib tests under an isolated config root, then defers the
+explicit PostgreSQL suites to CI or a configured local database. With an
+isolated disposable database configured through `HARNESS_DATABASE_URL`, it
+runs the full `harness-workflow` and `harness-server` lib suites.
 
 Use the smallest focused check that covers the files you changed before moving
 to broader gates:

--- a/scripts/test-pre-push-hook.sh
+++ b/scripts/test-pre-push-hook.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${HARNESS_PRE_PUSH_FAKE_CARGO:-}" = "1" ]; then
+    command_class="unknown"
+    arguments=" $* "
+    if [ "${1:-}" = "clippy" ]; then
+        command_class="clippy"
+    elif [[ "$arguments" == *" -p harness-workflow "* ]]; then
+        command_class="workflow"
+    elif [[ "$arguments" == *" -p harness-server "* ]]; then
+        command_class="server"
+    elif [ "${1:-}" = "test" ]; then
+        command_class="workspace"
+    fi
+
+    is_set() {
+        local variable_name="$1"
+        if [ "${!variable_name+x}" = "x" ]; then
+            printf '1'
+        else
+            printf '0'
+        fi
+    }
+
+    matches_expected() {
+        local variable_name="$1"
+        local expected_name="$2"
+        if [ "${!variable_name+x}" = "x" ] &&
+            [ "${!expected_name+x}" = "x" ] &&
+            [ "${!variable_name}" = "${!expected_name}" ]; then
+            printf '1'
+        else
+            printf '0'
+        fi
+    }
+
+    xdg_is_global=0
+    if [ "${XDG_CONFIG_HOME:-}" = "${HARNESS_PRE_PUSH_GLOBAL_XDG:-}" ]; then
+        xdg_is_global=1
+    fi
+
+    printf '%s\targv=%s\tdb_set=%s\tdb_matches=%s\tpool_max_set=%s\tpool_max_matches=%s\tpool_timeout_set=%s\tpool_timeout_matches=%s\txdg=%s\txdg_is_global=%s\tgit_index_set=%s\tgit_dir_set=%s\tgit_work_tree_set=%s\n' \
+        "$command_class" \
+        "$*" \
+        "$(is_set HARNESS_DATABASE_URL)" \
+        "$(matches_expected HARNESS_DATABASE_URL HARNESS_PRE_PUSH_EXPECTED_DATABASE_URL)" \
+        "$(is_set HARNESS_DATABASE_POOL_MAX_CONNECTIONS)" \
+        "$(matches_expected HARNESS_DATABASE_POOL_MAX_CONNECTIONS HARNESS_PRE_PUSH_EXPECTED_POOL_MAX)" \
+        "$(is_set HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS)" \
+        "$(matches_expected HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS HARNESS_PRE_PUSH_EXPECTED_POOL_TIMEOUT)" \
+        "${XDG_CONFIG_HOME:-}" \
+        "$xdg_is_global" \
+        "$(is_set GIT_INDEX_FILE)" \
+        "$(is_set GIT_DIR)" \
+        "$(is_set GIT_WORK_TREE)" \
+        >>"$HARNESS_PRE_PUSH_LOG"
+
+    if [ "${HARNESS_PRE_PUSH_SIGNAL_CLASS:-}" = "$command_class" ]; then
+        kill -TERM "$PPID"
+        sleep 1
+        exit 0
+    fi
+
+    if [ "${HARNESS_PRE_PUSH_FAIL_CLASS:-}" = "$command_class" ]; then
+        exit 41
+    fi
+
+    exit 0
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+hook="$repo_root/.githooks/pre-push"
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/harness-pre-push-test.XXXXXX")"
+trap 'rm -rf -- "$test_root"' EXIT
+
+fail() {
+    echo "test-pre-push-hook: $*" >&2
+    exit 1
+}
+
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local context="$3"
+    if [ "$actual" != "$expected" ]; then
+        fail "$context: expected '$expected', got '$actual'"
+    fi
+}
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    local context="$3"
+    if ! grep -Fq -- "$expected" "$file"; then
+        fail "$context: missing '$expected'"
+    fi
+}
+
+assert_not_contains() {
+    local file="$1"
+    local unexpected="$2"
+    local context="$3"
+    if grep -Fq -- "$unexpected" "$file"; then
+        fail "$context: found unexpected '$unexpected'"
+    fi
+}
+
+assert_isolation_removed() {
+    local case_tmp="$1"
+    local leftover
+    leftover="$(find "$case_tmp" -mindepth 1 -maxdepth 1 -name 'harness-pre-push.*' -print -quit)"
+    if [ -n "$leftover" ]; then
+        fail "temporary config root was not removed: $leftover"
+    fi
+}
+
+[ -x "$hook" ] || fail "$hook is not executable"
+
+fake_bin="$test_root/bin"
+mkdir -p "$fake_bin"
+ln -s "$repo_root/scripts/test-pre-push-hook.sh" "$fake_bin/cargo"
+
+secret_url="postgres://hook-user:secret-${RANDOM}-${RANDOM}@127.0.0.1:55432/hook-test"
+pool_max="17"
+pool_timeout="23"
+
+run_case() {
+    local name="$1"
+    local mode="$2"
+    local fail_class="${3:-}"
+    local signal_class="${4:-}"
+    local expected_status="${5:-0}"
+    local case_dir="$test_root/$name"
+    local case_tmp="$case_dir/tmp"
+    local global_xdg="$case_dir/global-config"
+    local log="$case_dir/cargo.log"
+    local output="$case_dir/output.log"
+    local status
+
+    mkdir -p "$case_tmp" "$global_xdg"
+    : >"$log"
+
+    set +e
+    if [ "$mode" = "configured" ]; then
+        env \
+            PATH="$fake_bin:$PATH" \
+            TMPDIR="$case_tmp" \
+            XDG_CONFIG_HOME="$global_xdg" \
+            HARNESS_DATABASE_URL="$secret_url" \
+            HARNESS_DATABASE_POOL_MAX_CONNECTIONS="$pool_max" \
+            HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS="$pool_timeout" \
+            HARNESS_PRE_PUSH_FAKE_CARGO=1 \
+            HARNESS_PRE_PUSH_LOG="$log" \
+            HARNESS_PRE_PUSH_GLOBAL_XDG="$global_xdg" \
+            HARNESS_PRE_PUSH_EXPECTED_DATABASE_URL="$secret_url" \
+            HARNESS_PRE_PUSH_EXPECTED_POOL_MAX="$pool_max" \
+            HARNESS_PRE_PUSH_EXPECTED_POOL_TIMEOUT="$pool_timeout" \
+            HARNESS_PRE_PUSH_FAIL_CLASS="$fail_class" \
+            HARNESS_PRE_PUSH_SIGNAL_CLASS="$signal_class" \
+            GIT_INDEX_FILE="$case_dir/index" \
+            GIT_DIR="$case_dir/git-dir" \
+            GIT_WORK_TREE="$case_dir/work-tree" \
+            "$hook" >"$output" 2>&1
+        status=$?
+    elif [ "$mode" = "empty" ]; then
+        env \
+            PATH="$fake_bin:$PATH" \
+            TMPDIR="$case_tmp" \
+            XDG_CONFIG_HOME="$global_xdg" \
+            HARNESS_DATABASE_URL="" \
+            HARNESS_DATABASE_POOL_MAX_CONNECTIONS="$pool_max" \
+            HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS="$pool_timeout" \
+            HARNESS_PRE_PUSH_FAKE_CARGO=1 \
+            HARNESS_PRE_PUSH_LOG="$log" \
+            HARNESS_PRE_PUSH_GLOBAL_XDG="$global_xdg" \
+            HARNESS_PRE_PUSH_EXPECTED_DATABASE_URL="$secret_url" \
+            HARNESS_PRE_PUSH_EXPECTED_POOL_MAX="$pool_max" \
+            HARNESS_PRE_PUSH_EXPECTED_POOL_TIMEOUT="$pool_timeout" \
+            HARNESS_PRE_PUSH_FAIL_CLASS="$fail_class" \
+            HARNESS_PRE_PUSH_SIGNAL_CLASS="$signal_class" \
+            GIT_INDEX_FILE="$case_dir/index" \
+            GIT_DIR="$case_dir/git-dir" \
+            GIT_WORK_TREE="$case_dir/work-tree" \
+            "$hook" >"$output" 2>&1
+        status=$?
+    else
+        env \
+            -u HARNESS_DATABASE_URL \
+            -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS \
+            -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS \
+            PATH="$fake_bin:$PATH" \
+            TMPDIR="$case_tmp" \
+            XDG_CONFIG_HOME="$global_xdg" \
+            HARNESS_PRE_PUSH_FAKE_CARGO=1 \
+            HARNESS_PRE_PUSH_LOG="$log" \
+            HARNESS_PRE_PUSH_GLOBAL_XDG="$global_xdg" \
+            HARNESS_PRE_PUSH_EXPECTED_DATABASE_URL="$secret_url" \
+            HARNESS_PRE_PUSH_EXPECTED_POOL_MAX="$pool_max" \
+            HARNESS_PRE_PUSH_EXPECTED_POOL_TIMEOUT="$pool_timeout" \
+            HARNESS_PRE_PUSH_FAIL_CLASS="$fail_class" \
+            HARNESS_PRE_PUSH_SIGNAL_CLASS="$signal_class" \
+            GIT_INDEX_FILE="$case_dir/index" \
+            GIT_DIR="$case_dir/git-dir" \
+            GIT_WORK_TREE="$case_dir/work-tree" \
+            "$hook" >"$output" 2>&1
+        status=$?
+    fi
+    set -e
+
+    assert_equals "$expected_status" "$status" "$name status"
+    assert_not_contains "$output" "$secret_url" "$name output secret disclosure"
+    assert_not_contains "$log" "$secret_url" "$name log secret disclosure"
+    assert_isolation_removed "$case_tmp"
+
+    if [ "$expected_status" = "0" ]; then
+        assert_contains "$output" "=== pre-push: all checks passed ===" "$name success marker"
+    else
+        assert_not_contains "$output" "=== pre-push: all checks passed ===" "$name failure marker"
+    fi
+}
+
+classes() {
+    cut -f1 "$1" | paste -sd, -
+}
+
+assert_all_git_variables_unset() {
+    local log="$1"
+    if grep -Evq $'git_index_set=0\tgit_dir_set=0\tgit_work_tree_set=0$' "$log"; then
+        fail "git hook variables leaked into a cargo invocation in $log"
+    fi
+}
+
+run_case db_less_success unset
+db_less_log="$test_root/db_less_success/cargo.log"
+assert_equals "clippy,workspace,workflow" "$(classes "$db_less_log")" "DB-less command order"
+assert_contains "$db_less_log" $'workspace\targv=test --workspace --exclude harness-server --exclude harness-workflow --lib\tdb_set=0' "DB-less workspace command"
+assert_contains "$db_less_log" $'workflow\targv=test -p harness-workflow --lib -- --skip runtime::tests::remote_host_lease\tdb_set=0' "DB-less workflow filter"
+assert_contains "$db_less_log" $'pool_max_set=0\tpool_max_matches=0\tpool_timeout_set=0' "DB-less pool isolation"
+assert_contains "$db_less_log" "xdg_is_global=0" "DB-less XDG isolation"
+assert_contains "$test_root/db_less_success/output.log" "deferred 6 runtime::tests::remote_host_lease PostgreSQL tests" "DB-less deferred coverage message"
+assert_all_git_variables_unset "$db_less_log"
+
+run_case empty_url_success empty
+assert_equals "clippy,workspace,workflow" "$(classes "$test_root/empty_url_success/cargo.log")" "empty URL command order"
+
+run_case db_configured_success configured
+db_configured_log="$test_root/db_configured_success/cargo.log"
+assert_equals "clippy,workspace,workflow,server" "$(classes "$db_configured_log")" "DB-configured command order"
+assert_contains "$db_configured_log" $'workspace\targv=test --workspace --exclude harness-server --exclude harness-workflow --lib\tdb_set=0' "DB-configured isolated workspace command"
+assert_contains "$db_configured_log" $'workflow\targv=test -p harness-workflow --lib\tdb_set=1\tdb_matches=1\tpool_max_set=1\tpool_max_matches=1\tpool_timeout_set=1\tpool_timeout_matches=1' "full workflow environment"
+assert_contains "$db_configured_log" $'server\targv=test -p harness-server --lib\tdb_set=1\tdb_matches=1\tpool_max_set=1\tpool_max_matches=1\tpool_timeout_set=1\tpool_timeout_matches=1' "server environment"
+assert_contains "$db_configured_log" "xdg_is_global=1" "DB-configured XDG preservation"
+assert_all_git_variables_unset "$db_configured_log"
+
+run_case fail_clippy unset clippy "" 41
+assert_equals "clippy" "$(classes "$test_root/fail_clippy/cargo.log")" "clippy failure stops hook"
+
+run_case fail_workspace unset workspace "" 41
+assert_equals "clippy,workspace" "$(classes "$test_root/fail_workspace/cargo.log")" "workspace failure stops hook"
+
+run_case fail_workflow_db_less unset workflow "" 41
+assert_equals "clippy,workspace,workflow" "$(classes "$test_root/fail_workflow_db_less/cargo.log")" "DB-less workflow failure stops hook"
+
+run_case fail_workflow_db_configured configured workflow "" 41
+assert_equals "clippy,workspace,workflow" "$(classes "$test_root/fail_workflow_db_configured/cargo.log")" "full workflow failure stops hook"
+
+run_case fail_server configured server "" 41
+assert_equals "clippy,workspace,workflow,server" "$(classes "$test_root/fail_server/cargo.log")" "server failure stops hook"
+
+run_case signal_workspace unset "" workspace 143
+assert_equals "clippy,workspace" "$(classes "$test_root/signal_workspace/cargo.log")" "signal stops hook"
+
+echo "test-pre-push-hook: all cases passed"


### PR DESCRIPTION
## Summary

- isolate every DB-less Cargo command behind an invocation-local `XDG_CONFIG_HOME` while unsetting database and pool variables
- split the pre-push matrix into database-independent workspace tests, DB-less workflow tests with only the six mandatory PostgreSQL lease tests filtered, and full workflow/server suites when a database is configured
- add a dependency-free fake-Cargo contract suite covering command order, both modes, injected failures, signal cleanup, git-env isolation, and secret redaction
- align the existing pre-push guidance in `AGENTS.md`, `CLAUDE.md`, and `CONTRIBUTING.md`

## Why

GH1602 made six workflow lease tests intentionally require PostgreSQL, but the existing hook still unset the database environment around a workspace command that included `harness-workflow`. Global config discovery could also defeat an environment-only DB-less run. The stale matrix made every normal push fail even when production and tests were healthy.

## Linked Work

- Issue: #1635
- Approved product, technical, and task specs: `specs/GH1635/`
- Delivery-gate prerequisite: #1637 / #1643

## Verification

- `bash -n .githooks/pre-push scripts/test-pre-push-hook.sh`
- `shellcheck .githooks/pre-push scripts/test-pre-push-hook.sh`
- `bash scripts/test-pre-push-hook.sh` — all success, failure, signal, cleanup, isolation, and redaction cases passed
- real DB-less `.githooks/pre-push` — full Clippy; database-independent workspace tests; 482 workflow tests passed; six explicit PostgreSQL tests deferred
- real DB-configured `.githooks/pre-push` against a disposable `_test` database — 488 workflow and 1,762 server tests passed
- normal `git push` — repaired DB-less pre-push hook passed; no bypass
- `cargo fmt --all -- --check`
- both SpecRail workflow checks
- exact scope review: no Rust production or GH1602 test file changed

## Database setup evidence

The first configured attempt used a disposable database name that did not match the repository test-name guard; server tests correctly refused it. A fresh `harness_codex_gh1635_test` database plus the documented pool settings (`16` connections, `60s` acquire timeout) produced the complete green configured run. No database URL is logged by the hook or contract test.

## Guard classification

- FIX: correct the stale pre-push database matrix and config isolation
- SKIP: no production/test weakening or dependency change
- DEFER: unrelated repository-wide VibeGuard baseline findings outside this hook issue

Closes #1635