### PR TITLE
docs(spec): define GitHub coverage recovery contract

### DIFF
--- a/specs/GH1707/product.md
+++ b/specs/GH1707/product.md
@@ -15,8 +15,9 @@ as the coverage authority after recovery.
 
 ## Goals
 
-- Reconstruct issue coverage from authoritative GitHub issue and pull-request
-  facts when local runtime coverage is absent.
+- Reconstruct issue coverage from GitHub GraphQL
+  `issue.closedByPullRequestsReferences` and complete pull-request facts when
+  local runtime coverage is absent.
 - Persist the recovered issue-to-PR binding and server-owned PR evidence.
 - Resume the workflow in the state implied by current PR facts without
   dispatching implementation work.
@@ -33,18 +34,22 @@ as the coverage authority after recovery.
 
 ## User-Visible Behavior
 
-1. **B-001:** With no local runtime coverage, an open issue with an
-   authoritative open closing PR is covered and produces zero
-   `implement_issue` jobs.
+1. **B-001:** With no local runtime coverage, an open issue with an eligible
+   active PR in the complete GitHub GraphQL
+   `issue.closedByPullRequestsReferences` connection is covered and produces
+   zero `implement_issue` jobs.
 2. **B-002:** Recovery persists the issue-to-PR binding and a server-owned PR
    fact snapshot before reporting the issue covered.
-3. **B-003:** An open PR is reconstructed as `pr_open`,
-   `awaiting_feedback`, or `ready_to_merge` according to its current checks,
-   review, and merge facts.
+3. **B-003:** Recovery applies this exact state matrix: waiting checks or
+   mergeability becomes `pr_open`; CI or review repair becomes
+   `awaiting_feedback`; a ready snapshot becomes `quality_gate_pending` and
+   starts the quality gate; only a successful quality gate may later advance
+   it to `ready_to_merge`.
 4. **B-004:** A merged PR plus a closed issue reconstructs terminal evidence
    and produces zero implementation or repair agent jobs.
-5. **B-005:** A closed-unmerged PR does not cover the issue; a later valid PR
-   may independently restore coverage.
+5. **B-005:** Neither a closed-unmerged PR nor a merged PR while the issue is
+   still open is durable coverage; a later eligible active PR, or a merged PR
+   observed with the issue closed, may independently restore coverage.
 6. **B-006:** Repeated polls and restart recovery are idempotent: they preserve
    one binding, one current workflow state, and no duplicate agent work.
 7. **B-007:** A cancelled or stale local workflow cannot override a current
@@ -53,10 +58,17 @@ as the coverage authority after recovery.
 8. **B-008:** GitHub HTTP, GraphQL, pagination, parsing, or completeness
    failures are visible errors and fail closed for that intake poll. Partial
    scans must never be interpreted as “no closing PR exists.”
-9. **B-009:** Closing references are repository-qualified and exact; unrelated
-   issue numbers, cross-repository references, or non-closing mentions do not
-   create coverage.
-10. **B-010:** Concurrent/repeated recovery attempts converge without duplicate
+9. **B-009:** The complete, repository-qualified GraphQL issue-link connection
+   is the only closing-relation authority. A linked PR needs no closing keyword
+   in its title or body; REST keyword matches, unrelated issue numbers,
+   cross-repository links, and non-closing mentions without an authoritative
+   issue link do not create coverage.
+10. **B-010:** After complete snapshots are collected for every same-repository
+    linked candidate, selection is independent of GraphQL/API order: when the
+    issue is closed, eligible merged candidates outrank eligible active
+    candidates; otherwise only eligible active candidates qualify; the highest
+    PR number wins within the selected class. Barrier-synchronized concurrent
+    and repeated attempts must converge on that candidate without duplicate
     commands, regressed terminal state, or overwritten newer evidence.
 
 ## Acceptance Criteria
@@ -66,7 +78,15 @@ as the coverage authority after recovery.
 - [ ] The Remem canary scenario—empty store plus open closing PR—reconstructs
       coverage with zero `implement_issue` jobs.
 - [ ] Open, feedback, ready, merged, and closed-unmerged PR states are covered.
+- [ ] A ready snapshot first reconstructs `quality_gate_pending`; a passing
+      quality gate is the only tested path from that state to `ready_to_merge`.
+- [ ] Merged-plus-open is tested as uncovered, while merged-plus-closed is
+      tested as terminal `done` coverage.
+- [ ] Reversed GraphQL candidate orders select the same precedence class and
+      highest PR number.
 - [ ] Restart and repeated-poll tests prove idempotency.
+- [ ] A barrier-controlled concurrency test proves simultaneous recovery
+      attempts converge on one binding and one deduplicated command set.
 - [ ] GitHub failures, page-limit exhaustion, and repeated pagination URLs all
       fail closed.
 - [ ] Exact-head CI, independent review, review-thread audit, and SpecRail PR
@@ -79,7 +99,7 @@ as the coverage authority after recovery.
 | Empty / missing input | Covered by B-001, B-008, and B-009. |
 | Error and failure paths | Covered by B-008. |
 | Authorization / permission | Covered by B-008; unavailable or unauthorized GitHub reads cannot authorize dispatch. |
-| Concurrency / race / ordering | Covered by B-002 and B-010. |
+| Concurrency / race / ordering | Covered by B-002 and B-010, including order-independent candidate arbitration and a barrier-controlled race. |
 | Retry / repetition / idempotency | Covered by B-006 and B-010. |
 | Illegal state transitions | Covered by B-003, B-004, B-005, and B-007. |
 | Compatibility / migration | Covered by B-006 and B-007 for empty or stale local stores. |
@@ -89,12 +109,18 @@ as the coverage authority after recovery.
 
 ## Edge Cases
 
-- GraphQL reports no closing link while REST finds an exact closing keyword.
-- A closing-reference connection is truncated or a REST next-page URL loops.
+- A complete GraphQL issue-link connection reports no closing link while REST
+  finds an exact closing keyword; recovery remains `Uncovered` and does not
+  consult REST as an alternate authority.
+- The GraphQL closing-reference connection is truncated, exceeds its page
+  limit, repeats an unusable cursor, or changes issue state during pagination.
 - The matching PR is merged while GitHub still reports the issue open.
