### PR TITLE
docs: define GH1673 runtime worker test extraction

### DIFF
--- a/specs/GH1673/product.md
+++ b/specs/GH1673/product.md
@@ -1,0 +1,82 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1673
+
+## User Problem
+
+Harness maintainers must navigate an 802-line `runtime/worker.rs` file even
+though the production workflow-runtime worker implementation ends at line 522
+and the remaining 279 lines are one cohesive inline test module. The combined
+file exceeds the repository 800-line hard ceiling and mixes runtime dispatch,
+lease renewal, child completion, budget, and failure-side-effect logic with
+five focused tests and their fixtures.
+
+## Goals
+
+- Give the existing runtime worker tests a dedicated private child module
+  while retaining their current parent module and test names.
+- Reduce both resulting Rust files to no more than 800 formatted lines.
+- Preserve the production implementation exactly and preserve every test's
+  non-whitespace Rust tokens, assertion, fixture, string, attribute, helper,
+  and coverage point; only deterministic whitespace reflow required by
+  `rustfmt` is permitted.
+- Make workflow-runtime worker changes reviewable without traversing the
+  complete worker test suite in the same physical source file.
+- Provide deterministic evidence that the extraction is mechanical.
+
+## Non-Goals
+
+- Changing runtime dispatch, job claims, lease renewal, child completion,
+  activity results, budgets, failure metadata, events, commands, or profiles.
+- Adding, deleting, renaming, consolidating, or rewriting tests or fixtures.
+- Changing public APIs, private production visibility, dependencies,
+  manifests, lockfiles, persistence, database setup, or serialized formats.
+- Addressing unrelated workflow-runtime behavior or coverage findings.
+
+## User-Visible Behavior
+
+There is no intended user-visible behavior change. Runtime worker job
+selection, execution, lease management, child completion propagation, budget
+enforcement, failure metadata, and database-backed tests must remain identical
+to current `origin/main`.
+
+## Acceptance Criteria
+
+- [ ] B-001: `runtime/worker.rs` and the extracted test module each contain no
+      more than 800 formatted lines.
+- [ ] B-002: Lines 1-522 of the exact-base production implementation and the
+      complete production item inventory remain byte-for-byte unchanged.
+- [ ] B-003: All five test names, attributes, order, assertions, fixtures,
+      strings, calls, helpers, non-whitespace Rust tokens, and
+      `runtime::worker::tests::*` paths remain unchanged. Whitespace may differ
+      only when the unindented baseline test body is canonically formatted by
+      the repository `rustfmt` version.
+- [ ] B-004: No workflow runtime behavior, public API, production visibility,
+      dependency, manifest, lockfile, persistence, event, command, lease,
+      dispatch, profile, or failure-side-effect change.
+- [ ] B-005: Focused worker tests, `harness-workflow` checks/tests, workspace
+      Clippy/tests, VibeGuard, exact-head CI, review-thread audit, and SpecRail
+      gates pass.
+- [ ] B-006: The implementation is delivered in a separate PR only after this
+      specification PR is merged.
+
+## Edge Cases
+
+- Tests must retain child-module access to private worker helpers, traits, and
+  failure-side-effect logic through the existing `use super::*` relationship
+  without widening production visibility.
+- Database-backed tests must continue to use the repository database resolver
+  and retain their existing skip/error behavior, SQL-backed store calls, and
+  serial execution coverage.
+- Test filtering by the existing `runtime::worker::tests::...` path must
+  continue to select the same five tests.
+- The module declaration remains test-only and must not affect production
+  builds or exported symbols.
+
+## Rollout Notes
+
+This is a test-source layout refactor only. It requires no data migration,
+feature flag, configuration change, operator action, or compatibility
+communication. Squash-reverting the implementation PR is the rollback path.

