### PR TITLE
spec(GH1717): define protocol context boundary

### DIFF
--- a/specs/GH1717/product.md
+++ b/specs/GH1717/product.md
@@ -26,6 +26,9 @@ implementation graph cannot evolve independently.
 
 - Changing context composition, provider selection, budgeting, degradation,
   manifests, endpoint names, or response payloads.
+- Adding protocol-owned response DTOs. `RpcResponse.result` remains
+  `serde_json::Value`; protocol-only Rust consumers continue to deserialize the
+  stable response JSON into their own type or inspect it as JSON.
 - Reusing `harness_core::types::ContextItem`, which models agent execution
   context and has a different shape and meaning.
 - Replacing typed fields with `serde_json::Value`, `Any`, aliases, or silent

--- a/specs/GH1717/product.md
+++ b/specs/GH1717/product.md
@@ -1,0 +1,118 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1717
+
+## User Problem
+
+Clients use the typed `context/preview` JSON-RPC contract to inspect a context
+composition before starting agent work. Today that one protocol method exposes
+types owned by the context-composer implementation crate. As a result,
+consumers that only need protocol messages also acquire the composer and its
+rules, skills, GC, and exec dependencies. The transport contract and the
+implementation graph cannot evolve independently.
+
+## Goals
+
+- Make the protocol layer own the typed `context/preview` request contract.
+- Remove the normal `harness-protocol -> harness-context` dependency.
+- Preserve the existing JSON field names, nesting, enum values, defaults, and
+  successful response behavior.
+- Keep malformed requests fail-closed and make the server boundary conversion
+  explicit, exhaustive, and testable.
+
+## Non-Goals
+
+- Changing context composition, provider selection, budgeting, degradation,
+  manifests, endpoint names, or response payloads.
+- Reusing `harness_core::types::ContextItem`, which models agent execution
+  context and has a different shape and meaning.
+- Replacing typed fields with `serde_json::Value`, `Any`, aliases, or silent
+  fallback behavior.
+- Introducing a shared-types crate or making `harness-context` depend on
+  transport-layer types in this change.
+- Guaranteeing source compatibility for Rust callers that directly construct
+  `Method::ContextPreview` with `harness_context` types; this risk must be
+  documented and reviewed before implementation merge.
+
+## User-Visible Behavior
+
+1. **B-001:** Building or consuming `harness-protocol` no longer requires a
+   normal dependency on `harness-context`, and the context implementation
+   crates are not reachable through the protocol dependency graph.
+2. **B-002:** Every JSON request that is valid under the current
+   `context/preview` contract remains valid with identical field names,
+   nesting, snake_case enum values, and serialized representation.
+3. **B-003:** Missing optional `run_id` and `dedupe_key`, omitted `degrade` and
+   `supplied_items`, empty lists, and absent optional task-profile fields keep
+   their current distinct meanings and defaults.
+4. **B-004:** Missing required fields, unknown enum values, and malformed
+   degradation payloads remain explicit request-deserialization failures. The
+   boundary must not invent values or continue with a partial request.
+5. **B-005:** For a valid request, conversion preserves every request and item
+   value: IDs, paths, task-profile fields, budget, item order, content, token
+   estimate, class, priority, relevance, all degradation variants and NAP
+   status, dedupe key, and instruction-bearing flag.
+6. **B-006:** Repeated conversion of the same valid request is deterministic,
+   does not mutate caller-visible data, and does not reorder supplied items or
+   degradation ladders.
+7. **B-007:** After conversion, the server invokes the existing context
+   composer preview path, so rendered content, manifest decisions, run-ID
+   fallback, error propagation, and response shape remain unchanged.
+8. **B-008:** Completion evidence includes deterministic protocol and server
+   tests plus dependency-graph evidence; passing behavior tests without proving
+   removal of the dependency edge is incomplete.
+
+## Acceptance Criteria
+
+- [ ] B-001 through B-008 have deterministic implementation and verification
+      evidence.
+- [ ] Protocol tests cover the full valid wire shape, all defaults, every
+      degradation variant, and representative malformed payloads.
+- [ ] Server tests prove exhaustive field preservation and unchanged
+      `ContextComposer::compose_supplied` behavior.
+- [ ] Dependency evidence proves `harness-context`, `harness-rules`,
+      `harness-skills`, `harness-gc`, and `harness-exec` are not reachable
+      through `harness-protocol`.
+- [ ] The implementation PR documents the Rust source-compatibility impact for
+      direct `Method::ContextPreview` constructors.
+
+## Boundary Checklist
+
+| Boundary | Verdict |
+| --- | --- |
+| Empty / missing input | Covered by B-003 and B-004. |
+| Error and failure paths | Covered by B-004 and B-007. |
+| Authorization / permission | N/A: request decoding and conversion make no authorization decision. Existing endpoint authorization remains unchanged. |
+| Concurrency / race / ordering | Covered by B-005 and B-006; conversion is local and must preserve order. |
+| Retry / repetition / idempotency | Covered by B-006. |
+| Illegal state transitions | N/A: this change has no lifecycle state or persistence transition. |
+| Compatibility / migration | Covered by B-002, B-003, B-005, and B-007. |
+| Degradation / fallback | Covered by B-004 and B-005; degradation data is preserved and malformed data cannot silently fall back. |
+| Evidence and audit integrity | Covered by B-008. |
+| Cancellation / interruption / partial completion | N/A: decoding and conversion are synchronous and stateless; no partial state is committed. |
+
+## Edge Cases
+
+- `supplied_items` omitted versus explicitly empty.
+- A task profile with every optional field absent and `target_paths` omitted.
+- `run_id` and `dedupe_key` omitted independently.
+- Empty content, zero `est_tokens`, zero `budget_hint`, and boundary relevance
+  values accepted by the current contract.
+- Mixed `summary`, `pointer`, and `summarized` degradation entries, including
+  every valid NAP status, in a caller-defined order.
+- Unknown item class, priority, degradation level, or malformed nested
+  `summarized` content.
+- A current run identity exists while the request omits `run_id`; server
+  fallback remains unchanged.
+
+## Rollout Notes
+
+The JSON-RPC contract needs no client migration. Rust callers that construct
+`Method::ContextPreview` directly will use protocol-owned DTOs after this
+change, so the implementation PR and release notes must identify that source
+compatibility change. If repository evidence shows that preserving Rust type
+identity is mandatory, stop implementation and return to spec review for the
+lightweight shared-types alternative rather than reintroducing the dependency
+or adding an untyped bridge.

