### PR TITLE
spec(GH1772): define runtime reliability hardening

### DIFF
--- a/docs/references/runtime-reliability.md
+++ b/docs/references/runtime-reliability.md
@@ -1,0 +1,284 @@
+# Runtime Reliability Analysis: Leases, Versioning, Retention, and Loop Supervision
+
+> Status: analysis reference for GH-1772
+> Date: 2026-07-26
+> Method: read-only source inspection on `main` (81c78255); all file:line
+> citations verified against that revision.
+
+## Scope
+
+This report analyzes four reliability defect clusters in the workflow runtime
+and server orchestration layer:
+
+1. Two independent lease systems (runtime jobs vs workspaces) that can
+   disagree, with completed work silently dropped when they do.
+2. `WorkflowInstance.version` — a serialized counter shaped like an optimistic
+   concurrency token that no code path actually checks.
+3. Retention and watchdog loops that exist but default off, leaving unbounded
+   table growth and unsurfaced stuck workflows as the default posture.
+4. A single-process orchestrator whose background loops are unsupervised and
+   whose per-tick config reload turns a malformed `WORKFLOW.md` into a silent
+   partial outage.
+
+Each cluster is presented as evidence → failure scenario → remediation
+direction. The corresponding fail-closed behavior contract lives in
+`specs/GH1772/`.
+
+## Cluster A — Dual leases: lost completions and dirty re-runs
+
+### Evidence
+
+Two lease systems govern one unit of work, in two different tables, with two
+different liveness models, and no atomic relationship:
+
+- **Runtime job leases** — `runtime_jobs` rows carry
+  `WorkflowLease { owner, expires_at }` plus a `lease_generation` counter.
+  Claim, defer, and completion are owner-scoped:
+  `claim_next_runtime_job_excluding_runtime_kind`,
+  `defer_runtime_job_claim_if_owned`, and
+  `commit_runtime_activity_completion_with_transcript_if_owned`
+  (`crates/harness-workflow/src/runtime/store/runtime_job_leases.rs`,
+  `runtime/lease_state.rs`, `runtime/job_claim.rs`). TTL is
+  `runtime_worker.lease_ttl_secs: 600` (`WORKFLOW.md:53`, applied at
+  `crates/harness-server/src/http/background/runtime_workers.rs:6-7`).
+- **Workspace leases** — `workspace_leases` rows keyed
+  `(store_key, project_key, slot_index)` carry `owner_session`, `process_id`,
+  and `process_started_at`, with liveness judged by PID inspection via
+  `sysinfo` (`crates/harness-server/src/workspace_lease_store.rs:19-77`).
+
+The worker renews its job lease during execution
+(`execute_with_lease_renewal`, `crates/harness-workflow/src/runtime/worker.rs:162`),
+but when renewal lapses — a long blocking turn, a paused process, a renewal
+write failure — the completion path fails *silently from the workflow's
+perspective*:
+
+```text
+crates/harness-workflow/src/runtime/worker.rs:172-188
+    let Some(completion) = self.store
+        .commit_runtime_activity_completion_with_transcript_if_owned(...)
+        .await?
+    else {
+        tracing::warn!(
+            runtime_job_id = %job.id,
+            owner = %self.owner,
+            "runtime job completion ignored because the worker no longer owns the lease"
+        );
+        return Ok(None);
+    };
+```
+
+The entire `ActivityResult` — potentially a finished implementation turn with
+a pushed branch — is dropped with a `warn`. No runtime event records the
+rejected completion; no dead-letter row preserves the result; nothing tells
+the workspace lease system that its co-owner just lost the job.
+
+### Failure scenario
+
+1. Worker W1 claims job J (lease TTL 600s) and acquires workspace slot S.
+2. The agent turn runs 12 minutes; lease renewal misses the TTL window.
+3. Worker W2 claims J (lease expired) and — because slot S is still leased to
+   W1's session — acquires a *different* slot, or waits, while W1's agent
+   continues mutating S.
+4. W1's agent finishes; `...if_owned` returns `None`; the result (including
+   the transcript that `prepare_runtime_transcript` just built) is discarded.
+5. W2 re-runs the same activity from scratch. If it lands on slot S after
+   W1's PID finally exits, it inherits a dirty tree with W1's uncommitted or
+   unpushed state; if W1's agent had already pushed, W2's fresh attempt now
+   races a remote branch that the workflow believes does not exist.
+
+Every step is individually "working as designed"; the composition loses work,
+occupies workspaces, and can produce duplicate PRs or corrupted branch state.
+
+### Remediation direction
+
+- **Single ownership epoch.** Introduce an ownership epoch (the existing
+  `lease_generation` is the natural candidate) minted at job claim and
+  propagated into the workspace lease row. Workspace lease acquisition and
+  renewal validate the epoch; job lease renewal extends both records in one
+  transaction where they share a store, or via an epoch check where they do
+  not.
+- **Dead-letter, not drop.** A completion rejected for lost ownership must be
+  persisted as a dead-letter completion (job id, owner, epoch, full
+  `ActivityResult`, transcript reference) and surfaced as a runtime event, so
+  reconciliation can adopt the result when the re-run has not yet started, or
+  an operator can compare divergent attempts when it has.
+- **Cross-system release.** Losing the job lease must schedule release of the
+  workspace lease held under the same epoch once the agent process exits,
+  instead of leaving slot occupancy to PID-liveness decay.
+
+## Cluster B — `WorkflowInstance.version`: a CAS token nothing checks
+
+### Evidence
+
+`WorkflowInstance` carries `pub version: u64`
+(`crates/harness-workflow/src/runtime/model.rs:87`). It is incremented on
+mutation (`instance.version = instance.version.saturating_add(1)`,
+`crates/harness-workflow/src/runtime/store/instances.rs:80,124`) and bound
+into every INSERT/UPDATE (`instances.rs:48,226`,
+`store/transaction_helpers.rs:170,202`).
+
+It is **never read back as a predicate**. Every mutation path serializes on a
+pessimistic row lock plus a state-string check:
+
+```text
+crates/harness-workflow/src/runtime/store/transaction_helpers.rs:93
+    sqlx::query_as("SELECT data::text FROM workflow_instances WHERE id = $1 FOR UPDATE")
+```
+
+with `WorkflowDecisionTransition { expected_state, .. }` supplying the
+precondition. A grep for `version` in a `WHERE` clause across
+`runtime/store/` returns nothing.
+
+### Why this matters
+
+Correctness currently depends on an unwritten rule: *every* writer must go
+through `select_instance_for_update_tx` inside one transaction. The field's
+name and type advertise the opposite contract — read, modify, write back with
+`WHERE version = $expected`. The first future code path that takes the
+advertised contract at face value (an API-side patch endpoint, a bulk
+migration, a reconciliation fix-up) will read version N, write version N+1
+without a lock, and silently overwrite a concurrent committed transition.
+Because the column is dead weight today, no test can catch that regression:
+the decoy is strictly worse than either honest alternative.
+
+### Remediation direction
+
+Decide once, mechanically:
+
+- **Enforce**: make every instance UPDATE carry
+  `WHERE id = $1 AND version = $expected` and treat zero rows affected as a
+  typed conflict, keeping the row lock for the multi-statement transactions
+  that need it; or
+- **Remove/rename**: drop the field from the public model (or rename it to
+  `mutation_count` with a doc comment stating it is informational), so no
+  future writer can mistake it for a guard.
+
+Either resolution is acceptable; the current ambiguous state is not.
+
+## Cluster C — Retention and watchdog default off
+
+### Evidence
+
+`WORKFLOW.md` ships, and documentation recommends, the following defaults:
+
+```text
+WORKFLOW.md:61   orphan_reaper_enabled: true
+WORKFLOW.md:65   workflow_watchdog_enabled: false
+WORKFLOW.md:69   runtime_retention_enabled: false
+WORKFLOW.md:73   task_retention_enabled: false
+```
+
+Consequences of the default posture:
+
+- `workflow_events`, `workflow_decisions`, `runtime_events`, and
+  `workflow_artifacts` — the last including full agent transcripts stored via
+  the durable-transcript path — grow without bound.
+- Stuck workflows in `blocked` / `awaiting_feedback` are never surfaced,
+  because the loop that would alert on them (`http/workflow_watchdog.rs`) is
+  compiled, spawned, and then no-ops every tick behind its config gate.
+- `postgres_catalog.rs` only counts schemas and warns past a threshold; the
+  one reaper that acts (`orphan_reaper_enabled: true`) covers only
+  path-derived schemas.
+
+The codebase has already paid for this exact defect class once. The orphan
+reaper's own module comment is a postmortem:
+
+```text
+crates/harness-server/src/http/orphan_reaper.rs:1-14
+//! `reap_orphaned_path_schemas` was added in #1216 but only exposed via the
+//! `harness-pg-schema-cleanup` CLI — it was never wired into the running
+//! server, so Postgres catalog growth was never actually bounded
+//! automatically (a declaration-execution gap).
+```
+
+That gap produced a Postgres catalog that peaked around 538k schemas before
+the reaper landed. Retention today sits in the same pre-reaper position:
+implemented, spawned, and off.
+
+### Remediation direction
+
+- Ship safe-by-default retention: terminal-workflow event/decision compaction
+  and transcript archival after a conservative age (e.g. 30 days), applied
+  only to workflows in a terminal state.
+- First activation runs in an operator-visible dry-run mode: the retention
+  tick reports what *would* be deleted (counts, oldest/newest, bytes) as
+  runtime events for at least one interval before destructive mode engages.
+- Watchdog enabled by default with alert-on-transition semantics (already
+  implemented at `workflow_watchdog.rs:17-24`) so enabling it is not noisy.
+
+## Cluster D — Unsupervised loops and the silent config outage
+
+### Evidence
+
+The HTTP server entry point spawns the orchestration loops directly:
+
+```text
+crates/harness-server/src/http/mod.rs:190-217
+    background::spawn_auto_recovery(&state);
+    background::spawn_runtime_pr_feedback_sweeper(&state);
+    orphan_reaper::spawn_orphan_schema_reaper(&state);
+    workflow_watchdog::spawn_workflow_watchdog(&state);
+    runtime_retention::spawn_runtime_retention(&state);
+    background::spawn_runtime_command_dispatcher(&state);
+    background::spawn_runtime_job_workers(&state);
+    ...
+```
+
+Each helper is a bare `tokio::spawn` holding a `Weak<AppState>` in a
+`loop { work; sleep(interval) }` (e.g. `background/auto_recovery.rs:111`,
+`background/pr_feedback.rs:258`, `background/runtime_workers.rs:164`,
+`background/runtime_command_dispatch.rs:494`). Properties of this shape:
+
+- **No supervision.** A panicked or wedged loop dies (or stalls) invisibly;
+  nothing restarts it and no health surface reports it absent. Failure
+  handling inside the loops is warn-and-continue.
+- **No cross-instance coordination.** The dispatcher identity is
+  per-process-random (`dispatcher_id: format!("dispatcher:{}", Uuid::new_v4())`,
+  `runtime/dispatcher.rs:141`). Safety under two server processes on one
+  schema rests entirely on every individual claim being lease-guarded; the
+  loops themselves have no leader election or singleton guard.
+- **Per-tick config reload with divergent failure arms.** Watchdog, retention,
+  and reaper re-run `load_workflow_config` on every tick. On parse failure the
+  watchdog logs a warn (`workflow_watchdog.rs:28-37`); the orphan reaper's
+  failure arm is `Err(_) => { sleep(30s); continue; }` with **no log at all**
+  (`orphan_reaper.rs:40-48`). A malformed `WORKFLOW.md` therefore disables
+  watchdog, retention, and reaping simultaneously — the reaper silently —
+  while the dispatcher and job workers keep executing agent work at full
+  speed. The system's *safety* loops fail off while its *spend* loops fail on.
+
+### Remediation direction
+
+- **Supervised task set.** Register each background loop in a supervisor
+  (name, tick interval, last-success timestamp). The health endpoint reports
+  per-loop staleness; a loop that has not completed a tick within N×interval
+  flips the health surface to degraded.
+- **Loud degraded mode on config failure.** A `WORKFLOW.md` parse failure is
+  one event affecting every consumer; it must be surfaced once, at error
+  level, on the health endpoint, and — because safety loops are disabled
+  while dispatch continues — should optionally gate new dispatch after a
+  configurable grace period. All config-reload failure arms converge on one
+  shared handler so no loop can silently diverge again.
+- **Leader-election design note.** Multi-instance orchestration is out of
+  scope for the first remediation, but the supervisor abstraction should keep
+  singleton loops (retention, reaper, watchdog) behind an advisory-lock
+  acquisition so a future second instance is safe by construction rather than
+  by audit.
+
+## Priority and sequencing
+
+| Order | Item | Rationale |
+| --- | --- | --- |
+| 1 | Dead-letter for rejected completions (A) | Stops silent loss of finished agent work; smallest blast radius. |
+| 2 | Ownership epoch binding job + workspace leases (A) | Removes the dirty re-run window; builds on the dead-letter path for adoption. |
+| 3 | Config-failure loud mode + loop supervision (D) | Cheap; converts silent partial outages into visible degraded state. |
+| 4 | Retention defaults with dry-run (C) | Unbounded growth is certain, just slow; dry-run makes activation safe. |
+| 5 | `version` enforce-or-remove (B) | No live defect today; closes a latent trap before new writers appear. |
+
+## Related work
+
+- `specs/GH1772/product.md`, `specs/GH1772/tech.md` — the behavior contract
+  derived from this analysis.
+- `docs/postgres-schema-cleanup.md`, `crates/harness-server/src/http/orphan_reaper.rs`
+  — prior instance of the declaration-execution-gap class.
+- GH-1716 (recovery CAS conflict handling) — adjacent spec covering recovery
+  action races; Cluster B here is the instance-mutation counterpart.

