### PR TITLE
spec(GH1768): define eval flywheel integration

### DIFF
--- a/docs/references/eval-flywheel.md
+++ b/docs/references/eval-flywheel.md
@@ -90,12 +90,17 @@ isolation model that `docs/parallel-pr-repair-bakeoff-spec.md` asks for.
 `EvalRunMetrics { pass_at_1, pass_to_k, ... }` (`report.rs:24-25`),
 per-case transitions, and `diff_eval_run_reports` producing
 `pass_at_1_delta` / `pass_to_k_delta` against a baseline report
-(`report.rs:230-231`). The regression-diff primitive already exists.
+(`report.rs:230-231`). The regression-diff primitive already exists, and it is
+already exposed on the CLI: `harness eval diff --baseline --candidate`
+(`commands/eval.rs::diff_eval_reports`, ~line 89) validates suite/k
+compatibility and emits the diff — but always exits 0; there is no threshold
+gate and no failing exit code on regression.
 
 ### 1.5 Evidence model — `eval/evidence.rs` (610 lines), `eval/model.rs`
 
-Typed `EvalCaseEvidence` with status, confidence (`Confidence` enum —
-estimated vs confirmed), usage snapshots, and remote-fact capture.
+Typed `EvalCaseEvidence` with status, confidence (`Confidence` enum:
+`Exact`, `Estimated`, `Observed`, `Unknown` — `model.rs:137`), usage
+snapshots, and remote-fact capture.
 
 ## 2. The Disconnection (verified)
 

