### PR TITLE
docs: define GH1659 GC agent test extraction

### DIFF
--- a/specs/GH1659/product.md
+++ b/specs/GH1659/product.md
@@ -1,0 +1,71 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1659
+
+## User Problem
+
+Harness maintainers must navigate a 1,047-line `gc_agent.rs` file even though
+the production implementation ends at line 626 and the remaining 421 lines
+are a cohesive inline test module. The combined file exceeds the repository
+800-line hard ceiling and makes production changes harder to review because
+test fixtures and assertions dominate the lower half of the source file.
+
+## Goals
+
+- Give the existing GC-agent tests a dedicated private module while retaining
+  their current parent module and test names.
+- Reduce both resulting Rust files to no more than 800 formatted lines.
+- Preserve the production implementation and all test bodies, assertions,
+  fixtures, and coverage exactly.
+- Make GC-agent production changes reviewable without traversing the complete
+  test suite in the same source file.
+- Provide deterministic inventory evidence that the extraction is mechanical.
+
+## Non-Goals
+
+- Changing GC signal detection, draft generation, adoption, rejection,
+  checkpoint, artifact parsing, path validation, or auto-adoption behavior.
+- Adding, deleting, renaming, consolidating, or rewriting tests.
+- Changing public APIs, private production visibility, errors, logs, prompts,
+  configuration, dependencies, manifests, lockfiles, or persisted formats.
+- Addressing unrelated GC behavior or coverage findings.
+
+## User-Visible Behavior
+
+There is no intended user-visible behavior change. GC runs, draft persistence,
+artifact parsing, adoption and rejection decisions, target-path validation,
+and auto-adoption must produce the same outputs, errors, logs, and side effects
+as current `origin/main`.
+
+## Acceptance Criteria
+
+- [ ] B-001: `gc_agent.rs` and the extracted test module each contain no more
+      than 800 formatted lines.
+- [ ] B-002: The complete production function/type inventory and every
+      production item body remain unchanged.
+- [ ] B-003: All 15 test names, bodies, assertions, fixtures, and the
+      `gc_agent::tests::*` module path remain unchanged.
+- [ ] B-004: No production behavior, public API, visibility, dependency,
+      manifest, lockfile, schema, persisted format, or test expectation changes.
+- [ ] B-005: Focused and full `harness-gc` tests, workspace Clippy/tests,
+      VibeGuard, exact-head CI, review-thread audit, and SpecRail gates pass.
+- [ ] B-006: The implementation is delivered in a separate PR only after this
+      spec PR is merged.
+
+## Edge Cases
+
+- Tests must retain child-module access to private GC-agent helpers through the
+  existing `use super::*` relationship without widening production visibility.
+- Async and synchronous tests must retain their current attributes and names.
+- Multi-line fixture strings, unified diffs, path traversal cases, and
+  temporary-directory lifetimes must move without textual rewriting.
+- Test filtering by the existing `gc_agent::tests::...` path must continue to
+  select the same 15 tests.
+
+## Rollout Notes
+
+This is a test-source layout refactor only. It requires no migration, feature
+flag, configuration change, operator action, or compatibility communication.
+Squash-reverting the implementation PR is the rollback path.

