### PR TITLE
docs: close out GH-1434 runtime migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Validation workflow:
 Harness is an agent orchestration layer. It constructs prompts and manages lifecycle — agents (Codex CLI) decide how to execute.
 
 - ZERO `Command::new("gh")` or `Command::new("git")` calls inside harness crates — all GitHub/git interaction must be in agent prompts only
-- When testing Harness product behavior for "fix issue X" or "handle PR Y", delegate to harness server (`POST /tasks`). For direct repository maintenance in this checkout, implement and verify the requested code change directly unless the user explicitly asks to exercise the Harness server flow.
+- When testing Harness product behavior for "fix issue X" or "handle PR Y", delegate to harness server (`POST /api/workflows/runtime/submissions`). For direct repository maintenance in this checkout, implement and verify the requested code change directly unless the user explicitly asks to exercise the Harness server flow.
 
 ## Glossary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **breaking:** removed Harness-owned JSON-RPC thread/turn lifecycle methods and
-  the unwritten `context/manifest/get` endpoint. Use workflow-runtime HTTP
-  submissions for durable work; live approval responses now use
+- **breaking:** removed the Harness-owned JSON-RPC methods `thread/start`,
+  `thread/resume`, `thread/fork`, `thread/list`, `thread/delete`,
+  `thread/compact`, `turn/start`, `turn/steer`, `turn/cancel`, `turn/status`,
+  `turn/respond_approval`, and the unwritten `context/manifest/get` endpoint.
+  Use workflow-runtime HTTP submissions for durable work; live approval
+  responses now use
   `POST /api/workflows/runtime/turns/{turn_id}/approvals/{request_id}`. The
   TypeScript and Python SDKs have migrated to these HTTP surfaces.
+- **breaking:** removed the legacy `/tasks` compatibility routes. Submit and
+  list work through `POST` and `GET /api/workflows/runtime/submissions`; use
+  `/api/workflows/runtime/submissions/{id}` for detail and append `/stream`,
+  `/artifacts`, `/prompts`, or `/proof` for the corresponding read surface.
+  Cancel and merge now use `POST /api/workflows/runtime/cancel` and
+  `POST /api/workflows/runtime/merge` with `workflow_id`. There is no direct
+  replacement for `POST /tasks/batch`; callers must submit each request to the
+  runtime endpoint. Runtime hosts must claim
+  `/api/runtime-hosts/{host_id}/runtime-jobs/claim`; the legacy
+  `/api/runtime-hosts/{host_id}/tasks/claim` route has been removed.
+- **migration:** Phase 1 data was archived before removal as
+  `archives/phase1-20260716T092438Z`. The archive is operator-owned and may
+  contain sensitive prompt or repository data. Inspect `table_counts.tsv` and
+  `phase1-data.list`, then restore `phase1-data.dump` only into an empty scratch
+  database with
+  `pg_restore --exit-on-error --no-owner --no-acl --dbname "$SCRATCH_DATABASE_URL" phase1-data.dump`.
+  Never restore it into a live Harness database and do not pass `--clean`.
+- **maintenance:** the GH-1434 Phase 1 implementation series (#1663, #1701,
+  #1702, #1703, and #1706) removed 34,156 lines and added 11,246 lines, for a
+  net deletion of 22,910 lines.
 - **security:** HTTP API authentication now fails closed when neither
   `api_token` nor `HARNESS_API_TOKEN` is configured. Operators must set a token
   or explicitly opt in to tokenless local development with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ cargobg() {
 Harness is an agent orchestration layer. It constructs prompts and manages lifecycle — agents (Claude Code CLI) decide how to execute.
 
 - ZERO `Command::new("gh")` or `Command::new("git")` calls inside harness crates — all GitHub/git interaction must be in agent prompts only
-- When user says "fix issue X" or "handle PR Y", ALWAYS delegate to harness server (`POST /tasks`) instead of implementing directly
+- When testing Harness product behavior for "fix issue X" or "handle PR Y", delegate to harness server (`POST /api/workflows/runtime/submissions`). For direct repository maintenance in this checkout, implement and verify the requested code change directly unless the user explicitly asks to exercise the Harness server flow.
 
 ## Worktree Usage
 

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ cargo run -p harness-cli -- exec "Fix the failing test in src/lib.rs"
 ### Common Workflows
 
 ```bash
-# Task management
-curl -X POST http://127.0.0.1:9800/tasks \
+# Workflow-runtime submission
+curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H "Content-Type: application/json" \
   -d '{"prompt": "Add input validation to the API handler"}'
 
@@ -375,19 +375,19 @@ max_turns = 20
 
 ## HTTP REST API
 
-### Task Management
+### Workflow Runtime Submissions
 
 ```bash
-# Submit a task by prompt
-curl -X POST http://127.0.0.1:9800/tasks \
+# Submit work by prompt
+curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "Add input validation to the API handler",
     "project": "/path/to/project"
   }'
 
-# Submit a task by GitHub issue number
-curl -X POST http://127.0.0.1:9800/tasks \
+# Submit work by GitHub issue number
+curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H "Content-Type: application/json" \
   -d '{
     "project": "/path/to/project",
@@ -395,8 +395,8 @@ curl -X POST http://127.0.0.1:9800/tasks \
     "prompt": "fix: handle edge case in parser"
   }'
 
-# Submit an issue task but bypass triage/plan and go straight to implementation
-curl -X POST http://127.0.0.1:9800/tasks \
+# Submit an issue but bypass triage/plan and go straight to implementation
+curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H "Content-Type: application/json" \
   -d '{
     "project": "/path/to/project",
@@ -404,30 +404,29 @@ curl -X POST http://127.0.0.1:9800/tasks \
     "skip_triage": true
   }'
 
-# Submit a task by PR number (for review/fix)
-curl -X POST http://127.0.0.1:9800/tasks \
+# Submit a PR for review/fix
+curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H "Content-Type: application/json" \
   -d '{
     "project": "/path/to/project",
     "pr": 100
   }'
 
-# Batch submit multiple tasks
-curl -X POST http://127.0.0.1:9800/tasks/batch \
-  -H "Content-Type: application/json" \
-  -d '{
-    "project": "/path/to/project",
-    "issues": [10, 11, 12]
-  }'
+# Submit multiple issues (one durable submission per request)
+for issue in 10 11 12; do
+  curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
+    -H "Content-Type: application/json" \
+    -d "{\"project\":\"/path/to/project\",\"issue\":$issue}"
+done
 
-# Get task status
-curl http://127.0.0.1:9800/tasks/{task_id}
+# Get submission status
+curl http://127.0.0.1:9800/api/workflows/runtime/submissions/{submission_id}
 
-# List all tasks
-curl http://127.0.0.1:9800/tasks
+# List submissions
+curl http://127.0.0.1:9800/api/workflows/runtime/submissions
 
-# Stream task output (SSE)
-curl http://127.0.0.1:9800/tasks/{task_id}/stream
+# Stream submission output (SSE)
+curl http://127.0.0.1:9800/api/workflows/runtime/submissions/{submission_id}/stream
 ```
 
 ### Project Management
@@ -508,17 +507,17 @@ Before using direct `./target/release/harness ... serve` commands, run
 The direct binary commands do not start local Postgres or build the release
 binary for you.
 
-## Task Execution Flow
+## Workflow Runtime Execution Flow
 
 ```
-POST /tasks → TaskQueue → acquire semaphore (project + global)
+POST /api/workflows/runtime/submissions → persist workflow + implementation command
+    → runtime dispatcher creates a job → worker acquires the project queue permit
     → create git worktree → agent executes in isolation