--- a/specs/GH1717/product.md
+++ b/specs/GH1717/product.md
@@ -44,9 +44,10 @@ implementation graph cannot evolve independently.
 2. **B-002:** Every JSON request that is valid under the current
    `context/preview` contract remains valid with identical field names,
    nesting, snake_case enum values, and serialized representation.
-3. **B-003:** Missing optional `run_id` and `dedupe_key`, omitted `degrade` and
-   `supplied_items`, empty lists, and absent optional task-profile fields keep
-   their current distinct meanings and defaults.
+3. **B-003:** Missing optional `run_id` and `dedupe_key` remain absent.
+   Omitted `degrade`, `supplied_items`, and `target_paths` remain equivalent
+   to explicit empty lists, and absent optional task-profile fields retain
+   their current default and serialization behavior.
 4. **B-004:** Missing required fields, unknown enum values, and malformed
    degradation payloads remain explicit request-deserialization failures. The
    boundary must not invent values or continue with a partial request.
@@ -68,7 +69,8 @@ implementation graph cannot evolve independently.
 
 - [ ] B-001 through B-008 have deterministic implementation and verification
       evidence.
-- [ ] Protocol tests cover the full valid wire shape, all defaults, every
+- [ ] Golden protocol fixtures captured from the current composer-owned types
+      prove the full valid wire shape, defaults, `None` serialization, every
       degradation variant, and representative malformed payloads.
 - [ ] Server tests prove exhaustive field preservation and unchanged
       `ContextComposer::compose_supplied` behavior.
