### PR TITLE
spec(GH1766): define server-verified completion evidence

### DIFF
--- a/docs/references/server-verified-completion.md
+++ b/docs/references/server-verified-completion.md
@@ -32,25 +32,25 @@ survives this boundary.
 
 `crates/harness-server/src/workflow_runtime_worker/activity_result.rs`
 counts assistant messages, tool invocations, and structured result blocks
-(`agent_activity_summary`, line 431; `is_zero_output`, line 424). A turn that
-completes with no observable work is classified as
-`ActivityResultEnvelopeOutcome::ZeroOutputSpawnFailure` (line 232, consumed at
-line 356), logged at error level, and surfaced as an
-`AgentZeroOutputSpawnFailure` signal (line 254). An exit-0 no-op spawn cannot
-become `succeeded`. This closed the worst historical false-done class
+(`agent_activity_summary` / `is_zero_output`). A turn that completes with no
+observable work is classified as
+`ActivityResultEnvelopeOutcome::ZeroOutputSpawnFailure`, logged at error
+level, and surfaced as an `AgentZeroOutputSpawnFailure` signal. An exit-0
+no-op spawn cannot become `succeeded`. This closed the worst historical
+false-done class
 (zero-output spawns counted as done during the 2026-07 retry storms).
 
 ### 1.2 Structured result required, fail-closed
 
 A `Completed` turn without a fenced `harness-activity-result` JSON block is
-`MissingStructuredOutput` (line 215) and maps to a failed activity, explicitly
+`MissingStructuredOutput` and maps to a failed activity, explicitly
 to prevent silent state-machine no-progress loops. Invalid JSON or a
 mismatched activity name also fails.
 
 ### 1.3 Self-contradiction downgrade
 
 `workflow_runtime_worker/activity_status_contract.rs::enforce_activity_status_contract`
-(line 4) rewrites `succeeded` to `blocked` when the agent's own payload
+rewrites `succeeded` to `blocked` when the agent's own payload
 reports blockers: blocking signals (`ChangesRequested`, `ChecksFailed`,
 `QualityFailed`, …), structured fields (`failing_checks`,
 `unresolved_review_threads`, adverse `merge_state_status`), or textual
@@ -68,19 +68,18 @@ harness never calls the GitHub review-approval API.
 
 ### 1.5 Piecemeal reducer contract checks
 
-`pr_feedback_completion.rs::pr_feedback_success_contract_error` (line 62)
+`pr_feedback_completion.rs::pr_feedback_success_contract_error`
 rejects an `address_pr_feedback` success that lacks a `pr_repair_snapshot`
 proving pushed changes, review-thread action, or an explicit no-code-change
-reason plus validation (line 71-78). This is the model the rest of the system
+reason plus validation. This is the model the rest of the system
 should follow — but it is hand-built for one activity, not a general
 mechanism.
 
 ### 1.6 Terminal-evidence validation for hidden transitions
 
 `runtime/validator_github_issue_pr.rs::validate_reconciliation_only_done`