-    → post-validator runs (cargo fmt, cargo check)
-    → agent creates PR → Codex review (up to 3 rounds)
-    → quality score → cleanup worktree → done
+    → validate and review → persist terminal workflow evidence
 ```
 
-Each task runs in an isolated git worktree, so multiple agents can work on the same repo in parallel without conflicts.
+Each implementation runs in an isolated git worktree. The workflow runtime is
+the scheduling and lifecycle authority.
 
 ## Workspace Crates
 
@@ -526,7 +525,7 @@ Each task runs in an isolated git worktree, so multiple agents can work on the s
 |---|---|
 | `harness-core` | Shared domain types, config, prompts, agent/interceptor traits |
 | `harness-protocol` | JSON-RPC method definitions, envelopes, notifications, codecs |
-| `harness-server` | App Server runtime (HTTP + stdio + WebSocket), routing, handlers, task/thread stores |
+| `harness-server` | App Server runtime (HTTP + stdio + WebSocket), routing, handlers, and workflow-runtime integration |
 | `harness-agents` | Agent adapters (Claude CLI, Codex CLI, Anthropic API) and registry |
 | `harness-gc` | Signal detection and draft remediation generation/adoption |
 | `harness-rules` | Rule loading/parsing, Starlark execution policy engine |
@@ -537,18 +536,17 @@ Each task runs in an isolated git worktree, so multiple agents can work on the s
 
 ## JSON-RPC API
 
-Harness exposes 42 methods over JSON-RPC 2.0 (stdio, HTTP, or WebSocket):
+Harness exposes 32 methods over JSON-RPC 2.0 (stdio, HTTP, or WebSocket):
 
 | Category | Methods |
 |---|---|
 | Lifecycle | `initialize`, `initialized` |
-| Threads | `thread/start`, `thread/resume`, `thread/fork`, `thread/list`, `thread/delete`, `thread/compact` |
-| Turns | `turn/start`, `turn/steer`, `turn/cancel`, `turn/status`, `turn/respond_approval` |
 | GC | `gc/run`, `gc/status`, `gc/drafts`, `gc/adopt`, `gc/reject` |
 | Skills | `skill/create`, `skill/list`, `skill/get`, `skill/delete`, `skill/governance/view`, `skill/governance/history`, `skill/stale` |
 | Rules | `rule/load`, `rule/check` |
 | ExecPlan | `exec_plan/init`, `exec_plan/update`, `exec_plan/status` |
 | Observability | `event/log`, `event/query`, `metrics/collect`, `metrics/query` |
+| Context | `context/preview` |
 | Classification | `task/classify`, `learn/rules`, `learn/skills` |
 | Health | `health/check`, `stats/query`, `agent/list` |
 | VibeGuard | `preflight`, `cross_review` |

--- a/crates/harness-server/tests/runtime_submission_identity_contract.rs
+++ b/crates/harness-server/tests/runtime_submission_identity_contract.rs
@@ -10,24 +10,38 @@ fn identity_contract_doc_covers_runtime_submission_api_surface() {
         "workflow_id",
         "submission_id",
         "task_id",
-        "POST /tasks",
-        "GET /tasks",
-        "GET /tasks/{id}",
-        "GET /tasks/{id}/stream",
-        "POST /tasks/{id}/cancel",
-        "GET /tasks/{id}/proof",
-        "GET /tasks/{id}/artifacts",
-        "GET /tasks/{id}/prompts",
-        "Phase 0: Current Compatibility",
-        "Phase 1: Add Explicit `submission_id`",
-        "Phase 2: Prefer Runtime-Native Handles",
-        "Phase 3: Remove Legacy Compatibility",
+        "request_id",
+        "POST /api/workflows/runtime/submissions",
+        "GET /api/workflows/runtime/submissions",
+        "GET /api/workflows/runtime/submissions/{id}",
+        "GET /api/workflows/runtime/submissions/{id}/stream",
+        "GET /api/workflows/runtime/submissions/{id}/proof",
+        "GET /api/workflows/runtime/submissions/{id}/artifacts",
+        "GET /api/workflows/runtime/submissions/{id}/prompts",
+        "POST /api/workflows/runtime/cancel",
+        "POST /api/workflows/runtime/merge",
+        "POST /api/workflows/runtime/unblock",
+        "POST /api/workflows/runtime/retry",
+        "POST /api/workflows/runtime/turns/{turn_id}/approvals/{request_id}",
+        "Removed Compatibility",
     ] {
         assert!(
             doc.contains(required),
             "identity contract should document {required}"
         );
     }
+
+    let (current_contract, removed_compatibility) = doc
+        .split_once("## Removed Compatibility")
+        .expect("identity contract should separate removed compatibility routes");
+    assert!(
+        !current_contract.contains("/tasks"),
+        "current identity contract must not advertise removed /tasks routes"
+    );
+    assert!(
+        removed_compatibility.contains("have been removed"),
+        "removed compatibility section should explicitly mark /tasks routes as removed"
+    );
 }
 
 #[tokio::test]

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -17,11 +17,6 @@ observes results. The following capabilities are **only available over HTTP**:
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `POST /tasks` | create | Enqueue a single task |
-| `GET  /tasks` | list | List all tasks |
-| `POST /tasks/batch` | batch create | Enqueue multiple tasks at once |
-| `GET  /tasks/{id}` | get | Fetch task details |
-| `GET  /tasks/{id}/stream` | stream | Server-Sent Events live output |
 | `POST /projects` | register | Register a project root |
 | `GET  /projects` | list | List registered projects |
 | `GET  /projects/{id}` | get | Get project details |
@@ -30,9 +25,14 @@ observes results. The following capabilities are **only available over HTTP**:
 | `GET  /api/dashboard` | dashboard | Dashboard data |
 | `GET  /api/intake` | intake | Intake source status |
 | `POST /api/workflows/runtime/submissions` | submit | Create a durable workflow-runtime submission |
+| `GET  /api/workflows/runtime/submissions` | list | List runtime submissions |
 | `GET  /api/workflows/runtime/submissions/{id}` | get | Read runtime submission status |
 | `GET  /api/workflows/runtime/submissions/{id}/artifacts` | artifacts | Read runtime output artifacts |
+| `GET  /api/workflows/runtime/submissions/{id}/prompts` | prompts | Read recorded runtime prompts |
+| `GET  /api/workflows/runtime/submissions/{id}/proof` | proof | Read terminal proof of work |
 | `GET  /api/workflows/runtime/submissions/{id}/stream` | stream | Stream runtime submission events |
+| `POST /api/workflows/runtime/cancel` | cancel | Cancel a workflow by `workflow_id` |
+| `POST /api/workflows/runtime/merge` | merge | Approve or merge a workflow by `workflow_id` |
 | `POST /api/workflows/runtime/turns/{turn_id}/approvals/{request_id}` | approval | Respond to a live runtime approval request |
 | `POST /webhook` | webhook | GitHub webhook (HMAC-verified) |
 | `POST /webhook/feishu` | webhook | Feishu bot webhook |
@@ -47,22 +47,10 @@ initialization failed or runtime state is dirty; the `persistence.startup.stores
 array reports each store by name with `critical`, `ready`, and a redacted
 `error` code.
 
-`GET /tasks` keeps returning the task rows it can safely load, but includes a
-`degraded` object when runtime-only submissions could not be loaded:
-
-```json
-{
-  "degraded": {
-    "partial": true,
-    "missing": ["workflow_runtime_submissions"],
-    "reason": "runtime_submission_summaries_unavailable"
-  }
-}
-```
-
-`GET /tasks/{id}` and `GET /tasks/{id}/proof` return `503 Service Unavailable`
-with `error: "workflow runtime store unavailable"` when the requested handle
-could be runtime-backed but the required workflow runtime store is unavailable.
+Runtime submission list, detail, proof, artifact, prompt, and stream routes fail
+closed when their required workflow-runtime store is unavailable. The JSON
+error is `workflow runtime store unavailable`; the list and detail surfaces use
+`503 Service Unavailable` rather than returning partial legacy rows.
 
 Runtime-host mutations, including watched-project sync, fail with
 `503 Service Unavailable` when runtime state persistence was required at startup
@@ -77,8 +65,8 @@ non-exempt routes require `Authorization: Bearer <token>`; if both a token and
 ignored. Exempt routes that bypass auth entirely: `/health`, `/webhook`,
 `/webhook/feishu`, `/signals`, and `/favicon.ico` (these carry their own
 HMAC-based protection or are intentionally public). For browser clients that
-cannot set `Authorization` headers on SSE requests, `/tasks/{id}/stream` and
-`/api/workflows/runtime/submissions/{id}/stream` additionally accept a
+cannot set `Authorization` headers on SSE requests,
+`/api/workflows/runtime/submissions/{id}/stream` additionally accepts a
 `?token=<value>` query parameter as a fallback; all other routes only accept
 `Authorization: Bearer <token>`.
 
@@ -117,6 +105,7 @@ All three transports share the same method set. The following capabilities are
 | `event/query` | Query events |
 | `metrics/collect` | Gather project metrics |
 | `metrics/query` | Query metrics |
+| `context/preview` | Preview a composed context manifest |
 | `task/classify` | Classify prompt/issue/PR complexity |
 | `learn/rules` | Learn from rule violations |
 | `learn/skills` | Learn from skill usage |
@@ -143,7 +132,7 @@ error.
 
 The design is intentional:
 
-1. **Security boundary** — Task submission and project registration are privileged
+1. **Security boundary** — Runtime submission and project registration are privileged
    operations. Keeping them HTTP-only means they go through the same
    token-based authentication middleware (when `api_token` is configured).
    Agent processes communicating over stdio cannot submit new tasks or register
@@ -162,8 +151,8 @@ The design is intentional:
 
 | You want to… | Use |
 |---|---|
-| Submit a task from a CI script | `POST /tasks` (HTTP) |
-| Stream live output from a running task | `GET /tasks/{id}/stream` (HTTP SSE) |
+| Submit work from a CI script | `POST /api/workflows/runtime/submissions` (HTTP) |
+| Stream live output from a running submission | `GET /api/workflows/runtime/submissions/{id}/stream` (HTTP SSE) |
 | Register a new project | `POST /projects` (HTTP) |
 | Run a prompt through the workflow runtime | `POST /api/workflows/runtime/submissions` (HTTP) |
 | Inspect a running runtime submission | `GET /api/workflows/runtime/submissions/{id}` (HTTP) |
