### PR TITLE
docs: GH1656 declarative intake bindings spec packet

### DIFF
--- a/specs/GH1656/product.md
+++ b/specs/GH1656/product.md
@@ -1,0 +1,104 @@
+# GH1656 Product Spec: Source-Agnostic Intake Bindings for Declarative Definitions
+
+GitHub issue: `#1656`
+Depends on: GH-1609 (declarative definitions, merged). Related: GH-1652
+(declarative observability), GH-1607 (agent-as-probe continuation).
+
+## Goals
+
+- Let a WORKFLOW.md `definition` declare where its instances come from: an
+  optional `intake` binding routes incoming issues from any registered
+  intake source into the declarative definition, completing the
+  "give a WORKFLOW.md and work arrives by itself" loop.
+- Keep the binding schema strictly source-agnostic: filters operate on the
+  normalized `IncomingIssue`, never on GitHub-specific structures.
+  Trackers such as Linear are optional future sources behind the existing
+  `IntakeSource` trait and must need zero binding-schema changes.
+- Preserve today's intake behavior exactly for unmatched issues and for
+  deployments without bindings.
+- Bound unattended instance creation: per-binding dedupe and an
+  active-instance cap, with every skip audited.
+
+## Non-Goals
+
+- No new tracker sources (Linear or otherwise) in this feature.
+- No external-state lifecycle mirroring (auto-cancel on issue close);
+  workflows observe external state through their own activities.
+- No changes to github_issue_pr intake for unmatched issues.
+- No per-binding scheduling or priority beyond the active-instance cap.
+
+## Users
+
+- Repo owners running custom declarative flows who today must feed
+  instances through the submission API by hand.
+- Operators running unattended multi-repo deployments who need custom
+  flows to be discovered, deduped, and capped like built-in ones.
+
+## Behavior Invariants
+
+- `B-001` A definition without an `intake` block, and any deployment with
+  no bindings at all, produces byte-identical intake behavior to today —
+  routing, coverage gating, and dispatch of github_issue_pr included.
+- `B-002` Binding validation is fail-closed at startup: unknown or
+  disabled `source`, empty `filter.labels`, or `max_active_instances < 1`
+  aborts startup with an actionable error and zero partial registration.
+- `B-003` The binding schema is source-agnostic: matching consumes only
+  normalized `IncomingIssue` fields (`labels`, `source`, `repo`); nothing
+  in the schema or matcher references GitHub-specific data. A
+  non-GitHub-source routing path is exercised by test.
+- `B-004` Routing is deterministic: bindings match by declared source and
+  label filter; an issue matching multiple bindings routes to the
+  lexicographically smallest definition id and the tie is recorded in the
+  submission audit (same rule as GH-1609 signal precedence).
+- `B-005` A matched issue creates the instance through the existing
+  declarative submission path with the pinned definition version; the
+  instance subject carries external id, repo, url, and title, and
+  `author_trust_class` flows through unchanged.
+- `B-006` Unmatched issues follow the existing github_issue_pr path with
+  no behavior change; a matched issue never *also* dispatches to
+  github_issue_pr (routing is exclusive).
+- `B-007` Dedupe: at most one nonterminal instance per
+  `(definition_id, external_id)`. A live instance suppresses re-dispatch
+  silently-visibly (audited as suppressed, not dropped); a terminal
+  instance permits a new one.
+- `B-008` `max_active_instances` is enforced per binding: at cap, new
+  matches are skipped with an audited reason and naturally revisited on
+  later poll ticks — never enqueued into an unbounded backlog and never
+  silently dropped.
+- `B-009` Routing decisions, suppressions, and cap-skips are observable:
+  each produces an audit record naming the issue, the binding, and the
+  outcome; declarative instances born from intake are visible on operator
+  surfaces per GH-1652.
+- `B-010` The harness process gains no tracker/API calls from this
+  feature: bindings only consume what registered sources already poll.
+- `B-011` Intake-born instances are ordinary declarative instances:
+  pinning, recovery, cancel, and continuation semantics apply without
+  special cases; nothing distinguishes them at runtime except subject
+  metadata.
+- `B-012` A source that is registered but yields an issue whose repo maps
+  to a project without the bound definition does not create an instance
+  and does not error the tick: the mismatch is audited and the issue
+  follows the unmatched path (definitions are per-project; bindings match
+  within their own project scope only).
+
+## Boundary Checklist
+
+| Category | Coverage |
+|---|---|
+| Empty input | covered: B-001 (no bindings = today), B-002 (empty label filter rejected) |
+| Failure paths | covered: B-002 (fail-closed startup), B-012 (cross-project mismatch audited, tick survives); source poll errors keep today's per-source error handling |
+| Authorization | covered: B-005 (`author_trust_class` passthrough), B-010 (no new external calls/credentials) |
+| Concurrency | covered: B-007/B-008 (dedupe and cap checked against store state at dispatch; per-repo parallel dispatch unchanged) |
+| Retry + idempotency | covered: B-007 (re-polled issues suppressed while live), B-008 (cap skips retried naturally on later ticks) |
+| Illegal transitions | N/A — creation only; instance lifecycle unchanged (B-011) |
+| Compatibility | covered: B-001, B-006 (unmatched path untouched), B-003 (schema future-proof for new sources) |
+| Degradation / fallback | covered: B-008/B-009 (skips audited, never silent), B-012 |
+| Evidence / audit | covered: B-004 (tie reasons), B-009 (route/suppress/skip records) |
+| Cancellation / partial | covered: B-011 (cancel semantics inherited); terminal instance reopens intake for the same external id (B-007) |
+
+Cross-product boundary called out explicitly: the same external id
+arriving from two different sources is two distinct dedupe keys only if
+the definitions differ — within one binding, `external_id` uniqueness is
+the source's contract (B-003 + B-007); and a cap-skipped issue must
+remain eligible on the next tick even though its remote fact snapshot was
+already recorded (B-008 + existing coverage-gate semantics).

