### PR TITLE
docs(spec): pin deterministic Bun toolchain for GH1686

### DIFF
--- a/specs/GH1686/product.md
+++ b/specs/GH1686/product.md
@@ -1,0 +1,79 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1686
+
+## User Problem
+
+Harness maintainers cannot rely on pull-request validation when unrelated Rust
+changes are blocked before project code runs. The `Web Build` dependency and
+two other active workflows configure `oven-sh/setup-bun@v2` with
+`bun-version: latest`. That resolution path enumerates the complete Bun tag
+collection through the GitHub API. On 2026-07-17, the endpoint returned HTTP
+503 in two consecutive exact-head runs for PR #1685, so web build, Clippy, and
+tests never started even though the exact web build passed locally.
+
+## Goals
+
+- Make the Bun toolchain deterministic across all active workflows.
+- Avoid the full Bun tag-discovery request during CI setup.
+- Keep one repository-owned Bun version as the source of truth.
+- Preserve all existing dependency-install, typecheck, test, build, artifact,
+  and Rust validation commands.
+- Restore reliable validation for unrelated Rust pull requests.
+
+## Non-Goals
+
+- Changing web or TypeScript dependencies, manifests, or lockfiles.
+- Changing web, SDK, Rust production, or Rust test behavior.
+- Adding a custom installer, mirror, retry loop, or fallback runtime.
+- Updating GitHub Action revisions unrelated to Bun version resolution.
+- Automating future Bun upgrades.
+
+## User-Visible Behavior
+
+There is no intended Harness product behavior change. CI installs the
+repository-selected Bun 1.3.14 release instead of resolving `latest` on every
+run. Existing web and Rust validation commands and artifacts remain unchanged.
+
+## Acceptance Criteria
+
+- [ ] B-001: A root `.bun-version` file contains exactly the strict semantic
+      version `1.3.14` followed by one newline.
+- [ ] B-002: `.github/workflows/ci.yml`,
+      `.github/workflows/web-ci.yml`, and
+      `.github/workflows/ci-disabled-modules.yml` configure
+      `oven-sh/setup-bun@v2` through `bun-version-file: .bun-version`.
+- [ ] B-003: No active workflow retains `bun-version: latest` or duplicates a
+      literal Bun version.
+- [ ] B-004: The strict version path constructs the release download without
+      requesting `https://api.github.com/repos/oven-sh/bun/git/refs/tags`.
+- [ ] B-005: Bun 1.3.14 completes frozen dependency installation, web
+      typecheck, tests, SDK prebuild, and production build without manifest or
+      lockfile changes.
+- [ ] B-006: Existing workflow triggers, job dependencies, commands, artifact
+      handling, and Rust validation behavior remain unchanged.
+- [ ] B-007: Format, web validation, workflow syntax/scope checks, manual
+      VibeGuard review, exact-head CI, review-thread audit, and SpecRail gates
+      pass.
+- [ ] B-008: The implementation is delivered in a separate PR only after this
+      specification PR is merged.
+
+## Edge Cases
+
+- The version file must use a strict three-component semantic version; a
+  range, `latest`, or malformed value would re-enter tag discovery.
+- All three active Bun-using workflows must move together so pull-request,
+  web-only, and all-features validation cannot drift.
+- A cached runner and an uncached runner must resolve the same release.
+- Existing frozen lockfiles must remain accepted by Bun 1.3.14.
+- Historical examples under `docs/` are records, not active workflow
+  configuration, and remain unchanged.
+
+## Rollout Notes
+
+This is a CI-toolchain reliability change. It needs no migration, feature flag,
+operator action, or compatibility communication. Future Bun upgrades should
+change `.bun-version` in a separately verified dependency-maintenance PR.
+Squash-reverting the implementation PR restores the prior resolver behavior.

--- a/specs/GH1686/product.md
+++ b/specs/GH1686/product.md
@@ -19,6 +19,7 @@ tests never started even though the exact web build passed locally.
 - Make the Bun toolchain deterministic across all active workflows.
 - Avoid the full Bun tag-discovery request during CI setup.
 - Keep one repository-owned Bun version as the source of truth.
