### PR TITLE
docs: define GH1670 plan database test extraction

### DIFF
--- a/specs/GH1670/product.md
+++ b/specs/GH1670/product.md
@@ -1,0 +1,80 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1670
+
+## User Problem
+
+Harness maintainers must navigate an 822-line `plan_db.rs` file even though
+the production persistence implementation ends at line 388 and the remaining
+434 lines are a cohesive inline test module. The combined file exceeds the
+repository 800-line hard ceiling and mixes production database logic with 15
+database, migration, transaction, and search tests.
+
+## Goals
+
+- Give the existing plan database tests a dedicated private child module while
+  retaining their current parent module and test names.
+- Reduce both resulting Rust files to no more than 800 formatted lines.
+- Preserve the production implementation exactly and preserve every test's
+  non-whitespace Rust tokens, assertion, fixture, SQL statement, attribute,
+  and coverage point; only deterministic whitespace reflow required by
+  `rustfmt` is permitted.
+- Make plan persistence changes reviewable without traversing the complete
+  database test suite in the same physical source file.
+- Provide deterministic evidence that the extraction is mechanical.
+
+## Non-Goals
+
+- Changing plan creation, lookup, update, delete, search, migration, backfill,
+  transaction, schema, store-key, or NUL-byte sanitization behavior.
+- Adding, deleting, renaming, consolidating, or rewriting tests.
+- Changing SQL, migrations, public APIs, private production visibility,
+  configuration, dependencies, manifests, lockfiles, or persisted formats.
+- Addressing unrelated plan database behavior or coverage findings.
+
+## User-Visible Behavior
+
+There is no intended user-visible behavior change. Plan persistence, filtering,
+search, transaction updates, legacy backfill, schema migration, deletion, and
+error behavior must remain identical to current `origin/main`.
+
+## Acceptance Criteria
+
+- [ ] B-001: `plan_db.rs` and the extracted test module each contain no more
+      than 800 formatted lines.
+- [ ] B-002: The complete production function/type/constant inventory and
+      every production item body remain unchanged.
+- [ ] B-003: All 15 test names, non-whitespace Rust tokens, assertions,
+      fixtures, SQL statements, attributes, ordering, and
+      `plan_db::tests::*` module paths remain unchanged. Whitespace may differ
+      only when the unindented baseline test body is canonically formatted by
+      the repository `rustfmt` version.
+- [ ] B-004: No production behavior, public API, visibility, dependency,
+      manifest, lockfile, SQL, migration, schema, or persisted-format change.
+- [ ] B-005: Focused plan database tests, `harness-workflow` checks/tests,
+      workspace Clippy/tests, VibeGuard, exact-head CI, review-thread audit,
+      and SpecRail gates pass.
+- [ ] B-006: The implementation is delivered in a separate PR only after this
+      spec PR is merged.
+
+## Edge Cases
+
+- Tests must retain child-module access to private migration arrays, helpers,
+  pools, transaction methods, and store keys through the existing
+  `use super::*` relationship without widening production visibility.
+- PostgreSQL schema names, SQL strings, JSON fixtures, NUL-byte inputs,
+  markdown migration fixtures, assertions, and cleanup behavior must move
+  without token rewriting; indentation-driven `rustfmt` line wrapping is
+  permitted.
+- Test filtering by the existing `plan_db::tests::...` path must continue to
+  select the same 15 tests.
+- The module declaration remains test-only and must not affect production
+  builds or exported symbols.
+
+## Rollout Notes
+
+This is a test-source layout refactor only. It requires no data migration,
+feature flag, configuration change, operator action, or compatibility
+communication. Squash-reverting the implementation PR is the rollback path.