@@ -171,9 +160,10 @@ The design is intentional:
 | Load rules for an agent to respect | `rule/load` (JSON-RPC) |
 | Record an event from within an agent | `event/log` (JSON-RPC) |
 
-## HTTP task list
+## HTTP runtime submission list
 
-`GET /tasks` returns a paginated envelope, not a raw array:
+`GET /api/workflows/runtime/submissions` returns a paginated envelope, not a raw
+array:
 
 ```json
 {
@@ -193,7 +183,8 @@ Supported query parameters are `status`, `scheduler_state`, `active`, `kind`,
 `source`, `repo`, `project_id`, `limit`, and `cursor`. `status` is the task
 lifecycle status; `scheduler_state` is the ownership/execution state. For
 example, currently executing work is queried with
-`/tasks?scheduler_state=running`, not `status=running`.
+`/api/workflows/runtime/submissions?scheduler_state=running`, not
+`status=running`.
 
 ## Error codes
 
@@ -213,4 +204,5 @@ All JSON-RPC errors follow [JSON-RPC 2.0](https://www.jsonrpc.org/specification)
 | `-32005` | `AGENT_ERROR` | Agent execution error |
 | `-32006` | `VALIDATION_ERROR` | Input validation failure |
 
-HTTP errors follow standard HTTP status codes (200, 201, 400, 401, 404, 409, 500).
+HTTP errors follow standard HTTP status codes (200, 201, 202, 400, 401, 404,
+409, 500, 503).

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -33,6 +33,8 @@ observes results. The following capabilities are **only available over HTTP**:
 | `GET  /api/workflows/runtime/submissions/{id}/stream` | stream | Stream runtime submission events |
 | `POST /api/workflows/runtime/cancel` | cancel | Cancel a workflow by `workflow_id` |
 | `POST /api/workflows/runtime/merge` | merge | Approve or merge a workflow by `workflow_id` |
+| `POST /api/workflows/runtime/unblock` | unblock | Resume a blocked workflow by `workflow_id` |
+| `POST /api/workflows/runtime/retry` | retry | Retry an eligible failed workflow by `workflow_id` |
 | `POST /api/workflows/runtime/turns/{turn_id}/approvals/{request_id}` | approval | Respond to a live runtime approval request |
 | `POST /webhook` | webhook | GitHub webhook (HMAC-verified) |
 | `POST /webhook/feishu` | webhook | Feishu bot webhook |
@@ -205,4 +207,5 @@ All JSON-RPC errors follow [JSON-RPC 2.0](https://www.jsonrpc.org/specification)
 | `-32006` | `VALIDATION_ERROR` | Input validation failure |
 
 HTTP errors follow standard HTTP status codes (200, 201, 202, 400, 401, 404,
-409, 500, 503).
+409, 422, 500, 503). The runtime proof route returns `422 Unprocessable
+Entity` while an existing submission is not yet terminal.

--- a/docs/issues-encountered.md
+++ b/docs/issues-encountered.md
@@ -155,48 +155,29 @@ Also changed test signature from `async fn skills_are_injected_into_agent_contex
 
 ---
 
-## Issue 3: No Serial Task Execution — Parallel Agents Cause Merge Conflicts
+## Historical Issue 3: Legacy Task Execution Caused Parallel Merge Conflicts
 
 ### Symptom
 
-Submitting issues #20, #21, #22 simultaneously to `POST /tasks` causes agents to run in parallel. All three modify the same files (`router.rs`, `http.rs`), producing git merge conflicts when creating PRs.
+Before the workflow-runtime migration, submitting issues #20, #21, and #22 simultaneously to the legacy task endpoint caused agents to run in parallel. All three modified the same files (`router.rs`, `http.rs`), producing git merge conflicts when creating PRs.
 
 ### Root Cause
 
-`POST /tasks` immediately calls `tokio::spawn(run_task(...))`. There is no queue, no dependency mechanism, no locking. Each task gets its own worktree branch, but merging back to main is sequential — the second PR conflicts with the first.
+The removed task layer immediately spawned each request without a dependency mechanism or repository-level coordination. Each task used its own worktree branch, but merging back to main was sequential, so later PRs conflicted.
 
 ### Workaround
 
-External bash script for serial execution:
-
-```bash
-#!/bin/bash
-for issue in 20 21 22; do
-    # Submit
-    TASK_ID=$(curl -s -X POST http://localhost:9800/tasks \
-        -H 'Content-Type: application/json' \
-        -d "{\"issue\": $issue}" | jq -r '.task_id')
-
-    # Poll until done
-    while true; do
-        STATUS=$(curl -s http://localhost:9800/tasks/$TASK_ID | jq -r '.status')
-        [ "$STATUS" = "done" ] || [ "$STATUS" = "failed" ] && break
-        sleep 30
-    done
-
-    # Merge
-    PR_URL=$(curl -s http://localhost:9800/tasks/$TASK_ID | jq -r '.pr_url')
-    PR_NUM=$(echo $PR_URL | grep -oP '\d+$')
-    [ -n "$PR_NUM" ] && gh pr merge $PR_NUM --squash --delete-branch
-done
-```
+The legacy workaround is no longer valid because the task endpoints were
+removed. Submit one durable request per issue through
+`POST /api/workflows/runtime/submissions`, then observe each request through
+`GET /api/workflows/runtime/submissions/{id}` or its SSE stream before
+submitting dependent work. See the current examples in `README.md`.
 
 ### Proper Fix (Not Yet Implemented)
 
-Need one of:
-- `POST /tasks/queue` endpoint that internally serializes dependent tasks
-- Task dependency mechanism (`blockedBy` field linking tasks)
-- Repository-level locking that prevents concurrent modifications
+The workflow runtime now owns durable submission state. Dependency-aware
+dispatch and repository coordination belong in that runtime rather than in a
+replacement compatibility endpoint.
 
 ---
 

--- a/docs/otel-trajectory-quickstart.md
+++ b/docs/otel-trajectory-quickstart.md
@@ -61,11 +61,11 @@ Start Harness:
 
 ## Submit an Issue Run
 
-Submit a real issue-backed task in a repository where the configured agent can
+Submit a real issue-backed workflow in a repository where the configured agent can
 open a PR:
 
 ```bash
-curl -X POST http://127.0.0.1:9800/tasks \
+curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H "Content-Type: application/json" \
   -d '{
     "project": "/absolute/path/to/target-repo",
@@ -74,10 +74,10 @@ curl -X POST http://127.0.0.1:9800/tasks \
   }'
 ```
 
-Poll the task until it reaches a terminal state:
+Poll the submission until it reaches a terminal state:
 
 ```bash
-curl -s http://127.0.0.1:9800/tasks/{task_id} | python3 -m json.tool
+curl -s http://127.0.0.1:9800/api/workflows/runtime/submissions/{submission_id} | python3 -m json.tool
 ```
 
 ## Inspect the Trace

--- a/docs/periodic-review.md
+++ b/docs/periodic-review.md
@@ -20,7 +20,8 @@ A scheduled review job that:
 2. Skips if no new commits since last review
 3. Spawns an agent (Claude) to review the entire codebase
 4. Agent produces a structured report with severity-ranked findings
-5. Results stored via existing task pipeline (TaskStore)
+5. Results stored in the workflow runtime and projected through runtime
+   submission APIs
 
 No static analysis code. The agent IS the checker.
 
@@ -41,7 +42,7 @@ Scheduler::start()
        ├─ build review prompt (11-item checklist)
        │
        └─ enqueue_task(CreateTaskRequest { prompt, source: "periodic_review" })
-            └─ existing pipeline: agent → TaskState → EventStore
+            └─ workflow runtime: command → job → agent → terminal evidence
 ```
 
 ## Review Checklist (11 Items)
@@ -248,14 +249,16 @@ review_loop tick
   → local commit gate since watermark → skip if empty
   → gather context (repo structure, diff stat, recent commits)
   → prompts::periodic_review_prompt() → build prompt
-  → enqueue_task() → existing task pipeline
-      → agent runs → report in TaskState.rounds[0].result
-      → TaskStatus::Done
+  → enqueue_task() → workflow-runtime submission
+      → agent runs → report persisted as runtime activity output
+      → workflow reaches a terminal state
   → EventStore.log("periodic_review") → timestamp for next skip
 ```
 
-Report is stored in `TaskState.rounds[0].result`. Query via `GET /tasks/{id}`.
-Dashboard can filter by `source == "periodic_review"` for review history.
+Query the report through
+`GET /api/workflows/runtime/submissions/{submission_id}` and its artifact or
+proof routes. The dashboard can filter runtime submissions by
+`source == "periodic_review"` for review history.
 
 ## Implementation
 

