### PR TITLE
docs(spec): make quality split boundary whitespace-safe

### DIFF
--- a/specs/GH1690/product.md
+++ b/specs/GH1690/product.md
@@ -45,9 +45,9 @@ current `origin/main`.
 - [ ] B-001: `completion_reducer_quality.rs` and
       `completion_reducer_quality_gate.rs` each contain no more than 800
       formatted lines.
-- [ ] B-002: Exact-base lines 1-498 remain byte-for-byte unchanged in
+- [ ] B-002: Exact-base lines 1-497 remain byte-for-byte unchanged in
       `completion_reducer_quality.rs`.
-- [ ] B-003: Exact-base lines 499-896 appear byte-for-byte unchanged and in
+- [ ] B-003: Exact-base lines 498-896 appear byte-for-byte unchanged and in
       order in `completion_reducer_quality_gate.rs`.
 - [ ] B-004: `runtime/tests.rs` adds exactly one sibling
       `include!("tests/completion_reducer_quality_gate.rs");` immediately after
@@ -73,6 +73,9 @@ current `origin/main`.
 - Quality-gate rejection tests for missing, conflicting, invalid, and
   incomplete evidence must remain exact; test integrity must not be weakened.
 - No test may be duplicated or omitted across the split boundary.
+- Exact-base line 498 is a blank separator. It must move to the start of the
+  sibling file so the retained file does not end with a blank line rejected by
+  the mandatory committed-whitespace check.
 - The sibling include must remain adjacent so source organization mirrors the
   conceptual reducer grouping.
 

--- a/specs/GH1690/tasks.md
+++ b/specs/GH1690/tasks.md
@@ -40,6 +40,7 @@ GH-1690
   - `test ! -e "$MOVED"`;
   - `test "$(wc -l < "$SOURCE" | tr -d ' ')" = 896`;
   - `test "$(sed -nE 's/^(async )?fn ([A-Za-z0-9_]+)\(.*/runtime::tests::\2/p' "$SOURCE" | wc -l | tr -d ' ')" = 23`;
+  - `test -z "$(sed -n '498p' "$SOURCE")"`;
   - `test "$(sed -n '499p' "$SOURCE")" = '#[test]'`;
   - `test "$(sed -n '500p' "$SOURCE")" = 'fn quality_gate_run_decision_starts_runtime_activity() {'`;
   - `cargo check -p harness-workflow --all-targets`;
@@ -52,8 +53,8 @@ GH-1690
 - Dependencies: SP1690-T1.
 - Covers: B-001 through B-006.
 - Work:
-  - retain exact-base lines 1-498;
-  - create the sibling include file from exact-base lines 499-896;
+  - retain exact-base lines 1-497;
+  - create the sibling include file from exact-base lines 498-896;
   - add exactly one adjacent include to `runtime/tests.rs`;
   - preserve every attribute, name, body, assertion, helper call, artifact,
     signal, JSON value, string, non-whitespace Rust token, and logical test
@@ -62,7 +63,8 @@ GH-1690
     line ceilings, include adjacency, and approved three-file scope;
   - run focused and full workflow tests before committing.
 - Done when:
-  - the retained and sibling files are each at most 800 formatted lines;
+  - the retained and sibling files contain 497 and 399 formatted lines,
+    respectively;
   - all 23 tests appear exactly once and every logical path is unchanged;
   - exact movement and verification pass;
   - no file outside the approved three changes.
@@ -116,7 +118,7 @@ sequentially.
 ## Handoff Notes
 
 - Exact issue/spec base: `888c64a48995b4fc89532b06434b562960c7f4b9`.
-- Baseline: 896 lines, 23 tests, retained lines 1-498, moved lines 499-896,
+- Baseline: 896 lines, 23 tests, retained lines 1-497, moved lines 498-896,
   and 47 focused reducer tests passing.
 - Preserve test bodies and logical paths exactly; use sibling `include!`, not a
   nested module.

