### PR TITLE
feat(stack): define canonical Agent Stack component model

### DIFF
--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod review;
 pub mod run_id;
 pub mod run_registry;
 pub mod shell_safety;
+pub mod stack;
 pub mod store_backend;
 #[cfg(test)]
 mod test_support;

--- a/crates/harness-core/src/stack/mod.rs
+++ b/crates/harness-core/src/stack/mod.rs
@@ -1,0 +1,800 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Deserializer, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+use thiserror::Error;
+use uuid::Uuid;
+#[cfg(test)]
+mod tests;
+pub const AGENT_STACK_COMPONENT_SCHEMA_VERSION: &str = "agent-stack-component/v0.1";
+
+macro_rules! closed_enum {
+    ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub enum $name { $($variant),+ }
+        impl $name {
+            pub const ALL: &'static [Self] = &[$(Self::$variant),+];
+            pub const fn as_str(&self) -> &'static str {
+                match self { $(Self::$variant => $wire),+ }
+            }
+        }
+    };
+}
+#[rustfmt::skip]
+closed_enum!(AgentStackComponentKind { Instructions => "instructions", Skill => "skill", McpServer => "mcp_server", McpTool => "mcp_tool", Hook => "hook", Memory => "memory", Policy => "policy", Workflow => "workflow", Validation => "validation", AgentRuntime => "agent_runtime" });
+#[rustfmt::skip]
+closed_enum!(AgentStackSourceScope { Repository => "repository", UserGlobal => "user_global", Admin => "admin", System => "system", Runtime => "runtime", Runner => "runner" });
+#[rustfmt::skip]
+closed_enum!(AgentStackUserGlobalRoot { HomeHarness => "home_harness", XdgConfigHarness => "xdg_config_harness", PlatformConfigHarness => "platform_config_harness", ConfiguredUser => "configured_user" });
+#[rustfmt::skip]
+closed_enum!(AgentStackObservationClass { RepositoryObserved => "repository_observed", RuntimeObserved => "runtime_observed", RunnerObserved => "runner_observed" });
+#[rustfmt::skip]
+closed_enum!(AgentStackSelectionState { Discovered => "discovered", Eligible => "eligible", Selected => "selected", Loaded => "loaded", Observed => "observed" });
+#[rustfmt::skip]
+closed_enum!(AgentStackCapability { Destructive => "destructive", SecretRead => "secret_read", Network => "network", Privileged => "privileged", ProductionWrite => "production_write", Shell => "shell", FileWrite => "file_write" });
+#[rustfmt::skip]
+closed_enum!(AgentStackTrustLevel { SelfDeclared => "self_declared", RepositoryObserved => "repository_observed", RuntimeObserved => "runtime_observed", RunnerObserved => "runner_observed" });
+#[rustfmt::skip]
+closed_enum!(AgentStackFreshness { Unknown => "unknown", Fresh => "fresh", Stale => "stale", Expired => "expired" });
+macro_rules! string_newtype {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+        impl $name {
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+    };
+}
+macro_rules! copy_getters {
+    ($($name:ident: $ty:ty),+ $(,)?) => { $(pub const fn $name(&self) -> $ty { self.$name })+ };
+}
+macro_rules! borrow_getters {
+    ($($name:ident: $ty:ty),+ $(,)?) => { $(pub fn $name(&self) -> &$ty { &self.$name })+ };
+}
+macro_rules! option_getters {
+    ($($name:ident: $ty:ty),+ $(,)?) => {
+        $(pub fn $name(&self) -> Option<&$ty> { self.$name.as_ref() })+
+    };
+}
+
+string_newtype!(AgentStackComponentId);
+string_newtype!(AgentStackSourceLocator);
+string_newtype!(Sha256Digest);
+impl AgentStackComponentId {
+    pub fn from_source(kind: AgentStackComponentKind, source: &AgentStackSource) -> Self {
+        Self(format!(
+            "{}:{}:{}",
+            source.scope.as_str(),
+            kind.as_str(),
+            source.locator.as_str()
+        ))
+    }
+}
+impl Sha256Digest {
+    pub fn parse(value: &str) -> Result<Self, AgentStackComponentError> {
+        let valid = value.len() == 64
+            && value
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+            && value.bytes().any(|b| b != b'0');
+        valid
+            .then(|| Self(value.to_owned()))
+            .ok_or(AgentStackComponentError::InvalidSha256Digest)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut value = String::with_capacity(64);
+        for byte in Sha256::digest(bytes) {
+            use fmt::Write as _;
+            write!(&mut value, "{byte:02x}").expect("writing to a String cannot fail");
+        }
+        Self(value)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct AgentStackSource {
+    scope: AgentStackSourceScope,
+    locator: AgentStackSourceLocator,
+}
+
+impl AgentStackSource {
+    pub fn new(
+        scope: AgentStackSourceScope,
+        locator: &str,
+    ) -> Result<Self, AgentStackComponentError> {
+        validate_source_locator(scope, locator)?;
+        Ok(Self {
+            scope,
+            locator: AgentStackSourceLocator(locator.to_owned()),
+        })
+    }
+
+    pub fn repository_from_path(
+        root: &Path,
+        source: &Path,
+    ) -> Result<Self, AgentStackComponentError> {
+        Self::new(
+            AgentStackSourceScope::Repository,
+            &relative_portable_path(root, source)?,
+        )
+    }
+
+    pub fn admin_from_path(source: &Path) -> Result<Self, AgentStackComponentError> {
+        let root = Path::new("/etc/harness");
+        Self::new(
+            AgentStackSourceScope::Admin,
+            &relative_portable_path(root, source)?,
+        )
+    }
+
+    pub fn user_global_from_path(
+        source: &Path,
+        home_harness: Option<&Path>,
+        xdg_config_harness: Option<&Path>,
+        platform_config_harness: Option<&Path>,
+        configured_user_roots: &[(&str, &Path)],
+    ) -> Result<Self, AgentStackComponentError> {
+        let (_, locator) = select_user_global_root(
+            source,
+            home_harness,
+            xdg_config_harness,
+            platform_config_harness,
+            configured_user_roots,
+        )?;
+        Self::new(AgentStackSourceScope::UserGlobal, locator.as_str())
+    }
+
+    pub fn logical(
+        scope: AgentStackSourceScope,
+        namespace: &str,
+        stable_path: &str,
+    ) -> Result<Self, AgentStackComponentError> {
+        if !matches!(
+            scope,
+            AgentStackSourceScope::System
+                | AgentStackSourceScope::Runtime
+                | AgentStackSourceScope::Runner
+        ) || !is_snake_case(namespace)
+            || is_uuid_shaped(namespace)
+            || is_reserved(namespace)
+            || !valid_logical_segments(stable_path)
+        {
+            return Err(AgentStackComponentError::InvalidSourceLocator);
+        }
+        let locator = if scope == AgentStackSourceScope::System {
+            format!("builtin/{namespace}/{stable_path}")
+        } else {
+            format!("{namespace}/{stable_path}")
+        };
+        Self::new(scope, &locator)
+    }
+
+    pub const fn scope(&self) -> AgentStackSourceScope {
+        self.scope
+    }
+    pub fn locator(&self) -> &AgentStackSourceLocator {
+        &self.locator
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentStackFreshnessEvidence {
+    authoritatively_invalidated: bool,
+    observation_time: Option<DateTime<Utc>>,
+    valid_until: Option<DateTime<Utc>>,
+    current_source_observed: bool,
+    cached_prior_observation: bool,
+}
+
+impl AgentStackFreshnessEvidence {
+    pub fn new(
+        authoritatively_invalidated: bool,
+        observation_time: Option<DateTime<Utc>>,
+        valid_until: Option<DateTime<Utc>>,
+        current_source_observed: bool,
+        cached_prior_observation: bool,
+    ) -> Self {
+        Self {
+            authoritatively_invalidated,
+            observation_time,
+            valid_until,
+            current_source_observed,
+            cached_prior_observation,
+        }
+    }
+
+    pub fn classify(&self) -> AgentStackFreshness {
+        if self.authoritatively_invalidated
+            || matches!(
+                (&self.observation_time, &self.valid_until),
+                (Some(observed), Some(valid_until)) if observed >= valid_until
+            )
+        {
+            AgentStackFreshness::Expired
+        } else if self.current_source_observed {
+            AgentStackFreshness::Fresh
+        } else if self.cached_prior_observation {
+            AgentStackFreshness::Stale
+        } else {
+            AgentStackFreshness::Unknown
+        }
+    }
+
+    copy_getters!(
+        authoritatively_invalidated: bool,
+        current_source_observed: bool,
+        cached_prior_observation: bool,
+    );
+    option_getters!(observation_time: DateTime<Utc>, valid_until: DateTime<Utc>);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AgentStackComponent {
+    schema_version: &'static str,
+    component_id: AgentStackComponentId,
+    kind: AgentStackComponentKind,
+    source: AgentStackSource,
+    observation_class: AgentStackObservationClass,
+    selection_state: AgentStackSelectionState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    integrity: Option<Sha256Digest>,
+    capabilities: Vec<AgentStackCapability>,
+    trust_level: AgentStackTrustLevel,
+    freshness: AgentStackFreshness,
+}
+
+impl AgentStackComponent {
+    pub fn new(
+        kind: AgentStackComponentKind,
+        source: AgentStackSource,
+        observation_class: AgentStackObservationClass,
+        selection_state: AgentStackSelectionState,
+        trust_level: AgentStackTrustLevel,
+        freshness: AgentStackFreshness,
+    ) -> Result<Self, AgentStackComponentError> {
+        validate_selection(observation_class, selection_state)?;
+        validate_trust(observation_class, trust_level)?;
+        let component_id = AgentStackComponentId::from_source(kind, &source);
+        Ok(Self {
+            schema_version: AGENT_STACK_COMPONENT_SCHEMA_VERSION,
+            component_id,
+            kind,
+            source,
+            observation_class,
+            selection_state,
+            integrity: None,
+            capabilities: Vec::new(),
+            trust_level,
+            freshness,
+        })
+    }
+
+    pub fn with_integrity(mut self, integrity: Option<Sha256Digest>) -> Self {
+        self.integrity = integrity;
+        self
+    }
+
+    pub fn with_capabilities(
+        mut self,
+        capabilities: impl IntoIterator<Item = AgentStackCapability>,
+    ) -> Result<Self, AgentStackComponentError> {
+        self.capabilities = capabilities.into_iter().collect();
+        if has_duplicate_capabilities(&self.capabilities) {
+            return Err(AgentStackComponentError::DuplicateCapability);
+        }
+        self.capabilities.sort_by_key(AgentStackCapability::as_str);
+        Ok(self)
+    }
+
+    pub fn validate(&self) -> Result<(), AgentStackComponentError> {
+        if self.schema_version != AGENT_STACK_COMPONENT_SCHEMA_VERSION {
+            return Err(AgentStackComponentError::UnsupportedSchemaVersion);
+        }
+        validate_source_locator(self.source.scope, self.source.locator.as_str())?;
+        if self.component_id != AgentStackComponentId::from_source(self.kind, &self.source) {
+            return Err(AgentStackComponentError::NonCanonicalComponentId);
+        }
+        self.integrity
+            .as_ref()
+            .map(|digest| Sha256Digest::parse(digest.as_str()))
+            .transpose()?;
+        validate_selection(self.observation_class, self.selection_state)?;
+        validate_trust(self.observation_class, self.trust_level)?;
+        if has_duplicate_capabilities(&self.capabilities) {
+            Err(AgentStackComponentError::DuplicateCapability)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn from_json(value: &str) -> Result<Self, AgentStackComponentParseError> {
+        let envelope: VersionEnvelope =
+            serde_json::from_str(value).map_err(AgentStackComponentParseError::Syntax)?;
+        if envelope.schema_version.as_deref() != Some(AGENT_STACK_COMPONENT_SCHEMA_VERSION) {
+            return Err(AgentStackComponentError::UnsupportedSchemaVersion.into());
+        }
+        let wire: V01WireComponent =
+            serde_json::from_str(value).map_err(AgentStackComponentParseError::Syntax)?;
+        wire.try_into().map_err(Into::into)
+    }
+
+    pub fn schema_version(&self) -> &str {
+        self.schema_version
+    }
+    copy_getters!(
+        kind: AgentStackComponentKind,
+        observation_class: AgentStackObservationClass,
+        selection_state: AgentStackSelectionState,
+        trust_level: AgentStackTrustLevel,
+        freshness: AgentStackFreshness,
+    );
+    borrow_getters!(component_id: AgentStackComponentId, source: AgentStackSource);
+    option_getters!(integrity: Sha256Digest);
+    pub fn capabilities(&self) -> &[AgentStackCapability] {
+        &self.capabilities
+    }
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum AgentStackComponentError {
+    #[error("the Agent Stack component schema version is unsupported")]
+    UnsupportedSchemaVersion,
+    #[error("the Agent Stack source locator is invalid")]
+    InvalidSourceLocator,
+    #[error("the Agent Stack source locator contains non-UTF-8 data")]
+    NonUtf8SourceLocator,
+    #[error("the Agent Stack source is outside its declared root")]
+    SourceOutsideRoot,
+    #[error("multiple configured user roots are ambiguous")]
+    AmbiguousConfiguredUserRoot,
+    #[error("an XDG Harness configuration root cannot be resolved")]
+    XdgConfigRootUnavailable,
+    #[error("the discovery source has no typed ownership")]
+    UntypedDiscoverySource,
+    #[error("the Agent Stack component ID is not canonical")]
+    NonCanonicalComponentId,
+    #[error("the SHA-256 digest is invalid")]
+    InvalidSha256Digest,
+    #[error("the selection state is unsupported by the observation class")]
+    SelectionNotSupported,
+    #[error("the trust level exceeds the observation class")]
+    TrustExceedsObservation,
+    #[error("the capability list contains a duplicate")]
+    DuplicateCapability,
+}
+
+#[derive(Debug, Error)]
+pub enum AgentStackComponentParseError {
+    #[error("the Agent Stack component JSON has invalid syntax or shape")]
+    Syntax(#[source] serde_json::Error),
+    #[error(transparent)]
+    Validation(#[from] AgentStackComponentError),
+}
+
+#[derive(Deserialize)]
+struct VersionEnvelope {
+    schema_version: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct V01WireSource {
+    scope: AgentStackSourceScope,
+    locator: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct V01WireComponent {
+    schema_version: String,
+    component_id: String,
+    kind: AgentStackComponentKind,
+    source: V01WireSource,
+    observation_class: AgentStackObservationClass,
+    selection_state: AgentStackSelectionState,
+    #[serde(default, deserialize_with = "deserialize_present_integrity")]
+    integrity: Option<String>,
+    capabilities: Vec<AgentStackCapability>,
+    trust_level: AgentStackTrustLevel,
+    freshness: AgentStackFreshness,
+}
+
+impl TryFrom<V01WireComponent> for AgentStackComponent {
+    type Error = AgentStackComponentError;
+
+    fn try_from(wire: V01WireComponent) -> Result<Self, Self::Error> {
+        if wire.schema_version != AGENT_STACK_COMPONENT_SCHEMA_VERSION {
+            return Err(AgentStackComponentError::UnsupportedSchemaVersion);
+        }
+        let source = AgentStackSource::new(wire.source.scope, &wire.source.locator)?;
+        let expected = AgentStackComponentId::from_source(wire.kind, &source);
+        if wire.component_id != expected.as_str() {
+            return Err(AgentStackComponentError::NonCanonicalComponentId);
+        }
+        let integrity = wire
+            .integrity
+            .as_deref()
+            .map(Sha256Digest::parse)
+            .transpose()?;
+        AgentStackComponent::new(
+            wire.kind,
+            source,
+            wire.observation_class,
+            wire.selection_state,
+            wire.trust_level,
+            wire.freshness,
+        )?
+        .with_integrity(integrity)
+        .with_capabilities(wire.capabilities)
+    }
+}
+
+fn deserialize_present_integrity<'de, D>(d: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(d).map(Some)
+}
+
+fn validate_selection(
+    observation: AgentStackObservationClass,
+    selection: AgentStackSelectionState,
+) -> Result<(), AgentStackComponentError> {
+    if observation == AgentStackObservationClass::RepositoryObserved
+        && matches!(
+            selection,
+            AgentStackSelectionState::Loaded | AgentStackSelectionState::Observed
+        )
+    {
+        Err(AgentStackComponentError::SelectionNotSupported)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_trust(
+    observation: AgentStackObservationClass,
+    trust: AgentStackTrustLevel,
+) -> Result<(), AgentStackComponentError> {
+    let allowed = match observation {
+        AgentStackObservationClass::RepositoryObserved => matches!(
+            trust,
+            AgentStackTrustLevel::SelfDeclared | AgentStackTrustLevel::RepositoryObserved
+        ),
+        AgentStackObservationClass::RuntimeObserved => {
+            trust != AgentStackTrustLevel::RunnerObserved
+        }
+        AgentStackObservationClass::RunnerObserved => true,
+    };
+    allowed
+        .then_some(())
+        .ok_or(AgentStackComponentError::TrustExceedsObservation)
+}
+
+fn has_duplicate_capabilities(capabilities: &[AgentStackCapability]) -> bool {
+    (0..capabilities.len()).any(|index| capabilities[..index].contains(&capabilities[index]))
+}
+
+fn validate_source_locator(
+    scope: AgentStackSourceScope,
+    locator: &str,
+) -> Result<(), AgentStackComponentError> {
+    match scope {
+        AgentStackSourceScope::Repository | AgentStackSourceScope::Admin => {
+            validate_portable_path(locator)?;
+            reject_reserved_segments(locator)
+        }
+        AgentStackSourceScope::UserGlobal => validate_user_global_locator(locator),
+        AgentStackSourceScope::System
+        | AgentStackSourceScope::Runtime
+        | AgentStackSourceScope::Runner => validate_logical_locator(scope, locator),
+    }
+}
+
+fn validate_portable_path(value: &str) -> Result<(), AgentStackComponentError> {
+    let drive_prefixed = value
+        .as_bytes()
+        .get(0..2)
+        .is_some_and(|head| head[0].is_ascii_alphabetic() && head[1] == b':');
+    if value.is_empty()
+        || value.starts_with('/')
+        || value.contains('\\')
+        || value.contains('\0')
+        || drive_prefixed
+        || value
+            .split('/')
+            .any(|segment| segment.is_empty() || segment == "." || segment == "..")
+    {
+        Err(AgentStackComponentError::InvalidSourceLocator)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_user_global_locator(locator: &str) -> Result<(), AgentStackComponentError> {
+    validate_portable_path(locator)?;
+    let mut segments = locator.split('/');
+    match segments.next().expect("validated non-empty locator") {
+        "home_harness" | "xdg_config_harness" | "platform_config_harness" => {}
+        "configured_user" => validate_configured_user_key(
+            segments
+                .next()
+                .ok_or(AgentStackComponentError::InvalidSourceLocator)?,
+        )?,
+        _ => return Err(AgentStackComponentError::InvalidSourceLocator),
+    }
+    if segments.next().is_none() {
+        return Err(AgentStackComponentError::InvalidSourceLocator);
+    }
+    reject_reserved_segments(locator)
+}
+
+fn validate_logical_locator(
+    scope: AgentStackSourceScope,
+    locator: &str,
+) -> Result<(), AgentStackComponentError> {
+    validate_portable_path(locator)?;
+    let mut segments = locator.split('/');
+    if scope == AgentStackSourceScope::System && segments.next() != Some("builtin") {
+        return Err(AgentStackComponentError::InvalidSourceLocator);
+    }
+    let namespace = segments
+        .next()
+        .ok_or(AgentStackComponentError::InvalidSourceLocator)?;
+    let remaining = segments.collect::<Vec<_>>();
+    if !is_snake_case(namespace)
+        || is_uuid_shaped(namespace)
+        || remaining.is_empty()
+        || remaining
+            .iter()
+            .any(|segment| !valid_logical_segment(segment))
+    {
+        return Err(AgentStackComponentError::InvalidSourceLocator);
+    }
+    reject_reserved_segments(locator)
+}
+
+fn valid_logical_segments(value: &str) -> bool {
+    !value.is_empty() && value.split('/').all(valid_logical_segment)
+}
+
+fn valid_logical_segment(segment: &str) -> bool {
+    segment
+        .as_bytes()
+        .first()
+        .is_some_and(u8::is_ascii_alphanumeric)
+        && segment
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+        && !is_reserved(segment)
+        && !is_uuid_shaped(segment)
+}
+
+fn validate_configured_user_key(key: &str) -> Result<(), AgentStackComponentError> {
+    if is_snake_case(key) && !is_reserved(key) && !is_uuid_shaped(key) {
+        Ok(())
+    } else {
+        Err(AgentStackComponentError::InvalidSourceLocator)
+    }
+}
+
+fn is_snake_case(value: &str) -> bool {
+    !value.is_empty()
+        && !value.starts_with('_')
+        && !value.ends_with('_')
+        && !value.contains("__")
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+}
+
+fn reject_reserved_segments(value: &str) -> Result<(), AgentStackComponentError> {
+    if value.split('/').any(is_reserved) {
+        Err(AgentStackComponentError::InvalidSourceLocator)
+    } else {
+        Ok(())
+    }
+}
+
+fn is_reserved(value: &str) -> bool {
+    [
+        "unknown",
+        "unknown-component",
+        "unknown_component",
+        "missing",
+        "null",
+        "none",
+    ]
+    .iter()
+    .any(|reserved| value.eq_ignore_ascii_case(reserved))
+}
+
+fn is_uuid_shaped(value: &str) -> bool {
+    Uuid::parse_str(value).is_ok()
+}
+
+pub fn resolve_xdg_config_harness_root(
+    xdg_config_home: Option<&Path>,
+    home: Option<&Path>,
+) -> Result<PathBuf, AgentStackComponentError> {
+    let root = if let Some(xdg) = xdg_config_home.filter(|path| path.is_absolute()) {
+        xdg.join("harness")
+    } else if let Some(home) = home.filter(|path| path.is_absolute()) {
+        home.join(".config").join("harness")
+    } else {
+        return Err(AgentStackComponentError::XdgConfigRootUnavailable);
+    };
+    normalize_absolute_path(&root)
+}
+
+pub fn select_user_global_root(
+    source: &Path,
+    home_harness: Option<&Path>,
+    xdg_config_harness: Option<&Path>,
+    platform_config_harness: Option<&Path>,
+    configured_user_roots: &[(&str, &Path)],
+) -> Result<(AgentStackUserGlobalRoot, AgentStackSourceLocator), AgentStackComponentError> {
+    if configured_user_roots.len() > 1 {
+        return Err(AgentStackComponentError::AmbiguousConfiguredUserRoot);
+    }
+    if let Some((key, _)) = configured_user_roots.first() {
+        validate_configured_user_key(key)?;
+    }
+    for (root_kind, namespace, root) in [
+        (
+            AgentStackUserGlobalRoot::HomeHarness,
+            "home_harness",
+            home_harness,
+        ),
+        (
+            AgentStackUserGlobalRoot::XdgConfigHarness,
+            "xdg_config_harness",
+            xdg_config_harness,
+        ),
+        (
+            AgentStackUserGlobalRoot::PlatformConfigHarness,
+            "platform_config_harness",
+            platform_config_harness,
+        ),
+    ] {
+        if let Some(root) = root {
+            if let Some(relative) = relative_portable_path_if_within(root, source)? {
+                return user_root_result(root_kind, format!("{namespace}/{relative}"));
+            }
+        }
+    }
+    if let Some((key, root)) = configured_user_roots.first() {
+        if let Some(relative) = relative_portable_path_if_within(root, source)? {
+            return user_root_result(
+                AgentStackUserGlobalRoot::ConfiguredUser,
+                format!("configured_user/{key}/{relative}"),
+            );
+        }
+    }
+    Err(AgentStackComponentError::UntypedDiscoverySource)
+}
+
+fn user_root_result(
+    root: AgentStackUserGlobalRoot,
+    locator: String,
+) -> Result<(AgentStackUserGlobalRoot, AgentStackSourceLocator), AgentStackComponentError> {
+    validate_user_global_locator(&locator)?;
+    Ok((root, AgentStackSourceLocator(locator)))
+}
+
+fn relative_portable_path(root: &Path, source: &Path) -> Result<String, AgentStackComponentError> {
+    relative_portable_path_if_within(root, source)?
+        .ok_or(AgentStackComponentError::SourceOutsideRoot)
+}
+
+fn relative_portable_path_if_within(
+    root: &Path,
+    source: &Path,
+) -> Result<Option<String>, AgentStackComponentError> {
+    let root = absolute_path_key(root, true)?;
+    let source = absolute_path_key(source, false)?;
+    if !root_key_matches(root.drive, &root.segments, source.drive, &source.segments)
+        || source.segments.len() <= root.segments.len()
+    {
+        return Ok(None);
+    }
+    let relative = source.segments[root.segments.len()..].join("/");
+    validate_portable_path(&relative)?;
+    Ok(Some(relative))
+}
+
+fn normalize_absolute_path(path: &Path) -> Result<PathBuf, AgentStackComponentError> {
+    let key = absolute_path_key(path, true)?;
+    let mut result = PathBuf::new();
+    #[cfg(unix)]
+    result.push("/");
+    #[cfg(windows)]
+    if let Some(drive) = key.drive {
+        result.push(format!("{}:\\", drive as char));
+    }
+    for segment in key.segments {
+        result.push(segment);
+    }
+    Ok(result)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AbsolutePathKey {
+    drive: Option<u8>,
+    segments: Vec<String>,
+}
+
+fn absolute_path_key(
+    path: &Path,
+    resolve_parent: bool,
+) -> Result<AbsolutePathKey, AgentStackComponentError> {
+    if !path.is_absolute() {
+        return Err(AgentStackComponentError::InvalidSourceLocator);
+    }
+    #[cfg(windows)]
+    let mut drive = None;
+    #[cfg(not(windows))]
+    let drive = None;
+    let mut segments = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(value) => {
+                #[cfg(windows)]
+                {
+                    use std::path::Prefix;
+                    drive = Some(match value.kind() {
+                        Prefix::Disk(drive) | Prefix::VerbatimDisk(drive) => {
+                            drive.to_ascii_uppercase()
+                        }
+                        _ => return Err(AgentStackComponentError::InvalidSourceLocator),
+                    });
+                }
+                #[cfg(not(windows))]
+                {
+                    let _ = value;
+                    return Err(AgentStackComponentError::InvalidSourceLocator);
+                }
+            }
+            Component::RootDir | Component::CurDir => {}
+            Component::ParentDir if resolve_parent && !segments.is_empty() => {
+                segments.pop();
+            }
+            Component::ParentDir => return Err(AgentStackComponentError::InvalidSourceLocator),
+            Component::Normal(value) => segments.push(
+                value
+                    .to_str()
+                    .ok_or(AgentStackComponentError::NonUtf8SourceLocator)?
+                    .to_owned(),
+            ),
+        }
+    }
+    Ok(AbsolutePathKey { drive, segments })
+}
+
+fn drives_match(left: Option<u8>, right: Option<u8>) -> bool {
+    left.map(|drive| drive.to_ascii_uppercase()) == right.map(|drive| drive.to_ascii_uppercase())
+}
+
+fn root_key_matches<T: PartialEq>(
+    root_drive: Option<u8>,
+    root: &[T],
+    source_drive: Option<u8>,
+    source: &[T],
+) -> bool {
+    drives_match(root_drive, source_drive) && source.starts_with(root)
+}
+
+#[cfg(test)]
+fn root_keys_match_for_test(
+    drive_a: Option<u8>,
+    segments_a: &[&str],
+    drive_b: Option<u8>,
+    segments_b: &[&str],
+) -> bool {
+    segments_a.len() == segments_b.len()
+        && root_key_matches(drive_a, segments_a, drive_b, segments_b)
+}

--- a/crates/harness-core/src/stack/tests.rs
+++ b/crates/harness-core/src/stack/tests.rs
@@ -1,0 +1,795 @@
+use super::*;
+use chrono::{DateTime, Utc};
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::{json, Value};
+use std::fmt::Debug;
+use std::path::{Path, PathBuf};
+
+const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+fn assert_wire_roundtrip<T>(values: &[T], expected: &[&str])
+where
+    T: Copy + Debug + PartialEq + Serialize + DeserializeOwned,
+{
+    assert_eq!(values.len(), expected.len());
+    for (value, wire) in values.iter().zip(expected) {
+        let encoded = serde_json::to_string(value).expect("enum serialization");
+        assert_eq!(encoded, format!("\"{wire}\""));
+        let decoded: T = serde_json::from_str(&encoded).expect("enum deserialization");
+        assert_eq!(*value, decoded);
+    }
+}
+
+fn repository_source(locator: &str) -> AgentStackSource {
+    AgentStackSource::new(AgentStackSourceScope::Repository, locator)
+        .expect("valid repository source")
+}
+
+fn test_component(
+    kind: AgentStackComponentKind,
+    source: AgentStackSource,
+    observation: AgentStackObservationClass,
+    selection: AgentStackSelectionState,
+    trust: AgentStackTrustLevel,
+) -> Result<AgentStackComponent, AgentStackComponentError> {
+    AgentStackComponent::new(
+        kind,
+        source,
+        observation,
+        selection,
+        trust,
+        AgentStackFreshness::Unknown,
+    )
+}
+
+fn base_component() -> AgentStackComponent {
+    test_component(
+        AgentStackComponentKind::Skill,
+        repository_source("skills/example/SKILL.md"),
+        AgentStackObservationClass::RepositoryObserved,
+        AgentStackSelectionState::Discovered,
+        AgentStackTrustLevel::RepositoryObserved,
+    )
+    .expect("valid base component")
+}
+
+fn base_value() -> Value {
+    serde_json::to_value(base_component()).expect("base component JSON")
+}
+
+fn validation_error(value: Value) -> AgentStackComponentError {
+    match AgentStackComponent::from_json(&value.to_string()) {
+        Err(AgentStackComponentParseError::Validation(error)) => error,
+        Err(other) => panic!("expected validation error, got {other:?}"),
+        Ok(_) => panic!("expected validation error, got success"),
+    }
+}
+
+fn assert_error_variant(error: AgentStackComponentError, expected: &str) {
+    let actual = format!("{error:?}");
+    assert!(
+        actual.starts_with(expected),
+        "expected {expected}, got {actual}"
+    );
+}
+
+fn assert_syntax_value(value: Value) {
+    assert!(matches!(
+        AgentStackComponent::from_json(&value.to_string()),
+        Err(AgentStackComponentParseError::Syntax(_))
+    ));
+}
+
+fn timestamp(seconds: i64) -> DateTime<Utc> {
+    DateTime::from_timestamp(seconds, 0).expect("valid fixed timestamp")
+}
+
+fn host_root(name: &str) -> PathBuf {
+    std::env::temp_dir().join("harness-stack-tests").join(name)
+}
+
+fn assert_source(source: AgentStackSource, scope: AgentStackSourceScope, locator: &str) {
+    assert_eq!(source.scope(), scope);
+    assert_eq!(source.locator().as_str(), locator);
+    let item = test_component(
+        AgentStackComponentKind::Skill,
+        source,
+        AgentStackObservationClass::RepositoryObserved,
+        AgentStackSelectionState::Selected,
+        AgentStackTrustLevel::SelfDeclared,
+    )
+    .unwrap();
+    let decoded = AgentStackComponent::from_json(&serde_json::to_string(&item).unwrap()).unwrap();
+    assert_eq!(decoded.source().scope(), scope);
+}
+
+fn assert_logical(scope: AgentStackSourceScope, namespace: &str, path: &str, locator: &str) {
+    assert_source(
+        AgentStackSource::logical(scope, namespace, path).unwrap(),
+        scope,
+        locator,
+    );
+}
+
+macro_rules! stack_tests {
+    ($($item:item)*) => { $(#[test] $item)* };
+}
+
+stack_tests! {
+fn schema_version_is_required_and_exact() {
+    assert!(base_component().validate().is_ok());
+    assert!(AgentStackComponent::from_json(&base_value().to_string()).is_ok());
+
+    for replacement in [None, Some(""), Some("agent-stack-component/v9")] {
+        let mut value = base_value();
+        match replacement {
+            Some(version) => value["schema_version"] = json!(version),
+            None => {
+                value.as_object_mut().unwrap().remove("schema_version");
+            }
+        }
+        assert_error_variant(validation_error(value), "UnsupportedSchemaVersion");
+    }
+
+    let mut unknown = base_value();
+    unknown["extra"] = json!(true);
+    assert_syntax_value(unknown);
+
+    let mut missing = base_value();
+    missing.as_object_mut().unwrap().remove("kind");
+    assert_syntax_value(missing);
+
+    let mut null_integrity = base_value();
+    null_integrity["integrity"] = Value::Null;
+    assert_syntax_value(null_integrity);
+}
+
+fn unsupported_version_precedes_strict_v01_shape_validation() {
+    let mut future = base_value();
+    future["schema_version"] = json!("agent-stack-component/v0.2");
+    future["future_only_field"] = json!({"shape": "unknown to v0.1"});
+    assert_error_variant(validation_error(future), "UnsupportedSchemaVersion");
+
+    assert!(matches!(
+        AgentStackComponent::from_json("{not-json"),
+        Err(AgentStackComponentParseError::Syntax(_))
+    ));
+
+    let mut invalid_locator = base_value();
+    invalid_locator["source"]["locator"] = json!("../escape");
+    assert_error_variant(validation_error(invalid_locator), "InvalidSourceLocator");
+}
+
+fn wire_parser_is_environment_independent() {
+    let source = AgentStackSource::new(
+        AgentStackSourceScope::UserGlobal,
+        "home_harness/skills/example/SKILL.md",
+    )
+    .unwrap();
+    let item = test_component(
+        AgentStackComponentKind::Skill,
+        source,
+        AgentStackObservationClass::RuntimeObserved,
+        AgentStackSelectionState::Loaded,
+        AgentStackTrustLevel::RuntimeObserved,
+    )
+    .unwrap();
+    let value = serde_json::to_string(&item).unwrap();
+    let first = temp_env::with_vars(
+        [("HOME", Some("/tmp/first")), ("XDG_CONFIG_HOME", None)],
+        || AgentStackComponent::from_json(&value).unwrap(),
+    );
+    let second = temp_env::with_vars(
+        [("HOME", Some("/tmp/second")), ("XDG_CONFIG_HOME", Some("relative"))],
+        || AgentStackComponent::from_json(&value).unwrap(),
+    );
+    assert_eq!(
+        serde_json::to_string(&first).unwrap(),
+        serde_json::to_string(&second).unwrap()
+    );
+}
+
+fn all_component_values_round_trip_in_canonical_wire_order() {
+    for kind in AgentStackComponentKind::ALL {
+        let item = test_component(
+            *kind,
+            repository_source("components/example"),
+            AgentStackObservationClass::RepositoryObserved,
+            AgentStackSelectionState::Eligible,
+            AgentStackTrustLevel::SelfDeclared,
+        )
+        .unwrap()
+        .with_integrity(Some(Sha256Digest::parse(HASH_A).unwrap()))
+        .with_capabilities([
+            AgentStackCapability::Shell,
+            AgentStackCapability::Destructive,
+            AgentStackCapability::FileWrite,
+        ])
+        .unwrap();
+        let encoded = serde_json::to_string(&item).unwrap();
+        let decoded = AgentStackComponent::from_json(&encoded).unwrap();
+        assert_eq!(decoded.kind(), *kind);
+        assert_eq!(
+            decoded
+                .capabilities()
+                .iter()
+                .map(AgentStackCapability::as_str)
+                .collect::<Vec<_>>(),
+            ["destructive", "file_write", "shell"]
+        );
+    }
+
+    let expected = "{\"schema_version\":\"agent-stack-component/v0.1\",\"component_id\":\"repository:skill:skills/example/SKILL.md\",\"kind\":\"skill\",\"source\":{\"scope\":\"repository\",\"locator\":\"skills/example/SKILL.md\"},\"observation_class\":\"repository_observed\",\"selection_state\":\"discovered\",\"capabilities\":[],\"trust_level\":\"repository_observed\",\"freshness\":\"unknown\"}";
+    assert_eq!(serde_json::to_string(&base_component()).unwrap(), expected);
+
+    let duplicate = base_component()
+        .with_capabilities([AgentStackCapability::Shell, AgentStackCapability::Shell]);
+    assert_error_variant(duplicate.unwrap_err(), "DuplicateCapability");
+
+    let mut duplicate_wire = base_value();
+    duplicate_wire["capabilities"] = json!(["shell", "shell"]);
+    assert_error_variant(validation_error(duplicate_wire), "DuplicateCapability");
+}
+
+#[rustfmt::skip]
+fn component_kind_wire_vocabulary_is_closed() { assert_wire_roundtrip(AgentStackComponentKind::ALL, &["instructions", "skill", "mcp_server", "mcp_tool", "hook", "memory", "policy", "workflow", "validation", "agent_runtime"]); for invalid in ["instruction", "Skill", "mcp-server", "unknown"] { assert!(serde_json::from_str::<AgentStackComponentKind>(&format!("\"{invalid}\"")).is_err()); } }
+
+fn explicit_multi_role_bindings_have_distinct_component_ids() {
+    let source = repository_source("shared/definition.md");
+    let skill = AgentStackComponentId::from_source(AgentStackComponentKind::Skill, &source);
+    let policy = AgentStackComponentId::from_source(AgentStackComponentKind::Policy, &source);
+    assert_eq!(skill.as_str(), "repository:skill:shared/definition.md");
+    assert_eq!(policy.as_str(), "repository:policy:shared/definition.md");
+    assert_ne!(skill.as_str(), policy.as_str());
+}
+
+#[rustfmt::skip]
+fn capability_wire_vocabulary_is_closed() { assert_wire_roundtrip(AgentStackCapability::ALL, &["destructive", "secret_read", "network", "privileged", "production_write", "shell", "file_write"]); for invalid in ["write", "SecretRead", "secret-read", "unknown"] { assert!(serde_json::from_str::<AgentStackCapability>(&format!("\"{invalid}\"")).is_err()); } }
+
+#[rustfmt::skip]
+fn remaining_wire_vocabularies_are_closed() { assert_wire_roundtrip(AgentStackSourceScope::ALL, &["repository", "user_global", "admin", "system", "runtime", "runner"]); assert_wire_roundtrip(AgentStackUserGlobalRoot::ALL, &["home_harness", "xdg_config_harness", "platform_config_harness", "configured_user"]); assert_wire_roundtrip(AgentStackSelectionState::ALL, &["discovered", "eligible", "selected", "loaded", "observed"]); assert_wire_roundtrip(AgentStackTrustLevel::ALL, &["self_declared", "repository_observed", "runtime_observed", "runner_observed"]); assert_wire_roundtrip(AgentStackFreshness::ALL, &["unknown", "fresh", "stale", "expired"]); }
+
+fn observation_class_round_trips_without_implied_trust() {
+    assert_wire_roundtrip(
+        AgentStackObservationClass::ALL,
+        &["repository_observed", "runtime_observed", "runner_observed"],
+    );
+    let item = test_component(
+        AgentStackComponentKind::Workflow,
+        repository_source("WORKFLOW.md"),
+        AgentStackObservationClass::RuntimeObserved,
+        AgentStackSelectionState::Loaded,
+        AgentStackTrustLevel::SelfDeclared,
+    )
+    .unwrap();
+    assert_eq!(item.trust_level(), AgentStackTrustLevel::SelfDeclared);
+}
+
+fn selection_state_requires_supporting_observation() {
+    for observation in AgentStackObservationClass::ALL {
+        for selection in AgentStackSelectionState::ALL {
+            let expected = !matches!(
+                (observation, selection),
+                (
+                    AgentStackObservationClass::RepositoryObserved,
+                    AgentStackSelectionState::Loaded | AgentStackSelectionState::Observed
+                )
+            );
+            let result = test_component(
+                AgentStackComponentKind::Instructions,
+                repository_source("AGENTS.md"),
+                *observation,
+                *selection,
+                AgentStackTrustLevel::SelfDeclared,
+            );
+            assert_eq!(result.is_ok(), expected, "{observation:?} × {selection:?}");
+            if let Err(error) = result {
+                assert_error_variant(error, "SelectionNotSupported");
+            }
+        }
+    }
+}
+
+fn trust_cannot_exceed_observation_source() {
+    for observation in AgentStackObservationClass::ALL {
+        for trust in AgentStackTrustLevel::ALL {
+            let expected = match observation {
+                AgentStackObservationClass::RepositoryObserved => matches!(
+                    trust,
+                    AgentStackTrustLevel::SelfDeclared | AgentStackTrustLevel::RepositoryObserved
+                ),
+                AgentStackObservationClass::RuntimeObserved => {
+                    !matches!(trust, AgentStackTrustLevel::RunnerObserved)
+                }
+                AgentStackObservationClass::RunnerObserved => true,
+            };
+            let result = test_component(
+                AgentStackComponentKind::Validation,
+                repository_source("checks/specrail.py"),
+                *observation,
+                AgentStackSelectionState::Selected,
+                *trust,
+            );
+            assert_eq!(result.is_ok(), expected, "{observation:?} × {trust:?}");
+            if let Err(error) = result {
+                assert_error_variant(error, "TrustExceedsObservation");
+            }
+        }
+    }
+}
+
+fn component_identity_is_stable_across_observation_classes() {
+    let id = |observation, selection| {
+        test_component(
+            AgentStackComponentKind::Skill,
+            repository_source("skills/stable/SKILL.md"),
+            observation,
+            selection,
+            AgentStackTrustLevel::RepositoryObserved,
+        )
+        .unwrap()
+        .component_id()
+        .as_str()
+        .to_string()
+    };
+    let ids = [
+        id(
+            AgentStackObservationClass::RepositoryObserved,
+            AgentStackSelectionState::Selected,
+        ),
+        id(
+            AgentStackObservationClass::RuntimeObserved,
+            AgentStackSelectionState::Loaded,
+        ),
+        id(
+            AgentStackObservationClass::RunnerObserved,
+            AgentStackSelectionState::Observed,
+        ),
+    ];
+    assert!(ids.windows(2).all(|pair| pair[0] == pair[1]));
+}
+
+fn missing_freshness_is_explicitly_unknown() {
+    let evidence = AgentStackFreshnessEvidence::new(false, None, None, false, false);
+    assert_eq!(evidence.classify(), AgentStackFreshness::Unknown);
+    assert!(!evidence.authoritatively_invalidated());
+    assert!(evidence.observation_time().is_none());
+    assert!(evidence.valid_until().is_none());
+    assert!(!evidence.current_source_observed());
+    assert!(!evidence.cached_prior_observation());
+}
+
+fn freshness_evidence_mapping_is_deterministic() {
+    let before = timestamp(10);
+    let deadline = timestamp(20);
+    let cases = [
+        (
+            AgentStackFreshnessEvidence::new(false, Some(before), Some(deadline), true, true),
+            AgentStackFreshness::Fresh,
+        ),
+        (
+            AgentStackFreshnessEvidence::new(false, None, None, false, true),
+            AgentStackFreshness::Stale,
+        ),
+        (
+            AgentStackFreshnessEvidence::new(false, Some(before), None, false, false),
+            AgentStackFreshness::Unknown,
+        ),
+        (
+            AgentStackFreshnessEvidence::new(false, None, Some(deadline), false, false),
+            AgentStackFreshness::Unknown,
+        ),
+    ];
+    for (evidence, expected) in cases {
+        assert_eq!(evidence.classify(), expected);
+        assert_eq!(evidence.classify(), expected);
+    }
+}
+
+fn freshness_deadline_is_expired_at_exact_boundary() {
+    let boundary = timestamp(100);
+    let evidence =
+        AgentStackFreshnessEvidence::new(false, Some(boundary), Some(boundary), false, false);
+    assert_eq!(evidence.classify(), AgentStackFreshness::Expired);
+}
+
+fn explicit_expiry_precedes_current_and_cached_evidence() {
+    let evidence = AgentStackFreshnessEvidence::new(true, None, None, true, true);
+    assert_eq!(evidence.classify(), AgentStackFreshness::Expired);
+
+    let deadline = AgentStackFreshnessEvidence::new(
+        false,
+        Some(timestamp(101)),
+        Some(timestamp(100)),
+        true,
+        true,
+    );
+    assert_eq!(deadline.classify(), AgentStackFreshness::Expired);
+}
+
+fn cached_without_current_observation_is_stale() {
+    let evidence = AgentStackFreshnessEvidence::new(false, None, None, false, true);
+    assert_eq!(evidence.classify(), AgentStackFreshness::Stale);
+}
+
+fn source_mapping_contract_examples_are_canonical() {
+    let repo_root = host_root("repository");
+    assert_source(
+        AgentStackSource::repository_from_path(&repo_root, &repo_root.join("AGENTS.md")).unwrap(),
+        AgentStackSourceScope::Repository,
+        "AGENTS.md",
+    );
+    let home_root = host_root("user").join(".harness");
+    assert_source(
+        AgentStackSource::user_global_from_path(
+            &home_root.join("skills/a/SKILL.md"),
+            Some(&home_root),
+            None,
+            None,
+            &[],
+        )
+        .unwrap(),
+        AgentStackSourceScope::UserGlobal,
+        "home_harness/skills/a/SKILL.md",
+    );
+    #[cfg(unix)]
+    let admin = AgentStackSource::admin_from_path(Path::new("/etc/harness/rules/base.md")).unwrap();
+    #[cfg(not(unix))]
+    let admin = AgentStackSource::new(AgentStackSourceScope::Admin, "rules/base.md").unwrap();
+    #[cfg(windows)]
+    assert!(AgentStackSource::admin_from_path(Path::new(r"C:\ProgramData\Harness\rules\base.md")).is_err());
+    assert_source(admin, AgentStackSourceScope::Admin, "rules/base.md");
+    assert_logical(
+        AgentStackSourceScope::System,
+        "core",
+        "golden-principles.md",
+        "builtin/core/golden-principles.md",
+    );
+    assert_logical(
+        AgentStackSourceScope::Runtime,
+        "workflow_runtime",
+        "codex-default",
+        "workflow_runtime/codex-default",
+    );
+    assert_logical(
+        AgentStackSourceScope::Runner,
+        "probe",
+        "getUser",
+        "probe/getUser",
+    );
+}
+
+fn user_global_root_selection_collapses_overlaps_by_precedence() {
+    let root = host_root("same-root");
+    let source = root.join("skills/a/SKILL.md");
+    let (selected, locator) =
+        select_user_global_root(&source, Some(&root), Some(&root), Some(&root), &[]).unwrap();
+    assert_eq!(selected, AgentStackUserGlobalRoot::HomeHarness);
+    assert_eq!(locator.as_str(), "home_harness/skills/a/SKILL.md");
+
+    let parent = host_root("overlap");
+    let nested = parent.join("nested");
+    let source = nested.join("config.toml");
+    let (selected, _) =
+        select_user_global_root(&source, Some(&parent), Some(&nested), None, &[]).unwrap();
+    assert_eq!(selected, AgentStackUserGlobalRoot::HomeHarness);
+
+    let outside_prefix = parent.with_file_name("overlap-suffix").join("item");
+    let error =
+        select_user_global_root(&outside_prefix, Some(&parent), None, None, &[]).unwrap_err();
+    assert_error_variant(error, "UntypedDiscoverySource");
+    let error =
+        select_user_global_root(&root.join("missing"), Some(&root), None, None, &[]).unwrap_err();
+    assert_error_variant(error, "InvalidSourceLocator");
+}
+
+fn multiple_configured_user_roots_fail_as_ambiguous() {
+    let root = host_root("configured");
+    let nested = root.join("nested");
+    let configured = [("primary", root.as_path()), ("nested", nested.as_path())];
+    let error = select_user_global_root(&root.join("nested/item"), None, None, None, &configured)
+        .unwrap_err();
+    assert_error_variant(error, "AmbiguousConfiguredUserRoot");
+}
+
+fn configured_user_key_uses_strict_snake_case() {
+    let root = host_root("configured-valid");
+    let source = AgentStackSource::user_global_from_path(
+        &root.join("skills/example"),
+        None,
+        None,
+        None,
+        &[("team_one2", root.as_path())],
+    )
+    .unwrap();
+    assert_eq!(
+        source.locator().as_str(),
+        "configured_user/team_one2/skills/example"
+    );
+}
+
+fn configured_user_key_rejects_display_uuid_and_reserved_segments() {
+    let root = host_root("configured-invalid");
+    for key in [
+        "Team_one",
+        "team-one",
+        "display name",
+        "unknown",
+        "550e8400-e29b-41d4-a716-446655440000",
+    ] {
+        let error = AgentStackSource::user_global_from_path(
+            &root.join("item"),
+            None,
+            None,
+            None,
+            &[(key, root.as_path())],
+        )
+        .unwrap_err();
+        assert_error_variant(error, "InvalidSourceLocator");
+    }
+}
+
+fn xdg_root_falls_back_to_absolute_home_when_xdg_is_missing_or_relative() {
+    let home = host_root("home");
+    let expected = home.join(".config").join("harness");
+    assert_eq!(
+        resolve_xdg_config_harness_root(None, Some(&home)).unwrap(),
+        expected
+    );
+    assert_eq!(
+        resolve_xdg_config_harness_root(Some(Path::new("relative")), Some(&home)).unwrap(),
+        expected
+    );
+
+    let absolute_xdg = host_root("xdg");
+    assert_eq!(
+        resolve_xdg_config_harness_root(Some(&absolute_xdg), Some(&home)).unwrap(),
+        absolute_xdg.join("harness")
+    );
+}
+
+fn xdg_root_fails_when_xdg_and_home_are_unusable() {
+    for (xdg, home) in [
+        (None, None),
+        (Some(Path::new("relative-xdg")), None),
+        (
+            Some(Path::new("relative-xdg")),
+            Some(Path::new("relative-home")),
+        ),
+    ] {
+        let error = resolve_xdg_config_harness_root(xdg, home).unwrap_err();
+        assert_error_variant(error, "XdgConfigRootUnavailable");
+    }
+}
+
+fn path_locator_rejects_non_utf8_without_lossy_conversion() {
+    #[cfg(unix)]
+    let (root, source) = {
+        use std::os::unix::ffi::OsStringExt;
+        let root = PathBuf::from("/repo");
+        let source = root.join(std::ffi::OsString::from_vec(b"bad-\xff".to_vec()));
+        (root, source)
+    };
+    #[cfg(windows)]
+    let (root, source) = {
+        use std::os::windows::ffi::OsStringExt;
+        let root = PathBuf::from(r"C:\repo");
+        let source = root.join(std::ffi::OsString::from_wide(&[0xd800]));
+        (root, source)
+    };
+    assert_error_variant(
+        AgentStackSource::repository_from_path(&root, &source).unwrap_err(),
+        "NonUtf8SourceLocator",
+    );
+}
+
+fn portable_segment_encoder_uses_forward_slashes() {
+    let root = host_root("portable");
+    let source = AgentStackSource::repository_from_path(
+        &root,
+        &root.join("skills").join("nested").join("SKILL.md"),
+    )
+    .unwrap();
+    assert_eq!(source.locator().as_str(), "skills/nested/SKILL.md");
+    assert!(!source.locator().as_str().contains('\\'));
+}
+
+fn path_adapter_canonicalizes_curdir_and_rejects_parentdir() {
+    let root = host_root("components");
+    let canonical =
+        AgentStackSource::repository_from_path(&root, &root.join("a").join(".").join("b")).unwrap();
+    assert_eq!(canonical.locator().as_str(), "a/b");
+
+    let error = AgentStackSource::repository_from_path(&root, &root.join("a").join("..").join("b"))
+        .unwrap_err();
+    assert_error_variant(error, "InvalidSourceLocator");
+
+    let outside = root.parent().unwrap().join("outside");
+    let error = AgentStackSource::repository_from_path(&root, &outside).unwrap_err();
+    assert_error_variant(error, "SourceOutsideRoot");
+}
+
+fn windows_drive_letter_casing_is_canonical_equivalent() {
+    assert!(super::root_keys_match_for_test(
+        Some(b'c'),
+        &["Root", "Project"],
+        Some(b'C'),
+        &["Root", "Project"],
+    ));
+}
+
+fn windows_directory_segment_casing_remains_distinct() {
+    assert!(!super::root_keys_match_for_test(
+        Some(b'C'),
+        &["Root", "Project"],
+        Some(b'c'),
+        &["root", "Project"],
+    ));
+}
+
+fn logical_path_grammar_covers_system_runtime_and_runner() {
+    assert_logical(
+        AgentStackSourceScope::System,
+        "core_rules",
+        "exec-plan/golden-principles.md",
+        "builtin/core_rules/exec-plan/golden-principles.md",
+    );
+    assert_logical(
+        AgentStackSourceScope::Runtime,
+        "workflow_runtime",
+        "DATA_EXPORT_v2",
+        "workflow_runtime/DATA_EXPORT_v2",
+    );
+    assert_logical(
+        AgentStackSourceScope::Runner,
+        "mcp_probe",
+        "getUser/v2.1",
+        "mcp_probe/getUser/v2.1",
+    );
+    for (namespace, path) in [
+        ("Bad-Namespace", "valid"),
+        ("0123456789abcdef0123456789abcdef", "tool"),
+        ("valid", ""),
+        ("valid", "-leading"),
+        ("valid", ".."),
+        ("valid", "display name"),
+        ("valid", "550e8400-e29b-41d4-a716-446655440000"),
+    ] {
+        let error =
+            AgentStackSource::logical(AgentStackSourceScope::Runtime, namespace, path).unwrap_err();
+        assert_error_variant(error, "InvalidSourceLocator");
+    }
+}
+
+fn logical_path_preserves_case_distinct_tool_names() {
+    let upper = AgentStackSource::logical(AgentStackSourceScope::Runner, "mcp", "getUser").unwrap();
+    let lower = AgentStackSource::logical(AgentStackSourceScope::Runner, "mcp", "getuser").unwrap();
+    assert_eq!(upper.locator().as_str(), "mcp/getUser");
+    assert_eq!(lower.locator().as_str(), "mcp/getuser");
+    assert_ne!(upper.locator().as_str(), lower.locator().as_str());
+}
+
+fn untyped_custom_discovery_source_fails_closed() {
+    let source = host_root("untyped").join("custom/item");
+    let error =
+        AgentStackSource::user_global_from_path(&source, None, None, None, &[]).unwrap_err();
+    assert_error_variant(error, "UntypedDiscoverySource");
+}
+
+fn source_locator_rejects_reserved_sentinels() {
+    for (scope, locator) in [
+        (AgentStackSourceScope::Repository, "unknown"),
+        (AgentStackSourceScope::Admin, "rules/null"),
+        (AgentStackSourceScope::UserGlobal, "home_harness/missing"),
+        (AgentStackSourceScope::UserGlobal, "custom/item"),
+        (AgentStackSourceScope::Runtime, "0123456789abcdef0123456789abcdef/tool"),
+        (AgentStackSourceScope::Repository, "/absolute"),
+        (AgentStackSourceScope::Repository, "C:/drive"),
+        (AgentStackSourceScope::Repository, r"a\b"),
+        (AgentStackSourceScope::Repository, "a//b"),
+        (AgentStackSourceScope::Repository, "a/./b"),
+        (AgentStackSourceScope::Repository, "a/../b"),
+    ] {
+        let error = AgentStackSource::new(scope, locator).unwrap_err();
+        assert_error_variant(error, "InvalidSourceLocator");
+    }
+}
+
+fn runtime_locator_rejects_reserved_segments() {
+    for path in [
+        "unknown_component/item",
+        "item/null",
+        "missing",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "0123456789abcdef0123456789abcdef",
+        "display name",
+    ] {
+        let error =
+            AgentStackSource::logical(AgentStackSourceScope::Runtime, "runtime", path).unwrap_err();
+        assert_error_variant(error, "InvalidSourceLocator");
+    }
+}
+
+fn portable_path_locator_rejects_nul() {
+    let error =
+        AgentStackSource::new(AgentStackSourceScope::Repository, "skills/bad\0name").unwrap_err();
+    assert_error_variant(error, "InvalidSourceLocator");
+}
+
+fn source_locator_validation_precedes_component_id_derivation() {
+    let mut value = base_value();
+    value["component_id"] = json!("repository:skill:wrong");
+    value["source"]["locator"] = json!("../escape");
+    assert_error_variant(validation_error(value), "InvalidSourceLocator");
+
+    let mut id_only = base_value();
+    id_only["component_id"] = json!("repository:skill:wrong");
+    assert_error_variant(validation_error(id_only), "NonCanonicalComponentId");
+}
+
+fn sha256_digest_rejects_blank_malformed_and_mixed_case_values() {
+    for invalid in [
+        "",
+        "abc",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+    ] {
+        assert_error_variant(
+            Sha256Digest::parse(invalid).unwrap_err(),
+            "InvalidSha256Digest",
+        );
+    }
+
+    let mut value = base_value();
+    value["integrity"] = json!("bad");
+    assert_error_variant(validation_error(value), "InvalidSha256Digest");
+}
+
+fn sha256_digest_hashes_exact_source_bytes() {
+    let digest = Sha256Digest::from_bytes(b"abc");
+    assert_eq!(
+        digest.as_str(),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+}
+
+fn sha256_digest_distinguishes_lf_crlf_bom_and_unicode_bytes() {
+    let inputs: &[&[u8]] = &[
+        b"x\n",
+        b"x\r\n",
+        b"\xef\xbb\xbfx\n",
+        "é\n".as_bytes(),
+        &[0x00, 0xe9, 0x00, 0x0a],
+    ];
+    let digests = inputs
+        .iter()
+        .map(|bytes| Sha256Digest::from_bytes(bytes).as_str().to_string())
+        .collect::<Vec<_>>();
+    for left in 0..digests.len() {
+        for right in (left + 1)..digests.len() {
+            assert_ne!(digests[left], digests[right]);
+        }
+    }
+}
+
+fn empty_content_digest_is_distinct_from_missing_integrity() {
+    let empty = Sha256Digest::from_bytes(b"");
+    assert_eq!(
+        empty.as_str(),
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+    let absent = base_component();
+    assert!(absent.integrity().is_none());
+}
+
+fn missing_optional_facts_are_not_fabricated() {
+    let component = base_component().with_integrity(None);
+    assert!(component.integrity().is_none());
+    let value = serde_json::to_value(component).unwrap();
+    assert!(value.get("integrity").is_none());
+    let encoded = value.to_string();
+    assert!(!encoded.contains("unknown-component"));
+    assert!(!encoded.contains("0000000000000000000000000000000000000000000000000000000000000000"));
+}
+}


### PR DESCRIPTION
Fixes #1730

## Summary

- add the versioned Agent Stack component schema and closed wire vocabularies
- enforce canonical source identity, observation/selection/trust rules, exact-byte SHA-256 integrity, and freshness evidence
- add strict two-phase JSON validation plus portable repository, user-global, admin, system, runtime, and runner source mapping
- cover the contract with exhaustive focused fixtures, cross-product matrices, and deterministic round trips

## Verification

- cargo fmt --all -- --check
- cargo check -p harness-core --all-targets
- cargo test -p harness-core
- cargo clippy --workspace --all-targets -- -D warnings
- python3 checks/check_workflow.py --repo .
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1730
- pre-push DB-independent workspace and workflow tests

## Notes

- no dependency, persistence, producer, or consumer changes
- PostgreSQL-dependent suites remain delegated to CI when HARNESS_DATABASE_URL is unavailable locally