### PR TITLE
refactor(protocol): own context preview request DTOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,7 +1367,6 @@ version = "0.6.34"
 dependencies = [
  "anyhow",
  "chrono",
- "harness-context",
  "harness-core",
  "serde",
  "serde_json",

--- a/crates/harness-protocol/Cargo.toml
+++ b/crates/harness-protocol/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 harness-core = { workspace = true }
-harness-context = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/harness-protocol/src/context.rs
+++ b/crates/harness-protocol/src/context.rs
@@ -30,7 +30,7 @@ pub struct ContextPreviewTaskProfile {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct ContextPreviewItemId(pub String);
+pub struct ContextPreviewItemId(String);
 
 impl ContextPreviewItemId {
     pub fn new(value: impl Into<String>) -> Self {
@@ -39,6 +39,10 @@ impl ContextPreviewItemId {
 
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
     }
 }
 
@@ -112,6 +116,13 @@ mod tests {
             },
             budget_hint: 4096,
         }
+    }
+
+    #[test]
+    fn context_preview_item_id_accessors_preserve_value() {
+        let id = ContextPreviewItemId::new("rule:accessors");
+        assert_eq!(id.as_str(), "rule:accessors");
+        assert_eq!(id.into_inner(), "rule:accessors");
     }
 
     fn item(

--- a/crates/harness-protocol/src/context.rs
+++ b/crates/harness-protocol/src/context.rs
@@ -382,6 +382,18 @@ mod tests {
             "instruction_bearing": false
         }))
         .expect("item defaults parse");
