### PR TITLE
spec(GH1767): define review integrity hardening

### DIFF
--- a/docs/references/review-integrity.md
+++ b/docs/references/review-integrity.md
@@ -1,0 +1,207 @@
+# Review Integrity — Analysis Report
+
+> Linked issue: GH-1767
+> Date: 2026-07-26
+> Scope: the code-review layer of the harness — cross-agent review, review
+> degradation behavior, and the fate of the external-bot review escalation
+> ladder after the legacy `task_executor` removal (#1725).
+> Method: read-only inspection at commit `81c78255`. All file:line references
+> were re-verified at that commit.
+
+## 1. The live review chain (what runs today)
+
+A `github_issue_pr` workflow passes through four review-relevant gates before
+merge:
+
+1. **`local_review_gate`** — the runtime enqueues a `run_local_review`
+   activity. An agent reviews the PR diff and reports
+   `LocalReviewPassed / LocalReviewChangesRequested / LocalReviewBlocked`
+   signals (`crates/harness-workflow/src/runtime/pr_feedback.rs`). The
+   reviewer's verdict arrives through the agent-authored
+   `harness-activity-result` block.
+2. **`awaiting_feedback`** — a child `pr_feedback` workflow runs
+   `inspect_pr_feedback`, which is **server-owned**: the server queries GitHub
+   GraphQL itself (`crates/harness-server/src/github_pr_snapshot.rs`) and no
+   LLM is involved in observing review threads, check status, or mergeability.
+3. **`quality_gate_pending`** — a child `quality_gate` workflow runs
+   validation commands from `WORKFLOW.md` via a `run_quality_gate` activity.
+4. **`ready_to_merge` → `merging`** — the merge is executed server-side
+   (`crates/harness-server/src/workflow_runtime_worker/server_merge.rs`),
+   re-snapshotting before the merge call and verifying
+   `expected_head_sha_for_merge` (`server_merge.rs:136-151`), under the
+   deterministic policy in `crates/harness-server/src/http/auto_merge.rs`
+   (`status_check_rollup_state == SUCCESS`, `review_decision == APPROVED`,
+   draft = false, review threads resolved, base-ref match).
+
+### Structural strengths worth preserving
+
+- **The merge gate is deterministic and server-fed.** Every predicate is
+  evaluated against a server-collected GraphQL snapshot, never against agent
+  prose.
+- **No self-approval by construction.** The harness never calls the GitHub
+  review-submission API (no `submit_review` / `pulls/*/reviews` call sites
+  anywhere in `crates/`), so the `review_decision == APPROVED` requirement can
+  only be satisfied by an external reviewer.
+- **Head identity is pinned at merge.** A stale snapshot cannot merge a PR
+  whose head moved (`server_merge.rs:147-151`).
+
+## 2. Defect G — cross-review fails open on protocol violation
+
+`crates/harness-server/src/handlers/cross_review.rs:224-239`:
+
+```rust
+consensus_issues = extract_tagged(&challenger_review, "CONFIRMED")
+    .into_iter()
+    .chain(extract_tagged(&challenger_review, "MISSED"))
+    .collect();
+
+if consensus_issues.is_empty() {
+    ...
+    final_verdict: "APPROVED".to_string(),
+```
+
+`extract_tagged` matches line prefixes (`CONFIRMED:` / `MISSED:` /
+`FALSE-POSITIVE:`). Any challenger output that does not use the tag protocol —
+an empty string, a refusal, a quota-exhaustion error message that reached
+stdout, or ordinary prose describing real problems — produces an empty
+`consensus_issues` set and therefore the verdict `APPROVED`.
+
+The now-deleted sibling implementation made the opposite (correct) choice: the
+legacy `task_executor/agent_review.rs:430-454` treated reviewer output with
+neither `APPROVED` nor `ISSUE:` lines as a **protocol failure that fails the
+task**, precisely to avoid crediting no-op review passes. The same repository
+therefore shipped both polarities of the same decision; the surviving one is
+the unsafe one.
+
+Failure scenario: the challenger CLI hits a usage limit and prints a
+one-line quota message. `extract_tagged` finds no tags, the function returns
+`final_verdict: "APPROVED"` with `contested_issues: []`, and the caller
+records a clean cross-review that never happened.
+
+## 3. Defect H — silent single-model degradation
+
+Two variants:
+
+1. **No challenger registered.**
+   `cross_review.rs:135-148`: when `challenger` is `None` the function returns
+   a result whose only distinguishing marks are `challenger_review: ""` and
+   `rounds: 1`. The doc comment calls this "graceful degradation", but nothing
+   in `CrossReviewResult` names it: there is no `degraded: bool`, no
+   `challenger_id`, and `final_verdict` is the same `"APPROVED"` string the
+   full protocol produces. Downstream consumers cannot distinguish
+   "two models agreed" from "one model reviewed itself" without string-sniffing
+   an empty field.
+2. **Primary and challenger are the same model.**
+   `cross_review.rs:59-64`: `primary` is `agent_registry.default_agent()` and
+   `challenger` is `agent_registry.get("codex")`. If the default agent *is*
+   codex, the same model plays both roles. No identity comparison exists, so
+   the result is presented as adversarial cross-review while being a
+   self-conversation.
+
+The value of cross-review is exactly its independence assumption; a result
+object that cannot express "independence was not achieved" converts every
+degraded run into silent overconfidence.
+
+## 4. Defect: the external-review escalation ladder was deleted without a port
+
+History:
+
+- The legacy `task_executor/` layer contained the external-bot review driver:
+  `ReviewBotKey::{Gemini, Codex}` reviewer identities, quota-exhaustion
+  detection (`is_quota_exhausted`, "codex usage limits have been reached"),
+  the `ReviewFallbackTier::{A, B, C}` /
+  `ReviewFallbackTrigger::{GeminiQuota, CodexQuota, AllBotsQuota, Silence}`
+  graduation ladder, Jaccard-similarity repeat-issue detection
+  (`agent_review.rs`), and head-SHA-bound local-review approval verification
+  (`local_review_completion.rs`: approvals carried an `approved_review_sha`,
+  re-verified against the live head before completion).
+- Commit `af5bcd26` (`refactor(server): remove legacy task_executor execution
+  path (GH-1434 T008)`, PR #1725) deleted the entire layer: 72 files,
+  **−19,436 lines**.
+
+What survived, verified at `81c78255`:
+
+- The **data model** survived: `ReviewFallbackSnapshot`, `ReviewFallbackTier`,
+  `ReviewFallbackTrigger` in
+  `crates/harness-workflow/src/issue_lifecycle.rs:102-121`, plus the store
+  method `record_ready_to_merge_with_fallback`
+  (`issue_workflow_store.rs:411`).
+- The **producers did not**: the only non-test constructor of
+  `ReviewFallbackSnapshot` is inside `issue_lifecycle.rs` itself; grep over
+  `crates/harness-server/src/workflow_runtime_worker/`,
+  `workflow_runtime_pr_feedback/`, and `crates/harness-workflow/src/runtime/`
+  finds **zero** references to Gemini, review bots, quota triggers, or
+  fallback tiers. Nothing on the live path ever creates a Tier-A/B/C
+  snapshot.
+
+Consequences:
+
+1. **No review-bot escalation exists anywhere.** When the external reviewer
+   (e.g. the Gemini bot the PR workflow depends on) is silent or
+   quota-exhausted, the live system has no fallback: the workflow simply
+   waits in `awaiting_feedback` / fails the `review_decision == APPROVED`
+   merge predicate indefinitely. The legacy ladder existed precisely because
+   bot quota exhaustion is a routine operational event (documented in the
+   2026-07 operations audit: Gemini/Codex bots hitting quota blocked merge
+   gates across repos).
+2. **Head-bound local-review approval verification is gone.** The runtime's
+   head pinning now exists only at the merge step (`server_merge.rs`); the
+   local review gate accepts a `LocalReviewPassed` signal without proof of
+   *which commit* was reviewed. A review of head N followed by a push of
+   head N+1 still passes the local gate.
+3. **Vestigial model invites false confidence.** `GH-1715`'s transition
+   contract carefully specifies Tier-C fallback snapshot semantics
+   (`Mergeable` event, `review_fallback` preservation) for a producer that no
+   longer exists. Readers of `issue_lifecycle.rs` and its tests reasonably —
+   and wrongly — conclude the ladder is live.
+
+## 5. Port-or-delete analysis
+
+Two coherent end states:
+
+**Option A — port the escalation ladder into the workflow runtime.**
+Reintroduce external-review escalation as runtime concepts: a
+`review_escalation` state or signal family on the `pr_feedback` child
+workflow, driven by the server-owned snapshot (bot silence = no review events
+after N sweeps; quota = bot comment matching known quota patterns), graduating
+review authority Tier A (external bot) → Tier B (alternate bot) → Tier C
+(harness-internal independent agent review with distinct-model guarantee +
+operator gate). Keeps the merge predicate `review_decision == APPROVED`
+intact for Tiers A/B and substitutes an explicit operator-visible fallback
+receipt for Tier C.
+
+**Option B — delete the vestigial model.**
+Remove `ReviewFallbackSnapshot`/`Tier`/`Trigger` and
+`record_ready_to_merge_with_fallback`, accept "wait for external review or
+operator intervention" as the only behavior, and document it.
+
+**Recommendation: Option A, in reduced form.** Operational history shows bot
+quota exhaustion and bot silence are weekly events, not corner cases; without
+escalation, every such event is an indefinite stall that pages an operator.
+The reduced port keeps the ladder's *decision structure* (trigger taxonomy +
+tier graduation + durable snapshot) but re-grounds every trigger in the
+server-owned GraphQL snapshot instead of legacy prose parsing. The vestigial
+data model should be reused, not duplicated: it already has validated
+transition semantics from GH-1715.
+
+Independent of A/B, defects G and H are unconditional fixes: cross-review must
+fail closed on protocol violation, and degraded runs must say so in the
+result.
+
+## 6. Recommended contract (summary)
+
+1. Challenger output containing no protocol tags is a **protocol failure**:
+   the round is invalid, and cross-review returns an error or a
+   `PROTOCOL_FAILURE` verdict — never `APPROVED`.
+2. `CrossReviewResult` carries `mode` (`cross_model` | `single_model_degraded`),
+   `primary_agent_id`, `challenger_agent_id`. Same-identity primary/challenger
+   is refused or reported as degraded, never as cross-review.
+3. External-review escalation is a runtime-owned ladder driven by server
+   snapshots, with each tier transition recorded as a durable, operator-visible
+   event; Tier-C completion requires an operator gate.
+4. The legacy fallback data model either gains a live producer (Option A) or
+   is deleted with its store method (Option B); it does not remain
+   producer-less.
+
+See `specs/GH1767/product.md` and `specs/GH1767/tech.md` for the binding
+behavior contract.

--- a/docs/references/review-integrity.md
+++ b/docs/references/review-integrity.md
@@ -38,10 +38,11 @@ merge:
 - **The merge gate is deterministic and server-fed.** Every predicate is
   evaluated against a server-collected GraphQL snapshot, never against agent
   prose.
-- **No self-approval by construction.** The harness never calls the GitHub
-  review-submission API (no `submit_review` / `pulls/*/reviews` call sites
-  anywhere in `crates/`), so the `review_decision == APPROVED` requirement can
-  only be satisfied by an external reviewer.
+- **No self-approval by construction.** The harness never submits reviews:
+  the only `pulls/*/reviews` references in `crates/` are read-only `gh api`
+  GETs embedded in agent prompts (`prompts/pr.rs:25,204`;
+  `prompts/review.rs:94,124`), so the `review_decision == APPROVED`
+  requirement can only be satisfied by an external reviewer.
 - **Head identity is pinned at merge.** A stale snapshot cannot merge a PR
   whose head moved (`server_merge.rs:147-151`).
 
@@ -123,16 +124,25 @@ What survived, verified at `81c78255`:
 
 - The **data model** survived: `ReviewFallbackSnapshot`, `ReviewFallbackTier`,
   `ReviewFallbackTrigger` in
-  `crates/harness-workflow/src/issue_lifecycle.rs:102-121`, plus the store
+  `crates/harness-workflow/src/issue_lifecycle.rs:101-126`, plus the store
   method `record_ready_to_merge_with_fallback`
   (`issue_workflow_store.rs:411`).
 - The **producers did not**: the only non-test constructor of
   `ReviewFallbackSnapshot` is inside `issue_lifecycle.rs` itself; grep over
   `crates/harness-server/src/workflow_runtime_worker/`,
   `workflow_runtime_pr_feedback/`, and `crates/harness-workflow/src/runtime/`
-  finds **zero** references to Gemini, review bots, quota triggers, or
-  fallback tiers. Nothing on the live path ever creates a Tier-A/B/C
-  snapshot.
+  finds **zero** references to fallback tiers or any `ReviewFallbackSnapshot`
+  producer. Nothing on the live path ever creates a Tier-A/B/C snapshot.
+  Quota *detection* does exist on the runtime path — but it is derived from
+  agent-reported prose, not server observation:
+  `turn_error_is_non_retryable_agent_limit` calls
+  `is_quota_failure_message` over turn error text
+  (`workflow_runtime_worker/activity_result.rs:462`), and the status contract
+  emits a `text:review_quota_blocker` signal from substring matching on the
+  agent's own summary (`activity_status_contract.rs:204-205`). Neither feeds
+  any escalation; both strengthen the case for B-009's server-derived
+  triggers, since today's only quota signals originate in the very
+  agent-authored text the escalation contract must not trust.
 
 Consequences:
 

--- a/specs/GH1767/product.md
+++ b/specs/GH1767/product.md
@@ -40,6 +40,12 @@ response to external-reviewer unavailability.
   triggers.
 - Changing the `pr_feedback` inspection ownership (it remains server-owned).
 - Altering the GH-1715 legacy lifecycle transition contract.
+- Head-SHA-bound local-review verification. The runtime's local review gate
+  currently accepts `LocalReviewPassed` without binding the approval to the
+  reviewed commit (the legacy `approved_review_sha` re-verification was
+  deleted with `task_executor`); restoring that binding is a real gap but is
+  deferred to a follow-up spec — this contract covers cross-review protocol
+  integrity and external-review escalation only.
 
 ## User-Visible Behavior
 

--- a/specs/GH1767/product.md
+++ b/specs/GH1767/product.md
@@ -1,0 +1,144 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1767
+
+## User Problem
+
+Cross-agent review is the harness's independence guarantee between
+implementation and merge. Today that guarantee fails open: a challenger reply
+that violates the tag protocol (empty output, refusal, quota error, untagged
+prose) yields the verdict `APPROVED`, and a run with no challenger — or with
+the same model in both roles — produces a result indistinguishable from a
+genuine two-model review. Separately, the external-review escalation ladder
+(bot quota / bot silence fallback) was deleted with the legacy `task_executor`
+path (#1725) without a runtime replacement, leaving its data model
+(`ReviewFallbackSnapshot` and tiers) producer-less and leaving workflows with
+no defined behavior when the external reviewer never responds.
+
+Operators need review verdicts that cannot be manufactured by protocol
+violations, degraded runs that identify themselves, and a defined, escalating
+response to external-reviewer unavailability.
+
+## Goals
+
+- Cross-review fails closed on challenger protocol violations.
+- Every cross-review result names its mode and the identities of both
+  reviewers; single-model and same-model runs are explicitly marked degraded.
+- Define a runtime-owned external-review escalation ladder driven by
+  server-collected GitHub snapshots, reusing the existing
+  `ReviewFallbackSnapshot` tier model.
+- End the producer-less state of the review-fallback data model: it gains a
+  live runtime producer under this contract.
+
+## Non-Goals
+
+- Changing the server merge-gate policy (`auto_merge.rs` predicates) itself.
+- Adding new external review-bot integrations or changing bot identities.
+- Reintroducing the deleted `task_executor` code or its prose-parsing
+  triggers.
+- Changing the `pr_feedback` inspection ownership (it remains server-owned).
+- Altering the GH-1715 legacy lifecycle transition contract.
+
+## User-Visible Behavior
+
+1. **B-001:** A challenger reply containing no protocol tag lines
+   (`CONFIRMED:` / `FALSE-POSITIVE:` / `MISSED:`) is a protocol failure. The
+   cross-review result records verdict `PROTOCOL_FAILURE` for that run; it is
+   never reported as `APPROVED`.
+2. **B-002:** A protocol-failure verdict identifies the failing round, the
+   challenger identity, and a bounded excerpt of the offending reply for
+   diagnosis.
+3. **B-003:** Every cross-review result carries `mode`
+   (`cross_model` | `single_model_degraded`), `primary_agent_id`, and
+   `challenger_agent_id`.
+4. **B-004:** A run with no available challenger completes only as
+   `single_model_degraded`; its verdict namespace is distinct (e.g.
+   `APPROVED_DEGRADED`), so no consumer can mistake it for a two-model
+   approval.
+5. **B-005:** A run whose resolved challenger identity equals the primary
+   identity is treated exactly as "no challenger": it cannot produce a
+   `cross_model` result.
+6. **B-006:** External-review escalation is a runtime ladder over the
+   `pr_feedback` workflow: Tier A (primary external bot) → Tier B (alternate
+   external bot) → Tier C (harness-internal independent review + operator
+   gate). Tier transitions occur only on defined triggers observed from
+   server-collected snapshots: reviewer quota exhaustion or reviewer silence
+   past a configured threshold.
+7. **B-007:** Each tier transition persists a `ReviewFallbackSnapshot` (tier,
+   trigger, active bot, activation time) as durable, operator-visible
+   evidence, honoring the GH-1715 preservation semantics (first snapshot
+   wins; a conflicting logical fallback is an error).
+8. **B-008:** Tier C never self-satisfies the merge gate: completing a Tier-C
+   internal review routes the workflow to an operator gate; the merge
+   predicate `review_decision == APPROVED` is not simulated or bypassed.
+9. **B-009:** Escalation triggers derive only from server-owned GitHub
+   snapshot data (review events, bot comments, timestamps) — never from
+   agent-authored activity results.
+10. **B-010:** When escalation is disabled by configuration, reviewer
+    unavailability leaves the workflow in its waiting state and emits a
+    distinct operator-attention signal instead of stalling silently.
+
+## Acceptance Criteria
+
+- [ ] Unit tests prove empty, refusal-shaped, and untagged challenger replies
+      produce `PROTOCOL_FAILURE`, never `APPROVED`, at every round position.
+- [ ] Tests prove tagged replies still classify CONFIRMED / FALSE-POSITIVE /
+      MISSED exactly as before (no behavior change for protocol-conforming
+      output).
+- [ ] Tests prove `mode`, `primary_agent_id`, and `challenger_agent_id` are
+      populated in all paths, and that the no-challenger and same-identity
+      paths produce `single_model_degraded` with the degraded verdict
+      namespace.
+- [ ] Runtime tests prove Tier A→B and B→C transitions fire only on the
+      defined snapshot-derived triggers, persist exactly one fallback
+      snapshot per logical fallback, and are idempotent under repeated
+      observation.
+- [ ] Tests prove Tier-C completion routes to an operator gate and cannot
+      reach `merging` without it.
+- [ ] Tests prove agent-authored activity results cannot trigger or advance
+      escalation.
+- [ ] `ReviewFallbackSnapshot` has at least one non-test producer, or —
+      should the escalation scope be cut during implementation — the model
+      and `record_ready_to_merge_with_fallback` are removed in the same
+      change (no third producer-less state).
+
+## Boundary Checklist
+
+| Boundary | Verdict |
+| --- | --- |
+| Empty / missing input | Covered by B-001, B-004: empty challenger output and absent challenger are both explicit, named outcomes. |
+| Error and failure paths | Covered by B-001, B-002, B-010: protocol failure and reviewer unavailability are visible errors/signals, never success-shaped. |
+| Authorization / permission | Covered by B-008: Tier C cannot satisfy the merge approval predicate; operator authority is preserved. |
+| Concurrency / race / ordering | Covered by B-007 via GH-1715 first-snapshot-wins semantics; repeated trigger observation is idempotent. |
+| Retry / repetition / idempotency | Covered by B-007; re-observing the same trigger does not duplicate snapshots or re-escalate. |
+| Illegal state transitions | Covered by B-006: tier order is monotonic A→B→C; skipping or reversing tiers is illegal. |
+| Compatibility / migration | Covered by Non-Goals: merge gate, snapshot ownership, and GH-1715 contract unchanged; existing rows readable. |
+| Degradation / fallback | Covered by B-003–B-005: degradation is always named, never silent. |
+| Evidence and audit integrity | Covered by B-002, B-007, B-009: all escalation evidence is server-derived and durable. |
+| Cancellation / interruption / partial completion | Covered by B-010 and B-007: interrupted escalation leaves a durable snapshot and a waiting state with operator signal. |
+
+## Edge Cases
+
+- Challenger returns tags plus a trailing quota-error line (valid round; the
+  error text is not a tag and is ignored).
+- Challenger returns only `FALSE-POSITIVE:` lines (valid: consensus empty,
+  contested populated — genuine `APPROVED`, not protocol failure).
+- The registry's default agent is the same binary/model as the named
+  challenger under a different registration key.
+- The external bot posts a quota-exhaustion comment and later recovers before
+  the silence threshold elapses.
+- Both external bots are quota-exhausted in the same sweep (A→B→C in rapid
+  succession must still record each transition).
+- Escalation configured off while a persisted Tier-B snapshot exists from an
+  earlier deployment.
+
+## Rollout Notes
+
+Protocol-failure hardening (B-001–B-005) is a behavior change for consumers
+that previously received `APPROVED` from malformed challenger output; monitor
+cross-review failure rates after rollout — a spike reveals latent challenger
+misconfiguration, not a regression. The escalation ladder ships behind
+configuration (default off for one release), then defaults on. Reverting
+restores fail-open review verdicts and producer-less fallback state.

--- a/specs/GH1767/tech.md
+++ b/specs/GH1767/tech.md
@@ -1,0 +1,201 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1767
+
+## Context
+
+Three review-integrity defects verified at commit `81c78255` (full analysis:
+`docs/references/review-integrity.md`):
+
+1. `crates/harness-server/src/handlers/cross_review.rs:224-239` — challenger
+   output with no `CONFIRMED:`/`MISSED:` tag lines yields an empty consensus
+   set, which returns `final_verdict: "APPROVED"`. Fail-open.
+2. `cross_review.rs:135-148` — absent challenger silently degrades to a
+   single-model result distinguishable only by `challenger_review: ""`;
+   `cross_review.rs:59-64` — `default_agent()` vs `get("codex")` can resolve
+   to the same agent with no identity check.
+3. PR #1725 (`af5bcd26`) deleted the legacy `task_executor` layer (−19,436
+   lines) including the external-bot review escalation driver
+   (`ReviewBotKey`, quota detection, `ReviewFallbackTier` graduation). The
+   data model survives producer-less in
+   `crates/harness-workflow/src/issue_lifecycle.rs:102-121` and
+   `issue_workflow_store.rs:411`; no runtime path references bot fallback at
+   all.
+
+## Design
+
+### D1 — Fail-closed cross-review protocol
+
+Extend `CrossReviewResult` (`handlers/cross_review.rs:40-48`):
+
+```rust
+pub struct CrossReviewResult {
+    pub mode: CrossReviewMode,          // CrossModel | SingleModelDegraded
+    pub primary_agent_id: String,
+    pub challenger_agent_id: Option<String>,
+    pub primary_review: String,
+    pub challenger_review: String,
+    pub consensus_issues: Vec<String>,
+    pub contested_issues: Vec<String>,
+    pub rounds: u32,
+    pub final_verdict: CrossReviewVerdict,
+    pub protocol_failure: Option<ProtocolFailure>, // round, excerpt (bounded)
+}
+
+pub enum CrossReviewVerdict {
+    Approved,            // cross_model, tags parsed, no consensus issues
+    ApprovedDegraded,    // single_model_degraded, no issues
+    NotConverged,
+    ProtocolFailure,
+}
+```
+
+Rules in `run_cross_review_with_context`:
+
+- After each challenger round, if
+  `extract_tagged(reply, "CONFIRMED") ∪ extract_tagged(reply, "MISSED") ∪
+  extract_tagged(reply, "FALSE-POSITIVE")` is empty **and** the reply contains
+  no tag prefix at all, return `ProtocolFailure { round, excerpt }` with
+  verdict `ProtocolFailure`. A reply with only `FALSE-POSITIVE:` tags remains
+  a valid approving round (protocol was followed).
+- The no-challenger branch (`:135-148`) sets
+  `mode = SingleModelDegraded`, `challenger_agent_id = None`, and maps an
+  empty issue set to `ApprovedDegraded` (never `Approved`).
+- Identity guard at `cross_review(...)` (`:59-64`): resolve both agents, and
+  if `primary.id() == challenger.id()` treat as no-challenger. `CodeAgent`
+  gains an `fn id(&self) -> &str` (registry key + model) — additive trait
+  method with a default implementation returning the registry key.
+
+Serialization: `final_verdict` continues to serialize as an uppercase string
+(`"APPROVED"`, `"APPROVED_DEGRADED"`, `"NOT_CONVERGED"`,
+`"PROTOCOL_FAILURE"`) for RPC compatibility; `mode` and agent ids are new
+additive fields.
+
+### D2 — Runtime external-review escalation ladder
+
+New module `crates/harness-workflow/src/runtime/review_escalation.rs` plus a
+server driver hooked into the existing `pr_feedback` sweep (the same loop
+that runs server-owned `inspect_pr_feedback`).
+
+Trigger evaluation (pure function over the server GraphQL snapshot +
+persisted fallback state):
+
+```rust
+pub enum EscalationTrigger {
+    ReviewerQuotaExhausted { bot: String },  // bot comment matches quota patterns
+    ReviewerSilence { waited_secs: u64 },    // no review event since PR head push, past threshold
+}
+
+pub fn evaluate_escalation(
+    snapshot: &PrSnapshot,
+    current: Option<&ReviewFallbackSnapshot>,
+    policy: &EscalationPolicy,
+    now: DateTime<Utc>,
+) -> Option<EscalationStep>; // None | Some(ToTierB{..}) | Some(ToTierC{..})
+```
+
+- Inputs are exclusively server-collected (`github_pr_snapshot.rs` output:
+  review events, comment bodies + authors, timestamps, head push time).
+  Agent activity results are not consulted (B-009).
+- Quota patterns are configuration (`WORKFLOW.md` `review_escalation.bots[]`
+  with `name`, `quota_patterns[]`), not hardcoded prose heuristics.
+- Tier order is monotonic; `evaluate_escalation` returns `None` when the
+  persisted tier already covers the observed trigger (idempotent under
+  re-observation, satisfying GH-1715 first-snapshot-wins).
+
+Persistence reuses the existing model: the driver applies the `Mergeable` /
+fallback path through `IssueWorkflowStore::record_ready_to_merge_with_fallback`
+for legacy rows and stores the snapshot in `workflow.data.review_fallback`
+for runtime instances (same shape, one serializer). Each transition also
+emits a `WorkflowEvent` so escalation history is auditable in
+`workflow_events`.
+
+Tier C: enqueue an internal independent review activity that runs under D1's
+cross-review with `mode` required to be `CrossModel` (distinct model enforced
+by the identity guard); on completion the workflow enters
+`ready_to_merge`-adjacent **operator gate** (`RequestOperatorAttention`
+command), never `merging` directly. The `auto_merge.rs` predicate set is
+untouched: without an external `review_decision == APPROVED`, server merge
+still refuses; Tier C exists to hand an operator a reviewed, evidence-backed
+PR, not to merge it.
+
+Configuration:
+
+```yaml
+review_escalation:
+  enabled: false          # default off for one release
+  silence_threshold_secs: 86400
+  bots:
+    - name: gemini
+      quota_patterns: ["exceeded your current quota", ...]
+    - name: codex
+      quota_patterns: ["usage limits have been reached", ...]
+```
+
+`enabled: false` + observed trigger → emit `RequestOperatorAttention` with a
+distinct reason code (B-010).
+
+### D3 — No producer-less model
+
+This spec's implementation lands the D2 producer. If D2 is descoped, the
+same change set must instead delete `ReviewFallbackSnapshot`,
+`ReviewFallbackTier`, `ReviewFallbackTrigger`,
+`record_ready_to_merge_with_fallback`, and their GH-1715 contract rows —
+tracked as an explicit either/or acceptance criterion, so the vestigial state
+cannot persist.
+
+## Affected Surface
+
+| Area | Files |
+| --- | --- |
+| Cross-review protocol | `crates/harness-server/src/handlers/cross_review.rs`, `crates/harness-core/src/prompts/cross_review.rs` (challenger prompt states the fail-closed tag contract), `crates/harness-core/src/agent.rs` (additive `CodeAgent::id`) |
+| Escalation ladder | new `crates/harness-workflow/src/runtime/review_escalation.rs`, `crates/harness-server/src/workflow_runtime_pr_feedback/` (sweep driver hook), `crates/harness-workflow/src/issue_lifecycle.rs` (reused model, no shape change) |
+| Config | `WORKFLOW.md` schema (`review_escalation` block), `crates/harness-core/src/config/` |
+| Docs | `docs/references/review-integrity.md` (this analysis) |
+
+## Test Plan
+
+1. **Protocol table test** (`cross_review` unit): reply matrix {empty,
+   whitespace, refusal prose, quota message, untagged issue prose,
+   only FALSE-POSITIVE tags, mixed tags + trailing error line} × round
+   position {1, mid, final} → expected verdict per B-001/B-002; snapshot the
+   bounded excerpt.
+2. **Identity/degradation tests**: no challenger; same registry key; same
+   model under different keys → `SingleModelDegraded` + `ApprovedDegraded`;
+   distinct models → `CrossModel`.
+3. **Escalation pure-function table test**: snapshot fixtures for quota
+   comment, silence below/above threshold, recovery-before-threshold,
+   both-bots-exhausted, existing Tier-B snapshot, disabled policy →
+   expected `EscalationStep`/`None`/operator-signal.
+4. **Runtime integration**: Tier transition persists exactly one snapshot and
+   one `WorkflowEvent` under repeated sweeps; Tier-C completion cannot reach
+   `merging` without the operator gate (reuse `server_merge.rs` stale-head
+   test harness); agent activity result attempting to set
+   `review_fallback` is rejected by the existing
+   `agent_must_not_edit_workflow_tables` contract.
+5. **Compatibility**: existing serialized `CrossReviewResult` consumers
+   (RPC round-trip test) tolerate the additive fields; legacy lifecycle rows
+   with persisted fallback snapshots load unchanged (GH-1715 tests stay
+   green).
+
+## Risks
+
+- **Verdict namespace change**: consumers switching on the exact string
+  `"APPROVED"` will now also see `"APPROVED_DEGRADED"` and
+  `"PROTOCOL_FAILURE"`. This is the point — but it must be called out in the
+  changelog; grep shows the only in-repo consumer is the RPC handler and
+  tests.
+- **Quota-pattern drift**: bot quota messages change wording; patterns are
+  config, and a miss degrades to the silence trigger (bounded delay, not a
+  stall).
+- **False silence triggers** on repos with genuinely slow human review:
+  threshold is per-config; the default (24h) errs long, and Tier B is another
+  bot, not a merge shortcut.
+
+## Effort
+
+- D1 (fail-closed + identity + degradation marking): ~1 day incl. tests.
+- D2 (escalation ladder, config, driver, integration tests): ~3–4 days.
+- D3 rides on D2 (or is a half-day deletion if D2 is descoped).

--- a/specs/GH1767/tech.md
+++ b/specs/GH1767/tech.md
@@ -20,7 +20,7 @@ Three review-integrity defects verified at commit `81c78255` (full analysis:
    lines) including the external-bot review escalation driver
    (`ReviewBotKey`, quota detection, `ReviewFallbackTier` graduation). The
    data model survives producer-less in
-   `crates/harness-workflow/src/issue_lifecycle.rs:102-121` and
+   `crates/harness-workflow/src/issue_lifecycle.rs:101-126` and
    `issue_workflow_store.rs:411`; no runtime path references bot fallback at
    all.
 
@@ -100,7 +100,13 @@ pub fn evaluate_escalation(
   review events, comment bodies + authors, timestamps, head push time).
   Agent activity results are not consulted (B-009).
 - Quota patterns are configuration (`WORKFLOW.md` `review_escalation.bots[]`
-  with `name`, `quota_patterns[]`), not hardcoded prose heuristics.
+  with `name`, `quota_patterns[]`), not hardcoded prose heuristics. This is
+  distinct from the legacy approach in kind, not just configurability: the
+  patterns match against **server-collected bot comments** from the GraphQL
+  snapshot (attributed author, timestamp, durable), whereas the deleted
+  ladder — and the surviving `is_quota_failure_message` /
+  `text:review_quota_blocker` checks — match agent-reported stdout/summary
+  prose, which B-009 excludes as a trigger source.
 - Tier order is monotonic; `evaluate_escalation` returns `None` when the
   persisted tier already covers the observed trigger (idempotent under
   re-observation, satisfying GH-1715 first-snapshot-wins).