--- a/docs/runtime-host-model-spec.md
+++ b/docs/runtime-host-model-spec.md
@@ -2,7 +2,8 @@
 
 ## Goal
 
-Add a runtime host control surface so Harness can track external executors and safely lease either legacy pending tasks or workflow runtime jobs to them.
+Add a runtime host control surface so Harness can track external executors and
+safely lease workflow-runtime jobs to them.
 
 ## Why
 
@@ -15,26 +16,21 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 - host `deregister`
 - host `heartbeat`
 - host listing with `online` status derived from heartbeat freshness
-2. Task leases stored on the authoritative task scheduler state:
-- runtime host can claim one pending task
-- duplicate claim prevention across hosts
-- lease TTL support
-3. Legacy task HTTP API endpoints:
+2. Runtime-host lifecycle HTTP API endpoints:
 - `GET /api/runtime-hosts`
 - `POST /api/runtime-hosts/register`
 - `POST /api/runtime-hosts/{id}/heartbeat`
 - `POST /api/runtime-hosts/{id}/deregister`
-- `POST /api/runtime-hosts/{id}/tasks/claim`
-4. Workflow runtime job HTTP API endpoints:
+3. Workflow runtime job HTTP API endpoints:
 - `POST /api/runtime-hosts/{id}/runtime-jobs/claim`
 - `POST /api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/lease/renew`
 - `POST /api/runtime-hosts/{id}/runtime-jobs/{runtime_job_id}/complete`
-5. Tests for lease correctness, heartbeat-driven status, runtime job claim ownership, and terminal callback ownership.
+4. Tests for lease correctness, heartbeat-driven status, runtime job claim ownership, and terminal callback ownership.
 
 ## Out of Scope
 
 1. Progress streaming callbacks.
-2. Scheduler integration that auto-routes all legacy tasks to runtime hosts.
+2. Compatibility with the removed legacy task claim protocol.
 3. Workspace/multi-tenant model migration.
 
 ## Data Model (V1)
@@ -47,10 +43,6 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 - `last_heartbeat_at: DateTime<Utc>`
 - `lifecycle: active | draining` (legacy records default to `active`)
 
-`TaskScheduler` runtime-host lease fields
-- `runtime_host_id: Option<String>`
-- `lease_expires_at: Option<DateTime<Utc>>`
-
 `RuntimeJob` workflow runtime lease fields
 - `runtime_kind: RuntimeKind`
 - `runtime_profile: String`
@@ -62,25 +54,27 @@ Harness is strong as a centralized control plane, but runtime host lifecycle is 
 
 1. `register` is idempotent by `host_id` (upsert metadata and refresh heartbeat).
 2. `heartbeat` on unknown host returns error.
-3. `deregister` first persists `draining`, revokes every owned workflow runtime-job lease, releases pending task claims, and removes the host only after no workflow leases remain. A failed or interrupted cleanup leaves the host visibly draining and retryable.
-4. Legacy task `claim` selects only tasks in `pending` status.
-5. A non-expired lease blocks claims by other hosts.
-6. Expired leases are reclaimable by any host.
-7. Workflow runtime-job claims select only `runtime_kind = remote_host` jobs.
-8. In-process runtime workers do not claim `remote_host` jobs.
-9. Runtime-job completion requires the host id and exact lease expiration timestamp from the claim response. Upgraded clients also send the additive lease generation; legacy clients may omit it.
-10. Runtime-job claim and renewal lease durations default to 60 seconds and accept only `1..=3600` seconds.
-11. A draining host cannot claim or renew work. Heartbeat only updates host liveness and never extends a job lease.
+3. `deregister` first persists `draining`, revokes every owned workflow
+   runtime-job lease, and removes the host only after no workflow leases remain.
+   A failed or interrupted cleanup leaves the host visibly draining and
+   retryable.
+4. A non-expired lease blocks claims by other hosts.
+5. Expired leases are reclaimable by any host.
+6. Workflow runtime-job claims select only `runtime_kind = remote_host` jobs.
+7. In-process runtime workers do not claim `remote_host` jobs.
+8. Runtime-job completion requires the host id and exact lease expiration
+   timestamp from the claim response. Upgraded clients also send the additive
+   lease generation; legacy clients may omit it.
+9. Runtime-job claim and renewal lease durations default to 60 seconds and
+   accept only `1..=3600` seconds.
+10. A draining host cannot claim or renew work. Heartbeat only updates host
+    liveness and never extends a job lease.
 
 ## API Response Shape
 
 `GET /api/runtime-hosts`
 - `hosts: [{ id, display_name, capabilities, registered_at, last_heartbeat_at, online, lifecycle }]`
 - `online` is computed as `now - last_heartbeat_at <= heartbeat_timeout_secs`
-
-`POST /api/runtime-hosts/{id}/tasks/claim`
-- success: `{ claimed: true, task_id, lease_expires_at }`
-- none available: `{ claimed: false }`
 
 `POST /api/runtime-hosts/{id}/runtime-jobs/claim`
 - request: `{ lease_secs?: number }`
@@ -118,8 +112,8 @@ Stop remote clients from calling renewal before disabling the renew route. The a
 ## Risks
 
 1. Claim fairness is best-effort because pending selection is linear scan.
-2. Host state is lightweight; legacy task lease truth is intentionally owned by the task store.
-3. Workflow runtime-job lease truth is owned by `WorkflowRuntimeStore`.
+2. Host state is lightweight; workflow runtime-job lease truth is owned by
+   `WorkflowRuntimeStore`.
 
 ## Verification
 
@@ -127,8 +121,8 @@ Stop remote clients from calling renewal before disabling the renew route. The a
 - registration upserts host metadata
 - heartbeat updates online status
 - stale heartbeat marks a host offline
-2. Task-store and handler tests:
+2. Runtime-host handler tests:
 - register + heartbeat + list returns online host
-- claim endpoint returns expected payload and prevents double-claim
+- runtime-job claim returns the expected payload and prevents double-claim
 - workflow runtime-job claim endpoint ignores local runtime jobs
 - workflow runtime-job completion accepts terminal `ActivityResult` only when the exact lease is still owned by that host

--- a/docs/runtime-submission-identity-contract.md
+++ b/docs/runtime-submission-identity-contract.md
@@ -2,190 +2,124 @@
 
 Issue: #1127
 
-This document defines the identity model for runtime-owned submissions and the
-compatibility rules that must stay in place while Harness migrates away from
-legacy task-row semantics.
+This document defines the identity model after removal of the legacy task HTTP
+compatibility layer. Workflow-runtime state is authoritative for every public
+submission route.
 
 ## Terms
 
 ### `workflow_id`
 
-`workflow_id` is the workflow runtime instance id. It identifies the state
-machine row in `WorkflowRuntimeStore` and is the authoritative handle for
-workflow-runtime operations:
+`workflow_id` identifies the state-machine instance in
+`WorkflowRuntimeStore`. Use it for workflow actions and correlation:
 
-- runtime cancellation
-- runtime merge or approve actions
+- cancel, merge, unblock, and retry
 - runtime tree inspection
 - workflow event, decision, command, and job correlation
 
-`workflow_id` is not a legacy task row id and must not be used as a `/tasks/{id}`
-path parameter unless an endpoint explicitly documents workflow-id addressing.
+Do not use a `workflow_id` as a submission path parameter unless a route
+explicitly documents workflow-id addressing.
 
 ### `submission_id`
 
-`submission_id` is the long-term public submission handle. It identifies the
-operator-facing submission across task-compatible routes such as detail, stream,
-proof, artifacts, and prompts.
+`submission_id` is the public handle for an operator-facing submission. Use it
+with list-derived links for detail, stream, proof, artifacts, and prompts.
 
-During the migration, existing runtime workflows may not have a stored
-`submission_id`. For those rows, the compatibility submission handle is:
-
-1. the first string in `data.task_ids`, when present
-2. otherwise `data.task_id`
-
-That rule preserves links created before explicit `submission_id` support while
-still allowing newer `data.task_id` values to be recorded as retry or
-resubmission correlation handles.
+Historical runtime rows created before explicit submission ids may derive the
+handle from the first string in `data.task_ids`, or from `data.task_id` when the
+array is absent. That lookup rule preserves old runtime links; it does not imply
+that a legacy task row exists.
 
 ### `task_id`
 
-`task_id` has two meanings today:
+`task_id` is a deprecated response alias for `submission_id`. Runtime responses
+keep the alias for serialized-client compatibility, but callers must not infer
+task-store ownership from it. New clients should persist `submission_id` and
+`workflow_id` instead.
 
-- for legacy task-runner rows, it is the real `TaskStore` row id
-- for runtime-owned submissions, it is a compatibility alias for the submission
-  handle
+### `request_id`
 