--- a/docs/references/eval-flywheel.md
+++ b/docs/references/eval-flywheel.md
@@ -1,0 +1,216 @@
+# Eval Flywheel — Analysis Report
+
+> Linked issue: GH-1768
+> Date: 2026-07-26
+> Scope: why the existing eval infrastructure produces no feedback loop, and what
+> is required to close it. Read-only analysis; the companion spec packet is
+> `specs/GH1768/`.
+
+## Executive Summary
+
+Harness already contains the hard 80% of a state-of-the-art evaluation system:
+a deterministic PR-repair scorecard with fail-closed hard gates, a
+SWE-bench-style replay manifest with per-case verify commands, isolated
+dispatch through the production runtime, and pass@1 / pass^k reporting with
+baseline diffing. None of it is connected to anything. The scorer has no
+caller outside the CLI, the CLI cannot execute a case ("live eval execution is
+not wired to the CLI yet", `crates/harness-cli/src/commands/eval.rs:82`), no CI
+workflow runs evals, no baseline report is committed, and no eval outcome ever
+reaches skill governance, GC signals, or prompt selection.
+
+The consequence is that every change to prompts, routing, gates, and context
+assembly ships judged by anecdote. The difference between an orchestrator and
+a self-improving system is exactly this loop. Closing it is mostly plumbing,
+not research.
+
+## 1. What Exists (verified 2026-07-26)
+
+### 1.1 Deterministic scoring — `crates/harness-workflow/src/runtime/eval/scoring.rs` (449 lines)
+
+`score_pr_repair_eval(PrRepairEvalInput) -> QualitySnapshot` is a pure
+function over collected evidence. It computes eleven hard gates
+(`scoring.rs:44-110`), each of which caps the final grade via
+`most_restrictive_cap` (`scoring.rs:126-127`):
+
+| Gate | Cap on failure | Meaning |
+|---|---|---|
+| `TargetCorrectness` | F | final PR matches the requested target |
+| `BranchSafety` | F | base/head refs stayed on the requested PR |
+| `NoUnrelatedPrCreation` | F | run did not create an unrelated PR |
+| `ScopeContainment` | F | diff stayed within repair scope |
+| head-change gate (scenario-dependent) | — | baseline `head_oid` ≠ final `head_oid` (`scoring.rs:30`) |
+| `HeadFreshness` | C | final evidence collected for the final head (`scoring.rs:31-34`) |
+| `RequiredChecks` | C | checks passing on final head |
+| `MergeabilityClean` | C | mergeability clean |
+| `ReviewThreadClosure` | C | threads fully enumerated, none unresolved |
+| `RuntimeArtifactCompleteness` | B | usable runtime task/workflow/job artifact present |
+| reviewer gate | — | reviewer evidence consistency |
+
+Two properties are worth calling out because they are exactly what most
+LLM-judge eval stacks lack:
+
+- **"Did anything actually change" is a first-class check** — `head_changed`
+  and `final_evidence_fresh` make a do-nothing run or a stale-evidence run
+  unable to score well.
+- **Grades are capped, not averaged** — a run that fabricates success on one
+  axis cannot buy the grade back on the others.
+
+`scoring_tests.rs` (491 lines) pins the rubric.
+
+### 1.2 Replay manifest — `eval/manifest.rs` + `evals/benchmarks/harness-core.toml`
+
+The manifest defines a suite of real, historical harness issues replayed from
+pinned commits, each with objective verification:
+
+```toml
+[[cases]]
+case_id = "gh1437-runtime-stall-detection"
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "8b3a328375178f98d3aac0865d49fc1bf81c869e"
+verify_commands = ["cargo test -p harness-server stall"]
+```
+
+14+ cases, `default_timeout_secs = 7200`. This is the same shape as
+SWE-bench-verified: frozen base commit, real issue, deterministic verify
+command. The corpus regenerates itself for free — every merged fix with a
+driving issue is a candidate case.
+
+### 1.3 Isolated dispatch through the production runtime — `eval/run.rs` (768 lines)
+
+`enqueue_eval_case_workflow` / `dispatch_eval_case_workflow`
+(`run.rs:122,207`) submit eval cases through the normal workflow runtime with
+`EVAL_BRANCH_PREFIX = "harness-eval/"` and `EVAL_PR_DRAFT_MODE = "draft"`
+(`run.rs:12-13`) — shadow branches and draft PRs, so eval traffic exercises
+the real pipeline without touching production branches. This matches the
+isolation model that `docs/parallel-pr-repair-bakeoff-spec.md` asks for.
+
+### 1.4 Reporting — `eval/report.rs` (399 lines)
+
+`EvalRunMetrics { pass_at_1, pass_to_k, ... }` (`report.rs:24-25`),
+per-case transitions, and `diff_eval_run_reports` producing
+`pass_at_1_delta` / `pass_to_k_delta` against a baseline report
+(`report.rs:230-231`). The regression-diff primitive already exists.
+
+### 1.5 Evidence model — `eval/evidence.rs` (610 lines), `eval/model.rs`
+
+Typed `EvalCaseEvidence` with status, confidence (`Confidence` enum —
+estimated vs confirmed), usage snapshots, and remote-fact capture.
+
+## 2. The Disconnection (verified)
+
+1. **No runtime consumer.** The only references to `score_pr_repair_eval`
+   outside the eval module are the re-export in `runtime/mod.rs` and
+   `harness-cli/src/commands/eval.rs`. Nothing in `harness-server` consults an
+   eval score for any decision.
+2. **The CLI cannot execute a case.** `harness eval run` accepts `--manifest`
+   plus either `--dry-run` (validate manifest) or `--evidence <json>`
+   (pre-collected). With neither it bails: *"live eval execution is not wired
+   to the CLI yet; pass --evidence to report collected evidence or --dry-run
+   to validate the manifest"* (`commands/eval.rs:82`). Evidence collection —
+   the actual running of agents against cases — is external and manual.
+3. **No CI wiring.** `.github/workflows/` contains no job invoking
+   `harness eval`; the only grep hit for "eval" across workflows is unrelated
+   (`workflow-check.yml`). There is no nightly run, no PR-triggered run.
+4. **No committed baselines.** `evals/` contains only `benchmarks/`. No
+   `evals/baselines/` directory, no historical report to feed
+   `diff_eval_run_reports`. The diffing code has never had two real inputs.
+5. **Prior eval attempts were manual one-offs.** The `docs/pr-repair-evals/`
+   artifacts (uncommitted working-tree material) are hand-written scorecards
+   from individual Codex sessions; one records that the evaluator script
+   itself was broken (empty `task_detail_final.json` from unencoded task-id
+   polling). Two of four runs were aborted. This is what eval-by-hand
+   converges to.
+6. **Scores feed nothing.** Skill governance maintains an EMA
+   `quality_score` with Active/Watch/Quarantine/Retired states
+   (`harness-skills/src/store.rs:37,53-54`) — updated from usage outcomes,
+   never from eval results. GC's `SignalDetector` consumes observe events —
+   no eval events exist to consume. Prompt/template selection has no notion
+   of measured quality at all.
+
+## 3. Why This Is the Highest-Leverage Gap
+
+Harness's own operational history is the argument:
+
+- The 2026-07 audit of 132 autonomous sessions found "false done" claims,
+  spec busywork (~24 PRs, 1 real implementation), and review-gate driftage —
+  all failure modes a replayed benchmark with hard gates detects mechanically.
+- The runtime has since grown strong per-run defenses (zero-output detection,
+  status-contract downgrade, server-owned PR snapshots). Those verify a
+  *single run*. Nothing verifies the *system*: after a prompt rewrite, a
+  router change, or a context-composer rollout, there is no number that says
+  whether harness got better or worse at its actual job.
+- Every mature harness effort (internal SWE-bench-style suites at the model
+  labs, Codex's own eval gating) converges on the same loop:
+  **change → replay suite → pass^k diff → accept/revert**. Harness has every
+  component of this loop built and none of the edges.
+
+The flywheel, once closed, also compounds the other improvement tracks:
+semantic retrieval (GH-1769), context-composer enforcement, and prompt changes
+all become measurable experiments instead of vibes.
+
+## 4. Target Design
+
+### 4.1 Self-driving evidence collection
+
+`harness eval run --manifest ... --execute` performs, per case, in-process:
+prepare shadow workspace at `base_commit` → submit through
+`dispatch_eval_case_workflow` (existing) → await terminal state → collect
+evidence (PR snapshot, runtime artifacts, verify-command results) into
+`EvalCaseEvidence` → score. The manual `--evidence` path remains for offline
+re-scoring. Verify commands run server-side with recorded exit codes and
+output digests — evidence is collected by the evaluator, never self-reported
+by the evaluated agent.
+
+### 4.2 Nightly CI run + committed baselines
+
+A scheduled workflow executes the suite against pinned base commits on a
+runner with an agent runtime, then uploads the `EvalRunReport` and opens a PR
+updating `evals/baselines/<suite>/latest.json` (plus a dated history file).
+Baselines live in-repo so `diff_eval_run_reports` has a canonical input and
+report changes are themselves reviewable.
+
+### 4.3 Regression gate
+
+`harness eval diff --baseline ... --candidate ... --max-pass-drop <t>` exits
+nonzero when `pass_at_1_delta` or `pass_to_k_delta` falls below the threshold
+or any previously-passing case newly fails a hard gate at F-cap severity. The
+nightly job fails loudly on regression; an optional PR-labelled job lets
+high-risk changes (prompt templates, routing, context assembly) request a
+pre-merge eval.
+
+### 4.4 Outcome feedback into the observe stream
+
+Each scored case emits a typed observe event (`eval_case_scored`: suite,
+case_id, grade, failed gates, usage) into the existing EventStore. GC's
+SignalDetector gains an eval-regression signal; skill governance can
+attribute eval outcomes to skills that were injected into the run's prompts,
+finally grounding the EMA `quality_score` in measured task success.
+
+## 5. Non-Goals (this iteration)
+
+- Authoring new benchmark cases (corpus growth is continuous, separate work).
+- External benchmark integration (SWE-bench proper, Terminal-Bench).
+- Blocking merges on eval results — the gate starts advisory in CI; merge
+  gating is a policy decision for after the suite proves stable.
+- LLM-judge scoring — the rubric stays deterministic.
+
+## 6. Risks
+
+- **Cost**: a full nightly suite is 14+ agent runs. Mitigations: per-case
+  usage budgets recorded in evidence, suite-level USD ceiling (aligns with
+  GH-1770), and k=1 nightly with k>1 weekly.
+- **Flake**: verify commands depend on toolchain determinism; pinned
+  base commits and recorded command output digests keep failures diagnosable.
+- **Benchmark overfitting**: cases derive from harness's own history; the
+  corpus must keep growing from newly merged fixes to stay representative.
+
+## 7. Related Documents
+
+- `specs/GH1768/product.md`, `specs/GH1768/tech.md` — the spec packet.
+- `docs/parallel-pr-repair-bakeoff-spec.md` — draft bakeoff design sharing the
+  shadow-branch isolation model.
+- `docs/references/server-verified-completion.md` (GH-1766) — the trust
+  boundary evals depend on.
+- `docs/references/budget-enforcement.md` (GH-1770) — cost ceilings for eval
+  traffic.

--- a/specs/GH1768/product.md
+++ b/specs/GH1768/product.md
@@ -1,0 +1,146 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1768
+
+## User Problem
+
+Harness ships a deterministic PR-repair scorecard, a replay benchmark
+manifest, isolated eval dispatch, and pass@1/pass^k reporting — but no way to
+run them end to end. `harness eval run` refuses live execution and requires
+hand-collected evidence, no CI job ever executes the suite, no baseline report
+exists to diff against, and no eval outcome reaches skill governance or GC.
+
+Operators changing prompts, routing, gates, or context assembly have no
+mechanical answer to "did this make the fleet better or worse?" Every quality
+claim rests on anecdote, which the 2026-07 session audit showed to be
+unreliable at scale.
+
+## Goals
+
+- Make `harness eval run` execute manifest cases end to end without external
+  evidence collection.
+- Establish committed, reviewable baseline reports and a deterministic
+  regression diff against them.
+- Run the suite on a schedule in CI with a loud failure on regression.
+- Emit typed eval-outcome events into the observe stream so downstream
+  consumers (skill governance, GC signals) can attribute measured quality.
+
+## Non-Goals
+
+- Authoring new benchmark cases or changing the existing manifest schema
+  beyond what execution requires.
+- Integrating external benchmarks (SWE-bench proper, Terminal-Bench).
+- Gating PR merges on eval results (nightly gate is advisory-then-blocking for
+  the eval job itself, not for feature merges).
+- LLM-judge scoring; the rubric remains the deterministic
+  `score_pr_repair_eval` scorecard.
+- Redesigning the scoring rubric, hard gates, or grade caps.
+- Cross-provider model comparison dashboards.
+
+## User-Visible Behavior
+
+1. **B-001:** `harness eval run --manifest <path> --execute` runs each case
+   end to end: shadow workspace at the pinned `base_commit`, dispatch through
+   the existing eval workflow path (`harness-eval/` branch prefix, draft PR
+   mode), evidence collection, scoring, and report emission — with no
+   `--evidence` input required.
+2. **B-002:** The existing `--evidence` and `--dry-run` modes are unchanged;
+   `--execute` is mutually exclusive with both and its absence preserves
+   today's behavior exactly.
+3. **B-003:** Evidence for an executed case is collected by the evaluator
+   process (workflow terminal state, server-side PR snapshot, verify-command
+   exit codes and output digests). No field of the scored evidence is copied
+   from agent self-reported success claims.
+4. **B-004:** Each executed case ends in exactly one terminal evidence status
+   (passed, failed, timed out, dispatch-failed, evidence-incomplete);
+   timeouts and dispatch failures score as failures, never as skips.
+5. **B-005:** A completed run writes an `EvalRunReport` JSON artifact whose
+   metrics include `pass_at_1` and `pass_to_k`, plus per-case grades, failed
+   hard gates, and usage totals.
+6. **B-006:** `harness eval diff --baseline <report> --candidate <report>`
+   exits nonzero when `pass_at_1` or `pass_to_k` drops by more than a
+   configured threshold, or when any case that passed in the baseline newly
+   fails an F-cap hard gate. The diff output names each regressing case and
+   gate.
+7. **B-007:** Baseline reports live in-repo under `evals/baselines/<suite>/`
+   (a `latest.json` plus dated history). Updating a baseline is an ordinary
+   reviewed change, never a silent side effect of a run.
+8. **B-008:** A scheduled CI workflow executes the suite, compares against the
+   committed baseline, uploads the candidate report as an artifact, and fails
+   the job on regression per B-006. Baseline refresh is proposed as a PR, not
+   pushed directly.
+9. **B-009:** Every scored case emits one `eval_case_scored` event into the
+   observe event stream carrying suite, case id, run id, grade, failed gates,
+   and usage. Every completed run emits one `eval_run_completed` event with
+   the run metrics. Event emission failure fails the run loudly rather than
+   silently dropping the record.
+10. **B-010:** Each case run records its token/usage totals in evidence, and a
+    suite-level usage ceiling aborts remaining cases with an explicit
+    `budget-exhausted` status when exceeded — never reported as passed or
+    silently truncated.
+11. **B-011:** Eval traffic remains isolated: branches under the eval prefix,
+    PRs in draft mode, and no writes to non-eval branches. A case observed
+    escaping isolation fails its `BranchSafety`/`NoUnrelatedPrCreation` gates
+    as today.
+12. **B-012:** Re-running `harness eval run` with the same manifest and run id
+    refuses to overwrite an existing completed report for that run id.
+
+## Acceptance Criteria
+
+- [ ] CLI test: `--execute` with `--evidence` or `--dry-run` is rejected;
+      absent `--execute` preserves current formatter behavior byte-for-byte on
+      existing fixtures.
+- [ ] Integration test (DB-backed): a manifest case dispatched via `--execute`
+      reaches a terminal state and produces evidence with verify-command exit
+      codes and output digests recorded by the evaluator.
+- [ ] Unit tests: each terminal evidence status (timeout, dispatch failure,
+      incomplete evidence) maps to a failing case, never a skip.
+- [ ] Report test: an executed run's report round-trips through
+      `diff_eval_run_reports` against a committed baseline fixture.
+- [ ] Diff-gate tests: threshold breach on `pass_at_1`, on `pass_to_k`, and a
+      newly failing F-cap gate each produce a nonzero exit and name the case.
+- [ ] CI workflow present, schedule-triggered, comparing against
+      `evals/baselines/`, failing on regression, uploading the candidate
+      report artifact.
+- [ ] Observe test: scoring a case emits `eval_case_scored`; completing a run
+      emits `eval_run_completed`; an event-store write failure fails the run.
+- [ ] Budget test: exceeding the suite usage ceiling marks remaining cases
+      `budget-exhausted` and the run as failed.
+- [ ] Idempotency test: duplicate run id against an existing completed report
+      is refused without modifying the original.
+
+## Boundary Checklist
+
+| Boundary | Verdict |
+| --- | --- |
+| Empty / missing input | Covered by B-002 and B-012; missing manifest/evidence errors are unchanged existing behavior. |
+| Error and failure paths | Covered by B-004, B-009, B-010; every failure mode is a scored failure or a loud run failure. |
+| Authorization / permission | Eval dispatch reuses existing runtime submission authority; CI baseline refresh goes through PR review (B-008). |
+| Concurrency / race / ordering | Covered by B-012 (run-id uniqueness); per-case dispatch reuses existing runtime leasing. |
+| Retry / repetition / idempotency | Covered by B-012; re-scoring from saved evidence remains available via `--evidence`. |
+| Illegal state transitions | Cases inherit the runtime's transition validation; evidence-incomplete is an explicit terminal status (B-004). |
+| Compatibility / migration | Covered by B-002; no manifest schema break, no change to existing report consumers. |
+| Degradation / fallback | Covered by B-004, B-009, B-010; no silent skip, no estimate presented as confirmed. |
+| Evidence and audit integrity | Covered by B-003, B-007; evaluator-collected evidence, reviewed baselines. |
+| Cancellation / interruption / partial completion | Covered by B-010; an interrupted run leaves per-case evidence with explicit non-passed statuses. |
+
+## Edge Cases
+
+- A case's `base_commit` no longer exists on the remote (history rewrite).
+- The verify command passes but the workflow ended `failed` (or vice versa).
+- Two cases target the same repo concurrently and contend for workspaces.
+- The scheduled CI run starts while a previous scheduled run is still active.
+- A regression is caused by a benchmark-environment change (toolchain bump),
+  not a harness change — the diff output must make the failing verify command
+  and digest visible enough to diagnose.
+- The observe event store is unavailable mid-run.
+
+## Rollout Notes
+
+Phase the gate: first scheduled runs publish reports without failing
+(collect variance), then enable the regression threshold. Seed
+`evals/baselines/<suite>/latest.json` from the first green full run via a
+reviewed PR. No migration; all new surfaces are additive. Reverting removes
+the CI job and CLI flag without affecting existing evidence-based reporting.

--- a/specs/GH1768/tech.md
+++ b/specs/GH1768/tech.md
@@ -1,0 +1,187 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1768
+
+## Context
+
+All building blocks exist in `crates/harness-workflow/src/runtime/eval/`:
+
+- `scoring.rs` — `score_pr_repair_eval` with eleven hard gates and grade caps
+  (`most_restrictive_cap`).
+- `manifest.rs` — `EvalBenchmarkManifest` parsed from
+  `evals/benchmarks/<suite>.toml` (`case_id`, `repo`, `issue`, `base_commit`,
+  `verify_commands`, `default_timeout_secs`).
+- `run.rs` — `enqueue_eval_case_workflow` / `dispatch_eval_case_workflow`
+  submitting through the production runtime with
+  `EVAL_BRANCH_PREFIX = "harness-eval/"`, `EVAL_PR_DRAFT_MODE = "draft"`.
+- `evidence.rs` / `model.rs` — typed `EvalCaseEvidence`, `Confidence`,
+  usage snapshots.
+- `report.rs` — `EvalRunReport`, `EvalRunMetrics { pass_at_1, pass_to_k }`,
+  `diff_eval_run_reports` with `pass_at_1_delta` / `pass_to_k_delta`.
+
+The gap is orchestration: `harness-cli/src/commands/eval.rs:82` bails on live
+execution; nothing collects evidence in-process; no CI job or baseline exists;
+no observe events are emitted.
+
+## Design Overview
+
+Four additive components, no changes to scoring or the manifest schema:
+
+```
+┌ CLI: harness eval run --execute ──────────────────────────────┐
+│  EvalExecutor (new, harness-workflow::runtime::eval::execute) │
+│    for each case (bounded concurrency, suite usage ceiling):  │
+│      1 dispatch_eval_case_workflow (existing)                 │
+│      2 await terminal state (poll store, case timeout)        │
+│      3 collect_case_evidence (new): PR snapshot via server    │
+│        GraphQL collector, runtime artifacts, verify commands  │
+│        with exit codes + sha256 output digests                │
+│      4 score_pr_repair_eval (existing)                        │
+│      5 emit eval_case_scored (observe EventStore)             │
+│  write EvalRunReport → emit eval_run_completed                │
+└───────────────────────────────────────────────────────────────┘
+   harness eval diff --baseline evals/baselines/<suite>/latest.json
+       --candidate <report> --max-pass-drop <t>   → exit code gate
+   .github/workflows/eval-nightly.yml → schedule → run + diff + artifact
+```
+
+## Component Changes
+
+### 1. `EvalExecutor` — new module `runtime/eval/execute.rs` (harness-workflow)
+
+```rust
+pub struct EvalExecuteConfig {
+    pub run_id: String,
+    pub k: u32,                       // attempts per case, default 1
+    pub case_timeout: Duration,       // manifest default_timeout_secs override
+    pub max_concurrent_cases: usize,  // default 1
+    pub suite_usage_ceiling: Option<UsageCeiling>,
+}
+
+pub async fn execute_manifest(
+    store: &dyn WorkflowRuntimeStore,
+    observe: &dyn EventSink,
+    manifest: &EvalBenchmarkManifest,
+    cfg: EvalExecuteConfig,
+) -> Result<EvalRunReport, EvalExecuteError>;
+```
+
+- Per case: `dispatch_eval_case_workflow` → poll instance until a terminal
+  state or `case_timeout` → build `EvalCaseEvidence`.
+- Terminal mapping (product B-004): workflow `failed`/`cancelled`, dispatch
+  error, timeout, and incomplete evidence each map to a distinct
+  `EvalEvidenceStatus` variant that scores as a failed case. No skip path.
+- Run-id uniqueness (B-012): `execute_manifest` refuses to start when a
+  completed report artifact for `run_id` already exists at the output path.
+- Suite ceiling (B-010): accumulated usage from case evidence is checked
+  before each dispatch; on breach, remaining cases get status
+  `BudgetExhausted` and the run result is an error carrying the partial
+  report.
+
+### 2. Evidence collection — new `runtime/eval/execute/collect.rs`
+
+- **PR snapshot**: reuse the server-owned GraphQL snapshot path
+  (`github_pr_snapshot`-equivalent collector exposed from the runtime), so
+  `snapshot_source` on eval evidence matches the production
+  `server_github_graphql` provenance. No agent-reported PR state enters
+  evidence.
+- **Verify commands**: executed by the evaluator in the case's shadow
+  workspace via the existing sandboxed command execution used by quality
+  validation; record `{command, exit_code, output_sha256, duration_ms}` per
+  command. Command text comes only from the committed manifest — never from
+  workflow data — so agent-influenced state cannot alter what is verified.
+- **Runtime artifacts**: read `workflow_artifacts` rows for the case instance
+  (transcript reference, activity gate artifacts) to populate
+  `RuntimeSnapshot` for the `RuntimeArtifactCompleteness` gate.
+- Missing/partial collection yields `EvidenceIncomplete` (fail), preserving
+  the scorer's fail-closed posture.
+
+### 3. CLI — `harness-cli/src/commands/eval.rs`
+
+- Add `--execute` flag; mutually exclusive with `--evidence` and `--dry-run`
+  (extend the existing exclusivity check at `eval.rs:67`).
+- `--execute` requires a configured runtime store (same resolution as
+  `serve`); absence is a hard error naming the missing configuration.
+- Add `eval diff` subcommand flags: `--baseline`, `--candidate`,
+  `--max-pass-drop <float>` (applies to both `pass_at_1_delta` and
+  `pass_to_k_delta`), `--fail-on-new-f-gate` (default true). Wraps
+  `diff_eval_run_reports`; nonzero exit on breach; output lists each
+  regressing case with the failed gate names.
+
+### 4. Observe events — `harness-observe`
+
+Two new event kinds through the existing `EventStore` write path:
+
+- `eval_case_scored { suite, run_id, case_id, grade, failed_gates: Vec<String>, usage }`
+- `eval_run_completed { suite, run_id, pass_at_1, pass_to_k, passed_cases, total_cases, usage }`
+
+Emission failure aborts the run (B-009). Consumers (GC `SignalDetector`
+eval-regression signal, skill attribution) are follow-up work and explicitly
+out of scope here; this spec only guarantees the events exist and are durable.
+
+### 5. CI — `.github/workflows/eval-nightly.yml`
+
+- `schedule` trigger (nightly) + `workflow_dispatch`.
+- Steps: build CLI → provision disposable Postgres (existing
+  `scripts/dev-db.sh` pattern) → `harness eval run --manifest
+  evals/benchmarks/harness-core.toml --execute --run-id nightly-<date>` →
+  `harness eval diff --baseline evals/baselines/harness-core/latest.json
+  --candidate <report>` → upload candidate report artifact.
+- Concurrency group `eval-nightly` with `cancel-in-progress: false` so
+  overlapping scheduled runs queue rather than race.
+- Baseline refresh: a manual `workflow_dispatch` input `refresh-baseline=true`
+  opens a PR (never a direct push) replacing `latest.json` and appending
+  `history/<date>.json`.
+- Rollout phase 1 runs the diff step with `continue-on-error: true` (variance
+  collection); phase 2 removes it.
+
+### 6. Repo layout
+
+- `evals/baselines/<suite>/latest.json` + `evals/baselines/<suite>/history/`
+  — committed, reviewed.
+- Run outputs default to `artifacts/eval/<run_id>/report.json` locally
+  (untracked), uploaded as CI artifacts in the workflow.
+
+## Constraints Honored
+
+- **No `Command::new("gh")`/`Command::new("git")` in harness crates**: shadow
+  workspace preparation and PR snapshotting reuse the existing agent-prompt /
+  server-collector paths; verify commands are project build/test commands
+  executed through the existing sandboxed executor, not git/gh invocations.
+- Scoring, manifest schema, and report schema are untouched; all new types are
+  additive (`EvalEvidenceStatus` gains variants only if serialization remains
+  backward-compatible; otherwise a parallel field is used).
+- No `Cargo.toml` version changes.
+
+## Error Handling
+
+| Failure | Behavior |
+| --- | --- |
+| Dispatch rejected (config invalid, tier unavailable) | Case status `DispatchFailed`, scored fail, run continues. |
+| Case timeout | Case status `TimedOut`, scored fail, instance cancellation requested. |
+| Evidence collection partial | `EvidenceIncomplete`, scored fail. |
+| Observe write failure | Run aborts with error; partial report retained on disk. |
+| Suite ceiling breached | Remaining cases `BudgetExhausted`; run exits nonzero with partial report. |
+| Existing report for run id | Refused before any dispatch. |
+
+## Test Plan
+
+- `runtime/eval/execute` unit tests with a mock store: terminal-status
+  mapping table (every non-passed terminal → failed case), run-id refusal,
+  ceiling breach ordering (no dispatch after breach).
+- DB-backed integration test (feature-gated like other Postgres suites): one
+  synthetic manifest case through dispatch → terminal → evidence → score.
+- CLI tests: flag exclusivity matrix; `eval diff` exit codes for pass_at_1
+  drop, pass_to_k drop, new F-gate failure, and clean pass.
+- Observe tests: event emission on score/complete; abort on sink failure.
+- Fixture round-trip: executed-run report diffs cleanly against a committed
+  baseline fixture.
+
+## Rollout / Revert
+
+Additive only. Phase 1: land executor + CLI + events, run nightly in
+report-only mode. Phase 2: seed baseline via reviewed PR, enable the diff
+gate. Revert = delete workflow file and `--execute`/`diff` flags; evidence
+formatter mode is untouched throughout.

--- a/specs/GH1768/tech.md
+++ b/specs/GH1768/tech.md
@@ -4,6 +4,10 @@
 
 GH-1768
 
+## Product Spec
+
+`specs/GH1768/product.md`
+
 ## Context
 
 All building blocks exist in `crates/harness-workflow/src/runtime/eval/`:
@@ -20,6 +24,10 @@ All building blocks exist in `crates/harness-workflow/src/runtime/eval/`:
   usage snapshots.
 - `report.rs` — `EvalRunReport`, `EvalRunMetrics { pass_at_1, pass_to_k }`,
   `diff_eval_run_reports` with `pass_at_1_delta` / `pass_to_k_delta`.
+- `harness eval diff` already exists on the CLI
+  (`harness-cli/src/commands/eval.rs::diff_eval_reports`): takes
+  `--baseline`/`--candidate`, validates suite and k compatibility, and emits
+  the diff — but always exits 0, with no regression threshold.
 
 The gap is orchestration: `harness-cli/src/commands/eval.rs:82` bails on live
 execution; nothing collects evidence in-process; no CI job or baseline exists;
@@ -61,12 +69,18 @@ pub struct EvalExecuteConfig {
 }
 
 pub async fn execute_manifest(
-    store: &dyn WorkflowRuntimeStore,
-    observe: &dyn EventSink,
+    store: &WorkflowRuntimeStore,
+    runtime_profile: RuntimeProfile,
+    observe: &EventStore,
     manifest: &EvalBenchmarkManifest,
     cfg: EvalExecuteConfig,
 ) -> Result<EvalRunReport, EvalExecuteError>;
 ```
+
+`store` and `runtime_profile` match the existing concrete signature of
+`dispatch_eval_case_workflow(&WorkflowRuntimeStore, RuntimeProfile, ...)`
+(`run.rs:207`); `observe` is the concrete `harness_observe::EventStore` — no
+new trait abstraction is introduced by this spec.
 
 - Per case: `dispatch_eval_case_workflow` → poll instance until a terminal
   state or `case_timeout` → build `EvalCaseEvidence`.
@@ -104,11 +118,13 @@ pub async fn execute_manifest(
   (extend the existing exclusivity check at `eval.rs:67`).
 - `--execute` requires a configured runtime store (same resolution as
   `serve`); absence is a hard error naming the missing configuration.
-- Add `eval diff` subcommand flags: `--baseline`, `--candidate`,
+- Extend the **existing** `eval diff` subcommand (`diff_eval_reports`,
+  already accepting `--baseline`/`--candidate` and always exiting 0) with
   `--max-pass-drop <float>` (applies to both `pass_at_1_delta` and
-  `pass_to_k_delta`), `--fail-on-new-f-gate` (default true). Wraps
-  `diff_eval_run_reports`; nonzero exit on breach; output lists each
-  regressing case with the failed gate names.
+  `pass_to_k_delta`) and `--fail-on-new-f-gate` (default true), adding
+  nonzero-exit semantics on breach. Output lists each regressing case with
+  the failed gate names. Without the new flags, current exit-0 behavior is
+  preserved.
 
 ### 4. Observe events — `harness-observe`
 
@@ -179,9 +195,42 @@ out of scope here; this spec only guarantees the events exist and are durable.
 - Fixture round-trip: executed-run report diffs cleanly against a committed
   baseline fixture.
 
+## Product-to-Test Mapping
+
+| Product behavior | Test(s) in Test Plan |
+| --- | --- |
+| B-001 end-to-end `--execute` | DB-backed integration test |
+| B-002 mode compatibility | CLI flag-exclusivity matrix; formatter fixture byte-for-byte check |
+| B-003 evaluator-collected evidence | Integration test asserting evidence provenance + digests |
+| B-004 terminal statuses fail-closed | Terminal-status mapping table tests |
+| B-005 report contents | Fixture round-trip test |
+| B-006 regression gate | `eval diff` exit-code tests (pass drop, new F-gate, clean) |
+| B-007 committed baselines | Fixture round-trip against committed baseline fixture |
+| B-008 CI behavior | Workflow file review + phase-1 report-only dry runs |
+| B-009 observe events | Event emission + sink-failure abort tests |
+| B-010 usage ceiling | Ceiling-breach ordering test |
+| B-011 isolation | Existing `BranchSafety`/`NoUnrelatedPrCreation` gate tests (unchanged) |
+| B-012 run-id idempotency | Run-id refusal unit test |
+
 ## Rollout / Revert
 
 Additive only. Phase 1: land executor + CLI + events, run nightly in
 report-only mode. Phase 2: seed baseline via reviewed PR, enable the diff
 gate. Revert = delete workflow file and `--execute`/`diff` flags; evidence
 formatter mode is untouched throughout.
+
+## Rollback Plan
+
+Every component is independently revertible with no data migration:
+
+1. **CI gate misfires** — set the diff step back to `continue-on-error: true`
+   (phase-1 posture) without touching code.
+2. **Executor defects** — remove `--execute` wiring; `--evidence`/`--dry-run`
+   formatter paths are untouched and remain the fallback.
+3. **Observe event issues** — the two event kinds are additive; consumers do
+   not exist yet, so dropping emission has no downstream effect.
+4. **Baseline corruption** — baselines are reviewed in-repo files; revert the
+   baseline commit.
+
+No persisted schema changes anywhere; rollback is `git revert` plus CI
+workflow deletion at worst.


### PR DESCRIPTION
## Summary

Analysis report + spec packet for closing the eval feedback loop.

- `docs/references/eval-flywheel.md` — full analysis: the eval module (deterministic PR-repair scorecard with hard gates and grade caps, replay manifest with pinned base commits and verify commands, isolated dispatch via `harness-eval/` draft-PR branches, pass@1/pass^k reporting with baseline diffing) is complete but has no caller beyond a CLI report formatter — no live execution, no CI runs, no committed baselines, no downstream consumers.
- `specs/GH1768/product.md` — behavior contract (B-001..B-012): in-process end-to-end execution via `harness eval run --execute`, evaluator-collected evidence (never agent self-reports), committed reviewed baselines under `evals/baselines/`, deterministic regression gate on pass@1/pass^k and newly failing F-cap gates, typed `eval_case_scored` / `eval_run_completed` observe events, suite usage ceiling, fail-closed terminal statuses.
- `specs/GH1768/tech.md` — additive design: `EvalExecutor` in `runtime/eval/execute.rs`, server-provenance evidence collection, `eval diff` CLI gate, nightly CI workflow with report-only rollout phase, no changes to scoring or manifest schema.

Spec-only PR; no code changes.

Refs #1768