### PR TITLE
spec(GH1769): define semantic retrieval and context enforcement

### DIFF
--- a/docs/references/semantic-retrieval-and-context.md
+++ b/docs/references/semantic-retrieval-and-context.md
@@ -1,0 +1,198 @@
+# Semantic Retrieval and Context Enforcement — Analysis
+
+> Date: 2026-07-26
+> Scope: every mechanism that selects knowledge (skills, repo memory, context
+> items, routing) for injection into agent prompts.
+> Method: read-only inspection at commit `81c78255`. Line numbers cited were
+> verified against that commit.
+> Linked issue: GH-1769. Spec packet: `specs/GH1769/`.
+
+## Executive Summary
+
+Harness has accumulated four distinct knowledge-selection surfaces — skill
+matching, repo memory retrieval, context composition, and complexity routing —
+and every one of them selects by substring, recency, or token counting. There
+is no embedding, no reranking, and no learned signal anywhere in the retrieval
+path. Worse, the two most sophisticated pieces are disconnected from
+production: the Context Composer (budgets, dedupe, degradation ladder,
+manifest) is reachable only from the `context/preview` RPC, and after the
+legacy task layer removal, skill matching has **no runtime call site at all**.
+The consequence is that the knowledge the system works hardest to accumulate —
+skills with EMA quality scores and governance states, per-repo failure
+lessons — reaches live prompts either crudely or not at all.
+
+Retrieval precision is the ceiling on knowledge reuse. This document
+inventories each surface with evidence, explains the compounding cost across a
+multi-repo deployment, and lays out a graduated design: pluggable retrieval
+with shadow comparison, Composer enforce mode behind a per-activity flag, and
+opt-in cross-repo memory with provenance.
+
+## Inventory of Retrieval Surfaces
+
+### 1. Skill matching — substring, and currently orphaned
+
+`crates/harness-context/src/providers.rs` implements `SkillsProvider`. Its
+relevance test lowercases the prompt and checks whether any trigger pattern is
+a literal substring:
+
+- `providers.rs:71` — `.to_lowercase()` on the prompt.
+- `providers.rs:76-82` — a skill matches when `trigger_patterns.is_empty()`
+  (always injected) or `.any(|pattern| prompt.contains(&pattern.to_lowercase()))`.
+- `providers.rs:93` — relevance is a coarse constant depending only on whether
+  trigger patterns exist, not on match quality.
+
+`crates/harness-core/src/prompts/context.rs:82`
+(`build_matched_skills_section`) renders the matched set into a prompt
+section.
+
+**Call-site reality (verified at `81c78255`):** the only consumer of
+`SkillsProvider` and `build_matched_skills_section` outside their defining
+crates is `crates/harness-server/src/handlers/context.rs:115` — the
+`context/preview` RPC. The legacy `augment_prompt_with_skills` path was
+removed with the legacy task layer, and the live runtime prompt packet
+(`crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs`) injects
+`repo_memory` (`prompt_packet.rs:88-89`) but has no skills section. The skill
+store's governance machinery — `SkillGovernanceStatus`
+(`crates/harness-skills/src/store.rs:14`), EMA `quality_score`,
+`canary_ratio` (`store.rs:43`) — governs a library that runtime prompts never
+see. Skills currently reach agents only through agent-native discovery (e.g.
+Claude CLI's own skill loading), which Harness neither ranks nor governs.
+
+Two defects, then: the matcher is a substring test, and the matcher is dead.
+
+### 2. Repo memory retrieval — recency-ordered, repo-fenced
+
+`crates/harness-workflow/src/runtime/memory_retrieval.rs` is real and wired
+into the live prompt packet, but its ranking is minimal:
+
+- `memory_retrieval.rs:7-9` — top-5 records, 800-token budget, 50-candidate
+  SQL fetch.
+- `memory_retrieval.rs:44-52` — the query:
+  `WHERE repo = $1 ... ORDER BY CASE WHEN activity_class = $2 THEN 0 ELSE 1
+  END ASC, created_at DESC LIMIT $3`. Exact-match-on-activity-class then
+  recency; no content relevance of any kind.
+- `memory_retrieval.rs:85-89` — in-process reranking
+  (`rank_repo_memory_candidates`) re-applies the same two keys.
+- `memory_retrieval.rs:47` — `WHERE repo = $1` hard-fences memory by repo
+  string. A `FailureLesson` learned in one repository can never inform work in
+  another.
+
+The stored kinds (`ValidationCommand`, `FailureLesson`, `ReviewerPattern`,
+`EnvironmentNote` in `runtime/repo_memory.rs`) are exactly the categories
+where cross-repo transfer pays: the deployment runs webhook intake for ~25
+repositories that share toolchains, reviewers, and infrastructure quirks.
+Today each repo re-learns every lesson from scratch, and within a repo the
+freshest five records win regardless of whether they match the task at hand.
+
+### 3. Context Composer — built, budgeted, and stuck in shadow
+
+`crates/harness-context/src/composer.rs` (652 lines) implements what a
+state-of-the-art context assembler needs: per-class token budgets, duplicate
+suppression, a degradation ladder that trims lower-priority classes first, and
+a manifest recording what was selected and why. Providers exist for Rules,
+Skills, Contract, ExecPlan, TaskBrief, GcDrafts, Static, and Error content.
+
+Its only call site outside the crate is
+`crates/harness-server/src/handlers/context.rs:17` (`context_preview`) — the
+shadow-mode RPC. Zero execution-path call sites. Live prompt assembly instead
+happens ad hoc in `workflow_runtime_worker/prompt_packet.rs`, which
+concatenates workflow config, runtime contract, command input, and repo memory
+into the `harness.runtime.prompt_packet.v1` JSON without class budgets or
+dedupe. The spec that introduced the Composer
+(`specs/context-composer/product.md`) explicitly staged shadow-first; the
+enforce stage never landed.
+
+The recently merged GH-1732 provenance spec (`specs/GH1732/`) records *which*
+sources were selected into a prompt packet. It is the natural audit substrate
+for an enforce-mode Composer: the manifest the Composer already emits is the
+provenance record GH-1732 wants.
+
+### 4. Complexity routing — token counting
+
+`crates/harness-server/src/complexity_router.rs:41` (`classify`) counts
+distinct file-path-shaped tokens in the prompt (`complexity_router.rs:36,42`)
+and maps the count to a complexity tier. It is deterministic and cheap, but it
+routes model/agent selection on a proxy (mentioned file count) that neither
+correlates reliably with difficulty nor adapts from outcomes.
+
+## Why Retrieval Precision Bounds Everything Else
+
+1. **Knowledge reuse is the product's compounding asset.** The harness's
+   differentiation over raw agent CLIs is accumulated, governed knowledge —
+   skills, lessons, reviewer patterns. Each percentage point of retrieval
+   precision/recall directly scales how much of that asset reaches the agent
+   within the fixed token budget (800 tokens for memory; 2% skills budget on
+   the Codex side per `activity_result.rs:16`).
+2. **Substring matching fails in both directions.** It misses paraphrases
+   ("upgrade the toolchain" never matches trigger "rust version bump") and
+   false-fires on incidental mentions, and it cannot rank partial matches —
+   `providers.rs:93` assigns one constant relevance to all matched skills.
+3. **Recency is anti-signal for stable lessons.** `EnvironmentNote`s
+   ("worktree layout breaks `gh pr merge --delete-branch`") stay true for
+   months; `ORDER BY created_at DESC` evicts them the moment five newer
+   records exist in the same activity class.
+4. **Un-budgeted assembly wastes the window.** Without the Composer's dedupe
+   and degradation ladder, live packets carry redundant sections while
+   relevant knowledge is truncated by coarse limits.
+5. **25-repo deployment multiplies every miss.** Repo-fenced memory means the
+   same failure is re-discovered up to 25 times, each discovery costing agent
+   turns and tokens.
+
+## Design
+
+### D1. Pluggable retrieval with shadow comparison
+
+Introduce a retrieval trait covering both surfaces (skills, repo memory):
+candidate fetch → score → rank, with two implementations: the current
+substring/recency logic (baseline) and an embedding scorer (pgvector on the
+existing Postgres, or an in-process model; no external vector service). Both
+run in shadow: the baseline's selection ships to the agent, both selections
+are logged with overlap/rank-divergence telemetry. Promotion to primary is a
+config flip once shadow data shows parity-or-better on the eval flywheel
+(GH-1768) — measuring retrieval quality without replayable evals reduces to
+anecdote, so GH-1768 is a soft dependency for promotion, not for landing.
+
+### D2. Composer enforce mode, per-activity flag
+
+Wire `ContextComposer` into `prompt_packet.rs` behind a per-activity flag
+(default off). Stage 1: shadow-diff — compose in parallel, log the manifest
+and the byte/token delta versus the ad-hoc packet, ship the ad-hoc packet.
+Stage 2: enforce for one low-risk activity class, manifest recorded via the
+GH-1732 provenance path. Stage 3: graduate per activity on operator review of
+diffs. This also resurrects skills injection on the runtime path — the
+Composer's `SkillsProvider` becomes the (single) live skill matcher, ranked by
+D1.
+
+### D3. Cross-repo memory with provenance
+
+Add an opt-in share class for memory kinds where transfer is safe
+(`EnvironmentNote`, `FailureLesson`): retrieval may include foreign-repo
+records when the owning repo opts in, every injected foreign record carries
+`source_repo` provenance in the prompt section (extending the untrusted-data
+preamble in `repo_memory_prompt.rs`), and ranking discounts foreign records
+relative to native ones. `ValidationCommand` and `ReviewerPattern` stay
+repo-fenced — they encode repo-specific truth.
+
+## Risks and Alternatives
+
+- **Embedding cost/latency.** Mitigation: embed at write time (one embedding
+  per memory record / skill), query-time embedding is a single call; candidate
+  set stays SQL-prefiltered (50 rows) so reranking is cheap. Alternative: a
+  pure lexical upgrade (BM25 via Postgres full-text search) captures much of
+  the win with zero new dependencies; the trait makes this a third pluggable
+  implementation, and it is the fallback if embedding shadow data disappoints.
+- **Composer enforce regressions.** Mitigation: shadow-diff stage plus
+  per-activity flag bounds the blast radius to one activity class; rollback is
+  a config flip.
+- **Cross-repo poisoning.** A malicious or wrong lesson in one repo could
+  steer agents in another. Mitigation: opt-in per repo, provenance-labeled
+  injection inside the existing untrusted fence, and foreign records excluded
+  from `ValidationCommand`-class trust.
+
+## Recommended Order
+
+1. D1 trait extraction + shadow telemetry (no behavior change).
+2. D2 stage 1 shadow-diff (no behavior change; produces evidence).
+3. D2 stage 2 enforce on one activity; skills return to runtime prompts.
+4. D1 promotion decision from shadow + eval data.
+5. D3 cross-repo opt-in.

--- a/specs/GH1769/product.md
+++ b/specs/GH1769/product.md
@@ -1,0 +1,150 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1769
+
+## User Problem
+
+Every mechanism that selects accumulated knowledge for agent prompts ranks by
+literal substring match, recency, or token counting. Skill matching is a
+lowercase `contains` test whose only remaining call site is the
+`context/preview` RPC — after the legacy task layer removal, governed skills
+reach no runtime prompt at all. Repo memory retrieval orders by activity-class
+equality then `created_at DESC` inside a hard `WHERE repo = $1` fence, so
+stable environment lessons are evicted by newer noise and nothing learned in
+one repository ever helps another. The Context Composer's budgets, dedupe, and
+degradation ladder run only in preview shadow mode while live packets are
+assembled ad hoc.
+
+Operators accumulate skills and memory that the system then fails to deliver
+to the agents doing the work.
+
+## Goals
+
+- Make knowledge retrieval pluggable: one trait, with the current
+  substring/recency behavior and a semantic (embedding) scorer as
+  interchangeable implementations.
+- Run semantic retrieval in shadow first, with telemetry that quantifies
+  divergence from the baseline before any behavior change.
+- Give the Context Composer an enforce mode, gated per activity class, with a
+  recorded selection manifest, and restore skill injection to the runtime
+  prompt path through it.
+- Allow explicitly opted-in cross-repo sharing for transfer-safe memory kinds
+  (`EnvironmentNote`, `FailureLesson`) with visible source-repo provenance.
+
+## Non-Goals
+
+- No external vector database or retrieval service dependency; embedding
+  storage uses Postgres (pgvector) or an in-process index only.
+- No change to the `harness.runtime.prompt_packet.v1` schema without an
+  explicit schema-version bump.
+- No removal of the substring retrieval path until shadow telemetry
+  demonstrates parity or better for the semantic path.
+- No cross-repo sharing of `ValidationCommand` or `ReviewerPattern` memory
+  kinds.
+- No changes to skill governance semantics (EMA scoring, canary, quarantine)
+  beyond connecting governed skills to a live injection path.
+- No learned or model-based complexity routing in this spec.
+
+## User-Visible Behavior
+
+1. **B-001:** Skill and repo-memory retrieval each route through one
+   retrieval interface with named implementations. The default primary
+   implementation reproduces current selection byte-for-byte for identical
+   inputs.
+2. **B-002:** When shadow retrieval is enabled, every retrieval executes the
+   primary and shadow implementations; only the primary's selection is
+   injected into any prompt. Shadow results affect telemetry only.
+3. **B-003:** Each shadowed retrieval emits a comparison record containing:
+   surface (skill | repo_memory), both implementation names, both ranked
+   selection lists (ids and scores), overlap count, and rank divergence. A
+   shadow implementation failure is recorded and never fails the retrieval.
+4. **B-004:** Composer enforce mode is configured per activity class and
+   defaults to off. In shadow-diff stage, the Composer runs alongside ad-hoc
+   assembly, the packet delta is recorded, and the ad-hoc packet ships. In
+   enforce stage, the Composer's output becomes the shipped packet section
+   set.
+5. **B-005:** Every enforce-mode composition records a selection manifest
+   (item class, source identity, order, selection reason, token cost,
+   degradation actions) linked to the runtime job's existing prompt-packet
+   evidence. A manifest that cannot be recorded is an error for that
+   composition, not a silent skip.
+6. **B-006:** Under enforce mode, governed skills are matched and injected
+   into runtime prompts via the Composer's skill provider; skills with
+   governance status `Quarantine` or `Retired` are never injected.
+7. **B-007:** Cross-repo memory retrieval returns foreign-repo records only
+   for kinds `EnvironmentNote` and `FailureLesson`, only from repositories
+   that have opted in to sharing, and ranks foreign records below equally
+   scored native records.
+8. **B-008:** Every injected foreign-repo memory record is rendered inside
+   the existing untrusted repo-memory fence and labeled with its source
+   repository. An unlabeled foreign record is a composition error.
+9. **B-009:** Disabling shadow retrieval, enforce mode, or cross-repo sharing
+   returns the affected surface to its prior behavior with no data migration.
+10. **B-010:** Retrieval implementation choice, shadow enablement, enforce
+    stage, and sharing opt-ins are visible in configuration inspection output
+    so an operator can determine the active retrieval posture without reading
+    logs.
+
+## Acceptance Criteria
+
+- [ ] A characterization test proves the baseline implementation reproduces
+      current skill matching (`providers.rs` substring semantics) and current
+      repo-memory ordering (`memory_retrieval.rs` activity-class-then-recency)
+      for fixed fixtures.
+- [ ] Shadow-mode tests prove: primary-only injection, comparison record
+      emission with overlap and divergence fields, and shadow-failure
+      isolation (retrieval succeeds, failure recorded).
+- [ ] Composer shadow-diff tests prove the ad-hoc packet ships unchanged
+      while the diff record is persisted.
+- [ ] Enforce-mode tests prove manifest recording, linkage to prompt-packet
+      evidence, and hard failure on unrecordable manifest.
+- [ ] A test proves `Quarantine`/`Retired` skills are excluded from
+      enforce-mode injection.
+- [ ] Cross-repo tests prove: kind allowlist enforcement, opt-in gating,
+      foreign-below-native ranking, provenance labeling inside the untrusted
+      fence, and rejection of unlabeled foreign records.
+- [ ] A rollback test proves each flag independently restores prior behavior.
+- [ ] Existing prompt-packet schema tests pass unchanged when all flags are
+      off.
+
+## Boundary Checklist
+
+| Boundary | Verdict |
+| --- | --- |
+| Empty / missing input | Empty candidate sets, empty trigger patterns, and empty prompts flow through both implementations; B-001 fixes baseline semantics for the always-inject empty-trigger case. |
+| Error and failure paths | B-003 (shadow failure isolation), B-005 (manifest failure is loud), B-008 (unlabeled foreign record is an error). |
+| Authorization / permission | B-007: sharing requires explicit per-repository opt-in; no ambient cross-repo read. |
+| Concurrency / race / ordering | Shadow comparison records are per-retrieval and append-only; no shared mutable ranking state between concurrent retrievals. |
+| Retry / repetition / idempotency | Retrieval is read-only and idempotent; repeated composition for the same job produces a new manifest linked to the same packet evidence. |
+| Illegal state transitions | Enforce stages progress off → shadow-diff → enforce per activity; configuration cannot express enforce without manifest recording. |
+| Compatibility / migration | B-009: all features are flag-gated with off defaults; no schema change without version bump (Non-Goals). |
+| Degradation / fallback | Shadow implementation failure degrades to primary-only with a recorded event, never silently. |
+| Evidence and audit integrity | B-005/B-010: manifests link to existing runtime-job evidence; retrieval posture is inspectable. |
+| Cancellation / interruption / partial completion | A composition interrupted before manifest persistence ships nothing; there is no partially-enforced packet. |
+
+## Edge Cases
+
+- A skill with empty `trigger_patterns` (currently always injected) under
+  semantic scoring.
+- Two memory records with identical scores but different repos (native must
+  win).
+- A repo opts out of sharing after its records were already retrieved
+  elsewhere (next retrieval excludes them; no retroactive prompt rewrite).
+- The embedding column is absent for old records (fall back to baseline score
+  for those candidates, recorded in telemetry).
+- Shadow and primary implementations disagree on candidate-set size limits.
+- An activity class configured for enforce mode receives a prompt with zero
+  matched items (compose an empty section set with a manifest, not an error).
+
+## Rollout Notes
+
+Land in the order: trait extraction with characterization tests → shadow
+telemetry → Composer shadow-diff → enforce on one low-risk activity class →
+semantic-primary promotion → cross-repo opt-in. Promotion of the semantic
+implementation to primary requires shadow telemetry review and replayable eval
+evidence (GH-1768 flywheel); until then the substring path remains primary.
+Reverting any stage is a configuration flip; no data migration is required in
+either direction. Embedding backfill for existing records may run as an
+offline job at any point after trait extraction.

--- a/specs/GH1769/tech.md
+++ b/specs/GH1769/tech.md
@@ -21,8 +21,9 @@ GH-1769
   RPC). The live runtime packet builder
   (`crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs`) has
   no skills section; grep for `SkillsProvider` /
