### PR TITLE
spec: define GH1680 runtime worker child test split

### DIFF
--- a/specs/GH1680/product.md
+++ b/specs/GH1680/product.md
@@ -1,0 +1,78 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1680
+
+## User Problem
+
+Harness maintainers must navigate an 822-line
+`http/tests/runtime_worker_tests.rs` file that exceeds the repository 800-line
+hard ceiling. The file combines three runtime-job execution and terminal-state
+tests with four cohesive tests for starting child workflows without an agent
+turn.
+
+## Goals
+
+- Give the four child-workflow-start tests a dedicated private child module.
+- Reduce both resulting test files to no more than 800 formatted lines.
+- Preserve all seven test names, attributes, bodies, assertions, fixtures,
+  database gates, and non-whitespace Rust tokens exactly.
+- Keep the three retained test paths unchanged and change the four moved paths
+  only by adding the `child_workflows` module segment.
+- Provide deterministic evidence that the split is a mechanical test-source
+  relocation with no production change.
+
+## Non-Goals
+
+- Changing runtime worker, child-workflow, runtime-turn, workflow-state,
+  persistence, or database behavior.
+- Adding, deleting, renaming, consolidating, or rewriting tests or fixtures.
+- Changing production source, public APIs, dependencies, manifests, lockfiles,
+  schemas, persistence, or serialized formats.
+- Splitting unrelated HTTP test modules.
+
+## User-Visible Behavior
+
+There is no intended user-visible behavior change. Runtime jobs, child
+workflows, agent-turn suppression, workflow state, persistence, and HTTP
+behavior must remain identical to current `origin/main`.
+
+## Acceptance Criteria
+
+- [ ] B-001: `runtime_worker_tests.rs` and
+      `runtime_worker_tests/child_workflows.rs` each contain no more than 800
+      formatted lines.
+- [ ] B-002: Exact-base lines 1-409 remain byte-for-byte unchanged in the root
+      file, apart from appending the one child-module declaration.
+- [ ] B-003: Exact-base lines 410-822 appear byte-for-byte unchanged and in
+      order after `use super::*;` in the child file.
+- [ ] B-004: All seven test names, attributes, bodies, assertions, fixtures,
+      database gates, and non-whitespace Rust tokens remain present exactly
+      once. The three retained paths stay unchanged; the four moved paths gain
+      only `child_workflows`.
+- [ ] B-005: No production behavior, production source, public API,
+      dependency, manifest, lockfile, persistence, schema, or serialized
+      format change.
+- [ ] B-006: Focused PostgreSQL tests, `harness-server` checks/tests, workspace
+      Clippy/tests, VibeGuard review, exact-head CI, review-thread audit, and
+      SpecRail gates pass.
+- [ ] B-007: The implementation is delivered in a separate PR only after this
+      specification PR is merged.
+
+## Edge Cases
+
+- The child file must retain access to the parent test module's imported
+  fixtures and helpers through `use super::*;` without widening visibility.
+- The existing filter `http::tests::runtime_worker_tests` must continue to
+  select all seven tests, including the nested child module.
+- All seven tests must continue using the same dedicated PostgreSQL setup and
+  `db_tests_enabled` gate.
+- Child-workflow tests must retain their existing serialized execution order
+  under `--test-threads=1` verification.
+
+## Rollout Notes
+
+This is a test-source layout refactor only. It requires no data migration,
+feature flag, configuration change, operator action, or compatibility
+communication. Squash-reverting the implementation PR is the rollback path.

