### PR TITLE
docs(spec): define quality-gate reducer test split

### DIFF
--- a/specs/GH1690/product.md
+++ b/specs/GH1690/product.md
@@ -1,0 +1,83 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1690
+
+## User Problem
+
+Harness maintainers must navigate an 896-line
+`runtime/tests/completion_reducer_quality.rs` file that exceeds the
+repository's 800-line hard ceiling. Its first 13 tests cover PR feedback,
+structured-decision rejection, stale completions, and terminal workflow
+handling, while its final 10 tests form a contiguous quality-gate group.
+
+## Goals
+
+- Give the final 10 quality-gate reducer tests a dedicated sibling include
+  file.
+- Reduce both resulting formatted test files to no more than 800 lines.
+- Preserve all 23 test names, attributes, bodies, assertions, fixtures,
+  strings, and non-whitespace Rust tokens exactly.
+- Preserve every logical test path by keeping both files included directly in
+  the existing `runtime::tests` module.
+- Provide deterministic evidence that the split is a mechanical test-source
+  relocation with no workflow-runtime or production change.
+
+## Non-Goals
+
+- Changing PR-feedback, quality-gate, retry, reducer, validation, workflow, or
+  terminal-state behavior.
+- Adding, deleting, renaming, consolidating, or rewriting tests or helpers.
+- Changing production source, public APIs, dependencies, manifests, lockfiles,
+  persistence, schemas, or serialized formats.
+- Splitting unrelated workflow-runtime test sources.
+
+## User-Visible Behavior
+
+There is no intended user-visible behavior change. PR feedback decisions,
+quality-gate dispatch and completion, evidence rejection, retries, stale
+completion handling, and terminal workflow handling must remain identical to
+current `origin/main`.
+
+## Acceptance Criteria
+
+- [ ] B-001: `completion_reducer_quality.rs` and
+      `completion_reducer_quality_gate.rs` each contain no more than 800
+      formatted lines.
+- [ ] B-002: Exact-base lines 1-498 remain byte-for-byte unchanged in
+      `completion_reducer_quality.rs`.
+- [ ] B-003: Exact-base lines 499-896 appear byte-for-byte unchanged and in
+      order in `completion_reducer_quality_gate.rs`.
+- [ ] B-004: `runtime/tests.rs` adds exactly one sibling
+      `include!("tests/completion_reducer_quality_gate.rs");` immediately after
+      the existing quality reducer include and changes nothing else.
+- [ ] B-005: All 23 test names, attributes, bodies, assertions, fixtures,
+      strings, and non-whitespace Rust tokens remain present exactly once, and
+      all 23 logical test paths remain unchanged.
+- [ ] B-006: No production behavior, production source, public API,
+      dependency, manifest, lockfile, persistence, schema, or serialized
+      format changes.
+- [ ] B-007: Focused and full `harness-workflow` tests, workspace Clippy/tests,
+      manual VibeGuard review, exact-head CI, review-thread audit, and SpecRail
+      gates pass.
+- [ ] B-008: The implementation is delivered in a separate PR only after this
+      specification PR is merged.
+
+## Edge Cases
+
+- Both files must remain direct `include!` sources in `runtime::tests`; adding
+  a Rust module would change test paths and violate B-005.
+- The existing `completion_reducer` filter must continue selecting all current
+  reducer tests, including both source files.
+- Quality-gate rejection tests for missing, conflicting, invalid, and
+  incomplete evidence must remain exact; test integrity must not be weakened.
+- No test may be duplicated or omitted across the split boundary.
+- The sibling include must remain adjacent so source organization mirrors the
+  conceptual reducer grouping.
+
+## Rollout Notes
+
+This is a test-source layout refactor only. It requires no migration, feature
+flag, configuration change, operator action, or compatibility communication.
+Squash-reverting the implementation PR is the rollback path.