--- a/specs/GH1656/tasks.md
+++ b/specs/GH1656/tasks.md
@@ -1,0 +1,49 @@
+# GH1656 Task Plan
+
+## Linked Issue
+
+GH-1656 (depends on GH-1609, merged; related: GH-1652, GH-1607)
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1656-T001` Owner: `config-schema` | Done when: `WorkflowDefinitionIntakePolicy` / `IntakeFilterPolicy` land as an optional `intake` field on `WorkflowDefinitionPolicy` with parse-level checks (non-empty labels, no duplicates/empties, cap >= 1) and an atomic-merge regression test covering a definition with an `intake` block (B-001, B-002) | Verify: `cargo test -p harness-core config`
+- [ ] `SP1656-T002` Owner: `binding-registry` | Done when: startup registration validates bindings fail-closed against configured intake sources and builds an immutable project-scoped `IntakeBindingRegistry` on AppState; invalid bindings abort startup with actionable errors (B-002) | Verify: `cargo test -p harness-server` boot-validation tests
+- [ ] `SP1656-T003` Owner: `matcher` | Done when: the source-agnostic matcher (source name + all-labels + no-exclude-labels over normalized `IncomingIssue`) exists with unit tests including a non-GitHub fixture source and deterministic multi-match tie-break with audited tie list (B-003, B-004) | Verify: `cargo test -p harness-server intake::binding`
+- [ ] `SP1656-T004` Owner: `routing` | Done when: `poll_tick`'s shared dispatch path routes matched issues through `resolve_declarative_definition_for_project` + `record_declarative_submission` with subject metadata and trust class, exclusive of the github path; unmatched issues are byte-identical to today; mark/unmark_dispatched mirrors the existing failure handling; webhook-mode delivery goes through the same step (B-005, B-006) | Verify: `cargo test -p harness-server intake`
+- [ ] `SP1656-T005` Owner: `dedupe-cap` | Done when: store-backed `(definition_id, external_id)` dedupe (live suppresses, terminal reopens) and per-binding `max_active_instances` enforcement land, both with audited outcomes and natural next-tick retry (B-007, B-008) | Verify: `cargo test -p harness-server intake::dedupe`
+- [ ] `SP1656-T006` Owner: `audit` | Done when: `intake_routing` observe events record routed / suppressed_live / skipped_at_cap / unmatched outcomes with issue, source, definition, and tie list; cross-project mismatches are audited without failing the tick (B-009, B-012) | Verify: `cargo test -p harness-server intake::audit`
+- [ ] `SP1656-T007` Owner: `e2e-docs` | Done when: an end-to-end stub-runtime test drives fixture-source emission → routing → declarative instance → terminal → dedupe reopen; `docs/workflow-declarative-definitions.md` gains an `intake` section with a doc-lint-validated example (extending the GH-1653 test) (B-001..B-012 integration) | Verify: `cargo test -p harness-server intake_e2e && cargo test -p harness-workflow --test docs_examples`
+
+## Parallelization
+
+- `SP1656-T001` first; `SP1656-T002` and `SP1656-T003` in parallel after
+  T001 (registry vs matcher, disjoint files).
+- `SP1656-T004` after T002+T003; `SP1656-T005` alongside T004's tail
+  (store queries are separable); `SP1656-T006` after T004.
+- `SP1656-T007` last.
+
+## Verification
+
+- `cargo check --workspace --all-targets`
+- `cargo test -p harness-core -p harness-server`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1656`
+
+## Handoff Notes
+
+Source pluggability is the load-bearing constraint (maintainer decision):
+the binding schema and matcher must consume only normalized
+`IncomingIssue` fields so a future Linear source (separate issue, purely
+additive behind `IntakeSource`) needs zero schema work. Routing is
+exclusive — a matched issue must never also dispatch to github_issue_pr.
+The dedupe key is `(definition_id, external_id)`; the query plan is the
+implementer's choice but the invariant is store-backed, not in-memory.
+Cap skips must not call `mark_dispatched`, or the issue becomes
+permanently invisible — this is the easiest correctness trap in the
+whole feature.