-New runtime-owned API contracts must treat `task_id` as an alias only. The
-presence of `task_id` in a runtime response must not imply that a legacy
-`TaskStore` row exists.
+`request_id` identifies the accepted intake request. It may differ from the
+stable public submission handle after a retry or resubmission. It is a
+correlation value, not a detail-route handle.
 
-### Runtime Workspace Task Id
+### Runtime workspace task id
 
 Runtime worktree leases may use synthetic workspace ids such as
-`runtime-wf-...`. Those ids are workspace lease identifiers, not public
-submission handles. Worktree cards must carry `workflow_id` separately when a
-runtime workflow owns the lease.
+`runtime-wf-...`. Those ids identify workspace leases only. They are neither
+submission handles nor workflow ids.
 
-## API Contract
+## HTTP Contract
 
-### `POST /tasks`
+### Create and list
 
-Runtime-owned issue and prompt submissions return:
+`POST /api/workflows/runtime/submissions` returns an accepted runtime
+submission with:
 
 - `execution_path: "workflow_runtime"`
 - `workflow_id`
-- `task_id` as the current compatibility alias
+- `submission_id`
+- `task_id`, equal to `submission_id`, as a deprecated alias
+- `request_id`
 
-After #1128, runtime-owned submissions should also return `submission_id`.
-During the migration, `submission_id` and `task_id` must be equal for runtime
-responses.
+`GET /api/workflows/runtime/submissions` lists only workflow-runtime
+projections. Every row exposes the public submission handle and the underlying
+workflow identity needed by dashboard actions.
 
-Legacy task-runner submissions may keep returning only `task_id` when no
-runtime workflow exists.
+### Detail and evidence
 
-### `GET /tasks`
+The following routes address `{id}` as a submission handle:
 
-Runtime-owned rows returned by the list endpoint must expose enough identity for
-all dashboard actions:
+- `GET /api/workflows/runtime/submissions/{id}`
+- `GET /api/workflows/runtime/submissions/{id}/stream`
+- `GET /api/workflows/runtime/submissions/{id}/proof`
+- `GET /api/workflows/runtime/submissions/{id}/artifacts`
+- `GET /api/workflows/runtime/submissions/{id}/prompts`
 
-- `workflow_id` for workflow-runtime actions
-- `submission_id` once #1128 lands
-- `task_id` as a temporary compatibility alias
-- `execution_path: "workflow_runtime"`
+Rows with an explicit `submission_id` resolve through that value. Historical
+runtime rows may continue to resolve through the pre-existing alias derivation
+described above. All data comes from workflow-runtime state and must not require
+a legacy `TaskStore` row.
 
-Legacy task rows keep `task_id` as the primary id and omit `workflow_id`.
+### Workflow actions
 
-### `GET /tasks/{id}`
+Use `workflow_id`, not a submission handle, with these authenticated actions:
 
-The `{id}` parameter addresses a submission handle during migration:
+- `POST /api/workflows/runtime/cancel`
+- `POST /api/workflows/runtime/merge`
+- `POST /api/workflows/runtime/unblock`
+- `POST /api/workflows/runtime/retry`
 
-- runtime-owned rows with explicit `submission_id` resolve by `submission_id`
-- persisted runtime rows without `submission_id` continue to resolve by the
-  historical `task_id` alias recorded in `data.task_ids` or `data.task_id`
-- legacy rows resolve by real `TaskStore` task id
+Live approval responses use the turn and request ids supplied by runtime events:
 
-The response for a runtime-owned row must include `workflow_id` so clients do
-not need to infer runtime ownership from the path id.
+`POST /api/workflows/runtime/turns/{turn_id}/approvals/{request_id}`.
 
-### `GET /tasks/{id}/stream`
+## Removed Compatibility
 
-The stream route accepts the same submission handle as `GET /tasks/{id}`.
-Runtime-owned streams are resolved through workflow-runtime metadata and events.
-
-### `POST /tasks/{id}/cancel`
-
-This route remains a compatibility endpoint during migration. It may accept a
-runtime submission handle, but clients that have `workflow_id` must prefer:
-
-```text
-POST /api/workflows/runtime/cancel
-```
-
-with `workflow_id` in the request body.
-
-### `GET /tasks/{id}/proof`
-
-The proof route accepts the submission handle. Runtime-owned proof responses
-must include `workflow_id` as a quality signal or explicit field so proof
-consumers can trace the underlying workflow.
-
-### `GET /tasks/{id}/artifacts`
-
-The artifacts route accepts the submission handle. Runtime-owned artifact lookup
-must not require a legacy `TaskStore` row once #1128 lands.
-
-### `GET /tasks/{id}/prompts`
-
-The prompts route accepts the submission handle. Runtime-owned prompt lookup
-must not require a legacy `TaskStore` row once #1128 lands.
-
-## Migration Phases
-
-### Phase 0: Current Compatibility
-
-- Runtime workflows persist `data.task_id` and `data.task_ids`.
-- The public runtime submission handle is the compatibility handle derived from
-  `data.task_ids[0]` or `data.task_id`.
-- Historical handles in `data.task_ids` remain lookup aliases.
-- `task_id` in runtime API responses is an alias, not proof of a legacy row.
-
-### Phase 1: Add Explicit `submission_id`
-
-- Runtime workflow data gains `data.submission_id`.
-- New runtime workflow rows write `submission_id` at creation.
-- Existing rows derive `submission_id` from the Phase 0 compatibility handle.
-- Runtime responses include both `submission_id` and `task_id`.
-- `task_id` remains equal to `submission_id` for runtime-owned responses.
-
-### Phase 2: Prefer Runtime-Native Handles
-
-- Dashboard and SDK flows store `submission_id` for task-compatible routes.
-- Dashboard and SDK flows store `workflow_id` for runtime workflow actions.
-- Runtime-owned detail, stream, cancel, proof, artifacts, and prompts work
-  without a legacy task row.
-- Legacy task rows continue to use real `task_id` values.
-
-### Phase 3: Remove Legacy Compatibility
-
-- Remove runtime-owned reliance on `data.task_id` as the public handle.
-- Keep historical alias lookup only for persisted workflows that predate
-  `submission_id`; rows with explicit `submission_id` must not use retry
-  `task_id` values as public lookup aliases.
-- Remove `/tasks` compatibility branches that only exist to make runtime-owned
-  workflows look like legacy task rows.
+The `/tasks` create, batch, list, detail, stream, proof, artifact, prompt,
+cancel, and merge routes have been removed. Callers must not construct those
+paths from `task_id`. Batch callers submit each item separately to the runtime
+submission endpoint so every request receives its own durable workflow result.
 
 ## Route Ownership Rules
 
 - Use `workflow_id` for workflow-runtime actions.
-- Use `submission_id` for task-compatible read and stream routes.
-- Use `task_id` only for real legacy task rows or as a temporary response alias.
-- Do not use runtime workspace ids as submission handles.
-- Do not infer runtime ownership from id shape. Use `execution_path` or
-  `workflow_id`.
+- Use `submission_id` for submission read and stream routes.
+- Treat `task_id` as a deprecated serialized alias only.
+- Treat `request_id` as intake correlation only.
+- Do not use runtime workspace ids as public handles.
+- Do not infer ownership from id shape; use explicit response fields.
 
 ## Test Contract
 
-Contract tests must lock these invariants before #1128 and #1129 change the
-implementation:
+Contract tests lock these invariants:
 
-- runtime submissions preserve historical task handles for lookup
-- the Phase 0 compatibility handle is stable even if `data.task_id` changes on a
-  later resubmission
-- runtime create, list, detail, stream, cancel, proof, artifact, and prompt
-  routes document their identity ownership
-- runtime-owned responses expose `workflow_id`
-- runtime-owned flows do not require a legacy `TaskStore` row
-- rows with explicit `submission_id` resolve through that handle, while
-  historical `task_id` aliases remain limited to rows that predate
-  `submission_id`
+- new submissions persist and return stable `submission_id` values
+- `task_id` equals `submission_id` in runtime responses
+- retries do not change the public submission handle
+- historical runtime aliases remain resolvable
+- create, list, detail, stream, proof, artifact, and prompt routes do not depend
+  on a legacy task row
+- workflow actions require `workflow_id`
+- missing workflow-runtime persistence fails closed rather than returning
+  partial legacy data

--- a/docs/runtime-submission-identity-contract.md
+++ b/docs/runtime-submission-identity-contract.md
@@ -27,8 +27,10 @@ with list-derived links for detail, stream, proof, artifacts, and prompts.
 
 Historical runtime rows created before explicit submission ids may derive the
 handle from the first string in `data.task_ids`, or from `data.task_id` when the
-array is absent. That lookup rule preserves old runtime links; it does not imply
-that a legacy task row exists.
+array is absent. For those legacy rows, every existing string in
+`data.task_ids` remains a resolvable lookup alias, as does `data.task_id`. These
+lookup rules preserve old runtime links; they do not imply that a legacy task
+row exists.
 
 ### `task_id`
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -164,7 +164,7 @@ Response:
 
 ```json
 {
-  "status": "pending",
+  "status": "implementing",
   "execution_path": "workflow_runtime",
   "submission_id": "prompt-task:...",
   "task_id": "prompt-task:...",
@@ -172,9 +172,9 @@ Response:
 }
 ```
 
