### PR TITLE
docs: specify runtime-store support extraction (GH-1697)

### DIFF
--- a/specs/GH1697/product.md
+++ b/specs/GH1697/product.md
@@ -1,0 +1,70 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1697
+
+## User Problem
+
+Harness maintainers must navigate a 900-line
+`runtime/tests/runtime_store.rs` module that exceeds the repository's
+800-line hard ceiling. Eleven behavior tests are interrupted by a contiguous
+213-line block of nine database fixture and assertion helpers.
+
+## Goals
+
+- Extract the nine helpers to a direct support include.
+- Reduce both resulting formatted files below 800 lines.
+- Preserve every test, helper, assertion, source byte, and logical test path.
+- Prove that the change is a mechanical test-source relocation with no
+  runtime-store or production behavior change.
+
+## Non-Goals
+
+- Changing runtime-store behavior, SQL, migrations, persistence, or schemas.
+- Adding, deleting, renaming, consolidating, reordering, or rewriting tests,
+  helpers, or assertions.
+- Changing production source, APIs, dependencies, manifests, or lockfiles.
+- Splitting unrelated workflow test sources.
+
+## User-Visible Behavior
+
+There is no intended user-visible behavior change. Runtime-job status,
+referential-integrity, dispatch, migration, listing, retention, and dedupe
+behavior must remain identical to current `origin/main`.
+
+## Acceptance Criteria
+
+- [ ] B-001: `runtime_store.rs` is exactly 688 formatted lines and
+      `runtime_store_support.rs` is exactly 213 formatted lines.
+- [ ] B-002: The support file equals exact-base lines 620-832 byte-for-byte.
+- [ ] B-003: The main file equals exact-base lines 1-619, followed by exactly
+      `include!("runtime_store_support.rs");`, followed by exact-base lines
+      833-900.
+- [ ] B-004: All 11 test names, attributes, bodies, logical paths, nine helper
+      names/bodies, and 43 assertion/expectation occurrences remain unchanged.
+- [ ] B-005: Only the approved two test files change.
+- [ ] B-006: No production behavior, source, API, dependency, manifest,
+      lockfile, persistence, schema, or serialized-format change.
+- [ ] B-007: Formatting, diff, source, inventory, compiled-path, focused/full
+      test, package, workspace Clippy/test, VibeGuard, exact-head CI,
+      review-thread, independent-review, and SpecRail gates pass.
+- [ ] B-008: Implementation is delivered in a separate PR only after this
+      specification PR merges.
+
+## Edge Cases
+
+- The support file must use `include!`, not a nested module, so all items remain
+  in `runtime::tests::runtime_store`.
+- Exact-base line 833 is the blank separator before the final dedupe test and
+  remains in the main file.
+- The support file must end at line 832's closing brace, not line 833's blank
+  separator, so committed-whitespace checks pass.
+- Item order in Rust does not affect helper availability; tests before and
+  after the include must continue to call the same helpers.
+
+## Rollout Notes
+
+This test-source layout refactor requires no migration, feature flag,
+configuration, or operator action. Squash-reverting the implementation PR is
+the rollback path.

--- a/specs/GH1697/tasks.md
+++ b/specs/GH1697/tasks.md
@@ -21,6 +21,9 @@ GH-1697
 
 - Dependencies: merged GH-1697 spec PR; fresh worktree from `origin/main`.
 - Covers: B-001 through B-007.
+- Require the complete source file to match pinned issue/spec base
+  `08157897b686c6ae9245d626c7d2997b93acdf27` byte-for-byte; stop for a new
+  spec if it drifted.
 - Preserve the complete `--list` output before editing.
 - Stop if the base, inventories, target absence, focused tests, or package
   check differ from the packet.

--- a/specs/GH1697/tasks.md
+++ b/specs/GH1697/tasks.md
@@ -35,7 +35,7 @@ GH-1697
 - Create the support file from exact-base lines 620-832.
 - Replace only that range with the single direct include.
 - Prove 688/213 lines, 11 tests, nine helpers, 43 occurrences, identical
-  compiled paths, exact source ranges, and exact two-file scope.
+  compiled paths, exact source ranges, and exact two-file working-tree scope.
 - Run final formatting, diff, package, focused, and sanitized full workflow
   checks before commit; require configured exact-head CI for the six deferred
   PostgreSQL lease tests.