--- a/specs/GH1680/tasks.md
+++ b/specs/GH1680/tasks.md
@@ -1,0 +1,110 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1680
+
+## Spec Packet
+
+- Product: `specs/GH1680/product.md`
+- Tech: `specs/GH1680/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1680-T1` Owner: Codex | Done when: exact-base boundaries, ordered test inventory, duplicate/overlap checks, compile, seven PostgreSQL tests, and VibeGuard baseline are recorded | Verify: commands in T1 below
+- [ ] `SP1680-T2` Owner: Codex | Done when: the four child-workflow tests are moved mechanically, exact retained/moved comparisons and namespace expectations pass, both files are within the ceiling, and all seven tests pass | Verify: commands in T2 below
+- [ ] `SP1680-T3` Owner: Codex | Done when: local, exact-head CI, review-thread, and SpecRail gates pass for the separate implementation PR and cleanup is verified | Verify: commands in T3 below
+
+### SP1680-T1 — Capture the exact implementation baseline
+
+- Owner: Codex implementation agent.
+- Dependencies: merged GH-1680 specification PR and a fresh worktree from
+  current `origin/main`.
+- Covers: B-001 through B-006.
+- Work:
+  - record the exact base SHA, line boundary, ordered seven-test inventory, and
+    current test paths;
+  - confirm the child target does not exist and no duplicate issue or open PR
+    overlaps either approved path;
+  - run the all-target check and seven focused tests against a dedicated
+    PostgreSQL database;
+  - record the manual VibeGuard baseline and stop if any baseline is red.
+- Done when:
+  - exact inventories and baseline output are preserved;
+  - all seven tests pass with the database enabled;
+  - the planned two-file scope is unambiguous.
+- Verify:
+  - `git rev-parse HEAD`;
+  - `wc -l crates/harness-server/src/http/tests/runtime_worker_tests.rs`;
+  - inventory and boundary searches from `tech.md`;
+  - `cargo check -p harness-server --all-targets`;
+  - the focused PostgreSQL command from `tech.md`.
+
+### SP1680-T2 — Extract the child-workflow test group
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1680-T1.
+- Covers: B-001 through B-005.
+- Work:
+  - retain exact-base lines 1-409 and append `mod child_workflows;`;
+  - create the child file with `use super::*;` and exact-base lines 410-822;
+  - preserve every attribute, name, body, fixture, assertion, database gate,
+    workflow value, command payload, string, and call without semantic edits;
+  - prove exact retained and moved content, ordered inventory, documented path
+    changes, line ceilings, and approved two-file scope;
+  - run focused and full server tests before committing.
+- Done when:
+  - the root and child files are each at most 800 formatted lines;
+  - all seven tests appear exactly once and all documented paths are correct;
+  - exact movement and PostgreSQL verification pass;
+  - no file outside the approved pair changes.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-server --all-targets`;
+  - focused and full server PostgreSQL tests from `tech.md`;
+  - exact root, exact child, inventory, namespace, size, and scope checks.
+
+### SP1680-T3 — Prove PR readiness and clean up
+
+- Owner: Codex implementation agent; human final review remains authoritative.
+- Dependencies: SP1680-T2.
+- Covers: B-001 through B-007.
+- Work:
+  - compare the implementation with the issue and complete spec packet;
+  - run the deterministic verification matrix at final head;
+  - open the separate implementation PR with reason, plan, movement evidence,
+    namespace change, scope, risk, and verification;
+  - wait for exact-head CI and Gemini review, address valid findings, audit all
+    review threads, run the required SpecRail PR gate, and merge only under the
+    standing authorization;
+  - remove the worktree and disposable database.
+- Done when:
+  - B-001 through B-007 have fresh evidence;
+  - local and exact-head remote gates pass with no unresolved active thread;
+  - authorized merge, issue closure, and cleanup are verified.
+- Verify:
+  - format, check, focused/full server test, workspace Clippy/test, SpecRail,
+    exact-head CI, review-thread, and required PR gate commands from this packet.
+
+## Parallelization
+
+No parallel writable lanes are planned. The two files form one Rust test module
+namespace and will be moved, verified, and committed sequentially.
+
+## Verification
+
+- [ ] Global and GH-1680 SpecRail checks pass.
+- [ ] Product behaviors B-001 through B-007 map to tasks and verification.
+- [ ] Exact retained/moved content and ordered test inventory match the base.
+- [ ] Both Rust files are at most 800 formatted lines.
+- [ ] Focused, server, workspace, Clippy, VibeGuard, CI, review-thread, and PR
+      gates pass on the exact implementation head.
+
+## Handoff Notes
+
+- Exact issue/spec base: `968d0058d852b9ef44bad37a3527938f3852e812`.
+- Baseline: 822 lines, seven PostgreSQL tests, retained lines 1-409, moved lines
+  410-822, all seven focused tests passing.
+- Preserve test bodies exactly; only the four moved logical paths gain
+  `child_workflows`.
+- Route any production or behavioral finding to a separate issue/spec cycle.

--- a/specs/GH1680/tech.md
+++ b/specs/GH1680/tech.md
@@ -1,0 +1,113 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1680
+
+## Product Spec
+
+See `specs/GH1680/product.md`.
+
+## Current System
+
+On base `968d0058d852b9ef44bad37a3527938f3852e812`,
+`crates/harness-server/src/http/tests/runtime_worker_tests.rs` contains 822
+lines and seven `#[tokio::test]` functions. Lines 1-409 contain three tests for
+registered-agent execution, terminal-workspace cleanup, and already-terminal
+workflow cancellation. Lines 410-822 contain four cohesive tests that start
+generic prompt, open-PR prompt-feedback, PR-feedback, and quality-gate child
+workflows without an agent turn.
+
+The root test module imports its parent with `use super::*`. A nested child
+module can import the root test namespace the same way without changing
+production visibility.
+
+## Proposed Design
+
+Keep exact-base lines 1-409 in `runtime_worker_tests.rs`, then append:
+
+```rust
+mod child_workflows;
+```
+
+Create
+`crates/harness-server/src/http/tests/runtime_worker_tests/child_workflows.rs`
+with `use super::*;`, one blank line, and exact-base lines 410-822 in their
+current order.
+
+The three retained tests keep their current logical paths. The four moved
+tests intentionally become
+`http::tests::runtime_worker_tests::child_workflows::<test_name>`. The existing
+parent filter continues to select all seven tests.
+
+## Invariants and Inventory
+
+- Record the exact base SHA, root line count, ordered seven-test list,
+  attributes, and split boundary before editing.
+- Require final root lines 1-409 to match the exact base byte-for-byte and the
+  only appended root content to be `mod child_workflows;`.
+- Generate the expected child file from `use super::*;`, a blank line, and
+  exact-base lines 410-822; require an exact diff after repository `rustfmt`.
+- Preserve all seven `#[tokio::test]` attributes, names, result types, bodies,
+  assertions, fixtures, workflow definitions, command payloads, database
+  gates, store calls, strings, and non-whitespace Rust tokens exactly once.
+- Require the three retained paths to remain unchanged and the four moved paths
+  to differ only by the new `child_workflows` segment.
+- Require both formatted files to contain no more than 800 lines and no file
+  outside the approved pair to change.
+
+## Affected Files
+
+- `crates/harness-server/src/http/tests/runtime_worker_tests.rs`
+- `crates/harness-server/src/http/tests/runtime_worker_tests/child_workflows.rs`
+
+No production source, other test, manifest, lockfile, configuration,
+persistence, schema, or serialized-format file is expected to change.
+
+## Data Flow
+
+Production runtime jobs, workflow instances, commands, child workflows, agent
+turns, databases, and HTTP requests do not change. Only Rust test module layout
+changes under the existing test-only namespace.
+
+## Alternatives Considered
+
+- Leave the file unchanged: rejected because it remains above the hard ceiling
+  and mixes two distinct runtime-worker test concerns.
+- Move only the final quality-gate test: rejected because the four tests share
+  one bounded child-workflow-start concern and fit comfortably together.
+- Split every test into a separate module: rejected because it fragments a
+  seven-test suite without improving cohesion.
+- Refactor shared fixtures or production code simultaneously: rejected because
+  it expands scope beyond a safe mechanical relocation.
+
+## Risks
+
+- Security: low; production source, input handling, authentication, process
+  execution, and persistence implementation are unchanged.
+- Compatibility: low; only four test paths gain one documented module segment,
+  while the stable parent filter still selects the full suite.
+- Performance: none expected outside negligible test compilation layout.
+- Test integrity: low if the exact retained/moved comparisons pass; inventory
+  and PostgreSQL execution remain mandatory.
+- Maintenance: improved by separating execution/terminal-state coverage from
+  child-workflow-start coverage.
+
+## Test Plan
+
+- [ ] Baseline and final `cargo check -p harness-server --all-targets`.
+- [ ] Baseline and final PostgreSQL-backed
+      `cargo test -p harness-server http::tests::runtime_worker_tests -- --test-threads=1`,
+      with all seven tests passing.
+- [ ] Final `cargo test -p harness-server --lib` against a dedicated database.
+- [ ] `cargo fmt --all -- --check`, line-count, exact root, exact child,
+      ordered inventory, namespace, and two-file scope checks.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` and workspace
+      tests under the repository test environment.
+- [ ] SpecRail global/packet/route checks, manual VibeGuard L1-L7 review,
+      exact-head CI, review-thread audit, and required PR gate.
+
+## Rollback Plan
+
+Squash-revert the implementation PR. No data, schema, migration,
+configuration, dependency, or operator rollback step is required.


### PR DESCRIPTION
## Reason

`crates/harness-server/src/http/tests/runtime_worker_tests.rs` is 822 formatted lines and exceeds the repository hard ceiling. Its final four tests form one cohesive child-workflow-start group that can move to a standard nested test module without changing production code or test bodies.

## Plan

1. Preserve exact-base lines 1-409 and append only `mod child_workflows;`.
2. Create the child file from `use super::*;` plus exact-base lines 410-822.
3. Preserve all seven test names, attributes, bodies, fixtures, assertions, database gates, and non-whitespace tokens exactly once.
4. Keep the three retained paths unchanged; document the four moved paths gaining only `child_workflows`.
5. Run exact movement, PostgreSQL, server, workspace, CI, review-thread, and SpecRail gates in a separate implementation PR.

## Scope

This PR contains only `specs/GH1680/product.md`, `tech.md`, and `tasks.md`. It intentionally contains no implementation change.

## Verification

- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1680`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- dedicated PostgreSQL baseline: 7 focused tests passed
- pre-push: 488 workflow tests and 1762 server DB-backed tests passed
- manual VibeGuard L1-L7 review passed; no automated scan is claimed because the external executable is unavailable

Linked work: #1680