-The submission is accepted immediately and persisted as pending runtime work.
-Use `GET /api/workflows/runtime/submissions/{submission_id}` to observe when
-execution starts.
+The submission is accepted immediately and persisted as active runtime work in
+the `implementing` state. Use
+`GET /api/workflows/runtime/submissions/{submission_id}` to observe progress.
 
 ### By GitHub Issue
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -144,14 +144,14 @@ ANTHROPIC_API_KEY=sk-ant-xxx ./target/release/harness --config config/default.to
   --port 9800
 ```
 
-## Submitting Tasks
+## Submitting Work
 
 ### By Prompt
 
 For ad-hoc work without a GitHub issue:
 
 ```bash
-curl -X POST http://127.0.0.1:9800/tasks \
+curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H "Content-Type: application/json" \
   -d '{
     "project": "/path/to/project",
@@ -163,18 +163,25 @@ curl -X POST http://127.0.0.1:9800/tasks \
 Response:
 
 ```json
-{ "status": "queued", "task_id": "a1b2c3d4-..." }
+{
+  "status": "pending",
+  "execution_path": "workflow_runtime",
+  "submission_id": "prompt-task:...",
+  "task_id": "prompt-task:...",
+  "workflow_id": "workflow-..."
+}
 ```
 
-The task is accepted immediately and registered as pending work. Use
-`GET /tasks/{task_id}` to observe when execution actually starts.
+The submission is accepted immediately and persisted as pending runtime work.
+Use `GET /api/workflows/runtime/submissions/{submission_id}` to observe when
+execution starts.
 
 ### By GitHub Issue
 
 The agent reads the issue title and body, then implements it:
 
 ```bash
-curl -X POST http://127.0.0.1:9800/tasks \
+curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H "Content-Type: application/json" \
   -d '{
     "project": "/path/to/project",
@@ -188,7 +195,7 @@ curl -X POST http://127.0.0.1:9800/tasks \
 For reviewing or fixing an existing PR:
 
 ```bash
-curl -X POST http://127.0.0.1:9800/tasks \
+curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H "Content-Type: application/json" \
   -d '{
     "project": "/path/to/project",
@@ -196,31 +203,21 @@ curl -X POST http://127.0.0.1:9800/tasks \
   }'
 ```
 
-### Batch Submit
+### Submit Multiple Issues
 
-Submit multiple issues at once:
+The removed `/tasks/batch` compatibility route has no direct replacement.
+Submit each issue separately so each request receives a durable runtime result:
 
 ```bash
-curl -X POST http://127.0.0.1:9800/tasks/batch \
-  -H "Content-Type: application/json" \
-  -d '{
-    "project": "/path/to/project",
-    "issues": [10, 11, 12, 13]
-  }'
+for issue in 10 11 12 13; do
+  curl -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
+    -H "Content-Type: application/json" \
+    -d "{\"project\":\"/path/to/project\",\"issue\":$issue}"
+done
 ```
 
-Response:
-
-```json
-[
-  { "task_id": "...", "status": "queued" },
-  { "task_id": "...", "status": "queued" },
-  { "task_id": "...", "status": "queued" },
-  { "task_id": "...", "status": "queued" }
-]
-```
-
-Tasks respect concurrency limits — excess tasks are queued.
+Runtime submissions respect project and review concurrency limits. Excess work
+remains pending until a worker acquires the corresponding queue permit.
 
 ## Monitoring
 
@@ -258,14 +255,14 @@ curl -s http://127.0.0.1:9800/api/dashboard | python3 -m json.tool
 }
 ```
 
-### Task Status
+### Submission Status
 
 ```bash
-# Single task
-curl http://127.0.0.1:9800/tasks/{task_id}
+# Single submission
+curl http://127.0.0.1:9800/api/workflows/runtime/submissions/{submission_id}
 
-# All tasks
-curl http://127.0.0.1:9800/tasks
+# All submissions
+curl http://127.0.0.1:9800/api/workflows/runtime/submissions
 ```
 
 ### SSE Streaming
@@ -273,7 +270,7 @@ curl http://127.0.0.1:9800/tasks
 Stream real-time output from a running task:
 
 ```bash
-curl -N http://127.0.0.1:9800/tasks/{task_id}/stream
+curl -N http://127.0.0.1:9800/api/workflows/runtime/submissions/{submission_id}/stream
 ```
 
 ### Health Check
@@ -551,21 +548,17 @@ Tempo walkthrough.
 | `default_agent` | no | — | Override `agents.default_agent` for this project |
 | `max_concurrent` | no | — | Override `concurrency.max_concurrent_tasks` for this project |
 
-## Task Execution Pipeline
+## Workflow Runtime Execution Pipeline
 
 ```
-1. POST /tasks                    → validate request, resolve project
-2. TaskQueue.acquire()            → acquire per-project + global semaphore
-3. WorkspaceManager.create()      → create isolated git worktree
-4. Agent.execute_stream()         → agent runs in worktree (Claude/Codex/API)
-5. PostValidator.run()            → cargo fmt, cargo check (language-detected)
-   └─ on failure: retry up to max_retries, agent fixes issues
-6. Agent creates PR               → git push + gh pr create
-7. Codex review                   → independent review, up to max_rounds
-   └─ on issues: agent fixes → Codex re-reviews → repeat
-8. QualityGrader.score()          → compute quality grade (A/B/C/D/F)
-9. WorkspaceManager.cleanup()     → remove worktree
-10. Task status → done/failed
+1. POST /api/workflows/runtime/submissions → validate request and resolve project
+2. WorkflowRuntimeStore                  → persist workflow and implementation command
+3. Runtime dispatcher                    → claim the command and create a runtime job
+4. Runtime worker                        → acquire the project queue permit
+5. WorkspaceManager.create()             → create an isolated git worktree
+6. Agent executes                        → stream work through the configured agent adapter
+7. Runtime validation/review             → persist evidence and follow-up commands
+8. Workflow terminal transition          → expose done, failed, blocked, or cancelled state
 ```
 
 ## Workflow Runtime Recovery API
@@ -619,8 +612,8 @@ Every 24 hours, runs `RuleEngine::scan()` on the project root:
 
 ### Workflow Runtime Sweepers
 
-The watchdog is read-only; runtime and task retention remain disabled by
-default. Configure and roll them out in that order using
+The watchdog is read-only; workflow-runtime recovery remains opt-in. Configure
+it using
 [Workflow Runtime Operations](workflow-runtime-operations.md). See
 [Postgres Schema Cleanup](postgres-schema-cleanup.md) for orphan schema reaping.
 

--- a/docs/workflow-multi-project-batch.md
+++ b/docs/workflow-multi-project-batch.md
@@ -53,7 +53,7 @@ Example for vibeguard:
 ### By prompt (for new work)
 
 ```bash
-curl -s -X POST http://127.0.0.1:9800/tasks \
+curl -s -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H 'Content-Type: application/json' \
   -d '{
     "project": "/path/to/project",
@@ -65,7 +65,7 @@ curl -s -X POST http://127.0.0.1:9800/tasks \
 ### By issue number (for existing GitHub issues)
 
 ```bash
-curl -s -X POST http://127.0.0.1:9800/tasks \
+curl -s -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H 'Content-Type: application/json' \
   -d '{
     "project": "/path/to/project",

--- a/docs/workflow-runtime-decoupling-plan.md
+++ b/docs/workflow-runtime-decoupling-plan.md
@@ -1,5 +1,10 @@
 # Workflow Runtime Decoupling Plan
 
+> Historical migration record: `/tasks` references below document the
+> compatibility path used while the workflow runtime was being decoupled. PR
+> #1706 removed those routes; the current public surface is
+> `/api/workflows/runtime/submissions` plus workflow-runtime action endpoints.
+
 ## Goal
 
 Split Harness into two explicit layers:

--- a/docs/workflow-runtime-operations.md
+++ b/docs/workflow-runtime-operations.md
@@ -56,11 +56,11 @@ definition-id collisions. Each instance is pinned to the declaration's SHA-256
 content hash; an instance whose pinned version is unavailable blocks with
 `definition_version_missing` instead of running under a changed shape.
 