@@ -46,6 +46,8 @@ GH-1697
 - Covers: B-001 through B-008.
 - Open a separate implementation PR with reason, plan, exact movement,
   inventory, scope, test, and rollback evidence.
+- After committing, require a clean worktree and the exact two-file committed
+  scope gate from `tech.md`.
 - Wait for exact-head CI and advisory review, address valid findings, audit
   review threads, obtain independent read-only review, run the required PR
   gate, and merge only under standing authorization.

--- a/specs/GH1697/tasks.md
+++ b/specs/GH1697/tasks.md
@@ -1,0 +1,71 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1697
+
+## Spec Packet
+
+- Product: `specs/GH1697/product.md`
+- Tech: `specs/GH1697/tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1697-T1` Owner: Codex | Done when: exact base, duplicate/overlap search, line/test/helper/assertion inventories, compiled test list, package check, 11 focused tests, and VibeGuard baseline are recorded | Verify: before-edit commands in `tech.md`
+- [ ] `SP1697-T2` Owner: Codex | Done when: exact-base lines 620-832 move to the support include, exact main/support comparisons and inventories pass, both files are below the ceiling, and focused/full tests pass | Verify: after-edit and test commands in `tech.md`
+- [ ] `SP1697-T3` Owner: Codex | Done when: the separate implementation PR passes exact-head CI, review-thread, independent-review, and required SpecRail gates and cleanup is verified | Verify: final PR evidence and `checks/pr_gate.py`
+
+## Task Details
+
+### SP1697-T1 — Capture baseline
+
+- Dependencies: merged GH-1697 spec PR; fresh worktree from `origin/main`.
+- Covers: B-001 through B-007.
+- Preserve the complete `--list` output before editing.
+- Stop if the base, inventories, target absence, focused tests, or package
+  check differ from the packet.
+
+### SP1697-T2 — Extract support block
+
+- Dependencies: SP1697-T1.
+- Covers: B-001 through B-006.
+- Create the support file from exact-base lines 620-832.
+- Replace only that range with the single direct include.
+- Prove 688/213 lines, 11 tests, nine helpers, 43 occurrences, identical
+  compiled paths, exact source ranges, and exact two-file scope.
+- Run formatting, diff, focused, full workflow, and package checks before
+  commit.
+
+### SP1697-T3 — Prove readiness
+
+- Dependencies: SP1697-T2.
+- Covers: B-001 through B-008.
+- Open a separate implementation PR with reason, plan, exact movement,
+  inventory, scope, test, and rollback evidence.
+- Wait for exact-head CI and advisory review, address valid findings, audit
+  review threads, obtain independent read-only review, run the required PR
+  gate, and merge only under standing authorization.
+- Verify issue closure, branch/worktree cleanup, and refreshed `origin/main`.
+
+## Parallelization
+
+Writable work is serialized because both files expand into one Rust module.
+An independent read-only reviewer may inspect the spec and implementation PRs.
+
+## Verification
+
+- [ ] Global and GH-1697 SpecRail checks pass.
+- [ ] B-001 through B-008 map to tasks and executable commands.
+- [ ] Exact source, line, test, helper, assertion, compiled-path, and scope
+      checks pass.
+- [ ] Focused/full workflow tests, workspace Clippy/tests, VibeGuard,
+      exact-head CI, review threads, independent review, and PR gate pass.
+
+## Handoff Notes
+
+- Exact issue/spec base: `08157897b686c6ae9245d626c7d2997b93acdf27`.
+- Baseline: 900 lines, 11 tests, nine helpers, and 43
+  assertion/expectation occurrences.
+- Extract exact lines 620-832; retain line 833's blank separator in the main
+  module.
+- Route behavioral or SQL findings to a separate issue/spec cycle.

--- a/specs/GH1697/tasks.md
+++ b/specs/GH1697/tasks.md
@@ -24,6 +24,9 @@ GH-1697
 - Preserve the complete `--list` output before editing.
 - Stop if the base, inventories, target absence, focused tests, or package
   check differ from the packet.
+- Run the package check and 11 focused module tests in the before-edit block,
+  using the sanitized database-independent environment specified in
+  `tech.md`.
 
 ### SP1697-T2 — Extract support block
 
