### PR TITLE
test(server): serialize context preview env access

### DIFF
--- a/crates/harness-server/src/router/tests/observability.rs
+++ b/crates/harness-server/src/router/tests/observability.rs
@@ -658,6 +658,7 @@ async fn context_rpc_preview_with_supplied_items_returns_manifest() -> anyhow::R
         ContextPreviewPriority, ContextPreviewRequest, ContextPreviewTaskProfile,
     };
 
+    let _env_lock = CONTEXT_RUN_ID_ENV_LOCK.lock().await;
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
     let request = ContextPreviewRequest {
@@ -759,6 +760,7 @@ async fn context_preview_preserves_composer_error_mapping() -> anyhow::Result<()
         ContextPreviewRequest, ContextPreviewTaskProfile,
     };
 
+    let _env_lock = CONTEXT_RUN_ID_ENV_LOCK.lock().await;
     let dir = tempfile::tempdir()?;
     let state = make_test_state(dir.path()).await?;
     let req = RpcRequest {


### PR DESCRIPTION
## Summary

- serialize all context-preview router tests with the existing `CONTEXT_RUN_ID_ENV_LOCK`
- prevent concurrent environment reads while the run-ID fallback test mutates `HARNESS_AGENT_RUN_ID`
- close the two unresolved high-priority Gemini findings discovered after PR #1723 merged

## Root cause

PR #1723 added two context-preview tests that invoke the handler without acquiring the mutex already used by the environment-mutating run-ID fallback test. Parallel test execution could therefore race a process-environment write against handler reads.

## Scope

This follow-up changes only `crates/harness-server/src/router/tests/observability.rs` and adds one existing-lock acquisition to each affected test. Production behavior and the protocol contract are unchanged.

## Validation

- `cargo check -p harness-server --all-targets`
- `cargo fmt --all -- --check`
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/check_workflow.py --repo . --spec-dir specs/GH1717`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-commit staged-scope clippy
- pre-push DB-independent workspace and workflow test gates

Local PostgreSQL-backed targeted tests were attempted against a disposable `_test` database but the local bootstrap pool timed out; exact-head CI is required for the DB-backed verification.

Fixes #1717