### PR TITLE
docs(workflow): document definition block and continuation policy (GH-1653)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
  "harness-observe",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "sqlx",
  "tempfile",

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,4 +1,6 @@
 ---
+# Custom workflow shapes (`definition` block) and prompt-task continuation
+# policies are documented in docs/workflow-declarative-definitions.md.
 workflow:
   id: github_issue_pr
   version: 1

--- a/config/WORKFLOW.md
+++ b/config/WORKFLOW.md
@@ -7,6 +7,29 @@
 # field-by-field, so a repo only needs a WORKFLOW.md to override repo-specific
 # fields such as `source.repo` or per-language `activities.*.validation`
 # commands. A repo with no WORKFLOW.md inherits this base entirely.
+#
+# Exception: a repo-level `definition` block (declarative workflow shape)
+# replaces the base's declaration wholesale — state machines are never
+# merged field-by-field. Repos can also opt prompt tasks into bounded
+# external-state continuation loops. Both features, with validated
+# examples, are documented in docs/workflow-declarative-definitions.md.
+# Skeleton of a repo-level declarative definition:
+#
+#   definition:
+#     id: my_custom_flow
+#     initial: implementing
+#     states:
+#       implementing:
+#         activity: implement_issue
+#         on_success: done
+#       blocked:
+#         progress: operator_gate   # required safety fallback state
+#     terminal:
+#       done: succeeded
+#       failed: failed
+#       cancelled: cancelled
+#     recovery_targets:
+#       - implementing
 workflow:
   id: github_issue_pr
   version: 1

--- a/crates/harness-workflow/Cargo.toml
+++ b/crates/harness-workflow/Cargo.toml
@@ -31,4 +31,5 @@ tempfile = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
+serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/harness-workflow/tests/docs_examples.rs
+++ b/crates/harness-workflow/tests/docs_examples.rs
@@ -1,0 +1,91 @@
+//! Doc-lint: the examples in docs/workflow-declarative-definitions.md must
+//! parse and pass the real validation paths, so documentation cannot drift
+//! from the implemented schema.
+
+use harness_core::config::workflow::{WorkflowActivityPolicy, WorkflowDefinitionPolicy};
+use harness_workflow::runtime::{
+    build_declarative_definition, parse_external_state_signal, ActivityResult, ActivitySignal,
+    PromptContinuationPolicy,
+};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+const DOC_RELATIVE_PATH: &str = "../../docs/workflow-declarative-definitions.md";
+
+fn doc_text() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DOC_RELATIVE_PATH);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+/// Returns the fenced code block that follows `<!-- doc-example:{name} -->`.
+fn doc_example(doc: &str, name: &str) -> String {
+    let marker = format!("<!-- doc-example:{name} -->");
+    let after_marker = doc
+        .split_once(&marker)
+        .unwrap_or_else(|| panic!("doc example marker `{marker}` not found"))
+        .1;
+    let fence_start = after_marker
+        .find("```")
+        .unwrap_or_else(|| panic!("no code fence after marker `{marker}`"));
+    let after_fence = &after_marker[fence_start..];
+    let body_start = after_fence
+        .find('\n')
+        .unwrap_or_else(|| panic!("unterminated fence line after marker `{marker}`"))
+        + 1;
+    let body = &after_fence[body_start..];
+    let body_end = body
+        .find("```")
+        .unwrap_or_else(|| panic!("unterminated code fence after marker `{marker}`"));
+    body[..body_end].to_string()
+}
+
+#[derive(Deserialize)]
+struct DeclarativeDocExample {
+    activities: BTreeMap<String, WorkflowActivityPolicy>,
+    definition: WorkflowDefinitionPolicy,
+}
+
+#[test]
+fn declarative_definition_example_passes_structural_validation() {
+    let yaml = doc_example(&doc_text(), "declarative-definition");
+    let example: DeclarativeDocExample =
+        serde_yaml::from_str(&yaml).expect("documented definition example must parse as YAML");
+
+    let compiled = build_declarative_definition(&example.definition, &example.activities)
+        .expect("documented definition example must pass structural validation");
+    assert_eq!(compiled.policy().id, "docs_review_flow");
+}
+
+#[derive(Deserialize)]
+struct ContinuationDocExample {
+    continuation: PromptContinuationPolicy,
+}
+
+#[test]
+fn continuation_policy_example_passes_validation() {
+    let json = doc_example(&doc_text(), "continuation-policy");
+    let example: ContinuationDocExample =
+        serde_json::from_str(&json).expect("documented continuation example must parse as JSON");
+
+    example
+        .continuation
+        .validate()
+        .expect("documented continuation policy must pass validation");
+    assert!(example.continuation.active_states.contains("In Progress"));
+}
+
+#[test]
+fn external_state_signal_example_passes_the_signal_contract() {
+    let json = doc_example(&doc_text(), "external-state-signal");
+    let signal: ActivitySignal =
+        serde_json::from_str(&json).expect("documented signal example must parse as JSON");
+
+    let mut result = ActivityResult::succeeded("implement_prompt", "attempt finished");
+    result.signals.push(signal);
+
+    let parsed = parse_external_state_signal(&result)
+        .expect("documented signal example must satisfy the external_state contract");
+    assert_eq!(parsed.state, "In Progress");
+}

