### PR TITLE
docs: define GH1665 webhook test extraction

### DIFF
--- a/specs/GH1665/product.md
+++ b/specs/GH1665/product.md
@@ -1,0 +1,75 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1665
+
+## User Problem
+
+Harness maintainers must navigate a 985-line `webhook.rs` file even though the
+production implementation ends at line 333 and the remaining 652 lines are a
+cohesive inline test module. The combined file exceeds the repository 800-line
+hard ceiling and makes production webhook changes harder to review because
+fixtures and assertions occupy roughly two thirds of the source file.
+
+## Goals
+
+- Give the existing GitHub webhook tests a dedicated private child module while
+  retaining their current parent module and test names.
+- Reduce both resulting Rust files to no more than 800 formatted lines.
+- Preserve the production implementation and every test body, assertion,
+  fixture, attribute, and coverage point exactly.
+- Make webhook production changes reviewable without traversing the complete
+  test suite in the same physical source file.
+- Provide deterministic evidence that the extraction is mechanical.
+
+## Non-Goals
+
+- Changing webhook event parsing, HMAC verification, issue/comment/review
+  routing, label handling, request construction, error behavior, or logs.
+- Adding, deleting, renaming, consolidating, or rewriting tests.
+- Changing public APIs, private production visibility, configuration,
+  dependencies, manifests, lockfiles, schemas, persisted formats, or prompts.
+- Addressing unrelated webhook behavior or coverage findings.
+
+## User-Visible Behavior
+
+There is no intended user-visible behavior change. Supported GitHub issue,
+comment, pull-request review, ping, signature, and invalid-payload inputs must
+produce the same task requests, ignored-event reasons, errors, and validation
+results as current `origin/main`.
+
+## Acceptance Criteria
+
+- [ ] B-001: `webhook.rs` and the extracted test module each contain no more
+      than 800 formatted lines.
+- [ ] B-002: The complete production function/type inventory and every
+      production item body remain unchanged.
+- [ ] B-003: All 33 test names, bodies, assertions, fixtures, attributes,
+      ordering, and `webhook::tests::*` module paths remain unchanged.
+- [ ] B-004: No production behavior, public API, visibility, dependency,
+      manifest, lockfile, schema, persisted format, or test expectation changes.
+- [ ] B-005: Focused webhook tests, `harness-server` checks/tests, workspace
+      Clippy/tests, VibeGuard, exact-head CI, review-thread audit, and SpecRail
+      gates pass.
+- [ ] B-006: The implementation is delivered in a separate PR only after this
+      spec PR is merged.
+
+## Edge Cases
+
+- Tests must retain child-module access to private webhook payload types and
+  parsing helpers through the existing `use super::*` relationship without
+  widening production visibility.
+- HMAC fixtures, JSON payload strings, case-insensitive review states, empty
+  bodies, invalid payloads, label filters, and ignored actions must move without
+  textual rewriting.
+- Test filtering by the existing `webhook::tests::...` path must continue to
+  select the same 33 tests.
+- The module declaration remains test-only and must not affect production
+  builds or exported symbols.
+
+## Rollout Notes
+
+This is a test-source layout refactor only. It requires no migration, feature
+flag, configuration change, operator action, or compatibility communication.
+Squash-reverting the implementation PR is the rollback path.