-Submit the registered workflow through the normal task endpoint. Declarative
-v1 submissions do not support `depends_on`.
+Submit the registered workflow through the runtime submission endpoint.
+Declarative v1 submissions do not support `depends_on`.
 
 ```bash
-curl -sS -X POST http://127.0.0.1:9800/tasks \
+curl -sS -X POST http://127.0.0.1:9800/api/workflows/runtime/submissions \
   -H "Authorization: Bearer ${HARNESS_API_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/workflow-runtime-v2-state-machine-spec.md
+++ b/docs/workflow-runtime-v2-state-machine-spec.md
@@ -1,5 +1,10 @@
 # Workflow Runtime V2 State Machine Spec
 
+> Historical design record: references to `/tasks` and live legacy task rows
+> describe the pre-GH-1434 migration state. The compatibility routes and legacy
+> orchestration branches were removed in PR #1706. Current clients use
+> `/api/workflows/runtime/submissions` and workflow-runtime action endpoints.
+
 Status: Draft v1
 Date: 2026-05-21
 Compatibility: no backward compatibility with live legacy task orchestration

--- a/specs/GH1434/product.md
+++ b/specs/GH1434/product.md
@@ -70,17 +70,17 @@ direction is direct deletion after safety evidence, not plugin extraction.
 
 - [x] Usage probes have landed for the Phase 1 target surfaces. PR #1453 added
       `UsageProbe`, `probe_report`, and target-surface instrumentation.
-- [ ] Deletion PRs cite at least 7 days of zero-count `probe_report` evidence
+- [x] Deletion PRs cite at least 7 days of zero-count `probe_report` evidence
       or a maintainer waiver recorded on GH-1434 with scope and reason.
-- [ ] Thread/task archive execution has produced dump artifacts and restore
+- [x] Thread/task archive execution has produced dump artifacts and restore
       instructions before related code is removed.
-- [ ] After all removal PRs merge, `harness-eval` is no longer a workspace
+- [x] After all removal PRs merge, `harness-eval` is no longer a workspace
       member, `review_store` is gone, removable thread/turn and task layers are
       gone, and no dangling protocol/router/CLI/dashboard references remain.
-- [ ] The final Phase 1 summary reports net deleted LOC. The expected target is
+- [x] The final Phase 1 summary reports net deleted LOC. The expected target is
       more than 10,000 net deleted LOC.
-- [ ] `cargo test --workspace` exits 0.
-- [ ] Smoke checks pass: serve startup, status, `pr fix --help`, webhook
+- [x] `cargo test --workspace` exits 0.
+- [x] Smoke checks pass: serve startup, status, `pr fix --help`, webhook
       health, and dashboard first viewport.
 
 ## Edge Cases
@@ -93,16 +93,14 @@ direction is direct deletion after safety evidence, not plugin extraction.
 - `thread_manager` has a hot in-memory role for workflow-runtime jobs. Phase 1
   may delete thread/turn RPCs and `thread_db` persistence, but the in-memory
   role must remain or be inlined safely.
-- The dashboard currently uses `/tasks` as a compatibility surface for
-  workflow-runtime submission handles, details, logs, proof, and artifacts.
-  Deleting those consumers before equivalent runtime APIs exist would regress
-  the dashboard.
+- Before `SP1434-T006`, the dashboard used `/tasks` as a compatibility surface
+  for workflow-runtime submission handles, details, logs, proof, and artifacts.
+  The consumer migration landed before those compatibility routes were removed.
 - CLI compatibility changes for thread/turn/task endpoints are breaking
   changes and must be documented.
 
 ## Rollout Notes
 
-PR #1453 provided the probe and archive-script prerequisite, but the 7-day
-deletion gate is not satisfied as of 2026-07-05. Future removal PRs must either
-attach fresh zero-count probe evidence from the required window or cite an
-explicit maintainer waiver comment on GH-1434.
+PR #1453 provided the probe and archive-script prerequisite. The removal series
+used the scoped maintainer waivers recorded on GH-1434, preserved the archived
+database tables, and completed consumer migration before endpoint deletion.

--- a/specs/GH1434/tasks.md
+++ b/specs/GH1434/tasks.md
@@ -18,9 +18,9 @@ GH-1434
 - [x] `SP1434-T005` Owner: `server` | Dependencies: `SP1434-T003` | Done when: `review_store` modules and router/handler references are removed | Verify: `cargo test --workspace && test "$(rg -l review_store crates | wc -l)" -eq 0`
 - [x] `SP1434-T006` Owner: `consumers` | Dependencies: runtime replacement APIs for any live compatibility behavior being moved | Done when: CLI, dashboard, and websocket references to thread/turn/task endpoints are removed or repointed to workflow-runtime equivalents before the old endpoints are deleted | Verify: `cargo test --workspace` plus dashboard first-viewport smoke
 - [x] `SP1434-T007` Owner: `server` | Dependencies: `SP1434-T003`, `SP1434-T006` | Done when: thread/turn RPC methods are removed from protocol definitions, router registration, and handlers; thread persistence is removed; the live in-memory role is retained or safely inlined | Verify: `cargo test --workspace && ! rg 'Thread(Start|Resume|Fork|List|Delete|Compact)|Turn(Start|Steer|Cancel|Status|RespondApproval)' crates/harness-protocol/src/methods.rs && ! rg 'Method::(Thread(Start|Resume|Fork|List|Delete|Compact)|Turn(Start|Steer|Cancel|Status|RespondApproval))' crates/harness-server/src/router crates/harness-server/src/handlers && ! rg 'thread_db|ThreadDb' crates --glob '!CHANGELOG.md'`
-- [ ] `SP1434-T008` Owner: `server` | Dependencies: `SP1434-T003`, `SP1434-T006`, extraction evidence for live workflow-runtime turn-engine dependencies | Done when: dependency scanning identifies live `task_*` references; live pieces are moved without semantic changes into workflow-runtime-adjacent modules; removable task-layer code is deleted | Verify: `cargo test --workspace` plus a PR migration table showing moved code and unchanged behavior
-- [ ] `SP1434-T009` Owner: `docs` | Dependencies: all removal PRs | Done when: CHANGELOG documents removed RPC methods, task endpoint compatibility changes, and archive/restore instructions; final summary reports net deleted LOC | Verify: reviewer checks method list and `git diff --shortstat`
-- [ ] `SP1434-T010` Owner: `tests` | Dependencies: all removal PRs | Done when: full workspace tests, clippy, and smoke checks pass | Verify: `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `SP1434-T008` Owner: `server` | Dependencies: `SP1434-T003`, `SP1434-T006`, extraction evidence for live workflow-runtime turn-engine dependencies | Done when: dependency scanning identifies live `task_*` references; live pieces are moved without semantic changes into workflow-runtime-adjacent modules; removable task-layer code is deleted | Verify: `cargo test --workspace` plus a PR migration table showing moved code and unchanged behavior
+- [x] `SP1434-T009` Owner: `docs` | Dependencies: all removal PRs | Done when: CHANGELOG documents removed RPC methods, task endpoint compatibility changes, and archive/restore instructions; final summary reports net deleted LOC | Verify: reviewer checks method list and `git diff --shortstat`
+- [x] `SP1434-T010` Owner: `tests` | Dependencies: all removal PRs | Done when: full workspace tests, clippy, and smoke checks pass | Verify: `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings`
 
 ## Parallelization
 
@@ -45,22 +45,22 @@ GH-1434
 
 - PR #1453 is the evidence for `SP1434-T001` and the archive tooling. Archive
   execution completed on 2026-07-16 at `archives/phase1-20260716T092438Z`.
+  The scoped T007/T008 maintainer waiver records the archive/restore evidence
+  as complete:
+  <https://github.com/majiayu000/harness/issues/1434#issuecomment-5006185197>.
 - The explicit maintainer waiver on GH-1434 satisfies `SP1434-T003` for T004
   and T005 based on the recorded zero-traffic evidence and completed archive:
   <https://github.com/majiayu000/harness/issues/1434#issuecomment-4993856096>.
-- Dashboard `/tasks` references are live compatibility paths for
-  workflow-runtime submission handles, details, streams, proof, artifacts,
-  merge, and cancel. Do not remove them until equivalent runtime APIs exist and
-  tests cover the replacement.
+- Dashboard consumers moved from `/tasks` to runtime-native submission routes in
+  `SP1434-T006`; PR #1706 subsequently removed the compatibility paths.
 - The GH-1434 maintainer comment from 2026-07-03 narrows the deletion boundary:
   `task_executor/turn_lifecycle.rs` and `task_executor/helpers.rs` are live,
   and the in-memory `thread_manager` role is live. Treat that as boundary
   evidence, not as a broad deletion waiver.
 - The GH-1434 gate comment from 2026-07-05 records that deletion PRs need either
   7 days of probe evidence or an explicit waiver with scope and reason.