-(line 58) restricts hidden `→ done` transitions to the `reconciliation` actor
-and requires `pr_number` plus `github_pr`/`github_issue` evidence (lines
-62-97). Reconciliation itself maps real GitHub facts (`PrMerged`,
+restricts hidden `→ done` transitions to the `reconciliation` actor
+and requires `pr_number` plus `github_pr`/`github_issue` evidence. Reconciliation itself maps real GitHub facts (`PrMerged`,
 `IssueCompleted`) to terminal states independently of any agent claim.
 
 ## 2. The false-done risks
@@ -89,8 +88,7 @@ and requires `pr_number` plus `github_pr`/`github_issue` evidence (lines
 
 `crates/harness-workflow/src/runtime/reducer/prompt_task_completion.rs`:
 with no continuation policy configured, a `succeeded` `implement_prompt`
-activity immediately produces `single_shot_done_decision` (call at line 30,
-definition at line 166) — a `MarkDone` command with only
+activity immediately produces `single_shot_done_decision` — a `MarkDone` command with only
 `runtime_completion_evidence` (a record *of the agent's result*, not an
 independent fact). The activity contract for `implement_prompt` nominally
 requires `validation_evidence`
@@ -118,8 +116,8 @@ There is no server-side re-execution of any claimed validation for
 ### Risk C — `BindPr` trusts an agent artifact at bind time
 
 `runtime/reducer/github_issue_completion.rs::bind_pr_from_activity_result`
-(line 177) reads `pr_number`/`pr_url` straight from the agent artifact via
-`pull_request_artifact(result)` (line 193) and issues
+reads `pr_number`/`pr_url` straight from the agent artifact via
+`pull_request_artifact(result)` and issues
 `WorkflowCommand::bind_pr`. No GraphQL existence check, no verification that
 the PR head belongs to the workflow's branch, no repo match. A fabricated or
 mistyped PR number moves the workflow to `pr_open`, and server verification
@@ -128,24 +126,33 @@ dashboards, and coverage accounting operate on an unverified binding.
 
 ### Risk D — `required_evidence` is empty for every built-in workflow
 
-`runtime/validator.rs` defines `TransitionRule::required_evidence` (line 24),
-but both rule constructors default it to empty (lines 39, 53), and all four
-built-in allowlists (`github_issue_pr_defaults` line 119,
-`quality_gate_defaults` line 275, `pr_feedback_defaults` line 293,
-`prompt_task_defaults` line 312) build rules exclusively via `.allow(...)`.
+`runtime/validator.rs` defines `TransitionRule::required_evidence`, but both
+rule constructors default it to empty, and all four built-in allowlists
+(`github_issue_pr_defaults`, `quality_gate_defaults`, `pr_feedback_defaults`,
+`prompt_task_defaults`) build rules exclusively via `.allow(...)`.
 `implementing → done` is an allowed transition gated on nothing but the
-command being `MarkDone` (lines 211 and 334). The only population site is
-`declarative.rs:526` (YAML policy files) and the only enforcement site is
-`store/runtime_completion.rs:169`
-(`declarative_decision_missing_required_evidence`, line 219) — so the evidence
-machinery protects optional declarative workflows while the shipped
-workflows that do all the real work run without it. The machinery's presence
-gives false assurance in audits.
+command being `MarkDone`.
+
+Importantly, the *enforcement* path is already general: every decision
+transition passes through
+`validator_progress::validate_declarative_transition_metadata` (called from
+`DecisionValidator::validate_decision` in `validator.rs`), which rejects a
+decision missing any kind in the rule's `required_evidence` set — regardless
+of whether the definition is built-in or declarative. (The similarly named
+`declarative_decision_missing_required_evidence` in
+`store/runtime_completion.rs` is an additional declarative-only pre-check,
+not the enforcement site.) The gap is therefore purely one of population:
+the only site that ever fills `required_evidence` is `declarative.rs:526`
+(YAML policy files). The shipped workflows that do all the real work run
+with empty sets, so the machinery protects optional declarative workflows
+while giving false assurance about the built-ins. One nuance to preserve:
+the check deliberately exempts same-state `retry_failed_runtime_activity`
+decisions, so evidence requirements bind terminal transitions, not retries.
 
 ### Risk E — quality gate is an LLM reporting on itself
 
 `runtime/quality_gate.rs` (62 lines) only *builds the decision* to enqueue a
-`run_quality_gate` activity carrying `validation_commands` (line 20, 49). The
+`run_quality_gate` activity carrying `validation_commands`. The
 activity is executed by an agent under the output contract
 `quality_gate_status_signal_and_validation_evidence`
 (`activity_contract.rs:153-155`) — i.e. the "independent" gate is another LLM
@@ -157,7 +164,7 @@ this agent-executed gate.)
 
 ### Risk F — advisory quality grading scores a do-nothing window as 100/A
 
-`crates/harness-observe/src/quality.rs::grade` (line 26): with zero events,
+`crates/harness-observe/src/quality.rs::grade`: with zero events,
 `total = events.len().max(1)`, so security/stability/coverage/performance all
 compute to 100 and the weighted grade is A. Mitigated by being advisory (it
 only tunes GC trigger frequency), but it is a misleading surface on
@@ -168,20 +175,28 @@ the bias.
 
 ### R1 — Populate `required_evidence` on built-in critical transitions
 
-Pure wiring of existing machinery. Define evidence classes and attach them to
+Because enforcement is already live in the shared validation path (Risk D),
+populating the sets in the built-in default constructors activates it
+directly — no enforcement-path changes are needed. The remaining work beyond
+population is defining the evidence-kind constants, building the producers
+that mint them server-side (R2–R4), and tests. Attach evidence classes to
 the transitions that mint user-visible facts:
 
 | Workflow | Transition | Required evidence class |
 | --- | --- | --- |
 | `github_issue_pr` | `* → done` (non-reconciliation) | `github_pr` (verified PR identity) + `server_pr_snapshot` |
 | `github_issue_pr` | `implementing → pr_open` | `verified_pr_binding` (see R3) |
-| `prompt_task` | `implementing → done` | `validation_report` or `no_change_rationale` |
+| `prompt_task` | `implementing → done` | `prompt_completion_evidence` (umbrella kind, see R4) |
 | `quality_gate` | `checking → passed` | `server_validation_digest` (see R2) |
 | `pr_feedback` | `inspecting → ready_to_merge` | `server_pr_snapshot` (already produced; make it structurally required) |
 
-Enforcement generalizes `declarative_decision_missing_required_evidence` from
-declarative-only to all definitions. Fail closed: missing evidence blocks the
-decision with a typed reason code; it must never downgrade to a warning.
+`required_evidence` is a conjunctive set — every listed kind must be present.
+Where the product rule is disjunctive ("validation report OR explicit
+no-change rationale"), the reducer checks the concrete alternatives and mints
+a single umbrella evidence kind that the transition requires (R4), keeping
+the validator check simple and conjunctive. Fail closed: missing evidence
+blocks the decision with a typed reason code
+(`MissingRequiredEvidence`); it must never downgrade to a warning.
 
 ### R2 — Server-side re-execution of quality-gate validation
 
@@ -207,10 +222,15 @@ than `pr_open`. This converts Risk C's delay-shaped hole into a gate.
 
 `single_shot_done_decision` and `settled_done_decision` require either a
 `validation_report` artifact (server-checkable: command list + exit codes) or
-an explicit structured `no_change_rationale`. Absent both, the decision is
-`blocked` with reason `prompt_completion_evidence_missing`. The continuation
-path keeps its external-state semantics; only the terminal step gains an
-evidence requirement.
+an explicit structured `no_change_rationale`. When either is present, the
+reducer attaches the umbrella `prompt_completion_evidence` kind (recording
+which alternative satisfied it), and the transition's `required_evidence`
+names only that umbrella kind — encoding the OR in the reducer, where the
+branching context lives, rather than extending `TransitionRule` with
+alternative-set semantics. Absent both, the decision is `blocked` with reason
+`prompt_completion_evidence_missing`. The continuation path keeps its
+external-state semantics; only the terminal step gains an evidence
+requirement.
 
 ### R5 — Truthful empty-window grading (small, independent)
 

--- a/docs/references/server-verified-completion.md
+++ b/docs/references/server-verified-completion.md
@@ -1,0 +1,242 @@
+# Server-Verified Completion: The Trust Boundary of "Done"
+
+> Status: analysis reference for GH-1766
+> Date: 2026-07-26
+> Scope: how the workflow runtime decides an activity or workflow succeeded, which
+> parts of that decision are server-verified facts, and which parts are the
+> agent's own claims. All citations verified against `main` at the time of
+> writing.
+
+## Summary
+
+The runtime has a strong *format* contract for completion — a missing or
+malformed structured result fails the activity, zero-output spawns are
+classified as failures, and self-contradictory success claims are downgraded.
+But the *content* of a successful result is still almost entirely
+agent-authored. The server-side evidence machinery that could turn "done" into
+a verified fact exists (`TransitionRule::required_evidence`, evidence classes,
+reducer contract checks) and is enforced for declarative YAML workflows, while
+all four built-in workflow definitions run with empty evidence requirements.
+Quality-gate validation commands are executed by an LLM, never re-run by the
+server. A PR number is bound to a workflow straight from an agent artifact
+with no existence check. A prompt task reaches `done` on nothing more than the
+agent's own `succeeded` status.
+
+Every downstream consumer — skill-quality EMAs, GC signals, eval baselines,
+operator dashboards, GitHub coverage accounting — inherits whatever fiction
+survives this boundary.
+
+## 1. What already works (and must be preserved)
+
+### 1.1 Zero-output detection
+
+`crates/harness-server/src/workflow_runtime_worker/activity_result.rs`
+counts assistant messages, tool invocations, and structured result blocks
+(`agent_activity_summary`, line 431; `is_zero_output`, line 424). A turn that
+completes with no observable work is classified as
+`ActivityResultEnvelopeOutcome::ZeroOutputSpawnFailure` (line 232, consumed at
+line 356), logged at error level, and surfaced as an
+`AgentZeroOutputSpawnFailure` signal (line 254). An exit-0 no-op spawn cannot
+become `succeeded`. This closed the worst historical false-done class
+(zero-output spawns counted as done during the 2026-07 retry storms).
+
+### 1.2 Structured result required, fail-closed
+
+A `Completed` turn without a fenced `harness-activity-result` JSON block is
+`MissingStructuredOutput` (line 215) and maps to a failed activity, explicitly
+to prevent silent state-machine no-progress loops. Invalid JSON or a
+mismatched activity name also fails.
+
+### 1.3 Self-contradiction downgrade
+
+`workflow_runtime_worker/activity_status_contract.rs::enforce_activity_status_contract`
+(line 4) rewrites `succeeded` to `blocked` when the agent's own payload
+reports blockers: blocking signals (`ChangesRequested`, `ChecksFailed`,
+`QualityFailed`, …), structured fields (`failing_checks`,
+`unresolved_review_threads`, adverse `merge_state_status`), or textual
+blockers in the summary.
+
+### 1.4 Server-owned PR inspection and merge gate
+
+`inspect_pr_feedback` is a server-owned activity: the server itself queries
+GitHub GraphQL and builds the snapshot; no LLM is involved. PR readiness
+demands `snapshot_source == "server_github_graphql"` with matching PR
+identity, head, and thread/check state
+(`runtime/reducer/pr_feedback_completion.rs`, `ready_snapshot_proves_pr_ready`).
+The auto-merge gate is deterministic over a server-fetched snapshot and
+harness never calls the GitHub review-approval API.
+
+### 1.5 Piecemeal reducer contract checks
+
+`pr_feedback_completion.rs::pr_feedback_success_contract_error` (line 62)
+rejects an `address_pr_feedback` success that lacks a `pr_repair_snapshot`
+proving pushed changes, review-thread action, or an explicit no-code-change
+reason plus validation (line 71-78). This is the model the rest of the system
+should follow — but it is hand-built for one activity, not a general
+mechanism.
+
+### 1.6 Terminal-evidence validation for hidden transitions
+
+`runtime/validator_github_issue_pr.rs::validate_reconciliation_only_done`
+(line 58) restricts hidden `→ done` transitions to the `reconciliation` actor
+and requires `pr_number` plus `github_pr`/`github_issue` evidence (lines
+62-97). Reconciliation itself maps real GitHub facts (`PrMerged`,
+`IssueCompleted`) to terminal states independently of any agent claim.
+
+## 2. The false-done risks
+
+### Risk A — prompt tasks reach `done` on the agent's word alone
+
+`crates/harness-workflow/src/runtime/reducer/prompt_task_completion.rs`:
+with no continuation policy configured, a `succeeded` `implement_prompt`
+activity immediately produces `single_shot_done_decision` (call at line 30,
+definition at line 166) — a `MarkDone` command with only
+`runtime_completion_evidence` (a record *of the agent's result*, not an
+independent fact). The activity contract for `implement_prompt` nominally
+requires `validation_evidence`
+(`workflow_runtime_worker/activity_contract.rs:143`), but `success_requires`
+is consumed **only** by `prompt_packet.rs` — it is prompt text shown to the
+agent, not a server-side check. Nothing verifies a diff exists, a validation
+command ran, or a `validation_report` artifact is present.
+
+Consequence: an agent that writes a paragraph and emits
+`status: succeeded` completes a prompt workflow. The legacy
+`task_executor` path that had the same defect (`outcome.rs` marking Done on
+non-empty text) was deleted in #1706, but the live runtime path reproduces
+the same trust shape.
+
+### Risk B — the structured result is agent-authored, with no independent re-verification
+
+Status, artifacts, signals, and validation records in the
+`harness-activity-result` block are all written by the agent
+(`activity_result.rs` scrapes the fenced block from agent output). The only
+counterweight, `enforce_activity_status_contract`, catches
+*self-contradiction*; a confident, internally consistent fabrication passes.
+There is no server-side re-execution of any claimed validation for
+`implement_issue` or `implement_prompt`.
+
+### Risk C — `BindPr` trusts an agent artifact at bind time
+
+`runtime/reducer/github_issue_completion.rs::bind_pr_from_activity_result`
+(line 177) reads `pr_number`/`pr_url` straight from the agent artifact via
+`pull_request_artifact(result)` (line 193) and issues
+`WorkflowCommand::bind_pr`. No GraphQL existence check, no verification that
+the PR head belongs to the workflow's branch, no repo match. A fabricated or
+mistyped PR number moves the workflow to `pr_open`, and server verification
+arrives only later (inspection / merge), meaning intermediate states,
+dashboards, and coverage accounting operate on an unverified binding.
+
+### Risk D — `required_evidence` is empty for every built-in workflow
+
+`runtime/validator.rs` defines `TransitionRule::required_evidence` (line 24),
+but both rule constructors default it to empty (lines 39, 53), and all four
+built-in allowlists (`github_issue_pr_defaults` line 119,
+`quality_gate_defaults` line 275, `pr_feedback_defaults` line 293,
+`prompt_task_defaults` line 312) build rules exclusively via `.allow(...)`.
+`implementing → done` is an allowed transition gated on nothing but the
+command being `MarkDone` (lines 211 and 334). The only population site is
+`declarative.rs:526` (YAML policy files) and the only enforcement site is
+`store/runtime_completion.rs:169`
+(`declarative_decision_missing_required_evidence`, line 219) — so the evidence
+machinery protects optional declarative workflows while the shipped
+workflows that do all the real work run without it. The machinery's presence
+gives false assurance in audits.
+
+### Risk E — quality gate is an LLM reporting on itself
+
+`runtime/quality_gate.rs` (62 lines) only *builds the decision* to enqueue a
+`run_quality_gate` activity carrying `validation_commands` (line 20, 49). The
+activity is executed by an agent under the output contract
+`quality_gate_status_signal_and_validation_evidence`
+(`activity_contract.rs:153-155`) — i.e. the "independent" gate is another LLM
+emitting `QualityPassed` plus a self-authored `validation_report`. The server
+never re-executes the configured commands to confirm the claimed evidence.
+(The legacy `validation_gate.rs`, which soft-passed when no test command was
+detectable, was removed with the legacy task layer; the surviving defect is
+this agent-executed gate.)
+
+### Risk F — advisory quality grading scores a do-nothing window as 100/A
+
+`crates/harness-observe/src/quality.rs::grade` (line 26): with zero events,
+`total = events.len().max(1)`, so security/stability/coverage/performance all
+compute to 100 and the weighted grade is A. Mitigated by being advisory (it
+only tunes GC trigger frequency), but it is a misleading surface on
+dashboards and any future consumer that treats Grade A as "healthy" inherits
+the bias.
+
+## 3. Remediation design (priority order)
+
+### R1 — Populate `required_evidence` on built-in critical transitions
+
+Pure wiring of existing machinery. Define evidence classes and attach them to
+the transitions that mint user-visible facts:
+
+| Workflow | Transition | Required evidence class |
+| --- | --- | --- |
+| `github_issue_pr` | `* → done` (non-reconciliation) | `github_pr` (verified PR identity) + `server_pr_snapshot` |
+| `github_issue_pr` | `implementing → pr_open` | `verified_pr_binding` (see R3) |
+| `prompt_task` | `implementing → done` | `validation_report` or `no_change_rationale` |
+| `quality_gate` | `checking → passed` | `server_validation_digest` (see R2) |
+| `pr_feedback` | `inspecting → ready_to_merge` | `server_pr_snapshot` (already produced; make it structurally required) |
+
+Enforcement generalizes `declarative_decision_missing_required_evidence` from
+declarative-only to all definitions. Fail closed: missing evidence blocks the
+decision with a typed reason code; it must never downgrade to a warning.
+
+### R2 — Server-side re-execution of quality-gate validation
+
+The server (not the agent) runs the configured `validation_commands` in the
+workflow's workspace, records exit codes plus an output digest
+(command, cwd, exit, sha256 of captured output, duration), and attaches the
+digest as `server_validation_digest` evidence. The agent-executed activity
+remains as triage/diagnosis input; its `QualityPassed` signal alone no longer
+satisfies the gate. Timeouts and non-zero exits map to `QualityFailed` with
+the digest attached, so operators can distinguish "validation failed" from
+"validation never ran".
+
+### R3 — Verify PR binding at `BindPr`
+
+Before applying `WorkflowCommand::bind_pr`, the server resolves the claimed
+PR via the existing GraphQL client: it must exist, be open, target the
+expected repo, and have a head ref/branch consistent with the workflow's
+workspace branch. Success attaches `verified_pr_binding` evidence (pr number,
+head oid, observed time); failure produces a typed blocked decision rather
+than `pr_open`. This converts Risk C's delay-shaped hole into a gate.
+
+### R4 — Prompt-task done contract
+
+`single_shot_done_decision` and `settled_done_decision` require either a
+`validation_report` artifact (server-checkable: command list + exit codes) or
+an explicit structured `no_change_rationale`. Absent both, the decision is
+`blocked` with reason `prompt_completion_evidence_missing`. The continuation
+path keeps its external-state semantics; only the terminal step gains an
+evidence requirement.
+
+### R5 — Truthful empty-window grading (small, independent)
+
+`QualityGrader::grade` should return an explicit `Grade::Unknown` (or skip
+emission) for an empty event window instead of manufacturing 100/A.
+
+## 4. What this deliberately does not change
+
+- The agent-authored result block stays — as *input* to decisions, never as
+  the verdict.
+- No new workflow states and no changes to the state graphs; evidence
+  attaches to existing transitions.
+- Declarative YAML workflow semantics are unchanged (they already enforce
+  evidence); the built-ins are brought up to the same bar.
+- Reconciliation's authority over terminal states is preserved — it is the
+  model: server-observed GitHub facts outrank agent claims.
+
+## 5. Verification sketch
+
+- Table tests per built-in definition proving each critical transition
+  rejects a decision lacking its evidence class and accepts one carrying it.
+- A quality-gate integration test where the agent claims `QualityPassed` but
+  the server re-run fails → workflow blocks with the digest recorded.
+- A `BindPr` test with a nonexistent PR number → typed blocked decision, no
+  `pr_open` transition, no coverage claim.
+- A prompt-task test where the agent returns prose + `succeeded` and no
+  validation artifact → blocked, not done.
+- Regression tests proving reconciliation-driven done paths still work
+  unchanged.

--- a/specs/GH1766/product.md
+++ b/specs/GH1766/product.md
@@ -66,7 +66,10 @@ quality, GC) inherits unverified state.
    claim is recorded for the issue.
 7. **B-007:** A prompt task reaches `done` only when its result carries a
    `validation_report` artifact (command list and exit codes) or an explicit
-   structured `no_change_rationale`. Otherwise the decision is blocked with
+   structured `no_change_rationale`. When either is present, the server
+   records a single `prompt_completion_evidence` evidence entry naming which
+   alternative satisfied it, and the `implementing → done` transition
+   requires that evidence kind. Otherwise the decision is blocked with
    reason `prompt_completion_evidence_missing`.
 8. **B-008:** Prompt-task continuation semantics (external-state signals,
    attempt budgets, scope-too-large) are unchanged; only the terminal step
@@ -86,7 +89,7 @@ quality, GC) inherits unverified state.
 | --- | --- | --- |
 | `github_issue_pr` | `implementing → pr_open` | `verified_pr_binding` |
 | `github_issue_pr` | any non-reconciliation `→ done` | `github_pr` + `server_pr_snapshot` |