-- More than one historical PR references the same issue.
+- Multiple linked PRs arrive in opposite API orders, including merged, active,
+  and closed-unmerged candidates with different PR numbers.
 - A stale cancelled workflow has pending commands when recovery begins.
 - The process stops after persisting the PR fact but before the next poll.
+- Two recovery attempts reach candidate selection and persistence at the same
+  barrier before either one commits.
 
 ## Rollout Notes
 

--- a/specs/GH1707/product.md
+++ b/specs/GH1707/product.md
@@ -1,0 +1,105 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1707
+
+## User Problem
+
+After workflow-runtime persistence is lost or rebuilt, GitHub intake can treat
+an issue as uncovered even though an authoritative open or merged pull request
+already closes it. That can enqueue duplicate implementation work, spend agent
+tokens twice, and create competing pull requests. The production incident in
+`majiayu000/remem` demonstrated that local runtime state alone is insufficient
+as the coverage authority after recovery.
+
+## Goals
+
+- Reconstruct issue coverage from authoritative GitHub issue and pull-request
+  facts when local runtime coverage is absent.
+- Persist the recovered issue-to-PR binding and server-owned PR evidence.
+- Resume the workflow in the state implied by current PR facts without
+  dispatching implementation work.
+- Make repeated polls and process restarts idempotent.
+- Fail closed whenever the GitHub fact set is unavailable or incomplete.
+
+## Non-Goals
+
+- Reconstructing raw agent transcripts; GH-1704 owns that contract.
+- Trusting PR title or branch-name similarity as closing evidence.
+- Auto-merging, approving, or resolving review feedback.
+- Treating a closed-unmerged PR as durable issue coverage.
+- Repairing repositories other than the configured intake repository.
+
+## User-Visible Behavior
+
+1. **B-001:** With no local runtime coverage, an open issue with an
+   authoritative open closing PR is covered and produces zero
+   `implement_issue` jobs.
+2. **B-002:** Recovery persists the issue-to-PR binding and a server-owned PR
+   fact snapshot before reporting the issue covered.
+3. **B-003:** An open PR is reconstructed as `pr_open`,
+   `awaiting_feedback`, or `ready_to_merge` according to its current checks,
+   review, and merge facts.
+4. **B-004:** A merged PR plus a closed issue reconstructs terminal evidence
+   and produces zero implementation or repair agent jobs.
+5. **B-005:** A closed-unmerged PR does not cover the issue; a later valid PR
+   may independently restore coverage.
+6. **B-006:** Repeated polls and restart recovery are idempotent: they preserve
+   one binding, one current workflow state, and no duplicate agent work.
+7. **B-007:** A cancelled or stale local workflow cannot override a current
+   authoritative closing PR; recovery replaces stale pending work with the
+   reconstructed PR-owned state.
+8. **B-008:** GitHub HTTP, GraphQL, pagination, parsing, or completeness
+   failures are visible errors and fail closed for that intake poll. Partial
+   scans must never be interpreted as “no closing PR exists.”
+9. **B-009:** Closing references are repository-qualified and exact; unrelated
+   issue numbers, cross-repository references, or non-closing mentions do not
+   create coverage.
+10. **B-010:** Concurrent/repeated recovery attempts converge without duplicate
+    commands, regressed terminal state, or overwritten newer evidence.
+
+## Acceptance Criteria
+
+- [ ] B-001 through B-010 have deterministic tests and implementation
+      evidence.
+- [ ] The Remem canary scenario—empty store plus open closing PR—reconstructs
+      coverage with zero `implement_issue` jobs.
+- [ ] Open, feedback, ready, merged, and closed-unmerged PR states are covered.
+- [ ] Restart and repeated-poll tests prove idempotency.
+- [ ] GitHub failures, page-limit exhaustion, and repeated pagination URLs all
+      fail closed.
+- [ ] Exact-head CI, independent review, review-thread audit, and SpecRail PR
+      gate pass before implementation merge.
+
+## Boundary Checklist
+
+| Boundary | Verdict |
+| --- | --- |
+| Empty / missing input | Covered by B-001, B-008, and B-009. |
+| Error and failure paths | Covered by B-008. |
+| Authorization / permission | Covered by B-008; unavailable or unauthorized GitHub reads cannot authorize dispatch. |
+| Concurrency / race / ordering | Covered by B-002 and B-010. |
+| Retry / repetition / idempotency | Covered by B-006 and B-010. |
+| Illegal state transitions | Covered by B-003, B-004, B-005, and B-007. |
+| Compatibility / migration | Covered by B-006 and B-007 for empty or stale local stores. |
+| Degradation / fallback | Covered by B-008; incomplete evidence is an error, never success. |
+| Evidence and audit integrity | Covered by B-002, B-008, and B-009. |
+| Cancellation / interruption / partial completion | Covered by B-007, B-008, and B-010. |
+
+## Edge Cases
+
+- GraphQL reports no closing link while REST finds an exact closing keyword.
+- A closing-reference connection is truncated or a REST next-page URL loops.
+- The matching PR is merged while GitHub still reports the issue open.
+- More than one historical PR references the same issue.
+- A stale cancelled workflow has pending commands when recovery begins.
+- The process stops after persisting the PR fact but before the next poll.
+
+## Rollout Notes
+
+Recovery is activated within the existing intake coverage gate and needs no
+operator migration. Errors intentionally suppress dispatch for the affected
+poll and remain visible so operators can restore GitHub connectivity. Reverting
+the implementation restores the prior behavior but also restores the duplicate
+dispatch risk.

--- a/specs/GH1707/product.md
+++ b/specs/GH1707/product.md
@@ -45,11 +45,12 @@ as the coverage authority after recovery.
    `awaiting_feedback`; a ready snapshot becomes `quality_gate_pending` and
    starts the quality gate; only a successful quality gate may later advance
    it to `ready_to_merge`.