-- `/tasks` is currently a workflow-runtime compatibility API for dashboard
-  submission handles and observation. Removing it requires replacement runtime
-  APIs first.
+- `/api/workflows/runtime/submissions` is now the only public submission list,
+  detail, and stream surface. Workflow actions use `workflow_id`.
 - `SP1434-T004` landed under the explicit maintainer waiver recorded on GH-1434
   (<https://github.com/majiayu000/harness/issues/1434#issuecomment-4993856096>),
   which waives the 7-day probe window for T004/T005 based on zero-count
@@ -90,3 +90,17 @@ GH-1434
   submissions, live approval responses use the authenticated runtime HTTP
   endpoint, and the unwritten context-manifest getter is removed with its sole
   legacy writer.
+- `SP1434-T008` landed in PR #1706. The legacy `/tasks` compatibility routes,
+  background recovery loops, task retention, and legacy remote-host task claim
+  path are removed. Runtime submission request/state models now live beside the
+  workflow-runtime submission layer. Review/planner execution policy and review
+  queue serialization remain enforced by the workflow runtime.
+- `SP1434-T009` records the exact removed RPC and HTTP compatibility surfaces,
+  the archive restore safety contract, and the Phase 1 implementation total:
+  34,156 deletions minus 11,246 additions equals 22,910 net deleted lines
+  across PRs #1663, #1701, #1702, #1703, and #1706.
+- `SP1434-T010` passed `cargo fmt --all -- --check`,
+  `cargo clippy --workspace --all-targets -- -D warnings`, PostgreSQL-backed
+  `cargo test --workspace`, both SpecRail checks, and runtime smoke for serve,
+  status, `pr fix --help`, health, dashboard first viewport, runtime submission
+  list, intake status, and a signed GitHub webhook ping.

--- a/specs/GH1434/tasks.md
+++ b/specs/GH1434/tasks.md
@@ -45,9 +45,10 @@ GH-1434
 
 - PR #1453 is the evidence for `SP1434-T001` and the archive tooling. Archive
   execution completed on 2026-07-16 at `archives/phase1-20260716T092438Z`.
-  The scoped T007/T008 maintainer waiver records the archive/restore evidence
-  as complete:
-  <https://github.com/majiayu000/harness/issues/1434#issuecomment-5006185197>.
+  The archive comment records dump creation, restore instructions, and table
+  counts, but neither it nor the scoped T007/T008 waiver records an executed
+  scratch restore. The referenced operator-owned archive is not present in this
+  PR worktree, so this PR does not claim restore rehearsal completion.
 - The explicit maintainer waiver on GH-1434 satisfies `SP1434-T003` for T004
   and T005 based on the recorded zero-traffic evidence and completed archive:
   <https://github.com/majiayu000/harness/issues/1434#issuecomment-4993856096>.

--- a/specs/GH1434/tech.md
+++ b/specs/GH1434/tech.md
@@ -91,13 +91,15 @@ merge, and cancel before the compatibility endpoint can be removed.
 
 - [x] Probe tests for `UsageProbe` and `probe_report` behavior landed with
       PR #1453.
-- [ ] Removal PRs run focused package tests for the touched crate or module.
-- [ ] Removal PRs run `cargo test --workspace`.
-- [ ] Final readiness runs `cargo clippy --workspace --all-targets -- -D warnings`.
-- [ ] Smoke checks cover serve startup, status, `pr fix --help`, webhook health,
+- [x] Removal PRs run focused package tests for the touched crate or module.
+- [x] Removal PRs run `cargo test --workspace`.
+- [x] Final readiness runs `cargo clippy --workspace --all-targets -- -D warnings`.
+- [x] Smoke checks cover serve startup, status, `pr fix --help`, webhook health,
       and dashboard first viewport.
-- [ ] Archive restore is exercised against a temporary database before deleting
-      related code.
+- [x] Archive restore is exercised against a temporary database before deleting
+      related code. The maintainer records the archive/restore evidence as
+      complete in the scoped T007/T008 waiver:
+      <https://github.com/majiayu000/harness/issues/1434#issuecomment-5006185197>.
 
 ## Rollback Plan
 

--- a/specs/GH1434/tech.md
+++ b/specs/GH1434/tech.md
@@ -96,10 +96,12 @@ merge, and cancel before the compatibility endpoint can be removed.
 - [x] Final readiness runs `cargo clippy --workspace --all-targets -- -D warnings`.
 - [x] Smoke checks cover serve startup, status, `pr fix --help`, webhook health,
       and dashboard first viewport.
-- [x] Archive restore is exercised against a temporary database before deleting
-      related code. The maintainer records the archive/restore evidence as
-      complete in the scoped T007/T008 waiver:
-      <https://github.com/majiayu000/harness/issues/1434#issuecomment-5006185197>.
+- [x] Archive creation produced a dump, restore instructions, and table counts
+      before related code was deleted, as recorded in the archive evidence:
+      <https://github.com/majiayu000/harness/issues/1434#issuecomment-4990260785>.
+- [ ] A scratch-database restore rehearsal is not evidenced. The referenced
+      operator-owned archive is not present in this PR worktree, and the scoped
+      waiver does not include restore command output or row-count comparisons.
 
 ## Rollback Plan
 

--- a/specs/GH1437/product.md
+++ b/specs/GH1437/product.md
@@ -32,7 +32,7 @@ GH-1437
 ## Acceptance Criteria
 
 - [ ] With a simulated silent agent stream, the turn fails with a stall reason within the stall window (not after 3600 s).
-- [ ] Failure reason strings differ between stall and wall-clock timeout; both appear in `GET /tasks` failure output.
+- [ ] Failure reason strings differ between stall and wall-clock timeout; both appear in runtime submission detail output from `GET /api/workflows/runtime/submissions/{id}`.
 - [ ] Default config ships a stall window ≤ 15 min while wall-clock stays 3600 s; `config/default.toml.example` documents both.
 - [ ] Workflow runtime (codex_exec) jobs demonstrate the same stall abort in a test.
 

--- a/specs/GH1437/tech.md
+++ b/specs/GH1437/tech.md
@@ -33,7 +33,7 @@ See `specs/GH1437/product.md`.
 | P1 stall aborts early | `turn_lifecycle.rs` + shared driver | Mock stream: no items → failure within window (test clock) |
 | P2 default ordering enforced | `config/misc.rs` validation | Unit test: equal/larger stall default clamps + warns |
 | P3 activity resets clock | stall arm reset on item | Test: item every window/2 → runs to wall-clock |
-| P4 distinct reasons | failure strings | Assert both strings; `GET /tasks` fixture |
+| P4 distinct reasons | failure strings | Assert both strings in the runtime submission detail fixture |
 | P5 uniform coverage | workflow runtime path | Runtime-job test with silent codex_exec stream |
 | P6 override clamped | `task_runner/request.rs` | Unit test: override > wall-clock → clamped with warning |
 
@@ -58,7 +58,7 @@ Input: agent stream items (stdout/events) per turn; config `concurrency.stall_ti
 
 - [ ] Unit tests: config validation/clamping, floor, override clamp.
 - [ ] Integration tests: silent stream stall abort (task executor and workflow runtime paths), activity-reset behavior, post-abort late-result rejection.
-- [ ] Manual verification: replay a proxy-drop window locally (kill upstream mid-turn) and confirm failure within the stall window with the stall reason in `GET /tasks`.
+- [ ] Manual verification: replay a proxy-drop window locally (kill upstream mid-turn) and confirm failure within the stall window with the stall reason in `GET /api/workflows/runtime/submissions/{id}`.
 
 ## Rollback Plan
 


### PR DESCRIPTION
## Summary

- document the removed Harness JSON-RPC thread/turn methods and the runtime-native HTTP replacements for every legacy task compatibility route
- update active agent instructions, operational guidance, and the GH-1437 spec to use `/api/workflows/runtime/submissions`
- replace the stale identity-contract test with assertions for the complete runtime-native API and an explicit removed-compatibility boundary
- close the documentation and contract portions of SP1434-T008 through T010 without claiming an unproven archive restore rehearsal

## HTTP migration

| Removed | Replacement |
| --- | --- |
| task submission | `POST /api/workflows/runtime/submissions` |
| task list | `GET /api/workflows/runtime/submissions` |
| task detail and evidence/stream suffixes | `/api/workflows/runtime/submissions/{id}` with the corresponding suffix |
| task cancellation | `POST /api/workflows/runtime/cancel` with `workflow_id` |
| task merge approval | `POST /api/workflows/runtime/merge` with `workflow_id` |
| batch task submission | submit each item separately to the runtime endpoint |
| runtime-host task claim | `/api/runtime-hosts/{id}/runtime-jobs/claim` |

## Phase 1 evidence

PRs #1663, #1701, #1702, #1703, and #1706 contain 34,156 deletions and 11,246 additions: **22,910 net deleted lines**.

Archive creation is recorded in the GH-1434 archive comment: it reports a dump, restore instructions, and table counts at `archives/phase1-20260716T092438Z`. Neither that comment nor the later scoped waiver contains an executed scratch restore, PostgreSQL restore output, or row-count comparison. The operator-owned archive is not present in this checkout, so this PR deliberately does not claim that a restore rehearsal completed.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p harness-server --test runtime_submission_identity_contract`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1434`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1437`
- pre-push workspace checks
- independent exact-head documentation and evidence review

Refs #1434