--- a/specs/GH1690/tasks.md
+++ b/specs/GH1690/tasks.md
@@ -1,0 +1,115 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1690
+
+## Spec Packet
+
+- Product: `specs/GH1690/product.md`
+- Tech: `specs/GH1690/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1690-T1` Owner: Codex | Done when: exact-base boundaries, ordered test inventory, duplicate search, compile, 47 focused reducer tests, and VibeGuard baseline are recorded | Verify: commands in T1 below
+- [ ] `SP1690-T2` Owner: Codex | Done when: the final 10 quality-gate tests move mechanically to the sibling include, exact comparisons and path expectations pass, both files are within the ceiling, and all tests pass | Verify: commands in T2 below
+- [ ] `SP1690-T3` Owner: Codex | Done when: local, exact-head CI, review-thread, and SpecRail gates pass for the separate implementation PR and cleanup is verified | Verify: commands in T3 below
+
+### SP1690-T1 — Capture the exact implementation baseline
+
+- Owner: Codex implementation agent.
+- Dependencies: merged GH-1690 specification PR and a fresh worktree from
+  current `origin/main`.
+- Covers: B-001 through B-007.
+- Work:
+  - record the exact base SHA, line boundary, ordered 23-test inventory, and
+    current logical test paths;
+  - confirm the sibling target does not exist and no duplicate issue or open PR
+    overlaps any approved path;
+  - run the all-target check and 47 focused reducer tests;
+  - record the manual VibeGuard baseline and stop if any baseline is red.
+- Done when:
+  - exact inventories and baseline output are preserved;
+  - all 47 focused reducer tests pass;
+  - the planned three-file scope is unambiguous.
+- Verify:
+  - `git rev-parse HEAD`;
+  - `wc -l crates/harness-workflow/src/runtime/tests/completion_reducer_quality.rs`;
+  - inventory, include, and boundary searches from `tech.md`;
+  - `cargo check -p harness-workflow --all-targets`;
+  - `cargo test -p harness-workflow completion_reducer`.
+
+### SP1690-T2 — Extract the final quality-gate test group
+
+- Owner: Codex implementation agent.
+- Dependencies: SP1690-T1.
+- Covers: B-001 through B-006.
+- Work:
+  - retain exact-base lines 1-498;
+  - create the sibling include file from exact-base lines 499-896;
+  - add exactly one adjacent include to `runtime/tests.rs`;
+  - preserve every attribute, name, body, assertion, helper call, artifact,
+    signal, JSON value, string, non-whitespace Rust token, and logical test
+    path without semantic edits;
+  - prove exact retained and moved content, ordered inventory, unchanged paths,
+    line ceilings, include adjacency, and approved three-file scope;
+  - run focused and full workflow tests before committing.
+- Done when:
+  - the retained and sibling files are each at most 800 formatted lines;
+  - all 23 tests appear exactly once and every logical path is unchanged;
+  - exact movement and verification pass;
+  - no file outside the approved three changes.
+- Verify:
+  - `cargo fmt --all -- --check`;
+  - `cargo check -p harness-workflow --all-targets`;
+  - focused and full workflow tests from `tech.md`;
+  - exact retained, exact moved, inventory, path, include, size, and scope
+    checks.
+
+### SP1690-T3 — Prove PR readiness and clean up
+
+- Owner: Codex implementation agent; human final review remains authoritative.
+- Dependencies: SP1690-T2.
+- Covers: B-001 through B-008.
+- Work:
+  - compare the implementation with the issue and complete spec packet;
+  - run the deterministic verification matrix at final head;
+  - open the separate implementation PR with reason, plan, movement evidence,
+    unchanged paths, scope, risk, and verification;
+  - wait for exact-head CI and Gemini review, address valid findings, audit all
+    review threads, run the required SpecRail PR gate, and merge only under the
+    standing authorization;
+  - remove the worktree and any disposable resources.
+- Done when:
+  - B-001 through B-008 have fresh evidence;
+  - local and exact-head remote gates pass with no unresolved active thread;
+  - authorized merge, issue closure, and cleanup are verified.
+- Verify:
+  - format, check, focused/full workflow test, workspace Clippy/test, SpecRail,
+    exact-head CI, review-thread, and required PR gate commands from this
+    packet.
+
+## Parallelization
+
+No parallel writable lanes are planned. The three files form one direct
+`runtime::tests` namespace and will be moved, verified, and committed
+sequentially.
+
+## Verification
+
+- [ ] Global and GH-1690 SpecRail checks pass.
+- [ ] Product behaviors B-001 through B-008 map to tasks and verification.
+- [ ] Exact retained/moved content and ordered 23-test inventory match the base.
+- [ ] Both Rust test files are at most 800 formatted lines.
+- [ ] All logical test paths remain unchanged.
+- [ ] Focused, workflow, workspace, Clippy, VibeGuard, CI, review-thread, and PR
+      gates pass on the exact implementation head.
+
+## Handoff Notes
+
+- Exact issue/spec base: `888c64a48995b4fc89532b06434b562960c7f4b9`.
+- Baseline: 896 lines, 23 tests, retained lines 1-498, moved lines 499-896,
+  and 47 focused reducer tests passing.
+- Preserve test bodies and logical paths exactly; use sibling `include!`, not a
+  nested module.
+- Route any production or behavioral finding to a separate issue/spec cycle.

