### PR TITLE
spec: define GH1677 intake configuration test extraction

### DIFF
--- a/specs/GH1677/product.md
+++ b/specs/GH1677/product.md
@@ -1,0 +1,82 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1677
+
+## User Problem
+
+Harness maintainers must navigate an 803-line `config/intake.rs` file even
+though one cohesive inline test module occupies lines 492-792. The combined
+file exceeds the repository 800-line hard ceiling and mixes intake
+configuration types, defaults, validation, lookup, and redacted-debug behavior
+with 12 focused unit tests.
+
+## Goals
+
+- Give the existing intake configuration tests a dedicated private child
+  module while retaining their current parent module and test names.
+- Reduce both resulting Rust files to no more than 800 formatted lines.
+- Preserve the production implementation exactly and preserve every test's
+  non-whitespace Rust tokens, assertion, fixture, string, attribute, helper,
+  and coverage point; only deterministic whitespace reflow required by
+  `rustfmt` is permitted.
+- Make intake configuration changes reviewable without traversing the complete
+  test suite in the same physical source file.
+- Provide deterministic evidence that the extraction is mechanical.
+
+## Non-Goals
+
+- Changing intake defaults, parsing, validation, repository lookup, merge or
+  recovery policy, Feishu redaction, serialization, or debug behavior.
+- Adding, deleting, renaming, consolidating, or rewriting tests or fixtures.
+- Changing public APIs, private production visibility, dependencies,
+  manifests, lockfiles, persistence, schemas, or serialized formats.
+- Implementing the workflow-configuration work proposed by GH-1656 or
+  addressing unrelated configuration findings.
+
+## User-Visible Behavior
+
+There is no intended user-visible behavior change. GitHub and Feishu intake
+configuration defaults, parsing, validation, repository selection, policy
+resolution, serialization, and redacted debug output must remain identical to
+the exact `origin/main` baseline.
+
+## Acceptance Criteria
+
+- [ ] B-001: `config/intake.rs` and the extracted test module each contain no
+      more than 800 formatted lines.
+- [ ] B-002: Exact-base production lines 1-491 and 793-803, including the
+      complete `IntakeConfig` definition after the test block, remain
+      byte-for-byte unchanged.
+- [ ] B-003: All 12 test names, attributes, order, assertions, fixtures,
+      strings, calls, comments, non-whitespace Rust tokens, and
+      `config::intake::tests::*` paths remain unchanged. Whitespace may differ
+      only when the unindented baseline test body is canonically formatted by
+      the repository `rustfmt` version.
+- [ ] B-004: No intake behavior, public API, production visibility,
+      dependency, manifest, lockfile, persistence, schema, or serialized
+      format changes.
+- [ ] B-005: Focused intake tests, `harness-core` checks/tests, workspace
+      Clippy/tests, VibeGuard, exact-head CI, review-thread audit, and SpecRail
+      gates pass.
+- [ ] B-006: The implementation is delivered in a separate PR only after this
+      specification PR is merged.
+
+## Edge Cases
+
+- Tests must retain child-module access to private intake constants and helper
+  behavior through the existing `use super::*` relationship without widening
+  production visibility.
+- The `IntakeConfig` production type that follows the inline test block must
+  remain present, ordered, and byte-for-byte unchanged.
+- Test filtering by the existing `config::intake::tests::...` path must
+  continue to select the same 12 tests.
+- The module declaration remains test-only and must not affect production
+  builds or exported symbols.
+
+## Rollout Notes
+
+This is a test-source layout refactor only. It requires no data migration,
+feature flag, configuration change, operator action, or compatibility
+communication. Squash-reverting the implementation PR is the rollback path.

