### PR TITLE
fix(ops): make phase1 archives restorable

### DIFF
--- a/scripts/archive-phase1-data.sh
+++ b/scripts/archive-phase1-data.sh
@@ -61,9 +61,10 @@ write_row_count_verification() {
         printf 'UNION ALL\n'
       fi
       printf 'SELECT '\''%s'\''::text AS "table", count(*)::bigint AS rows FROM "%s"."%s"\n' \
-        "$table" "$schema" "$name"
+      "$table" "$schema" "$name"
       first=0
     done < "$tables_file"
+    printf 'ORDER BY "table"\n'
     printf ') TO STDOUT WITH (FORMAT csv, DELIMITER E'\''\\t'\'', HEADER true);\n'
   } > "$output_file"
 }
@@ -121,6 +122,7 @@ self_test() {
   grep -Fqx 'CREATE SCHEMA IF NOT EXISTS "eval_store";' "$test_dir/schema-bootstrap.sql"
   grep -Fqx 'CREATE SCHEMA IF NOT EXISTS "task_db";' "$test_dir/schema-bootstrap.sql"
   grep -Fq 'FROM "task_db"."tasks"' "$test_dir/verify-row-counts.sql"
+  grep -Fqx 'ORDER BY "table"' "$test_dir/verify-row-counts.sql"
   grep -Fq 'DELIMITER E'\''\t'\''' "$test_dir/verify-row-counts.sql"
   grep -Fq -- '--file schema-bootstrap.sql' "$test_dir/RESTORE.md"
   grep -Fq 'diff -u table_counts.tsv restored_table_counts.tsv' "$test_dir/RESTORE.md"

--- a/scripts/archive-phase1-data.sh
+++ b/scripts/archive-phase1-data.sh
@@ -26,6 +26,108 @@ need_tool() {
   die "$name not found; set $env_name"
 }
 
+validate_phase1_table() {
+  local table="$1"
+  [[ "$table" =~ ^(thread_db|task_db|eval_store|review_store|h[0-9a-f]{16})\.[a-z_]+$ ]] \
+    || die "refusing unexpected table name: $table"
+}
+
+write_schema_bootstrap() {
+  local tables_file="$1"
+  local output_file="$2"
+  while IFS= read -r table; do
+    validate_phase1_table "$table"
+    printf '%s\n' "${table%%.*}"
+  done < "$tables_file" | sort -u | while IFS= read -r schema; do
+    printf 'CREATE SCHEMA IF NOT EXISTS "%s";\n' "$schema"
+  done > "$output_file"
+}
+
+write_row_count_verification() {
+  local tables_file="$1"
+  local output_file="$2"
+  local first=1
+  {
+    printf 'COPY (\n'
+    while IFS= read -r table; do
+      validate_phase1_table "$table"
+      IFS=. read -r schema name <<<"$table"
+      if [[ "$first" -eq 0 ]]; then
+        printf 'UNION ALL\n'
+      fi
+      printf 'SELECT '\''%s'\''::text AS "table", count(*)::bigint AS rows FROM "%s"."%s"\n' \
+        "$table" "$schema" "$name"
+      first=0
+    done < "$tables_file"
+    printf ') TO STDOUT WITH (FORMAT csv, DELIMITER E'\''\\t'\'', HEADER true);\n'
+  } > "$output_file"
+}
+
+write_restore_readme() {
+  local output_file="$1"
+  local created_at="$2"
+  local lock_wait_timeout="$3"
+  local table_count="$4"
+  cat > "$output_file" <<EOF
+# Restore phase1 archive
+
+This archive contains Harness Phase 1 contraction data captured before code
+removal. It may include shared schemas (\`thread_db\`, \`task_db\`, \`eval_store\`,
+\`review_store\`) and path-derived \`h<hex>\` schemas when they contain matching
+thread, task, eval, or review tables.
+
+Restore only into an empty scratch database. The custom dump intentionally
+contains only selected tables, so create its validated schema containers first:
+
+\`\`\`bash
+: "\${SCRATCH_DATABASE_URL:?set SCRATCH_DATABASE_URL to an empty scratch database}"
+psql -X --set ON_ERROR_STOP=1 --dbname "\$SCRATCH_DATABASE_URL" \\
+  --file schema-bootstrap.sql
+pg_restore --exit-on-error --no-owner --no-acl \\
+  --dbname "\$SCRATCH_DATABASE_URL" phase1-data.dump
+psql -Xq --set ON_ERROR_STOP=1 --dbname "\$SCRATCH_DATABASE_URL" \\
+  --file verify-row-counts.sql > restored_table_counts.tsv
+diff -u table_counts.tsv restored_table_counts.tsv
+\`\`\`
+
+The restore is verified only when \`pg_restore\` exits zero and the row-count
+diff is empty. Do not restore directly into a live Harness database. Do not
+pass \`--clean\`. Use \`table_counts.tsv\` and \`phase1-data.list\` to confirm
+expected objects first.
+
+Created at: $created_at
+Lock wait timeout: $lock_wait_timeout
+Table count: $table_count
+EOF
+}
+
+self_test() {
+  local test_dir
+  test_dir="$(mktemp -d "${TMPDIR:-/tmp}/archive-phase1-data-test.XXXXXX")"
+  printf '%s\n' \
+    'eval_store.eval_runs' \
+    'task_db.tasks' \
+    'task_db.workspace_leases' > "$test_dir/tables.txt"
+  write_schema_bootstrap "$test_dir/tables.txt" "$test_dir/schema-bootstrap.sql"
+  write_row_count_verification "$test_dir/tables.txt" "$test_dir/verify-row-counts.sql"
+  write_restore_readme "$test_dir/RESTORE.md" '2026-07-21T00:00:00Z' '5s' '3'
+  [[ "$(wc -l < "$test_dir/schema-bootstrap.sql" | tr -d ' ')" == 2 ]]
+  grep -Fqx 'CREATE SCHEMA IF NOT EXISTS "eval_store";' "$test_dir/schema-bootstrap.sql"
+  grep -Fqx 'CREATE SCHEMA IF NOT EXISTS "task_db";' "$test_dir/schema-bootstrap.sql"
+  grep -Fq 'FROM "task_db"."tasks"' "$test_dir/verify-row-counts.sql"
+  grep -Fq 'DELIMITER E'\''\t'\''' "$test_dir/verify-row-counts.sql"
+  grep -Fq -- '--file schema-bootstrap.sql' "$test_dir/RESTORE.md"
+  grep -Fq 'diff -u table_counts.tsv restored_table_counts.tsv' "$test_dir/RESTORE.md"
+  rm -r "$test_dir"
+  printf 'archive-phase1-data self-test passed\n'
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test
+  exit 0
+fi
+[[ "$#" -eq 0 ]] || die "usage: $0 [--self-test]"
+
 [[ -n "${HARNESS_DATABASE_URL:-}" ]] || die "HARNESS_DATABASE_URL is required"
 
 PSQL="$(need_tool PSQL psql)"
@@ -87,14 +189,16 @@ dump_args=()
 {
   printf 'table\trows\n'
   for table in "${tables[@]}"; do
-    [[ "$table" =~ ^(thread_db|task_db|eval_store|review_store|h[0-9a-f]{16})\.[a-z_]+$ ]] \
-      || die "refusing unexpected table name: $table"
+    validate_phase1_table "$table"
     IFS=. read -r schema name <<<"$table"
     count="$("${psql_cmd[@]}" -c "SELECT count(*) FROM \"$schema\".\"$name\"")"
     printf '%s\t%s\n' "$table" "$count"
     dump_args+=(--table="$table")
   done
 } > "$OUT_DIR/table_counts.tsv"
+
+write_schema_bootstrap "$tables_file" "$OUT_DIR/schema-bootstrap.sql"
+write_row_count_verification "$tables_file" "$OUT_DIR/verify-row-counts.sql"
 
 "$PG_DUMP" \
   --format=custom \
@@ -107,31 +211,10 @@ dump_args=()
 
 "$PG_RESTORE" --list "$OUT_DIR/phase1-data.dump" > "$OUT_DIR/phase1-data.list"
 
-cat > "$OUT_DIR/RESTORE.md" <<'EOF'
-# Restore phase1 archive
-
-This archive contains Harness Phase 1 contraction data captured before code
-removal. It may include shared schemas (`thread_db`, `task_db`, `eval_store`,
-`review_store`) and path-derived `h<hex>` schemas when they contain matching
-thread, task, eval, or review tables.
-
-Restore only into an empty scratch database:
-
-```bash
-export SCRATCH_DATABASE_URL=postgres://harness:harness@localhost:5432/harness_phase1_restore
-pg_restore --exit-on-error --no-owner --no-acl \
-  --dbname "$SCRATCH_DATABASE_URL" phase1-data.dump
-```
-
-Do not restore directly into a live Harness database. Do not pass `--clean`.
-Use `table_counts.tsv` and `phase1-data.list` to confirm expected objects first.
-EOF
-
-{
-  echo
-  echo "Created at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  echo "Lock wait timeout: $LOCK_WAIT_TIMEOUT"
-  echo "Table count: ${#tables[@]}"
-} >> "$OUT_DIR/RESTORE.md"
+write_restore_readme \
+  "$OUT_DIR/RESTORE.md" \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  "$LOCK_WAIT_TIMEOUT" \
+  "${#tables[@]}"
 
 printf 'Archive written: %s\n' "$OUT_DIR"

--- a/scripts/archive-phase1-data.sh
+++ b/scripts/archive-phase1-data.sh
@@ -35,10 +35,13 @@ validate_phase1_table() {
 write_schema_bootstrap() {
   local tables_file="$1"
   local output_file="$2"
+  local schemas=()
+  local table schema
   while IFS= read -r table; do
     validate_phase1_table "$table"
-    printf '%s\n' "${table%%.*}"
-  done < "$tables_file" | sort -u | while IFS= read -r schema; do
+    schemas+=("${table%%.*}")
+  done < "$tables_file"
+  printf '%s\n' "${schemas[@]}" | sort -u | while IFS= read -r schema; do
     printf 'CREATE SCHEMA IF NOT EXISTS "%s";\n' "$schema"
   done > "$output_file"
 }
@@ -47,11 +50,13 @@ write_row_count_verification() {
   local tables_file="$1"
   local output_file="$2"
   local first=1
+  local table schema name
   {
     printf 'COPY (\n'
     while IFS= read -r table; do
       validate_phase1_table "$table"
-      IFS=. read -r schema name <<<"$table"
+      schema="${table%%.*}"
+      name="${table#*.}"
       if [[ "$first" -eq 0 ]]; then
         printf 'UNION ALL\n'
       fi

--- a/scripts/archive-phase1-data.sh
+++ b/scripts/archive-phase1-data.sh
@@ -37,7 +37,7 @@ write_schema_bootstrap() {
   local output_file="$2"
   local schemas=()
   local table schema
-  while IFS= read -r table; do
+  while IFS= read -r table || [[ -n "$table" ]]; do
     validate_phase1_table "$table"
     schemas+=("${table%%.*}")
   done < "$tables_file"
@@ -53,7 +53,7 @@ write_row_count_verification() {
   local table schema name
   {
     printf 'COPY (\n'
-    while IFS= read -r table; do
+    while IFS= read -r table || [[ -n "$table" ]]; do
       validate_phase1_table "$table"
       schema="${table%%.*}"
       name="${table#*.}"
@@ -109,10 +109,11 @@ EOF
 self_test() {
   local test_dir
   test_dir="$(mktemp -d "${TMPDIR:-/tmp}/archive-phase1-data-test.XXXXXX")"
-  printf '%s\n' \
-    'eval_store.eval_runs' \
-    'task_db.tasks' \
-    'task_db.workspace_leases' > "$test_dir/tables.txt"
+  trap 'rm -r -- "$test_dir"' EXIT
+  {
+    printf '%s\n' 'eval_store.eval_runs' 'task_db.tasks'
+    printf '%s' 'task_db.workspace_leases'
+  } > "$test_dir/tables.txt"
   write_schema_bootstrap "$test_dir/tables.txt" "$test_dir/schema-bootstrap.sql"
   write_row_count_verification "$test_dir/tables.txt" "$test_dir/verify-row-counts.sql"
   write_restore_readme "$test_dir/RESTORE.md" '2026-07-21T00:00:00Z' '5s' '3'
@@ -123,7 +124,8 @@ self_test() {
   grep -Fq 'DELIMITER E'\''\t'\''' "$test_dir/verify-row-counts.sql"
   grep -Fq -- '--file schema-bootstrap.sql' "$test_dir/RESTORE.md"
   grep -Fq 'diff -u table_counts.tsv restored_table_counts.tsv' "$test_dir/RESTORE.md"
-  rm -r "$test_dir"
+  rm -r -- "$test_dir"
+  trap - EXIT
   printf 'archive-phase1-data self-test passed\n'
 }
 

--- a/specs/GH1434/tasks.md
+++ b/specs/GH1434/tasks.md
@@ -45,10 +45,14 @@ GH-1434
 
 - PR #1453 is the evidence for `SP1434-T001` and the archive tooling. Archive
   execution completed on 2026-07-16 at `archives/phase1-20260716T092438Z`.
-  The archive comment records dump creation, restore instructions, and table
-  counts, but neither it nor the scoped T007/T008 waiver records an executed
-  scratch restore. The referenced operator-owned archive is not present in this
-  PR worktree, so this PR does not claim restore rehearsal completion.
+  The scratch restore rehearsal completed on 2026-07-21 against PostgreSQL
+  16.14: all 29 tables and 1,689 rows matched the archived counts with an empty
+  diff. The evidence and archive SHA-256 are recorded on GH-1434:
+  <https://github.com/majiayu000/harness/issues/1434#issuecomment-5033352086>.
+  The first attempt also proved that selected-table dumps omit schema creation;
+  the archive tooling now generates a validated schema bootstrap and a
+  deterministic row-count verification query. The failure-first evidence is
+  retained in the preceding GH-1434 evidence comment.
 - The explicit maintainer waiver on GH-1434 satisfies `SP1434-T003` for T004
   and T005 based on the recorded zero-traffic evidence and completed archive:
   <https://github.com/majiayu000/harness/issues/1434#issuecomment-4993856096>.

--- a/specs/GH1434/tech.md
+++ b/specs/GH1434/tech.md
@@ -99,9 +99,12 @@ merge, and cancel before the compatibility endpoint can be removed.
 - [x] Archive creation produced a dump, restore instructions, and table counts
       before related code was deleted, as recorded in the archive evidence:
       <https://github.com/majiayu000/harness/issues/1434#issuecomment-4990260785>.
-- [ ] A scratch-database restore rehearsal is not evidenced. The referenced
-      operator-owned archive is not present in this PR worktree, and the scoped
-      waiver does not include restore command output or row-count comparisons.
+- [x] A scratch-database restore rehearsal completed on 2026-07-21 against
+      PostgreSQL 16.14. The same archived dump restored 29 tables and 1,689
+      rows with an empty row-count diff; the failure-first evidence, SHA-256,
+      successful command contract, and retained operator artifact path are
+      recorded in
+      <https://github.com/majiayu000/harness/issues/1434#issuecomment-5033352086>.
 
 ## Rollback Plan
 


### PR DESCRIPTION
## Summary

- make Phase 1 archives self-contained by generating the required schema bootstrap
- generate deterministic row-count verification SQL and executable scratch-restore instructions
- record the real PostgreSQL 16 scratch restore and exact 29-table / 1,689-row comparison evidence

## Verification

- `bash -n scripts/archive-phase1-data.sh`
- `/bin/bash scripts/archive-phase1-data.sh --self-test`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `RUST_TEST_THREADS=1 cargo test -p harness-agents --lib`
- pre-push: `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push: database-independent workspace and workflow lib suites
- generated a fresh archive from the Apple host production database using the revised script
- restored that archive into an isolated PostgreSQL 16.14 scratch instance using only generated artifacts
- verified 29 tables and 1,689 rows with an empty row-count diff

Evidence: https://github.com/majiayu000/harness/issues/1434#issuecomment-5033352086

Closes #1434