-4. **B-004:** A merged PR plus a closed issue reconstructs terminal evidence
-   and produces zero implementation or repair agent jobs.
-5. **B-005:** Neither a closed-unmerged PR nor a merged PR while the issue is
-   still open is durable coverage; a later eligible active PR, or a merged PR
-   observed with the issue closed, may independently restore coverage.
+4. **B-004:** An authoritative linked merged PR reconstructs terminal `done`
+   evidence and produces zero implementation or repair agent jobs even when
+   GitHub still reports the issue `OPEN`; that combination is a fail-safe
+   issue-state propagation race, not evidence that implementation is missing.
+5. **B-005:** A closed-unmerged PR does not cover the issue; a later eligible
+   active or merged PR may independently restore coverage.
 6. **B-006:** Repeated polls and restart recovery are idempotent: they preserve
    one binding, one current workflow state, and no duplicate agent work.
 7. **B-007:** A cancelled or stale local workflow cannot override a current
@@ -64,12 +65,12 @@ as the coverage authority after recovery.
    cross-repository links, and non-closing mentions without an authoritative
    issue link do not create coverage.
 10. **B-010:** After complete snapshots are collected for every same-repository
-    linked candidate, selection is independent of GraphQL/API order: when the
-    issue is closed, eligible merged candidates outrank eligible active
-    candidates; otherwise only eligible active candidates qualify; the highest
-    PR number wins within the selected class. Barrier-synchronized concurrent
-    and repeated attempts must converge on that candidate without duplicate
-    commands, regressed terminal state, or overwritten newer evidence.
+    linked candidate, selection is independent of GraphQL/API order: eligible
+    merged candidates outrank eligible active candidates regardless of the
+    lagging issue state, and the highest PR number wins within the selected
+    class. Barrier-synchronized concurrent and repeated attempts must converge
+    on that candidate without duplicate commands, regressed terminal state, or
+    overwritten newer evidence.
 
 ## Acceptance Criteria
 
@@ -80,8 +81,8 @@ as the coverage authority after recovery.
 - [ ] Open, feedback, ready, merged, and closed-unmerged PR states are covered.
 - [ ] A ready snapshot first reconstructs `quality_gate_pending`; a passing
       quality gate is the only tested path from that state to `ready_to_merge`.
-- [ ] Merged-plus-open is tested as uncovered, while merged-plus-closed is
-      tested as terminal `done` coverage.
+- [ ] Merged-plus-open and merged-plus-closed are both tested as terminal
+      `done` coverage with zero implementation or repair agent jobs.
 - [ ] Reversed GraphQL candidate orders select the same precedence class and
       highest PR number.
 - [ ] Restart and repeated-poll tests prove idempotency.
@@ -114,7 +115,9 @@ as the coverage authority after recovery.
   consult REST as an alternate authority.
 - The GraphQL closing-reference connection is truncated, exceeds its page
   limit, repeats an unusable cursor, or changes issue state during pagination.
-- The matching PR is merged while GitHub still reports the issue open.
+- The authoritative linked PR is merged while GitHub still reports the issue
+  open; recovery treats the issue state as propagation lag and fails safe to
+  terminal coverage.
 - Multiple linked PRs arrive in opposite API orders, including merged, active,
   and closed-unmerged candidates with different PR numbers.
 - A stale cancelled workflow has pending commands when recovery begins.

--- a/specs/GH1707/tasks.md
+++ b/specs/GH1707/tasks.md
@@ -11,46 +11,55 @@ GH-1707
 
 ## Implementation Tasks
 
-- [ ] `SP1707-T1` Owner: implementation agent | Done when: authoritative candidate lookup fails closed and accepts only exact links | Verify: focused lookup and pagination tests below
-- [ ] `SP1707-T2` Owner: implementation agent | Done when: workflow ownership and PR facts reconstruct without duplicate work | Verify: recovery state matrix tests below
-- [ ] `SP1707-T3` Owner: verification owner | Done when: restart and repeated polls preserve one binding and zero agent jobs | Verify: restart and merged-terminal tests below
+- [ ] `SP1707-T1` Owner: implementation agent | Done when: GraphQL-only candidate lookup fails closed and deterministic arbitration accepts only exact issue links | Verify: authority, ordering, and pagination tests below
+- [ ] `SP1707-T2` Owner: implementation agent | Done when: workflow ownership and PR facts reconstruct through the exact state matrix without duplicate work | Verify: recovery and quality-gate transition tests below
+- [ ] `SP1707-T3` Owner: verification owner | Done when: restart, repeated polls, and barrier-synchronized attempts preserve one binding and one deduplicated command set | Verify: restart, merged-terminal, and concurrency tests below
 - [ ] `SP1707-T4` Owner: coordinator | Done when: all local and exact-head remote gates pass | Verify: repository, CI, review-thread, and PR-gate commands below
 
 ### SP1707-T1 — Collect and validate authoritative GitHub coverage
 
 - Owner: implementation agent.
 - Dependencies: merged GH-1707 spec PR.
-- Covers: B-001, B-005, B-008, B-009.
-- Work: enumerate exact closing candidates, fetch complete issue/PR snapshots,
-  and fail closed on transport, parsing, pagination, or completeness failure.
-- Done when: only exact repository-qualified candidates can produce coverage,
-  and incomplete scans return errors.
-- Verify: PR-discovery, lookup-failure, page-limit, repeated-URL, and
-  closed-unmerged focused tests from `tech.md`.
+- Covers: B-001, B-005, B-008, B-009, B-010.
+- Work: enumerate candidates only from the complete GraphQL issue-link
+  connection, fetch every same-repository snapshot, reject incomplete facts,
+  and select by eligibility-class precedence plus highest PR number. Do not
+  consult REST keywords or depend on API order.
+- Done when: only exact repository-qualified GraphQL links can produce
+  coverage; forward and reverse candidate orders select the same PR; merged
+  plus open and closed-unmerged candidates remain ineligible; incomplete scans
+  return errors.
+- Verify: `cargo test -p harness-server multiple_closing_pr_candidates_are_selected_deterministically`; `cargo test -p harness-server rest_keyword_without_authoritative_issue_link_is_uncovered`; PR-discovery, lookup-failure, page-limit, repeated-cursor, merged-open, and closed-unmerged focused tests from `tech.md`.
 
 ### SP1707-T2 — Reconstruct durable workflow ownership
 
 - Owner: implementation agent.
 - Dependencies: SP1707-T1.
