### PR TITLE
spec(GH1649): define PR feedback runtime modularization

### DIFF
--- a/specs/GH1649/product.md
+++ b/specs/GH1649/product.md
@@ -1,0 +1,90 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1649
+
+## User Problem
+
+Harness maintainers must review and change PR-feedback workflow behavior in a
+single 1,677-line production file that combines lifecycle entry points,
+persistence, command selection, suppression, target loading, and runtime data
+construction. The file is referenced by HTTP routes, background loops,
+reconciliation, and task execution, so an apparently local edit has a broad
+review surface and an elevated risk of accidental state-machine drift.
+
+## Goals
+
+- Give each PR-feedback workflow responsibility one clear production-module
+  owner while retaining the existing root module as the stable caller facade.
+- Reduce the root facade and every touched production module to no more than
+  800 formatted lines.
+- Preserve every existing caller path, workflow decision, persistence effect,
+  command query, suppression rule, and user-visible outcome.
+- Make future reviews able to isolate entry-point, persistence, command-state,
+  and runtime-data changes without reading the full lifecycle implementation.
+- Provide deterministic evidence that the extraction is complete and purely
+  mechanical.
+
+## Non-Goals
+
+- Changing PR feedback, local review, merge approval, hygiene repair, or sweep
+  policy.
+- Changing workflow definitions, states, transitions, evidence, commands,
+  dedupe keys, or persistence retry behavior.
+- Changing JSON fields, defaulting, validation, log severity, errors, HTTP
+  contracts, database schemas, migrations, runtime models, or dependencies.
+- Renaming public or `pub(crate)` types/functions or moving tests for cosmetic
+  reasons.
+- Fixing unrelated behavior or performance findings discovered during the
+  extraction.
+
+## User-Visible Behavior
+
+There is no intended user-visible behavior change. Requests that record PR
+detection, feedback, local-review completion, PR merge, feedback sweeps,
+hygiene repair, or merge approval must produce the same workflow state,
+commands, evidence, task identifiers, persistence operations, events, logs,
+errors, and return values as current `origin/main`.
+
+## Acceptance Criteria
+
+- [ ] B-001: All existing public and `pub(crate)` module paths, signatures,
+      types, enum variants, and return values remain compatible.
+- [ ] B-002: The formatted root facade and every touched production child
+      module contain no more than 800 lines.
+- [ ] B-003: A complete pre/post multiset of functions and types matches
+      exactly, and every original symbol has exactly one implementation owner.
+- [ ] B-004: PR detection, feedback, local-review, merge, sweep, hygiene, and
+      merge-approval decisions retain their exact inputs and outcomes.
+- [ ] B-005: Workflow persistence, retries, failure handling, event ordering,
+      and decision-commit behavior remain unchanged.
+- [ ] B-006: Active-command checks, deduplication, child-workflow selection,
+      and failed-child suppression retain the same queries and cutoffs.
+- [ ] B-007: Workflow target loading, instance identity, task IDs, definition
+      IDs, and runtime JSON data remain byte-for-byte compatible in behavior.
+- [ ] B-008: Existing unit, integration, database-backed server, workspace,
+      Clippy, CI, review-thread, VibeGuard, and SpecRail gates pass.
+- [ ] B-009: No manifest, lockfile, dependency, migration, schema, model, API,
+      or test file is changed.
+- [ ] B-010: The work is delivered as a separate implementation PR only after
+      this spec PR is merged.
+
+## Edge Cases
+
+- Issue-backed and PR-scoped workflows must retain their different identity
+  and target-loading paths.
+- Missing optional PR URLs, repositories, issue numbers, and runtime JSON
+  fields must keep their current defaults and validation failures.
+- Concurrent or repeated sweep/local-review requests must retain current active
+  command and failed-child suppression behavior.
+- Persistence retries, rejected decisions, terminal workflows, and merge
+  approval from non-candidate states must preserve current errors and outcomes.
+- Test-only visibility used by the existing nested test modules must remain
+  available without widening production APIs.
+
+## Rollout Notes
+
+This is a source-layout-only refactor. It requires no migration, feature flag,
+configuration change, operator action, or compatibility communication. A
+normal revert of the implementation PR is the rollback path.

--- a/specs/GH1649/tasks.md
+++ b/specs/GH1649/tasks.md
@@ -51,6 +51,8 @@ GH-1649
   - move active-command checks, status predicates, and failed-child suppression
     as complete bodies;
   - preserve every query, predicate, cutoff, JSON key, default, error, and log;