+- Ensure a Bun version-only change triggers the workflows that validate it.
 - Preserve all existing dependency-install, typecheck, test, build, artifact,
   and Rust validation commands.
 - Restore reliable validation for unrelated Rust pull requests.
@@ -44,7 +45,9 @@ run. Existing web and Rust validation commands and artifacts remain unchanged.
 - [ ] B-002: `.github/workflows/ci.yml`,
       `.github/workflows/web-ci.yml`, and
       `.github/workflows/ci-disabled-modules.yml` configure
-      `oven-sh/setup-bun@v2` through `bun-version-file: .bun-version`.
+      `oven-sh/setup-bun@v2` through `bun-version-file: .bun-version`;
+      `.bun-version` is also included in the main CI change filter and Web CI
+      path triggers.
 - [ ] B-003: No active workflow retains `bun-version: latest` or duplicates a
       literal Bun version.
 - [ ] B-004: The strict version path constructs the release download without
@@ -52,8 +55,9 @@ run. Existing web and Rust validation commands and artifacts remain unchanged.
 - [ ] B-005: Bun 1.3.14 completes frozen dependency installation, web
       typecheck, tests, SDK prebuild, and production build without manifest or
       lockfile changes.
-- [ ] B-006: Existing workflow triggers, job dependencies, commands, artifact
-      handling, and Rust validation behavior remain unchanged.
+- [ ] B-006: Apart from the narrow `.bun-version` path additions, existing
+      workflow triggers, job dependencies, commands, artifact handling, and
+      Rust validation behavior remain unchanged.
 - [ ] B-007: Format, web validation, workflow syntax/scope checks, manual
       VibeGuard review, exact-head CI, review-thread audit, and SpecRail gates
       pass.
@@ -66,6 +70,8 @@ run. Existing web and Rust validation commands and artifacts remain unchanged.
   range, `latest`, or malformed value would re-enter tag discovery.
 - All three active Bun-using workflows must move together so pull-request,
   web-only, and all-features validation cannot drift.
+- A pull request or push that changes only `.bun-version` must run main CI and
+  Web CI instead of silently skipping validation for the selected toolchain.
 - A cached runner and an uncached runner must resolve the same release.
 - Existing frozen lockfiles must remain accepted by Bun 1.3.14.
 - Historical examples under `docs/` are records, not active workflow

--- a/specs/GH1686/tasks.md
+++ b/specs/GH1686/tasks.md
@@ -48,16 +48,20 @@ GH-1686
 - Work:
   - add `.bun-version` with exact value `1.3.14`;
   - replace all three active `bun-version: latest` inputs with the shared file;
+  - add `.bun-version` to the main CI `ci` filter and Web CI paths so a
+    version-only change validates the selected toolchain;
   - preserve every unrelated workflow line and all manifests/lockfiles;
   - install or download Bun 1.3.14 and run the complete web validation surface;
   - prove exact version/reference counts and approved four-file scope.
 - Done when:
   - Bun 1.3.14 is the single active workflow version source;
+  - a `.bun-version`-only change selects main CI and Web CI;
   - all web and SDK checks pass with frozen dependencies;
   - workflow YAML parses and unrelated configuration is unchanged.
 - Verify:
   - exact `.bun-version` byte check;
-  - active-workflow input inventory and zero-`latest` assertion;
+  - active-workflow input inventory, zero-`latest` assertion, and exact path
+    filter/trigger inventory;
   - `bun --version` under the pinned binary;
   - web frozen install, typecheck, test, and build commands;
   - YAML parse, diff, manifest/lockfile, and four-file scope checks.
@@ -110,5 +114,5 @@ verified, and committed sequentially.
 - Upstream `setup-bun` uses direct release URL construction only for strict
   versions; ranges and `latest` enumerate tags.
 - Preserve historical documentation examples and all workflow behavior outside