@@ -95,7 +97,8 @@ implementation graph cannot evolve independently.
 
 ## Edge Cases
 
-- `supplied_items` omitted versus explicitly empty.
+- `supplied_items`, `degrade`, and `target_paths` omitted versus explicitly
+  empty; each pair must deserialize to the same typed value.
 - A task profile with every optional field absent and `target_paths` omitted.
 - `run_id` and `dedupe_key` omitted independently.
 - Empty content, zero `est_tokens`, zero `budget_hint`, and boundary relevance

--- a/specs/GH1717/tech.md
+++ b/specs/GH1717/tech.md
@@ -1,0 +1,163 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1717
+
+## Product Spec
+
+See `specs/GH1717/product.md`.
+
+<!-- specrail-planned-changes
+{"issue":1717,"complete":true,"paths":["Cargo.lock","crates/harness-protocol/Cargo.toml","crates/harness-protocol/src/context.rs","crates/harness-protocol/src/lib.rs","crates/harness-protocol/src/methods.rs","crates/harness-server/src/handlers/context.rs","crates/harness-server/src/router/tests/observability.rs"],"spec_refs":["B-001","B-002","B-003","B-004","B-005","B-006","B-007","B-008"]}
+-->
+
+## Current System
+
+- `crates/harness-protocol/Cargo.toml:12-21` declares protocol dependencies;
+  line 15 adds the direct `harness-context` edge.
+- `crates/harness-protocol/src/methods.rs:152-157` uses
+  `harness_context::ComposeRequest` and `harness_context::ContextItem` in the
+  public `Method::ContextPreview` variant. These are the only
+  `harness-context` uses in protocol source.
+- `crates/harness-context/src/types.rs:48-70` defines `ComposeRequest` and its
+  nested `TaskProfile`; lines 72-183 define the item enums, degradation
+  contract, and `ContextItem`.
+- `crates/harness-context/Cargo.toml:12-17` depends on `harness-core`,
+  `harness-rules`, `harness-skills`, `harness-gc`, and `harness-exec`, so the
+  protocol edge reaches the full implementation graph.
+- `crates/harness-protocol/src/methods.rs:335-378` contains the current
+  deserialization test but covers only one pointer degradation and does not
+  prove default, malformed, or round-trip compatibility.
+- `crates/harness-server/src/router/mod.rs:177-181` dispatches the typed method
+  fields directly to the context handler.
+- `crates/harness-server/src/handlers/context.rs:12-23` currently accepts
+  composer-domain types, fills a missing run ID, and calls
+  `ContextComposer::compose_supplied`.
+- `crates/harness-server/src/router/tests/observability.rs:610-666` verifies
+  that a supplied rule reaches the preview manifest.
+- `crates/harness-core/src/types.rs:596-606` defines a different
+  `ContextItem` enum for agent execution; its tagged variants cannot represent
+  the composer preview item contract.
+
+## Proposed Design
+
+Add `crates/harness-protocol/src/context.rs` containing protocol-owned,
+serde-derived DTOs dedicated to `context/preview`:
+
+- `ContextPreviewRequest` with `thread_id`, optional `run_id`, `project`,
+  `task_profile`, and `budget_hint`.
+- `ContextPreviewTaskProfile` with the current optional strings and defaulted
+  `target_paths`.
+- `ContextPreviewItem` with the current item fields and defaults.
+- Closed wire enums for item class, priority, and degradation. The degradation
+  enum retains the current internally tagged `level`, `content`, snake_case
+  representation, including structured `summarized` content and `NapStatus`.
+
+Use existing `harness-core` ID and NAP types where they are already protocol
+dependencies and exactly match the wire contract. Do not use the unrelated
+core agent `ContextItem`.
+
+Change `Method::ContextPreview` to hold the protocol DTOs. Keep the field names
+`request` and `supplied_items` and the existing serde default on
+`supplied_items`. Export the DTO module from `harness-protocol::lib`.
+
+At the start of `handlers::context::context_preview`, convert the request and
+each supplied item into the corresponding `harness-context` domain type using
+private, typed conversion functions. Every closed enum is matched
+exhaustively; every struct field is named explicitly. The conversion is
+infallible after serde validation and preserves vector order. Only after
+conversion does the existing run-ID fallback and
+`ContextComposer::compose_supplied` call execute.
+
+Remove `harness-context` from `harness-protocol/Cargo.toml` and refresh the
+`harness-protocol` dependency list in `Cargo.lock`. No context-composer source,
+router dispatch, public endpoint documentation, response schema, or
+persistence changes are required.
+
+## Data Flow
+
+`JSON-RPC bytes -> RpcRequest/Method deserialization into protocol DTOs ->
+exhaustive server conversion -> existing ComposeRequest/ContextItem domain
+values -> existing run-ID fallback -> ContextComposer::compose_supplied ->
+existing RpcResponse`.
+
+Malformed bytes stop during typed deserialization. Conversion performs no I/O,
+fallback, filtering, sorting, or persistence.
+
+## Product-to-Test Mapping
+
+| Behavior invariant | Implementation area | Verification |
+| --- | --- | --- |
+| B-001 | protocol manifest and lockfile | `cargo check -p harness-protocol --all-targets`; `! cargo tree -p harness-protocol --edges normal \| rg -q 'harness-(context\|rules\|skills\|gc\|exec) '` |
+| B-002 | protocol DTO serde definitions and `Method` | `cargo test -p harness-protocol context_preview_wire_json_round_trips --lib` |
+| B-003 | DTO serde defaults | `cargo test -p harness-protocol context_preview_defaults_and_empty_collections_deserialize --lib` |
+| B-004 | closed enums and required DTO fields | `cargo test -p harness-protocol context_preview_rejects_malformed_payloads --lib` |
+| B-005 | server conversion functions | `cargo test -p harness-server context_preview_conversion_preserves_every_field --lib` |
+| B-006 | server conversion functions | `cargo test -p harness-server context_preview_conversion_is_deterministic_and_order_preserving --lib` |
+| B-007 | existing handler/composer path and router integration | `cargo test -p harness-server context_rpc_preview_with_supplied_items_returns_manifest --lib` |
+| B-008 | protocol/server tests and dependency evidence | Run all commands above and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1717` |
+
+## Alternatives Considered
+
+- Add a lightweight `harness-context-types` crate and re-export its types from
+  `harness-context`: this avoids duplicate DTO/domain structures and better
+  preserves Rust type identity, but adds a workspace crate and moves multiple
+  nested domain types. It is the fallback if public Rust source compatibility
+  is a required gate.
+- Move composer-domain types into `harness-protocol` and make
+  `harness-context` depend on protocol: rejected because domain behavior would
+  depend on the transport layer and crate-private type helpers would cross the
+  ownership boundary.
+- Reuse `harness_core::types::ContextItem`: rejected because it is a
+  semantically different tagged enum without composer metadata.
+- Deserialize through `serde_json::Value` or a generic map: rejected because
+  it weakens validation, permits drift, and creates silent partial-conversion
+  paths.
+- Keep the current dependency: rejected because one wire method continues to
+  impose the implementation graph on every protocol consumer.
+
+## Risks
+
+- Security: no authorization or external-call change is planned. Typed closed
+  enums retain fail-closed decoding; review must reject untyped fallback.
+- Compatibility: the JSON contract remains stable, but direct Rust
+  construction of `Method::ContextPreview` changes from `harness-context`
+  types to protocol DTOs. The implementation PR must call this out. If source
+  compatibility is mandatory, return to spec review for the shared-types
+  alternative.
+- Data integrity: duplicated wire/domain fields can drift. Exhaustive
+  conversion and full-shape round-trip tests must change whenever either side
+  adds a field or enum variant.
+- Performance: conversion clones or moves bounded request data once before
+  composition. Tests should use owned conversion so no avoidable second clone
+  is introduced.
+- Maintenance: protocol and domain models now have separate owners by design;
+  explicit mapping is the enforcement point, not an alias or wildcard.
+
+## Test Plan
+
+- [ ] Run every command in the Product-to-Test Mapping.
+- [ ] Cover omitted and empty collections independently.
+- [ ] Round-trip every item class, priority, and degradation variant,
+      including every valid `NapStatus`.
+- [ ] Assert malformed required fields, enum values, and nested summarized
+      content fail deserialization before handler execution.
+- [ ] Use a full-field fixture to assert conversion equality field by field
+      and preserve supplied-item and degradation-ladder ordering.
+- [ ] Run `cargo check -p harness-protocol --all-targets`.
+- [ ] Run `cargo check -p harness-server --all-targets`.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Before pushing the implementation PR, run
+      `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] Run `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1717`.
+- [ ] Collect exact-head CI, Gemini review, independent reviewer evidence,
+      review-thread state, and SpecRail PR-gate evidence.
+
+## Rollback Plan
+
+Revert the implementation PR, restoring the two composer-domain types in
+`Method::ContextPreview` and the direct protocol dependency. No schema,
+persistence, or data migration rollback is required. If a compatibility issue
+is discovered before merge, keep the implementation unmerged and revise the
+approved specs for the lightweight shared-types design instead.