-- Covers: B-002, B-003, B-004, B-007, B-010.
+- Covers: B-002, B-003, B-004, B-007.
 - Work: persist the PR snapshot and binding, derive the workflow state, cancel
   stale implementation commands, and enqueue only state-appropriate deduped
   follow-up commands.
-- Done when: open, feedback, ready, and merged facts reconstruct the expected
-  workflow state with no competing agent work.
-- Verify: open-state matrix, merged-terminal, stale-work, and persistence tests
-  from the Product-to-Test Mapping.
+- Done when: waiting facts map to `pr_open`, repair facts map to
+  `awaiting_feedback`, a ready snapshot maps to `quality_gate_pending`, only a
+  passing quality gate advances to `ready_to_merge`, and merged-plus-closed
+  maps to terminal `done`, all with no competing agent work.
+- Verify: open-state matrix, quality-gate parent propagation,
+  merged-plus-closed terminal, merged-plus-open negative, stale-work, and
+  persistence tests from the Product-to-Test Mapping.
 
 ### SP1707-T3 — Prove restart and repeated-poll idempotency
 
 - Owner: verification owner.
 - Dependencies: SP1707-T2.
 - Covers: B-001, B-002, B-004, B-006, B-010.
-- Work: execute recovery twice, reopen the store, repeat intake, and inspect
-  commands, bindings, facts, and terminal evidence.
-- Done when: every repetition preserves one state/binding and zero duplicate
+- Work: execute recovery twice, reopen the store, repeat intake, then use an
+  explicit barrier to hold two attempts after candidate selection and release
+  them together at the persistence boundary. Inspect commands, bindings,
+  facts, and terminal evidence.
+- Done when: serial repetition and the controlled race preserve one selected
+  binding, one current state, one deduplicated command set, and zero duplicate
   implementation jobs.
-- Verify: `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart` and merged-terminal recovery test.
+- Verify: `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart`; `cargo test -p harness-server merged_pr_and_closed_issue_recover_terminal_coverage_without_agent_work`; barrier-controlled `cargo test -p harness-server concurrent_recovery_attempts_converge_on_one_binding_and_command_set`.
 
 ### SP1707-T4 — Complete repository and PR gates
 
@@ -76,6 +85,8 @@ may run after the implementation head is pushed.
 - [ ] Product invariant set equals task coverage union: B-001 through B-010.
 - [ ] Global and GH-1707 SpecRail checks pass.
 - [ ] Focused fail-closed and state-recovery tests pass.
+- [ ] Forward/reverse candidate ordering and GraphQL-only authority tests pass.
+- [ ] Barrier-controlled concurrent recovery test passes.
 - [ ] Workspace clippy and exact-head CI pass.
 - [ ] Gemini and independent review have no unresolved active finding.
 - [ ] PR gate is `allowed` at the exact merge head.

