### PR TITLE
docs: clarify GH1665 rustfmt movement invariant

### DIFF
--- a/specs/GH1665/product.md
+++ b/specs/GH1665/product.md
@@ -17,8 +17,9 @@ fixtures and assertions occupy roughly two thirds of the source file.
 - Give the existing GitHub webhook tests a dedicated private child module while
   retaining their current parent module and test names.
 - Reduce both resulting Rust files to no more than 800 formatted lines.
-- Preserve the production implementation and every test body, assertion,
-  fixture, attribute, and coverage point exactly.
+- Preserve the production implementation exactly and preserve every test's
+  Rust tokens, assertion, fixture, attribute, and coverage point; only
+  deterministic whitespace reflow required by `rustfmt` is permitted.
 - Make webhook production changes reviewable without traversing the complete
   test suite in the same physical source file.
 - Provide deterministic evidence that the extraction is mechanical.
@@ -45,8 +46,10 @@ results as current `origin/main`.
       than 800 formatted lines.
 - [ ] B-002: The complete production function/type inventory and every
       production item body remain unchanged.
-- [ ] B-003: All 33 test names, bodies, assertions, fixtures, attributes,
-      ordering, and `webhook::tests::*` module paths remain unchanged.
+- [ ] B-003: All 33 test names, non-whitespace Rust tokens, assertions,
+      fixtures, attributes, ordering, and `webhook::tests::*` module paths
+      remain unchanged. Whitespace may differ only when the unindented baseline
+      test body is canonically formatted by the repository `rustfmt` version.
 - [ ] B-004: No production behavior, public API, visibility, dependency,
       manifest, lockfile, schema, persisted format, or test expectation changes.
 - [ ] B-005: Focused webhook tests, `harness-server` checks/tests, workspace
@@ -62,7 +65,7 @@ results as current `origin/main`.
   widening production visibility.
 - HMAC fixtures, JSON payload strings, case-insensitive review states, empty
   bodies, invalid payloads, label filters, and ignored actions must move without
-  textual rewriting.
+  token rewriting; indentation-driven `rustfmt` line wrapping is permitted.
 - Test filtering by the existing `webhook::tests::...` path must continue to
   select the same 33 tests.
 - The module declaration remains test-only and must not affect production

--- a/specs/GH1665/tasks.md
+++ b/specs/GH1665/tasks.md
@@ -48,9 +48,12 @@ GH-1665
   - replace the inline test wrapper with `#[cfg(test)] mod tests;`;
   - move the wrapper contents to `webhook/tests.rs` in the same order;
   - preserve `use super::*`, local imports, attributes, names, JSON/HMAC
-    fixtures, strings, assertions, and helper calls without semantic edits;
+    fixtures, strings, assertions, and helper calls without token or semantic
+    edits;
+  - generate the expected child file by unindenting the exact-base test body
+    and formatting it with the repository `rustfmt`; require an exact diff;
   - compare exact production/test inventories and perform a movement-aware
-    diff review;
+    diff review that permits only the reproduced whitespace reflow;
   - commit the verified relocation before PR-readiness work.
 - Done when:
   - both formatted files are at most 800 lines;
@@ -61,7 +64,8 @@ GH-1665
   - `cargo fmt --all -- --check`;
   - `cargo check -p harness-server --all-targets`;
   - `cargo test -p harness-server webhook::tests -- --test-threads=1`;
-  - exact inventory, module-path, size, scope, and movement checks.
+  - exact inventory, module-path, size, scope, production-prefix, and
+    canonical-rustfmt movement checks.
 
 ### SP1665-T3 — Prove PR readiness and clean up
 

--- a/specs/GH1665/tech.md
+++ b/specs/GH1665/tech.md
@@ -48,9 +48,16 @@ production visibility or path change is required.
   the exact base and compare the complete production inventory.
 - Compare the ordered test-name and attribute inventory across the root plus
   `webhook/tests.rs` against the base; require every test exactly once.
-- Review the moved test content as a pure relocation. Permitted textual edits
-  are limited to replacing the inline wrapper with `mod tests;` and removing
-  one indentation level from the moved block.
+- Review the moved test content as a pure relocation. Permitted edits are
+  limited to replacing the inline wrapper with `mod tests;`, removing one
+  indentation level from the moved block, and accepting the deterministic line
+  wrapping produced when the repository `rustfmt` version formats that
+  unindented baseline body. No non-whitespace Rust token may change.
+- Generate the expected child file by extracting base lines 336-984, removing
+  one four-space indentation level, and piping the result through
+  `rustfmt --edition 2021 --emit stdout`; require an exact diff against
+  `webhook/tests.rs`. This makes the allowed whitespace delta reproducible
+  without weakening semantic or fixture integrity.
 - Preserve all JSON/HMAC fixtures, strings, assertions, local imports, request
   comparisons, ignored reasons, and helper calls.
 - Preserve the exact `webhook::tests::*` paths and require both Rust files to
@@ -81,9 +88,9 @@ format file is expected to change.
 
 - Compatibility: low; the logical test module path remains unchanged.
 - Production behavior: minimal; no production body or visibility changes.
-- Test integrity: low if the move is exact, but inventory and movement-aware
-  diff checks are mandatory to prevent a lost test, assertion, fixture, or
-  attribute.
+- Test integrity: low if the move matches the canonically formatted baseline,
+  but inventory and movement-aware diff checks are mandatory to prevent a lost
+  test, non-whitespace token, assertion, fixture, or attribute.
 - Security: low; production signature verification and event validation remain
   byte-for-byte unchanged.
 - Maintenance: reduced by separating production webhook handling from its test
@@ -99,7 +106,8 @@ format file is expected to change.
       repository database test environment.
 - [ ] `cargo fmt --all -- --check` and formatted line-count gates.
 - [ ] Exact production and ordered test inventory comparisons.
-- [ ] Diff-scope and movement review proving no test or production rewrite.
+- [ ] Exact production diff plus canonical-rustfmt movement comparison proving
+      no non-whitespace test token or production rewrite.
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings`.
 - [ ] Workspace tests under the repository test environment.
 - [ ] SpecRail global/packet/route checks, VibeGuard compliance, exact-head CI,


### PR DESCRIPTION
Linked work: #1665

## Why

Implementation preflight reproduced a specification contradiction: moving the inline body to a standard external module removes one indentation level, which changes available line width. Repository `rustfmt` then deterministically reflows eight calls. The original packet required both `cargo fmt --check` and no textual change beyond unindentation, so both gates could not pass simultaneously.

## Correction

- Keep the production prefix byte-for-byte invariant unchanged.
- Keep every non-whitespace Rust token, test name, assertion, fixture, attribute, order, and module path unchanged.
- Define the only permitted whitespace delta as the exact output of extracting base lines 336-984, removing one indentation level, and running repository `rustfmt`.
- Require an exact diff between that generated canonical output and `webhook/tests.rs`.

## Scope

This PR changes only the GH-1665 product, technical, and task specifications. It contains no implementation code and returns the issue to `ready_to_spec` until this correction merges.

## Verification

- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1665`
- Required SpecRail write-spec route
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Pre-push hook: 488 non-server tests and 1,762 `harness-server` tests passed