--- a/specs/GH1673/tasks.md
+++ b/specs/GH1673/tasks.md
@@ -1,0 +1,128 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1673
+
+## Spec Packet
+
+- Product: `specs/GH1673/product.md`
+- Tech: `specs/GH1673/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1673-T1` Owner: Codex | Done when: exact-base production/test inventories, line counts, duplicate search, focused compile, PostgreSQL tests, and VibeGuard baseline are recorded | Verify: commands in T1 below
+- [ ] `SP1673-T2` Owner: Codex | Done when: the inline test block is moved mechanically to the standard child module, exact inventories and paths match, both files are within the ceiling, and tests pass | Verify: commands in T2 below
+- [ ] `SP1673-T3` Owner: Codex | Done when: local, exact-head CI, review-thread, and SpecRail gates pass for the separate implementation PR and cleanup is verified | Verify: commands in T3 below
+
+### SP1673-T1 — Capture the exact implementation baseline
+
+- Owner: Codex implementation agent.
+- Dependencies: merged GH-1673 specification PR and a fresh worktree from
+  current `origin/main`.
+- Covers: B-001 through B-005.
+- Work:
+  - record the exact base SHA and formatted source/test line boundaries;
+  - record every production item, local test type/helper, test name, and test
+    attribute in order;
+  - confirm the standard child-module target does not already exist;
+  - run focused compile/tests with a dedicated PostgreSQL database and a
+    VibeGuard baseline before editing;
+  - stop and diagnose if the fresh baseline is red.
+- Done when:
+  - exact inventories and baseline output are preserved;
+  - `harness-workflow` all-target compile and all five filtered tests pass;
+  - no duplicate issue, PR, child file, or symbol exists.
+- Verify:
+  - `git rev-parse HEAD`;
+  - `wc -l crates/harness-workflow/src/runtime/worker.rs`;
+  - production/test inventory searches from `tech.md`;
+  - `cargo check -p harness-workflow --all-targets`;
+  - `cargo test -p harness-workflow runtime::worker::tests -- --test-threads=1`
+    with the dedicated database environment.
+
+### SP1673-T2 — Extract the private child test module
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1673-T1.
+- Covers: B-001 through B-004.
+- Work:
+  - replace the inline test wrapper with `#[cfg(test)] mod tests;`;
+  - move the wrapper contents to `runtime/worker/tests.rs` in the same order;
+  - preserve `use super::*`, local imports, fixture types, trait
+    implementations, helpers, attributes, names, JSON, strings, assertions,
+    database gates, store calls, and other calls without token or semantic
+    edits;
+  - generate the expected child file by unindenting the exact-base test body
+    and formatting it with the repository `rustfmt`; require an exact diff;
+  - compare exact production/test inventories and perform a movement-aware
+    diff review that permits only the reproduced whitespace reflow;
+  - commit the verified relocation before PR-readiness work.
+- Done when:
+  - both formatted files are at most 800 lines;
+  - every production, helper, fixture, and test inventory item appears exactly
+    once;
+  - the five focused tests retain `runtime::worker::tests::*` paths and pass
+    against the dedicated PostgreSQL database;
+  - no file outside the approved pair changes.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-workflow --all-targets`;
+  - focused PostgreSQL test command above;
+  - exact inventory, module-path, size, scope, production-prefix, and
+    canonical-rustfmt movement checks.
+
+### SP1673-T3 — Prove PR readiness and clean up
+
+- Owner: Codex implementation agent; human final review remains authoritative.
+- Dependencies: SP1673-T2.
+- Covers: B-001 through B-006.
+- Work:
+  - compare the implementation with the issue and all three spec files;
+  - run the complete deterministic verification matrix at final head;
+  - open the separate implementation PR with reason, plan, inventory, scope,
+    risk, and verification evidence;
+  - wait for exact-head CI and Gemini review, address valid findings, audit all
+    review threads, run the required SpecRail PR gate, and merge only under the
+    standing authorization;
+  - remove the implementation worktree and all disposable resources.
+- Done when:
+  - B-001 through B-006 have fresh evidence;
+  - local and exact-head remote gates pass with no unresolved active thread;
+  - only the approved test relocation is present;
+  - authorized merge, issue closure, and cleanup are verified.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-workflow --all-targets`;
+  - focused and full `harness-workflow` library tests above;
+  - `cargo clippy --workspace --all-targets -- -D warnings`;
+  - workspace tests under the repository test environment;
+  - `python3 checks/check_workflow.py --repo .`;
+  - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1673`;
+  - fresh GitHub evidence and
+    `python3 checks/pr_gate.py --repo . --evidence <evidence.json> --mode required --json`.
+
+## Parallelization
+
+No parallel writable lanes are planned. The change is one atomic relocation in
+one Rust module namespace, so one implementation agent will move, verify, and
+commit it sequentially.
+
+## Verification
+
+- [ ] Global and GH-1673 SpecRail checks pass.
+- [ ] Product behaviors B-001 through B-006 map to tasks and verification.
+- [ ] Production and test/helper inventories match the exact base.
+- [ ] Both Rust files are at most 800 formatted lines.
+- [ ] Focused, package, workspace, Clippy, VibeGuard, CI, review-thread, and PR
+      gates pass on the exact implementation head.
+
+## Handoff Notes
+
+- Exact issue/spec base: `5a0a71b4755ccaac9c22f06949db117ffcb2beed`.
+- Baseline: 802 lines, production through line 522, inline tests from lines
+  524-802, five focused PostgreSQL tests passing.
+- Preserve the logical `runtime::worker::tests::*` namespace and private parent
+  access.
+- This packet authorizes test relocation only. Route any production, runtime,
+  persistence, or behavioral finding to a separate issue/spec cycle.

--- a/specs/GH1673/tech.md
+++ b/specs/GH1673/tech.md
@@ -1,0 +1,127 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1673
+
+## Product Spec
+
+See `specs/GH1673/product.md`.
+
+## Current System
+
+On base `5a0a71b4755ccaac9c22f06949db117ffcb2beed`,
+`crates/harness-workflow/src/runtime/worker.rs` contains 802 lines. Lines 1-522
+own the production implementation, including runtime job execution, claim
+guards, lease renewal, child-completion propagation, activity result handling,
+turn budgets, runtime profiles, and failure metadata side effects. Lines
+524-802 contain `#[cfg(test)] mod tests`, with five tests.
+
+The test module already imports its parent with `use super::*`, so it is a
+natural Rust child module that does not require inline physical ownership.
+
+## Proposed Design
+
+Keep `runtime/worker.rs` as the stable production module. Replace the inline
+block with:
+
+```rust
+#[cfg(test)]
+mod tests;
+```
+
+Move only the contents inside the existing `mod tests { ... }` block into
+`crates/harness-workflow/src/runtime/worker/tests.rs`. The extracted file
+begins with the existing `use super::*;` import and retains every local import,
+fixture type, trait implementation, helper, and test in its current order.
+
+Rust resolves the child file under the `runtime/worker/` directory while
+preserving the logical module path `runtime::worker::tests`. Child-module
+privacy continues to allow tests to access parent-private worker types and
+helpers, so no production visibility or path change is required.
+
+## Invariants and Inventory
+
+- Record the exact base SHA, root line count, production item list, ordered
+  five-test list, helper/type list, and test attributes before editing.
+- After formatting, compare lines 1-522 of `worker.rs` byte-for-byte against
+  the exact base and compare the complete production inventory.
+- Compare the ordered helper/type/test/attribute inventory across the root and
+  `runtime/worker/tests.rs` against the base; require every item exactly once.
+- Review the moved test content as a pure relocation. Permitted edits are
+  limited to replacing the inline wrapper with `mod tests;`, removing one
+  indentation level from the moved block, and accepting deterministic line
+  wrapping produced when the repository `rustfmt` version formats that
+  unindented baseline body. No non-whitespace Rust token may change.
+- Generate the expected child file by extracting exact-base lines 526-801,
+  removing one four-space indentation level, and piping the result through
+  `rustfmt --edition 2021 --emit stdout`; require an exact diff against
+  `runtime/worker/tests.rs`.
+- Preserve the three `#[tokio::test]` and two `#[test]` attributes, database
+  resolver gates, local executor/guard implementations, job fixtures,
+  assertions, JSON values, strings, store calls, and helper calls.
+- Preserve exact `runtime::worker::tests::*` paths and require both Rust files
+  to contain no more than 800 formatted lines.
+
+## Affected Files
+
+- `crates/harness-workflow/src/runtime/worker.rs`
+- `crates/harness-workflow/src/runtime/worker/tests.rs`
+
+No other source, test, manifest, lockfile, configuration, persistence, schema,
+event, or serialized-format file is expected to change.
+
+## Data Flow
+
+Production runtime jobs, commands, events, leases, workflow instances,
+activity results, database connections, and external calls do not change. Only
+Rust test source layout changes at compile time under `cfg(test)`.
+
+## Alternatives Considered
+
+- Leave the inline tests in place: rejected because the file remains above the
+  hard ceiling and mixes a bounded production implementation with 279 lines of
+  runtime worker tests.
+- Move tests to a top-level `runtime_worker_tests.rs` with a path attribute:
+  rejected because standard Rust child-module layout preserves the existing
+  namespace without an explicit path override.
+- Split the five tests across several child modules: rejected because the
+  extracted test module remains well below the ceiling and the tests share
+  executor, guard, job, and workflow fixtures.
+- Refactor production worker logic at the same time: rejected because it would
+  expand scope beyond the safe test relocation.
+
+## Risks
+
+- Security: low; production execution, persistence, and input handling remain
+  byte-for-byte unchanged.
+- Compatibility: low; the logical test module path remains unchanged.
+- Performance: none expected; production builds do not compile the test child
+  module and test behavior is unchanged.
+- Test integrity: low if the move matches the canonically formatted baseline,
+  but inventory and movement-aware diff checks are mandatory to prevent a lost
+  test, helper, attribute, assertion, or database setup path.
+- Maintenance: reduced by separating runtime worker implementation from its
+  focused verification while retaining direct child-module access.
+
+## Test Plan
+
+- [ ] Baseline and final `cargo check -p harness-workflow --all-targets`.
+- [ ] Baseline and final
+      `cargo test -p harness-workflow runtime::worker::tests -- --test-threads=1`
+      against a dedicated PostgreSQL database, with all five tests passing.
+- [ ] Final `cargo test -p harness-workflow --lib` against the repository
+      database test environment.
+- [ ] `cargo fmt --all -- --check` and formatted line-count gates.
+- [ ] Exact production and ordered test/helper inventory comparisons.
+- [ ] Exact production diff plus canonical-rustfmt movement comparison proving
+      no non-whitespace test token or production rewrite.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Workspace tests under the repository test environment.
+- [ ] SpecRail global/packet/route checks, VibeGuard compliance, exact-head CI,
+      review-thread audit, and required PR gate.
+
+## Rollback Plan
+
+Squash-revert the implementation PR. No data, schema, migration,
+configuration, dependency, or operator rollback step is required.