--- a/specs/GH1670/tasks.md
+++ b/specs/GH1670/tasks.md
@@ -1,0 +1,124 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1670
+
+## Spec Packet
+
+- Product: `specs/GH1670/product.md`
+- Tech: `specs/GH1670/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1670-T1` Owner: Codex | Done when: exact-base production/test inventories, line counts, duplicate search, focused compile, PostgreSQL tests, and VibeGuard baseline are recorded | Verify: commands in T1 below
+- [ ] `SP1670-T2` Owner: Codex | Done when: the inline test block is moved mechanically to the standard child module, exact inventories and paths match, both files are within the ceiling, and tests pass | Verify: commands in T2 below
+- [ ] `SP1670-T3` Owner: Codex | Done when: local, exact-head CI, review-thread, and SpecRail gates pass for the separate implementation PR and cleanup is verified | Verify: commands in T3 below
+
+### SP1670-T1 — Capture the exact implementation baseline
+
+- Owner: Codex implementation agent.
+- Dependencies: merged GH-1670 spec PR and a fresh worktree from current
+  `origin/main`.
+- Covers: B-001 through B-005.
+- Work:
+  - record the exact base SHA and formatted source/test line boundaries;
+  - record every production item, test helper, test name, and test attribute in
+    order;
+  - confirm the standard child-module target does not already exist;
+  - run focused compile/tests with a dedicated PostgreSQL database and a
+    VibeGuard baseline before editing;
+  - stop and diagnose if the fresh baseline is red.
+- Done when:
+  - exact inventories and baseline output are preserved;
+  - `harness-workflow` all-target compile and all 15 filtered tests pass;
+  - no duplicate issue, PR, child file, or symbol exists.
+- Verify:
+  - `git rev-parse HEAD`;
+  - `wc -l crates/harness-workflow/src/plan_db.rs`;
+  - production/test inventory searches from `tech.md`;
+  - `cargo check -p harness-workflow --all-targets`;
+  - `cargo test -p harness-workflow plan_db::tests -- --test-threads=1` with
+    the dedicated database environment.
+
+### SP1670-T2 — Extract the private child test module
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1670-T1.
+- Covers: B-001 through B-004.
+- Work:
+  - replace the inline test wrapper with `#[cfg(test)] mod tests;`;
+  - move the wrapper contents to `plan_db/tests.rs` in the same order;
+  - preserve `use super::*`, local imports, helpers, statics, attributes,
+    names, SQL, fixtures, strings, assertions, and calls without token or
+    semantic edits;
+  - generate the expected child file by unindenting the exact-base test body
+    and formatting it with the repository `rustfmt`; require an exact diff;
+  - compare exact production/test inventories and perform a movement-aware
+    diff review that permits only the reproduced whitespace reflow;
+  - commit the verified relocation before PR-readiness work.
+- Done when:
+  - both formatted files are at most 800 lines;
+  - every production and test inventory item appears exactly once;
+  - the 15 focused tests retain `plan_db::tests::*` paths and pass against the
+    dedicated PostgreSQL database;
+  - no file outside the approved pair changes.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-workflow --all-targets`;
+  - focused PostgreSQL test command above;
+  - exact inventory, module-path, size, scope, production-prefix, and
+    canonical-rustfmt movement checks.
+
+### SP1670-T3 — Prove PR readiness and clean up
+
+- Owner: Codex implementation agent; human final review remains authoritative.
+- Dependencies: SP1670-T2.
+- Covers: B-001 through B-006.
+- Work:
+  - compare the implementation with the issue and all three spec files;
+  - run the complete deterministic verification matrix at final head;
+  - open the separate implementation PR with reason, plan, inventory, scope,
+    risk, and verification evidence;
+  - wait for exact-head CI and Gemini review, address valid findings, audit all
+    review threads, run the required SpecRail PR gate, and merge only under the
+    standing authorization;
+  - remove the implementation worktree and all disposable resources.
+- Done when:
+  - B-001 through B-006 have fresh evidence;
+  - local and exact-head remote gates pass with no unresolved active thread;
+  - only the approved test relocation is present;
+  - authorized merge, issue closure, and cleanup are verified.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-workflow --all-targets`;
+  - focused and full `harness-workflow` library tests above;
+  - `cargo clippy --workspace --all-targets -- -D warnings`;
+  - workspace tests under the repository test environment;
+  - `python3 checks/check_workflow.py --repo .`;
+  - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1670`;
+  - fresh GitHub evidence and `python3 checks/pr_gate.py --repo . --evidence <evidence.json> --mode required --json`.
+
+## Parallelization
+
+No parallel writable lanes are planned. The change is one atomic relocation in
+one Rust module namespace, so one implementation agent will move, verify, and
+commit it sequentially.
+
+## Verification
+
+- [ ] Global and GH-1670 SpecRail checks pass.
+- [ ] Product behaviors B-001 through B-006 map to tasks and verification.
+- [ ] Production and test inventories match the exact base.
+- [ ] Both Rust files are at most 800 formatted lines.
+- [ ] Focused, package, workspace, Clippy, VibeGuard, CI, review-thread, and PR
+      gates pass on the exact implementation head.
+
+## Handoff Notes
+
+- Exact issue/spec base: `654751c3a83672bfbdcdf2c771c69a199a96de3f`.
+- Baseline: 822 lines, production through line 388, inline tests from lines
+  389-822, 15 focused PostgreSQL tests passing.
+- Preserve the logical `plan_db::tests::*` namespace and private parent access.
+- This packet authorizes test relocation only. Route any production, SQL,
+  migration, or behavioral finding to a separate issue/spec cycle.

--- a/specs/GH1670/tech.md
+++ b/specs/GH1670/tech.md
@@ -1,0 +1,126 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1670
+
+## Product Spec
+
+See `specs/GH1670/product.md`.
+
+## Current System
+
+On base `654751c3a83672bfbdcdf2c771c69a199a96de3f`,
+`crates/harness-workflow/src/plan_db.rs` contains 822 lines. Lines 1-388 own
+the production implementation, including migrations, `PlanDb`, CRUD/search
+operations, transaction updates, markdown imports, shared-schema access, and
+legacy backfill. Lines 389-822 contain `#[cfg(test)] mod tests`, with 15 tests.
+
+The test module already imports its parent with `use super::*`, so it is a
+natural Rust child module that does not require inline physical ownership.
+
+## Proposed Design
+
+Keep `plan_db.rs` as the stable production module. Replace the inline block
+with:
+
+```rust
+#[cfg(test)]
+mod tests;
+```
+
+Move only the contents inside the existing `mod tests { ... }` block into
+`crates/harness-workflow/src/plan_db/tests.rs`. The extracted file begins with
+the existing `use super::*;` import and retains every helper, import, static,
+and test in its current order.
+
+Rust resolves the child file under the `plan_db/` directory while preserving
+the logical module path `plan_db::tests`. Child-module privacy continues to
+allow tests to access parent-private constants, migrations, methods, and
+helpers, so no production visibility or path change is required.
+
+## Invariants and Inventory
+
+- Record the exact base SHA, root line count, production item list, ordered
+  15-test list, and test attributes before editing.
+- After formatting, compare lines 1-388 of `plan_db.rs` byte-for-byte against
+  the exact base and compare the complete production inventory.
+- Compare the ordered helper/test/attribute inventory across the root plus
+  `plan_db/tests.rs` against the base; require every test exactly once.
+- Review the moved test content as a pure relocation. Permitted edits are
+  limited to replacing the inline wrapper with `mod tests;`, removing one
+  indentation level from the moved block, and accepting deterministic line
+  wrapping produced when the repository `rustfmt` version formats that
+  unindented baseline body. No non-whitespace Rust token may change.
+- Generate the expected child file by extracting base lines 391-821, removing
+  one four-space indentation level, and piping the result through
+  `rustfmt --edition 2021 --emit stdout`; require an exact diff against
+  `plan_db/tests.rs`.
+- Preserve all migration arrays, SQL strings, schema construction, JSON and
+  markdown fixtures, assertions, transaction calls, database gates, imports,
+  and helper calls.
+- Preserve the exact `plan_db::tests::*` paths and require both Rust files to
+  contain no more than 800 formatted lines.
+
+## Affected Files
+
+- `crates/harness-workflow/src/plan_db.rs`
+- `crates/harness-workflow/src/plan_db/tests.rs`
+
+No other source, test, manifest, lockfile, configuration, migration, schema,
+or persisted-format file is expected to change.
+
+## Data Flow
+
+Production inputs, outputs, database connections, SQL execution, persisted
+plans, migrations, and external calls do not change. Only Rust test source
+layout changes at compile time under `cfg(test)`.
+
+## Alternatives Considered
+
+- Leave the inline tests in place: rejected because the file remains above the
+  hard ceiling and mixes a bounded production implementation with 434 lines of
+  database tests.
+- Move tests to a top-level `plan_db_tests.rs` with a path attribute: rejected
+  because standard Rust child-module layout preserves the existing namespace
+  without an explicit path override.
+- Split tests by migration and CRUD behavior: rejected because the extracted
+  test module remains below the ceiling and the 15 tests share database setup
+  and serialization helpers.
+- Refactor production persistence logic at the same time: rejected because
+  that would expand scope beyond the safe test relocation.
+
+## Risks
+
+- Security: low; SQL, migrations, database URLs, and production persistence
+  code remain byte-for-byte unchanged.
+- Compatibility: low; the logical test module path remains unchanged.
+- Performance: none expected; production builds do not compile the test child
+  module and test behavior is unchanged.
+- Test integrity: low if the move matches the canonically formatted baseline,
+  but inventory and movement-aware diff checks are mandatory to prevent a lost
+  test, non-whitespace token, SQL statement, assertion, fixture, or attribute.
+- Maintenance: reduced by separating plan persistence implementation from its
+  database verification while retaining direct child-module access.
+
+## Test Plan
+
+- [ ] Baseline and final `cargo check -p harness-workflow --all-targets`.
+- [ ] Baseline and final
+      `cargo test -p harness-workflow plan_db::tests -- --test-threads=1`
+      against a dedicated PostgreSQL database, with all 15 tests passing.
+- [ ] Final `cargo test -p harness-workflow --lib` against the repository
+      database test environment.
+- [ ] `cargo fmt --all -- --check` and formatted line-count gates.
+- [ ] Exact production and ordered test inventory comparisons.
+- [ ] Exact production diff plus canonical-rustfmt movement comparison proving
+      no non-whitespace test token, SQL, fixture, or production rewrite.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Workspace tests under the repository test environment.
+- [ ] SpecRail global/packet/route checks, VibeGuard compliance, exact-head CI,
+      review-thread audit, and required PR gate.
+
+## Rollback Plan
+
+Squash-revert the implementation PR. No data, schema, migration,
+configuration, dependency, or operator rollback step is required.