-| `prompt_task` | `implementing → done` | `validation_report` or `no_change_rationale` |
+| `prompt_task` | `implementing → done` | `prompt_completion_evidence` (umbrella kind) |
 | `quality_gate` | `checking → passed` | `server_validation_digest` |
 | `pr_feedback` | `inspecting → ready_to_merge` | `server_pr_snapshot` |
 

--- a/specs/GH1766/product.md
+++ b/specs/GH1766/product.md
@@ -1,0 +1,157 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1766
+
+## User Problem
+
+Workflow completion decisions rest on the agent's own structured result. The
+server has evidence machinery (`TransitionRule::required_evidence`, evidence
+classes, reducer contract checks) but the four built-in workflow definitions
+run with empty evidence requirements, the quality gate's validation commands
+are executed only by an LLM, a PR number is bound from an agent artifact with
+no existence check, and a prompt task reaches `done` on a bare `succeeded`
+status. Operators cannot distinguish a verified completion from a confident
+claim, and every downstream signal (coverage accounting, dashboards, skill
+quality, GC) inherits unverified state.
+
+## Goals
+
+- Make every fact-minting transition of the built-in workflows require
+  server-verifiable evidence, enforced fail-closed.
+- Re-execute quality-gate validation commands server-side and record an
+  output digest as the gate's authoritative evidence.
+- Verify PR existence and head ownership before `BindPr` is applied.
+- Require validation evidence or an explicit no-change rationale before a
+  prompt task completes.
+
+## Non-Goals
+
+- No new workflow states, no renamed states, and no changes to any state
+  graph or transition allowlist topology.
+- No changes to declarative YAML workflow semantics (they already enforce
+  `required_evidence`).
+- No removal or redesign of the agent-authored `harness-activity-result`
+  block; it remains an input to decisions, never the verdict.
+- No changes to reconciliation's authority over terminal states.
+- No changes to the auto-merge gate, PR-feedback inspection, or zero-output
+  detection (already server-owned).
+- No redesign of `QualityGrader` beyond honest empty-window output.
+
+## User-Visible Behavior
+
+1. **B-001:** Every transition listed in the Evidence Contract below rejects
+   a decision that does not carry the named evidence class. Rejection is a
+   typed blocked outcome with a stable reason code; it is never downgraded to
+   a warning or reported as success.
+2. **B-002:** `required_evidence` enforcement applies uniformly to built-in
+   and declarative definitions through one code path. Declarative workflows
+   observe no behavioral change.
+3. **B-003:** The quality gate passes only when the server itself has
+   executed the configured validation commands in the workflow's workspace
+   and recorded a validation digest (command, working directory, exit code,
+   output hash, duration) as evidence. An agent-emitted `QualityPassed`
+   signal without a matching server digest does not satisfy the gate.
+4. **B-004:** A server validation run that fails, times out, or cannot start
+   produces `QualityFailed` or a blocked outcome with the digest (or the
+   startup error) attached. Absence of a configured validation command is an
+   explicit, visible gate outcome — never a silent pass.
+5. **B-005:** `BindPr` is applied only after the server resolves the claimed
+   PR: it exists, is open, targets the expected repository, and its head is
+   consistent with the workflow's branch. Verification produces
+   `verified_pr_binding` evidence (PR number, head OID, observation time).
+6. **B-006:** A `BindPr` claim that fails verification produces a typed
+   blocked decision; the workflow does not enter `pr_open` and no coverage
+   claim is recorded for the issue.
+7. **B-007:** A prompt task reaches `done` only when its result carries a
+   `validation_report` artifact (command list and exit codes) or an explicit
+   structured `no_change_rationale`. Otherwise the decision is blocked with
+   reason `prompt_completion_evidence_missing`.
+8. **B-008:** Prompt-task continuation semantics (external-state signals,
+   attempt budgets, scope-too-large) are unchanged; only the terminal step
+   gains the evidence requirement.
+9. **B-009:** Reconciliation-driven terminal transitions (merged PR, closed
+   issue) remain valid without agent evidence, as today.
+10. **B-010:** Evidence rejection leaves the workflow instance unchanged
+    except for the recorded blocked decision; no partial state or metadata
+    mutation from the rejected decision persists.
+11. **B-011:** An empty observation window grades as `Unknown` rather than
+    100/A; consumers that key on Grade A see no change for non-empty
+    windows.
+
+## Evidence Contract
+
+| Workflow | Transition | Required evidence class |
+| --- | --- | --- |
+| `github_issue_pr` | `implementing → pr_open` | `verified_pr_binding` |
+| `github_issue_pr` | any non-reconciliation `→ done` | `github_pr` + `server_pr_snapshot` |
+| `prompt_task` | `implementing → done` | `validation_report` or `no_change_rationale` |
+| `quality_gate` | `checking → passed` | `server_validation_digest` |
+| `pr_feedback` | `inspecting → ready_to_merge` | `server_pr_snapshot` |
+
+All other transitions keep their current requirements. Evidence classes are
+produced server-side; agent-authored artifacts may inform but cannot satisfy
+them.
+
+## Acceptance Criteria
+
+- [ ] Table tests per built-in definition prove each contracted transition
+      rejects a decision missing its evidence class and accepts one carrying
+      it, with the typed reason code asserted.
+- [ ] A declarative-workflow regression test proves unchanged behavior
+      through the unified enforcement path.
+- [ ] A quality-gate integration test proves an agent `QualityPassed` claim
+      without a server digest blocks, and a server re-run failure records the
+      digest and fails the gate.
+- [ ] A missing-validation-command configuration produces a visible gate
+      outcome, asserted by test.
+- [ ] `BindPr` tests cover: nonexistent PR, closed PR, wrong repository,
+      mismatched head — each yields a blocked decision and no `pr_open`
+      transition; a valid PR binds with `verified_pr_binding` evidence.
+- [ ] A prompt-task test proves prose + `succeeded` with no validation
+      artifact blocks with `prompt_completion_evidence_missing`; tests cover
+      both the `validation_report` and `no_change_rationale` paths to done.
+- [ ] Reconciliation terminal-path regression tests pass unchanged.
+- [ ] Rejected decisions leave the persisted instance row unchanged except
+      for the blocked decision record, proven by snapshot comparison.
+- [ ] Empty-window grading returns `Unknown`, asserted by test.
+
+## Boundary Checklist
+
+| Boundary | Verdict |
+| --- | --- |
+| Empty / missing input | Covered by B-001, B-004, B-007: missing evidence or missing validation configuration is a visible blocked/failed outcome, never a silent pass. |
+| Error and failure paths | Covered by B-004, B-006; verification and validation failures are typed outcomes with evidence attached. |
+| Authorization / permission | Verification uses the server's existing GitHub credentials; no new authority is granted to agents. |
+| Concurrency / race / ordering | Evidence checks run inside the existing decision-transition transaction and row lock; B-010 guarantees rejected contenders persist nothing. |
+| Retry / repetition / idempotency | A retried activity re-presents evidence; verification is re-run on each bind attempt; digests are per-execution and append-only. |
+| Illegal state transitions | Covered by B-001/B-002; the transition allowlist topology is unchanged, only its evidence requirements tighten. |
+| Compatibility / migration | Existing rows need no migration; in-flight workflows encounter the new requirements at their next transition (see Rollout Notes). |
+| Degradation / fallback | Covered by B-001 and B-004: enforcement never downgrades to warnings; absence of data blocks. |
+| Evidence and audit integrity | Server digests and `verified_pr_binding` are server-authored and hash-anchored; agent artifacts cannot forge them. |
+| Cancellation / interruption / partial completion | A validation run interrupted mid-execution records a failed digest; the gate does not pass on partial output. |
+
+## Edge Cases
+
+- The agent claims `QualityPassed` while the server re-run fails on the same
+  commands (divergent environments must surface, not average out).
+- A PR exists but was opened by an unrelated actor against the same branch
+  name in a fork.
+- The claimed PR is merged or closed between the agent's claim and server
+  verification.
+- A prompt task legitimately requires no code change (documentation answer)
+  and uses `no_change_rationale`.
+- Validation commands are configured but the workspace was reclaimed before
+  the server re-run starts.
+- A reconciliation done-transition arrives for a workflow that is mid-flight
+  under the new evidence rules.
+
+## Rollout Notes
+
+Enforcement lands behind a single runtime configuration flag defaulting to
+enabled, with a documented kill switch for one release. In-flight workflows
+meet the new requirements at their next transition; operators should expect a
+one-time surfacing of previously invisible unverified completions as blocked
+decisions with typed reason codes. Reverting restores trust-by-claim behavior
+but not any corrupted state, since rejected decisions persist nothing.