--- a/specs/GH1717/tech.md
+++ b/specs/GH1717/tech.md
@@ -115,9 +115,14 @@ Run the dependency assertion as an actual shell pipeline from this fenced
 block; do not copy an escaped table delimiter:
 
 ```sh
-cargo tree -p harness-protocol --edges normal --prefix none > /tmp/harness-protocol-tree.txt
-if rg -q 'harness-(context|rules|skills|gc|exec) ' /tmp/harness-protocol-tree.txt; then
+tree_file="$(mktemp)"
+trap 'rm -f "$tree_file"' EXIT
+cargo tree -p harness-protocol --edges normal --prefix none > "$tree_file" || exit 1
+if rg -q 'harness-(context|rules|skills|gc|exec) ' "$tree_file"; then
   exit 1
+else
+  rg_status=$?
+  test "$rg_status" -eq 1 || exit "$rg_status"
 fi
 ```
 

--- a/specs/GH1717/tech.md
+++ b/specs/GH1717/tech.md
@@ -49,14 +49,20 @@ serde-derived DTOs dedicated to `context/preview`:
   `task_profile`, and `budget_hint`.
 - `ContextPreviewTaskProfile` with the current optional strings and defaulted
   `target_paths`.
-- `ContextPreviewItem` with the current item fields and defaults.
+- `ContextPreviewItemId(pub String)`, a protocol-local
+  `#[serde(transparent)]` newtype whose JSON representation is the same string
+  representation as the current composer `ItemId`.
+- `ContextPreviewItem` with the current item fields and defaults, using
+  `ContextPreviewItemId` for `id`.
 - Closed wire enums for item class, priority, and degradation. The degradation
   enum retains the current internally tagged `level`, `content`, snake_case
   representation, including structured `summarized` content and `NapStatus`.
 