--- a/specs/GH1665/tasks.md
+++ b/specs/GH1665/tasks.md
@@ -1,0 +1,117 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1665
+
+## Spec Packet
+
+- Product: `specs/GH1665/product.md`
+- Tech: `specs/GH1665/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1665-T1` Owner: Codex | Done when: exact-base production/test inventories, line counts, duplicate search, focused compile, tests, and VibeGuard baseline are recorded | Verify: commands in T1 below
+- [ ] `SP1665-T2` Owner: Codex | Done when: the inline test block is moved mechanically to the standard child module, exact inventories and paths match, both files are within the ceiling, and tests pass | Verify: commands in T2 below
+- [ ] `SP1665-T3` Owner: Codex | Done when: local, exact-head CI, review-thread, and SpecRail gates pass for the separate implementation PR and cleanup is verified | Verify: commands in T3 below
+
+### SP1665-T1 — Capture the exact implementation baseline
+
+- Owner: Codex implementation agent.
+- Dependencies: merged GH-1665 spec PR and a fresh worktree from current
+  `origin/main`.
+- Covers: B-001 through B-005.
+- Work:
+  - record the exact base SHA and formatted source/test line boundaries;
+  - record every production function/type, test name, and test attribute in
+    order;
+  - confirm the standard child-module target does not already exist;
+  - run focused compile/tests and VibeGuard baseline before editing;
+  - stop and diagnose if the fresh baseline is red.
+- Done when:
+  - exact inventories and baseline output are preserved;
+  - `harness-server` all-target compile and all 33 filtered tests pass;
+  - no duplicate issue, PR, child file, or symbol exists.
+- Verify:
+  - `git rev-parse HEAD`;
+  - `wc -l crates/harness-server/src/webhook.rs`;
+  - production/test inventory searches from `tech.md`;
+  - `cargo check -p harness-server --all-targets`;
+  - `cargo test -p harness-server webhook::tests -- --test-threads=1`.
+
+### SP1665-T2 — Extract the private child test module
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1665-T1.
+- Covers: B-001 through B-004.
+- Work:
+  - replace the inline test wrapper with `#[cfg(test)] mod tests;`;
+  - move the wrapper contents to `webhook/tests.rs` in the same order;
+  - preserve `use super::*`, local imports, attributes, names, JSON/HMAC
+    fixtures, strings, assertions, and helper calls without semantic edits;
+  - compare exact production/test inventories and perform a movement-aware
+    diff review;
+  - commit the verified relocation before PR-readiness work.
+- Done when:
+  - both formatted files are at most 800 lines;
+  - every production and test inventory item appears exactly once;
+  - the 33 focused tests retain `webhook::tests::*` paths and pass;
+  - no file outside the approved pair changes.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-server --all-targets`;
+  - `cargo test -p harness-server webhook::tests -- --test-threads=1`;
+  - exact inventory, module-path, size, scope, and movement checks.
+
+### SP1665-T3 — Prove PR readiness and clean up
+
+- Owner: Codex implementation agent; human final review remains authoritative.
+- Dependencies: SP1665-T2.
+- Covers: B-001 through B-006.
+- Work:
+  - compare the implementation with the issue and all three spec files;
+  - run the complete deterministic verification matrix at final head;
+  - open the separate implementation PR with reason, plan, inventory, scope,
+    risk, and verification evidence;
+  - wait for exact-head CI and Gemini review, address valid findings, audit all
+    review threads, run the required SpecRail PR gate, and merge only under the
+    standing authorization;
+  - remove the implementation worktree and any disposable resources.
+- Done when:
+  - B-001 through B-006 have fresh evidence;
+  - local and exact-head remote gates pass with no unresolved active thread;
+  - only the approved test relocation is present;
+  - authorized merge, issue closure, and cleanup are verified.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-server --all-targets`;
+  - focused and server library test commands above;
+  - `cargo clippy --workspace --all-targets -- -D warnings`;
+  - workspace tests under the repository test environment;
+  - `python3 checks/check_workflow.py --repo .`;
+  - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1665`;
+  - fresh GitHub evidence and `python3 checks/pr_gate.py --repo . --evidence <evidence.json> --mode required --json`.
+
+## Parallelization
+
+No parallel writable lanes are planned. The change is one atomic relocation in
+one Rust module namespace, so one implementation agent will move, verify, and
+commit it sequentially.
+
+## Verification
+
+- [ ] Global and GH-1665 SpecRail checks pass.
+- [ ] Product behaviors B-001 through B-006 map to tasks and verification.
+- [ ] Production and test inventories match the exact base.
+- [ ] Both Rust files are at most 800 formatted lines.
+- [ ] Focused, server, workspace, Clippy, VibeGuard, CI, review-thread, and PR
+      gates pass on the exact implementation head.
+
+## Handoff Notes
+
+- Exact issue/spec base: `25213f83e7448a6cf06ee46b20b956313833e567`.
+- Baseline: 985 lines, production through line 333, inline tests from lines
+  334-985, 33 focused tests passing.
+- Preserve the logical `webhook::tests::*` namespace and private parent access.
+- This packet authorizes test relocation only. Route any production refactor or
+  behavioral finding to a separate issue/spec cycle.

--- a/specs/GH1665/tech.md
+++ b/specs/GH1665/tech.md
@@ -1,0 +1,111 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1665
+
+## Product Spec
+
+See `specs/GH1665/product.md`.
+
+## Current System
+
+On base `25213f83e7448a6cf06ee46b20b956313833e567`,
+`crates/harness-server/src/webhook.rs` contains 985 lines. Lines 1-333 own the
+production implementation, including GitHub payload types, task-request
+construction, event parsing, event-name validation, hexadecimal decoding, and
+HMAC signature verification. Lines 334-985 contain `#[cfg(test)] mod tests`,
+with 33 synchronous tests.
+
+The test module already imports its parent with `use super::*`, so it is a
+natural Rust child module that does not require inline physical ownership.
+
+## Proposed Design
+
+Keep `webhook.rs` as the stable production module. Replace the inline block
+with:
+
+```rust
+#[cfg(test)]
+mod tests;
+```
+
+Move only the contents inside the existing `mod tests { ... }` block into
+`crates/harness-server/src/webhook/tests.rs`. The extracted file begins with
+the existing `use super::*;` import and retains every test and local import in
+its current order.
+
+Rust resolves the child file under the `webhook/` directory while preserving
+the logical module path `webhook::tests`. Child-module privacy continues to
+allow tests to access parent-private payload types and helpers, so no
+production visibility or path change is required.
+
+## Invariants and Inventory
+
+- Record the exact base SHA, root line count, production function/type list,
+  and ordered 33-test list before editing.
+- After formatting, compare lines 1-333 of `webhook.rs` byte-for-byte against
+  the exact base and compare the complete production inventory.
+- Compare the ordered test-name and attribute inventory across the root plus
+  `webhook/tests.rs` against the base; require every test exactly once.
+- Review the moved test content as a pure relocation. Permitted textual edits
+  are limited to replacing the inline wrapper with `mod tests;` and removing
+  one indentation level from the moved block.
+- Preserve all JSON/HMAC fixtures, strings, assertions, local imports, request
+  comparisons, ignored reasons, and helper calls.
+- Preserve the exact `webhook::tests::*` paths and require both Rust files to
+  contain no more than 800 formatted lines.
+
+## Affected Files
+
+- `crates/harness-server/src/webhook.rs`
+- `crates/harness-server/src/webhook/tests.rs`
+
+No other source, test, manifest, lockfile, configuration, schema, or persisted
+format file is expected to change.
+
+## Alternatives Considered
+
+- Leave the inline tests in place: rejected because the file remains above the
+  hard ceiling and mixes a bounded production implementation with 652 lines of
+  tests.
+- Move tests to a top-level `webhook_tests.rs` with a path attribute: rejected
+  because standard Rust child-module layout preserves the existing namespace
+  without an explicit path override.
+- Split tests into event-specific files: rejected because the extracted module
+  remains below the ceiling and the 33 tests form one cohesive parser suite.
+- Refactor production event handlers at the same time: rejected because that
+  would expand scope beyond the safe test relocation.
+
+## Risks
+
+- Compatibility: low; the logical test module path remains unchanged.
+- Production behavior: minimal; no production body or visibility changes.
+- Test integrity: low if the move is exact, but inventory and movement-aware
+  diff checks are mandatory to prevent a lost test, assertion, fixture, or
+  attribute.
+- Security: low; production signature verification and event validation remain
+  byte-for-byte unchanged.
+- Maintenance: reduced by separating production webhook handling from its test
+  suite while retaining direct child-module access.
+
+## Test Plan
+
+- [ ] Baseline and final `cargo check -p harness-server --all-targets`.
+- [ ] Baseline and final
+      `cargo test -p harness-server webhook::tests -- --test-threads=1` with all
+      33 tests.
+- [ ] Final `cargo test -p harness-server --lib -- --test-threads=1` against the
+      repository database test environment.
+- [ ] `cargo fmt --all -- --check` and formatted line-count gates.
+- [ ] Exact production and ordered test inventory comparisons.
+- [ ] Diff-scope and movement review proving no test or production rewrite.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Workspace tests under the repository test environment.
+- [ ] SpecRail global/packet/route checks, VibeGuard compliance, exact-head CI,
+      review-thread audit, and required PR gate.
+
+## Rollback Plan
+
+Squash-revert the implementation PR. No data, configuration, dependency, or
+operator rollback step is required.


### PR DESCRIPTION
Linked work: #1665

## Why

`crates/harness-server/src/webhook.rs` is 985 lines because 33 cohesive tests occupy lines 334-985 after a 333-line production implementation. The packet defines a mechanical child-module extraction that brings both files below the 800-line hard ceiling without changing webhook behavior or test semantics.

## Plan

- Preserve the production prefix and inventory exactly.
- Move only the inline test body to `webhook/tests.rs`.
- Preserve all 33 `webhook::tests::*` names, paths, fixtures, attributes, assertions, and ordering.
- Require focused/server/workspace verification, VibeGuard, exact-head CI, review-thread audit, and SpecRail gates in the separate implementation PR.

## Spec packet

- `specs/GH1665/product.md`
- `specs/GH1665/tech.md`
- `specs/GH1665/tasks.md`

## Verification

- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1665`
- Required SpecRail write-spec route
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Pre-push hook: 488 non-server tests and 1,762 `harness-server` tests passed