-  `build_matched_skills_section` / `trigger_patterns` under
-  `harness-server/src` matches only `handlers/context.rs`. Skill governance
+  `build_matched_skills_section` under `harness-server/src` matches only
+  `handlers/context.rs`, and `trigger_patterns` has zero hits there at all.
+  Skill governance
   (`crates/harness-skills/src/store.rs:14` `SkillGovernanceStatus`,
   `store.rs:43` `canary_ratio`) therefore governs an injection path that does
   not exist at runtime.

--- a/specs/GH1769/tech.md
+++ b/specs/GH1769/tech.md
@@ -1,0 +1,200 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1769
+
+## Current State (verified at commit `81c78255`)
+
+### Skill matching
+
+- `crates/harness-context/src/providers.rs:71-93` — `SkillsProvider`
+  lowercases the prompt and selects a skill when `trigger_patterns` is empty
+  or any pattern is a literal substring
+  (`.any(|pattern| prompt.contains(&pattern.to_lowercase()))`, line 80).
+  Relevance is a constant chosen only by whether trigger patterns exist
+  (line 93).
+- `crates/harness-core/src/prompts/context.rs:82` —
+  `build_matched_skills_section` renders matched skills.
+- **Only consumer outside the defining crates:**
+  `crates/harness-server/src/handlers/context.rs:115` (`context_preview`
+  RPC). The live runtime packet builder
+  (`crates/harness-server/src/workflow_runtime_worker/prompt_packet.rs`) has
+  no skills section; grep for `SkillsProvider` /
+  `build_matched_skills_section` / `trigger_patterns` under
+  `harness-server/src` matches only `handlers/context.rs`. Skill governance
+  (`crates/harness-skills/src/store.rs:14` `SkillGovernanceStatus`,
+  `store.rs:43` `canary_ratio`) therefore governs an injection path that does
+  not exist at runtime.
+
+### Repo memory retrieval
+
+- `crates/harness-workflow/src/runtime/memory_retrieval.rs:7-9` — limits:
+  top-5 injected, 800-token budget, 50-row candidate fetch.
+- `memory_retrieval.rs:44-56` — SQL: `WHERE repo = $1` then
+  `ORDER BY CASE WHEN activity_class = $2 THEN 0 ELSE 1 END ASC,
+  created_at DESC LIMIT $3`.
+- `memory_retrieval.rs:85-97` — `rank_repo_memory_candidates` re-sorts by the
+  same (activity-class match, recency) keys in process.
+- Injection: `workflow_runtime_worker/prompt_packet.rs:88-89` sets
+  `packet["repo_memory"]` (`harness.runtime.repo_memory.v1`,
+  `prompt_packet.rs:259-263`), rendered with an untrusted preamble via
+  `repo_memory_prompt.rs`.
+
+### Context Composer
+
+- `crates/harness-context/src/composer.rs` (652 lines): class budgets,
+  dedupe, degradation ladder, selection manifest.
+- Only external call site: `handlers/context.rs:17` (`context_preview`).
+  Zero execution-path call sites; `specs/context-composer/product.md` staged
+  shadow-first and enforce never landed.
+- Adjacent landed work: `specs/GH1732/` (runtime context provenance) defines
+  the provenance manifest for prompt-packet sources; the Composer manifest is
+  the natural producer for it.
+
+### Complexity routing
+
+- `crates/harness-server/src/complexity_router.rs:41` — `classify` counts
+  file-path-shaped tokens (`complexity_router.rs:36`) and maps count →
+  complexity tier. Out of scope for change here (Non-Goal), documented for
+  completeness.
+
+## Design
+
+### 1. Retrieval trait and implementations
+
+New module `crates/harness-context/src/retrieval.rs`:
+
+```rust
+pub struct RetrievalQuery<'a> {
+    pub surface: RetrievalSurface,          // Skill | RepoMemory
+    pub text: &'a str,                      // prompt or activity brief
+    pub activity_class: Option<&'a str>,
+    pub repo: Option<&'a str>,
+    pub limit: usize,
+}
+
+pub struct ScoredCandidate {
+    pub id: String,
+    pub score: f64,
+    pub native_repo: bool,
+}
+
+pub trait KnowledgeRetriever: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn rank(&self, query: &RetrievalQuery<'_>, candidates: &[Candidate])
+        -> Result<Vec<ScoredCandidate>, RetrievalError>;
+}
+```
+
+Implementations:
+
+- `SubstringRetriever` — extracted verbatim from `providers.rs:76-93` and
+  `memory_retrieval.rs:85-97`; characterization tests pin byte-identical
+  selection.
+- `EmbeddingRetriever` — cosine over stored embeddings. Storage: new nullable
+  column `embedding vector(D)` on `workflow_repo_memory` and on the skill
+  store's persistence (pgvector when available; when the extension is absent,
+  an in-process index built from stored `f32` blobs — no external service).
+  Embeddings are computed at record write time; the query embedding is
+  computed once per retrieval. Records with NULL embedding fall back to the
+  substring score for that candidate, flagged in telemetry (product edge
+  case).
+
+Candidate fetch stays SQL-prefiltered (existing 50-row query for memory; the
+skill store's discovery list for skills), so ranking cost is bounded.
+
+### 2. Shadow comparison
+
+`RetrievalExecutor` wraps a primary and optional shadow retriever:
+
+- Runs primary; if shadow configured, runs shadow on the same inputs.
+- Emits one `retrieval_comparison` event to the observe event stream
+  (`harness-observe` EventStore) per retrieval: surface, implementation
+  names, both ranked id/score lists, `overlap_at_k`, Kendall-tau-style rank
+  divergence, shadow latency, shadow error (if any).
+- Shadow errors are caught; primary selection always ships (product B-003).
+
+Config (`WORKFLOW.md` runtime section, all default off):
+
+```yaml
+retrieval:
+  skills:      { primary: substring, shadow: embedding }
+  repo_memory: { primary: substring, shadow: embedding }
+```
+
+Promotion = swapping `primary`; no code change.
+
+### 3. Composer enforce mode
+
+Config per activity class:
+
+```yaml
+context_composer:
+  implement_issue: off | shadow_diff | enforce
+```
+
+- `shadow_diff`: after ad-hoc packet assembly in `prompt_packet.rs`, run
+  `ContextComposer` with providers fed from the same inputs; persist a
+  `composer_shadow_diff` artifact (section-set delta, token delta, manifest);
+  ship the ad-hoc packet unchanged.
+- `enforce`: the Composer's composed sections replace the corresponding
+  ad-hoc packet sections. The packet schema is unchanged (sections are the
+  same keys; Non-Goal guards any schema change behind a version bump). The
+  selection manifest persists through the GH-1732 provenance path, linked to
+  the runtime job's prompt-packet digest. Manifest persistence failure fails
+  the composition (product B-005) and surfaces as an activity configuration
+  error, which the existing retry taxonomy classifies as non-retryable
+  `Configuration`.
+- Skills: under `enforce`, `SkillsProvider` (ranked via the retrieval trait)
+  contributes the skills section; provider filters out
+  `SkillGovernanceStatus::Quarantine | Retired` before ranking.
+
+### 4. Cross-repo memory sharing
+
+- New table `workflow_repo_memory_sharing (repo text primary key,
+  share_kinds text[], opted_in_at timestamptz)`; opt-in written by operator
+  config sync, never by agents.
+- Retrieval for kinds `EnvironmentNote` / `FailureLesson` adds a second
+  candidate query over opted-in foreign repos (same 50-row cap, separate
+  pool), tags candidates `native_repo: false`.
+- Ranking: foreign score is multiplied by a discount factor (config, default
+  0.8); ties break native-first (product B-007).
+- Rendering: `repo_memory_prompt.rs` labels each foreign record
+  `source_repo: <repo>` inside the existing untrusted fence; a foreign record
+  reaching rendering without a label is a hard error (product B-008).
+- `ValidationCommand` / `ReviewerPattern` kinds are excluded at the query
+  level, not by post-filtering.
+
+## Migration / Landing Order
+
+1. Extract `SubstringRetriever` + characterization tests (no behavior
+   change; refactor only).
+2. Shadow executor + comparison telemetry (flag-gated, default off).
+3. Embedding column migrations + write-time embedding + offline backfill job.
+4. Composer `shadow_diff` stage in `prompt_packet.rs`.
+5. Composer `enforce` for one low-risk activity class; skills return to
+   runtime prompts.
+6. Primary promotion per surface after telemetry + eval (GH-1768) review.
+7. Cross-repo sharing table + retrieval + rendering.
+
+Each step is independently revertible by config flip; steps 3 and 7 add
+nullable columns / new tables only (no destructive migration).
+
+## Validation
+
+- `cargo test -p harness-context` — trait, characterization, composer
+  shadow/enforce unit tests.
+- `cargo test -p harness-workflow memory_retrieval` — ranking, cross-repo
+  gating, discount, label enforcement.
+- `cargo test -p harness-server workflow_runtime_worker` — packet parity with
+  flags off; shadow-diff artifact; enforce-mode manifest linkage.
+- `cargo clippy --workspace --all-targets -- -D warnings` and
+  `cargo fmt --all -- --check` per repo gates.
+
+## Open Questions
+
+- Embedding model/provider choice (local model vs API) and dimension `D` —
+  decided at step 3; the column and trait are dimension-agnostic until then.
+- Whether `context_preview` should preview enforce-mode output once a class
+  is enforced (recommended: yes, same code path, keeps preview honest).


### PR DESCRIPTION
Defines the spec packet and full analysis for GH-1769: every knowledge-selection surface (skill matching, repo memory retrieval, context composition, complexity routing) currently ranks by substring, recency, or token counting, and the two most capable pieces are disconnected — the Context Composer runs only in preview shadow mode, and skill matching has no runtime call site after the legacy task layer removal.

Contents:

- `docs/references/semantic-retrieval-and-context.md` — verified inventory of each retrieval surface with file:line evidence at commit 81c78255, analysis of why retrieval precision bounds knowledge reuse across the multi-repo deployment, and the graduated design.
- `specs/GH1769/product.md` — behaviors B-001..B-010: pluggable retrieval trait (substring + embedding) with shadow comparison telemetry, Composer enforce mode per activity class with recorded selection manifests (linked to GH-1732 provenance), and opt-in cross-repo sharing for EnvironmentNote/FailureLesson with source-repo provenance inside the untrusted fence.
- `specs/GH1769/tech.md` — trait shape, pgvector/in-process storage (no external vector service), shadow executor, enforce-mode wiring into prompt_packet.rs, sharing table, landing order, and validation commands.

Docs-only change; no code paths affected. Promotion of the semantic retriever to primary is explicitly gated on shadow telemetry plus eval-flywheel evidence (GH-1768).

Refs #1769