--- a/specs/GH1690/tech.md
+++ b/specs/GH1690/tech.md
@@ -19,12 +19,13 @@ the `runtime::tests` module by:
 include!("tests/completion_reducer_quality.rs");
 ```
 
-Lines 1-498 contain 13 tests covering PR-feedback decisions, invalid or
+Lines 1-497 contain 13 tests covering PR-feedback decisions, invalid or
 unknown structured decisions, stale completion handling, child start
-acknowledgements, and already-terminal workflows. Lines 499-896 contain 10
-contiguous tests covering quality-gate dispatch, successful completion,
-issue-PR readiness, missing or conflicting evidence, invalid structured
-decisions, and transient retries.
+acknowledgements, and already-terminal workflows. Line 498 is the blank
+separator before the quality-gate group. Lines 499-896 contain 10 contiguous
+tests covering quality-gate dispatch, successful completion, issue-PR
+readiness, missing or conflicting evidence, invalid structured decisions, and
+transient retries.
 
 Because `include!` expands both sibling files into the same Rust module, the
 quality-gate tests can move without adding a module segment to their logical
@@ -32,12 +33,14 @@ paths.
 
 ## Proposed Design
 
-Keep exact-base lines 1-498 in
+Keep exact-base lines 1-497 in
 `runtime/tests/completion_reducer_quality.rs`.
 
 Create
 `runtime/tests/completion_reducer_quality_gate.rs` from exact-base lines
-499-896 in their current order.
+498-896 in their current order. Moving the blank separator with the
+quality-gate group prevents the retained file from ending with a blank line,
+which the mandatory committed-whitespace CI check rejects.
 
 In `runtime/tests.rs`, add:
 
@@ -84,8 +87,8 @@ expand into the existing `runtime::tests` namespace.
 
 - Record the exact base SHA, line count, ordered 23-test inventory, attributes,
   and split boundary before editing.
-- Require the final retained file to equal exact-base lines 1-498.
-- Require the new sibling file to equal exact-base lines 499-896.
+- Require the final retained file to equal exact-base lines 1-497.
+- Require the new sibling file to equal exact-base lines 498-896.
 - Preserve all 23 attributes, names, bodies, assertions, helper calls,
   artifacts, signals, JSON values, strings, and non-whitespace Rust tokens
   exactly once.
@@ -146,10 +149,10 @@ files into the same existing test namespace.
   INCLUDES=crates/harness-workflow/src/runtime/tests.rs
 
   diff -u \
-    <(git show "$BASE:$SOURCE" | sed -n '1,498p') \
+    <(git show "$BASE:$SOURCE" | sed -n '1,497p') \
     "$RETAINED"
   diff -u \
-    <(git show "$BASE:$SOURCE" | sed -n '499,896p') \
+    <(git show "$BASE:$SOURCE" | sed -n '498,896p') \
     "$MOVED"
   diff -u \
     <(git show "$BASE:$INCLUDES" | awk '


### PR DESCRIPTION
Linked work: #1690

## Summary

Amend the GH1690 mechanical split boundary from retained/moved lines `1-498` and `499-896` to `1-497` and `498-896`.

## Why

Implementation PR #1692 produced deterministic evidence that the original boundary cannot satisfy both acceptance criteria:

- retaining line 498 preserves the specified bytes
- line 498 is blank, so it becomes a blank EOF
- the required `workflow-check` runs `git diff --check` and rejects that EOF

The revised boundary moves the existing blank separator with the quality-gate group. It changes no test token, assertion, name, order, path, or production behavior.

## Revised Plan

- retain exact-base lines 1-497
- move exact-base lines 498-896, including the separator, to the sibling file
- expect final sizes of 497 and 399 lines
- keep the direct adjacent sibling include and all prior verification requirements
- merge this amendment before updating the original implementation PR #1692 on its original branch

## Evidence

A disposable detached worktree from `origin/main@4dec1824` applied the revised boundary and proved:

- exact retained and moved comparisons pass
- final files contain 497 and 399 lines
- `git diff --check` passes
- the combined source remains the original 896 lines

## Verification

- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1690`
- SpecRail `write_spec` advisory route
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook — 482 workflow tests passed; 6 PostgreSQL lease tests deferred because `HARNESS_DATABASE_URL` was not configured
- manual VibeGuard L1-L7 review

## Scope

Only `specs/GH1690/product.md`, `tech.md`, and `tasks.md` change. The original implementation PR #1692 remains open and unchanged until this amendment merges.

## Agent Disclosure

- [x] Agent assisted; human author should review before merge.