### PR DESCRIPTION
## Summary

Analysis report + spec packet for review-integrity hardening:

- `docs/references/review-integrity.md` — full analysis of the live review chain and three defects, re-verified at `81c78255`: (1) cross-review fails open on challenger protocol violations (`handlers/cross_review.rs:224-239` — untagged/empty output → `APPROVED`); (2) silent single-model degradation and undetected primary==challenger identity (`cross_review.rs:135-148`, `:59-64`); (3) the external-bot review escalation ladder was deleted with the legacy `task_executor` path (#1725, −19,436 lines) without a runtime port, leaving `ReviewFallbackSnapshot`/`ReviewFallbackTier` producer-less and reviewer quota/silence with no defined response.
- `specs/GH1767/product.md` — behavior contract: fail-closed protocol verdicts (`PROTOCOL_FAILURE`), explicit degradation mode + reviewer identities in every result, a snapshot-driven Tier A→B→C escalation ladder with operator-gated Tier C, and an either/or criterion ending the producer-less model state.
- `specs/GH1767/tech.md` — design: `CrossReviewVerdict`/`CrossReviewMode` extension, `CodeAgent::id` identity guard, pure-function `evaluate_escalation` over server-owned GraphQL snapshots, reuse of the GH-1715 fallback model, config schema, test plan.

Spec-only: no code behavior changes in this PR.

Refs #1767