--- a/specs/GH1766/tech.md
+++ b/specs/GH1766/tech.md
@@ -8,10 +8,10 @@ GH-1766
 
 Four fail-closed changes, all reusing existing machinery:
 
-1. **Evidence enforcement unification** — populate
-   `TransitionRule::required_evidence` for the built-in definitions and move
-   enforcement from the declarative-only check into the shared decision
-   transition path.
+1. **Evidence population** — populate
+   `TransitionRule::required_evidence` for the built-in definitions; the
+   shared decision-validation path already enforces the field for all
+   definition kinds, so population alone activates it.
 2. **Server-side quality-gate validation** — the runtime worker executes the
    configured `validation_commands` itself and attaches a
    `server_validation_digest` evidence record; the reducer requires it for
@@ -31,9 +31,11 @@ fact before the claim can mint a transition.
 | Fact | Location |
 | --- | --- |
 | `required_evidence` field exists, defaults empty | `crates/harness-workflow/src/runtime/validator.rs:24,39,53` |
-| Built-in allowlists never populate it | `validator.rs:119` (`github_issue_pr_defaults`), `:275`, `:293`, `:312`; `implementing → done` via bare `.allow` at `:211` and `:334` |
+| Built-in allowlists never populate it | `validator.rs`: `github_issue_pr_defaults`, `quality_gate_defaults`, `pr_feedback_defaults`, `prompt_task_defaults`; `implementing → done` via bare `.allow("implementing", "done", [MarkDone])` in the `github_issue_pr` and `prompt_task` defaults |
 | Only declarative workflows populate evidence | `crates/harness-workflow/src/runtime/declarative.rs:526` |