-Use existing `harness-core` ID and NAP types where they are already protocol
-dependencies and exactly match the wire contract. Do not use the unrelated
-core agent `ContextItem`.
+Use existing `harness-core` thread, project, run, and NAP types where they are
+already protocol dependencies and exactly match the wire contract. Convert
+`ContextPreviewItemId` explicitly to `harness_context::ItemId` in the server
+handler. Do not move the composer `ItemId` or use the unrelated core agent
+`ContextItem`.
 
 Change `Method::ContextPreview` to hold the protocol DTOs. Keep the field names
 `request` and `supplied_items` and the existing serde default on
@@ -90,8 +96,8 @@ fallback, filtering, sorting, or persistence.
 | Behavior invariant | Implementation area | Verification |
 | --- | --- | --- |
 | B-001 | protocol manifest and lockfile | `cargo check -p harness-protocol --all-targets`; `! cargo tree -p harness-protocol --edges normal \| rg -q 'harness-(context\|rules\|skills\|gc\|exec) '` |
-| B-002 | protocol DTO serde definitions and `Method` | `cargo test -p harness-protocol context_preview_wire_json_round_trips --lib` |
-| B-003 | DTO serde defaults | `cargo test -p harness-protocol context_preview_defaults_and_empty_collections_deserialize --lib` |
+| B-002 | protocol DTO serde definitions, item-ID newtype, and `Method` | `cargo test -p harness-protocol context_preview_wire_json_matches_legacy_golden_fixtures --lib` compares literal JSON captured from the current composer-owned types with the new DTO output |
+| B-003 | DTO serde defaults | `cargo test -p harness-protocol context_preview_defaults_and_empty_collections_are_equivalent --lib` proves omitted and explicit-empty vectors deserialize equally and asserts current `None` serialization |
 | B-004 | closed enums and required DTO fields | `cargo test -p harness-protocol context_preview_rejects_malformed_payloads --lib` |
 | B-005 | server conversion functions | `cargo test -p harness-server context_preview_conversion_preserves_every_field --lib` |
 | B-006 | server conversion functions | `cargo test -p harness-server context_preview_conversion_is_deterministic_and_order_preserving --lib` |