--- a/docs/workflow-declarative-definitions.md
+++ b/docs/workflow-declarative-definitions.md
@@ -1,0 +1,183 @@
+# WORKFLOW.md: Declarative Definitions and Continuation Policies
+
+This page documents the two WORKFLOW.md features that let a repository
+define workflow behavior without Rust changes:
+
+- the **`definition` block** — declare a custom workflow shape (states,
+  activities, transitions, terminal mapping, evidence) interpreted by the
+  runtime (GH-1609);
+- the **continuation policy** — run a single prompt task as a bounded
+  loop that re-invokes the agent while an external tracker subject stays
+  active (GH-1607).
+
+Both features are inert unless configured. The examples below are
+validated by `crates/harness-workflow/tests/docs_examples.rs`, which
+parses this file and runs the real structural validation, so they cannot
+drift from the implementation.
+
+## Declarative workflow definitions
+
+Add a `definition` block to the YAML frontmatter of a managed repo's
+`WORKFLOW.md`. At server startup the declaration is structurally
+validated, compiled, and registered; instances then run on the existing
+durable runtime (leases, retries, circuit breaker, audit).
+
+<!-- doc-example:declarative-definition -->
+```yaml
+activities:
+  implement_issue:
+    prompt: default
+    validation:
+      - cargo check
+  run_local_review:
+    prompt: pr_feedback
+
+definition:
+  id: docs_review_flow
+  initial: implementing
+  states:
+    implementing:
+      activity: implement_issue
+      on_success: reviewing
+      on_signal:
+        SCOPE_TOO_LARGE: blocked
+    reviewing:
+      activity: run_local_review
+      on_success: done
+      on_failure: implementing
+    blocked:
+      progress: operator_gate
+  terminal:
+    done: succeeded
+    failed: failed
+    cancelled: cancelled
+  evidence_required:
+    done: [github_pr]
+  recovery_targets:
+    - implementing
+```
+
+### Schema rules (enforced at startup)
+
+Startup fails with an actionable error — never a partially registered
+definition — when a declaration violates any of these:
+
+- `id` must not be empty and must not collide with a built-in definition
+  (`github_issue_pr`, `prompt_task`, `quality_gate`, `pr_feedback`).
+- `initial` must name a declared active state (not a terminal one).
+- Every active state declares **exactly one** progress mode: an
+  `activity` (which must exist in the `activities` policy map) **or**
+  `progress: external_wait` / `progress: operator_gate`.
+- A `blocked` active state is **required**, must declare exactly
+  `progress: operator_gate`, no activity, and no outgoing routes. It is
+  the runtime's safety fallback for invalid agent output; operators leave
+  it through `recovery_targets`.
+- `terminal` must assign **exactly one** state to each class:
+  `succeeded`, `failed`, and `cancelled`.
+- Every routing target (`on_success`, `on_failure`, `on_blocked`,
+  `on_signal` values) must name a declared state; every declared state
+  must be reachable from `initial` (`blocked` and the failed/cancelled
+  terminals are implicitly reachable from any active state).
+- `evidence_required` may not target `blocked` and may not repeat an
+  evidence kind; `recovery_targets` must name active states other than
+  `blocked`.
+
+### Routing semantics
+
+- On a successful activity completion, a declared `on_signal` match wins
+  over `on_success`; when several mapped signal types appear on one
+  result, the lexicographically smallest signal type wins and the
+  decision records the tie.
+- Blocked/failed activity results follow `on_blocked` / `on_failure` when
+  declared, otherwise the runtime's generic blocked/retry handling.
+- A completion for a `(state, activity)` pair the declaration does not
+  expect lands in `blocked` — never an implicit transition.
+- Transitions into terminal states emit the matching command:
+  `succeeded` → `MarkDone`, `failed` → `MarkFailed`, `cancelled` →
+  `MarkCancelled`.
+
+### Pinning: editing WORKFLOW.md while instances are in flight
+
+Each instance pins the definition content at creation:
+`definition_version` (truncated content hash) plus the full hash in
+instance data. Editing the `definition` block affects only instances
+created after the next startup. An in-flight instance whose pinned
+version is no longer registered transitions to `blocked` with
+`definition_version_missing` — it is never silently reinterpreted under
+the new shape. Operators resolve by restoring the old declaration or
+cancelling the instance.
+
+### Merge semantics
+
+The `definition` block does **not** deep-merge. A repo-level `definition`
+replaces the central base's declaration wholesale; state machines are
+never merged field-by-field.
+
+## Prompt-task continuation policies
+
+A prompt task submission may carry an optional `continuation` object.
+Without one, prompt tasks stay single-shot. With one, the runtime
+re-enqueues the implement activity — with attempt context — while the
+agent reports the external subject as still active.
+
+<!-- doc-example:continuation-policy -->
+```json
+{
+  "prompt": "Work the tracker ticket per the status map in this repo's WORKFLOW.md.",
+  "continuation": {
+    "max_attempts": 10,
+    "attempt_delay_secs": 300,
+    "active_states": ["Todo", "In Progress", "Rework"],
+    "no_progress_limit": 3
+  }
+}
+```
+
+- `max_attempts` (≥ 1, server-capped) bounds the loop.
+- `attempt_delay_secs` delays dispatch of the next attempt.
+- `active_states` is the exact, case-sensitive set of external states
+  that mean "keep going".
+- `no_progress_limit` (default 3) bounds attempts that report the same
+  external state with no new artifacts and no new validation records.
+
+### The agent's signal contract
+
+The harness process never contacts the tracker; the agent is the probe.
+Each implement attempt must end with **exactly one** `external_state`
+signal on its activity result, whose payload is a JSON object with a
+non-empty string `state` field:
+
+<!-- doc-example:external-state-signal -->
+```json
+{
+  "signal_type": "external_state",
+  "signal": {
+    "state": "In Progress",
+    "subject": "TEAM-123"
+  }
+}
+```
+
+The reported `state` is compared against `active_states`:
+
+- state in `active_states`, attempts remaining → the workflow re-enters
+  `implementing` and the next attempt is enqueued in the same
+  transaction, with `attempt`, `previous_external_state`, and the
+  previous attempt summary injected into the prompt packet as
+  `continuation_context`.
+- state not in `active_states` → the task completes as `done` through
+  the normal evidence path.
+
+### Blocked outcomes (never silent)
+
+The loop terminates in `blocked` — with an auditable reason — when:
+
+- the signal is missing, duplicated, a non-object payload, or lacks a
+  string `state` (malformed contract);
+- the attempt budget is exhausted while the subject is still active;
+- `no_progress_limit` consecutive attempts report the same state with no
+  new artifacts and no new validation records.
+
+A continuation can never silently complete: malformed signals and
+exhaustion both stop in `blocked`, and operator cancellation between
+attempts ends the loop without enqueueing further work.