-  the three input substitutions.
+  the three input substitutions and two `.bun-version` path additions.
 - Route any web, SDK, or Rust product finding to a separate issue/spec cycle.

--- a/specs/GH1686/tasks.md
+++ b/specs/GH1686/tasks.md
@@ -1,0 +1,114 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1686
+
+## Spec Packet
+
+- Product: `specs/GH1686/product.md`
+- Tech: `specs/GH1686/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1686-T1` Owner: Codex | Done when: exact-base workflow inventory, upstream resolver behavior, duplicate search, failure reproduction, Bun release availability, and local baseline are recorded | Verify: commands in T1 below
+- [ ] `SP1686-T2` Owner: Codex | Done when: the root version pin and all three workflow references are implemented with exact scope and Bun 1.3.14 passes web validation | Verify: commands in T2 below
+- [ ] `SP1686-T3` Owner: Codex | Done when: workflow, Rust, exact-head CI, review-thread, and SpecRail gates pass for the separate implementation PR and cleanup is verified | Verify: commands in T3 below
+
+### SP1686-T1 — Capture the resolver and CI baseline
+
+- Owner: Codex implementation agent.
+- Dependencies: merged GH-1686 specification PR and a fresh worktree from
+  current `origin/main`.
+- Covers: B-001 through B-007.
+- Work:
+  - record the exact base SHA and all active `setup-bun` inputs;
+  - confirm no version file, duplicate issue, or overlapping open PR exists;
+  - preserve both failed setup logs and the upstream exact-version resolver
+    evidence;
+  - verify the Bun 1.3.14 release asset and run the current local web baseline;
+  - run manual VibeGuard baseline review and stop for any unrelated red build.
+- Done when:
+  - the four-file implementation scope and strict-version behavior are
+    unambiguous;
+  - project web commands pass independently of the failing `latest` resolver;
+  - no hidden duplicate or baseline failure remains.
+- Verify:
+  - `git rev-parse HEAD`;
+  - searches in `tech.md` for active setup inputs and version files;
+  - failed Actions job logs for run `29539326830`;
+  - upstream `setup-bun` strict-version resolver inspection;
+  - current web frozen install, typecheck, test, and build commands.
+
+### SP1686-T2 — Pin and verify the Bun toolchain
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1686-T1.
+- Covers: B-001 through B-006.
+- Work:
+  - add `.bun-version` with exact value `1.3.14`;
+  - replace all three active `bun-version: latest` inputs with the shared file;
+  - preserve every unrelated workflow line and all manifests/lockfiles;
+  - install or download Bun 1.3.14 and run the complete web validation surface;
+  - prove exact version/reference counts and approved four-file scope.
+- Done when:
+  - Bun 1.3.14 is the single active workflow version source;
+  - all web and SDK checks pass with frozen dependencies;
+  - workflow YAML parses and unrelated configuration is unchanged.
+- Verify:
+  - exact `.bun-version` byte check;
+  - active-workflow input inventory and zero-`latest` assertion;
+  - `bun --version` under the pinned binary;
+  - web frozen install, typecheck, test, and build commands;
+  - YAML parse, diff, manifest/lockfile, and four-file scope checks.
+
+### SP1686-T3 — Prove PR readiness and clean up
+
+- Owner: Codex implementation agent; human final review remains authoritative.
+- Dependencies: SP1686-T2.
+- Covers: B-001 through B-008.
+- Work:
+  - compare the implementation with the issue and complete spec packet;
+  - run the deterministic local verification matrix at final head;
+  - open the separate implementation PR with root cause, plan, exact resolver
+    evidence, scope, risks, verification, and rollback;
+  - wait for exact-head CI and Gemini review, address valid findings, audit all
+    review threads, run the required SpecRail PR gate, and merge only under the
+    standing authorization;
+  - rerun or update dependent PRs only after the fix is present on `main`;
+  - remove worktrees and temporary downloaded artifacts.
+- Done when:
+  - B-001 through B-008 have fresh evidence;
+  - local and exact-head remote gates pass with no unresolved active thread;
+  - authorized merge, issue closure, dependent-PR recovery, and cleanup are
+    verified.
+- Verify:
+  - version/reference/scope, web, format, all-features, workspace Clippy/test,
+    SpecRail, exact-head CI, review-thread, and required PR gate commands from
+    this packet.
+
+## Parallelization
+
+No parallel writable lanes are planned. The version file and three workflow
+references are one atomic toolchain selection change and will be implemented,
+verified, and committed sequentially.
+
+## Verification
+
+- [ ] Global and GH-1686 SpecRail checks pass.
+- [ ] Product behaviors B-001 through B-008 map to tasks and verification.
+- [ ] The strict semantic version bypasses tag enumeration in upstream source.
+- [ ] One version file and all three active workflow references are exact.
+- [ ] Bun 1.3.14 web/SDK validation and repository Rust gates pass.
+- [ ] VibeGuard, exact-head CI, review-thread, and PR gates pass.
+
+## Handoff Notes
+
+- Exact issue/spec base: `807e129e746bb95afa9cba896d1c1916e7e6ea35`.
+- Failure evidence: PR #1685 run `29539326830`, setup jobs `87757987147` and
+  `87758451029`, both HTTP 503 before project commands.
+- Upstream `setup-bun` uses direct release URL construction only for strict
+  versions; ranges and `latest` enumerate tags.
+- Preserve historical documentation examples and all workflow behavior outside
+  the three input substitutions.
+- Route any web, SDK, or Rust product finding to a separate issue/spec cycle.