+        let explicit_empty_item: ContextPreviewItem = serde_json::from_value(serde_json::json!({
+            "id": "rule:none",
+            "class": "rule",
+            "content": "",
+            "est_tokens": 0,
+            "priority": "p2",
+            "relevance": 0.0,
+            "degrade": [],
+            "instruction_bearing": false
+        }))
+        .expect("explicit empty item parse");
+        assert_eq!(item, explicit_empty_item);
         assert!(item.degrade.is_empty());
         assert_eq!(
             serde_json::to_value(item).expect("serialize item defaults"),

--- a/crates/harness-protocol/src/context.rs
+++ b/crates/harness-protocol/src/context.rs
@@ -1,0 +1,484 @@
+use harness_core::compress::NapStatus;
+use harness_core::run_id::RunId;
+use harness_core::types::{ProjectId, ThreadId};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContextPreviewRequest {
+    pub thread_id: ThreadId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<RunId>,
+    pub project: ProjectId,
+    pub task_profile: ContextPreviewTaskProfile,
+    pub budget_hint: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ContextPreviewTaskProfile {
+    #[serde(default)]
+    pub task_kind: Option<String>,
+    #[serde(default)]
+    pub target_paths: Vec<PathBuf>,
+    #[serde(default)]
+    pub agent_kind: Option<String>,
+    #[serde(default)]
+    pub prompt: Option<String>,
+    #[serde(default)]
+    pub contract: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ContextPreviewItemId(pub String);
+
+impl ContextPreviewItemId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ContextPreviewItemId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextPreviewItemClass {
+    Rule,
+    Skill,
+    Contract,
+    Brief,
+    Draft,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextPreviewPriority {
+    P0,
+    P1,
+    P2,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "level", content = "content", rename_all = "snake_case")]
+pub enum ContextPreviewDegraded {
+    Summary(String),
+    Pointer(String),
+    Summarized { text: String, nap: NapStatus },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContextPreviewItem {
+    pub id: ContextPreviewItemId,
+    pub class: ContextPreviewItemClass,
+    pub content: String,
+    pub est_tokens: u32,
+    pub priority: ContextPreviewPriority,
+    pub relevance: f32,
+    #[serde(default)]
+    pub degrade: Vec<ContextPreviewDegraded>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dedupe_key: Option<String>,
+    pub instruction_bearing: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::methods::{Method, RpcRequest};
+
+    fn request_with_all_fields() -> ContextPreviewRequest {
+        ContextPreviewRequest {
+            thread_id: ThreadId::from_str("thread-golden"),
+            run_id: Some(
+                "ar-01j1qb3c9r7v5m2k8x4tznq6wf"
+                    .parse()
+                    .expect("valid run id"),
+            ),
+            project: ProjectId::from_str("project-golden"),
+            task_profile: ContextPreviewTaskProfile {
+                task_kind: Some("implementation".to_string()),
+                target_paths: vec!["src/lib.rs".into(), "tests/wire.rs".into()],
+                agent_kind: Some("codex".to_string()),
+                prompt: Some("Preserve the wire contract.".to_string()),
+                contract: Some("typed-boundary".to_string()),
+            },
+            budget_hint: 4096,
+        }
+    }
+
+    fn item(
+        id: &str,
+        class: ContextPreviewItemClass,
+        priority: ContextPreviewPriority,
+        relevance: f32,
+        degrade: Vec<ContextPreviewDegraded>,
+        dedupe_key: Option<&str>,
+    ) -> ContextPreviewItem {
+        ContextPreviewItem {
+            id: ContextPreviewItemId::new(id),
+            class,
+            content: format!("content for {id}"),
+            est_tokens: 17,
+            priority,
+            relevance,
+            degrade,
+            dedupe_key: dedupe_key.map(str::to_string),
+            instruction_bearing: true,
+        }
+    }
+
+    #[test]
+    fn context_preview_wire_json_matches_legacy_golden_fixtures() {
+        let request = request_with_all_fields();
+        let supplied_items = vec![
+            item(
+                "rule:golden",
+                ContextPreviewItemClass::Rule,
+                ContextPreviewPriority::P0,
+                1.0,
+                vec![
+                    ContextPreviewDegraded::Summary("rule summary".to_string()),
+                    ContextPreviewDegraded::Pointer("rule pointer".to_string()),
+                    ContextPreviewDegraded::Summarized {
+                        text: "verified summary".to_string(),
+                        nap: NapStatus::Verified,
+                    },
+                    ContextPreviewDegraded::Summarized {
+                        text: "sample skipped".to_string(),
+                        nap: NapStatus::SkippedSample,
+                    },
+                    ContextPreviewDegraded::Summarized {
+                        text: "fell back".to_string(),
+                        nap: NapStatus::Failed { fell_back: true },
+                    },
+                    ContextPreviewDegraded::Summarized {
+                        text: "did not fall back".to_string(),
+                        nap: NapStatus::Failed { fell_back: false },
+                    },
+                ],
+                Some("rule-dedupe"),
+            ),
+            item(
+                "skill:golden",
+                ContextPreviewItemClass::Skill,
+                ContextPreviewPriority::P1,
+                0.75,
+                Vec::new(),
+                None,
+            ),
+            item(
+                "contract:golden",
+                ContextPreviewItemClass::Contract,
+                ContextPreviewPriority::P2,
+                0.5,
+                Vec::new(),
+                None,
+            ),
+            item(
+                "brief:golden",
+                ContextPreviewItemClass::Brief,
+                ContextPreviewPriority::P1,
+                0.25,
+                Vec::new(),
+                None,
+            ),
+            item(
+                "draft:golden",
+                ContextPreviewItemClass::Draft,
+                ContextPreviewPriority::P2,
+                0.0,
+                Vec::new(),
+                None,
+            ),
+        ];
+
+        let actual = serde_json::to_value(serde_json::json!({
+            "request": request,
+            "supplied_items": supplied_items,
+        }))
+        .expect("serialize fixture");
+        let expected = serde_json::json!({
+            "request": {
+                "thread_id": "thread-golden",
+                "run_id": "ar-01j1qb3c9r7v5m2k8x4tznq6wf",
+                "project": "project-golden",
+                "task_profile": {
+                    "task_kind": "implementation",
+                    "target_paths": ["src/lib.rs", "tests/wire.rs"],
+                    "agent_kind": "codex",
+                    "prompt": "Preserve the wire contract.",
+                    "contract": "typed-boundary"
+                },
+                "budget_hint": 4096
+            },
+            "supplied_items": [
+                {
+                    "id": "rule:golden",
+                    "class": "rule",
+                    "content": "content for rule:golden",
+                    "est_tokens": 17,
+                    "priority": "p0",
+                    "relevance": 1.0,
+                    "degrade": [
+                        {"level": "summary", "content": "rule summary"},
+                        {"level": "pointer", "content": "rule pointer"},
+                        {
+                            "level": "summarized",
+                            "content": {
+                                "text": "verified summary",
+                                "nap": {"status": "verified"}
+                            }
+                        },
+                        {
+                            "level": "summarized",
+                            "content": {
+                                "text": "sample skipped",
+                                "nap": {"status": "skipped_sample"}
+                            }
+                        },
+                        {
+                            "level": "summarized",
+                            "content": {
+                                "text": "fell back",
+                                "nap": {"status": "failed", "fell_back": true}
+                            }
+                        },
+                        {
+                            "level": "summarized",
+                            "content": {
+                                "text": "did not fall back",
+                                "nap": {"status": "failed", "fell_back": false}
+                            }
+                        }
+                    ],
+                    "dedupe_key": "rule-dedupe",
+                    "instruction_bearing": true
+                },
+                {
+                    "id": "skill:golden",
+                    "class": "skill",
+                    "content": "content for skill:golden",
+                    "est_tokens": 17,
+                    "priority": "p1",
+                    "relevance": 0.75,
+                    "degrade": [],
+                    "instruction_bearing": true
+                },
+                {
+                    "id": "contract:golden",
+                    "class": "contract",
+                    "content": "content for contract:golden",
+                    "est_tokens": 17,
+                    "priority": "p2",
+                    "relevance": 0.5,
+                    "degrade": [],
+                    "instruction_bearing": true
+                },
+                {
+                    "id": "brief:golden",
+                    "class": "brief",
+                    "content": "content for brief:golden",
+                    "est_tokens": 17,
+                    "priority": "p1",
+                    "relevance": 0.25,
+                    "degrade": [],
+                    "instruction_bearing": true
+                },
+                {
+                    "id": "draft:golden",
+                    "class": "draft",
+                    "content": "content for draft:golden",
+                    "est_tokens": 17,
+                    "priority": "p2",
+                    "relevance": 0.0,
+                    "degrade": [],
+                    "instruction_bearing": true
+                }
+            ]
+        });
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn context_preview_defaults_and_empty_collections_are_equivalent() {
+        let omitted = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "context/preview",
+            "params": {
+                "request": {
+                    "thread_id": "thread-defaults",
+                    "project": "project-defaults",
+                    "task_profile": {},
+                    "budget_hint": 0
+                }
+            }
+        });
+        let explicit_empty = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "context/preview",
+            "params": {
+                "request": {
+                    "thread_id": "thread-defaults",
+                    "project": "project-defaults",
+                    "task_profile": {"target_paths": []},
+                    "budget_hint": 0
+                },
+                "supplied_items": []
+            }
+        });
+
+        let omitted: RpcRequest = serde_json::from_value(omitted).expect("omitted defaults parse");
+        let explicit_empty: RpcRequest =
+            serde_json::from_value(explicit_empty).expect("explicit empty values parse");
+        let (
+            Method::ContextPreview {
+                request: omitted_request,
+                supplied_items: omitted_items,
+            },
+            Method::ContextPreview {
+                request: explicit_request,
+                supplied_items: explicit_items,
+            },
+        ) = (omitted.method, explicit_empty.method)
+        else {
+            panic!("expected context preview methods");
+        };
+
+        assert_eq!(omitted_request, explicit_request);
+        assert_eq!(omitted_items, explicit_items);
+        assert_eq!(
+            serde_json::to_value(omitted_request).expect("serialize defaults"),
+            serde_json::json!({
+                "thread_id": "thread-defaults",
+                "project": "project-defaults",
+                "task_profile": {
+                    "task_kind": null,
+                    "target_paths": [],
+                    "agent_kind": null,
+                    "prompt": null,
+                    "contract": null
+                },
+                "budget_hint": 0
+            })
+        );
+
+        let item: ContextPreviewItem = serde_json::from_value(serde_json::json!({
+            "id": "rule:none",
+            "class": "rule",
+            "content": "",
+            "est_tokens": 0,
+            "priority": "p2",
+            "relevance": 0.0,
+            "instruction_bearing": false
+        }))
+        .expect("item defaults parse");
+        assert!(item.degrade.is_empty());
+        assert_eq!(
+            serde_json::to_value(item).expect("serialize item defaults"),
+            serde_json::json!({
+                "id": "rule:none",
+                "class": "rule",
+                "content": "",
+                "est_tokens": 0,
+                "priority": "p2",
+                "relevance": 0.0,
+                "degrade": [],
+                "instruction_bearing": false
+            })
+        );
+    }
+
+    #[test]
+    fn context_preview_rejects_malformed_payloads() {
+        fn wire_with_item(item: serde_json::Value) -> serde_json::Value {
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "context/preview",
+                "params": {
+                    "request": {
+                        "thread_id": "thread-invalid",
+                        "project": "project-invalid",
+                        "task_profile": {},
+                        "budget_hint": 100
+                    },
+                    "supplied_items": [item]
+                }
+            })
+        }
+
+        let valid_item = serde_json::json!({
+            "id": "rule:invalid",
+            "class": "rule",
+            "content": "content",
+            "est_tokens": 1,
+            "priority": "p1",
+            "relevance": 1.0,
+            "degrade": [],
+            "instruction_bearing": true
+        });
+        let mut malformed = Vec::new();
+        for required_field in ["thread_id", "project", "task_profile", "budget_hint"] {
+            let mut missing_required_request = wire_with_item(valid_item.clone());
+            missing_required_request["params"]["request"]
+                .as_object_mut()
+                .expect("request object")
+                .remove(required_field);
+            malformed.push(missing_required_request);
+        }
+        for required_field in [
+            "id",
+            "class",
+            "content",
+            "est_tokens",
+            "priority",
+            "relevance",
+            "instruction_bearing",
+        ] {
+            let mut missing_required_item = valid_item.clone();
+            missing_required_item
+                .as_object_mut()
+                .expect("item object")
+                .remove(required_field);
+            malformed.push(wire_with_item(missing_required_item));
+        }
+
+        for (field, invalid_value) in [
+            ("class", serde_json::json!("unknown")),
+            ("priority", serde_json::json!("urgent")),
+        ] {
+            let mut item = valid_item.clone();
+            item[field] = invalid_value;
+            malformed.push(wire_with_item(item));
+        }
+        for invalid_degrade in [
+            serde_json::json!({"level": "unknown", "content": "value"}),
+            serde_json::json!({"level": "summarized", "content": {"text": "missing nap"}}),
+            serde_json::json!({
+                "level": "summarized",
+                "content": {"text": "bad nap", "nap": {"status": "unknown"}}
+            }),
+        ] {
+            let mut item = valid_item.clone();
+            item["degrade"] = serde_json::json!([invalid_degrade]);
+            malformed.push(wire_with_item(item));
+        }
+
+        for value in malformed {
+            assert!(
+                serde_json::from_value::<RpcRequest>(value).is_err(),
+                "malformed request must fail deserialization"
+            );
+        }
+    }
+}