@@ -33,8 +36,9 @@ GH-1697
 - Replace only that range with the single direct include.
 - Prove 688/213 lines, 11 tests, nine helpers, 43 occurrences, identical
   compiled paths, exact source ranges, and exact two-file scope.
-- Run formatting, diff, focused, full workflow, and package checks before
-  commit.
+- Run final formatting, diff, package, focused, and sanitized full workflow
+  checks before commit; require configured exact-head CI for the six deferred
+  PostgreSQL lease tests.
 
 ### SP1697-T3 — Prove readiness
 

--- a/specs/GH1697/tech.md
+++ b/specs/GH1697/tech.md
@@ -1,0 +1,142 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1697
+
+## Product Spec
+
+See `specs/GH1697/product.md`.
+
+## Current System
+
+On base `08157897b686c6ae9245d626c7d2997b93acdf27`,
+`crates/harness-workflow/src/runtime/tests/runtime_store.rs` is a 900-line
+module with 11 `#[tokio::test]` functions and 43 assertion/expectation
+occurrences. Lines 620-832 are a contiguous block of nine helper functions;
+line 833 is the blank separator before the final test.
+
+## Proposed Design
+
+Create
+`crates/harness-workflow/src/runtime/tests/runtime_store_support.rs` from
+exact-base lines 620-832.
+
+Replace those lines in `runtime_store.rs` with:
+
+```rust
+include!("runtime_store_support.rs");
+```
+
+Retain exact-base lines 1-619 and 833-900 around the include. The include
+expands inside the existing `runtime::tests::runtime_store` module, so imports,
+visibility, helper calls, and logical test paths do not change.
+
+## Helper Inventory
+
+1. `runtime_job_status_str`
+2. `insert_legacy_orphan_command`
+3. `insert_runtime_job_record`
+4. `update_runtime_job_record`
+5. `assert_constraint_error`
+6. `drop_runtime_graph_fk_constraints`
+7. `insert_legacy_orphan_runtime_graph_rows`
+8. `insert_runtime_job_with_status`
+9. `test_runtime_job_command_id`
+
+## Invariants
+
+- Capture the exact base SHA, 900-line count, ordered 11-test inventory, nine
+  helpers, 43 assertion/expectation occurrences, and compiled test list before
+  editing.
+- Require exact support and reconstructed-main comparisons.
+- Preserve all source bytes except replacing the helper block with the include.
+- Require all compiled test paths to match the baseline exactly.
+- Require only the approved two files to change.
+
+## Affected Files
+
+- `crates/harness-workflow/src/runtime/tests/runtime_store.rs`
+- `crates/harness-workflow/src/runtime/tests/runtime_store_support.rs`
+
+## Alternatives Considered
+
+- Leave the file unchanged: rejected because it remains above the hard ceiling.
+- Split behavior tests into a nested module: rejected because it changes
+  logical test paths.
+- Move the final dedupe test to another include: rejected as unnecessary
+  fragmentation; extracting the cohesive support block already reduces the
+  main module to 688 lines.
+- Refactor helpers or SQL: rejected as behavioral scope expansion.
+
+## Risks
+
+- Security and production risk: none expected; production and SQL source are
+  unchanged.
+- Test discovery risk: low; the support file is included in the same module.
+- Test integrity risk: low when exact source, inventories, compiled paths, and
+  full CI pass.
+
+## Test Plan
+
+Before editing:
+
+```bash
+BASE="$(git rev-parse HEAD)"
+SOURCE=crates/harness-workflow/src/runtime/tests/runtime_store.rs
+SUPPORT=crates/harness-workflow/src/runtime/tests/runtime_store_support.rs
+BASE_LIST=/tmp/GH1697-base-tests.txt
+
+test ! -e "$SUPPORT"
+test "$(wc -l < "$SOURCE" | tr -d ' ')" = 900
+test "$(rg -c '^#\[tokio::test\]' "$SOURCE")" = 11
+test "$(rg -o 'assert(_eq|_ne)?!|expect\(' "$SOURCE" | wc -l | tr -d ' ')" = 43
+cargo test -p harness-workflow --lib -- --list > "$BASE_LIST"
+```
+
+After editing:
+
+```bash
+FINAL_LIST=/tmp/GH1697-final-tests.txt
+
+diff -u \
+  <(git show "$BASE:$SOURCE" | sed -n '620,832p') \
+  "$SUPPORT"
+diff -u \
+  <(git show "$BASE:$SOURCE" | awk '
+    NR == 620 { print "include!(\"runtime_store_support.rs\");" }
+    NR < 620 || NR >= 833 { print }
+  ') \
+  "$SOURCE"
+test "$(wc -l < "$SOURCE" | tr -d ' ')" = 688
+test "$(wc -l < "$SUPPORT" | tr -d ' ')" = 213
+test "$(rg -c '^#\[tokio::test\]' "$SOURCE" "$SUPPORT" |
+  awk -F: '{ total += $2 } END { print total }')" = 11
+test "$(rg -o 'assert(_eq|_ne)?!|expect\(' "$SOURCE" "$SUPPORT" |
+  wc -l | tr -d ' ')" = 43
+test "$(sed -nE 's/^(async )?fn ([A-Za-z0-9_]+)\(.*/\2/p' "$SUPPORT" |
+  wc -l | tr -d ' ')" = 9
+cargo test -p harness-workflow --lib -- --list > "$FINAL_LIST"
+diff -u "$BASE_LIST" "$FINAL_LIST"
+diff -u \
+  <(printf '%s\n' \
+    crates/harness-workflow/src/runtime/tests/runtime_store.rs \
+    crates/harness-workflow/src/runtime/tests/runtime_store_support.rs) \
+  <(git diff --name-only "$BASE"...HEAD | sort)
+```
+
+Also run:
+
+- `cargo fmt --all -- --check`
+- `git diff --check`
+- `cargo check -p harness-workflow --all-targets`
+- `cargo test -p harness-workflow --lib runtime::tests::runtime_store::`
+- database-independent full `cargo test -p harness-workflow --lib`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- repository pre-push tests, SpecRail checks, manual VibeGuard L1-L7 review,
+  exact-head CI, review-thread audit, independent review, and required PR gate.
+
+## Rollback Plan
+
+Inline the exact support-file source at the include and delete the support
+file, or squash-revert the implementation PR.