--- a/specs/GH1659/tasks.md
+++ b/specs/GH1659/tasks.md
@@ -1,0 +1,118 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1659
+
+## Spec Packet
+
+- Product: `specs/GH1659/product.md`
+- Tech: `specs/GH1659/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1659-T1` Owner: Codex | Done when: exact-base production/test inventories, line counts, duplicate search, focused compile, tests, and VibeGuard baseline are recorded | Verify: commands in T1 below
+- [ ] `SP1659-T2` Owner: Codex | Done when: the inline test block is moved mechanically to the standard child module, exact inventories and paths match, all files are within the ceiling, and tests pass | Verify: commands in T2 below
+- [ ] `SP1659-T3` Owner: Codex | Done when: local, exact-head CI, review-thread, and SpecRail gates pass for the separate implementation PR and cleanup is verified | Verify: commands in T3 below
+
+### SP1659-T1 — Capture the exact implementation baseline
+
+- Owner: Codex implementation agent.
+- Dependencies: merged GH-1659 spec PR and a fresh worktree from current
+  `origin/main`.
+- Covers: B-001 through B-005.
+- Work:
+  - record the exact base SHA and formatted source/test line boundaries;
+  - record every production function/type, test fixture, test name, and test
+    attribute in order;
+  - confirm the standard child-module target does not already exist;
+  - run focused compile/tests and VibeGuard baseline before editing;
+  - stop and diagnose if the fresh baseline is red.
+- Done when:
+  - exact inventories and baseline output are preserved;
+  - `harness-gc` all-target compile and all 15 filtered tests pass;
+  - no duplicate issue, PR, child file, or symbol exists.
+- Verify:
+  - `git rev-parse HEAD`;
+  - `wc -l crates/harness-gc/src/gc_agent.rs`;
+  - production/test inventory searches from `tech.md`;
+  - `cargo check -p harness-gc --all-targets`;
+  - `cargo test -p harness-gc gc_agent`.
+
+### SP1659-T2 — Extract the private child test module
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1659-T1.
+- Covers: B-001 through B-004.
+- Work:
+  - replace the inline test wrapper with `#[cfg(test)] mod tests;`;
+  - move the wrapper contents to `gc_agent/tests.rs` in the same order;
+  - preserve `use super::*`, fixtures, attributes, names, strings, assertions,
+    and helper calls without semantic edits;
+  - compare exact production/test inventories and perform a movement-aware
+    diff review;
+  - commit the verified relocation before PR-readiness work.
+- Done when:
+  - both formatted files are at most 800 lines;
+  - every production and test inventory item appears exactly once;
+  - the 15 focused tests retain `gc_agent::tests::*` paths and pass;
+  - full `harness-gc` tests pass with no other changed file.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-gc --all-targets`;
+  - `cargo test -p harness-gc gc_agent`;
+  - `cargo test -p harness-gc`;
+  - exact inventory, module-path, size, scope, and movement checks.
+
+### SP1659-T3 — Prove PR readiness and clean up
+
+- Owner: Codex implementation agent; human final review remains authoritative.
+- Dependencies: SP1659-T2.
+- Covers: B-001 through B-006.
+- Work:
+  - compare the implementation with the issue and all three spec files;
+  - run the complete deterministic verification matrix at final head;
+  - open the separate implementation PR with reason, plan, inventory, scope,
+    risk, and verification evidence;
+  - wait for exact-head CI and Gemini review, address valid findings, audit all
+    review threads, run the required SpecRail PR gate, and merge only under the
+    standing authorization;
+  - remove the implementation worktree and any disposable resources.
+- Done when:
+  - B-001 through B-006 have fresh evidence;
+  - local and exact-head remote gates pass with no unresolved active thread;
+  - only the approved test relocation is present;
+  - authorized merge, issue closure, and cleanup are verified.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-gc --all-targets`;
+  - focused and full `harness-gc` test commands above;
+  - `cargo clippy --workspace --all-targets -- -D warnings`;
+  - workspace tests under the repository test environment;
+  - `python3 checks/check_workflow.py --repo .`;
+  - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1659`;
+  - fresh GitHub evidence and `python3 checks/pr_gate.py --repo . --evidence <evidence.json> --mode required --json`.
+
+## Parallelization
+
+No parallel writable lanes are planned. The change is one atomic relocation in
+one Rust module namespace, so one implementation agent will move, verify, and
+commit it sequentially.
+
+## Verification
+
+- [ ] Global and GH-1659 SpecRail checks pass.
+- [ ] Product behaviors B-001 through B-006 map to tasks and verification.
+- [ ] Production and test inventories match the exact base.
+- [ ] Both Rust files are at most 800 formatted lines.
+- [ ] Focused, crate, workspace, Clippy, VibeGuard, CI, review-thread, and PR
+      gates pass on the exact implementation head.
+
+## Handoff Notes
+
+- Exact issue/spec base: `849d416195dbfa5caabbba2ac8c3c4d3975f39c9`.
+- Baseline: 1,047 lines, production through line 626, inline tests from lines
+  627-1,047, 15 focused tests passing.
+- Preserve the logical `gc_agent::tests::*` namespace and private parent access.
+- This packet authorizes test relocation only. Route any production refactor or
+  behavioral finding to a separate issue/spec cycle.

--- a/specs/GH1659/tech.md
+++ b/specs/GH1659/tech.md
@@ -1,0 +1,107 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1659
+
+## Product Spec
+
+See `specs/GH1659/product.md`.
+
+## Current System
+
+On base `849d416195dbfa5caabbba2ac8c3c4d3975f39c9`,
+`crates/harness-gc/src/gc_agent.rs` contains 1,047 lines. Lines 1-626 own the
+production implementation, including two public types and the GC run,
+adoption, checkpoint, path-validation, prompt, and artifact-parsing functions.
+Lines 627-1,047 contain `#[cfg(test)] mod tests`, with three private fixtures
+and 15 tests.
+
+The test module already imports its parent with `use super::*`, so it is a
+natural Rust child module that does not require inline physical ownership.
+
+## Proposed Design
+
+Keep `gc_agent.rs` as the stable production module. Replace the inline block
+with:
+
+```rust
+#[cfg(test)]
+mod tests;
+```
+
+Move only the contents inside the existing `mod tests { ... }` block into
+`crates/harness-gc/src/gc_agent/tests.rs`. The extracted file begins with the
+existing `use super::*;` import and retains every fixture and test in its
+current order.
+
+Rust resolves the child file under the `gc_agent/` directory while preserving
+the logical module path `gc_agent::tests`. Child-module privacy continues to
+allow tests to access parent-private helpers, so no production visibility or
+path change is required.
+
+## Invariants and Inventory
+
+- Record the exact base SHA, root line count, production function/type list,
+  fixture list, test-name list, attributes, and focused test output before
+  editing.
+- After formatting, compare the production inventory in `gc_agent.rs` exactly
+  against the base.
+- Compare the ordered test-name and fixture inventory across the root plus
+  `gc_agent/tests.rs` against the base; require every item exactly once.
+- Review the moved test content as a pure relocation. Permitted textual edits
+  are limited to replacing the inline wrapper with `mod tests;` and removing
+  one indentation level from the moved block.
+- Preserve all attributes, strings, assertions, temporary-directory setup,
+  error matching, and helper calls.
+- Require both Rust files to contain no more than 800 formatted lines.
+
+## Affected Files
+
+- `crates/harness-gc/src/gc_agent.rs`
+- `crates/harness-gc/src/gc_agent/tests.rs`
+
+No other source, test, manifest, lockfile, configuration, schema, or persisted
+format file is expected to change.
+
+## Alternatives Considered
+
+- Leave the inline tests in place: rejected because the file remains above the
+  hard ceiling and mixes a bounded production implementation with 421 lines of
+  tests.
+- Move tests to a top-level `gc_agent_tests.rs` with a path attribute: rejected
+  because Rust standard child-module layout preserves the existing namespace
+  without an explicit path override.
+- Split tests into several files: rejected because 421 lines are below the
+  ceiling and the 15 tests form one cohesive GC-agent suite.
+- Refactor artifact parsing or adoption into new production modules at the
+  same time: rejected because that would expand scope beyond the safe test
+  relocation.
+
+## Risks
+
+- Compatibility: low; the logical test module path remains unchanged.
+- Production behavior: minimal; no production body or visibility changes.
+- Test integrity: low if the move is exact, but inventory and diff checks are
+  mandatory to prevent a lost test, assertion, attribute, or fixture.
+- Security: low; no auth, secret, command, network, or permission path changes.
+- Maintenance: reduced by separating production implementation from its test
+  suite while retaining direct child-module access.
+
+## Test Plan
+
+- [ ] Baseline and final `cargo check -p harness-gc --all-targets`.
+- [ ] Baseline and final `cargo test -p harness-gc gc_agent` with all 15 tests.
+- [ ] Final `cargo test -p harness-gc`.
+- [ ] `cargo fmt --all -- --check` and formatted line-count gates.
+- [ ] Exact production and test inventory comparisons.
+- [ ] Diff scope and movement review proving no test or production rewrite.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Workspace tests under the repository test environment.
+- [ ] SpecRail global/packet/route checks, VibeGuard compliance, exact-head CI,
+      review-thread audit, and required PR gate.
+
+## Rollback Plan
+
+Squash-revert the implementation PR. No data, configuration, dependency, or
+operator rollback step is required.


### PR DESCRIPTION
Linked work: #1659

## Summary

Defines the SpecRail product, technical, and task packet for extracting the 421-line inline GC-agent test module from the 1,047-line production source file.

## Why

The production implementation ends at line 626, but 15 cohesive inline tests keep `gc_agent.rs` above the repository 800-line hard ceiling and increase navigation and review cost.

## Plan

- Preserve `gc_agent.rs` as the stable production module.
- Replace the inline wrapper with `#[cfg(test)] mod tests;`.
- Move only the existing wrapper contents to `gc_agent/tests.rs`.
- Preserve every production body, test name, test body, assertion, fixture, attribute, and `gc_agent::tests::*` path.
- Verify exact production/test inventories, line limits, focused/full crate tests, workspace gates, CI, review threads, and SpecRail readiness.

## Scope

This PR contains specs only. It does not implement the extraction or change production code, tests, dependencies, manifests, lockfiles, schemas, or behavior.

## Verification

- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1659`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Repository pre-push gate (all configured checks passed)