--- a/crates/harness-protocol/src/lib.rs
+++ b/crates/harness-protocol/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod codec;
+pub mod context;
 pub mod contract;
 pub mod methods;
 pub mod notifications;

--- a/crates/harness-protocol/src/methods.rs
+++ b/crates/harness-protocol/src/methods.rs
@@ -1,3 +1,4 @@
+use crate::context::{ContextPreviewItem, ContextPreviewRequest};
 use harness_core::types::{
     DraftId, Event, EventFilters, ExecPlanId, MetricFilters, ProjectId, SkillId,
 };
@@ -151,9 +152,9 @@ pub enum Method {
 
     // === Context composer ===
     ContextPreview {
-        request: harness_context::ComposeRequest,
+        request: ContextPreviewRequest,
         #[serde(default)]
-        supplied_items: Vec<harness_context::ContextItem>,
+        supplied_items: Vec<ContextPreviewItem>,
     },
 }
 

--- a/crates/harness-server/src/handlers/context.rs
+++ b/crates/harness-server/src/handlers/context.rs
@@ -52,7 +52,7 @@ fn into_task_profile(task_profile: ContextPreviewTaskProfile) -> TaskProfile {
 
 fn into_context_item(item: ContextPreviewItem) -> ContextItem {
     ContextItem {
-        id: ItemId::new(item.id.0),
+        id: ItemId::new(item.id.into_inner()),
         class: into_item_class(item.class),
         content: item.content,
         est_tokens: item.est_tokens,

--- a/crates/harness-server/src/handlers/context.rs
+++ b/crates/harness-server/src/handlers/context.rs
@@ -5,21 +5,88 @@ use harness_context::{
         SkillsProvider, TaskBriefProvider,
     },
     ComposeConfig, ComposeMode, ComposeRequest, Composition, ContextComposer, ContextItem,
+    Degraded, ItemClass, ItemId, Priority, TaskProfile,
 };
 use harness_core::run_id::RunIdentity;
+use harness_protocol::context::{
+    ContextPreviewDegraded, ContextPreviewItem, ContextPreviewItemClass, ContextPreviewPriority,
+    ContextPreviewRequest, ContextPreviewTaskProfile,
+};
 use harness_protocol::methods::{RpcResponse, INTERNAL_ERROR};
 
 pub async fn context_preview(
     state: &AppState,
     id: Option<serde_json::Value>,
-    mut request: ComposeRequest,
-    supplied_items: Vec<ContextItem>,
+    request: ContextPreviewRequest,
+    supplied_items: Vec<ContextPreviewItem>,
 ) -> RpcResponse {
+    let mut request = into_compose_request(request);
+    let supplied_items = supplied_items.into_iter().map(into_context_item).collect();
     request.run_id = request.run_id.or_else(current_run_id);
     let composer = build_composer(state, ComposeMode::Preview).await;
     match composer.compose_supplied(&request, supplied_items) {
         Ok(composition) => RpcResponse::success(id, composition_response(composition)),
         Err(error) => RpcResponse::error(id, INTERNAL_ERROR, error.to_string()),
+    }
+}
+
+fn into_compose_request(request: ContextPreviewRequest) -> ComposeRequest {
+    ComposeRequest {
+        thread_id: request.thread_id,
+        run_id: request.run_id,
+        project: request.project,
+        task_profile: into_task_profile(request.task_profile),
+        budget_hint: request.budget_hint,
+    }
+}
+
+fn into_task_profile(task_profile: ContextPreviewTaskProfile) -> TaskProfile {
+    TaskProfile {
+        task_kind: task_profile.task_kind,
+        target_paths: task_profile.target_paths,
+        agent_kind: task_profile.agent_kind,
+        prompt: task_profile.prompt,
+        contract: task_profile.contract,
+    }
+}
+
+fn into_context_item(item: ContextPreviewItem) -> ContextItem {
+    ContextItem {
+        id: ItemId::new(item.id.0),
+        class: into_item_class(item.class),
+        content: item.content,
+        est_tokens: item.est_tokens,
+        priority: into_priority(item.priority),
+        relevance: item.relevance,
+        degrade: item.degrade.into_iter().map(into_degraded).collect(),
+        dedupe_key: item.dedupe_key,
+        instruction_bearing: item.instruction_bearing,
+    }
+}
+
+fn into_item_class(class: ContextPreviewItemClass) -> ItemClass {
+    match class {
+        ContextPreviewItemClass::Rule => ItemClass::Rule,
+        ContextPreviewItemClass::Skill => ItemClass::Skill,
+        ContextPreviewItemClass::Contract => ItemClass::Contract,
+        ContextPreviewItemClass::Brief => ItemClass::Brief,
+        ContextPreviewItemClass::Draft => ItemClass::Draft,
+    }
+}
+
+fn into_priority(priority: ContextPreviewPriority) -> Priority {
+    match priority {
+        ContextPreviewPriority::P0 => Priority::P0,
+        ContextPreviewPriority::P1 => Priority::P1,
+        ContextPreviewPriority::P2 => Priority::P2,
+    }
+}
+
+fn into_degraded(degraded: ContextPreviewDegraded) -> Degraded {
+    match degraded {
+        ContextPreviewDegraded::Summary(content) => Degraded::Summary(content),
+        ContextPreviewDegraded::Pointer(content) => Degraded::Pointer(content),
+        ContextPreviewDegraded::Summarized { text, nap } => Degraded::Summarized { text, nap },
     }
 }
 
@@ -72,4 +139,263 @@ fn current_run_id() -> Option<harness_core::run_id::RunId> {
         .ok()
         .flatten()
         .map(|identity| identity.run_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_core::compress::NapStatus;
+    use harness_core::types::{ProjectId, ThreadId};
+    use harness_protocol::context::ContextPreviewItemId;
+
+    fn full_request() -> ContextPreviewRequest {
+        ContextPreviewRequest {
+            thread_id: ThreadId::from_str("thread-conversion"),
+            run_id: Some(
+                "ar-01j1qb3c9r7v5m2k8x4tznq6wf"
+                    .parse()
+                    .expect("valid run id"),
+            ),
+            project: ProjectId::from_str("project-conversion"),
+            task_profile: ContextPreviewTaskProfile {
+                task_kind: Some("implementation".to_string()),
+                target_paths: vec!["src/lib.rs".into(), "tests/context.rs".into()],
+                agent_kind: Some("codex".to_string()),
+                prompt: Some("Preserve every field.".to_string()),
+                contract: Some("context-preview".to_string()),
+            },
+            budget_hint: 2048,
+        }
+    }
+
+    fn full_items() -> Vec<ContextPreviewItem> {
+        vec![
+            ContextPreviewItem {
+                id: ContextPreviewItemId::new("rule:first"),
+                class: ContextPreviewItemClass::Rule,
+                content: "first content".to_string(),
+                est_tokens: 11,
+                priority: ContextPreviewPriority::P0,
+                relevance: 1.0,
+                degrade: vec![
+                    ContextPreviewDegraded::Summary("first summary".to_string()),
+                    ContextPreviewDegraded::Pointer("first pointer".to_string()),
+                    ContextPreviewDegraded::Summarized {
+                        text: "first compressed".to_string(),
+                        nap: NapStatus::Verified,
+                    },
+                    ContextPreviewDegraded::Summarized {
+                        text: "second compressed".to_string(),
+                        nap: NapStatus::SkippedSample,
+                    },
+                    ContextPreviewDegraded::Summarized {
+                        text: "failed compressed".to_string(),
+                        nap: NapStatus::Failed { fell_back: true },
+                    },
+                    ContextPreviewDegraded::Summarized {
+                        text: "failed without fallback".to_string(),
+                        nap: NapStatus::Failed { fell_back: false },
+                    },
+                ],
+                dedupe_key: Some("rule-first".to_string()),
+                instruction_bearing: true,
+            },
+            ContextPreviewItem {
+                id: ContextPreviewItemId::new("skill:second"),
+                class: ContextPreviewItemClass::Skill,
+                content: String::new(),
+                est_tokens: 0,
+                priority: ContextPreviewPriority::P1,
+                relevance: 0.5,
+                degrade: Vec::new(),
+                dedupe_key: None,
+                instruction_bearing: false,
+            },
+            ContextPreviewItem {
+                id: ContextPreviewItemId::new("contract:third"),
+                class: ContextPreviewItemClass::Contract,
+                content: "third content".to_string(),
+                est_tokens: 33,
+                priority: ContextPreviewPriority::P2,
+                relevance: 0.0,
+                degrade: Vec::new(),
+                dedupe_key: Some("contract-third".to_string()),
+                instruction_bearing: true,
+            },
+            ContextPreviewItem {
+                id: ContextPreviewItemId::new("brief:fourth"),
+                class: ContextPreviewItemClass::Brief,
+                content: "fourth content".to_string(),
+                est_tokens: 44,
+                priority: ContextPreviewPriority::P1,
+                relevance: 0.25,
+                degrade: Vec::new(),
+                dedupe_key: None,
+                instruction_bearing: false,
+            },
+            ContextPreviewItem {
+                id: ContextPreviewItemId::new("draft:fifth"),
+                class: ContextPreviewItemClass::Draft,
+                content: "fifth content".to_string(),
+                est_tokens: 55,
+                priority: ContextPreviewPriority::P2,
+                relevance: 0.75,
+                degrade: Vec::new(),
+                dedupe_key: None,
+                instruction_bearing: true,
+            },
+        ]
+    }
+
+    #[test]
+    fn context_preview_conversion_preserves_every_field() {
+        let request = into_compose_request(full_request());
+        assert_eq!(request.thread_id.as_str(), "thread-conversion");
+        assert_eq!(
+            request.run_id.as_ref().map(|run_id| run_id.as_str()),
+            Some("ar-01j1qb3c9r7v5m2k8x4tznq6wf")
+        );
+        assert_eq!(request.project.as_str(), "project-conversion");
+        assert_eq!(
+            request.task_profile.task_kind.as_deref(),
+            Some("implementation")
+        );
+        assert_eq!(
+            request.task_profile.target_paths,
+            vec![
+                std::path::PathBuf::from("src/lib.rs"),
+                std::path::PathBuf::from("tests/context.rs")
+            ]
+        );
+        assert_eq!(request.task_profile.agent_kind.as_deref(), Some("codex"));
+        assert_eq!(
+            request.task_profile.prompt.as_deref(),
+            Some("Preserve every field.")
+        );
+        assert_eq!(
+            request.task_profile.contract.as_deref(),
+            Some("context-preview")
+        );
+        assert_eq!(request.budget_hint, 2048);
+
+        let source_items = full_items();
+        let source_items_json =
+            serde_json::to_value(&source_items).expect("serialize source items");
+        let items: Vec<_> = source_items.into_iter().map(into_context_item).collect();
+        assert_eq!(
+            serde_json::to_value(&items).expect("serialize converted items"),
+            source_items_json
+        );
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "rule:first",
+                "skill:second",
+                "contract:third",
+                "brief:fourth",
+                "draft:fifth"
+            ]
+        );
+        assert_eq!(
+            items.iter().map(|item| item.class).collect::<Vec<_>>(),
+            vec![
+                ItemClass::Rule,
+                ItemClass::Skill,
+                ItemClass::Contract,
+                ItemClass::Brief,
+                ItemClass::Draft
+            ]
+        );
+        assert_eq!(
+            items.iter().map(|item| item.priority).collect::<Vec<_>>(),
+            vec![
+                Priority::P0,
+                Priority::P1,
+                Priority::P2,
+                Priority::P1,
+                Priority::P2
+            ]
+        );
+        assert_eq!(items[0].content, "first content");
+        assert_eq!(items[0].est_tokens, 11);
+        assert_eq!(items[0].relevance, 1.0);
+        assert_eq!(items[0].dedupe_key.as_deref(), Some("rule-first"));
+        assert!(items[0].instruction_bearing);
+        assert_eq!(
+            items[0].degrade,
+            vec![
+                Degraded::Summary("first summary".to_string()),
+                Degraded::Pointer("first pointer".to_string()),
+                Degraded::Summarized {
+                    text: "first compressed".to_string(),
+                    nap: NapStatus::Verified
+                },
+                Degraded::Summarized {
+                    text: "second compressed".to_string(),
+                    nap: NapStatus::SkippedSample
+                },
+                Degraded::Summarized {
+                    text: "failed compressed".to_string(),
+                    nap: NapStatus::Failed { fell_back: true }
+                },
+                Degraded::Summarized {
+                    text: "failed without fallback".to_string(),
+                    nap: NapStatus::Failed { fell_back: false }
+                }
+            ]
+        );
+        assert_eq!(items[1].content, "");
+        assert_eq!(items[1].est_tokens, 0);
+        assert_eq!(items[1].relevance, 0.5);
+        assert_eq!(items[1].dedupe_key, None);
+        assert!(!items[1].instruction_bearing);
+    }
+
+    #[test]
+    fn context_preview_conversion_is_deterministic_and_order_preserving() {
+        let source_request = full_request();
+        let source_items = full_items();
+        let retained_request = source_request.clone();
+        let retained_items = source_items.clone();
+
+        let first_request = into_compose_request(source_request.clone());
+        let second_request = into_compose_request(source_request.clone());
+        let first_items: Vec<_> = source_items
+            .clone()
+            .into_iter()
+            .map(into_context_item)
+            .collect();
+        let second_items: Vec<_> = source_items
+            .clone()
+            .into_iter()
+            .map(into_context_item)
+            .collect();
+
+        assert_eq!(first_request, second_request);
+        assert_eq!(first_items, second_items);
+        assert_eq!(source_request, retained_request);
+        assert_eq!(source_items, retained_items);
+        assert_eq!(
+            first_items[0]
+                .degrade
+                .iter()
+                .map(|degraded| match degraded {
+                    Degraded::Summary(_) => "summary",
+                    Degraded::Pointer(_) => "pointer",
+                    Degraded::Summarized { .. } => "summarized",
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                "summary",
+                "pointer",
+                "summarized",
+                "summarized",
+                "summarized",
+                "summarized"
+            ]
+        );
+    }
 }

--- a/crates/harness-server/src/router/tests/observability.rs
+++ b/crates/harness-server/src/router/tests/observability.rs
@@ -1,5 +1,49 @@
 use super::*;
 
+static CONTEXT_RUN_ID_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct ContextRunIdEnvGuard {
+    original_run_id: Option<String>,
+    original_parent: Option<String>,
+}
+
+impl ContextRunIdEnvGuard {
+    fn set(run_id: &str) -> Self {
+        use harness_core::run_id::{AGENT_RUN_ID_ENV, AGENT_RUN_PARENT_ENV};
+
+        let original_run_id = std::env::var(AGENT_RUN_ID_ENV).ok();
+        let original_parent = std::env::var(AGENT_RUN_PARENT_ENV).ok();
+        // SAFETY: context tests serialize access with CONTEXT_RUN_ID_ENV_LOCK
+        // and this guard restores both variables on drop.
+        unsafe {
+            std::env::set_var(AGENT_RUN_ID_ENV, run_id);
+            std::env::remove_var(AGENT_RUN_PARENT_ENV);
+        }
+        Self {
+            original_run_id,
+            original_parent,
+        }
+    }
+}
+
+impl Drop for ContextRunIdEnvGuard {
+    fn drop(&mut self) {
+        use harness_core::run_id::{AGENT_RUN_ID_ENV, AGENT_RUN_PARENT_ENV};
+
+        // SAFETY: the guard is dropped while CONTEXT_RUN_ID_ENV_LOCK is held.
+        unsafe {
+            match self.original_run_id.take() {
+                Some(value) => std::env::set_var(AGENT_RUN_ID_ENV, value),
+                None => std::env::remove_var(AGENT_RUN_ID_ENV),
+            }
+            match self.original_parent.take() {
+                Some(value) => std::env::set_var(AGENT_RUN_PARENT_ENV, value),
+                None => std::env::remove_var(AGENT_RUN_PARENT_ENV),
+            }
+        }
+    }
+}
+
 #[tokio::test]
 async fn rule_check_returns_warning_when_no_guards_loaded() -> anyhow::Result<()> {
     let _lock = crate::test_helpers::HOME_LOCK.lock().await;
@@ -609,26 +653,31 @@ async fn skill_delete_removes_skill() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn context_rpc_preview_with_supplied_items_returns_manifest() -> anyhow::Result<()> {
+    use harness_protocol::context::{
+        ContextPreviewDegraded, ContextPreviewItem, ContextPreviewItemClass, ContextPreviewItemId,
+        ContextPreviewPriority, ContextPreviewRequest, ContextPreviewTaskProfile,
+    };
+
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
-    let request = harness_context::ComposeRequest {
+    let request = ContextPreviewRequest {
         thread_id: harness_core::types::ThreadId::from_str("thread-preview"),
         run_id: None,
         project: harness_core::types::ProjectId::from_str("project-preview"),
-        task_profile: harness_context::TaskProfile {
+        task_profile: ContextPreviewTaskProfile {
             prompt: Some("preview supplied context".to_string()),
             ..Default::default()
         },
         budget_hint: 100,
     };
-    let supplied = vec![harness_context::ContextItem {
-        id: harness_context::ItemId::new("rule:supplied"),
-        class: harness_context::ItemClass::Rule,
+    let supplied = vec![ContextPreviewItem {
+        id: ContextPreviewItemId::new("rule:supplied"),
+        class: ContextPreviewItemClass::Rule,
         content: "Follow the supplied rule.".to_string(),
         est_tokens: 0,
-        priority: harness_context::Priority::P1,
+        priority: ContextPreviewPriority::P1,
         relevance: 1.0,
-        degrade: vec![harness_context::Degraded::Pointer(
+        degrade: vec![ContextPreviewDegraded::Pointer(
             "See supplied rule.".to_string(),
         )],
         dedupe_key: None,
@@ -663,6 +712,93 @@ async fn context_rpc_preview_with_supplied_items_returns_manifest() -> anyhow::R
     assert!(manifest_items
         .iter()
         .any(|item| item["id"] == serde_json::json!("rule:supplied")));
+    Ok(())
+}
+
+#[tokio::test]
+async fn context_preview_uses_current_run_id_when_request_omits_run_id() -> anyhow::Result<()> {
+    use harness_protocol::context::{ContextPreviewRequest, ContextPreviewTaskProfile};
+
+    let _env_lock = CONTEXT_RUN_ID_ENV_LOCK.lock().await;
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    let run_id = "ar-01j1qb3c9r7v5m2k8x4tznq6wf";
+    let _env_guard = ContextRunIdEnvGuard::set(run_id);
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(2)),
+        method: Method::ContextPreview {
+            request: ContextPreviewRequest {
+                thread_id: harness_core::types::ThreadId::from_str("thread-run-fallback"),
+                run_id: None,
+                project: harness_core::types::ProjectId::from_str("project-run-fallback"),
+                task_profile: ContextPreviewTaskProfile::default(),
+                budget_hint: 100,
+            },
+            supplied_items: Vec::new(),
+        },
+    };
+
+    let resp = handle_request(&state, req).await.expect("response");
+    assert!(
+        resp.error.is_none(),
+        "context preview should succeed: {:?}",
+        resp.error
+    );
+    let result = resp
+        .result
+        .ok_or_else(|| anyhow::anyhow!("missing result"))?;
+    assert_eq!(result["manifest"]["run_id"], serde_json::json!(run_id));
+    Ok(())
+}
+
+#[tokio::test]
+async fn context_preview_preserves_composer_error_mapping() -> anyhow::Result<()> {
+    use harness_protocol::context::{
+        ContextPreviewItem, ContextPreviewItemClass, ContextPreviewItemId, ContextPreviewPriority,
+        ContextPreviewRequest, ContextPreviewTaskProfile,
+    };
+
+    let dir = tempfile::tempdir()?;
+    let state = make_test_state(dir.path()).await?;
+    let req = RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(3)),
+        method: Method::ContextPreview {
+            request: ContextPreviewRequest {
+                thread_id: harness_core::types::ThreadId::from_str("thread-overflow"),
+                run_id: None,
+                project: harness_core::types::ProjectId::from_str("project-overflow"),
+                task_profile: ContextPreviewTaskProfile::default(),
+                budget_hint: 1,
+            },
+            supplied_items: vec![ContextPreviewItem {
+                id: ContextPreviewItemId::new("rule:mandatory-overflow"),
+                class: ContextPreviewItemClass::Rule,
+                content: "mandatory content that cannot fit in the effective budget".repeat(4),
+                est_tokens: 0,
+                priority: ContextPreviewPriority::P0,
+                relevance: 1.0,
+                degrade: Vec::new(),
+                dedupe_key: None,
+                instruction_bearing: true,
+            }],
+        },
+    };
+
+    let resp = handle_request(&state, req).await.expect("response");
+    let error = resp
+        .error
+        .ok_or_else(|| anyhow::anyhow!("expected composer error"))?;
+    assert_eq!(error.code, harness_protocol::methods::INTERNAL_ERROR);
+    assert!(
+        error
+            .message
+            .contains("mandatory context exceeds effective budget"),
+        "unexpected error message: {}",
+        error.message
+    );
+    assert!(resp.result.is_none());
     Ok(())
 }
 

--- a/specs/GH1717/tasks.md
+++ b/specs/GH1717/tasks.md
@@ -1,0 +1,124 @@
+# Task Plan
+
+## Linked Issue
+
+GH-1717
+
+## Spec Packet
+
+- Product: `product.md`
+- Tech: `tech.md`
+
+## Implementation Tasks
+
+- [ ] `SP1717-T1` Owner: protocol contract | Done when: protocol-owned DTOs preserve the complete legacy wire contract | Verify: focused protocol golden, defaults, and malformed-payload tests
+- [ ] `SP1717-T2` Owner: protocol integration | Done when: the public method uses protocol DTOs and the normal composer dependency edge is absent | Verify: protocol check, parsing test, and dependency assertion
+- [ ] `SP1717-T3` Owner: server boundary | Done when: exhaustive typed conversion preserves every field and ordering | Verify: focused conversion tests and server check
+- [ ] `SP1717-T4` Owner: server integration tests | Done when: composer success, run-ID fallback, and error mapping remain unchanged | Verify: focused router tests
+- [ ] `SP1717-T5` Owner: integration verifier | Done when: local, SpecRail, CI, review, and compatibility evidence is complete | Verify: final verification matrix below
+
+### SP1717-T1 — Define protocol-owned context preview DTOs
+
+- Owner: protocol contract
+- Files: `crates/harness-protocol/src/context.rs`, `crates/harness-protocol/src/lib.rs`
+- Dependencies: none
+- Covers: B-002, B-003, B-004
+- Done when:
+  - Request, task-profile, item-ID, item, class, priority, degradation, and
+    NAP-bearing DTOs reproduce the legacy wire contract.
+  - Literal golden fixtures cover every item class, priority, degradation
+    variant, and NAP status.
+  - Optional and defaulted fields preserve their legacy serialization and
+    deserialization behavior.
+  - Missing required fields, unknown enums, and malformed degradation payloads
+    fail deserialization.
+- Verify:
+  - `cargo test -p harness-protocol context_preview_wire_json_matches_legacy_golden_fixtures --lib`
+  - `cargo test -p harness-protocol context_preview_defaults_and_empty_collections_are_equivalent --lib`
+  - `cargo test -p harness-protocol context_preview_rejects_malformed_payloads --lib`
+
+### SP1717-T2 — Move the public method boundary and remove the dependency edge
+
+- Owner: protocol integration
+- Files: `crates/harness-protocol/src/methods.rs`,
+  `crates/harness-protocol/Cargo.toml`, `Cargo.lock`
+- Dependencies: SP1717-T1
+- Covers: B-001, B-002, B-003, B-004, B-008
+- Done when:
+  - `Method::ContextPreview` uses protocol-owned DTOs while retaining its
+    existing method and field names and `supplied_items` default.
+  - The normal `harness-context` dependency is absent from the protocol
+    manifest, lockfile dependency list, and normal dependency graph.
+- Verify:
+  - `cargo check -p harness-protocol --all-targets`
+  - `cargo test -p harness-protocol context_rpc_preview_slash_method_deserializes --lib`
+  - Run the dependency assertion in `tech.md`.
+
+### SP1717-T3 — Add exhaustive server boundary conversion
+
+- Owner: server boundary
+- Files: `crates/harness-server/src/handlers/context.rs`
+- Dependencies: SP1717-T1; integration verification requires SP1717-T2
+- Covers: B-005, B-006, B-007
+- Done when:
+  - Private typed conversion functions explicitly map every field and
+    exhaustively match every closed enum.
+  - Conversion preserves values and vector order without fallback, filtering,
+    sorting, or caller-visible mutation.
+  - Existing run-ID fallback and composition execute only after conversion.
+- Verify:
+  - `cargo test -p harness-server context_preview_conversion_preserves_every_field --lib`
+  - `cargo test -p harness-server context_preview_conversion_is_deterministic_and_order_preserving --lib`
+  - `cargo check -p harness-server --all-targets`
+
+### SP1717-T4 — Prove unchanged router and composer behavior
+
+- Owner: server integration tests
+- Files: `crates/harness-server/src/router/tests/observability.rs`
+- Dependencies: SP1717-T2, SP1717-T3
+- Covers: B-005, B-007
+- Done when:
+  - Supplied protocol items still reach rendered output and the preview
+    manifest.
+  - Omitted request `run_id` still uses the current run identity.
+  - Composer failures retain the existing JSON-RPC error mapping.
+- Verify:
+  - `cargo test -p harness-server context_rpc_preview_with_supplied_items_returns_manifest --lib`
+  - `cargo test -p harness-server context_preview_uses_current_run_id_when_request_omits_run_id --lib`
+  - `cargo test -p harness-server context_preview_preserves_composer_error_mapping --lib`
+
+## Parallelization
+
+- After SP1717-T1, SP1717-T2 and SP1717-T3 may edit concurrently because their
+  file ownership is disjoint; verify their combined state before SP1717-T4.
+- SP1717-T4 waits for both integration surfaces.
+- `Cargo.lock` belongs exclusively to SP1717-T2.
+
+## Verification
+
+### SP1717-T5 — Collect completion and compatibility evidence
+
+- Owner: integration verifier
+- Files: none; verification and PR handoff only
+- Dependencies: SP1717-T1, SP1717-T2, SP1717-T3, SP1717-T4
+- Covers: B-001, B-002, B-003, B-004, B-005, B-006, B-007, B-008
+- Done when:
+  - Every targeted test and dependency assertion passes from the implementation
+    head.
+  - Workflow validation, formatting, package checks, and pre-push clippy pass.
+  - The implementation PR documents the Rust source-compatibility impact for
+    direct `Method::ContextPreview` constructors.
+- Verify:
+  - `cargo fmt --all -- --check`
+  - `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1717`
+  - `cargo clippy --workspace --all-targets -- -D warnings`
+
+## Handoff Notes
+
+- Preserve protocol DTO and composer-domain ownership separation.
+- Do not add aliases, wildcard conversions, untyped bridges, response DTOs, or
+  a shared-types crate.
+- Keep the handler sequence: typed conversion, run-ID fallback, existing
+  composer call, and existing response mapping.
+- Use literal legacy golden JSON so protocol tests do not recreate the removed
+  dependency.


### PR DESCRIPTION
## Summary

- add protocol-owned typed DTOs for the `context/preview` request contract
- remove the normal `harness-protocol -> harness-context` dependency edge
- convert protocol DTOs explicitly and exhaustively at the server handler boundary
- preserve JSON field names, defaults, ordering, run-ID fallback, composer behavior, response shape, and fail-closed decoding
- add golden/default/malformed protocol fixtures, conversion tests, router tests, and the approved GH1717 task plan

## Compatibility impact

The JSON-RPC wire contract and successful response behavior are unchanged. Rust callers that directly construct `Method::ContextPreview` must now use the protocol-owned DTOs instead of `harness_context` types. Repository search found only the in-tree server construction sites updated by this PR.

## Validation

- protocol library tests: 30 passed
- server conversion tests: 2 passed
- router integration tests: 3 passed against an isolated disposable PostgreSQL database
- `cargo check -p harness-protocol --all-targets`
- `cargo check -p harness-server --all-targets`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- SpecRail global and GH1717 checks
- dependency-tree assertion proving `harness-context`, `harness-rules`, `harness-skills`, `harness-gc`, and `harness-exec` are unreachable through normal `harness-protocol` edges

The disposable PostgreSQL database was removed after verification.

Fixes #1717