--- a/specs/GH1656/tech.md
+++ b/specs/GH1656/tech.md
@@ -1,0 +1,193 @@
+# GH1656 Tech Spec: Declarative Intake Bindings
+
+Product spec: `specs/GH1656/product.md`
+GitHub issue: `#1656`
+Depends on: GH-1609 (merged). Related: GH-1652, GH-1607.
+
+## Codebase Context (verified anchors, origin/main)
+
+- Intake trait and orchestrator:
+  `crates/harness-server/src/intake/mod.rs:51-69` (`IntakeSource`:
+  `poll() -> Vec<IncomingIssue>`, `mark_dispatched`, `unmark_dispatched`,
+  `on_task_complete`), `mod.rs:16-39` (`IncomingIssue` with `source`,
+  `external_id`, `labels`, `author_trust_class`, `project_root`),
+  `mod.rs:83-145` (orchestrator start + poll loop with maintenance
+  window), `mod.rs:145+` (`poll_tick`: group by repo → coverage gate →
+  dispatch), hardwired destination note at `mod.rs:84-86`.
+- Coverage gate (dedupe exemplar):
+  `crates/harness-server/src/intake/github_coverage_gate.rs:14-103`
+  (`issue_lifecycle_state_is_covered`, `runtime_issue_state_is_covered`,
+  `record_issue_remote_fact_snapshot`, `check_github_issue_coverage`).
+- Declarative submission (reuse point):
+  `crates/harness-server/src/workflow_runtime_submission/declarative.rs:27`
+  (`record_declarative_submission`), `declarative.rs:51`
+  (`resolve_declarative_definition_for_project`).
+- Declarative config + registration:
+  `crates/harness-core/src/config/workflow.rs:104-115`
+  (`WorkflowDefinitionPolicy`), startup registration + freeze
+  `crates/harness-server/src/server.rs:110-127`.
+- Sources: `intake/github_issues.rs` (REST poll + webhook modes),
+  `intake/feishu.rs`, `intake/direct_dispatch.rs`; source configs in
+  `crates/harness-core/src/config/intake.rs:241` (`GitHubIntakeConfig`),
+  `:439` (`FeishuIntakeConfig`), `:796` (`IntakeConfig`).
+- Instance store dedupe query surface:
+  `list_nonterminal_instances_by_definition` (used by dashboards; see
+  `handlers/dashboard_active_counts.rs:106-111`).
+
+## Proposed Design
+
+### Config schema (harness-core, `config/workflow.rs`)
+
+```rust
+pub struct WorkflowDefinitionIntakePolicy {
+    pub source: String,                 // registered intake source name (B-003)
+    pub filter: IntakeFilterPolicy,
+    pub max_active_instances: u32,      // >= 1 (B-002, B-008)
+}
+
+pub struct IntakeFilterPolicy {
+    pub labels: Vec<String>,            // non-empty; issue must carry ALL (B-002)
+    #[serde(default)]
+    pub exclude_labels: Vec<String>,    // issue must carry NONE
+}
+```
+
+- New optional field on `WorkflowDefinitionPolicy`:
+  `pub intake: Option<WorkflowDefinitionIntakePolicy>` with
+  `#[serde(default)]` (B-001). Rides the existing atomic `definition`
+  merge — no new merge rules.
+- Match semantics: `issue.source == binding.source` (source names as
+  registered, e.g. "github", "feishu") AND all `filter.labels` present
+  AND no `exclude_labels` present. Label matching is exact and
+  case-sensitive, consistent with `IncomingIssue.labels` as delivered by
+  sources. Nothing GitHub-specific (B-003).
+
+### Startup validation and binding registry (harness-server)
+
+Extend `register_declarative_workflow_definitions`
+(`server.rs:110-127`): after building each definition, if
+`policy.intake` is present, validate fail-closed (B-002):
+
+- `source` names a source that will be registered and enabled per
+  `IntakeConfig` (github/feishu/dashboard as configured);
+- `filter.labels` non-empty, no empty strings, no duplicate labels;
+- `max_active_instances >= 1`.
+
+Valid bindings collect into an `IntakeBindingRegistry` (project-scoped:
+`project_id -> Vec<Binding>`, each binding carrying definition id +
+pinned identity) stored on `AppState` alongside existing intake state.
+Built once at startup, immutable afterwards — same freeze discipline as
+the definition registry.
+
+### Routing in `poll_tick` (intake/mod.rs)
+
+Insert a routing step per issue, before the existing
+github-coverage-gate/dispatch path:
+
+1. Resolve the issue's project (the existing `project_root` →
+   `resolve_canonical_project` flow at `mod.rs:184-196`).
+2. Look up that project's bindings; collect matches
+   (source + labels). No match → existing path unchanged (B-006).
+3. Multiple matches → sort by definition id, take the smallest, record
+   the tie in the audit reason (B-004).
+4. Dedupe check: query nonterminal instances of the target definition
+   whose subject `external_id` equals the issue's. Live instance →
+   audited suppression, `mark_dispatched` NOT called (a terminal
+   instance later re-opens eligibility, B-007). Implementation note: add
+   a store lookup keyed by (definition_id, subject external_id) — an
+   indexed query or a filtered scan over
+   `list_nonterminal_instances_by_definition`, whichever the store
+   supports cheaply; the invariant is the key, not the query plan.
+5. Cap check: count nonterminal instances for the definition; at
+   `max_active_instances`, audited skip, no `mark_dispatched`, issue
+   naturally retried next tick (B-008).
+6. Dispatch: `resolve_declarative_definition_for_project` +
+   `record_declarative_submission` with subject metadata (external_id,
+   identifier, repo, url, title) and `author_trust_class` (B-005,
+   B-011). On success, `source.mark_dispatched(external_id, ...)`; on
+   failure, `unmark_dispatched` — mirroring the existing github path's
+   failure handling.
+7. Cross-project mismatch (binding exists in another project only):
+   falls out naturally from step 2's project-scoped lookup; audited via
+   the routing record (B-012).
+
+Audit records (B-009) reuse the observe event store with a new
+`intake_routing` event kind: fields issue identifier, source, matched
+definition (or none), outcome (routed / suppressed_live /
+skipped_at_cap / unmatched), tie list when applicable.
+
+### What does NOT change
+
+- github_issue_pr coverage gate and dispatch for unmatched issues.
+- Sources themselves — no `IntakeSource` trait change (B-010: adding a
+  Linear source later is purely additive and needs no binding-schema
+  work, satisfying the source-pluggability requirement).
+- Declarative runtime semantics (B-011): intake-born instances are
+  created by the same submission function operators use.
+
+## Edge Cases
+
+- Webhook-mode GitHub intake (poller off, `webhook.rs:179` note): the
+  routing step lives in the shared dispatch path used by both poll and
+  webhook deliveries, so bindings work in webhook-only mode too; the
+  spec's tick-retry semantics for cap-skips degrade to
+  next-delivery-retry there (documented in the audit reason).
+- An issue matching a binding whose label also matches github_issue_pr
+  triggers (e.g. `force-execute`): binding wins (routing is exclusive,
+  B-006); the audit record makes the diversion visible.
+- Source emitting duplicate external_ids in one tick: first routes,
+  second hits the dedupe check within the same tick (store-backed, not
+  in-memory only).
+- `max_active_instances` reduced across a restart below the current live
+  count: no instances are killed; new dispatch stays skipped until the
+  count drains below the cap.
+
+## Migration / Compatibility
+
+- `intake` is optional with `#[serde(default)]`; existing WORKFLOW.md
+  files parse unchanged (B-001). No schema migration; the audit event
+  kind is additive.
+- Bindings ride the definition content hash: adding/changing `intake`
+  changes `definition_version` for NEW instances only — in-flight
+  instances are unaffected (pinning semantics from GH-1609 carry over).
+
+## Verification Plan
+
+- harness-core: schema parse + validation unit tests (empty labels,
+  zero cap, duplicates); atomic-merge regression with an `intake` block.
+- harness-server unit: binding matcher (source + labels + excludes,
+  case sensitivity, non-GitHub source fixture — B-003); tie-break
+  ordering + audit reason (B-004).
+- Integration (stub runtime + fixture source): route → instance created
+  with subject + trust class (B-005); dedupe suppression while live and
+  re-eligibility after terminal (B-007); cap skip + next-tick retry
+  (B-008); unmatched issue still lands in github_issue_pr (B-001/B-006);
+  cross-project mismatch audited (B-012).
+- Full gates: `cargo check --workspace --all-targets`,
+  `cargo test -p harness-core -p harness-server`,
+  `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo fmt --all -- --check`.
+
+## Rollback Plan
+
+Feature is inert without `intake` blocks (B-001). Rollback = remove the
+blocks (instances already created finish normally under pinned
+versions). Code revert removes the config field, binding registry, and
+the routing step; the unmatched path is the existing code, untouched.
+
+## Product-to-Test Mapping
+
+| Invariant | Implementation area | Verification |
+|---|---|---|
+| B-001 | optional field + no-binding fast path | parse compat test + intake integration test without bindings (byte-identical dispatch) |
+| B-002 | startup validation in server.rs registration | `cargo test -p harness-server` boot-validation tests |
+| B-003 | matcher over normalized IncomingIssue | matcher unit tests incl. non-GitHub fixture source |
+| B-004 | sorted multi-match + audit reason | matcher unit test |
+| B-005 | submission call with subject + trust | integration test asserting instance fields |
+| B-006 | exclusive routing, unmatched fall-through | integration test (matched never reaches github path; unmatched unchanged) |
+| B-007 | store-backed (definition_id, external_id) dedupe | integration test live-suppress / terminal-reopen |
+| B-008 | cap check + skip audit | integration test at cap + next-tick retry |
+| B-009 | `intake_routing` audit events | assertions on event store records per outcome |
+| B-010 | no new external calls | review gate: diff adds no HTTP/tracker client |
+| B-011 | reuse of record_declarative_submission | integration test: cancel/recovery work on intake-born instance |
+| B-012 | project-scoped binding lookup | integration test with binding in another project |