### PR DESCRIPTION
## Summary

Defines the SpecRail product, technical, and task specifications for extracting the inline runtime worker test module into the standard private child file.

## Optimization Reason

On exact `origin/main` commit `5a0a71b4755ccaac9c22f06949db117ffcb2beed`, `crates/harness-workflow/src/runtime/worker.rs` is 802 formatted lines and exceeds the repository 800-line hard ceiling. Production code ends at line 522; the remaining 279 lines are a cohesive five-test module. A mechanical child-module extraction reduces production-file review noise without changing runtime or test behavior.

## Plan

1. Capture exact production, fixture, helper, attribute, and test inventories from the implementation base.
2. Replace only the inline wrapper with `#[cfg(test)] mod tests;`.
3. Move only the wrapper body to `runtime/worker/tests.rs`.
4. Require byte-identical production code and an exact canonical-rustfmt movement comparison.
5. Verify five preserved test paths, focused and full tests, workspace Clippy/tests, SpecRail, exact-head CI, review threads, and the required PR gate.

## Scope

- Adds `specs/GH1673/product.md`.
- Adds `specs/GH1673/tech.md`.
- Adds `specs/GH1673/tasks.md`.
- Contains no implementation or production-code change.

## Verification

- `cargo fmt --all -- --check`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1673`
- `cargo check -p harness-workflow --all-targets`
- Dedicated PostgreSQL baseline: `cargo test -p harness-workflow runtime::worker::tests -- --test-threads=1` — 5 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- Pre-push database-independent workspace tests — passed
- Pre-push `harness-workflow` library tests — 488 passed
- Pre-push PostgreSQL-backed `harness-server` library tests — 1762 passed

## Linked Work

Linked work: #1673
