### PR TITLE
spec(GH1765): define build iteration performance overhaul

### DIFF
--- a/docs/references/build-iteration-performance.md
+++ b/docs/references/build-iteration-performance.md
@@ -2,7 +2,7 @@
 
 > Linked issue: GH-1765
 > Original diagnosis: 2026-07-04 (read-only inspection + live measurement, M2 12-core / 96 GB, rustc 1.94)
-> State re-verified: 2026-07-26 against the current tree
+> State partially re-verified: 2026-07-26 (spot checks of the items in §4; not a full re-measurement)
 > Scope: why agent-driven iteration on this repository was slow, what has been
 > remediated since, what remains, and how to keep it from regressing.
 
@@ -68,7 +68,7 @@ Much of the original recommendation set has already landed:
 | R1 — unify the compile universe (manifest lints, no `RUSTFLAGS`) | **Done** | `Cargo.toml:26` `[workspace.lints.rust] warnings = "deny"`; all 13 crates carry `[lints] workspace = true`; `grep -r RUSTFLAGS .githooks .github/workflows Makefile scripts` → zero matches |
 | R2 — cut debuginfo | **Done** | `Cargo.toml:113-117`: `[profile.dev] debug = "line-tables-only"`, `[profile.dev.package."*"] debug = false` |
 | R3 — slim pre-commit | **Done** | `.githooks/pre-commit` now derives a staged-file package scope, skips clippy entirely for docs/specs-only commits, and no longer runs tests |