--- a/specs/GH1707/tasks.md
+++ b/specs/GH1707/tasks.md
@@ -1,0 +1,89 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1707
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1707-T1` Owner: implementation agent | Done when: authoritative candidate lookup fails closed and accepts only exact links | Verify: focused lookup and pagination tests below
+- [ ] `SP1707-T2` Owner: implementation agent | Done when: workflow ownership and PR facts reconstruct without duplicate work | Verify: recovery state matrix tests below
+- [ ] `SP1707-T3` Owner: verification owner | Done when: restart and repeated polls preserve one binding and zero agent jobs | Verify: restart and merged-terminal tests below
+- [ ] `SP1707-T4` Owner: coordinator | Done when: all local and exact-head remote gates pass | Verify: repository, CI, review-thread, and PR-gate commands below
+
+### SP1707-T1 — Collect and validate authoritative GitHub coverage
+
+- Owner: implementation agent.
+- Dependencies: merged GH-1707 spec PR.
+- Covers: B-001, B-005, B-008, B-009.
+- Work: enumerate exact closing candidates, fetch complete issue/PR snapshots,
+  and fail closed on transport, parsing, pagination, or completeness failure.
+- Done when: only exact repository-qualified candidates can produce coverage,
+  and incomplete scans return errors.
+- Verify: PR-discovery, lookup-failure, page-limit, repeated-URL, and
+  closed-unmerged focused tests from `tech.md`.
+
+### SP1707-T2 — Reconstruct durable workflow ownership
+
+- Owner: implementation agent.
+- Dependencies: SP1707-T1.
+- Covers: B-002, B-003, B-004, B-007, B-010.
+- Work: persist the PR snapshot and binding, derive the workflow state, cancel
+  stale implementation commands, and enqueue only state-appropriate deduped
+  follow-up commands.
+- Done when: open, feedback, ready, and merged facts reconstruct the expected
+  workflow state with no competing agent work.
+- Verify: open-state matrix, merged-terminal, stale-work, and persistence tests
+  from the Product-to-Test Mapping.
+
+### SP1707-T3 — Prove restart and repeated-poll idempotency
+
+- Owner: verification owner.
+- Dependencies: SP1707-T2.
+- Covers: B-001, B-002, B-004, B-006, B-010.
+- Work: execute recovery twice, reopen the store, repeat intake, and inspect
+  commands, bindings, facts, and terminal evidence.
+- Done when: every repetition preserves one state/binding and zero duplicate
+  implementation jobs.
+- Verify: `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart` and merged-terminal recovery test.
+
+### SP1707-T4 — Complete repository and PR gates
+
+- Owner: coordinator; independent reviewer owns review verdict.
+- Dependencies: SP1707-T3.
+- Covers: B-001 through B-010.
+- Work: run package checks, workspace clippy, PostgreSQL-backed tests when an
+  isolated database is configured, SpecRail checks, exact-head CI, Gemini,
+  independent review, thread audit, and PR gate.
+- Done when: all available deterministic gates pass, any DB deferral is
+  explicit, and the final implementation PR is merged only with current green
+  evidence.
+- Verify: commands in `tech.md` and exact-head GitHub evidence.
+
+## Parallelization
+
+The recovery transaction and candidate-validation behavior share acceptance
+state and should be implemented serially. Independent review is read-only and
+may run after the implementation head is pushed.
+
+## Verification
+
+- [ ] Product invariant set equals task coverage union: B-001 through B-010.
+- [ ] Global and GH-1707 SpecRail checks pass.
+- [ ] Focused fail-closed and state-recovery tests pass.
+- [ ] Workspace clippy and exact-head CI pass.
+- [ ] Gemini and independent review have no unresolved active finding.
+- [ ] PR gate is `allowed` at the exact merge head.
+
+## Handoff Notes
+
+- Production evidence is the Remem #882 / PR #887 persistence-loss incident
+  recorded in GH-1707.
+- Never convert GitHub lookup uncertainty into `Uncovered`.
+- The implementation PR is #1709; its pagination correction must remain on the
+  reviewed exact head.

--- a/specs/GH1707/tasks.md
+++ b/specs/GH1707/tasks.md
@@ -27,9 +27,9 @@ GH-1707
   consult REST keywords or depend on API order.
 - Done when: only exact repository-qualified GraphQL links can produce
   coverage; forward and reverse candidate orders select the same PR; merged
-  plus open and closed-unmerged candidates remain ineligible; incomplete scans
-  return errors.
-- Verify: `cargo test -p harness-server multiple_closing_pr_candidates_are_selected_deterministically`; `cargo test -p harness-server rest_keyword_without_authoritative_issue_link_is_uncovered`; PR-discovery, lookup-failure, page-limit, repeated-cursor, merged-open, and closed-unmerged focused tests from `tech.md`.
+  candidates outrank active candidates even while the issue remains open;
+  closed-unmerged candidates remain ineligible; incomplete scans return errors.
+- Verify: `cargo test -p harness-server multiple_closing_pr_candidates_are_selected_deterministically`; `cargo test -p harness-server rest_keyword_without_authoritative_issue_link_is_uncovered`; PR-discovery, lookup-failure, page-limit, repeated-cursor, merged-open terminal, and closed-unmerged focused tests from `tech.md`.
 
 ### SP1707-T2 — Reconstruct durable workflow ownership
 
@@ -42,9 +42,11 @@ GH-1707
 - Done when: waiting facts map to `pr_open`, repair facts map to
   `awaiting_feedback`, a ready snapshot maps to `quality_gate_pending`, only a
   passing quality gate advances to `ready_to_merge`, and merged-plus-closed
-  maps to terminal `done`, all with no competing agent work.
+  or merged-plus-open maps to terminal `done`, all with no competing agent
+  work. The merged-plus-open combination is recorded as issue-state propagation
+  lag rather than treated as missing coverage.
 - Verify: open-state matrix, quality-gate parent propagation,
-  merged-plus-closed terminal, merged-plus-open negative, stale-work, and
+  merged-plus-closed terminal, merged-plus-open terminal, stale-work, and
   persistence tests from the Product-to-Test Mapping.
 
 ### SP1707-T3 — Prove restart and repeated-poll idempotency
@@ -59,7 +61,7 @@ GH-1707
 - Done when: serial repetition and the controlled race preserve one selected
   binding, one current state, one deduplicated command set, and zero duplicate
   implementation jobs.
-- Verify: `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart`; `cargo test -p harness-server merged_pr_and_closed_issue_recover_terminal_coverage_without_agent_work`; barrier-controlled `cargo test -p harness-server concurrent_recovery_attempts_converge_on_one_binding_and_command_set`.
+- Verify: `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart`; `cargo test -p harness-server merged_pr_and_closed_issue_recover_terminal_coverage_without_agent_work`; `cargo test -p harness-server merged_pr_and_open_issue_recover_terminal_coverage_without_agent_work`; barrier-controlled `cargo test -p harness-server concurrent_recovery_attempts_converge_on_one_binding_and_command_set`.
 
 ### SP1707-T4 — Complete repository and PR gates
 

--- a/specs/GH1707/tech.md
+++ b/specs/GH1707/tech.md
@@ -9,7 +9,7 @@ GH-1707
 See `specs/GH1707/product.md`.
 
 <!-- specrail-planned-changes
-{"issue":1707,"complete":true,"paths":["crates/harness-server/src/github_pr_snapshot.rs","crates/harness-server/src/github_pr_snapshot_tests.rs","crates/harness-server/src/intake/github_coverage_gate.rs","crates/harness-server/src/intake/github_coverage_recovery.rs","crates/harness-server/src/intake/github_coverage_recovery_test_support.rs","crates/harness-server/src/intake/github_coverage_recovery_tests.rs","crates/harness-server/src/intake/github_issue_links.rs","crates/harness-server/src/intake/mod.rs","crates/harness-server/src/task_executor/pr_detection.rs","crates/harness-server/src/task_executor/pr_detection_tests.rs","crates/harness-server/src/workflow_runtime_pr_feedback/pr_detection.rs"],"spec_refs":["B-001","B-002","B-003","B-004","B-005","B-006","B-007","B-008","B-009","B-010"]}
+{"issue":1707,"complete":true,"paths":["crates/harness-server/src/github_pr_snapshot.rs","crates/harness-server/src/github_pr_snapshot_tests.rs","crates/harness-server/src/intake/github_coverage_gate.rs","crates/harness-server/src/intake/github_coverage_recovery.rs","crates/harness-server/src/intake/github_coverage_recovery_tests.rs","crates/harness-server/src/intake/github_coverage_recovery_tests/support.rs","crates/harness-server/src/intake/github_issue_links.rs","crates/harness-server/src/intake/mod.rs","crates/harness-server/src/task_executor/pr_detection.rs","crates/harness-server/src/task_executor/pr_detection_tests.rs","crates/harness-server/src/workflow_runtime_pr_feedback/pr_detection.rs"],"spec_refs":["B-001","B-002","B-003","B-004","B-005","B-006","B-007","B-008","B-009","B-010"]}
 -->
 
 ## Current System
@@ -27,26 +27,49 @@ See `specs/GH1707/product.md`.
 
 ## Proposed Design
 
-1. Discover exact closing PR candidates from repository-qualified GitHub issue
-   links and bounded REST fallback.
-2. Fetch a complete server-owned snapshot for each candidate and reject
-   incomplete, inconsistent, cross-repository, or closed-unmerged evidence.
-3. Derive the target workflow state from PR state, checks, review decision,
-   review threads, and merge facts.
-4. Upsert the issue-bound workflow, PR binding, remote fact snapshot, and only
+1. Page the GitHub GraphQL `issue.closedByPullRequestsReferences` connection to
+   completion. This repository-qualified connection is the only source of
+   closing candidates; do not run a REST keyword fallback or require a closing
+   keyword in the linked PR body.
+2. Fetch a complete server-owned snapshot for every same-repository candidate.
+   Any transport, parsing, pagination, or completeness error aborts the poll;
+   do not choose from a partial candidate set.
+3. Classify and select candidates with a stable comparison key, never API
+   order. If the issue is closed, eligible merged candidates have precedence
+   over eligible active candidates; if the issue is open, merged candidates
+   are ineligible. Closed-unmerged candidates are always ineligible. Within the
+   selected class, choose the highest PR number.
+4. Derive the target workflow state from PR state, checks, review decision,
+   review threads, and merge facts using the exact matrix below.
+5. Upsert the issue-bound workflow, PR binding, remote fact snapshot, and only
    the commands required for the derived state. Cancel stale implementation
    work before the coverage gate returns `Covered`.
-5. Reuse stable workflow and command dedupe keys so repeated polls and restarts
+6. Reuse stable workflow and command dedupe keys so repeated polls and restarts
    converge.
-6. Propagate every lookup/completeness error to intake. Page-limit exhaustion
+7. Propagate every lookup/completeness error to intake. Page-limit exhaustion
    and repeated pagination URLs are errors in both compiled PR-discovery
    implementations, not warning-plus-partial-result paths.
 
+## Recovery State Matrix
+
+| Complete GitHub facts | Recovery result |
+| --- | --- |
+| Open PR waiting for checks or mergeability | `pr_open` |
+| Open PR requiring CI or review repair | `awaiting_feedback` |
+| Open PR with ready snapshot | `quality_gate_pending` plus one deduplicated quality-gate child command |
+| Successful quality-gate child completion from `quality_gate_pending` | `ready_to_merge` |
+| Merged PR and closed issue | terminal `done` with merge evidence |
+| Merged PR and open issue | ineligible; not durable coverage |
+| Closed-unmerged PR | ineligible; not durable coverage |
+
+Recovery must never map a ready snapshot directly to `ready_to_merge`.
+
 ## Data Flow
 
-`GitHub poll -> local coverage lookup -> authoritative issue/PR discovery ->
-complete PR snapshot -> validate exact closing relation -> derive workflow
-state -> transactional persistence/deduped commands -> Covered/Uncovered/error`.
+`GitHub poll -> local coverage lookup -> complete authoritative GraphQL issue
+links -> complete snapshots for all same-repository candidates -> deterministic
+class/PR-number arbitration -> derive workflow state -> transactional
+persistence/deduped commands -> Covered/Uncovered/error`.
 
 Only a complete authoritative fact set can return `Covered` or `Uncovered`.
 An external read failure returns an error, and intake skips dispatch for that
@@ -58,14 +81,14 @@ poll.
 | --- | --- | --- |
 | B-001 | `intake/github_coverage_gate.rs`, `github_coverage_recovery.rs` | `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart` |
 | B-002 | recovery persistence and PR snapshot modules | `cargo test -p harness-server recovery_maps_open_pr_facts` |
-| B-003 | recovery state derivation | `cargo test -p harness-server recovery_maps_open_pr_facts` |
-| B-004 | merged-state recovery | `cargo test -p harness-server merged_pr_closed_issue_recovers_terminal_coverage_without_agent_work` |
-| B-005 | candidate validation | `cargo test -p harness-server closed_pr_is_uncovered_but_a_later_valid_pr_recovers_coverage` |
+| B-003 | recovery state derivation and quality-gate parent propagation | `cargo test -p harness-server recovery_maps_open_pr_facts`; `cargo test -p harness-workflow runtime_completion_reducer_marks_issue_pr_ready_after_quality_gate_pass` |
+| B-004 | merged-state recovery | `cargo test -p harness-server merged_pr_and_closed_issue_recover_terminal_coverage_without_agent_work` |
+| B-005 | candidate eligibility | `cargo test -p harness-server merged_pr_does_not_cover_an_issue_github_still_reports_open`; `cargo test -p harness-server closed_pr_is_uncovered_but_a_later_valid_pr_recovers_coverage` |
 | B-006 | stable IDs and command dedupe | `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart` |
 | B-007 | stale-work cancellation | `cargo test -p harness-server recovery_maps_open_pr_facts` |
 | B-008 | GitHub adapters and pagination guards | `cargo test -p harness-server github_lookup_failure_fails_closed_without_agent_work`; `cargo test -p harness-server existing_pr_lookup_fails_closed` |
-| B-009 | closing-reference validation | `cargo test -p harness-server issue_linked_pr_without_closing_keyword_recovers_coverage` plus negative PR-detection tests |
-| B-010 | recovery transaction/dedupe paths | restart test and `cargo test -p harness-server github_coverage_recovery` |
+| B-009 | GraphQL issue-link authority | `cargo test -p harness-server issue_linked_pr_without_closing_keyword_recovers_coverage`; negative test `rest_keyword_without_authoritative_issue_link_is_uncovered` |
+| B-010 | deterministic arbitration and recovery transaction/dedupe paths | `cargo test -p harness-server multiple_closing_pr_candidates_are_selected_deterministically`; barrier-controlled `cargo test -p harness-server concurrent_recovery_attempts_converge_on_one_binding_and_command_set` |
 
 ## Alternatives Considered
 
@@ -83,7 +106,8 @@ poll.
 - Security: GitHub tokens remain read-only for evidence collection; errors and
   redaction must not expose credentials.
 - Data integrity: incorrect candidate selection could bind the wrong PR; exact
-  repository-qualified closing evidence is mandatory.
+  repository-qualified GraphQL closing evidence and deterministic arbitration
+  are mandatory.
 - Compatibility: stale/cancelled local workflows must be reconciled without
   regressing newer or terminal state.
 - Availability: GitHub outages intentionally defer intake instead of silently
@@ -94,6 +118,12 @@ poll.
 ## Test Plan
 
 - [ ] Run every command in the Product-to-Test Mapping.
+- [ ] Run the multi-candidate test with the same candidates in forward and
+      reverse GraphQL order and assert the same selected PR.
+- [ ] Run the concurrency test with an explicit barrier that holds two
+      recovery attempts after candidate selection and releases both to race the
+      persistence boundary; assert one binding, one state, and one deduplicated
+      command set.
 - [ ] Run `cargo check -p harness-server --all-targets`.
 - [ ] Run `cargo fmt --all -- --check` and
       `cargo clippy --workspace --all-targets -- -D warnings`.

--- a/specs/GH1707/tech.md
+++ b/specs/GH1707/tech.md
@@ -1,0 +1,111 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1707
+
+## Product Spec
+
+See `specs/GH1707/product.md`.
+
+<!-- specrail-planned-changes
+{"issue":1707,"complete":true,"paths":["crates/harness-server/src/github_pr_snapshot.rs","crates/harness-server/src/github_pr_snapshot_tests.rs","crates/harness-server/src/intake/github_coverage_gate.rs","crates/harness-server/src/intake/github_coverage_recovery.rs","crates/harness-server/src/intake/github_coverage_recovery_test_support.rs","crates/harness-server/src/intake/github_coverage_recovery_tests.rs","crates/harness-server/src/intake/github_issue_links.rs","crates/harness-server/src/intake/mod.rs","crates/harness-server/src/task_executor/pr_detection.rs","crates/harness-server/src/task_executor/pr_detection_tests.rs","crates/harness-server/src/workflow_runtime_pr_feedback/pr_detection.rs"],"spec_refs":["B-001","B-002","B-003","B-004","B-005","B-006","B-007","B-008","B-009","B-010"]}
+-->
+
+## Current System
+
+- `crates/harness-server/src/intake/mod.rs:251` calls the coverage gate before
+  direct workflow-runtime dispatch.
+- `crates/harness-server/src/intake/github_coverage_gate.rs:103` checks local
+  runtime coverage, but the base implementation does not reconstruct complete
+  coverage from current GitHub PR facts after persistence loss.
+- `crates/harness-server/src/workflow_runtime_pr_feedback/pr_detection.rs`
+  already owns GitHub PR discovery helpers, while the still-compiled legacy
+  `task_executor/pr_detection.rs` contains the same pagination contract.
+- Server-owned PR snapshots and workflow-runtime commands are the durable
+  evidence surfaces that recovery must populate atomically and idempotently.
+
+## Proposed Design
+
+1. Discover exact closing PR candidates from repository-qualified GitHub issue
+   links and bounded REST fallback.
+2. Fetch a complete server-owned snapshot for each candidate and reject
+   incomplete, inconsistent, cross-repository, or closed-unmerged evidence.
+3. Derive the target workflow state from PR state, checks, review decision,
+   review threads, and merge facts.
+4. Upsert the issue-bound workflow, PR binding, remote fact snapshot, and only
+   the commands required for the derived state. Cancel stale implementation
+   work before the coverage gate returns `Covered`.
+5. Reuse stable workflow and command dedupe keys so repeated polls and restarts
+   converge.
+6. Propagate every lookup/completeness error to intake. Page-limit exhaustion
+   and repeated pagination URLs are errors in both compiled PR-discovery
+   implementations, not warning-plus-partial-result paths.
+
+## Data Flow
+
+`GitHub poll -> local coverage lookup -> authoritative issue/PR discovery ->
+complete PR snapshot -> validate exact closing relation -> derive workflow
+state -> transactional persistence/deduped commands -> Covered/Uncovered/error`.
+
+Only a complete authoritative fact set can return `Covered` or `Uncovered`.
+An external read failure returns an error, and intake skips dispatch for that
+poll.
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | `intake/github_coverage_gate.rs`, `github_coverage_recovery.rs` | `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart` |
+| B-002 | recovery persistence and PR snapshot modules | `cargo test -p harness-server recovery_maps_open_pr_facts` |
+| B-003 | recovery state derivation | `cargo test -p harness-server recovery_maps_open_pr_facts` |
+| B-004 | merged-state recovery | `cargo test -p harness-server merged_pr_closed_issue_recovers_terminal_coverage_without_agent_work` |
+| B-005 | candidate validation | `cargo test -p harness-server closed_pr_is_uncovered_but_a_later_valid_pr_recovers_coverage` |
+| B-006 | stable IDs and command dedupe | `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart` |
+| B-007 | stale-work cancellation | `cargo test -p harness-server recovery_maps_open_pr_facts` |
+| B-008 | GitHub adapters and pagination guards | `cargo test -p harness-server github_lookup_failure_fails_closed_without_agent_work`; `cargo test -p harness-server existing_pr_lookup_fails_closed` |
+| B-009 | closing-reference validation | `cargo test -p harness-server issue_linked_pr_without_closing_keyword_recovers_coverage` plus negative PR-detection tests |
+| B-010 | recovery transaction/dedupe paths | restart test and `cargo test -p harness-server github_coverage_recovery` |
+
+## Alternatives Considered
+
+- Trust local workflow rows only: rejected because those rows are precisely the
+  state lost in the incident.
+- Treat lookup failures as uncovered: rejected because that spends model work
+  under uncertainty and recreates the production defect.
+- Persist only a lightweight “covered” marker: rejected because downstream PR
+  feedback and terminal reconciliation need auditable PR facts and bindings.
+- Search branch names or PR titles: rejected because they are non-authoritative
+  and create false ownership.
+
+## Risks
+
+- Security: GitHub tokens remain read-only for evidence collection; errors and
+  redaction must not expose credentials.
+- Data integrity: incorrect candidate selection could bind the wrong PR; exact
+  repository-qualified closing evidence is mandatory.
+- Compatibility: stale/cancelled local workflows must be reconciled without
+  regressing newer or terminal state.
+- Availability: GitHub outages intentionally defer intake instead of silently
+  dispatching duplicate work.
+- Performance: candidate pagination is bounded; exhausting the bound is a loud
+  error rather than partial success.
+
+## Test Plan
+
+- [ ] Run every command in the Product-to-Test Mapping.
+- [ ] Run `cargo check -p harness-server --all-targets`.
+- [ ] Run `cargo fmt --all -- --check` and
+      `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Run PostgreSQL-backed `harness-server` tests with an isolated
+      `HARNESS_DATABASE_URL`, or rely on exact-head CI when no disposable local
+      database is configured.
+- [ ] Run `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1707`.
+- [ ] Collect exact-head CI, Gemini review, independent reviewer evidence,
+      GraphQL review-thread state, and SpecRail PR-gate evidence.
+
+## Rollback Plan
+
+Squash-revert the implementation PR. No schema rollback or destructive data
+operation is required. During rollback, disable affected repository intake if
+necessary rather than accepting duplicate dispatch under uncertain coverage.