### PR DESCRIPTION
Linked work: #1670

## Why

`crates/harness-workflow/src/plan_db.rs` is 822 lines because a 434-line inline database test module shares the production file. The production implementation itself ends at line 388. A standard private child module can bring both files below the repository 800-line ceiling without changing runtime behavior.

## Specification plan

- Preserve production lines 1-388 byte-for-byte.
- Preserve all 15 test names, paths, helpers, SQL, migrations, fixtures, assertions, attributes, and order.
- Allow only deterministic whitespace changes from one-level unindent plus repository rustfmt.
- Require an exact canonical-rustfmt comparison for the moved body.
- Verify focused tests against a dedicated PostgreSQL database plus package, workspace, CI, review-thread, VibeGuard, and SpecRail gates.

## Contents

- `specs/GH1670/product.md`: goals, non-goals, user-visible compatibility, B-001 through B-006, and edge cases.
- `specs/GH1670/tech.md`: exact base/boundaries, child-module design, invariants, risks, alternatives, verification, and rollback.
- `specs/GH1670/tasks.md`: stable task IDs, dependencies, done-when conditions, commands, and handoff evidence.

## Verification

- Global SpecRail check passed.
- GH-1670 packet check passed.
- Required write_spec route passed.
- `cargo fmt --all` and pre-commit checks passed.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- Pre-push database-independent workspace lib tests passed.
- Pre-push `harness-workflow` lib tests: 488 passed.
- Pre-push `harness-server` lib tests with dedicated PostgreSQL: 1,762 passed.

This PR contains specifications only. Implementation will follow in a separate PR after this packet merges.