-| R4 — GC `target/` | **Largely done, unautomated** | `target/` now ~18 GB total (`debug` 16 GB, `cargo-check` 866 MB, `release` 619 MB, remainder < 300 MB each); fingerprints fresh (2026-07-23). No recurring GC mechanism exists — the 176 GB state can regrow |
+| R4 — GC `target/` | **Largely done; tooling exists, gaps remain** | `target/` now ~18 GB total (`debug` 16 GB, `cargo-check` 866 MB, `release` 619 MB, remainder < 300 MB each); fingerprints fresh (2026-07-23). `scripts/gc-target.sh` (merged 2026-07-05, PR #1545) provides age-based cleanup (`--days`, default 14) with `--dry-run`, prefers `cargo sweep`, sweeps `target/` plus all `target/cargo-*` universes, is exposed as `make gc-target`, and has Python tests (`scripts/test_gc_target.py`). Remaining gaps: manual-only invocation, destructive by default, no sanctioned-universe list, no removal of unsanctioned universes, no active-build lock skip |
 | File splits | **Mostly done** | Files ≥ 1000 lines: 23 → **8** (largest now `harness-cli/src/commands.rs` at 1651) |
 | R5 — residual PG schema cleanup | **Improved, backlog remains** | Orphan-schema reaper wired (historic ~538k → ~17k schemas at last measurement); backlog cleanup is a runtime-performance item tracked separately |
 
@@ -82,10 +82,15 @@ Much of the original recommendation set has already landed:
    longer flipped — but the flags are now dead policy duplicated in four
    places, and any future edit to one site reintroduces drift between "what
    the manifest enforces" and "what hooks enforce".
-2. **No target-directory GC policy.** The 176 GB state accumulated silently
-   over months and taxed every build (I3). Nothing prevents recurrence: no
-   size bound, no age-based sweep of the parallel `CARGO_TARGET_DIR`
-   universes, no CI/ops surfacing of target size.
+2. **Target GC is manual and incomplete.** `scripts/gc-target.sh` already
+   handles age-based cleanup of `target/` and every `target/cargo-*`
+   universe, but it must be invoked by hand, deletes by default (dry-run is
+   opt-in), has no notion of a sanctioned universe list (an unsanctioned
+   universe is swept for stale files, never removed wholesale), does not
+   skip universes with an active cargo build, and is not wired into any
+   scheduled maintenance. The 176 GB state accumulated silently over months
+   and taxed every build (I3); a manual opt-in script does not prevent
+   recurrence.
 3. **Parallel target-dir scheme is convention-only.** `CLAUDE.md` sanctions
    per-command target dirs (`target/cargo-check`, `target/cargo-test`,
    `target/cargo-clippy`), but historical drift produced six universes with
@@ -117,16 +122,19 @@ lint set is enforced, from one place.
   policy that the manifest already owns is exactly the drift pattern that
   produced the original two-universe split.
 
-### R-B — Bounded, automated target GC
+### R-B — Extend `scripts/gc-target.sh` into a bounded, automated sweep
 
-Adopt a size/age budget for `target/` (e.g. warn > 40 GB, sweep artifacts
-untouched > 30 days) and enumerate the sanctioned universe list; anything
-outside the list is subject to removal by the sweep. Surface current size in
-the existing ops/health tooling rather than a new system.
+Keep the existing script as the single GC entry point and close the residual
+delta: enumerate the sanctioned universe list (anything outside it is
+removed wholesale, not just swept for stale files), flip the default to
+dry-run with an explicit `--delete` for destructive mode, skip universes
+holding an active cargo build lock, and wire a scheduled invocation so
+hygiene is not manual-only. Surface current size in the existing ops/health
+tooling rather than a new system.
 
 - Risk: an over-eager sweep forces a cold rebuild. Mitigate with age gating
-  and a dry-run mode.
-- Alternative: manual periodic cleanup. Rejected — the 176 GB state is
+  and the dry-run default.
+- Alternative: leave the script manual-only. Rejected — the 176 GB state is
   evidence that unowned manual hygiene does not happen.
 
 ### R-C — Regression guard in CI

--- a/docs/references/build-iteration-performance.md
+++ b/docs/references/build-iteration-performance.md
@@ -1,0 +1,160 @@
+# Build Iteration Performance — Analysis Report
+
+> Linked issue: GH-1765
+> Original diagnosis: 2026-07-04 (read-only inspection + live measurement, M2 12-core / 96 GB, rustc 1.94)
+> State re-verified: 2026-07-26 against the current tree
+> Scope: why agent-driven iteration on this repository was slow, what has been
+> remediated since, what remains, and how to keep it from regressing.
+
+## 1. Problem statement
+
+Harness evolves primarily through agent-driven iteration on its own codebase:
+edit → check → commit → hook gates → push → CI. Every second of build latency
+is multiplied by the per-step commit style agents use and by every concurrent
+agent lane. In July 2026 that loop had degraded to the point where the build
+system — not model latency — was the dominant cost of iteration.
+
+Because build speed is a multiplier on every other improvement loop
+(implementation, review, quality gates, evals), this is the highest-leverage,
+lowest-risk performance surface in the project.
+
+## 2. Measured facts (2026-07-04 baseline)
+
+| # | Fact | Source |
+|---|------|--------|
+| F1 | `target/` totaled **176 GB**: `debug` 133 GB (deps 73 GB + incremental 58 GB) plus six parallel `CARGO_TARGET_DIR` universes (`cargo-test` 15 GB, `cargo-check` 7 GB, `cargo-test-local-fresh` 4.4 GB, `cargo-build-main` 3.4 GB, `cargo-build` 3.4 GB, `cargo-check-warnings` 1.5 GB) | `du -sh target/*` |
+| F2 | Root `Cargo.toml` had **no `[profile]` section** → dev profile used default `debug = true` (full debuginfo); no `[lints]` table existed anywhere in the workspace | `Cargo.toml` at that commit |
+| F3 | Three flag universes shared one `target/debug`: (a) daily plain `cargo check`, (b) pre-commit `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets`, (c) pre-push/CI `RUSTFLAGS=-Dwarnings` as a global env | `.githooks/pre-commit`, `ci.yml` at that commit |
+| F4 | Pre-commit ran on **every commit**: `cargo fmt --check` + full-workspace clippy `--all-targets` + `cargo test --workspace --lib` | `.githooks/pre-commit` at that commit |
+| F5 | Workspace: 165k+ lines of Rust across 13 crates; 482 locked dependencies including compile-heavy sqlx, opentelemetry-otlp (tonic/prost), starlark, axum, reqwest | `wc -l`, `Cargo.lock` |
+| F6 | **23 source files ≥ 1000 lines**; largest `runtime/tests.rs` at 6480 lines | `wc -l` sweep |
+| F7 | Baseline `cargo check --workspace --all-targets` = **1m 41s wall; user 110.4 s, sys 95.7 s** | `/usr/bin/time -p` |
+| F8 | `target/debug` fingerprints last touched ~3 weeks before the measurement session | `stat .fingerprint` |
+| F9 | No sccache/mold/lld; no project or user `.cargo/config.toml` | filesystem check |
+| F10 | 2600 test functions; `build.rs` shells out to `git config core.hooksPath` on every build | grep count; `build.rs` |
+
+## 3. Inference chain
+
+- **I1 (high confidence)** — [F1, F3, F8] The dominant iteration cost was
+  flag-universe ping-pong. Changing `RUSTFLAGS` invalidates every Cargo
+  fingerprint in a shared target directory. A typical agent loop (plain check →
+  commit → `-Dwarnings` clippy → next plain check) forced a large rebuild on
+  each flip; the 73 GB of dependency artifacts and 58 GB of incremental state
+  were the two universes' artifacts accumulating in one directory.
+- **I2 (high confidence)** — [F4, F7] Per-commit gating cost minutes,
+  multiplied by per-step commits. Even the mild no-flip case measured 1m41s;
+  a universe flip additionally rebuilt dependency crates, with full clippy and
+  workspace lib tests on top.
+- **I3 (medium-high confidence)** — [F7] `sys` time (95.7 s) nearly equaled
+  `user` time (110.4 s); effective parallelism was ~2 of 12 cores.
+  Compilation is normally user-CPU-bound; this profile indicates heavy
+  filesystem metadata work — the bloated target directory itself taxed every
+  build.
+- **I4 (high confidence)** — [F2] Default `debug = true` inflated every
+  artifact and link step, multiplied across all test binaries under
+  `--all-targets`.
+- **I5 (medium confidence)** — [F6] Oversized files burn agent context on
+  every read/edit and concentrate merge conflicts across parallel agent lanes.
+- **I6 (medium confidence)** — [F1] Six parallel `CARGO_TARGET_DIR` universes
+  (a workaround for build-lock contention) each paid a cold build of all 482
+  dependencies, multiplying disk and cold-start cost.
+
+## 4. Remediation status (verified 2026-07-26)
+
+Much of the original recommendation set has already landed:
+
+| Item | Status | Evidence (current tree) |
+|------|--------|-------------------------|
+| R1 — unify the compile universe (manifest lints, no `RUSTFLAGS`) | **Done** | `Cargo.toml:26` `[workspace.lints.rust] warnings = "deny"`; all 13 crates carry `[lints] workspace = true`; `grep -r RUSTFLAGS .githooks .github/workflows Makefile scripts` → zero matches |
+| R2 — cut debuginfo | **Done** | `Cargo.toml:113-117`: `[profile.dev] debug = "line-tables-only"`, `[profile.dev.package."*"] debug = false` |
+| R3 — slim pre-commit | **Done** | `.githooks/pre-commit` now derives a staged-file package scope, skips clippy entirely for docs/specs-only commits, and no longer runs tests |
+| R4 — GC `target/` | **Largely done, unautomated** | `target/` now ~18 GB total (`debug` 16 GB, `cargo-check` 866 MB, `release` 619 MB, remainder < 300 MB each); fingerprints fresh (2026-07-23). No recurring GC mechanism exists — the 176 GB state can regrow |
+| File splits | **Mostly done** | Files ≥ 1000 lines: 23 → **8** (largest now `harness-cli/src/commands.rs` at 1651) |
+| R5 — residual PG schema cleanup | **Improved, backlog remains** | Orphan-schema reaper wired (historic ~538k → ~17k schemas at last measurement); backlog cleanup is a runtime-performance item tracked separately |
+
+## 5. Remaining gaps
+
+1. **Redundant `-D warnings` lint arguments.** Four sites still pass
+   `-- -D warnings` to clippy (`.githooks/pre-commit:74`,
+   `.githooks/pre-push:33`, `.github/workflows/ci.yml:124`, `Makefile:12`)
+   even though the manifest lint table now enforces the same policy. Trailing
+   lint args apply only to primary packages, so the dependency universe is no
+   longer flipped — but the flags are now dead policy duplicated in four
+   places, and any future edit to one site reintroduces drift between "what
+   the manifest enforces" and "what hooks enforce".
+2. **No target-directory GC policy.** The 176 GB state accumulated silently
+   over months and taxed every build (I3). Nothing prevents recurrence: no
+   size bound, no age-based sweep of the parallel `CARGO_TARGET_DIR`
+   universes, no CI/ops surfacing of target size.
+3. **Parallel target-dir scheme is convention-only.** `CLAUDE.md` sanctions
+   per-command target dirs (`target/cargo-check`, `target/cargo-test`,
+   `target/cargo-clippy`), but historical drift produced six universes with
+   ad-hoc names (`cargo-build-main`, `cargo-test-local-fresh`,
+   `cargo-check-warnings`). Each nonstandard universe pays a cold dependency
+   build.
+4. **No regression guard.** Nothing detects the reintroduction of `RUSTFLAGS`
+   into hooks/CI, a second lint universe, or a `[profile]` regression. All the
+   July gains are one careless PR away from silently unwinding.
+5. **No linker/cache assist.** No fast linker configuration and no
+   compilation cache (F9 unchanged). On macOS the default linker is adequate;
+   this is the lowest-priority residual.
+6. **Eight files ≥ 1000 lines remain** (`commands.rs` 1651,
+   `operator_monitor/tests.rs` 1595, `misc_routes.rs` 1120,
+   `prompts/parsing.rs` 1064, `types.rs` 1027, plus three test files).
+   Tracked by existing size-limit exemptions in `CLAUDE.md`; not re-scoped
+   here.
+
+## 6. Recommendations (priority order)
+
+### R-A — Single lint authority (low risk, removes drift)
+
+Delete the trailing `-- -D warnings` from the four call sites; the manifest
+lint table is the single source of truth. Semantics are unchanged: the same
+lint set is enforced, from one place.
+
+- Risk: none for workspace crates (manifest lints already deny warnings).
+- Alternative: keep the flags as belt-and-braces. Rejected — four copies of a
+  policy that the manifest already owns is exactly the drift pattern that
+  produced the original two-universe split.
+
+### R-B — Bounded, automated target GC
+
+Adopt a size/age budget for `target/` (e.g. warn > 40 GB, sweep artifacts
+untouched > 30 days) and enumerate the sanctioned universe list; anything
+outside the list is subject to removal by the sweep. Surface current size in
+the existing ops/health tooling rather than a new system.
+
+- Risk: an over-eager sweep forces a cold rebuild. Mitigate with age gating
+  and a dry-run mode.
+- Alternative: manual periodic cleanup. Rejected — the 176 GB state is
+  evidence that unowned manual hygiene does not happen.
+
+### R-C — Regression guard in CI
+
+A cheap CI step asserting: no `RUSTFLAGS` in `.githooks/`, workflow files, or
+`Makefile`; `[workspace.lints.rust]` present; every crate manifest carries
+`[lints] workspace = true`; `[profile.dev]` debuginfo setting intact.
+
+- Risk: trivially low; pure grep-level assertions.
+- Alternative: rely on review. Rejected — this class of regression is
+  invisible in diffs unless the reviewer knows the history.
+
+### R-D — Canonicalize the parallel-target scheme
+
+Document the exact sanctioned `CARGO_TARGET_DIR` names and fold stragglers
+into them; R-B's sweep enforces the list mechanically.
+
+### R-E (optional) — Compilation cache
+
+Evaluate sccache once R-A–R-D have landed and re-measure first; with a
+unified universe and slim debuginfo the residual win may not justify the
+operational surface.
+
+## 7. Why this compounds
+
+Every harness improvement loop terminates in a build: implement → check,
+review-fix → check, quality gate → validation commands, eval case →
+`verify_commands`. A 2× build speedup is a 2× speedup on the inner loop of
+all of them, and cheaper iteration directly raises how much verification the
+system can afford per change — which is the direction the rest of the
+roadmap (server-verified completion, eval flywheel) pushes.

--- a/specs/GH1765/product.md
+++ b/specs/GH1765/product.md
@@ -1,0 +1,127 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1765
+
+## User Problem
+
+Agent-driven iteration on this repository was throttled by the build system:
+conflicting compile-flag universes, full debuginfo, per-commit full-workspace
+gates, and a 176 GB `target/` directory that made every build
+filesystem-bound. Most of that has since been remediated (manifest lints,
+`line-tables-only` debuginfo, staged-scope pre-commit, target cleanup to
+~18 GB), but the fixes are unguarded: lint policy is still duplicated in four
+call sites, nothing prevents `target/` bloat from regrowing, the parallel
+target-directory scheme is convention-only, and no automated check stops a
+future PR from silently reintroducing the two-universe split.
+
+Operators and agents need the build-performance posture to be owned by
+configuration and enforced by automation, not by institutional memory.
+
+## Goals
+
+- Make the manifest lint table the single authority for warning policy;
+  remove the duplicated `-D warnings` invocation arguments.
+- Bound `target/` growth with an automated, age-gated garbage-collection
+  sweep over an explicit list of sanctioned target-directory universes.
+- Add a CI regression guard that fails when the unified-universe posture is
+  violated (reintroduced `RUSTFLAGS`, missing manifest lints, missing
+  per-crate `[lints]` table, altered dev-profile debuginfo).
+- Canonicalize the sanctioned `CARGO_TARGET_DIR` names used for concurrent
+  local commands.
+
+## Non-Goals
+
+- No dependency version changes of any kind.
+- No `Cargo.toml` workspace version bump (release-time only).
+- No weakening of CI semantics: the same lint set remains enforced with the
+  same `deny` severity; only its point of definition is consolidated.
+- No changes to which tests run in pre-commit, pre-push, or CI.
+- No adoption of sccache, alternative linkers, or build caching services.
+- No splitting of the remaining ≥ 1000-line source files.
+- No changes to Postgres schema cleanup (tracked separately).
+
+## User-Visible Behavior
+
+1. **B-001:** Warning policy is defined exactly once, in the workspace
+   manifest lint table, and inherited by every crate. Hook, Makefile, and CI
+   clippy invocations carry no trailing lint-flag arguments.
+2. **B-002:** A commit or CI run that violates the lint policy fails
+   identically before and after this change; consolidating the definition
+   point changes no pass/fail outcome.
+3. **B-003:** The sanctioned target-directory universes are explicitly
+   enumerated in repository documentation. Local tooling that isolates
+   concurrent cargo commands uses only sanctioned names.
+4. **B-004:** A garbage-collection sweep removes artifacts in unsanctioned
+   target universes and artifacts older than a configured age threshold, and
+   reports what it removed. It never deletes outside `target/`.
+5. **B-005:** The sweep supports a dry-run mode that reports candidates
+   without deleting, and dry-run is the default when invoked manually.
+6. **B-006:** CI includes a guard step that fails when any of the following
+   holds: `RUSTFLAGS` appears in `.githooks/`, workflow files, or `Makefile`;
+   the workspace manifest lacks the lint table; any workspace crate manifest
+   lacks `[lints] workspace = true`; the dev-profile debuginfo settings are
+   removed.
+7. **B-007:** The guard's failure output names the violated invariant and the
+   offending file so an agent can repair it without archaeology.
+8. **B-008:** All existing build entry points (`cargo check`, hook scripts,
+   `make lint`, CI jobs) continue to work unchanged from a contributor's
+   perspective.
+
+## Acceptance Criteria
+
+- [ ] `grep -rn "RUSTFLAGS" .githooks .github/workflows Makefile scripts`
+      returns no matches, and the four former `-- -D warnings` call sites
+      (`.githooks/pre-commit`, `.githooks/pre-push`, `.github/workflows/ci.yml`,
+      `Makefile`) carry no trailing lint arguments.
+- [ ] A deliberately introduced warning fails pre-commit clippy, pre-push
+      clippy, and the CI clippy job, proving B-002.
+- [ ] The GC sweep, run in dry-run mode against a fixture target layout
+      containing one sanctioned and one unsanctioned universe plus stale
+      artifacts, reports exactly the unsanctioned universe and stale
+      artifacts as candidates and deletes nothing.
+- [ ] The GC sweep in destructive mode removes exactly the reported
+      candidates and leaves sanctioned, fresh artifacts intact.
+- [ ] The CI guard fails on each seeded violation class from B-006 (one test
+      per class) and passes on the clean tree.
+- [ ] Documentation lists the sanctioned target-directory names and the GC
+      thresholds.
+- [ ] No `Cargo.lock` changes and no workspace version change in the
+      implementing PR.
+
+## Boundary Checklist
+
+| Boundary | Verdict |
+| --- | --- |
+| Empty / missing input | GC sweep on a missing or empty `target/` is a no-op success (B-004). Guard on a tree with no crates fails loudly on the missing lint table (B-006). |
+| Error and failure paths | Covered by B-006/B-007: guard failures are named and file-scoped. Sweep I/O errors abort the sweep without partial silent deletion beyond already-reported items. |
+| Authorization / permission | N/A. Local filesystem and CI-internal checks only; no privilege changes. |
+| Concurrency / race / ordering | Sweep must tolerate a concurrent cargo build holding locks: skip locked/active universes rather than fail (B-004). |
+| Retry / repetition / idempotency | Sweep and guard are idempotent; re-running after a clean pass reports zero candidates / zero violations. |
+| Illegal state transitions | N/A — no stateful lifecycle is introduced. |
+| Compatibility / migration | Covered by B-002/B-008: no pass/fail outcome changes; no contributor-visible workflow changes. |
+| Degradation / fallback | Guard step must not be skippable by path-filtering: it runs on every PR (cheap grep-level assertions). |
+| Evidence and audit integrity | Sweep reports what it removed (B-004); guard names the violated invariant (B-007). |
+| Cancellation / interruption / partial completion | An interrupted sweep leaves remaining artifacts for the next run; no tombstone state. |
+
+## Edge Cases
+
+- A contributor adds a new crate without `[lints] workspace = true` — the
+  guard must catch it on the introducing PR.
+- A new sanctioned universe is legitimately needed — adding it requires
+  updating the documented list, which the sweep consumes.
+- `target/` contains a universe currently in use by a running build — the
+  sweep skips it.
+- The dev profile is edited to `debug = true` for a local debugging session
+  and accidentally committed — the guard fails the PR.
+- A hook script is rewritten and someone re-adds `RUSTFLAGS=-Dwarnings` out
+  of habit — the guard fails the PR.
+
+## Rollout Notes
+
+No migration or feature flag required. The lint-argument removal and the CI
+guard land together so the guard immediately protects the consolidated
+state. The GC sweep ships with dry-run default; destructive mode is enabled
+after one observed clean dry-run cycle. Reverting the change restores the
+duplicated flags and removes the guard, with no data impact.

--- a/specs/GH1765/product.md
+++ b/specs/GH1765/product.md
@@ -12,9 +12,11 @@ gates, and a 176 GB `target/` directory that made every build
 filesystem-bound. Most of that has since been remediated (manifest lints,
 `line-tables-only` debuginfo, staged-scope pre-commit, target cleanup to
 ~18 GB), but the fixes are unguarded: lint policy is still duplicated in four
-call sites, nothing prevents `target/` bloat from regrowing, the parallel
-target-directory scheme is convention-only, and no automated check stops a
-future PR from silently reintroducing the two-universe split.
+call sites; the existing target GC script (`scripts/gc-target.sh`) is
+manual-only, destructive by default, and blind to unsanctioned target
+universes; the parallel target-directory scheme is convention-only; and no
+automated check stops a future PR from silently reintroducing the
+two-universe split.
 
 Operators and agents need the build-performance posture to be owned by
 configuration and enforced by automation, not by institutional memory.
@@ -23,8 +25,9 @@ configuration and enforced by automation, not by institutional memory.
 
 - Make the manifest lint table the single authority for warning policy;
   remove the duplicated `-D warnings` invocation arguments.
-- Bound `target/` growth with an automated, age-gated garbage-collection
-  sweep over an explicit list of sanctioned target-directory universes.
+- Extend the existing `scripts/gc-target.sh` into a bounded, automated,
+  age-gated sweep over an explicit list of sanctioned target-directory
+  universes.
 - Add a CI regression guard that fails when the unified-universe posture is
   violated (reintroduced `RUSTFLAGS`, missing manifest lints, missing
   per-crate `[lints]` table, altered dev-profile debuginfo).
@@ -53,11 +56,15 @@ configuration and enforced by automation, not by institutional memory.
 3. **B-003:** The sanctioned target-directory universes are explicitly
    enumerated in repository documentation. Local tooling that isolates
    concurrent cargo commands uses only sanctioned names.
-4. **B-004:** A garbage-collection sweep removes artifacts in unsanctioned
-   target universes and artifacts older than a configured age threshold, and
+4. **B-004:** The garbage-collection sweep (the extended
+   `scripts/gc-target.sh`) removes artifacts in unsanctioned target
+   universes and artifacts older than a configured age threshold, and
    reports what it removed. It never deletes outside `target/`.
-5. **B-005:** The sweep supports a dry-run mode that reports candidates
-   without deleting, and dry-run is the default when invoked manually.
+5. **B-005:** The sweep's default flips from destructive to dry-run — an
+   explicit behavior change to the existing `scripts/gc-target.sh`. A
+   flag-less invocation reports candidates and deletes nothing; destructive
+   mode requires an explicit `--delete`. The existing `--dry-run` flag
+   remains accepted as a no-op alias.
 6. **B-006:** CI includes a guard step that fails when any of the following
    holds: `RUSTFLAGS` appears in `.githooks/`, workflow files, or `Makefile`;
    the workspace manifest lacks the lint table; any workspace crate manifest
@@ -77,12 +84,13 @@ configuration and enforced by automation, not by institutional memory.
       `Makefile`) carry no trailing lint arguments.
 - [ ] A deliberately introduced warning fails pre-commit clippy, pre-push
       clippy, and the CI clippy job, proving B-002.