--- a/specs/GH1686/tech.md
+++ b/specs/GH1686/tech.md
@@ -1,0 +1,135 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1686
+
+## Product Spec
+
+See `specs/GH1686/product.md`.
+
+## Current System
+
+On base `807e129e746bb95afa9cba896d1c1916e7e6ea35`, three active workflows use
+`oven-sh/setup-bun@v2` with `bun-version: latest`:
+
+- `.github/workflows/ci.yml` builds the web bundle required by Rust Clippy and
+  test jobs.
+- `.github/workflows/web-ci.yml` runs web typecheck, tests, and build.
+- `.github/workflows/ci-disabled-modules.yml` builds the web bundle before the
+  all-features workspace check.
+
+The upstream action first accepts `bun-version`, then `bun-version-file`, then
+the package manifest. Its download resolver recognizes a strict semantic
+version with `validateStrict` and directly constructs the corresponding
+`bun-v<version>` release URL. For `latest`, ranges, or other unresolved values,
+it requests the complete `oven-sh/bun` tag collection from the GitHub API.
+
+PR #1685 run `29539326830` failed twice in `setup-bun` jobs `87757987147` and
+`87758451029`: the tags request returned HTTP 503 before any Harness build
+command ran. The exact local `bun install --frozen-lockfile && bun run build`
+command passed. The Bun 1.3.14 Linux release asset resolves successfully.
+
+## Proposed Design
+
+Add a root `.bun-version` containing:
+
+```text
+1.3.14
+```
+
+Replace each active workflow's `bun-version: latest` input with:
+
+```yaml
+bun-version-file: .bun-version
+```
+
+The action reads the trimmed file value, recognizes it as a strict semantic
+version, sets `tag = bun-v1.3.14`, and constructs the release asset URL without
+executing its tag-enumeration request. A root file is used because
+`setup-bun` resolves version files from `GITHUB_WORKSPACE`, including when
+later run steps use `working-directory: web`.
+
+## Invariants
+
+- `.bun-version` is the only active Bun version source and contains exactly
+  `1.3.14` plus one newline.
+- Every active `oven-sh/setup-bun@v2` step uses the same root version file.
+- No active workflow uses `latest`, a range, a literal duplicated version, a
+  custom download URL, or a fallback installer.
+- Workflow triggers, permissions, runners, dependencies, environment,
+  working directories, commands, artifact paths, and retention remain exact.
+- Web and SDK manifests and lockfiles remain byte-for-byte unchanged.
+- No Rust source or test file changes.
+
+## Affected Files
+
+- `.bun-version`
+- `.github/workflows/ci.yml`
+- `.github/workflows/web-ci.yml`
+- `.github/workflows/ci-disabled-modules.yml`
+
+No other configuration, workflow, dependency, manifest, lockfile, production,
+test, persistence, schema, or serialized-format file is expected to change.
+
+## Data Flow
+
+At workflow startup, `setup-bun` reads `.bun-version` from
+`GITHUB_WORKSPACE`, validates `1.3.14` strictly, derives the exact Bun release
+asset URL, restores or downloads that binary, and exposes it to unchanged web
+and Rust validation steps. No Harness runtime data flow changes.
+
+## Alternatives Considered
+
+- Keep `latest` and rerun failures: rejected because it leaves unrelated PRs
+  dependent on an avoidable full-tag API request and makes toolchain results
+  non-deterministic.
+- Add retries around setup: rejected because the action fails inside its own
+  JavaScript step and retries would retain the unstable resolver and increase
+  CI latency.
+- Repeat `bun-version: 1.3.14` in every workflow: rejected because three
+  literals can drift and make upgrades error-prone.
+- Use `bun-download-url`: rejected because platform-specific URLs bypass the
+  action's supported version selection and complicate portability.
+- Put the version in `web/package.json`: rejected because `engines.bun`
+  currently describes compatibility (`>=1.0.0`), not a repository toolchain
+  pin, and changing it would mix package contract and CI selection semantics.
+
+## Risks
+
+- Security: low; the existing official action and official release assets are
+  retained, with no secrets, authentication, shell construction, or custom
+  executable source introduced. Workflow changes require human review under
+  SEC-11 because they control downloaded tooling.
+- Compatibility: low; Bun 1.3.14 is a published release and frozen install,
+  typecheck, tests, SDK prebuild, and production build are required before
+  merge.
+- Availability: improved by eliminating the tag-list API request; release
+  asset availability remains an unavoidable external dependency.
+- Maintenance: future Bun upgrades become explicit one-line changes with
+  deterministic review and validation.
+- Staleness: a pin does not auto-upgrade; intentional dependency maintenance
+  is preferable to silently changing CI toolchains.
+
+## Test Plan
+
+- [ ] Verify the Bun 1.3.14 release asset resolves and the downloaded binary
+      reports `1.3.14`.
+- [ ] With Bun 1.3.14, run `bun install --frozen-lockfile`,
+      `bun run typecheck`, `bun run test`, and `bun run build` from `web/`.
+- [ ] Run `cargo fmt --all -- --check` and
+      `cargo check --workspace --all-features` after the web bundle exists.
+- [ ] Parse all changed YAML workflows and inspect the exact diff.
+- [ ] Assert one version file, three `bun-version-file` references, zero active
+      `bun-version: latest` references, unchanged manifests/lockfiles, and the
+      approved four-file scope.
+- [ ] Run repository-required workspace Clippy/tests, SpecRail checks, manual
+      VibeGuard L1-L7 review, exact-head CI, review-thread audit, and required
+      PR gate.
+
+## Rollback Plan
+
+Squash-revert the implementation PR. No data, schema, migration, application
+configuration, or operator rollback step is required. If Bun 1.3.14 itself is
+found incompatible before merge, stop and update this spec with a verified
+non-downgrade version rather than restoring `latest` silently.