--- a/specs/GH1697/tech.md
+++ b/specs/GH1697/tech.md
@@ -104,11 +104,17 @@ env -u HARNESS_DATABASE_URL \
   -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS \
   XDG_CONFIG_HOME="$BASE_CONFIG_HOME" \
   cargo test -p harness-workflow --lib runtime::tests::runtime_store::
+rm -rf -- "$BASE_CONFIG_HOME"
+trap - EXIT
 ```
 
 After editing:
 
 ```bash
+BASE="$(git merge-base HEAD origin/main)"
+SOURCE=crates/harness-workflow/src/runtime/tests/runtime_store.rs
+SUPPORT=crates/harness-workflow/src/runtime/tests/runtime_store_support.rs
+BASE_LIST=/tmp/GH1697-base-tests.txt
 FINAL_LIST=/tmp/GH1697-final-tests.txt
 FINAL_CONFIG_HOME="$(mktemp -d /tmp/harness-GH1697-final.XXXXXX)"
 trap 'rm -rf -- "$FINAL_CONFIG_HOME"' EXIT
@@ -153,6 +159,8 @@ env -u HARNESS_DATABASE_URL \
   XDG_CONFIG_HOME="$FINAL_CONFIG_HOME" \
   cargo test -p harness-workflow --lib -- \
     --skip runtime::tests::remote_host_lease