-- [ ] The GC sweep, run in dry-run mode against a fixture target layout
-      containing one sanctioned and one unsanctioned universe plus stale
-      artifacts, reports exactly the unsanctioned universe and stale
-      artifacts as candidates and deletes nothing.
-- [ ] The GC sweep in destructive mode removes exactly the reported
-      candidates and leaves sanctioned, fresh artifacts intact.
+- [ ] The extended `scripts/gc-target.sh`, invoked with no flags against a
+      fixture target layout containing one sanctioned and one unsanctioned
+      universe plus stale artifacts, reports exactly the unsanctioned
+      universe and stale artifacts as candidates and deletes nothing
+      (covered in `scripts/test_gc_target.py`).
+- [ ] The sweep with `--delete` removes exactly the reported candidates and
+      leaves sanctioned, fresh artifacts intact.
 - [ ] The CI guard fails on each seeded violation class from B-006 (one test
       per class) and passes on the clean tree.
 - [ ] Documentation lists the sanctioned target-directory names and the GC
@@ -122,6 +130,11 @@ configuration and enforced by automation, not by institutional memory.
 
 No migration or feature flag required. The lint-argument removal and the CI
 guard land together so the guard immediately protects the consolidated
-state. The GC sweep ships with dry-run default; destructive mode is enabled
-after one observed clean dry-run cycle. Reverting the change restores the
-duplicated flags and removes the guard, with no data impact.
+state. Note that flipping `scripts/gc-target.sh` to dry-run-by-default
+(B-005) is a behavior change for existing callers — `make gc-target` and
+any operator habit of flag-less destructive runs stop deleting until
+`--delete` is passed; this is the intended safe direction, and the
+`make gc-target` recipe is updated in the same change. Scheduled
+destructive invocation is enabled only after one observed clean dry-run
+cycle. Reverting the change restores the duplicated flags, the destructive
+default, and removes the guard, with no data impact.