### PR DESCRIPTION
## Summary

Implements #1653: user-facing documentation for the two features that make WORKFLOW.md self-sufficient, with a doc-lint test that keeps the examples honest.

- **New page** `docs/workflow-declarative-definitions.md`: the `definition` block (schema rules as enforced by `build_declarative_definition` — required `blocked` operator-gate state, exactly-one-state-per-terminal-class, activity XOR progress, reachability), routing semantics (signal precedence, terminal → Mark* mapping), pinning (`definition_version_missing` fails closed), and the atomic-merge rule; plus continuation policies (fields, the exactly-one `external_state` object-payload signal contract, and all blocked outcomes).
- **Doc-lint test** `crates/harness-workflow/tests/docs_examples.rs`: extracts the three marked examples from the page and runs them through real validation (`build_declarative_definition`, `PromptContinuationPolicy::validate`, `parse_external_state_signal`) — docs cannot drift from the schema.
- **Discovery**: inert YAML comments in root `WORKFLOW.md` and `config/WORKFLOW.md` point at the page; the central base documents the definition atomic-merge exception with a commented skeleton.

## Linked Issue

Closes #1653

## Test Plan

- `cargo test -p harness-workflow --test docs_examples` — 3/3 pass (this session)
- `cargo test -p harness-core --lib` — 592 pass (frontmatter parsing unaffected)
- Python YAML sanity parse of both edited WORKFLOW.md frontmatters: parse clean, no active `definition` block introduced
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all` — applied