--- a/specs/GH1707/tech.md
+++ b/specs/GH1707/tech.md
@@ -35,10 +35,11 @@ See `specs/GH1707/product.md`.
    Any transport, parsing, pagination, or completeness error aborts the poll;
    do not choose from a partial candidate set.
 3. Classify and select candidates with a stable comparison key, never API
-   order. If the issue is closed, eligible merged candidates have precedence
-   over eligible active candidates; if the issue is open, merged candidates
-   are ineligible. Closed-unmerged candidates are always ineligible. Within the
-   selected class, choose the highest PR number.
+   order. Eligible merged candidates have precedence over eligible active
+   candidates even while the linked issue remains `OPEN`; that combination is
+   treated as GitHub propagation lag and fails safe to terminal coverage.
+   Closed-unmerged candidates are always ineligible. Within the selected class,
+   choose the highest PR number.
 4. Derive the target workflow state from PR state, checks, review decision,
    review threads, and merge facts using the exact matrix below.
 5. Upsert the issue-bound workflow, PR binding, remote fact snapshot, and only
@@ -58,8 +59,8 @@ See `specs/GH1707/product.md`.
 | Open PR requiring CI or review repair | `awaiting_feedback` |
 | Open PR with ready snapshot | `quality_gate_pending` plus one deduplicated quality-gate child command |
 | Successful quality-gate child completion from `quality_gate_pending` | `ready_to_merge` |