--- a/specs/GH1690/tasks.md
+++ b/specs/GH1690/tasks.md
@@ -33,10 +33,15 @@ GH-1690
   - all 47 focused reducer tests pass;
   - the planned three-file scope is unambiguous.
 - Verify:
-  - `git rev-parse HEAD`;
-  - `wc -l crates/harness-workflow/src/runtime/tests/completion_reducer_quality.rs`;
-  - the executable retained, moved, include-only, and ordered logical-path
-    comparisons from `tech.md`;
+  - record `BASE="$(git rev-parse HEAD)"`;
+  - set `SOURCE=crates/harness-workflow/src/runtime/tests/completion_reducer_quality.rs`
+    and
+    `MOVED=crates/harness-workflow/src/runtime/tests/completion_reducer_quality_gate.rs`;
+  - `test ! -e "$MOVED"`;
+  - `test "$(wc -l < "$SOURCE" | tr -d ' ')" = 896`;
+  - `test "$(sed -nE 's/^(async )?fn ([A-Za-z0-9_]+)\(.*/runtime::tests::\2/p' "$SOURCE" | wc -l | tr -d ' ')" = 23`;
+  - `test "$(sed -n '499p' "$SOURCE")" = '#[test]'`;
+  - `test "$(sed -n '500p' "$SOURCE")" = 'fn quality_gate_run_decision_starts_runtime_activity() {'`;
   - `cargo check -p harness-workflow --all-targets`;
   - `cargo test -p harness-workflow completion_reducer`;
   - `cargo test -p harness-workflow quality_gate_run_decision_starts_runtime_activity`.

--- a/specs/GH1690/tasks.md
+++ b/specs/GH1690/tasks.md
@@ -35,9 +35,11 @@ GH-1690
 - Verify:
   - `git rev-parse HEAD`;
   - `wc -l crates/harness-workflow/src/runtime/tests/completion_reducer_quality.rs`;
-  - inventory, include, and boundary searches from `tech.md`;
+  - the executable retained, moved, include-only, and ordered logical-path
+    comparisons from `tech.md`;
   - `cargo check -p harness-workflow --all-targets`;
-  - `cargo test -p harness-workflow completion_reducer`.
+  - `cargo test -p harness-workflow completion_reducer`;
+  - `cargo test -p harness-workflow quality_gate_run_decision_starts_runtime_activity`.
 
 ### SP1690-T2 — Extract the final quality-gate test group
 
@@ -62,9 +64,10 @@ GH-1690
 - Verify:
   - `cargo fmt --all -- --check`;
   - `cargo check -p harness-workflow --all-targets`;
-  - focused and full workflow tests from `tech.md`;
-  - exact retained, exact moved, inventory, path, include, size, and scope
-    checks.
+  - both focused test commands and the full workflow test from `tech.md`;
+  - the executable retained, moved, include-only, and ordered logical-path
+    comparisons from `tech.md`;
+  - line-count and approved-scope checks.
 
 ### SP1690-T3 — Prove PR readiness and clean up
 