--- a/specs/GH1765/tech.md
+++ b/specs/GH1765/tech.md
@@ -80,10 +80,8 @@ every `target/cargo-*` universe, `make gc-target`, and Python tests
   if `flock` is unavailable on the platform) is skipped and reported as
   skipped, replacing the current "do not run during builds" doc-comment
   honor system.
-- **Scheduled invocation** — a maintenance entry point (launchd/cron
-  wrapper alongside the existing `scripts/gc-scheduled.sh` pattern) runs
-  the script with `--delete` after the rollout gate in product Rollout
-  Notes is met.
+- **Scheduled invocation** — a new launchd/cron wrapper runs the script
+  with `--delete` after the rollout gate in product Rollout Notes is met.
 - **Scope guard** — the script keeps refusing to operate outside the
   resolved repo `target/` root and never follows symlinks out of it.
 - **Tests** — extend `scripts/test_gc_target.py` to cover the new

--- a/specs/GH1765/tech.md
+++ b/specs/GH1765/tech.md
@@ -1,0 +1,138 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1765
+
+## Current State
+
+### Already landed (verified 2026-07-26)
+
+| Concern | State | Evidence |
+| --- | --- | --- |
+| Lint policy in manifest | Landed | `Cargo.toml:26` `[workspace.lints.rust] warnings = "deny"`; all 13 `crates/*/Cargo.toml` carry `[lints] workspace = true` |
+| `RUSTFLAGS` universes | Eliminated | zero matches for `RUSTFLAGS` under `.githooks/`, `.github/workflows/`, `Makefile`, `scripts/` |
+| Dev debuginfo | Landed | `Cargo.toml:113-117`: `[profile.dev] debug = "line-tables-only"`; `[profile.dev.package."*"] debug = false` |
+| Pre-commit scope | Landed | `.githooks/pre-commit` derives `-p` package scope from staged files; docs/specs-only commits skip clippy; no tests in pre-commit |
+| `target/` bloat | Reduced, unguarded | ~18 GB total (was 176 GB); six historical universes still present: `cargo-check` 866 MB, `cargo-build-main` 141 MB, `cargo-build` 138 MB, `cargo-test` 15 MB, `cargo-check-warnings` 9.7 MB, `cargo-test-local-fresh` 7.5 MB |
+
+### Remaining defects this spec addresses
+
+1. **Duplicated lint policy.** Four call sites still append `-- -D warnings`
+   to clippy even though the manifest owns the policy:
+   - `.githooks/pre-commit:74` — `cargo clippy $scope --all-targets -- -D warnings`
+   - `.githooks/pre-push:33` — `cargo clippy --workspace --all-targets -- -D warnings`
+   - `.github/workflows/ci.yml:124` — `cargo clippy --workspace --all-targets -- -D warnings`
+   - `Makefile:12` — same invocation
+   Trailing lint args affect only primary packages, so dependency
+   fingerprints no longer flip; the cost is policy drift, not rebuilds.
+2. **No target GC.** Nothing bounds `target/` size or removes dead
+   universes; the 176 GB state can silently regrow.
+3. **No regression guard.** No automated check protects the manifest-lints /
+   profile / no-RUSTFLAGS posture.
+4. **Universe list is convention-only.** `CLAUDE.md` sanctions
+   `target/cargo-check`, `target/cargo-test`, `target/cargo-clippy`; the
+   other three observed universes are drift.
+
+## Design
+
+### D1 — Single lint authority
+
+Remove the trailing `-- -D warnings` (and any other trailing lint args) from
+the four call sites. Resulting invocations:
+
+```
+cargo clippy $scope --all-targets        # pre-commit
+cargo clippy --workspace --all-targets   # pre-push, ci.yml, Makefile
+```
+
+Enforcement path: `[workspace.lints.rust] warnings = "deny"` +
+`[lints] workspace = true` in every crate. Clippy-specific lint groups can be
+added later under `[workspace.lints.clippy]` without touching call sites.
+
+No behavioral change: a warning in any workspace crate already fails
+compilation under the manifest table.
+
+### D2 — Target GC sweep
+
+New script `scripts/target-gc.sh` (bash, no new dependencies), invoked
+manually and optionally from a scheduled maintenance entry point:
+
+- **Sanctioned universe list** — a shell array at the top of the script,
+  mirrored in `CLAUDE.md`: `debug`, `release`, `cargo-check`, `cargo-test`,
+  `cargo-clippy`, `package`, `tmp`.
+- **Unsanctioned universes** — any other first-level directory under
+  `target/` is a removal candidate in full.
+- **Stale artifacts** — within sanctioned universes, files with mtime older
+  than `TARGET_GC_MAX_AGE_DAYS` (default 30) are candidates.
+- **Active-build safety** — a universe containing a live cargo lock
+  (`.cargo-lock` held; detected via a non-blocking `flock` probe, or
+  skipped wholesale if `flock` is unavailable on the platform) is skipped
+  and reported as skipped.
+- **Modes** — default is dry-run: print candidate paths and aggregate size,
+  delete nothing. `--delete` performs removal and prints a summary of
+  reclaimed bytes. Exit code 0 in both modes unless an I/O error occurs.
+- **Scope guard** — the script refuses to operate unless
+  `$(git rev-parse --show-toplevel)/target` is the resolved target root;
+  it never follows symlinks out of it.
+
+### D3 — CI regression guard
+
+New job step in `.github/workflows/ci.yml` (in the existing lint job, before
+clippy; runs on every PR, exempt from path filtering) executing
+`scripts/check-build-posture.sh`:
+
+```
+1. ! grep -rn "RUSTFLAGS" .githooks .github/workflows Makefile scripts
+2. grep -q "^\[workspace.lints.rust\]" Cargo.toml
+3. for m in crates/*/Cargo.toml: grep -q "^\[lints\]" $m && grep -q "workspace = true"
+4. grep -q 'debug = "line-tables-only"' Cargo.toml   # [profile.dev]
+5. ! grep -n '\-\- -D warnings' .githooks/* .github/workflows/ci.yml Makefile
+```
+
+Each failed assertion prints `posture violation: <invariant> in <file>` and
+exits 1. The script is also runnable locally.
+
+Note: check 1 must exclude `scripts/check-build-posture.sh` itself and
+documentation files; implement with an explicit exclude list.
+
+### D4 — Documentation
+
+`CLAUDE.md` "Local Cargo Concurrency" section updated with: the sanctioned
+universe list (single source shared with D2 via comment cross-reference),
+the GC thresholds, and a pointer to `scripts/target-gc.sh`.
+
+## Migration Order
+
+1. Land D1 + D3 in one PR (guard immediately protects the consolidated
+   state; guard check 5 makes D1 self-enforcing).
+2. Land D2 + D4 in a follow-up PR; run one dry-run cycle on the primary dev
+   machine; then enable `--delete` in the maintenance entry point.
+
+## Validation
+
+- `bash scripts/check-build-posture.sh` → exit 0 on clean tree.
+- Seed each violation class in a scratch branch (re-add `RUSTFLAGS` to
+  pre-commit; drop `[lints]` from one crate; drop the profile line; re-add
+  `-- -D warnings`) → guard exits 1 naming the invariant, one class per run.
+- `touch -t` fixture artifacts under a scratch `target/` layout →
+  `scripts/target-gc.sh` dry-run lists exactly the stale + unsanctioned
+  candidates; `--delete` removes exactly them.
+- `cargo clippy --workspace --all-targets` with a seeded
+  `let unused = 1;` fails, proving manifest-only enforcement (B-002).
+- Standard gates: `cargo fmt --all -- --check`; full CI on the PR.
+
+## Risks / Alternatives
+
+- **R1:** Guard greps are brittle to formatting. Mitigation: assert on
+  stable single-line tokens; keep the script trivial enough to fix inline.
+- **R2:** GC deletes something a developer wanted. Mitigation: dry-run
+  default, age gating, sanctioned-list skip, active-lock skip, and printed
+  candidate list before `--delete`.
+- **Alt considered:** adopting `cargo-sweep`/`cargo-cache` for D2. Rejected
+  for now — adds a tool dependency for what a 60-line script covers; the
+  guard (D3) is the part with durable value.
+- **Alt considered:** removing per-universe target dirs entirely now that
+  the flag universes are unified. Rejected — concurrent local cargo
+  commands still contend on one build lock; isolation by command class
+  remains the documented workaround.

