### PR TITLE
docs: GH1652 registry-driven definition enumeration spec packet

### DIFF
--- a/specs/GH1652/product.md
+++ b/specs/GH1652/product.md
@@ -1,0 +1,78 @@
+# GH1652 Product Spec: Registry-Driven Definition Enumeration for Operator Surfaces
+
+GitHub issue: `#1652`
+
+## Goals
+
+- Make every operator-facing surface that enumerates workflow definitions
+  (operator monitor, monitor sampling, dashboard active counts, overview
+  active counts) reflect the full set of definitions registered at
+  startup, including declarative definitions from WORKFLOW.md (GH-1609).
+- Guarantee a blocked, active, or failed declarative workflow instance is
+  as visible to operators as a built-in one.
+- Keep built-in-only deployments byte-identical: no output change when no
+  declarative definitions are registered.
+
+## Non-Goals
+
+- No workflow runtime, recovery, or registry semantic changes.
+- No new dashboard features, panels, or per-definition custom rendering;
+  declarative definitions render through the same generic projection as
+  built-ins.
+- No changes to per-definition behavioral branches (for example
+  quality-gate-specific projection logic); only enumeration sites are in
+  scope.
+
+## Users
+
+- Operators running unattended deployments who rely on the operator
+  monitor and dashboard to find stuck work.
+- GH-1609 adopters: anyone running declarative workflow definitions in
+  production.
+
+## Behavior Invariants
+
+- `B-001` The set of definition ids used by operator/dashboard
+  enumeration comes from the workflow definition registry at request
+  time; no operator-facing handler maintains its own definition id list.
+- `B-002` With only built-in definitions registered, monitor, sampling,
+  dashboard active counts, and overview output are byte-identical to
+  today (ordering included).
+- `B-003` A nonterminal declarative workflow instance appears in the
+  operator monitor payload with the same fields as built-in instances,
+  and in dashboard/overview active counts, without declarative-specific
+  code in those handlers.
+- `B-004` Enumeration order is deterministic (sorted by definition id, or
+  the registry's stable order) so payloads and counts do not flap between
+  requests.
+- `B-005` A definition registered but with zero instances contributes no
+  monitor rows and a zero (or absent, matching today's semantics for
+  empty definitions) count — never an error.
+- `B-006` If the registry is unavailable or empty (cannot happen after a
+  healthy startup, which seeds built-ins), enumeration surfaces an
+  explicit error path rather than silently rendering an empty dashboard.
+- `B-007` The audit closes the class: after this change, no
+  operator/dashboard/projection surface in `harness-server` enumerates
+  definition ids from a local static list; per-definition behavioral
+  matches (not enumerations) are exempt and documented.
+
+## Boundary Checklist
+
+| Category | Coverage |
+|---|---|
+| Empty input | covered: B-005 (registered-but-empty definitions), B-006 (empty registry is an explicit error path) |
+| Failure paths | covered: B-006; store list errors keep today's warn-and-continue semantics per surface |
+| Authorization | N/A — no new endpoints or permissions; same read paths |
+| Concurrency | covered: B-004 (deterministic order under concurrent requests); registry reads are the frozen post-startup snapshot |
+| Retry + idempotency | N/A — read-only surfaces |
+| Illegal transitions | N/A — no state changes |
+| Compatibility | covered: B-002 (byte-identical built-in-only output) |
+| Degradation / fallback | covered: B-006 (no silent empty dashboard) |
+| Evidence / audit | covered: B-007 (enumeration-site audit is an acceptance gate with a documented exemption list) |
+| Cancellation / partial | N/A — read-only surfaces |
+
+Cross-product boundary called out explicitly: a declarative instance in
+`blocked` (the state most needing attention) must surface in both the
+monitor rows and the active counts in the same request cycle (B-003), and
+adding a definition must never reorder or rename existing built-in
+entries in payload output (B-002 + B-004).

--- a/specs/GH1652/tasks.md
+++ b/specs/GH1652/tasks.md
@@ -1,0 +1,44 @@
+# GH1652 Task Plan
+
+## Linked Issue
+
+GH-1652 (related: GH-1609, GH-1608)
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1652-T001` Owner: `helper` | Done when: a shared `operator_definition_ids()` helper reads the frozen registry, sorts ids, and errors on an empty registry, with unit tests for order and the empty case (B-001, B-004, B-006) | Verify: `cargo test -p harness-server definition_ids`
+- [ ] `SP1652-T002` Owner: `history-check` | Done when: git history / code comments establish whether dashboard_active_counts and overview intentionally exclude pr_feedback/quality_gate (child workflows); the decision is encoded as an explicit documented predicate in the helper (preserve built-in exclusions exactly, include declarative ids) and recorded in tech.md (B-002, B-003) | Verify: updated tech.md note + code comment in the helper
+- [ ] `SP1652-T003` Owner: `monitor` | Done when: `operator_monitor.rs` const is deleted and monitor + `sampling.rs` iterate the helper's ids; built-in-only monitor payload snapshot is unchanged (B-001, B-002) | Verify: `cargo test -p harness-server operator_monitor`
+- [ ] `SP1652-T004` Owner: `counts` | Done when: `dashboard_active_counts.rs` and `overview.rs` use the helper (with the T002 predicate); built-in-only counts snapshots unchanged (B-001, B-002) | Verify: `cargo test -p harness-server dashboard overview`
+- [ ] `SP1652-T005` Owner: `visibility-tests` | Done when: a declarative fixture definition with a blocked instance appears in monitor payload, sampling output, dashboard active counts, and overview counts; a zero-instance declarative definition contributes nothing (B-003, B-005) | Verify: `cargo test -p harness-server declarative_visibility`
+- [ ] `SP1652-T006` Owner: `audit` | Done when: no static definition-id enumeration remains in `harness-server` outside the helper; per-definition behavioral branches are listed as exemptions in tech.md (B-007) | Verify: `git grep -n "DEFINITION_IDS" crates/harness-server/src` returns only the helper module
+
+## Parallelization
+
+- `SP1652-T001` and `SP1652-T002` first, in parallel (helper vs history
+  research).
+- `SP1652-T003` and `SP1652-T004` in parallel after T001+T002 (disjoint
+  files).
+- `SP1652-T005` after T003/T004; `SP1652-T006` last.
+
+## Verification
+
+- `cargo check --workspace --all-targets`
+- `cargo test -p harness-server`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1652`
+
+## Handoff Notes
+
+The one genuine design decision is T002: whether the two-id lists in
+active counts are a bug or an intentional child-workflow exclusion. Do
+not guess — check the blame/PR history. Everything else is mechanical.
+Declarative visibility tests should reuse the fixture-definition
+helpers introduced by the GH-1609 test suites rather than inventing new
+fixtures.

--- a/specs/GH1652/tech.md
+++ b/specs/GH1652/tech.md
@@ -1,0 +1,145 @@
+# GH1652 Tech Spec: Registry-Driven Definition Enumeration
+
+Product spec: `specs/GH1652/product.md`
+GitHub issue: `#1652`
+Related: GH-1609 (declarative definitions), GH-1608 (registry)
+
+## Codebase Context (verified anchors, origin/main)
+
+Static enumeration sites (in scope):
+
+- `crates/harness-server/src/handlers/operator_monitor.rs:39-44` —
+  `const WORKFLOW_DEFINITION_IDS: &[&str]` listing the four built-ins;
+  iterated at `operator_monitor.rs:364`.
+- `crates/harness-server/src/handlers/operator_monitor/sampling.rs:1`
+  imports that const; iterates it at `sampling.rs:10` and `sampling.rs:36`.
+- `crates/harness-server/src/handlers/dashboard_active_counts.rs:106-110`
+  — inline array `[GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID]`
+  feeding `list_nonterminal_instances_by_definition`.
+- `crates/harness-server/src/handlers/overview.rs:484-487` — same inline
+  two-id array feeding the same store call.
+
+Registry API (the replacement source):
+
+- `crates/harness-workflow/src/runtime/state_registry.rs:385`
+  (`known_workflow_definition_ids() -> Vec<String>`, free function over
+  the process registry), registry method `state_registry.rs:256`
+  (`known_definition_ids`). The registry is seeded with built-ins and
+  frozen after startup registration
+  (`crates/harness-server/src/server.rs:110-127`), so request-time reads
+  are stable snapshots.
+
+Exempt per-definition behavior (not enumeration; out of scope, B-007
+exemption list):
+
+- `crates/harness-server/src/runtime_projection.rs:295` (quality-gate
+  `pending` special case) and other `definition_id == ...` behavioral
+  branches in projection/worker code.
+
+Store query used by all four sites:
+`list_nonterminal_instances_by_definition(definition_id, ...)` — already
+string-keyed, works for declarative ids unchanged.
+
+## Proposed Design
+
+### One enumeration helper
+
+Add a small helper in `harness-server` (e.g.
+`crates/harness-server/src/handlers/definition_ids.rs` or an existing
+shared handlers module):
+
+```rust
+/// Definition ids for operator-facing enumeration, from the frozen
+/// registry, in sorted order (B-001, B-004). Errors if the registry
+/// reports no definitions (B-006) — impossible after healthy startup.
+pub fn operator_definition_ids() -> anyhow::Result<Vec<String>> {
+    let mut ids = harness_workflow::runtime::known_workflow_definition_ids();
+    if ids.is_empty() {
+        anyhow::bail!("workflow definition registry returned no definitions");
+    }
+    ids.sort();
+    Ok(ids)
+}
+```
+
+### Call-site changes
+
+1. `operator_monitor.rs`: delete `const WORKFLOW_DEFINITION_IDS`
+   (`:39-44`); `:364` iterates `operator_definition_ids()?`. The
+   `sampling.rs` functions take the id slice as a parameter or call the
+   helper — whichever keeps signatures smallest.
+2. `dashboard_active_counts.rs:106` and `overview.rs:484`: replace the
+   inline two-id arrays with the helper. Note both sites today enumerate
+   only two of the four built-ins — verify against git history whether
+   pr_feedback/quality_gate exclusion is intentional (child workflows may
+   be deliberately excluded from "active counts" because they shadow
+   their parents). If intentional, the helper gains an explicit filter
+   (`is_top_level_definition`, driven by registry metadata or a
+   documented predicate: built-in child definitions excluded, declarative
+   definitions included) rather than an id list; the exclusion decision
+   and rationale must land in the code comment and in this spec during
+   implementation (B-002 vs B-003 tension is resolved by preserving
+   today's built-in exclusions exactly and adding declarative ids).
+3. Ordering: sort ids before iterating so payload order is deterministic
+   (B-004). Today's const order is
+   github_issue_pr, pr_feedback, prompt_task, quality_gate — already
+   sorted alphabetically, so sorting preserves built-in output order
+   (B-002).
+
+### Determinism note
+
+Registry content is frozen post-startup, so per-request enumeration is
+stable. No caching needed; `known_workflow_definition_ids()` is a cheap
+read (`Vec<String>` clone of a small set).
+
+## Edge Cases
+
+- Declarative definition registered with zero instances: store query
+  returns empty; monitor/counts render nothing for it — same as a
+  built-in with no instances (B-005).
+- Multiple pinned versions of one declarative id: enumeration is by id,
+  not (id, version); instances of all versions list under the one id —
+  matches operator expectations.
+- Deployment with no WORKFLOW.md definitions: registry returns exactly
+  the four built-ins; with the preserved child-definition exclusions the
+  output is byte-identical (B-002).
+
+## Migration / Compatibility
+
+- No persisted data, wire schema, or config changes. Payload shape is
+  unchanged; only which definition ids contribute rows/counts changes,
+  and only when declarative definitions exist.
+
+## Verification Plan
+
+- Unit: helper returns sorted ids and errors on an empty registry
+  (test-only fresh registry) (B-001, B-004, B-006).
+- Handler tests: register a declarative fixture definition, create a
+  nonterminal (blocked) instance, assert it appears in the operator
+  monitor payload, sampling output, dashboard active counts, and
+  overview counts (B-003).
+- Regression: built-in-only snapshot tests for monitor payload and
+  active counts before/after refactor (B-002).
+- Audit gate: `git grep -n "DEFINITION_IDS\|for definition_id in \["
+  crates/harness-server/src` returns only the shared helper and
+  documented per-definition behavioral branches (B-007).
+- Full gates: `cargo test -p harness-server`,
+  `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo fmt --all -- --check`.
+
+## Rollback Plan
+
+Read-only surface refactor; revert restores the static lists. No data or
+config to unwind.
+
+## Product-to-Test Mapping
+
+| Invariant | Implementation area | Verification |
+|---|---|---|
+| B-001 | shared helper + 4 call sites | `cargo test -p harness-server handlers` + audit grep |
+| B-002 | preserved exclusions + sorted order | built-in-only snapshot tests |
+| B-003 | call-site swaps | declarative fixture visibility tests (monitor, sampling, counts, overview) |
+| B-004 | sort in helper | helper unit test |
+| B-005 | no-op for empty definitions | fixture test with zero-instance definition |
+| B-006 | empty-registry error | helper unit test with fresh registry |
+| B-007 | enumeration audit | grep gate in CI-visible test or review checklist |


### PR DESCRIPTION
## Summary

Spec packet (product/tech/tasks) for GH-1652: operator monitor (`operator_monitor.rs:39,364`, `sampling.rs:10,36`), dashboard active counts (`dashboard_active_counts.rs:106-110`), and overview (`overview.rs:484-487`) enumerate workflow definitions from static id lists, so declarative workflow instances (GH-1609) are invisible on every surface operators use to find stuck work.

Design: one shared `operator_definition_ids()` helper reading the frozen registry (`known_workflow_definition_ids()`, `state_registry.rs:385`), sorted for deterministic output, error on empty registry (no silent empty dashboard). Built-in-only deployments stay byte-identical — including an explicit research task (T002) on whether the two-id lists in active counts are an intentional child-workflow exclusion to preserve, before any code changes.

## Linked Issue

Refs #1652 (spec packet only; no implementation in this PR)

## Test Plan

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1652` — SpecRail check passed
- Docs-only change; no code surface