@@ -127,7 +133,7 @@ fallback, filtering, sorting, or persistence.
   compatibility is mandatory, return to spec review for the shared-types
   alternative.
 - Data integrity: duplicated wire/domain fields can drift. Exhaustive
-  conversion and full-shape round-trip tests must change whenever either side
+  conversion and legacy golden JSON fixtures must change whenever either side
   adds a field or enum variant.
 - Performance: conversion clones or moves bounded request data once before
   composition. Tests should use owned conversion so no avoidable second clone
@@ -138,9 +144,13 @@ fallback, filtering, sorting, or persistence.
 ## Test Plan
 
 - [ ] Run every command in the Product-to-Test Mapping.
-- [ ] Cover omitted and empty collections independently.
-- [ ] Round-trip every item class, priority, and degradation variant,
-      including every valid `NapStatus`.
+- [ ] Compare new DTO serialization against literal golden JSON captured from
+      the current composer-owned types, including omitted versus explicit-empty
+      inputs, `None` serialization, every item class and priority, `summary`,
+      `pointer`, structured `summarized`, and every valid `NapStatus`
+      representation including `failed { fell_back }`.
+- [ ] Prove omitted and explicit-empty `supplied_items`, `degrade`, and
+      `target_paths` deserialize to equal typed values.
 - [ ] Assert malformed required fields, enum values, and nested summarized
       content fail deserialization before handler execution.
 - [ ] Use a full-field fixture to assert conversion equality field by field

--- a/specs/GH1717/tech.md
+++ b/specs/GH1717/tech.md
@@ -36,6 +36,9 @@ See `specs/GH1717/product.md`.
   `ContextComposer::compose_supplied`.
 - `crates/harness-server/src/router/tests/observability.rs:610-666` verifies
   that a supplied rule reaches the preview manifest.
+- `crates/harness-protocol/src/methods.rs:239-245` stores every successful
+  JSON-RPC response payload in `RpcResponse.result: serde_json::Value`; the
+  protocol crate does not currently expose a typed context-preview response.
 - `crates/harness-core/src/types.rs:596-606` defines a different
   `ContextItem` enum for agent execution; its tagged variants cannot represent
   the composer preview item contract.
@@ -81,6 +84,10 @@ Remove `harness-context` from `harness-protocol/Cargo.toml` and refresh the
 router dispatch, public endpoint documentation, response schema, or
 persistence changes are required.
 