--- a/specs/GH1765/tech.md
+++ b/specs/GH1765/tech.md
@@ -14,7 +14,7 @@ GH-1765
 | `RUSTFLAGS` universes | Eliminated | zero matches for `RUSTFLAGS` under `.githooks/`, `.github/workflows/`, `Makefile`, `scripts/` |
 | Dev debuginfo | Landed | `Cargo.toml:113-117`: `[profile.dev] debug = "line-tables-only"`; `[profile.dev.package."*"] debug = false` |
 | Pre-commit scope | Landed | `.githooks/pre-commit` derives `-p` package scope from staged files; docs/specs-only commits skip clippy; no tests in pre-commit |
-| `target/` bloat | Reduced, unguarded | ~18 GB total (was 176 GB); six historical universes still present: `cargo-check` 866 MB, `cargo-build-main` 141 MB, `cargo-build` 138 MB, `cargo-test` 15 MB, `cargo-check-warnings` 9.7 MB, `cargo-test-local-fresh` 7.5 MB |
+| `target/` bloat | Reduced; manual GC tooling exists | ~18 GB total (was 176 GB); six historical universes still present: `cargo-check` 866 MB, `cargo-build-main` 141 MB, `cargo-build` 138 MB, `cargo-test` 15 MB, `cargo-check-warnings` 9.7 MB, `cargo-test-local-fresh` 7.5 MB. `scripts/gc-target.sh` (PR #1545): age-based cleanup (`--days`, default 14), `--dry-run` opt-in, prefers `cargo sweep`, sweeps `target/` + all `target/cargo-*`, exposed as `make gc-target` (`Makefile:17-18`), tested by `scripts/test_gc_target.py` |
 
 ### Remaining defects this spec addresses
 
@@ -26,8 +26,12 @@ GH-1765
    - `Makefile:12` — same invocation
    Trailing lint args affect only primary packages, so dependency
    fingerprints no longer flip; the cost is policy drift, not rebuilds.
-2. **No target GC.** Nothing bounds `target/` size or removes dead
-   universes; the 176 GB state can silently regrow.
+2. **Target GC is manual and incomplete.** `scripts/gc-target.sh` covers
+   age-based stale-artifact cleanup, but it is manual-only, destructive by
+   default (`--dry-run` is opt-in), removes no unsanctioned universe
+   wholesale, has no sanctioned-universe list, does not skip universes with
+   an active cargo build, and has no scheduled invocation — so the 176 GB
+   state can silently regrow between manual runs.
 3. **No regression guard.** No automated check protects the manifest-lints /
    profile / no-RUSTFLAGS posture.
 4. **Universe list is convention-only.** `CLAUDE.md` sanctions
@@ -53,34 +57,56 @@ added later under `[workspace.lints.clippy]` without touching call sites.
 No behavioral change: a warning in any workspace crate already fails
 compilation under the manifest table.
 
-### D2 — Target GC sweep
+### D2 — Extend `scripts/gc-target.sh`
 
-New script `scripts/target-gc.sh` (bash, no new dependencies), invoked
-manually and optionally from a scheduled maintenance entry point:
+The existing script stays the single GC entry point (no new script). It
+already provides: `--days N` age windows (default 14), `--dry-run`,
+`cargo sweep` preference with mtime fallback, enumeration of `target/` plus
+every `target/cargo-*` universe, `make gc-target`, and Python tests
+(`scripts/test_gc_target.py`). The residual delta to implement in place:
 
 - **Sanctioned universe list** — a shell array at the top of the script,
   mirrored in `CLAUDE.md`: `debug`, `release`, `cargo-check`, `cargo-test`,
   `cargo-clippy`, `package`, `tmp`.
 - **Unsanctioned universes** — any other first-level directory under
-  `target/` is a removal candidate in full.
-- **Stale artifacts** — within sanctioned universes, files with mtime older
-  than `TARGET_GC_MAX_AGE_DAYS` (default 30) are candidates.
-- **Active-build safety** — a universe containing a live cargo lock
-  (`.cargo-lock` held; detected via a non-blocking `flock` probe, or
-  skipped wholesale if `flock` is unavailable on the platform) is skipped
-  and reported as skipped.
-- **Modes** — default is dry-run: print candidate paths and aggregate size,
-  delete nothing. `--delete` performs removal and prints a summary of
-  reclaimed bytes. Exit code 0 in both modes unless an I/O error occurs.
-- **Scope guard** — the script refuses to operate unless
-  `$(git rev-parse --show-toplevel)/target` is the resolved target root;
-  it never follows symlinks out of it.
+  `target/` becomes a removal candidate in full (today such universes are
+  only swept for stale files, never retired).
+- **Dry-run by default** — flip the current destructive default: with no
+  flags the script prints candidates and deletes nothing; destructive mode
+  requires an explicit `--delete`. `--dry-run` is retained as a no-op alias
+  for compatibility. This is a deliberate behavior change (product B-005).
+- **Active-build safety** — a universe holding a live cargo build lock
+  (non-blocking `flock` probe on its lock file; skip the universe wholesale
+  if `flock` is unavailable on the platform) is skipped and reported as
+  skipped, replacing the current "do not run during builds" doc-comment
+  honor system.
+- **Scheduled invocation** — a maintenance entry point (launchd/cron
+  wrapper alongside the existing `scripts/gc-scheduled.sh` pattern) runs
+  the script with `--delete` after the rollout gate in product Rollout
+  Notes is met.
+- **Scope guard** — the script keeps refusing to operate outside the
+  resolved repo `target/` root and never follows symlinks out of it.
+- **Tests** — extend `scripts/test_gc_target.py` to cover the new
+  candidate classes, the flipped default, and lock-skip behavior.
 
 ### D3 — CI regression guard
 
-New job step in `.github/workflows/ci.yml` (in the existing lint job, before
-clippy; runs on every PR, exempt from path filtering) executing
-`scripts/check-build-posture.sh`:
+New **standalone job** `build-posture` in `.github/workflows/ci.yml`. It must
+be unconditional: no `if:` change-detection expression and no `needs:` on
+`changed` or `web-build`, because the existing clippy job is path-filtered
+(`if: needs.changed.outputs.rust == 'true' || needs.changed.outputs.ci ==
+'true'`, `ci.yml:109`) and a PR touching only `.githooks/` or `Makefile` —
+exactly the regression class B-006 targets — would skip a step placed there.
+The job is a single checkout + `scripts/check-build-posture.sh` run
+(seconds of runtime, so unconditional execution is cheap).
+
+Aggregation into the required check: the `CI Result` job (`ci.yml:233`,
+`if: always()`) adds `build-posture` to its `needs:` list and its
+`results=(...)` array, so a posture violation fails `CI Result` — the
+branch-protection-required status — even though `build-posture` itself is
+not individually required.
+
+The script asserts:
 
 ```
 1. ! grep -rn "RUSTFLAGS" .githooks .github/workflows Makefile scripts
@@ -100,7 +126,7 @@ documentation files; implement with an explicit exclude list.
 
 `CLAUDE.md` "Local Cargo Concurrency" section updated with: the sanctioned
 universe list (single source shared with D2 via comment cross-reference),
-the GC thresholds, and a pointer to `scripts/target-gc.sh`.
+the GC thresholds, and a pointer to `scripts/gc-target.sh`.
 
 ## Migration Order
 
@@ -109,6 +135,26 @@ the GC thresholds, and a pointer to `scripts/target-gc.sh`.
 2. Land D2 + D4 in a follow-up PR; run one dry-run cycle on the primary dev
    machine; then enable `--delete` in the maintenance entry point.
 
+## Product-to-Test Mapping
+
+| Behavior | Validation step |
+| --- | --- |
+| B-001 | Grep assertions over the four call sites + guard check 5; manifest lint table grep |
+| B-002 | Seeded-warning run fails pre-commit clippy, pre-push clippy, and CI clippy without trailing lint args |
+| B-003 | Sanctioned list present in script array and `CLAUDE.md`; unsanctioned fixture universe classified as removal candidate |
+| B-004 | `test_gc_target.py` fixture: destructive run removes exactly reported candidates, nothing outside `target/` |
+| B-005 | `test_gc_target.py`: flag-less invocation deletes nothing; `--delete` required for removal |
+| B-006 | One seeded-violation CI/guard-script test per invariant class |
+| B-007 | Guard output asserts `posture violation: <invariant> in <file>` format |
+| B-008 | Clean-tree runs of pre-commit, pre-push, `make lint`, and full CI pass unchanged |
+
+## Rollback
+
+Revert the implementing PR(s): call sites regain the redundant lint args,
+`gc-target.sh` returns to destructive-default, and the `build-posture` job
+disappears from `CI Result` aggregation. No data, schema, or state
+migration is involved in either direction.
+
 ## Validation
 
 - `bash scripts/check-build-posture.sh` → exit 0 on clean tree.
@@ -116,8 +162,9 @@ the GC thresholds, and a pointer to `scripts/target-gc.sh`.
   pre-commit; drop `[lints]` from one crate; drop the profile line; re-add
   `-- -D warnings`) → guard exits 1 naming the invariant, one class per run.
 - `touch -t` fixture artifacts under a scratch `target/` layout →
-  `scripts/target-gc.sh` dry-run lists exactly the stale + unsanctioned
-  candidates; `--delete` removes exactly them.
+  flag-less `scripts/gc-target.sh` lists exactly the stale + unsanctioned
+  candidates and deletes nothing; `--delete` removes exactly them
+  (extended `scripts/test_gc_target.py`).
 - `cargo clippy --workspace --all-targets` with a seeded
   `let unused = 1;` fails, proving manifest-only enforcement (B-002).
 - Standard gates: `cargo fmt --all -- --check`; full CI on the PR.
@@ -129,8 +176,10 @@ the GC thresholds, and a pointer to `scripts/target-gc.sh`.
 - **R2:** GC deletes something a developer wanted. Mitigation: dry-run
   default, age gating, sanctioned-list skip, active-lock skip, and printed
   candidate list before `--delete`.
-- **Alt considered:** adopting `cargo-sweep`/`cargo-cache` for D2. Rejected
-  for now — adds a tool dependency for what a 60-line script covers; the
+- **Alt considered:** replacing `scripts/gc-target.sh` with a new script or
+  a `cargo-cache` dependency. Rejected — the existing script already
+  integrates `cargo sweep` opportunistically and has tests; extending it
+  preserves the entry point (`make gc-target`) and its test suite. The
   guard (D3) is the part with durable value.
 - **Alt considered:** removing per-universe target dirs entirely now that
   the flag universes are unified. Rejected — concurrent local cargo


### PR DESCRIPTION
Adds the analysis report and spec packet for build iteration performance.

- `docs/references/build-iteration-performance.md` — full analysis: 2026-07-04 measured baseline (176 GB target, three RUSTFLAGS universes, 1m41s syscall-bound check), inference chain, and re-verified 2026-07-26 remediation status (manifest lints, line-tables-only debuginfo, staged-scope pre-commit all landed; target now ~18 GB).
- `specs/GH1765/product.md` + `specs/GH1765/tech.md` — spec for the remaining work: single lint authority (drop the four duplicated `-- -D warnings` call sites), bounded automated target GC with dry-run default, a CI posture guard preventing regression (RUSTFLAGS reintroduction, missing `[lints]` tables, profile drift), and canonicalized parallel target-dir names.

Docs-only change; no code, no dependency, and no version modifications.

Refs #1765