--- a/docs/references/runtime-reliability.md
+++ b/docs/references/runtime-reliability.md
@@ -34,11 +34,12 @@ different liveness models, and no atomic relationship:
 - **Runtime job leases** — `runtime_jobs` rows carry
   `WorkflowLease { owner, expires_at }` plus a `lease_generation` counter.
   Claim, defer, and completion are owner-scoped:
-  `claim_next_runtime_job_excluding_runtime_kind`,
-  `defer_runtime_job_claim_if_owned`, and
+  `claim_next_runtime_job`
+  (`crates/harness-workflow/src/runtime/store/runtime_jobs.rs:251`),
+  `defer_runtime_job_claim_if_owned`
+  (`store/runtime_job_state.rs:48`), and
   `commit_runtime_activity_completion_with_transcript_if_owned`
-  (`crates/harness-workflow/src/runtime/store/runtime_job_leases.rs`,
-  `runtime/lease_state.rs`, `runtime/job_claim.rs`). TTL is
+  (`store/activity_completion.rs:72`). TTL is
   `runtime_worker.lease_ttl_secs: 600` (`WORKFLOW.md:53`, applied at
   `crates/harness-server/src/http/background/runtime_workers.rs:6-7`).
 - **Workspace leases** — `workspace_leases` rows keyed