+  - retain helpers used by nested tests with `pub(super)` in the owner and
+    explicit root `#[cfg(test)] use` imports;
   - use only narrow sibling visibility and keep external caller paths stable.
 - Done when:
   - every moved symbol has one owner and the exact multiset still matches;
@@ -73,6 +75,8 @@ GH-1649
     logic as complete bodies;
   - preserve validator inputs, transition rejection, instance/command/evidence
     persistence, retry/failure handling, event order, errors, logs, and returns;
+  - preserve root test-namespace access to moved persistence helpers without
+    editing tests or widening production visibility;
   - retain existing facade entry points and context/outcome type paths.
 - Done when:
   - exact inventories and movement review show no missing, duplicate, or

--- a/specs/GH1649/tasks.md
+++ b/specs/GH1649/tasks.md
@@ -1,0 +1,142 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1649
+
+## Spec Packet
+
+- Product: `specs/GH1649/product.md`
+- Tech: `specs/GH1649/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1649-T1` Owner: Codex | Done when: exact-base inventory, call sites, formatted line counts, focused compile, VibeGuard baseline, and isolated PostgreSQL test baseline are recorded | Verify: commands in T1 below
+- [ ] `SP1649-T2` Owner: Codex | Done when: target loading, instance/data helpers, and command-state/suppression owners are extracted exactly once, all files are within the ceiling, and focused tests pass | Verify: commands in T2 below
+- [ ] `SP1649-T3` Owner: Codex | Done when: persistence/commit owners are extracted with unchanged lifecycle behavior and the verified step is committed | Verify: commands in T3 below
+- [ ] `SP1649-T4` Owner: Codex | Done when: local, exact-head CI, Gemini/thread, and SpecRail gates pass for the separate implementation PR and cleanup is verified | Verify: commands in T4 below
+
+### SP1649-T1 — Capture the exact implementation baseline
+
+- Owner: Codex implementation agent.
+- Dependencies: merged GH-1649 spec PR; fresh worktree from current
+  `origin/main`; one disposable PostgreSQL database.
+- Covers: B-001, B-003, B-004, B-005, B-006, B-007, B-009.
+- Work:
+  - record the exact base SHA, root/child line counts, all function/type names,
+    external caller paths, imports, and private cross-group calls;
+  - run duplicate-file/symbol searches before creating child modules;
+  - run focused compile, VibeGuard baseline, and database-backed PR-feedback
+    tests before editing;
+  - stop and diagnose if fresh production code is red.
+- Done when:
+  - the complete baseline inventory and exact base are preserved;
+  - focused compile and relevant isolated-database tests pass;
+  - any upstream failure is exposed rather than hidden by extraction.
+- Verify:
+  - `git rev-parse HEAD`;
+  - `wc -l crates/harness-server/src/workflow_runtime_pr_feedback.rs crates/harness-server/src/workflow_runtime_pr_feedback/*.rs`;
+  - symbol and external-reference searches from `tech.md`;
+  - `cargo check -p harness-server --all-targets`;
+  - `HARNESS_DATABASE_URL=<isolated-url> HARNESS_DATABASE_POOL_MAX_CONNECTIONS=8 cargo test -p harness-server workflow_runtime_pr_feedback -- --test-threads=1`.
+
+### SP1649-T2 — Extract target, data, and command-state owners
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1649-T1.
+- Covers: B-001, B-002, B-003, B-004, B-006, B-007, B-009.
+- Work:
+  - move workflow definition registration, target loading, instances, IDs,
+    runtime JSON, and field helpers as complete bodies;
+  - move active-command checks, status predicates, and failed-child suppression
+    as complete bodies;
+  - preserve every query, predicate, cutoff, JSON key, default, error, and log;
+  - use only narrow sibling visibility and keep external caller paths stable.
+- Done when:
+  - every moved symbol has one owner and the exact multiset still matches;
+  - all formatted touched production files are at most 800 lines;
+  - focused compile and relevant database-backed tests pass;
+  - the verified extraction step is committed before T3.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-server --all-targets`;
+  - exact inventory, caller-path, size, and scope gates;
+  - isolated-database PR-feedback runtime tests.
+
+### SP1649-T3 — Extract persistence and decision-commit owners
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1649-T2.
+- Covers: B-001, B-002, B-003, B-004, B-005, B-007, B-009.
+- Work:
+  - move private `persist_*`, merge approval, decision commit, and commit-outcome
+    logic as complete bodies;
+  - preserve validator inputs, transition rejection, instance/command/evidence
+    persistence, retry/failure handling, event order, errors, logs, and returns;
+  - retain existing facade entry points and context/outcome type paths.
+- Done when:
+  - exact inventories and movement review show no missing, duplicate, or
+    behavior-edited body;
+  - full isolated-database server library tests pass;
+  - no manifest, lockfile, dependency, migration, schema, model, API, caller,
+    or test file changed;
+  - the verified extraction step is committed before readiness work.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-server --all-targets`;
+  - `HARNESS_DATABASE_URL=<isolated-url> HARNESS_DATABASE_POOL_MAX_CONNECTIONS=8 cargo test -p harness-server --lib -- --test-threads=1`;
+  - exact inventory, caller, size, scope, and movement-aware diff checks.
+
+### SP1649-T4 — Prove PR readiness and clean up
+
+- Owner: Codex implementation agent; human final review remains authoritative.
+- Dependencies: SP1649-T3.
+- Covers: B-001 through B-010.
+- Work:
+  - compare the implementation against the issue and all three spec files;
+  - run the complete deterministic verification matrix at the final head;
+  - open the separate implementation PR with reason, plan, inventory, module
+    layout, risk, and verification evidence;
+  - wait for exact-head CI and Gemini review, address valid findings, audit all
+    review threads, run required SpecRail PR gate, and merge only under the
+    standing authorization;
+  - remove only the disposable database and implementation worktree.
+- Done when:
+  - every B-001 through B-010 item has fresh evidence;
+  - local and exact-head remote gates pass with no unresolved active thread;
+  - the PR contains only the approved mechanical extraction;
+  - authorized merge, issue closure, and cleanup are verified.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-server --all-targets`;
+  - isolated-database PR-feedback and server test commands above;
+  - `cargo clippy --workspace --all-targets -- -D warnings`;
+  - `HARNESS_DATABASE_URL=<isolated-url> HARNESS_DATABASE_POOL_MAX_CONNECTIONS=8 cargo test --workspace -- --test-threads=1`;
+  - `python3 checks/check_workflow.py --repo .`;
+  - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1649`;
+  - fresh GitHub evidence and `python3 checks/pr_gate.py --repo . --evidence <evidence.json> --mode required --json`.
+
+## Parallelization
+
+No parallel writable implementation lanes are planned. The target, command,
+and persistence groups have private cross-calls in one facade, so one agent
+will move and verify them sequentially. Read-only CI/review evidence collection
+may overlap only after the implementation branch is pushed.
+
+## Verification
+
+- [ ] Global and GH-1649 SpecRail checks pass.
+- [ ] Product behaviors B-001 through B-010 map to tasks and verification.
+- [ ] Exact function/type and caller inventories match the base.
+- [ ] Root and all touched production modules are at most 800 formatted lines.
+- [ ] Focused, server, workspace, Clippy, VibeGuard, CI, review-thread, and PR
+      gates pass on the exact implementation head.
+
+## Handoff Notes
+
+- Exact issue/spec base: `d812d82381517fa5da77302e4429b66c3a23f126`.
+- Baseline root: 1,677 lines, 47 functions, 10 types, nine external reference
+  files; focused all-target compile passed.
+- Preserve `pr_lifecycle_persist.rs` behavior and current nested test paths.
+- This packet authorizes mechanical extraction only. Route any behavior change
+  discovered during implementation to a separate issue/spec cycle.