--- a/specs/GH1686/tech.md
+++ b/specs/GH1686/tech.md
@@ -44,6 +44,13 @@ Replace each active workflow's `bun-version: latest` input with:
 bun-version-file: .bun-version
 ```
 
+Add `.bun-version` to the `ci` filter in `.github/workflows/ci.yml` so a
+version-only pull request runs the web bundle, Clippy, tests, and CI result.
+Add the same path to `.github/workflows/web-ci.yml` so version-only pull
+requests and pushes run web typecheck, tests, build, and artifact upload.
+`ci-disabled-modules.yml` already runs for every pull request and needs no
+trigger expansion.
+
 The action reads the trimmed file value, recognizes it as a strict semantic
 version, sets `tag = bun-v1.3.14`, and constructs the release asset URL without
 executing its tag-enumeration request. A root file is used because
@@ -57,7 +64,8 @@ later run steps use `working-directory: web`.
 - Every active `oven-sh/setup-bun@v2` step uses the same root version file.
 - No active workflow uses `latest`, a range, a literal duplicated version, a
   custom download URL, or a fallback installer.
-- Workflow triggers, permissions, runners, dependencies, environment,
+- The main CI `ci` change filter and Web CI paths include `.bun-version`;
+  all other triggers, filters, permissions, runners, dependencies, environment,
   working directories, commands, artifact paths, and retention remain exact.
 - Web and SDK manifests and lockfiles remain byte-for-byte unchanged.
 - No Rust source or test file changes.
@@ -94,6 +102,9 @@ and Rust validation steps. No Harness runtime data flow changes.
 - Put the version in `web/package.json`: rejected because `engines.bun`
   currently describes compatibility (`>=1.0.0`), not a repository toolchain
   pin, and changing it would mix package contract and CI selection semantics.
+- Preserve the existing path filters without `.bun-version`: rejected because
+  a later version-only change would select a new executable while skipping the
+  main and web validation intended to qualify it.
 
 ## Risks
 
@@ -121,8 +132,10 @@ and Rust validation steps. No Harness runtime data flow changes.
       `cargo check --workspace --all-features` after the web bundle exists.
 - [ ] Parse all changed YAML workflows and inspect the exact diff.
 - [ ] Assert one version file, three `bun-version-file` references, zero active
-      `bun-version: latest` references, unchanged manifests/lockfiles, and the
-      approved four-file scope.
+      `bun-version: latest` references, the two required `.bun-version` filter
+      entries, unchanged manifests/lockfiles, and the approved four-file scope.
+- [ ] Confirm a `.bun-version`-only path classification selects main CI and
+      Web CI while unrelated trigger/filter behavior remains unchanged.
 - [ ] Run repository-required workspace Clippy/tests, SpecRail checks, manual
       VibeGuard L1-L7 review, exact-head CI, review-thread audit, and required
       PR gate.


### PR DESCRIPTION
Linked work: #1686

## Why

PR #1685 exposed a CI reliability defect unrelated to its Rust-only diff: two exact-head attempts failed inside `oven-sh/setup-bun@v2` before any project command ran because `bun-version: latest` enumerated the Bun tag collection and GitHub returned HTTP 503. The exact web build passed locally.

The upstream action source confirms that a strict semantic version constructs the release URL directly, while `latest` and ranges request the full tags endpoint. Harness currently repeats `latest` in three active workflows.

## Specification plan

1. Establish root `.bun-version` as the single source of truth at Bun 1.3.14.
2. Point all three active setup-bun steps to that file.
3. Preserve every existing install, typecheck, test, build, artifact, and Rust validation command.
4. Verify exact resolver behavior, frozen web dependencies, workflow scope, CI, review threads, and SpecRail gates.

## Contents

- `product.md`: user problem, goals, non-goals, B-001 through B-008, edge cases, rollout.
- `tech.md`: exact root cause, upstream resolver behavior, four-file design, invariants, alternatives, risks, test and rollback plans.
- `tasks.md`: deterministic baseline, implementation, verification, PR gate, and dependent-PR recovery steps.

## Verification

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1686`
- `python3 checks/route_gate.py --repo . --route write_spec --issue 1686 --state ready_to_spec --label ready_to_spec --artifact product_spec=specs/GH1686/product.md --artifact tech_spec=specs/GH1686/tech.md --mode advisory --json`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Pre-push database-independent workspace library tests: 482 passed; 6 PostgreSQL lease tests deferred because this documentation-only worktree had no database URL.
- Manual VibeGuard L1-L7 review: passed; no automated VibeGuard CLI is installed.

## Scope

Specification only. This PR does not change workflow, toolchain, dependency, web, SDK, or Rust behavior. Implementation follows in a separate PR after this packet merges.