@@ -126,8 +127,10 @@ crates/harness-workflow/src/runtime/store/transaction_helpers.rs:93
 ```
 
 with `WorkflowDecisionTransition { expected_state, .. }` supplying the
-precondition. A grep for `version` in a `WHERE` clause across
-`runtime/store/` returns nothing.
+precondition. No UPDATE or SELECT on `workflow_instances` uses `version` as a
+predicate. (The pattern does exist in the codebase — `store/definitions.rs:46`
+guards `workflow_definitions` with `WHERE id = $1 AND version = $2` — which
+makes its absence on the instances table a choice, not a style gap.)
 
 ### Why this matters
 

--- a/specs/GH1772/product.md
+++ b/specs/GH1772/product.md
@@ -1,0 +1,160 @@
+# Product Spec
+
+## Linked Issue
+
+GH-1772
+
+## User Problem
+
+The workflow runtime can silently lose finished agent work: when a worker's
+job lease expires mid-turn, the completed activity result is discarded with a
+log line while the agent process and its workspace lease keep running, and a
+second worker re-runs the same activity against a potentially dirty tree.
+Separately, the runtime's safety loops (retention, watchdog, schema reaping)
+default off or fail silent on config errors while dispatch keeps executing,
+so unbounded table growth and stuck workflows are the default operating
+posture. `WorkflowInstance.version` looks like a concurrency guard but is
+never checked, inviting a future silent-lost-update bug.
+
+Operators need completion, ownership, and background maintenance to fail
+closed and visibly: no finished result dropped without a durable record, no
+workspace occupied by a job that lost ownership, no safety loop silently
+disabled while agents continue to spend.
+
+## Goals
+
+- Persist every lease-rejected activity completion as a durable dead-letter
+  record instead of dropping it.
+- Bind runtime job ownership and workspace ownership to one epoch so the two
+  lease systems cannot silently diverge.
+- Resolve `WorkflowInstance.version` into either an enforced concurrency
+  predicate or an explicitly informational field — not a decoy.
+- Ship safe retention defaults with an operator-visible dry-run before any
+  destructive action.
+- Supervise background loops and make `WORKFLOW.md` parse failure a single,
+  loud, health-surfaced degraded state.
+
+## Non-Goals
+
+- Multi-instance orchestration or leader election (design note only; no
+  implementation).
+- Schema migration of existing lease tables beyond additive columns.
+- Changes to workflow state graphs, transition allowlists, or lifecycle
+  semantics.
+- Changes to agent spawning, prompt construction, or review/merge gates.
+- Replacing the pessimistic row-lock transaction model for instance mutation.
+
+## User-Visible Behavior
+
+1. **B-001:** A completion rejected because the worker no longer owns the job
+   lease is persisted as a dead-letter completion record carrying the job id,
+   owner, ownership epoch, full activity result, and transcript reference,
+   and emits a runtime event. It is never reported as success and never
+   silently dropped.
+2. **B-002:** If the same activity has not been re-claimed when the
+   dead-letter record is written, reconciliation may adopt the dead-lettered
+   result through the normal completion path exactly once; adoption is
+   idempotent and recorded as an event. If a re-run is already active, the
+   record is retained for operator comparison and is not auto-adopted.
+3. **B-003:** Claiming a runtime job mints an ownership epoch, and any
+   workspace lease acquired for that job records the same epoch. Workspace
+   lease renewal under a stale epoch is rejected.
+4. **B-004:** When a job lease expires or is reclaimed, the workspace lease
+   held under the same epoch becomes releasable: it is released as soon as
+   the owning agent process is observed exited, and a re-claiming worker
+   never receives a workspace slot still writable by the previous epoch's
+   live process.
+5. **B-005:** Every UPDATE of a workflow instance row either includes the
+   instance version as a predicate and treats zero rows affected as a typed
+   conflict error, or the field is renamed/documented as informational with
+   no concurrency semantics. Exactly one of the two outcomes ships; the
+   current ambiguous state is removed.
+6. **B-006:** Runtime and task retention are enabled by default with
+   conservative terminal-only scope: only workflows in a terminal state older
+   than the configured age are eligible, and event/decision/transcript rows
+   for non-terminal workflows are never touched.
+7. **B-007:** The first retention activation for a store runs in dry-run
+   mode: at least one full interval reports would-delete counts and byte
+   estimates as runtime events before destructive mode engages. Dry-run
+   results are visible to operators without database access.
+8. **B-008:** Each background loop registers with a supervisor that records
+   its last successful tick. The health endpoint reports per-loop staleness,
+   and a loop that misses its staleness threshold flips the health surface to
+   degraded, naming the loop.
+9. **B-009:** A `WORKFLOW.md` parse failure is reported once per transition
+   at error level, is visible on the health endpoint, and marks every
+   config-gated loop as degraded rather than each loop silently retrying. No
+   config-failure arm may skip logging.
+10. **B-010:** While config parse failure persists beyond a configurable
+    grace period, new runtime dispatch is paused until the config loads
+    again; already-running activities are not interrupted.
+11. **B-011:** All new records and events introduced here (dead-letter
+    completions, epoch fields, dry-run reports, supervisor status) are
+    additive; existing rows, wire formats, and workflow semantics remain
+    readable and unchanged.
+
+## Acceptance Criteria
+
+- [ ] A store test proves a lease-expired completion writes a dead-letter
+      record with result and transcript reference and emits the event,
+      instead of returning silently.
+- [ ] A reconciliation test proves single adoption of a dead-lettered result
+      when no re-claim occurred, idempotent on repeat, and non-adoption when
+      a re-run is active.
+- [ ] A lease test proves workspace renewal under a stale epoch is rejected,
+      and a re-claiming worker cannot obtain a slot while the prior epoch's
+      process is still live.
+- [ ] Either conflict-on-stale-version store tests exist for every instance
+      UPDATE path, or the field is renamed/documented and a lint/test guards
+      against reintroducing version-as-predicate assumptions — matching
+      whichever resolution B-005 selects.
+- [ ] Retention tests prove terminal-only eligibility, age gating, and that
+      dry-run mode deletes nothing while reporting accurate counts.
+- [ ] A supervisor test proves a stalled loop surfaces as degraded health
+      naming the loop, and a recovered loop clears it.
+- [ ] A config-failure test proves one error-level report, degraded health,
+      all config-gated loops marked degraded (including the orphan reaper's
+      previously silent arm), and dispatch pausing after the grace period.
+- [ ] Existing lease, recovery, and retention tests continue to pass without
+      semantic weakening.
+
+## Boundary Checklist
+
+| Boundary | Verdict |
+| --- | --- |
+| Empty / missing input | Covered by B-009/B-010: missing or unparseable config is a loud degraded state, not a silent skip. |
+| Error and failure paths | Covered by B-001, B-008, B-009; no warn-and-drop for completed work, no unlogged failure arms. |
+| Authorization / permission | N/A. Ownership epochs constrain internal workers, not external caller authority. |
+| Concurrency / race / ordering | Covered by B-002, B-003, B-004, B-005. |
+| Retry / repetition / idempotency | Covered by B-002 (single adoption, idempotent repeat) and B-005 (typed conflict on stale write). |
+| Illegal state transitions | Covered by B-004 (stale-epoch renewal rejected) and B-005. |
+| Compatibility / migration | Covered by B-011: additive columns and records only. |
+| Degradation / fallback | Covered by B-007, B-009, B-010: degradation is visible and pauses spend, never silent. |
+| Evidence and audit integrity | Covered by B-001, B-002, B-007: dropped work and would-delete actions leave durable records. |
+| Cancellation / interruption / partial completion | Covered by B-001, B-004, B-010: interrupted ownership yields dead-letter plus releasable workspace, and running activities are not killed by config pauses. |
+
+## Edge Cases
+
+- A worker finishes its turn seconds after lease expiry while the re-claiming
+  worker has claimed but not yet started the activity.
+- The agent process outlives both its job lease and its worker, still holding
+  the workspace slot.
+- A dead-letter adoption races the re-run's own completion commit.
+- Retention dry-run reports rows that a concurrent recovery action then
+  makes non-terminal again before destructive mode engages.
+- `WORKFLOW.md` alternates between valid and invalid across consecutive
+  ticks (flapping), which must not spam error logs or flap dispatch pausing
+  within the grace period.
+- Two server processes point at the same schema while singleton loops run
+  (documented hazard; supervisor design keeps singleton loops behind an
+  advisory-lock acquisition as a forward-compatibility note).
+
+## Rollout Notes
+
+All schema changes are additive (epoch columns, dead-letter table, supervisor
+status). Retention flips from off to dry-run-by-default in the first release
+and to destructive-by-default only after the dry-run interval completes per
+store, giving operators one full cycle of visibility. Reverting restores the
+current behavior, including the silent-drop path; revert should therefore be
+paired with disabling lease-expiry-sensitive workloads or accepting the
+documented loss window.

--- a/specs/GH1772/tech.md
+++ b/specs/GH1772/tech.md
@@ -1,0 +1,189 @@
+# Tech Spec
+
+## Linked Issue
+
+GH-1772
+
+## Current State
+
+All citations verified on `main` (81c78255).
+
+### Dual lease systems
+
+- Runtime job leases: `runtime_jobs` rows carry `WorkflowLease { owner,
+  expires_at }` and `lease_generation`; owner-scoped operations live in
+  `crates/harness-workflow/src/runtime/store/runtime_job_leases.rs`,
+  `runtime/lease_state.rs`, `runtime/job_claim.rs`. TTL from
+  `WORKFLOW.md:53` (`lease_ttl_secs: 600`) applied at
+  `crates/harness-server/src/http/background/runtime_workers.rs:6-7`.
+- Workspace leases: `workspace_leases` keyed `(store_key, project_key,
+  slot_index)` with `owner_session`, `process_id`, `process_started_at`, PID
+  liveness via `sysinfo`
+  (`crates/harness-server/src/workspace_lease_store.rs:19-77`).
+- Rejected completion path: `crates/harness-workflow/src/runtime/worker.rs:172-188`
+  — `commit_runtime_activity_completion_with_transcript_if_owned` returning
+  `None` produces `tracing::warn!` + `return Ok(None)`; the `ActivityResult`
+  and prepared transcript are discarded. Lease renewal exists
+  (`execute_with_lease_renewal`, `worker.rs:162`) but the drop path remains
+  whenever renewal lapses.
+- No field or transaction ties `lease_generation` to a workspace lease row.
+
+### Version decoy
+
+- `WorkflowInstance.version: u64` (`runtime/model.rs:87`), incremented at
+  `runtime/store/instances.rs:80,124` and bound on writes
+  (`instances.rs:48,226`, `store/transaction_helpers.rs:170,202`), but never
+  used in a WHERE predicate. Mutation serializes on
+  `SELECT ... FOR UPDATE` + `expected_state`
+  (`store/transaction_helpers.rs:93`).
+
+### Retention / watchdog defaults
+
+- `WORKFLOW.md:61-73`: `orphan_reaper_enabled: true`,
+  `workflow_watchdog_enabled: false`, `runtime_retention_enabled: false`,
+  `task_retention_enabled: false`.
+- `crates/harness-server/src/http/orphan_reaper.rs:1-14` documents the prior
+  declaration-execution gap for schema reaping.
+
+### Loop supervision
+
+- Spawn sites: `crates/harness-server/src/http/mod.rs:190-217` (auto
+  recovery, pr-feedback sweeper, pr hygiene, orphan reaper, watchdog,
+  retention, command dispatcher, job workers, scheduler, alerting), each a
+  bare `tokio::spawn` loop over a `Weak<AppState>`.
+- Config reload per tick with divergent failure arms: watchdog warns
+  (`http/workflow_watchdog.rs:28-37`); orphan reaper's arm is
+  `Err(_) => { sleep(30s); continue; }` with no log
+  (`http/orphan_reaper.rs:40-48`); retention mirrors the watchdog
+  (`http/runtime_retention.rs:16-27`).
+- Dispatcher identity is per-process-random
+  (`runtime/dispatcher.rs:141`).
+
+## Design
+
+### D1 — Ownership epoch and dead-letter completions
+
+Additive schema:
+
+```sql
+ALTER TABLE workspace_leases ADD COLUMN ownership_epoch BIGINT;  -- nullable
+
+CREATE TABLE runtime_dead_letter_completions (
+    id             TEXT PRIMARY KEY,
+    runtime_job_id TEXT NOT NULL,
+    owner          TEXT NOT NULL,
+    ownership_epoch BIGINT NOT NULL,
+    result         JSONB NOT NULL,
+    transcript_ref TEXT,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    adopted_at     TIMESTAMPTZ,
+    adopted_by     TEXT,
+    superseded_by_rerun BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE UNIQUE INDEX ON runtime_dead_letter_completions (runtime_job_id, ownership_epoch);
+```
+
+- The epoch is the job's existing `lease_generation` at claim time; no new
+  counter. `claim_next_runtime_job_*` already increments it; the claim result
+  exposes it to the worker, which passes it to workspace acquisition.
+- `workspace_lease_store` acquisition/renewal accepts an optional epoch; when
+  present, renewal with an epoch older than the stored one is rejected
+  (return value, not error), and release-by-epoch marks the row releasable
+  once PID liveness fails.
+- Worker completion path: on `...if_owned` returning `None`, insert the
+  dead-letter row inside a new store call
+  `dead_letter_runtime_completion(...)`, emit runtime event
+  `ActivityCompletionDeadLettered`, then return. The unique index makes crash
+  retry idempotent.
+- Adoption: the auto-recovery sweep (`http/background/auto_recovery.rs`)
+  gains a step — for each unadopted, non-superseded dead letter whose job has
+  not been re-claimed since the epoch (`lease_generation` unchanged), commit
+  the stored result through the normal completion path within one
+  transaction, stamping `adopted_at`/`adopted_by`. If `lease_generation`
+  advanced, stamp `superseded_by_rerun = TRUE` and leave it for operators
+  (surfaced via the existing runtime events feed).
+
+### D2 — Version resolution
+
+Recommended resolution: **enforce**. Instance UPDATE statements gain
+`AND version = $expected`; helper `update_instance_checked_tx` returns a
+typed `InstanceVersionConflict` error on zero rows. The row lock remains for
+multi-statement transactions; the predicate is defense-in-depth against
+writers that bypass the helper. If review instead selects removal, the field
+is renamed `mutation_count` with a doc comment and a test asserting no SQL
+references `version` as a predicate. Exactly one resolution ships (product
+B-005).
+
+### D3 — Retention defaults and dry-run
+
+- Config default flips: `runtime_retention_enabled: true`,
+  `task_retention_enabled: true`, new `retention_dry_run: true` (per store,
+  auto-cleared after the first completed dry-run interval is acknowledged via
+  the existing config file, or left permanently on by the operator).
+- Eligibility: instance in a terminal state (`Succeeded`/`Failed`/
+  `Cancelled` mapping already defined by the state registry) AND
+  `updated_at < now() - retention_age` (default 30 days). Only
+  event/decision/artifact/transcript rows belonging to eligible instances are
+  candidates. Non-terminal instances are structurally excluded by the query.
+- Dry-run emits runtime event `RetentionDryRunReport { would_delete_events,
+  would_delete_decisions, would_delete_artifacts, estimated_bytes,
+  oldest, newest }` per tick.
+
+### D4 — Loop supervisor and loud config failure
+
+- New `BackgroundLoopSupervisor` in `harness-server`: `register(name,
+  interval)` returns a `LoopTicket`; loops call `ticket.tick_ok()` /
+  `ticket.tick_failed(reason)`. Supervisor state feeds the existing health
+  route: per-loop `{ name, last_ok, staleness, degraded }`, degraded when
+  `now - last_ok > staleness_factor * interval` (default factor 3).
+- Shared config loader: one `load_workflow_config_tracked(state)` wrapper
+  used by every config-gated loop. It logs at error level on the
+  Ok→Err transition only, sets a shared `config_degraded_since` in
+  `AppState`, and clears it on recovery. Individual loops lose their private
+  failure arms (fixing the reaper's silent arm).
+- Dispatch pause: the command dispatcher and job-worker claim path check
+  `config_degraded_since`; beyond `config_failure_grace_secs` (default 300)
+  they defer claims with reason code `config_degraded` (reusing the existing
+  dispatch-barrier defer mechanism). Running activities are unaffected.
+- Leader-election forward note: supervisor registration takes a
+  `singleton: bool`; singleton loops acquire a Postgres advisory lock keyed
+  by loop name before ticking. In a single-process deployment this is a
+  no-op cost; a second process becomes safe by construction. No further
+  multi-instance work in this spec.
+
+## Affected Files (expected)
+
+- `crates/harness-workflow/src/runtime/worker.rs` — dead-letter branch.
+- `crates/harness-workflow/src/runtime/store/runtime_job_leases.rs`,
+  `store/transaction_helpers.rs`, `store/instances.rs`,
+  `store_migrations.rs` — epoch exposure, dead-letter table, version
+  predicate.
+- `crates/harness-server/src/workspace_lease_store.rs`,
+  `workspace_pool.rs` — epoch-aware acquisition/renewal/release.
+- `crates/harness-server/src/http/background/auto_recovery.rs` — adoption
+  sweep.
+- `crates/harness-server/src/http/{mod.rs,workflow_watchdog.rs,
+  runtime_retention.rs,orphan_reaper.rs}` and
+  `http/background/*.rs` — supervisor registration, shared config loader.
+- `crates/harness-core/src/config/workflow.rs` — new defaults and knobs.
+- `WORKFLOW.md` — default changes and documentation.
+
+## Validation
+
+- `cargo test -p harness-workflow` (store, worker, reducer suites; requires
+  `HARNESS_DATABASE_URL` for the Postgres-backed lease/dead-letter tests).
+- `cargo test -p harness-server` (workspace lease, background loop,
+  health-route suites).
+- `cargo clippy --workspace --all-targets -- -D warnings` and
+  `cargo fmt --all -- --check` before push.
+
+## Risks
+
+- Epoch plumbing touches the hot claim path; mitigated by reusing
+  `lease_generation` instead of introducing a second counter.
+- Retention default flip is the only behavior change visible to existing
+  deployments; dry-run-first sequencing bounds it to reporting until
+  acknowledged.
+- The version predicate (D2) can surface latent writers that bypass the
+  helper today; that surfacing is the point, but rollout should watch for
+  `InstanceVersionConflict` in logs during the first release.

--- a/specs/GH1772/tech.md
+++ b/specs/GH1772/tech.md
@@ -11,9 +11,12 @@ All citations verified on `main` (81c78255).
 ### Dual lease systems
 
 - Runtime job leases: `runtime_jobs` rows carry `WorkflowLease { owner,
-  expires_at }` and `lease_generation`; owner-scoped operations live in
-  `crates/harness-workflow/src/runtime/store/runtime_job_leases.rs`,
-  `runtime/lease_state.rs`, `runtime/job_claim.rs`. TTL from
+  expires_at }` and `lease_generation`; owner-scoped operations are
+  `claim_next_runtime_job`
+  (`crates/harness-workflow/src/runtime/store/runtime_jobs.rs:251`),
+  `defer_runtime_job_claim_if_owned` (`store/runtime_job_state.rs:48`), and
+  `commit_runtime_activity_completion_with_transcript_if_owned`
+  (`store/activity_completion.rs:72`). TTL from
   `WORKFLOW.md:53` (`lease_ttl_secs: 600`) applied at
   `crates/harness-server/src/http/background/runtime_workers.rs:6-7`.
 - Workspace leases: `workspace_leases` keyed `(store_key, project_key,
@@ -145,16 +148,18 @@ B-005).
   `config_degraded_since`; beyond `config_failure_grace_secs` (default 300)
   they defer claims with reason code `config_degraded` (reusing the existing
   dispatch-barrier defer mechanism). Running activities are unaffected.
-- Leader-election forward note: supervisor registration takes a
-  `singleton: bool`; singleton loops acquire a Postgres advisory lock keyed
-  by loop name before ticking. In a single-process deployment this is a
-  no-op cost; a second process becomes safe by construction. No further
-  multi-instance work in this spec.
+- Leader-election forward-compatibility note (**non-normative**, per product
+  Non-Goals): a future multi-instance deployment could have the supervisor
+  take `singleton: bool` at registration and acquire a Postgres advisory lock
+  keyed by loop name before each singleton tick, making a second process safe
+  by construction. This spec neither requires nor tests that behavior; it
+  only asks that the supervisor API not preclude it.
 
 ## Affected Files (expected)
 
 - `crates/harness-workflow/src/runtime/worker.rs` — dead-letter branch.
-- `crates/harness-workflow/src/runtime/store/runtime_job_leases.rs`,
+- `crates/harness-workflow/src/runtime/store/{runtime_jobs.rs,
+  runtime_job_state.rs, activity_completion.rs}`,
   `store/transaction_helpers.rs`, `store/instances.rs`,
   `store_migrations.rs` — epoch exposure, dead-letter table, version
   predicate.


### PR DESCRIPTION
Defines the fail-closed behavior contract for four runtime reliability defect clusters: dead-letter persistence for lease-rejected activity completions plus an ownership epoch binding runtime job leases to workspace leases; resolution of the unchecked `WorkflowInstance.version` field (enforce-as-CAS or rename); safe terminal-only retention defaults with an operator-visible dry-run; and supervised background loops with a single loud degraded mode on `WORKFLOW.md` parse failure (including dispatch pause after a grace period).

Adds `docs/references/runtime-reliability.md` — the full evidence-based analysis (all file:line citations verified on main @ 81c78255) — and the spec packet `specs/GH1772/{product,tech}.md`.

Refs #1772