--- a/specs/GH1649/tech.md
+++ b/specs/GH1649/tech.md
@@ -52,6 +52,16 @@ split along the same responsibility boundaries rather than compressing or
 rewriting logic. Use the narrowest `pub(super)` visibility needed for sibling
 calls. Do not expose new `pub(crate)` APIs.
 
+Private helpers currently referenced by the nested test suite must remain
+available through the root test namespace. In particular, moved helpers such as
+`failed_child_suppression_cutoff`, `issue_instance`, `pr_scoped_instance`,
+`pr_workflow_id`, `commit_runtime_decision`,
+`upsert_github_issue_pr_definition`, and
+`has_active_pr_feedback_command` must use `pub(super)` in their owner module and
+an explicit `#[cfg(test)] use` in the root facade. This preserves the existing
+`use super::*` test contract without editing test files or widening the
+production API.
+
 The existing `pr_lifecycle_persist` module remains unchanged except for a
 minimal import path adjustment if Rust module ownership requires it.
 
@@ -80,6 +90,8 @@ No new persistence, external call, serialization step, or fallback is added.
   siblings, and qualified private paths only.
 - Preserve all `WorkflowDefinition`, `WorkflowDecision`, command/evidence,
   JSON, logging, error, retry, and timestamp expressions exactly.
