### PR TITLE
fix(server): fail closed on malformed WORKFLOW.md instead of silent defaults

### DIFF
--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use dashmap::DashMap;
 use std::path::Path;
 use std::sync::Arc;
@@ -37,8 +38,16 @@ pub(crate) async fn build_registry(
     tasks: &Arc<crate::task_runner::TaskStore>,
 ) -> anyhow::Result<RegistryBundle> {
     let configured_database_url = server.config.server.database_url.as_deref();
-    let workflow_config =
-        harness_core::config::workflow::load_workflow_config(project_root).unwrap_or_default();
+    // Fail closed: a malformed WORKFLOW.md must abort startup rather than
+    // silently booting with the default schema namespace and default policy.
+    // A missing WORKFLOW.md still yields the base/default config (Ok).
+    let workflow_config = harness_core::config::workflow::load_workflow_config(project_root)
+        .with_context(|| {
+            format!(
+                "failed to load workflow config for {}",
+                project_root.display()
+            )
+        })?;
     let workflow_ns = workflow_config.storage.schema_namespace;
     let mut startup_results = Vec::new();
     let plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>> = Arc::new(DashMap::new());

--- a/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
@@ -123,7 +123,7 @@ pub(super) async fn execute_start_child_workflow(
         .unwrap_or(false)
     {
         let labels = string_vec(command, "labels");
-        let force_execute = force_execute_from_project_policy(project_id, &labels);
+        let force_execute = force_execute_from_project_policy(project_id, &labels)?;
         let task_id = issue_task_id_from_command(command, job, repo, issue_number);
         let issue_task_prefix = issue_task_prefix_from_task_id(&task_id, issue_number);
         if !issue_submission_recorded(store, &child, &task_id).await? {

--- a/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/child_workflow.rs
@@ -123,7 +123,19 @@ pub(super) async fn execute_start_child_workflow(
         .unwrap_or(false)
     {
         let labels = string_vec(command, "labels");
-        let force_execute = force_execute_from_project_policy(project_id, &labels)?;
+        let force_execute = {
+            // load_workflow_config does synchronous disk IO; keep it off the
+            // async executor thread.
+            let project_id = project_id.to_string();
+            let labels = labels.clone();
+            tokio::task::spawn_blocking(move || {
+                force_execute_from_project_policy(&project_id, &labels)
+            })
+            .await
+            .map_err(|join_error| {
+                anyhow::anyhow!("force-execute policy load task failed: {join_error}")
+            })??
+        };
         let task_id = issue_task_id_from_command(command, job, repo, issue_number);
         let issue_task_prefix = issue_task_prefix_from_task_id(&task_id, issue_number);
         if !issue_submission_recorded(store, &child, &task_id).await? {

--- a/crates/harness-server/src/workflow_runtime_worker/data_helpers.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/data_helpers.rs
@@ -149,12 +149,17 @@ fn issue_task_id_from_dedupe_key(dedupe_key: &str, issue_number: u64) -> Option<
     Some(dedupe_key[..marker_end].to_string()).filter(|task_id| !task_id.is_empty())
 }
 
-pub(super) fn force_execute_from_project_policy(project_id: &str, labels: &[String]) -> bool {
+pub(super) fn force_execute_from_project_policy(
+    project_id: &str,
+    labels: &[String],
+) -> anyhow::Result<bool> {
+    // Fail closed: a malformed WORKFLOW.md must surface as a job error rather
+    // than silently falling back to the default force-execute label.
     let workflow_cfg = harness_core::config::workflow::load_workflow_config(Path::new(project_id))
-        .unwrap_or_default();
-    labels
+        .with_context(|| format!("failed to load workflow config for {project_id}"))?;
+    Ok(labels
         .iter()
-        .any(|label| label == &workflow_cfg.issue_workflow.force_execute_label)
+        .any(|label| label == &workflow_cfg.issue_workflow.force_execute_label))
 }
 
 pub(super) fn optional_data_u64(workflow: &WorkflowInstance, field: &str) -> Option<u64> {
@@ -558,6 +563,49 @@ mod tests {
         let task_id = issue_task_id_from_command(&command, &job, Some("owner/repo"), 42);
 
         assert_eq!(task_id.as_str(), "explicit-task");
+    }
+
+    #[test]
+    fn force_execute_policy_fails_closed_on_malformed_workflow_md() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("WORKFLOW.md"),
+            "---\nissue_workflow: [not, a, map\n---\nbody\n",
+        )
+        .expect("write malformed WORKFLOW.md");
+
+        let result = force_execute_from_project_policy(
+            dir.path().to_str().expect("utf8 path"),
+            &["force-execute".to_string()],
+        );
+
+        let error = result.expect_err("malformed WORKFLOW.md must error, not fall back");
+        assert!(
+            error.to_string().contains("failed to load workflow config"),
+            "error must name the config load failure, got: {error:#}"
+        );
+    }
+
+    #[test]
+    fn force_execute_policy_matches_default_label_without_workflow_md() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let default_label = harness_core::config::workflow::WorkflowConfig::default()
+            .issue_workflow
+            .force_execute_label;
+
+        let matched = force_execute_from_project_policy(
+            dir.path().to_str().expect("utf8 path"),
+            &[default_label],
+        )
+        .expect("missing WORKFLOW.md must fall back to defaults without error");
+        assert!(matched);
+
+        let unmatched = force_execute_from_project_policy(
+            dir.path().to_str().expect("utf8 path"),
+            &["unrelated-label".to_string()],
+        )
+        .expect("missing WORKFLOW.md must fall back to defaults without error");
+        assert!(!unmatched);
     }
 
     #[test]


### PR DESCRIPTION
Two call sites swallowed load_workflow_config errors with
unwrap_or_default(), while every other call site propagates them:

- http/builders/registry.rs: a malformed project WORKFLOW.md silently
  booted the server with the default storage.schema_namespace and
  default workflow policy, with no log line. Now aborts startup with
  context. A missing WORKFLOW.md still resolves to the base/default
  config without error.
- workflow_runtime_worker/data_helpers.rs
  force_execute_from_project_policy: a malformed WORKFLOW.md silently
  reverted to the default force-execute label. Now returns an error the
  runtime job propagates.

Tests: malformed front matter errors with load-failure context; missing
WORKFLOW.md still matches the default force-execute label.