-| Only declarative decisions are checked | `crates/harness-workflow/src/runtime/store/runtime_completion.rs:169,219` |
+| Enforcement is already general: every decision transition runs the `required_evidence` check for all definition kinds | `validator.rs::validate_decision` → `validator_progress::validate_declarative_transition_metadata` (rejects with `MissingRequiredEvidence`; exempts same-state `retry_failed_runtime_activity`) |
+| A separate declarative-only pre-check also exists | `crates/harness-workflow/src/runtime/store/runtime_completion.rs` (`declarative_decision_missing_required_evidence`) |
+| `required_evidence` is a conjunctive `BTreeSet` — no OR semantics | `validator_progress.rs` (missing-kind filter over the set) |
 | Quality gate builds an enqueue decision only | `crates/harness-workflow/src/runtime/quality_gate.rs` (62 lines) |
 | Gate contract is prompt prose, not enforcement | `crates/harness-server/src/workflow_runtime_worker/activity_contract.rs:25,63,153`; `success_requires` consumed only by `prompt_packet.rs` |
 | `BindPr` reads the agent artifact unverified | `crates/harness-workflow/src/runtime/reducer/github_issue_completion.rs:177,193` |
@@ -44,23 +46,35 @@ fact before the claim can mint a transition.
 
 ## Component Changes
 