-| Merged PR and closed issue | terminal `done` with merge evidence |
-| Merged PR and open issue | ineligible; not durable coverage |
+| Authoritative linked merged PR and closed issue | terminal `done` with merge evidence |
+| Authoritative linked merged PR and open issue | terminal `done` with merge evidence; issue state is treated as propagation lag |
 | Closed-unmerged PR | ineligible; not durable coverage |
 
 Recovery must never map a ready snapshot directly to `ready_to_merge`.
@@ -82,8 +83,8 @@ poll.
 | B-001 | `intake/github_coverage_gate.rs`, `github_coverage_recovery.rs` | `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart` |
 | B-002 | recovery persistence and PR snapshot modules | `cargo test -p harness-server recovery_maps_open_pr_facts` |
 | B-003 | recovery state derivation and quality-gate parent propagation | `cargo test -p harness-server recovery_maps_open_pr_facts`; `cargo test -p harness-workflow runtime_completion_reducer_marks_issue_pr_ready_after_quality_gate_pass` |
-| B-004 | merged-state recovery | `cargo test -p harness-server merged_pr_and_closed_issue_recover_terminal_coverage_without_agent_work` |
-| B-005 | candidate eligibility | `cargo test -p harness-server merged_pr_does_not_cover_an_issue_github_still_reports_open`; `cargo test -p harness-server closed_pr_is_uncovered_but_a_later_valid_pr_recovers_coverage` |
+| B-004 | merged-state recovery under settled and lagging issue state | `cargo test -p harness-server merged_pr_and_closed_issue_recover_terminal_coverage_without_agent_work`; `cargo test -p harness-server merged_pr_and_open_issue_recover_terminal_coverage_without_agent_work` |
+| B-005 | candidate eligibility | `cargo test -p harness-server closed_pr_is_uncovered_but_a_later_valid_pr_recovers_coverage` |
 | B-006 | stable IDs and command dedupe | `cargo test -p harness-server empty_store_recovers_ready_pr_and_stays_idempotent_after_restart` |
 | B-007 | stale-work cancellation | `cargo test -p harness-server recovery_maps_open_pr_facts` |
 | B-008 | GitHub adapters and pagination guards | `cargo test -p harness-server github_lookup_failure_fails_closed_without_agent_work`; `cargo test -p harness-server existing_pr_lookup_fails_closed` |