+rm -rf -- "$FINAL_CONFIG_HOME"
+trap - EXIT
 ```
 
 Also run:

--- a/specs/GH1697/tech.md
+++ b/specs/GH1697/tech.md
@@ -150,7 +150,10 @@ diff -u \
   <(printf '%s\n' \
     crates/harness-workflow/src/runtime/tests/runtime_store.rs \
     crates/harness-workflow/src/runtime/tests/runtime_store_support.rs) \
-  <(git diff --name-only "$BASE"...HEAD | sort)
+  <({
+    git diff --name-only "$BASE"
+    git ls-files --others --exclude-standard
+  } | sort)
 cargo check -p harness-workflow --all-targets
 env -u HARNESS_DATABASE_URL \
   -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS \
@@ -179,7 +182,22 @@ The sanitized local full suite must pass all database-independent workflow
 library tests while explicitly skipping the six
 `runtime::tests::remote_host_lease` PostgreSQL tests. Exact-head CI's
 configured full database profile is authoritative for those six tests and
-other DB-backed coverage.
+the 11 runtime-store tests' DB-backed SQL/assertion coverage.
+
+After committing, rerun the exact two-file scope gate against committed state
+and require a clean worktree:
+
+```bash
+set -euo pipefail
+
+BASE="$(git merge-base HEAD origin/main)"
+test -z "$(git status --porcelain)"
+diff -u \
+  <(printf '%s\n' \
+    crates/harness-workflow/src/runtime/tests/runtime_store.rs \
+    crates/harness-workflow/src/runtime/tests/runtime_store_support.rs) \
+  <(git diff --name-only "$BASE"...HEAD | sort)
+```
 
 ## Rollback Plan
 

--- a/specs/GH1697/tech.md
+++ b/specs/GH1697/tech.md
@@ -86,18 +86,32 @@ BASE="$(git rev-parse HEAD)"
 SOURCE=crates/harness-workflow/src/runtime/tests/runtime_store.rs
 SUPPORT=crates/harness-workflow/src/runtime/tests/runtime_store_support.rs
 BASE_LIST=/tmp/GH1697-base-tests.txt
+BASE_CONFIG_HOME="$(mktemp -d /tmp/harness-GH1697-base.XXXXXX)"
+trap 'rm -rf -- "$BASE_CONFIG_HOME"' EXIT
 
 test ! -e "$SUPPORT"
 test "$(wc -l < "$SOURCE" | tr -d ' ')" = 900
 test "$(rg -c '^#\[tokio::test\]' "$SOURCE")" = 11
 test "$(rg -o 'assert(_eq|_ne)?!|expect\(' "$SOURCE" | wc -l | tr -d ' ')" = 43
-cargo test -p harness-workflow --lib -- --list > "$BASE_LIST"
+env -u HARNESS_DATABASE_URL \
+  -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS \
+  -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS \
+  XDG_CONFIG_HOME="$BASE_CONFIG_HOME" \
+  cargo test -p harness-workflow --lib -- --list > "$BASE_LIST"
+cargo check -p harness-workflow --all-targets
+env -u HARNESS_DATABASE_URL \
+  -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS \
+  -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS \
+  XDG_CONFIG_HOME="$BASE_CONFIG_HOME" \
+  cargo test -p harness-workflow --lib runtime::tests::runtime_store::
 ```
 
 After editing:
 
 ```bash
 FINAL_LIST=/tmp/GH1697-final-tests.txt
+FINAL_CONFIG_HOME="$(mktemp -d /tmp/harness-GH1697-final.XXXXXX)"
+trap 'rm -rf -- "$FINAL_CONFIG_HOME"' EXIT
 
 diff -u \
   <(git show "$BASE:$SOURCE" | sed -n '620,832p') \
@@ -116,25 +130,44 @@ test "$(rg -o 'assert(_eq|_ne)?!|expect\(' "$SOURCE" "$SUPPORT" |
   wc -l | tr -d ' ')" = 43
 test "$(sed -nE 's/^(async )?fn ([A-Za-z0-9_]+)\(.*/\2/p' "$SUPPORT" |
   wc -l | tr -d ' ')" = 9
-cargo test -p harness-workflow --lib -- --list > "$FINAL_LIST"
+env -u HARNESS_DATABASE_URL \
+  -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS \
+  -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS \
+  XDG_CONFIG_HOME="$FINAL_CONFIG_HOME" \
+  cargo test -p harness-workflow --lib -- --list > "$FINAL_LIST"
 diff -u "$BASE_LIST" "$FINAL_LIST"
 diff -u \
   <(printf '%s\n' \
     crates/harness-workflow/src/runtime/tests/runtime_store.rs \
     crates/harness-workflow/src/runtime/tests/runtime_store_support.rs) \
   <(git diff --name-only "$BASE"...HEAD | sort)
+cargo check -p harness-workflow --all-targets
+env -u HARNESS_DATABASE_URL \
+  -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS \
+  -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS \
+  XDG_CONFIG_HOME="$FINAL_CONFIG_HOME" \
+  cargo test -p harness-workflow --lib runtime::tests::runtime_store::
+env -u HARNESS_DATABASE_URL \
+  -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS \
+  -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS \
+  XDG_CONFIG_HOME="$FINAL_CONFIG_HOME" \
+  cargo test -p harness-workflow --lib -- \
+    --skip runtime::tests::remote_host_lease
 ```
 
 Also run:
 
 - `cargo fmt --all -- --check`
 - `git diff --check`