+- Preserve root test-namespace access for every moved private helper through
+  `pub(super)` plus root `#[cfg(test)] use`; do not change test files.
 - Grep all external references to ensure stable caller paths remain unchanged.
 - Require root and touched production child files to be at most 800 formatted
   lines.

--- a/specs/GH1649/tech.md
+++ b/specs/GH1649/tech.md
@@ -1,0 +1,143 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1649
+
+## Product Spec
+
+See `specs/GH1649/product.md`.
+
+## Current System
+
+`crates/harness-server/src/workflow_runtime_pr_feedback.rs` is a 1,677-line
+module on base `d812d82381517fa5da77302e4429b66c3a23f126`. It contains 47
+functions and 10 types and exposes the stable paths used by nine external
+server source files. It already owns two child areas:
+
+- `workflow_runtime_pr_feedback/pr_lifecycle_persist.rs` for the bounded
+  lifecycle-persistence retry helper;
+- `workflow_runtime_pr_feedback/tests.rs` plus nested test modules.
+
+The remaining root combines four implementation groups:
+
+1. public record/request/approval entry points and their context/outcome types;
+2. workflow decision construction, persistence, and commit outcomes;
+3. active-command queries and failed-child suppression;
+4. workflow target loading, instance construction, and runtime JSON helpers.
+
+These groups share workflow runtime types but do not need a single physical
+file. The current module boundary therefore creates maintenance coupling rather
+than representing one indivisible runtime operation.
+
+## Proposed Design
+
+Keep `workflow_runtime_pr_feedback.rs` as the stable facade for all external
+callers and retain public or `pub(crate)` context/outcome types at their current
+path. Extract complete function bodies, without rewriting them, into narrowly
+owned child modules:
+
+- `persistence.rs`: private `persist_*` functions, merge approval persistence,
+  decision commit, and `RuntimeDecisionCommitOutcome`;
+- `command_state.rs`: active-command queries, failed-child suppression, and
+  command-status predicates;
+- `targets.rs`: definition registration, issue/PR target loading, workflow
+  instance construction, workflow IDs, runtime JSON construction, and field
+  parsing helpers;
+- the root facade: public entry points, stable types, small orchestration
+  wrappers, constants, child wiring, and existing test wiring.
+
+If formatted line counts show that a proposed child would exceed 800 lines,
+split along the same responsibility boundaries rather than compressing or
+rewriting logic. Use the narrowest `pub(super)` visibility needed for sibling
+calls. Do not expose new `pub(crate)` APIs.
+
+The existing `pr_lifecycle_persist` module remains unchanged except for a
+minimal import path adjustment if Rust module ownership requires it.
+
+## Data Flow
+
+1. HTTP/background/task-executor callers continue calling the existing root
+   module paths with the same context values.
+2. Root entry points load or construct the same workflow target and build the
+   same decision inputs.
+3. Private child functions query the same command rows and apply the same
+   dedupe/suppression predicates.
+4. Persistence functions validate and commit the same decisions, instances,
+   commands, evidence, events, and failure records in the same order.
+5. Existing outcome enums and errors return through the unchanged root paths.
+
+No new persistence, external call, serialization step, or fallback is added.
+
+## Invariants and Inventory
+
+- Capture the exact base SHA and an ordered multiset containing all function
+  and type names before editing.
+- After formatting, build the same multiset across the root and new child
+  modules; require an exact diff with no missing or duplicate symbol.
+- Compare the moved bodies against the base with a movement-aware review;
+  permitted edits are module declarations, imports, visibility required for
+  siblings, and qualified private paths only.
+- Preserve all `WorkflowDefinition`, `WorkflowDecision`, command/evidence,
+  JSON, logging, error, retry, and timestamp expressions exactly.
+- Grep all external references to ensure stable caller paths remain unchanged.
+- Require root and touched production child files to be at most 800 formatted
+  lines.
+
+## Affected Files
+
+Expected production scope:
+
+- `crates/harness-server/src/workflow_runtime_pr_feedback.rs`
+- `crates/harness-server/src/workflow_runtime_pr_feedback/persistence.rs`
+- `crates/harness-server/src/workflow_runtime_pr_feedback/command_state.rs`
+- `crates/harness-server/src/workflow_runtime_pr_feedback/targets.rs`
+
+`pr_lifecycle_persist.rs` may receive import-only adjustments if required.
+No test, manifest, lockfile, migration, schema, model, or external caller file
+is expected to change.
+
+## Alternatives Considered
+
+- Leave the file unchanged: rejected because it remains more than twice the
+  hard production-file ceiling and couples four independently reviewable areas.
+- Rewrite the lifecycle into new abstractions: rejected because it would mix
+  behavior and architecture changes with the safe extraction.
+- Move context/outcome types into child modules and re-export them: rejected
+  unless required, because retaining them in the facade minimizes public-path
+  and documentation churn.
+- Split by individual workflow event: rejected because it would create many
+  tiny modules with shared persistence/query helpers and obscure ownership.
+
+## Risks
+
+- Security: low; no auth, secret, network, or permission behavior changes. The
+  diff must still be reviewed for accidental widening of visibility.
+- Compatibility: medium if caller paths or serialization fields drift. Stable
+  facade types and exact inventories mitigate this risk.
+- Performance: low; complete bodies and query order are preserved, so no new
+  allocation, query, retry, or external call is expected.
+- Maintenance: low after extraction; the main risk is a misplaced private
+  helper or duplicate implementation during movement.
+- Persistence: medium because workflow decisions are durable. Full isolated
+  PostgreSQL server tests and workspace tests are mandatory.
+
+## Test Plan
+
+- [ ] Baseline and final `cargo check -p harness-server --all-targets`.
+- [ ] Existing PR-feedback runtime tests with an isolated PostgreSQL database.
+- [ ] Existing HTTP/background/task-executor tests selected by changed call
+      paths if the focused filter does not cover them.
+- [ ] `cargo fmt --all -- --check` and post-format line-count gate.
+- [ ] Exact function/type multiset and no-scope diff checks.
+- [ ] Full `harness-server` library tests with isolated PostgreSQL.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Full database-backed workspace tests with one test thread.
+- [ ] SpecRail global/packet/route checks, VibeGuard baseline/compliance, exact
+      head CI, review-thread audit, and required PR gate.
+
+## Rollback Plan
+
+Squash-revert the implementation PR. Because the change adds no schema,
+configuration, dependency, or persisted-format change, no data rollback or
+operator procedure is required.