@@ -119,7 +120,10 @@ poll.
 
 - [ ] Run every command in the Product-to-Test Mapping.
 - [ ] Run the multi-candidate test with the same candidates in forward and
-      reverse GraphQL order and assert the same selected PR.
+      reverse GraphQL order and assert the same selected PR, including a
+      merged candidate while the issue remains open.
+- [ ] Run merged-plus-open and merged-plus-closed terminal recovery tests and
+      assert `done`, merge evidence, and zero implementation or repair work.
 - [ ] Run the concurrency test with an explicit barrier that holds two
       recovery attempts after candidate selection and releases both to race the
       persistence boundary; assert one binding, one state, and one deduplicated


### PR DESCRIPTION
## Summary

- define the product contract for recovering issue coverage from authoritative GitHub closing-PR links
- specify fail-closed pagination, terminal evidence, idempotency, and observability requirements
- map all acceptance behaviors to an executable task plan

## Why

Issue #1707 changes persistence recovery and workflow coverage semantics. It is a heavy-tier change and requires an approved spec packet before implementation PR #1709 can merge.

## Spec packet

- `specs/GH1707/product.md`
- `specs/GH1707/tech.md`
- `specs/GH1707/tasks.md`

## Verification

- `python3 checks/route_gate.py --repo . --route write_spec --issue 1707 --state ready_to_spec --json`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1707`
- `cargo fmt --all -- --check`

Refs #1707

Issue: #1707