-- `cargo check -p harness-workflow --all-targets`
-- `cargo test -p harness-workflow --lib runtime::tests::runtime_store::`
-- database-independent full `cargo test -p harness-workflow --lib`
 - `cargo clippy --workspace --all-targets -- -D warnings`
 - repository pre-push tests, SpecRail checks, manual VibeGuard L1-L7 review,
   exact-head CI, review-thread audit, independent review, and required PR gate.
+
+The sanitized local full suite must pass all database-independent workflow
+library tests while explicitly skipping the six
+`runtime::tests::remote_host_lease` PostgreSQL tests. Exact-head CI's
+configured full database profile is authoritative for those six tests and
+other DB-backed coverage.
 
 ## Rollback Plan
 

--- a/specs/GH1697/tech.md
+++ b/specs/GH1697/tech.md
@@ -84,6 +84,7 @@ Before editing:
 ```bash
 set -euo pipefail
 
+PINNED_BASE=08157897b686c6ae9245d626c7d2997b93acdf27
 BASE="$(git rev-parse HEAD)"
 SOURCE=crates/harness-workflow/src/runtime/tests/runtime_store.rs
 SUPPORT=crates/harness-workflow/src/runtime/tests/runtime_store_support.rs
@@ -92,6 +93,7 @@ BASE_CONFIG_HOME="$(mktemp -d /tmp/harness-GH1697-base.XXXXXX)"
 trap 'rm -rf -- "$BASE_CONFIG_HOME"' EXIT
 
 test ! -e "$SUPPORT"
+cmp <(git show "$PINNED_BASE:$SOURCE") "$SOURCE"
 test "$(wc -l < "$SOURCE" | tr -d ' ')" = 900
 test "$(rg -c '^#\[tokio::test\]' "$SOURCE")" = 11
 test "$(rg -o 'assert(_eq|_ne)?!|expect\(' "$SOURCE" | wc -l | tr -d ' ')" = 43

--- a/specs/GH1697/tech.md
+++ b/specs/GH1697/tech.md
@@ -82,6 +82,8 @@ visibility, helper calls, and logical test paths do not change.
 Before editing:
 
 ```bash
+set -euo pipefail
+
 BASE="$(git rev-parse HEAD)"
 SOURCE=crates/harness-workflow/src/runtime/tests/runtime_store.rs
 SUPPORT=crates/harness-workflow/src/runtime/tests/runtime_store_support.rs
@@ -111,6 +113,8 @@ trap - EXIT
 After editing:
 
 ```bash
+set -euo pipefail
+
 BASE="$(git merge-base HEAD origin/main)"
 SOURCE=crates/harness-workflow/src/runtime/tests/runtime_store.rs
 SUPPORT=crates/harness-workflow/src/runtime/tests/runtime_store_support.rs


### PR DESCRIPTION
Linked work: #1697

## Why

`runtime_store.rs` is 900 lines and mixes 11 behavior tests with a contiguous
213-line block of nine database test helpers. The packet specifies a
behavior-preserving extraction below the repository's 800-line ceiling.

## Specification

- move exact-base lines 620-832 to `runtime_store_support.rs`;
- replace that range with one direct include inside the existing module;
- preserve exact-base lines 1-619 and 833-900;
- preserve 11 logical test paths, nine helpers, and 43
  assertion/expectation occurrences;
- require exact 688/213 line counts and a strict two-file scope.

## Plan

Capture the compiled baseline, perform the exact extraction after this spec
merges, compare source/path/inventory/scope evidence, then run focused/full
workflow tests, workspace Clippy/tests, exact-head CI, independent review,
review-thread audit, and required SpecRail gates in a separate implementation
PR.

## Verification

- GH-1697 packet and global SpecRail checks passed
- required `write_spec` route gate passed
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push Clippy and database-independent workspace/workflow lib tests passed

## Risk

Documentation only. The future implementation is constrained to exact test
source movement with no production, SQL, persistence, API, or dependency
change.