--- a/specs/GH1677/tasks.md
+++ b/specs/GH1677/tasks.md
@@ -1,0 +1,123 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1677
+
+## Spec Packet
+
+- Product: `specs/GH1677/product.md`
+- Tech: `specs/GH1677/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1677-T1` Owner: Codex | Done when: exact-base production/test inventories, line counts, duplicate search, focused compile/tests, and VibeGuard baseline are recorded | Verify: commands in T1 below
+- [ ] `SP1677-T2` Owner: Codex | Done when: the inline test block is moved mechanically to the standard child module, exact inventories and paths match, both files are within the ceiling, and tests pass | Verify: commands in T2 below
+- [ ] `SP1677-T3` Owner: Codex | Done when: local, exact-head CI, review-thread, and SpecRail gates pass for the separate implementation PR and cleanup is verified | Verify: commands in T3 below
+
+### SP1677-T1 — Capture the exact implementation baseline
+
+- Owner: Codex implementation agent.
+- Dependencies: merged GH-1677 specification PR and a fresh worktree from
+  current `origin/main`.
+- Covers: B-001 through B-005.
+- Work:
+  - record the exact base SHA and formatted source/test line boundaries;
+  - record every production item, test name, and test attribute in order;
+  - confirm the standard child-module target does not already exist;
+  - run focused compile/tests and a VibeGuard baseline before editing;
+  - stop and diagnose if the fresh baseline is red.
+- Done when:
+  - exact inventories and baseline output are preserved;
+  - `harness-core` all-target compile and all 12 filtered tests pass;
+  - no duplicate issue, PR, child file, or symbol exists.
+- Verify:
+  - `git rev-parse HEAD`;
+  - `wc -l crates/harness-core/src/config/intake.rs`;
+  - production/test inventory searches from `tech.md`;
+  - `cargo check -p harness-core --all-targets`;
+  - `cargo test -p harness-core config::intake::tests`.
+
+### SP1677-T2 — Extract the private child test module
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1677-T1.
+- Covers: B-001 through B-004.
+- Work:
+  - replace the inline test wrapper with `#[cfg(test)] mod tests;`;
+  - move the wrapper contents to `config/intake/tests.rs` in the same order;
+  - preserve `use super::*`, attributes, names, TOML fixtures, comments,
+    strings, assertions, policy values, validation calls, redaction checks, and
+    other calls without token or semantic edits;
+  - generate the expected child file by unindenting the exact-base test body
+    and formatting it with the repository `rustfmt`; require an exact diff;
+  - compare exact production/test inventories and perform a movement-aware
+    diff review that permits only the reproduced whitespace reflow;
+  - commit the verified relocation before PR-readiness work.
+- Done when:
+  - both formatted files are at most 800 lines;
+  - every production item and test inventory item appears exactly once;
+  - the 12 focused tests retain `config::intake::tests::*` paths and pass;
+  - no file outside the approved pair changes.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-core --all-targets`;
+  - focused test command above;
+  - exact inventory, module-path, size, scope, production-section, and
+    canonical-rustfmt movement checks.
+
+### SP1677-T3 — Prove PR readiness and clean up
+
+- Owner: Codex implementation agent; human final review remains authoritative.
+- Dependencies: SP1677-T2.
+- Covers: B-001 through B-006.
+- Work:
+  - compare the implementation with the issue and all three spec files;
+  - run the complete deterministic verification matrix at final head;
+  - open the separate implementation PR with reason, plan, inventory, scope,
+    risk, and verification evidence;
+  - wait for exact-head CI and Gemini review, address valid findings, audit all
+    review threads, run the required SpecRail PR gate, and merge only under the
+    standing authorization;
+  - remove the implementation worktree and all disposable resources.
+- Done when:
+  - B-001 through B-006 have fresh evidence;
+  - local and exact-head remote gates pass with no unresolved active thread;
+  - only the approved test relocation is present;
+  - authorized merge, issue closure, and cleanup are verified.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-core --all-targets`;
+  - focused and full `harness-core` library tests above;
+  - `cargo clippy --workspace --all-targets -- -D warnings`;
+  - workspace tests under the repository test environment;
+  - `python3 checks/check_workflow.py --repo .`;
+  - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1677`;
+  - fresh GitHub evidence and
+    `python3 checks/pr_gate.py --repo . --evidence <evidence.json> --mode required --json`.
+
+## Parallelization
+
+No parallel writable lanes are planned. The change is one atomic relocation in
+one Rust module namespace, so one implementation agent will move, verify, and
+commit it sequentially.
+
+## Verification
+
+- [ ] Global and GH-1677 SpecRail checks pass.
+- [ ] Product behaviors B-001 through B-006 map to tasks and verification.
+- [ ] Production and test inventories match the exact base.
+- [ ] Both Rust files are at most 800 formatted lines.
+- [ ] Focused, package, workspace, Clippy, VibeGuard, CI, review-thread, and PR
+      gates pass on the exact implementation head.
+
+## Handoff Notes
+
+- Exact issue/spec base: `4db3d0d4842cebb25c4c69519acdd386e154a8e1`.
+- Baseline: 803 lines, production lines 1-491 and 793-803, inline tests from
+  lines 492-792, and 12 focused unit tests passing.
+- Preserve the logical `config::intake::tests::*` namespace and private parent
+  access.
+- This packet authorizes test relocation only. Route any production,
+  persistence, parsing, validation, or behavioral finding to a separate
+  issue/spec cycle.

--- a/specs/GH1677/tech.md
+++ b/specs/GH1677/tech.md
@@ -1,0 +1,126 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1677
+
+## Product Spec
+
+See `specs/GH1677/product.md`.
+
+## Current System
+
+On base `4db3d0d4842cebb25c4c69519acdd386e154a8e1`,
+`crates/harness-core/src/config/intake.rs` contains 803 lines. Lines 1-491 own
+the first production section. Lines 492-792 contain `#[cfg(test)] mod tests`,
+with 12 tests. Lines 793-803 resume production ownership with the complete
+`IntakeConfig` type.
+
+The test module already imports its parent with `use super::*`, so it is a
+natural Rust child module that does not require inline physical ownership.
+
+## Proposed Design
+
+Keep `config/intake.rs` as the stable production module. Replace the inline
+block with:
+
+```rust
+#[cfg(test)]
+mod tests;
+```
+
+Move only the contents inside the existing `mod tests { ... }` block into
+`crates/harness-core/src/config/intake/tests.rs`. The extracted file begins
+with the existing `use super::*;` import and retains every test and local value
+in its current order.
+
+Rust resolves the child file under the `config/intake/` directory while
+preserving the logical module path `config::intake::tests`. Child-module
+privacy continues to allow tests to access parent-private constants and
+helpers, so no production visibility or path change is required.
+
+## Invariants and Inventory
+
+- Record the exact base SHA, root line count, production item list, ordered
+  12-test list, and test attributes before editing.
+- After formatting, compare exact-base lines 1-491 and 793-803 byte-for-byte
+  against their corresponding final production sections and compare the
+  complete production inventory.
+- Compare the ordered test/attribute inventory across the root and
+  `config/intake/tests.rs` against the base; require every item exactly once.
+- Review the moved test content as a pure relocation. Permitted edits are
+  limited to replacing the inline wrapper with `mod tests;`, removing one
+  indentation level from the moved block, and accepting deterministic line
+  wrapping produced when the repository `rustfmt` version formats that
+  unindented baseline body. No non-whitespace Rust token may change.
+- Generate the expected child file by extracting exact-base lines 494-791,
+  removing one four-space indentation level, and piping the result through
+  `rustfmt --edition 2021 --emit stdout`; require an exact diff against
+  `config/intake/tests.rs`.
+- Preserve all 12 `#[test]` attributes, TOML fixtures, result types, comments,
+  assertions, strings, policy values, validation calls, and redaction checks.
+- Preserve exact `config::intake::tests::*` paths and require both Rust files
+  to contain no more than 800 formatted lines.
+
+## Affected Files
+
+- `crates/harness-core/src/config/intake.rs`
+- `crates/harness-core/src/config/intake/tests.rs`
+
+No other source, test, manifest, lockfile, configuration, persistence, schema,
+or serialized-format file is expected to change.
+
+## Data Flow
+
+Production intake configuration values, parsing, validation, serialization,
+debug output, repository selection, merge policy, recovery policy, and
+external calls do not change. Only Rust test source layout changes at compile
+time under `cfg(test)`.
+
+## Alternatives Considered
+
+- Leave the inline tests in place: rejected because the file remains above the
+  hard ceiling and mixes a bounded production implementation with 301 lines
+  of intake configuration tests.
+- Move tests to a top-level `intake_tests.rs` with a path attribute: rejected
+  because standard Rust child-module layout preserves the existing namespace
+  without an explicit path override.
+- Split the 12 tests across several child modules: rejected because the
+  extracted test module remains well below the ceiling and the tests share the
+  same parent configuration types and constants.
+- Refactor production configuration code at the same time: rejected because
+  it would expand scope beyond the safe test relocation.
+
+## Risks
+
+- Security: low; production parsing, validation, redaction, persistence, and
+  input handling remain byte-for-byte unchanged.
+- Compatibility: low; the logical test module path remains unchanged.
+- Performance: none expected; production builds do not compile the test child
+  module and test behavior is unchanged.
+- Test integrity: low if the move matches the canonically formatted baseline,
+  but inventory and movement-aware diff checks are mandatory to prevent a lost
+  test, assertion, fixture, comment, attribute, or redaction check.
+- Maintenance: reduced by separating intake configuration implementation from
+  its focused verification while retaining direct child-module access.
+
+## Test Plan
+
+- [ ] Baseline and final `cargo check -p harness-core --all-targets`.
+- [ ] Baseline and final
+      `cargo test -p harness-core config::intake::tests`, with all 12 tests
+      passing.
+- [ ] Final `cargo test -p harness-core --lib`.
+- [ ] `cargo fmt --all -- --check` and formatted line-count gates.
+- [ ] Exact production and ordered test inventory comparisons.
+- [ ] Exact production-section diffs plus canonical-rustfmt movement
+      comparison proving no non-whitespace test token or production rewrite.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Workspace tests under the repository test environment.
+- [ ] SpecRail global/packet/route checks, VibeGuard compliance, exact-head CI,
+      review-thread audit, and required PR gate.
+
+## Rollback Plan
+
+Squash-revert the implementation PR. No data, schema, migration,
+configuration, dependency, or operator rollback step is required.


### PR DESCRIPTION
## Reason

`crates/harness-core/src/config/intake.rs` is 803 lines and exceeds the repository hard ceiling because 301 lines of focused unit tests are embedded between two production sections. The tests already form a private child module, so a mechanical extraction can improve maintainability without changing production behavior.

## Plan

1. Preserve exact-base production lines 1-491 and 793-803 byte-for-byte.
2. Replace the inline test wrapper with the standard test-only child-module declaration.
3. Move exact-base test-body lines 494-791 to `config/intake/tests.rs`, permitting only canonical `rustfmt` whitespace reflow.
4. Prove the 12 tests retain their names, paths, attributes, assertions, fixtures, comments, strings, and non-whitespace tokens.
5. Run focused, package, workspace, CI, review-thread, and SpecRail gates in a separate implementation PR.

## Scope

This PR contains only `specs/GH1677/product.md`, `tech.md`, and `tasks.md`. It intentionally contains no implementation change.

## Verification

- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1677`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: database-independent workspace library tests passed, including 592 `harness-core` tests and 482 `harness-workflow` tests
- manual VibeGuard L1-L7 compliance review passed; the external `vibeguard` executable is not installed, so no automated scan is claimed

Linked work: #1677