+Do not add response DTOs in this change. The existing JSON response remains
+byte-compatible inside `RpcResponse.result`; protocol-only Rust consumers keep
+their current choice of a local response type or JSON inspection.
+
 ## Data Flow
 
 `JSON-RPC bytes -> RpcRequest/Method deserialization into protocol DTOs ->
@@ -95,14 +102,24 @@ fallback, filtering, sorting, or persistence.
 
 | Behavior invariant | Implementation area | Verification |
 | --- | --- | --- |
-| B-001 | protocol manifest and lockfile | `cargo check -p harness-protocol --all-targets`; `! cargo tree -p harness-protocol --edges normal \| rg -q 'harness-(context\|rules\|skills\|gc\|exec) '` |
+| B-001 | protocol manifest and lockfile | `cargo check -p harness-protocol --all-targets` plus the dependency assertion below |
 | B-002 | protocol DTO serde definitions, item-ID newtype, and `Method` | `cargo test -p harness-protocol context_preview_wire_json_matches_legacy_golden_fixtures --lib` compares literal JSON captured from the current composer-owned types with the new DTO output |
 | B-003 | DTO serde defaults | `cargo test -p harness-protocol context_preview_defaults_and_empty_collections_are_equivalent --lib` proves omitted and explicit-empty vectors deserialize equally and asserts current `None` serialization |
 | B-004 | closed enums and required DTO fields | `cargo test -p harness-protocol context_preview_rejects_malformed_payloads --lib` |
 | B-005 | server conversion functions | `cargo test -p harness-server context_preview_conversion_preserves_every_field --lib` |
 | B-006 | server conversion functions | `cargo test -p harness-server context_preview_conversion_is_deterministic_and_order_preserving --lib` |
-| B-007 | existing handler/composer path and router integration | `cargo test -p harness-server context_rpc_preview_with_supplied_items_returns_manifest --lib` |
+| B-007 | existing handler/composer path and router integration | `cargo test -p harness-server context_rpc_preview_with_supplied_items_returns_manifest --lib`; `cargo test -p harness-server context_preview_uses_current_run_id_when_request_omits_run_id --lib`; `cargo test -p harness-server context_preview_preserves_composer_error_mapping --lib` |
 | B-008 | protocol/server tests and dependency evidence | Run all commands above and `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1717` |
+
+Run the dependency assertion as an actual shell pipeline from this fenced
+block; do not copy an escaped table delimiter:
+
+```sh
+cargo tree -p harness-protocol --edges normal --prefix none > /tmp/harness-protocol-tree.txt
+if rg -q 'harness-(context|rules|skills|gc|exec) ' /tmp/harness-protocol-tree.txt; then
+  exit 1
+fi
+```
 
 ## Alternatives Considered
 
@@ -131,7 +148,8 @@ fallback, filtering, sorting, or persistence.
   construction of `Method::ContextPreview` changes from `harness-context`
   types to protocol DTOs. The implementation PR must call this out. If source
   compatibility is mandatory, return to spec review for the shared-types
-  alternative.
+  alternative. This change deliberately leaves responses in the existing
+  untyped `RpcResponse.result`; typed response DTOs require a separate spec.
 - Data integrity: duplicated wire/domain fields can drift. Exhaustive
   conversion and legacy golden JSON fixtures must change whenever either side
   adds a field or enum variant.
@@ -155,6 +173,10 @@ fallback, filtering, sorting, or persistence.
       content fail deserialization before handler execution.
 - [ ] Use a full-field fixture to assert conversion equality field by field
       and preserve supplied-item and degradation-ladder ordering.
+- [ ] Set a current run identity, omit request `run_id`, and assert the
+      existing fallback reaches the preview manifest.
+- [ ] Force the context-composer error path and assert the existing JSON-RPC
+      error code/message mapping remains unchanged.
 - [ ] Run `cargo check -p harness-protocol --all-targets`.
 - [ ] Run `cargo check -p harness-server --all-targets`.
 - [ ] Run `cargo fmt --all -- --check`.


### PR DESCRIPTION
## Summary

- define protocol-owned typed DTOs for the `context/preview` JSON-RPC request
- preserve the existing JSON contract through exhaustive server-side conversion
- remove the normal `harness-protocol -> harness-context` dependency edge without changing composer behavior

## Scope

Spec-only PR containing:

- `specs/GH1717/product.md`
- `specs/GH1717/tech.md`

Implementation and `tasks.md` remain gated until the specs are approved.

## Verification

- `python3 checks/route_gate.py --repo . --route write_spec --issue 1717 --state ready_to_spec --label ready_to_spec --json`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1717`
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

Refs #1717

## Agent Disclosure

Agent-assisted draft. Human review and approval are required before implementation or merge.