-### 1. Evidence enforcement (`harness-workflow`)
+### 1. Evidence population (`harness-workflow`)
+
+Enforcement already exists and is general:
+`DecisionValidator::validate_decision` calls
+`validator_progress::validate_declarative_transition_metadata` for every
+matched rule, and that function rejects any decision missing a kind from the
+rule's `required_evidence` set with `MissingRequiredEvidence`, for built-in
+and declarative definitions alike (exempting same-state
+`retry_failed_runtime_activity` decisions). No enforcement-path change is
+required or made.
+
+The work is therefore population plus producers:
 
 - `runtime/validator.rs`: add a builder method
-  `require_evidence(from, to, [classes])` usable by the default constructors;
-  populate the Evidence Contract table from `product.md` in
-  `github_issue_pr_defaults`, `prompt_task_defaults`,
-  `quality_gate_defaults`, `pr_feedback_defaults`.
-- `runtime/store/runtime_completion.rs`: generalize
-  `declarative_decision_missing_required_evidence` into
-  `decision_missing_required_evidence(definition, transition, decision)`
-  applied to every decision transition, keeping the declarative call site's
-  behavior byte-compatible. Missing evidence yields the existing
-  `missing_required_evidence` reason-code path
-  (`store/recovery_validation.rs:51` already knows it).
-- Evidence classes are matched by `WorkflowEvidence` kind string; new kinds:
-  `verified_pr_binding`, `server_validation_digest`, `validation_report`,
-  `no_change_rationale`. Kinds are constants in `runtime/model.rs`.
+  `require_evidence(from, to, [classes])` and populate the Evidence Contract
+  table from `product.md` in `github_issue_pr_defaults`,
+  `prompt_task_defaults`, `quality_gate_defaults`, `pr_feedback_defaults`.
+  Population alone activates enforcement on the next decision through the
+  existing path.
+- `runtime/store/runtime_completion.rs`
+  (`declarative_decision_missing_required_evidence`) stays as-is: it is a
+  declarative-only pre-check layered above the general validator and its
+  behavior must remain byte-compatible.
+- Evidence classes are matched by `WorkflowEvidence` kind string
+  (conjunctive `BTreeSet` — see Component 4 for how the one disjunctive rule
+  is encoded). New kinds: `verified_pr_binding`, `server_validation_digest`,
+  `prompt_completion_evidence`. Kinds are constants in `runtime/model.rs`.
+- The retry exemption is intentional and preserved: evidence requirements
+  bind fact-minting transitions, not same-state activity retries.
 
 ### 2. Server-side quality-gate validation (`harness-server`)
 
