### PR TITLE
spec(GH1770): define budget enforcement and spend caps

### DIFF
--- a/docs/references/budget-enforcement.md
+++ b/docs/references/budget-enforcement.md
@@ -38,10 +38,13 @@ So the plumbing for per-request budgets is done and durable.
 Enforcement, however, is delegated entirely to the agent CLI:
 `crates/harness-agents/src/claude.rs:148-150` appends
 `--max-budget-usd <value>` to the Claude CLI invocation when the field
-is set. Harness itself never compares accumulated spend against the
-budget. If the CLI ignores the flag, miscounts, or the adapter is Codex
-or the direct Anthropic API (neither of which receives an equivalent
-cap), the budget is advisory fiction.
+is set — and only on the batch path. The streaming adapter
+(`crates/harness-agents/src/claude_adapter.rs`), which is the runtime's
+live spawn path, never passes the flag at all, and neither the Codex
+nor the direct Anthropic API adapter receives an equivalent cap.
+Harness itself never compares accumulated spend against the budget. So
+even for the one field that exists, coverage is one adapter out of
+four, and honesty depends on that CLI: the budget is advisory fiction.
 
 ### 2. The only subsystem that sets a budget: GC
 
@@ -58,11 +61,17 @@ with `max_budget_usd: None`.
 
 `crates/harness-core/src/config/concurrency.rs:39-40,90` defines
 `max_turns` with a default of 20 (asserted at `concurrency.rs:191`).