--- a/specs/GH1690/tech.md
+++ b/specs/GH1690/tech.md
@@ -1,0 +1,154 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1690
+
+## Product Spec
+
+See `specs/GH1690/product.md`.
+
+## Current System
+
+On base `888c64a48995b4fc89532b06434b562960c7f4b9`,
+`crates/harness-workflow/src/runtime/tests/completion_reducer_quality.rs`
+contains 896 lines and 23 `#[test]` functions. It is included directly into
+the `runtime::tests` module by:
+
+```rust
+include!("tests/completion_reducer_quality.rs");
+```
+
+Lines 1-498 contain 13 tests covering PR-feedback decisions, invalid or
+unknown structured decisions, stale completion handling, child start
+acknowledgements, and already-terminal workflows. Lines 499-896 contain 10
+contiguous tests covering quality-gate dispatch, successful completion,
+issue-PR readiness, missing or conflicting evidence, invalid structured
+decisions, and transient retries.
+
+Because `include!` expands both sibling files into the same Rust module, the
+quality-gate tests can move without adding a module segment to their logical
+paths.
+
+## Proposed Design
+
+Keep exact-base lines 1-498 in
+`runtime/tests/completion_reducer_quality.rs`.
+
+Create
+`runtime/tests/completion_reducer_quality_gate.rs` from exact-base lines
+499-896 in their current order.
+
+In `runtime/tests.rs`, add:
+
+```rust
+include!("tests/completion_reducer_quality_gate.rs");
+```
+
+immediately after the existing
+`include!("tests/completion_reducer_quality.rs");`.
+
+No imports or visibility changes are necessary because both include files
+expand into the existing `runtime::tests` namespace.
+
+## Retained Test Inventory
+
+1. `runtime_completion_reducer_maps_pr_feedback_sweep_signal_to_address_command`
+2. `runtime_completion_reducer_maps_pr_feedback_child_signal_to_parent_decision`
+3. `runtime_completion_reducer_updates_pr_feedback_child_from_inspection_signal`
+4. `runtime_completion_reducer_uses_pr_feedback_child_signal_when_structured_decision_is_invalid`
+5. `runtime_completion_reducer_prefers_blocking_pr_feedback_over_ready_signal`
+6. `runtime_completion_reducer_blocks_invalid_structured_workflow_decision`
+7. `runtime_completion_reducer_blocks_unknown_success_without_structured_decision`
+8. `runtime_completion_reducer_ignores_stale_pr_feedback_sweep_after_parent_advances`
+9. `runtime_completion_reducer_ignores_stale_pr_feedback_child_after_parent_advances`
+10. `runtime_completion_reducer_ignores_stale_local_review_after_pass_advances_parent`
+11. `runtime_completion_reducer_ignores_stale_local_review_after_changes_advance_parent`
+12. `runtime_completion_reducer_ignores_child_workflow_start_ack_without_parent_decision`
+13. `runtime_completion_reducer_ignores_success_for_already_terminal_workflow`
+
+## Moved Test Inventory
+
+1. `quality_gate_run_decision_starts_runtime_activity`
+2. `runtime_completion_reducer_passes_quality_gate_after_success`
+3. `runtime_completion_reducer_marks_issue_pr_ready_after_quality_gate_pass`
+4. `runtime_completion_reducer_blocks_issue_pr_quality_gate_without_validation`
+5. `runtime_completion_reducer_blocks_quality_gate_success_without_status_signal`
+6. `runtime_completion_reducer_blocks_quality_gate_success_without_validation_evidence`
+7. `runtime_completion_reducer_blocks_quality_gate_success_with_conflicting_status_signals`
+8. `runtime_completion_reducer_blocks_quality_gate_structured_pass_without_contract_evidence`
+9. `runtime_completion_reducer_blocks_quality_gate_invalid_structured_decision_with_contract_evidence`
+10. `runtime_completion_reducer_retries_quality_gate_transient_failure`
+
+## Invariants
+
+- Record the exact base SHA, line count, ordered 23-test inventory, attributes,
+  and split boundary before editing.
+- Require the final retained file to equal exact-base lines 1-498.
+- Require the new sibling file to equal exact-base lines 499-896.
+- Preserve all 23 attributes, names, bodies, assertions, helper calls,
+  artifacts, signals, JSON values, strings, and non-whitespace Rust tokens
+  exactly once.
+- Require every test path to remain unchanged.
+- Require the only `runtime/tests.rs` change to be the adjacent include line.
+- Require both formatted test files to contain no more than 800 lines and no
+  file outside the approved three-file set to change.
+
+## Affected Files
+
+- `crates/harness-workflow/src/runtime/tests.rs`
+- `crates/harness-workflow/src/runtime/tests/completion_reducer_quality.rs`
+- `crates/harness-workflow/src/runtime/tests/completion_reducer_quality_gate.rs`
+
+No production source, other test source, manifest, lockfile, configuration,
+persistence, schema, or serialized-format file is expected to change.
+
+## Data Flow
+
+Workflow instances, activity results, artifacts, signals, reducer decisions,
+quality-gate commands, retry decisions, and validations do not change. Only the
+physical source file containing 10 tests changes; Rust expands both include
+files into the same existing test namespace.
+
+## Alternatives Considered
+
+- Leave the file unchanged: rejected because it remains above the hard ceiling
+  and mixes a bounded quality-gate group with PR-feedback and stale-completion
+  tests.
+- Create a nested Rust module: rejected because it changes logical test paths
+  without providing a behavioral or maintenance benefit.
+- Move fewer final tests: rejected because it would fragment the cohesive
+  quality-gate group and leave the retained file closer to the ceiling.
+- Refactor shared helpers or production code simultaneously: rejected because
+  it expands scope beyond a safe mechanical relocation.
+
+## Risks
+
+- Security: low; production source, authentication, secrets, process
+  execution, input handling, and persistence implementation are unchanged.
+- Compatibility: low; all logical test paths and filters remain unchanged.
+- Performance: none expected outside negligible test compilation layout.
+- Test integrity: low if exact retained/moved comparisons and ordered inventory
+  checks pass; all assertions and rejection cases remain mandatory.
+- Maintenance: improved by separating quality-gate reducer tests from
+  PR-feedback and stale-completion reducer tests.
+
+## Test Plan
+
+- [ ] Baseline and final `cargo check -p harness-workflow --all-targets`.
+- [ ] Baseline and final
+      `cargo test -p harness-workflow completion_reducer`, with the same 47
+      selected tests passing and unchanged paths.
+- [ ] Final `cargo test -p harness-workflow --lib`.
+- [ ] `cargo fmt --all -- --check`, line-count, exact retained file, exact
+      moved file, ordered inventory, namespace, include adjacency, and
+      three-file scope checks.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` and workspace
+      tests under the repository test environment.
+- [ ] SpecRail global/packet/route checks, manual VibeGuard L1-L7 review,
+      exact-head CI, review-thread audit, and required PR gate.
+
+## Rollback Plan
+
+Squash-revert the implementation PR. No data, schema, migration,
+configuration, dependency, or operator rollback step is required.

--- a/specs/GH1690/tech.md
+++ b/specs/GH1690/tech.md
@@ -135,10 +135,44 @@ files into the same existing test namespace.
 
 ## Test Plan
 
+- [ ] Run the exact mechanical source checks below from the implementation
+      worktree:
+
+  ```bash
+  BASE="$(git merge-base HEAD origin/main)"
+  SOURCE=crates/harness-workflow/src/runtime/tests/completion_reducer_quality.rs
+  RETAINED=$SOURCE
+  MOVED=crates/harness-workflow/src/runtime/tests/completion_reducer_quality_gate.rs
+  INCLUDES=crates/harness-workflow/src/runtime/tests.rs
+
+  diff -u \
+    <(git show "$BASE:$SOURCE" | sed -n '1,498p') \
+    "$RETAINED"
+  diff -u \
+    <(git show "$BASE:$SOURCE" | sed -n '499,896p') \
+    "$MOVED"
+  diff -u \
+    <(git show "$BASE:$INCLUDES" | awk '
+      { print }
+      $0 == "include!(\"tests/completion_reducer_quality.rs\");" {
+        print "include!(\"tests/completion_reducer_quality_gate.rs\");"
+      }') \
+    "$INCLUDES"
+  diff -u \
+    <(git show "$BASE:$SOURCE" |
+      sed -nE 's/^(async )?fn ([A-Za-z0-9_]+)\(.*/runtime::tests::\2/p') \
+    <(sed -nE \
+      's/^(async )?fn ([A-Za-z0-9_]+)\(.*/runtime::tests::\2/p' \
+      "$RETAINED" "$MOVED")
+  ```
+
 - [ ] Baseline and final `cargo check -p harness-workflow --all-targets`.
 - [ ] Baseline and final
       `cargo test -p harness-workflow completion_reducer`, with the same 47
       selected tests passing and unchanged paths.
+- [ ] Final
+      `cargo test -p harness-workflow quality_gate_run_decision_starts_runtime_activity`
+      passes the moved test omitted by the `completion_reducer` filter.
 - [ ] Final `cargo test -p harness-workflow --lib`.
 - [ ] `cargo fmt --all -- --check`, line-count, exact retained file, exact
       moved file, ordered inventory, namespace, include adjacency, and


### PR DESCRIPTION
Linked work: #1690

## Summary

Define a behavior-preserving split for the 896-line completion reducer quality test module.

## Why

`completion_reducer_quality.rs` contains 23 tests across two distinct concerns. The file is above the repository's 800-line ceiling, which makes review and navigation unnecessarily expensive.

## Plan

- Keep the 13 PR-feedback, stale-recovery, and terminal-state tests in `completion_reducer_quality.rs`.
- Move the 10 quality-gate tests into `completion_reducer_quality_gate.rs`.
- Include both files directly from `runtime/tests.rs` so all logical test paths remain unchanged.
- Verify exact source partitioning and run the focused completion reducer suite.

## Verification

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1690`
- SpecRail `write_spec` advisory route
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: 482 `harness-workflow` tests passed; 6 database lease tests deferred because `HARNESS_DATABASE_URL` was not configured
- Manual VibeGuard L1-L7 review

## Agent Disclosure

- [x] Agent assisted; human author should review before merge.