@@ -103,14 +117,27 @@ fact before the claim can mint a transition.
 
 ### 4. Prompt-task completion evidence (`harness-workflow`)
 
+The product rule is disjunctive (`validation_report` OR
+`no_change_rationale`), but `TransitionRule::required_evidence` is a
+conjunctive set — listing both kinds would reject every valid decision, and
+listing neither enforces nothing. Chosen encoding: the reducer mints a
+single umbrella evidence kind, and the transition requires only that kind.
+This keeps the shared validator simple and conjunctive, avoids extending
+`TransitionRule` (and the declarative YAML schema that feeds it) with
+alternative-set semantics, and places the OR where the branching context
+already lives.
+
 - `reducer/prompt_task_completion.rs`: before returning
   `single_shot_done_decision` or `settled_done_decision`, check the result
   for a `validation_report` artifact (structured: list of `{command,
-  exit_code}`) or a `no_change_rationale` string artifact. Absent both,
-  return the existing `blocked_decision` helper with reason
+  exit_code}`) or a `no_change_rationale` string artifact. When either is
+  present, attach `WorkflowEvidence::new("prompt_completion_evidence",
+  <which alternative satisfied it>)` to the decision. Absent both, return
+  the existing `blocked_decision` helper with reason
   `prompt_completion_evidence_missing`.
-- The evidence is attached to the decision so the R1 transition check for
-  `implementing → done` observes it; the reducer check gives the agent a
+- `prompt_task_defaults` requires `prompt_completion_evidence` on
+  `implementing → done`, so a done-decision that bypasses the reducer check
+  still fails validation; the reducer check exists to give the agent a
   precise, retryable reason instead of a bare transition rejection.
 
 ### 5. Honest empty-window grading (`harness-observe`)

--- a/specs/GH1766/tech.md
+++ b/specs/GH1766/tech.md
@@ -1,0 +1,164 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1766
+
+## Design Overview
+
+Four fail-closed changes, all reusing existing machinery:
+
+1. **Evidence enforcement unification** — populate
+   `TransitionRule::required_evidence` for the built-in definitions and move
+   enforcement from the declarative-only check into the shared decision
+   transition path.
+2. **Server-side quality-gate validation** — the runtime worker executes the
+   configured `validation_commands` itself and attaches a
+   `server_validation_digest` evidence record; the reducer requires it for
+   `checking → passed`.
+3. **Verified PR binding** — resolve the claimed PR through the existing
+   GitHub client before applying `WorkflowCommand::bind_pr`.
+4. **Prompt-task completion evidence** — `single_shot_done_decision` /
+   `settled_done_decision` demand a `validation_report` artifact or a
+   structured `no_change_rationale`.
+
+The agent-authored `harness-activity-result` block remains the transport for
+claims; every change here converts one class of claim into a server-checked
+fact before the claim can mint a transition.
+
+## Current State (verified citations)
+
+| Fact | Location |
+| --- | --- |
+| `required_evidence` field exists, defaults empty | `crates/harness-workflow/src/runtime/validator.rs:24,39,53` |
+| Built-in allowlists never populate it | `validator.rs:119` (`github_issue_pr_defaults`), `:275`, `:293`, `:312`; `implementing → done` via bare `.allow` at `:211` and `:334` |
+| Only declarative workflows populate evidence | `crates/harness-workflow/src/runtime/declarative.rs:526` |
+| Only declarative decisions are checked | `crates/harness-workflow/src/runtime/store/runtime_completion.rs:169,219` |
+| Quality gate builds an enqueue decision only | `crates/harness-workflow/src/runtime/quality_gate.rs` (62 lines) |
+| Gate contract is prompt prose, not enforcement | `crates/harness-server/src/workflow_runtime_worker/activity_contract.rs:25,63,153`; `success_requires` consumed only by `prompt_packet.rs` |
+| `BindPr` reads the agent artifact unverified | `crates/harness-workflow/src/runtime/reducer/github_issue_completion.rs:177,193` |
+| Prompt task done on agent status | `crates/harness-workflow/src/runtime/reducer/prompt_task_completion.rs:30,166` |
+| Existing per-activity reducer check to generalize | `reducer/pr_feedback_completion.rs:62` (`pr_feedback_success_contract_error`) |
+| Terminal-evidence precedent | `crates/harness-workflow/src/runtime/validator_github_issue_pr.rs:58-97` |
+| Empty-window 100/A grading | `crates/harness-observe/src/quality.rs:26` |
+
+## Component Changes
+
+### 1. Evidence enforcement (`harness-workflow`)
+
+- `runtime/validator.rs`: add a builder method
+  `require_evidence(from, to, [classes])` usable by the default constructors;
+  populate the Evidence Contract table from `product.md` in
+  `github_issue_pr_defaults`, `prompt_task_defaults`,
+  `quality_gate_defaults`, `pr_feedback_defaults`.
+- `runtime/store/runtime_completion.rs`: generalize
+  `declarative_decision_missing_required_evidence` into
+  `decision_missing_required_evidence(definition, transition, decision)`
+  applied to every decision transition, keeping the declarative call site's
+  behavior byte-compatible. Missing evidence yields the existing
+  `missing_required_evidence` reason-code path
+  (`store/recovery_validation.rs:51` already knows it).
+- Evidence classes are matched by `WorkflowEvidence` kind string; new kinds:
+  `verified_pr_binding`, `server_validation_digest`, `validation_report`,
+  `no_change_rationale`. Kinds are constants in `runtime/model.rs`.
+
+### 2. Server-side quality-gate validation (`harness-server`)
+
+- New module `workflow_runtime_worker/server_validation.rs`:
+  `run_validation_commands(workspace_root, commands, timeout) -> ValidationDigest`
+  where `ValidationDigest { command, cwd, exit_code, output_sha256,
+  duration_ms, truncated }` per command, executed sequentially via the
+  existing process-spawn utilities (no shell interpolation: commands run via
+  the same argv-splitting path used elsewhere; commands come from
+  `WORKFLOW.md`, which is repo-owned configuration).
+- Integration point: when the worker completes a `run_quality_gate` activity,
+  it executes the commands itself in the leased workspace *after* the agent
+  turn, attaches the digest as `server_validation_digest` evidence on the
+  `ActivityResult`, and the `quality_gate` reducer requires that evidence for
+  `QualityPassed` to become `checking → passed`.
+- Failure modes: non-zero exit → `QualityFailed` with digest; spawn error or
+  timeout → blocked with a typed startup-error evidence record; no commands
+  configured → blocked with `validation_commands_missing` (never a pass).
+- Workspace note: reuses the activity's existing workspace lease; the run
+  happens before lease release in the same worker tick.
+
+### 3. Verified PR binding (`harness-server` + `harness-workflow`)
+
+- The reducer cannot call GitHub (workflow crate stays IO-free). Split the
+  flow: `bind_pr_from_activity_result` continues to produce the `BindPr`
+  command, but command application in the server-side dispatch path performs
+  verification via the existing GraphQL snapshot client
+  (`github_pr_snapshot.rs`) before commit:
+  - PR exists, state `OPEN`, repository matches the workflow subject.
+  - Head ref matches the workspace branch recorded in workflow data (or, for
+    deferred submissions, the candidate branch).
+  - On success: attach `verified_pr_binding { pr_number, head_oid,
+    observed_at }` evidence and apply the command.
+  - On failure: emit a blocked decision with reason
+    `pr_binding_verification_failed`; do not transition to `pr_open`; the
+    intake coverage gate must not count the issue as covered.
+- GitHub outage handling: verification errors (rate limit, 5xx) defer the
+  command via the existing dispatch-defer mechanism rather than blocking the
+  workflow, bounded by the standard retry policy.
+
+### 4. Prompt-task completion evidence (`harness-workflow`)
+
+- `reducer/prompt_task_completion.rs`: before returning
+  `single_shot_done_decision` or `settled_done_decision`, check the result
+  for a `validation_report` artifact (structured: list of `{command,
+  exit_code}`) or a `no_change_rationale` string artifact. Absent both,
+  return the existing `blocked_decision` helper with reason
+  `prompt_completion_evidence_missing`.
+- The evidence is attached to the decision so the R1 transition check for
+  `implementing → done` observes it; the reducer check gives the agent a
+  precise, retryable reason instead of a bare transition rejection.
+
+### 5. Honest empty-window grading (`harness-observe`)
+
+- `quality.rs::grade`: return a new `Grade::Unknown` variant (or
+  `Option<QualityReport>`) when `events.is_empty() && violation_count == 0`.
+  Sole consumer `quality_trigger.rs` treats `Unknown` as "no change to GC
+  cadence".
+
+## Data / Schema Impact
+
+None. Evidence rides the existing `WorkflowEvidence` records on decisions;
+digests are evidence payloads, not new tables. No migration.
+
+## Configuration
+
+- `runtime_completion_evidence_enforced: bool` (default `true`) in the
+  runtime section of `WORKFLOW.md` config — one release of kill-switch,
+  then removed.
+- Validation timeout: reuse the existing activity timeout configuration with
+  a dedicated `quality_gate_validation_timeout_secs` override (default 900).
+
+## Test Plan
+
+- `harness-workflow` unit: transition table tests per definition (accept
+  with evidence / reject without, reason codes asserted); prompt-task
+  reducer tests for all three terminal paths; declarative regression via the
+  unified check.
+- `harness-server` unit: `server_validation.rs` digest correctness, timeout,
+  spawn-failure, no-commands cases; `BindPr` verification against a mocked
+  snapshot client (nonexistent / closed / wrong-repo / wrong-head / valid).
+- Integration (Postgres-gated, existing harness): end-to-end quality-gate
+  flow where agent claims pass and server run fails; end-to-end prompt task
+  blocked on missing evidence; rejected decision leaves the instance row
+  unchanged (snapshot comparison).
+
+## Risks and Mitigations
+
+- **Legitimate work blocked** (agents not yet emitting `validation_report`):
+  reason codes are precise and retryable; the prompt packet already tells
+  agents the contract (`activity_contract.rs:143`), and the kill switch
+  covers the transition release.
+- **GitHub API dependence at bind time**: deferred (not blocked) on
+  transport errors; only definitive negative answers block.
+- **Double execution of validation commands** (agent ran them, server
+  re-runs): accepted cost — the server run is the authoritative one; agents
+  may skip self-running gate commands once the contract documents the server
+  re-run.
+- **Workspace state divergence** (server validates a tree the agent mutated
+  after its claimed run): inherent to re-verification and is the point — the
+  digest reflects the tree that will be pushed.


### PR DESCRIPTION
## Summary

Analysis report + spec packet for making workflow completion a server-verified fact instead of an agent-authored claim.

- `docs/references/server-verified-completion.md` — full trust-boundary analysis: what already works (zero-output detection, structured-result requirement, status-contract downgrade, server-owned PR inspection, terminal-evidence validation) and six false-done risks with verified citations (prompt tasks done on agent status alone; no independent re-verification of result blocks; unverified `BindPr`; `required_evidence` empty in all four built-in allowlists; LLM-executed quality gate; empty-window 100/A grading).
- `specs/GH1766/product.md` + `specs/GH1766/tech.md` — fail-closed spec for four changes: populate `required_evidence` on critical built-in transitions via one unified enforcement path, server-side re-execution of quality-gate validation commands with output digests, PR existence/head verification at `BindPr`, and prompt-task done requiring `validation_report` or explicit `no_change_rationale`.

Docs-only change; no code touched.

Refs #1766