### PR DESCRIPTION
Linked work: #1649

## Why

The PR-feedback workflow runtime still concentrates 1,677 lines, 47 functions, 10 types, and nine external integration surfaces in one persistence-critical production file. The packet defines a mechanical modularization that reduces review scope while preserving every workflow, persistence, command, suppression, JSON, logging, and caller contract.

## Packet

- `specs/GH1649/product.md`: user problem, non-goals, edge cases, and B-001 through B-010 acceptance criteria
- `specs/GH1649/tech.md`: facade/child-module design, data flow, invariants, risks, scope, verification, and rollback
- `specs/GH1649/tasks.md`: sequential SP1649-T1 through T4 plan with owners, dependencies, done-when conditions, commands, and handoff evidence

## Planned module ownership

- root facade: stable context/outcome types and public entry paths
- `persistence.rs`: decision construction/persistence and commit outcomes
- `command_state.rs`: command queries, deduplication, and failed-child suppression
- `targets.rs`: workflow targets, instances, IDs, runtime JSON, and field parsing
- existing `pr_lifecycle_persist.rs`: retained with unchanged behavior

## Scope controls

- No behavior, API, state, transition, command, evidence, persistence, JSON, logging, error, schema, migration, model, dependency, or test change
- Exact pre/post 47-function and 10-type multiset
- Stable external caller paths
- Root and all touched production modules at or below 800 formatted lines
- Separate implementation PR only after this spec merges

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1649`
- SpecRail `write_spec` route in required mode: allowed
- pre-push hook: all applicable checks passed (database-backed suites correctly deferred because this is a documentation-only PR)