-The task path treats the budget as global across the full task
-lifecycle rather than per retry (`task_runner/run_task.rs:68-69`
-records this as the fix for a budget-reset-on-retry bug). Exhaustion
-surfaces as explicit outcomes (`turn_budget_exhausted`,
-`ROUND_BUDGET_EXHAUSTED_REASON`). Candidate fan-out splits the turn
+The now-deleted legacy task layer (removed from main in PR #1725)
+documented in code that the turn budget must be global across the full
+task lifecycle rather than reset per retry — a fix for an actual
+budget-reset-on-retry bug; that precedent is historical, but the bug
+class it names is exactly what B-002 of the companion spec guards
+against for USD ledgers. In surviving code, exhaustion surfaces as
+explicit outcomes: `turn_budget_exhausted`
+(`crates/harness-server/src/workflow_runtime_plan_issue.rs:28,267`) and
+`ROUND_BUDGET_EXHAUSTED_REASON`
+(`crates/harness-server/src/workflow_runtime_submission/runtime_models.rs:8`).
+Candidate fan-out splits the turn
 budget across candidates
 (`runtime/dispatcher.rs:423 apply_candidate_runtime_budget`, keyed on
 `candidate.budget.max_turns_per_candidate`).
@@ -74,9 +83,10 @@ not per-item turns, was the runaway dimension.
 
 ### 4. Usage telemetry: rich, observation-only
 
-`crates/harness-observe/src/usage.rs` defines `UsageMetrics` (input /
-output / cache-read / cache-creation tokens plus
-`reported_total_tokens`) and parses adapter result payloads. The server
+`crates/harness-observe/src/usage.rs` defines `UsageMetrics`
+(`input_tokens`, `output_tokens`, `cache_read_input_tokens`,
+`cache_creation_input_tokens`, plus `reported_total_tokens`) and parses
+adapter result payloads. The server
 exposes nine usage-monitor handler modules
 (`handlers/usage_monitor*.rs`: active, aggregate, candidate,
 local_usage, process, records, plus `token_usage.rs`), and the web

--- a/docs/references/budget-enforcement.md
+++ b/docs/references/budget-enforcement.md
@@ -1,0 +1,228 @@
+# Budget Enforcement and Spend Caps — Analysis
+
+> Date: 2026-07-26
+> Linked issue: GH-1770
+> Scope: how Harness bounds model spend today, why the current controls
+> cannot stop the runaway-cost failure classes already observed in
+> operation, and the design direction for server-side budget enforcement.
+> Method: read-only code inspection with spot-checked citations.
+
+## Executive Summary
+
+Harness plumbs a USD budget field end to end but almost never sets it,
+never enforces it itself, and has no aggregate ceiling of any kind. The
+only cost control that reliably binds in production is the turn budget
+(`max_turns`, default 20). Spend accounting exists (token-level usage
+telemetry, nine usage-monitor handler modules, a detailed dashboard
+spec), but it is observation-only: nothing in the dispatch path can
+refuse, delay, or throttle work because money is running out. The
+operational history — a queue-drain session that accumulated 944M tokens
+across 50 compactions, and a 248-session retry storm in 35 minutes when
+an upstream OAuth token went invalid — is exactly the class of incident
+an admission-level budget gate exists to stop. Both incidents were
+bounded by human intervention, not by the system.
+
+## What Exists Today
+
+### 1. The USD budget field: plumbed, defaulted to unlimited
+
+`AgentRequest::max_budget_usd: Option<f64>`
+(`crates/harness-core/src/agent.rs:52`) defaults to `None`
+(`agent.rs:126`), meaning unlimited. The field survives the full
+submission lifecycle: `workflow_runtime_submission/runtime_request.rs`
+carries it on both the submission and stored-request forms (lines 53,
+159), copies it into the prepared request (line 202), restores it on
+redispatch/recovery (line 245), and defaults it to `None` (line 278).
+So the plumbing for per-request budgets is done and durable.
+
+Enforcement, however, is delegated entirely to the agent CLI:
+`crates/harness-agents/src/claude.rs:148-150` appends
+`--max-budget-usd <value>` to the Claude CLI invocation when the field
+is set. Harness itself never compares accumulated spend against the
+budget. If the CLI ignores the flag, miscounts, or the adapter is Codex
+or the direct Anthropic API (neither of which receives an equivalent
+cap), the budget is advisory fiction.
+
+### 2. The only subsystem that sets a budget: GC
+
+`crates/harness-core/src/config/misc.rs:159-160` defines
+`budget_per_signal_usd` / `total_budget_usd`, defaulted at
+`misc.rs:217-218` to $0.50 per signal and $5.00 total. These feed the GC
+agent (`harness-gc/src/gc_agent.rs`) and its handler. GC — the
+lowest-stakes, lowest-volume consumer in the system — is thus the only
+component with a spend ceiling. Issue implementation, PR feedback
+repair, review loops, quality gates, planning, and prompt tasks all run
+with `max_budget_usd: None`.
+
+### 3. The control that actually binds: turn budget
+
+`crates/harness-core/src/config/concurrency.rs:39-40,90` defines
+`max_turns` with a default of 20 (asserted at `concurrency.rs:191`).
+The task path treats the budget as global across the full task
+lifecycle rather than per retry (`task_runner/run_task.rs:68-69`
+records this as the fix for a budget-reset-on-retry bug). Exhaustion
+surfaces as explicit outcomes (`turn_budget_exhausted`,
+`ROUND_BUDGET_EXHAUSTED_REASON`). Candidate fan-out splits the turn
+budget across candidates
+(`runtime/dispatcher.rs:423 apply_candidate_runtime_budget`, keyed on
+`candidate.budget.max_turns_per_candidate`).
+
+Turns are a real but crude proxy for cost: a turn can be a 2k-token
+no-op or a 2M-token context-stuffed marathon. The 944M-token session
+was not stopped by turn budgeting because queue-drain work item count,
+not per-item turns, was the runaway dimension.
+
+### 4. Usage telemetry: rich, observation-only
+
+`crates/harness-observe/src/usage.rs` defines `UsageMetrics` (input /
+output / cache-read / cache-creation tokens plus
+`reported_total_tokens`) and parses adapter result payloads. The server
+exposes nine usage-monitor handler modules
+(`handlers/usage_monitor*.rs`: active, aggregate, candidate,
+local_usage, process, records, plus `token_usage.rs`), and the web
+dashboard has a `UsageMonitor` route. None of this feeds any control
+decision.
+
+### 5. The dashboard spec: controls still on paper
+
+`docs/cost-monitoring-dashboard-spec.md` already states the right
+principles: attribute usage to workflow-level units rather than process
+IDs (spec line 12), "Provide controls to pause, throttle, or cancel
+expensive workflow categories before the operator exhausts a quota
+window" (line 15), and "Local process sampling is allowed only for
+external user-owned … visibility" — the workflow runtime, not process
+scanning, must be the source of attribution (lines 39-42). The
+pause/throttle/cancel controls, the invocation-keyed usage events
+(`agent_invocation_id`), and the confidence separation are all
+unimplemented. The current `usage_monitor_process.rs` samples processes
+— the very mechanism the spec says must not be the source of truth.
+
+### 6. No token→USD bridge
+
+Usage is counted in tokens; the budget field is denominated in USD;
+nothing server-side converts between them. There is no pricing table in
+the codebase. The only `Confidence` enum lives in the eval module
+(`runtime/eval/model.rs:137`, with `token_confidence` /
+`cost_confidence` fields at lines 156-157) — the right concept, in a
+module the runtime never consults.
+
+## What Is Missing
+
+| Gap | Consequence |
+| --- | --- |
+| No default USD budget for issue/PR work | A single misbehaving workflow can spend without bound; only `max_turns` interferes |
+| No harness-side enforcement | Budget honesty depends on each agent CLI; Codex and direct-API adapters have no cap at all |
+| No global or daily cap | Parallel dispatch multiplies per-workflow spend with no aggregate ceiling; 8 workers × unlimited = unlimited |
+| No pre-dispatch budget denial | Retry storms and backlog sweeps are admitted at full rate even while spend is spiking; the 248-session storm was admitted job by job |
+| No token→USD conversion | Budgets in USD cannot be evaluated against telemetry in tokens; the field is unenforceable as specified |
+| No estimated-vs-confirmed labeling | Any future dollar figure would present estimates as facts, which the cost spec explicitly forbids |
+
+## Operational Grounding
+
+Two incident classes from the 2026-06-30 → 07-04 audit of 132 sessions:
+
+1. **Unbounded queue drain.** Worst session: 72.6MB transcript, 50
+   compactions, 944M cumulative tokens, ending mid-queue. A 20-hour
+   refactor consumed 8.8M tokens. Fork-per-review multiplied cost ~4×
+   per PR. Bounded reviewer lanes (<2M tokens) all behaved well — the
+   difference was precisely the presence of a bound.
+2. **Retry storm.** 248 sessions spawned in 35 minutes when a proxy
+   OAuth token went invalid; every spawn failed fast and was retried
+   with no backoff or breaker at admission time. Circuit breakers now
+   exist per failure class (`runtime_circuit_breaker.rs`), but they are
+   reactive per-profile trippers, not budget-aware admission control;
+   a storm of *successful-but-expensive* jobs trips nothing.
+
+Both incidents share a shape: each individual dispatch looked
+reasonable; the aggregate was the failure. Only an aggregate,
+server-side ceiling addresses that shape.
+
+## Design Direction
+
+### Layered budget model
+
+Three nested ceilings, each with an owner and a default:
+
+1. **Per-activity** — derived share of the workflow budget (analogous
+   to how candidate fan-out already splits `max_turns`), bounding a
+   single agent invocation.
+2. **Per-workflow** — default USD ceiling for every workflow instance,
+   overridable per definition/profile in `WORKFLOW.md`. Persisted with
+   the instance so redispatch/recovery inherit remaining budget, not a
+   fresh grant (the same bug class as budget-reset-on-retry).
+3. **Per-profile daily** — global cap per runtime profile per UTC day,
+   the aggregate backstop for parallel dispatch.
+
+### Server-side enforcement from streamed usage
+
+The worker already parses adapter usage events (`UsageMetrics`).
+Enforcement accumulates cost against the activity/workflow ledgers as
+usage arrives, and: (a) continues passing `--max-budget-usd` to CLIs
+that support it as a first line of defense, (b) terminates or declines
+to extend a turn when the harness-side ledger crosses the ceiling —
+uniformly across Claude, Codex, and direct-API adapters.
+
+### Graduated response, not a cliff
+
+Crossing thresholds triggers escalating responses:
+soft threshold (e.g. 80%) → throttle (deprioritize new dispatch for the
+category); hard per-workflow ceiling → block workflow with
+`RequestOperatorAttention` (recoverable via the existing operator
+unblock path); daily profile cap → halt new dispatch for that profile
+while allowing in-flight turns to finish and `address_pr_feedback`-class
+cheap work to proceed. This mirrors the dispatch-barrier reason-code
+pattern already in `dispatch_barrier.rs`.
+
+### Pre-dispatch budget gate
+
+The dispatcher consults, before claiming a command: remaining workflow
+budget, remaining daily profile budget, and the circuit-breaker state
+for the failure class of the target activity. Denials are deferred
+dispatches with an explicit reason code (extending the existing
+`runtime_policy_disabled | workflow_config_invalid |
+isolation_tier_unavailable` set), visible in the runtime tree — not
+silent drops.
+
+### Pricing with confidence labeling
+
+A versioned token→USD pricing table (per model, per token class
+including cache reads/writes) converts telemetry to dollars. Every
+dollar figure carries a confidence label (`Estimated` vs
+`ProviderConfirmed`), reusing the eval module's `Confidence` concept at
+the runtime layer. Estimates are never presented as provider-confirmed
+— the cost spec's own rule, now enforced by type.
+
+## Explicit Non-Goals
+
+- Provider billing reconciliation (invoice-level truth) — out of scope,
+  consistent with the cost-monitoring spec's non-goal.
+- Per-user quotas or multi-tenant accounting.
+- Changing GC's existing `budget_per_signal_usd` / `total_budget_usd`
+  mechanics; GC becomes a consumer of the same ledger, not a special
+  case, in a later phase.
+
+## Risks and Alternatives
+
+- **Pricing drift.** A stale pricing table under-counts spend. Mitigate
+  with a versioned table, a startup staleness warning, and conservative
+  (over-estimating) defaults for unknown models.
+- **False halts.** A too-low default workflow budget converts long
+  legitimate work into operator interrupts. Mitigate by deriving the
+  default from observed p95 workflow spend once telemetry exists, and
+  shipping enforcement in shadow (log-only) mode first.
+- **Alternative considered: turns-only tightening.** Lowering
+  `max_turns` and adding per-day turn caps would be simpler but keeps
+  the unit mismatch (turns ≠ cost) and cannot express "stop at $N/day",
+  which is the operator's actual constraint.
+
+## Related Specs and Files
+
+- `docs/cost-monitoring-dashboard-spec.md` — observability counterpart;
+  this analysis covers the enforcement half it deliberately deferred.
+- `specs/GH1770/` — product and tech spec for the enforcement work.
+- Key code: `crates/harness-core/src/agent.rs`,
+  `crates/harness-agents/src/claude.rs`,
+  `crates/harness-server/src/workflow_runtime_submission/runtime_request.rs`,
+  `crates/harness-workflow/src/runtime/dispatcher.rs`,
+  `crates/harness-observe/src/usage.rs`,
+  `crates/harness-core/src/config/misc.rs`.

--- a/specs/GH1770/product.md
+++ b/specs/GH1770/product.md
@@ -1,0 +1,159 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1770
+
+## User Problem
+
+Harness dispatches parallel agent workflows whose model spend is
+unbounded by default. `max_budget_usd` exists but defaults to unlimited,
+is set only by GC, and is enforced only by the Claude CLI rather than by
+Harness. There is no aggregate ceiling: no per-workflow default, no
+daily cap, and no admission-time check. Operators have already absorbed
+the consequences — a queue-drain session that accumulated 944M tokens
+and a 248-session retry storm — and each was stopped by a human, not by
+the system.
+
+Operators need spend to be bounded by server-enforced budgets with
+graduated, visible responses, so that a single runaway workflow or an
+aggregate dispatch storm degrades service predictably instead of
+draining a quota window.
+
+## Goals
+
+- Give every workflow instance a USD budget by default, overridable per
+  definition/profile via `WORKFLOW.md`, enforced server-side from
+  streamed usage telemetry uniformly across all agent adapters.
+- Add a per-profile daily spend cap with a graduated response ladder:
+  throttle, then operator attention, then dispatch halt.
+- Gate dispatch on remaining budget: the command dispatcher defers work
+  with an explicit reason code when the workflow or daily budget is
+  exhausted.
+- Convert token telemetry to USD through a versioned pricing table, and
+  label every dollar figure with an explicit confidence level
+  (estimated vs provider-confirmed).
+
+## Non-Goals
+
+- Provider billing reconciliation; dollars remain estimates unless a
+  provider-confirmed figure is available.
+- Per-user or multi-tenant quota accounting.
+- Changing GC's existing `budget_per_signal_usd` / `total_budget_usd`
+  mechanics.
+- Replacing or retiring the turn budget (`max_turns`); it remains an
+  independent bound.
+- Building new dashboard UI beyond exposing the budget/ledger fields to
+  existing monitor endpoints.
+
+## User-Visible Behavior
+
+1. **B-001:** Every workflow instance created after rollout carries a
+   USD budget: the profile default unless the workflow definition or
+   submission supplies an override. A missing configuration yields the
+   built-in default, never unlimited. An explicit opt-out to unlimited
+   must be a deliberate configuration value, not an omission.
+2. **B-002:** Accumulated workflow spend is computed server-side from
+   adapter usage telemetry and persisted with the instance. Redispatch,
+   retry, and recovery inherit the accumulated ledger; no path resets
+   spend to zero for the same instance.
+3. **B-003:** When a workflow's accumulated spend crosses its soft
+   threshold, new activity dispatch for that workflow is deprioritized
+   and the state is visible in runtime status. Crossing the hard
+   ceiling blocks the workflow through the existing operator-attention
+   path; the operator can raise the budget and unblock via existing
+   recovery actions.
+4. **B-004:** Per-profile daily spend is tracked against a configurable
+   cap. Crossing the throttle threshold slows new dispatch for that
+   profile; crossing the cap halts new dispatch for that profile while
+   in-flight activities run to completion. The halt clears when the UTC
+   day rolls over or the operator raises the cap.
+5. **B-005:** The dispatcher evaluates remaining workflow and daily
+   budget before dispatching a command. A denial is a deferred dispatch
+   with a typed reason code, visible wherever existing dispatch-barrier
+   reasons are visible. Denials are never silent drops.
+6. **B-006:** Agent CLIs that accept a budget flag still receive
+   `--max-budget-usd` derived from the remaining activity share.
+   Server-side enforcement is authoritative: an adapter that ignores or
+   cannot receive the flag is still terminated or not extended once the
+   server-side ledger crosses the ceiling.
+7. **B-007:** Every USD amount surfaced by API or logs carries a
+   confidence label: `estimated` (derived via the pricing table) or
+   `provider_confirmed`. An estimate is never presented as confirmed.
+   Usage rows for models absent from the pricing table are priced with
+   a conservative fallback and flagged.
+8. **B-008:** Budget enforcement ships with a shadow mode: ledgers are
+   computed and reason codes logged, but no dispatch is deferred and no
+   workflow blocked. Enforcement activates per profile via
+   configuration.
+9. **B-009:** Budget state is observable: workflow status exposes
+   budget, accumulated spend, and threshold state; profile status
+   exposes daily spend, cap, and ladder position. Existing usage
+   monitor endpoints gain the same fields rather than a parallel
+   surface.
+10. **B-010:** Exhaustion outcomes are distinct and typed. A workflow
+    stopped for budget reasons is distinguishable from `max_turns`
+    exhaustion, activity failure, and operator cancellation, in both
+    runtime events and workflow data.
+
+## Acceptance Criteria
+
+- [ ] A workflow created with no budget configuration receives the
+      built-in default; a definition override and a submission override
+      each take precedence in documented order; tests cover all three.
+- [ ] Ledger tests prove accumulated spend survives retry, redispatch,
+      and recovery without reset.
+- [ ] Threshold tests prove soft-threshold deprioritization, hard-cap
+      operator-attention blocking, and operator unblock-with-raised-
+      budget recovery.
+- [ ] Daily-cap tests prove throttle → halt progression, in-flight
+      completion during halt, and UTC-day reset.
+- [ ] Dispatcher tests prove budget denial defers with the typed reason
+      code and never silently drops a command.
+- [ ] Adapter tests prove the CLI flag is derived from remaining share
+      and that server-side termination triggers for an adapter that
+      never receives a flag.
+- [ ] Pricing tests prove token→USD conversion per token class, the
+      conservative unknown-model fallback, and confidence labeling on
+      every surfaced amount.
+- [ ] Shadow-mode tests prove no enforcement side effects while
+      shadow-mode ledgers and logs are produced.
+- [ ] GC budget behavior is unchanged by the entire suite.
+
+## Boundary Checklist
+
+| Boundary | Verdict |
+| --- | --- |
+| Empty / missing input | Covered by B-001 and B-007: missing budget config yields defaults, never unlimited; unknown models price conservatively with a flag. |
+| Error and failure paths | Covered by B-005, B-006, B-010: denials are typed and visible; adapter non-cooperation is bounded server-side; budget stops are distinct outcomes. |
+| Authorization / permission | Raising budgets/caps is an operator configuration action via existing config and recovery surfaces; no new privilege model. |
+| Concurrency / race / ordering | Covered by B-002 and B-004: ledgers are persisted with the instance and updated transactionally; daily counters tolerate concurrent workers (small overshoot from in-flight turns is accepted and bounded by B-004's in-flight rule). |
+| Retry / repetition / idempotency | Covered by B-002: no ledger reset on any re-execution path. |
+| Illegal state transitions | Budget blocking reuses existing operator-gate transitions; no new lifecycle states are introduced. |
+| Compatibility / migration | Covered by B-008: shadow mode first; existing instances without ledgers begin accumulating from activation, never retroactively blocked. |
+| Degradation / fallback | Covered by B-004 and B-007: halts are graduated and visible; pricing gaps degrade to conservative estimates, never silent zeros. |
+| Evidence and audit integrity | Covered by B-009 and B-010: ledger values, threshold crossings, and stop reasons are persisted and queryable. |
+| Cancellation / interruption / partial completion | Covered by B-004: in-flight activities complete during halts; partial turns still record their usage into the ledger. |
+
+## Edge Cases
+
+- An adapter reports usage late or never; the turn ends before
+  telemetry arrives.
+- A workflow's budget is lowered by configuration below its already
+  accumulated spend.
+- The pricing table lacks the model used by an in-flight turn.
+- The UTC day rolls over while a profile is halted and jobs are queued.
+- Candidate fan-out splits an activity share across candidates whose
+  summed spend exceeds the parent share mid-flight.
+- Shadow mode is switched to enforce while workflows are past their
+  hard ceiling.
+- Two workers commit usage for the same workflow concurrently.
+
+## Rollout Notes
+
+Phase 1 ships ledgers, pricing, and shadow mode; operators observe
+computed spend and would-have-fired reason codes. Phase 2 activates
+per-workflow enforcement for one low-volume profile, then broadly.
+Phase 3 activates daily caps. Reverting enforcement returns to
+observation-only behavior; ledgers and events remain. No database
+migration is destructive; new columns/tables are additive.

--- a/specs/GH1770/tech.md
+++ b/specs/GH1770/tech.md
@@ -11,8 +11,10 @@ GH-1770
 - `crates/harness-core/src/agent.rs:52,126` — `AgentRequest::max_budget_usd:
   Option<f64>`, default `None` (unlimited).
 - `crates/harness-agents/src/claude.rs:148-150` — when set, appended as
-  `--max-budget-usd`; enforcement delegated to the Claude CLI. The Codex
-  and direct Anthropic API adapters receive no equivalent cap.
+  `--max-budget-usd`; enforcement delegated to the Claude CLI. The
+  streaming path `crates/harness-agents/src/claude_adapter.rs` never
+  passes the flag at all today, and the Codex and direct Anthropic API
+  adapters receive no equivalent cap.
 - `crates/harness-server/src/workflow_runtime_submission/runtime_request.rs:53,159,202,245,278`
   — the field survives submission, storage, redispatch, and recovery,
   defaulting to `None`.
@@ -38,7 +40,7 @@ GH-1770
 ### Telemetry without control
 
 - `crates/harness-observe/src/usage.rs` — `UsageMetrics` {input_tokens,
-  output_tokens, cache_read_tokens, cache_creation_tokens,
+  output_tokens, cache_read_input_tokens, cache_creation_input_tokens,
   reported_total_tokens} parsed from adapter result payloads.
 - `crates/harness-server/src/handlers/usage_monitor*.rs` (active,
   aggregate, candidate, local_usage, process, records) +
@@ -137,15 +139,24 @@ the activity share across candidates, mirroring the existing
    (dispatch only when no under-threshold work is claimable). Reasons
    extend the existing `dispatch_barrier.rs` enum and surface through
    the same status paths.
-2. **Adapter flag** (`claude.rs`): populate `max_budget_usd` from the
-   activity share when unset. Codex/direct-API adapters skip the flag;
-   server-side enforcement covers them.
+2. **Adapter flag** (`claude.rs` AND `claude_adapter.rs`): populate
+   `max_budget_usd` from the activity share when unset. Today only the
+   batch path (`claude.rs:148-150`) forwards the flag; the streaming
+   adapter must gain the same argument, and per the project CLI-arg
+   rule any arg-construction change applies to both files, verified by
+   `cargo test --package harness-agents`. Codex/direct-API adapters
+   skip the flag; server-side enforcement covers them.
 3. **Turn-stream watchdog** (`workflow_runtime_worker`): accumulate
    `CostSample`s from streamed usage events; when the activity share is
    crossed mid-turn, request turn interruption via the adapter's
    existing interrupt path (Codex `interrupt`; process termination for
    batch CLIs) and record outcome
-   `ActivityErrorKind::BudgetExhausted`-equivalent (see §5).
+   `ActivityErrorKind::BudgetExhausted`-equivalent (see §5). This is a
+   deliberate departure from
+   `docs/cost-monitoring-dashboard-spec.md`'s "gate new dispatch only"
+   posture: hard per-activity ceilings terminate in-flight turns,
+   because an activity that has already blown its share is precisely
+   the case dispatch-time gating cannot catch.
 4. **Hard workflow ceiling** (reducer): when a completed activity's
    ledger commit crosses `budget_usd`, the reducer emits
    `RequestOperatorAttention` with reason `budget_exhausted` instead of
@@ -196,8 +207,9 @@ remain (harmless).
 - `cargo test -p harness-workflow` — ledger commit atomicity with
   activity completion; dispatcher gate defers with typed reasons;
   reducer operator-attention on ceiling; no ledger reset across
-  retry/redispatch/recovery (regression guard mirroring the
-  budget-reset-on-retry fix noted in `task_runner/run_task.rs:68`).
+  retry/redispatch/recovery (regression guard for the
+  budget-reset-on-retry bug class documented in the legacy task layer
+  before its removal in PR #1725).
 - `cargo test -p harness-server` — shadow vs enforce behavior, monitor
   payload fields, daily rollover.
 - `cargo test -p harness-agents` — flag derivation (both adapter files

--- a/specs/GH1770/tech.md
+++ b/specs/GH1770/tech.md
@@ -1,0 +1,216 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1770
+
+## Current State
+
+### Budget plumbing without enforcement
+
+- `crates/harness-core/src/agent.rs:52,126` — `AgentRequest::max_budget_usd:
+  Option<f64>`, default `None` (unlimited).
+- `crates/harness-agents/src/claude.rs:148-150` — when set, appended as
+  `--max-budget-usd`; enforcement delegated to the Claude CLI. The Codex
+  and direct Anthropic API adapters receive no equivalent cap.
+- `crates/harness-server/src/workflow_runtime_submission/runtime_request.rs:53,159,202,245,278`
+  — the field survives submission, storage, redispatch, and recovery,
+  defaulting to `None`.
+- `crates/harness-core/src/config/misc.rs:159-160,217-218` — GC is the
+  only setter: `budget_per_signal_usd` 0.50, `total_budget_usd` 5.0.
+
+### Real controls today
+
+- Turn budget: `crates/harness-core/src/config/concurrency.rs:39-40,90`
+  (`max_turns`, default 20; `concurrency.rs:191` asserts the default),
+  global across the task lifecycle. Candidate fan-out splits it:
+  `crates/harness-workflow/src/runtime/dispatcher.rs:423`
+  `apply_candidate_runtime_budget` reading
+  `candidate.budget.max_turns_per_candidate`.
+- Circuit breakers per failure class
+  (`crates/harness-server/src/runtime_circuit_breaker.rs`) — reactive,
+  not budget-aware.
+- Dispatch deferral reason codes exist in
+  `crates/harness-workflow/src/runtime/dispatch_barrier.rs`
+  (`runtime_policy_disabled | workflow_config_invalid |
+  isolation_tier_unavailable`).
+
+### Telemetry without control
+
+- `crates/harness-observe/src/usage.rs` — `UsageMetrics` {input_tokens,
+  output_tokens, cache_read_tokens, cache_creation_tokens,
+  reported_total_tokens} parsed from adapter result payloads.
+- `crates/harness-server/src/handlers/usage_monitor*.rs` (active,
+  aggregate, candidate, local_usage, process, records) +
+  `token_usage.rs` — read-only monitors. `usage_monitor_process.rs`
+  samples OS processes, which
+  `docs/cost-monitoring-dashboard-spec.md:39-42` says must not be the
+  attribution source of truth.
+- No token→USD table anywhere; the only `Confidence` enum is
+  `crates/harness-workflow/src/runtime/eval/model.rs:137` (with
+  `token_confidence` / `cost_confidence` at 156-157), unused by the
+  runtime.
+
+## Design
+
+### 1. Pricing table and cost computation (`harness-core`)
+
+New module `harness-core/src/pricing.rs`:
+
+```rust
+pub struct ModelPricing {
+    pub model_pattern: String,      // longest-prefix match, e.g. "claude-sonnet-5"
+    pub input_usd_per_mtok: f64,
+    pub output_usd_per_mtok: f64,
+    pub cache_read_usd_per_mtok: f64,
+    pub cache_write_usd_per_mtok: f64,
+}
+
+pub struct PricingTable {
+    pub version: String,            // e.g. "2026-07"
+    pub entries: Vec<ModelPricing>,
+    pub fallback: ModelPricing,     // conservative (max of table) for unknown models
+}
+
+pub enum CostConfidence { Estimated, ProviderConfirmed }
+
+pub struct CostSample {
+    pub usd: f64,
+    pub confidence: CostConfidence,
+    pub pricing_version: String,
+    pub priced_with_fallback: bool,
+}
+```
+
+Built-in defaults compiled in; overridable by a `pricing` section in the
+server config. `cost_for(model, &UsageMetrics) -> CostSample`. If the
+adapter payload ever carries a provider-confirmed dollar amount, that
+value wins and is labeled `ProviderConfirmed`; otherwise `Estimated`.
+Unknown model ⇒ fallback pricing, `priced_with_fallback = true`, and a
+rate-limited `warn!`.
+
+### 2. Budget configuration (`WORKFLOW.md` / config)
+
+Extend the runtime config front-matter:
+
+```yaml
+runtime_budget_policy:
+  default_workflow_budget_usd: 15.0     # built-in default if section absent
+  soft_threshold_ratio: 0.8
+  daily_profile_cap_usd: 200.0
+  daily_throttle_ratio: 0.8
+  enforcement: shadow | enforce         # default shadow
+  unlimited: false                      # explicit opt-out only
+```
+
+Precedence for a workflow instance's budget: submission override
+(`runtime_request.max_budget_usd`) > definition/profile
+`runtime_budget_policy` > built-in default. `None` at every layer no
+longer means unlimited; only `unlimited: true` does.
+
+### 3. Ledgers (Postgres, `harness-workflow` store)
+
+Additive tables in the runtime store migrations
+(`runtime/store_migrations.rs`):
+
+- `workflow_budget_ledger(workflow_id PK, budget_usd, spent_usd,
+  pricing_version, threshold_state, updated_at)` — one row per
+  instance; `spent_usd` monotonically increased in the same transaction
+  that commits activity completion
+  (`commit_runtime_activity_completion_*`), so retry/recovery paths
+  inherit it for free (B-002).
+- `profile_daily_spend(profile, utc_day, spent_usd, state, PRIMARY KEY
+  (profile, utc_day))` — upserted with `spent_usd = spent_usd + $n`;
+  concurrent workers tolerate small overshoot from in-flight turns.
+
+Per-activity share: `activity_budget_usd = remaining_workflow_budget /
+expected_remaining_activities` with a floor; candidate fan-out divides
+the activity share across candidates, mirroring the existing
+`max_turns_per_candidate` split in `dispatcher.rs:423`.
+
+### 4. Enforcement points
+
+1. **Pre-dispatch gate** (`runtime/dispatcher.rs`): before dispatching
+   a command, load ledger + daily row. Exhausted workflow budget ⇒
+   defer with new barrier reason `workflow_budget_exhausted`; daily cap
+   ⇒ `profile_daily_cap_reached`; throttle band ⇒ deprioritize
+   (dispatch only when no under-threshold work is claimable). Reasons
+   extend the existing `dispatch_barrier.rs` enum and surface through
+   the same status paths.
+2. **Adapter flag** (`claude.rs`): populate `max_budget_usd` from the
+   activity share when unset. Codex/direct-API adapters skip the flag;
+   server-side enforcement covers them.
+3. **Turn-stream watchdog** (`workflow_runtime_worker`): accumulate
+   `CostSample`s from streamed usage events; when the activity share is
+   crossed mid-turn, request turn interruption via the adapter's
+   existing interrupt path (Codex `interrupt`; process termination for
+   batch CLIs) and record outcome
+   `ActivityErrorKind::BudgetExhausted`-equivalent (see §5).
+4. **Hard workflow ceiling** (reducer): when a completed activity's
+   ledger commit crosses `budget_usd`, the reducer emits
+   `RequestOperatorAttention` with reason `budget_exhausted` instead of
+   scheduling further activities; existing operator unblock + config
+   raise recovers (reuses `OperatorGate` machinery; no new lifecycle
+   states).
+5. **Shadow mode**: all four points compute and log
+   (`budget_shadow_decision` runtime events) but take no action unless
+   `enforcement: enforce` for the profile.
+
+### 5. Typed outcomes
+
+- New dispatch-barrier reasons: `workflow_budget_exhausted`,
+  `profile_daily_cap_reached`, `profile_daily_throttled`.
+- New runtime event kinds: `budget_threshold_crossed`,
+  `budget_shadow_decision`, `budget_stop`.
+- Activity stop reason distinct from `turn_budget_exhausted`; classified
+  non-retryable-without-operator (maps to the existing
+  blocked/operator-attention path, not the transient retry path in
+  `reducer/runtime_failure.rs`).
+
+### 6. Observability
+
+- Workflow status payloads gain `budget_usd`, `spent_usd`,
+  `threshold_state`, `confidence`.
+- `handlers/usage_monitor_aggregate.rs` gains per-profile daily spend +
+  cap + ladder state.
+- All dollar fields serialize alongside their `confidence` and
+  `pricing_version` (B-007).
+
+## Migration / Rollout Order
+
+1. Land pricing table + ledger tables + ledger writes (shadow only;
+   additive migration).
+2. Wire shadow decisions at all four enforcement points; observe for a
+   week; tune `default_workflow_budget_usd` from observed p95 workflow
+   spend.
+3. Enable `enforce` for one low-volume profile; then broadly.
+4. Enable daily caps last.
+
+Rollback at any phase = revert config to `shadow`; tables and events
+remain (harmless).
+
+## Validation
+
+- `cargo test -p harness-core pricing` — table lookup, fallback,
+  confidence.
+- `cargo test -p harness-workflow` — ledger commit atomicity with
+  activity completion; dispatcher gate defers with typed reasons;
+  reducer operator-attention on ceiling; no ledger reset across
+  retry/redispatch/recovery (regression guard mirroring the
+  budget-reset-on-retry fix noted in `task_runner/run_task.rs:68`).
+- `cargo test -p harness-server` — shadow vs enforce behavior, monitor
+  payload fields, daily rollover.
+- `cargo test -p harness-agents` — flag derivation (both adapter files
+  per the CLI arg-order rule), absence for non-supporting adapters.
+- Full gate before PR: `cargo clippy --workspace --all-targets -- -D
+  warnings` + `cargo fmt --all`.
+
+## Out of Scope (tracked elsewhere)
+
+- Provider billing reconciliation (explicit non-goal of
+  `docs/cost-monitoring-dashboard-spec.md` as well).
+- Invocation-keyed usage event contract (`agent_invocation_id`) from the
+  cost-monitoring spec — complementary; this spec only adds ledger
+  fields to existing surfaces.
+- GC budget unification — GC keeps `budget_per_signal_usd` /
+  `total_budget_usd` untouched.


### PR DESCRIPTION
Defines server-side budget enforcement for agent spend, closing the gap where `max_budget_usd` defaults to unlimited, is set only by GC, and is enforced only by the Claude CLI.

Contents:

- `docs/references/budget-enforcement.md` — full analysis: current plumbing (`agent.rs`, `claude.rs:148`, `runtime_request.rs`), the turn budget as the only binding control, observation-only usage telemetry, missing token→USD bridge, and the operational incidents (944M-token queue-drain session, 248-session retry storm) that motivate admission-level control.
- `specs/GH1770/product.md` — behavior contract: default per-workflow USD budget with `WORKFLOW.md` override, per-profile daily cap with graduated throttle → operator-attention → dispatch-halt ladder, typed pre-dispatch denial reasons, confidence-labeled dollar amounts, shadow-mode-first rollout.
- `specs/GH1770/tech.md` — pricing table + `CostSample` in harness-core, additive ledger tables committed transactionally with activity completion, four enforcement points (dispatch gate, adapter flag, turn-stream watchdog, reducer ceiling), migration order, and validation commands.

Non-goals: provider billing reconciliation, per-user quotas, changes to GC's existing budget mechanics.

Refs #1770