### PR DESCRIPTION
## Summary

Spec packet (product/tech/tasks) for GH-1656: an optional `intake` binding on the WORKFLOW.md `definition` block, routing incoming issues from any registered intake source into declarative workflow instances — the discovery half of Symphony parity (shape = GH-1609, per-instance looping = GH-1607, visibility = GH-1652).

Key design points:
- **Source-agnostic by requirement** (maintainer decision): matching consumes only normalized `IncomingIssue` fields; Linear or any new tracker is a purely additive future `IntakeSource` with zero binding-schema impact.
- Exclusive deterministic routing in the shared poll/webhook dispatch path; multi-match resolves to the lexicographically smallest definition id with an audited tie (same rule as GH-1609 signal precedence); unmatched issues keep today's github_issue_pr path byte-identical.
- Store-backed `(definition_id, external_id)` dedupe (live suppresses, terminal reopens), per-binding `max_active_instances` cap with audited skips that never call `mark_dispatched`, and `intake_routing` audit events for every outcome.
- Fail-closed startup validation; feature fully inert without `intake` blocks.

## Dependencies

GH-1609 merged (submission path reused); GH-1652 implementation recommended first for operator visibility of intake-born instances.

## Linked Issue

Refs #1656 (spec packet only; no implementation in this PR)

## Test Plan

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1656` — SpecRail check passed
- Docs-only change; no code surface