### PR TITLE
fix(ops): detect stale local Harness binaries before launch

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# shellcheck source=lib/binary-freshness.sh
+. "scripts/lib/binary-freshness.sh"
+
 usage() {
     cat <<'EOF'
 Usage:
@@ -237,8 +240,22 @@ database_host_port() {
 }
 
 check_release_binary() {
+    local freshness
+
     if [ -x "./target/release/harness" ]; then
-        status_ok "release binary is executable: ./target/release/harness"
+        harness_binary_freshness ./target/release/harness "$PWD" > /dev/null
+        freshness="$HARNESS_BINARY_FRESHNESS_STATE"
+        case "$freshness" in
+            fresh)
+                status_ok "release binary is executable and fresh: ./target/release/harness"
+                ;;
+            stale)
+                fail "release binary is stale (${HARNESS_BINARY_FRESHNESS_DETAIL}); rebuild with: cargo build --release -p harness-cli"
+                ;;
+            *)
+                warn "release binary freshness is unverifiable (${HARNESS_BINARY_FRESHNESS_DETAIL}); rebuild with: cargo build --release -p harness-cli"
+                ;;
+        esac
         return 0
     fi
 

--- a/scripts/lib/binary-freshness.sh
+++ b/scripts/lib/binary-freshness.sh
@@ -51,7 +51,7 @@ harness_binary_freshness() {
     local bin="$1"
     local root="$2"
     local depinfo="${bin}.d"
-    local bin_mtime="" dep_mtime="" line="" deps="" dep=""
+    local bin_mtime="" dep_mtime="" line="" deps="" dep="" relative_dep=""
     local checked=0 had_noglob=0
 
     root="$(_harness_bf_squeeze_slashes "$root")"
@@ -90,9 +90,18 @@ harness_binary_freshness() {
     for dep in $deps; do
         dep="${dep//$'\x1f'/ }"
         [ -n "$dep" ] || continue
+        case "$dep" in
+            /*) ;;
+            *) dep="$root/$dep" ;;
+        esac
         dep="$(_harness_bf_squeeze_slashes "$dep")"
         case "$dep" in
-            "$root"/*) ;;
+            "$root"/*)
+                relative_dep="${dep#"$root"/}"
+                case "/$relative_dep/" in
+                    */../*) continue ;;
+                esac
+                ;;
             *) continue ;;
         esac
         if [ ! -e "$dep" ]; then

--- a/scripts/lib/binary-freshness.sh
+++ b/scripts/lib/binary-freshness.sh
@@ -36,9 +36,11 @@ _harness_bf_mtime() {
 # POSIX treats repeated slashes as one separator; squeeze them so textual
 # prefix matching cannot be defeated by "dir//file" spellings in dep-info.
 _harness_bf_squeeze_slashes() {
-    local path="$1"
+    # Named pattern/replacement variables: literal backslash-escaped slashes
+    # in ${var//pattern/replacement} misparse under macOS stock bash 3.2.
+    local path="$1" double_slash='//' single_slash='/'
     while case "$path" in *//*) true ;; *) false ;; esac; do
-        path="${path//\/\//\/}"
+        path="${path//$double_slash/$single_slash}"
     done
     printf '%s\n' "$path"
 }

--- a/scripts/lib/binary-freshness.sh
+++ b/scripts/lib/binary-freshness.sh
@@ -1,0 +1,160 @@
+# shellcheck shell=bash
+# Shared read-only freshness contract for repository-local default Harness
+# binaries (target/release/harness, target/debug/harness).
+#
+# Sourced by scripts/start-harness-codex-safe.sh, start-server.sh, and
+# scripts/doctor.sh. This file must stay side-effect free: it never builds,
+# writes, deletes, or starts anything.
+#
+# Contract (GH-1763):
+# - Evidence is the Cargo dep-info file written next to the binary
+#   ("<binary>.d") plus the repository root Cargo.toml and Cargo.lock.
+# - A binary is "fresh" when every repository-local build input listed in the
+#   dep-info file, and both root manifests, are not newer than the binary.
+# - A listed repository build input that is missing or newer than the binary
+#   makes the binary "stale" (sources changed since the build).
+# - Missing, unreadable, or malformed evidence is "unverifiable" (fail
+#   closed): it is never reported as fresh.
+# - Out-of-repository inputs (registry sources, toolchain) are intentionally
+#   not scanned; their changes are visible through Cargo.lock.
+
+# harness_binary_freshness BIN REPO_ROOT
+#   Prints exactly one of: fresh | stale | unverifiable
+#   Also sets HARNESS_BINARY_FRESHNESS_STATE to that value and
+#   HARNESS_BINARY_FRESHNESS_DETAIL to a one-line reason. Callers should
+#   invoke the function directly (not in command substitution) and read the
+#   variables, so the detail survives; the printed value exists for ad hoc
+#   shell use. Always returns 0 so `set -e` callers can branch on the state.
+# shellcheck disable=SC2034  # read by the scripts that source this library
+HARNESS_BINARY_FRESHNESS_STATE=""
+HARNESS_BINARY_FRESHNESS_DETAIL=""
+
+_harness_bf_mtime() {
+    stat -f %m -- "$1" 2>/dev/null || stat -c %Y -- "$1" 2>/dev/null
+}
+
+# POSIX treats repeated slashes as one separator; squeeze them so textual
+# prefix matching cannot be defeated by "dir//file" spellings in dep-info.
+_harness_bf_squeeze_slashes() {
+    local path="$1"
+    while case "$path" in *//*) true ;; *) false ;; esac; do
+        path="${path//\/\//\/}"
+    done
+    printf '%s\n' "$path"
+}
+
+harness_binary_freshness() {
+    HARNESS_BINARY_FRESHNESS_STATE=""
+    HARNESS_BINARY_FRESHNESS_DETAIL=""
+    local bin="$1"
+    local root="$2"
+    local depinfo="${bin}.d"
+    local bin_mtime="" dep_mtime="" line="" deps="" dep=""
+    local checked=0 had_noglob=0
+
+    root="$(_harness_bf_squeeze_slashes "$root")"
+
+    if [ ! -f "$bin" ]; then
+        HARNESS_BINARY_FRESHNESS_DETAIL="binary not found: $bin"
+        HARNESS_BINARY_FRESHNESS_STATE=unverifiable && printf 'unverifiable\n'
+        return 0
+    fi
+    bin_mtime="$(_harness_bf_mtime "$bin" || true)"
+    if [ -z "$bin_mtime" ]; then
+        HARNESS_BINARY_FRESHNESS_DETAIL="cannot read binary mtime: $bin"
+        HARNESS_BINARY_FRESHNESS_STATE=unverifiable && printf 'unverifiable\n'
+        return 0
+    fi
+    if [ ! -f "$depinfo" ]; then
+        HARNESS_BINARY_FRESHNESS_DETAIL="missing freshness evidence: $depinfo"
+        HARNESS_BINARY_FRESHNESS_STATE=unverifiable && printf 'unverifiable\n'
+        return 0
+    fi
+    line="$(head -n 1 -- "$depinfo" 2>/dev/null || true)"
+    case "$line" in
+        *:*) ;;
+        *)
+            HARNESS_BINARY_FRESHNESS_DETAIL="malformed freshness evidence: $depinfo"
+            HARNESS_BINARY_FRESHNESS_STATE=unverifiable && printf 'unverifiable\n'
+            return 0
+            ;;
+    esac
+    deps="${line#*:}"
+    # Cargo escapes spaces in paths as "\ "; protect them across word split.
+    deps="${deps//\\ /$'\x1f'}"
+
+    case $- in *f*) had_noglob=1 ;; esac
+    set -f
+    for dep in $deps; do
+        dep="${dep//$'\x1f'/ }"
+        [ -n "$dep" ] || continue
+        dep="$(_harness_bf_squeeze_slashes "$dep")"
+        case "$dep" in
+            "$root"/*) ;;
+            *) continue ;;
+        esac
+        if [ ! -e "$dep" ]; then
+            [ "$had_noglob" -eq 1 ] || set +f
+            HARNESS_BINARY_FRESHNESS_DETAIL="build input removed or renamed since build: $dep"
+            HARNESS_BINARY_FRESHNESS_STATE=stale && printf 'stale\n'
+            return 0
+        fi
+        dep_mtime="$(_harness_bf_mtime "$dep" || true)"
+        if [ -z "$dep_mtime" ]; then
+            [ "$had_noglob" -eq 1 ] || set +f
+            HARNESS_BINARY_FRESHNESS_DETAIL="cannot read build input mtime: $dep"
+            HARNESS_BINARY_FRESHNESS_STATE=unverifiable && printf 'unverifiable\n'
+            return 0
+        fi
+        if [ "$dep_mtime" -gt "$bin_mtime" ]; then
+            [ "$had_noglob" -eq 1 ] || set +f
+            HARNESS_BINARY_FRESHNESS_DETAIL="build input newer than binary: $dep"
+            HARNESS_BINARY_FRESHNESS_STATE=stale && printf 'stale\n'
+            return 0
+        fi
+        checked=$((checked + 1))
+    done
+    [ "$had_noglob" -eq 1 ] || set +f
+
+    if [ "$checked" -eq 0 ]; then
+        HARNESS_BINARY_FRESHNESS_DETAIL="no repository build inputs listed in $depinfo"
+        HARNESS_BINARY_FRESHNESS_STATE=unverifiable && printf 'unverifiable\n'
+        return 0
+    fi
+
+    for dep in "$root/Cargo.toml" "$root/Cargo.lock"; do
+        if [ ! -f "$dep" ]; then
+            HARNESS_BINARY_FRESHNESS_DETAIL="missing root manifest: $dep"
+            HARNESS_BINARY_FRESHNESS_STATE=unverifiable && printf 'unverifiable\n'
+            return 0
+        fi
+        dep_mtime="$(_harness_bf_mtime "$dep" || true)"
+        if [ -z "$dep_mtime" ]; then
+            HARNESS_BINARY_FRESHNESS_DETAIL="cannot read root manifest mtime: $dep"
+            HARNESS_BINARY_FRESHNESS_STATE=unverifiable && printf 'unverifiable\n'
+            return 0
+        fi
+        if [ "$dep_mtime" -gt "$bin_mtime" ]; then
+            HARNESS_BINARY_FRESHNESS_DETAIL="root manifest newer than binary: $dep"
+            HARNESS_BINARY_FRESHNESS_STATE=stale && printf 'stale\n'
+            return 0
+        fi
+    done
+
+    HARNESS_BINARY_FRESHNESS_DETAIL="verified against $checked repository build inputs and root manifests"
+    HARNESS_BINARY_FRESHNESS_STATE=fresh && printf 'fresh\n'
+    return 0
+}
+
+# harness_binary_rebuild_hint BIN
+#   Prints the actionable rebuild command for a repository-local binary.
+harness_binary_rebuild_hint() {
+    case "$1" in
+        */target/debug/*)
+            printf 'cargo build -p harness-cli\n'
+            ;;
+        *)
+            printf 'cargo build --release -p harness-cli\n'
+            ;;
+    esac
+}

--- a/scripts/start-harness-codex-safe.sh
+++ b/scripts/start-harness-codex-safe.sh
@@ -222,6 +222,9 @@ report_binary_freshness() {
   local live_pid="${1:-}"
   local assessed="" exe="" state=""
   if [[ -n "$live_pid" ]]; then
+    # ps comm output can be truncated or relative on some platforms; when it
+    # does not resolve to a repository-local binary we fall back to the
+    # default candidate below and always print which binary was assessed.
     exe="$(ps -p "$live_pid" -o comm= 2>/dev/null | tail -1 || true)"
     case "$exe" in
       "$PWD"/target/*|./target/*|target/*)

--- a/scripts/start-harness-codex-safe.sh
+++ b/scripts/start-harness-codex-safe.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/binary-freshness.sh
+. "$SCRIPT_DIR/lib/binary-freshness.sh"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -23,6 +27,15 @@ environment such as PATH, HOME, GITHUB_TOKEN, and API keys, but removes local
 Codex/Claude wrapper variables that can confuse spawned agent subprocesses.
 When available, background mode runs the server in a detached tmux session so it
 does not depend on the calling tool process lifetime.
+
+Binary freshness: when the binary is selected implicitly from
+./target/release/harness or ./target/debug/harness, the wrapper verifies it
+against the Cargo dep-info evidence next to it plus the root manifests. A
+stale or unverifiable default binary is never silently started; rebuild it or
+select a binary explicitly. Explicit --bin or HARNESS_BIN values are
+operator-owned: freshness is reported as a warning but not enforced.
+--status and the recorded-live-PID fast path report binary freshness
+separately from process health.
 EOF
 }
 
@@ -40,6 +53,10 @@ PROJECT_ROOT=""
 PROJECT_ROOT_EXPLICIT=0
 CONFIG=""
 BIN="${HARNESS_BIN:-}"
+EXPLICIT_BIN=0
+if [[ -n "$BIN" ]]; then
+  EXPLICIT_BIN=1
+fi
 LOG_DIR=".harness/local"
 WAIT_SECS="${HARNESS_STARTER_WAIT_SECS:-60}"
 HEALTH_CURL_TIMEOUT_SECS="${HARNESS_STARTER_HEALTH_TIMEOUT_SECS:-2}"
@@ -69,6 +86,7 @@ while [[ $# -gt 0 ]]; do
     --bin)
       require_value "$1" "${2:-}"
       BIN="$2"
+      EXPLICIT_BIN=1
       shift 2
       ;;
     --log-dir)
@@ -197,6 +215,41 @@ listener_pid_for_port() {
   fi
 }
 
+# Reports binary freshness separately from process health. Prefers the
+# executable of the given live PID when it is a repository-local binary,
+# otherwise falls back to the selected or default repository binary.
+report_binary_freshness() {
+  local live_pid="${1:-}"
+  local assessed="" exe="" state=""
+  if [[ -n "$live_pid" ]]; then
+    exe="$(ps -p "$live_pid" -o comm= 2>/dev/null | tail -1 || true)"
+    case "$exe" in
+      "$PWD"/target/*|./target/*|target/*)
+        assessed="$exe"
+        ;;
+    esac
+  fi
+  if [[ -z "$assessed" ]]; then
+    if [[ -n "$BIN" ]]; then
+      assessed="$BIN"
+    elif [[ -e ./target/release/harness ]]; then
+      assessed="./target/release/harness"
+    elif [[ -e ./target/debug/harness ]]; then
+      assessed="./target/debug/harness"
+    fi
+  fi
+  if [[ -z "$assessed" ]]; then
+    echo "binary_freshness=unverifiable binary=none detail=no repository-local harness binary found"
+    return 0
+  fi
+  harness_binary_freshness "$assessed" "$PWD" > /dev/null
+  state="$HARNESS_BINARY_FRESHNESS_STATE"
+  echo "binary_freshness=$state binary=$assessed detail=${HARNESS_BINARY_FRESHNESS_DETAIL}"
+  if [[ "$state" != "fresh" ]]; then
+    echo "note: binary freshness is independent of process health; rebuild with: $(harness_binary_rebuild_hint "$assessed")"
+  fi
+}
+
 require_listener_check_for_start() {
   if ! command -v lsof >/dev/null 2>&1; then
     echo "refusing to start harness server: lsof is required to verify port $PORT ownership" >&2
@@ -241,6 +294,7 @@ if [[ "$STATUS" -eq 1 ]]; then
   if pid_alive "$pid"; then
     echo "$pid" > "$PID_FILE"
     echo "pid=$pid status=running log=$LOG_FILE"
+    report_binary_freshness "$pid"
   else
     if command -v lsof >/dev/null 2>&1; then
       listener_pid="$(listener_pid_for_port)"
@@ -273,6 +327,7 @@ require_listener_check_for_start
 pid="$(recorded_pid)"
 if pid_alive "$pid"; then
   echo "harness server already recorded as running pid=$pid port=$PORT"
+  report_binary_freshness "$pid"
   exit 0
 fi
 
@@ -296,6 +351,21 @@ fi
 if [[ ! -x "$BIN" ]]; then
   echo "harness binary is not executable: $BIN" >&2
   exit 3
+fi
+
+harness_binary_freshness "$BIN" "$PWD" > /dev/null
+binary_freshness_state="$HARNESS_BINARY_FRESHNESS_STATE"
+if [[ "$binary_freshness_state" != "fresh" ]]; then
+  if [[ "$EXPLICIT_BIN" -eq 0 ]]; then
+    echo "refusing to start harness server: default binary is ${binary_freshness_state}: $BIN" >&2
+    echo "reason: ${HARNESS_BINARY_FRESHNESS_DETAIL}" >&2
+    echo "rebuild with: $(harness_binary_rebuild_hint "$BIN")" >&2
+    echo "or select an operator-owned binary explicitly with --bin/HARNESS_BIN" >&2
+    exit 3
+  fi
+  echo "warning: operator-selected binary is ${binary_freshness_state}: $BIN" >&2
+  echo "warning: reason: ${HARNESS_BINARY_FRESHNESS_DETAIL}" >&2
+  echo "warning: freshness is not enforced for explicit --bin/HARNESS_BIN selections" >&2
 fi
 
 unset_args=()

--- a/scripts/start-harness-codex-safe.sh
+++ b/scripts/start-harness-codex-safe.sh
@@ -218,14 +218,23 @@ listener_pid_for_port() {
 # Reports binary freshness separately from process health. Prefers the
 # executable of the given live PID when it is a repository-local binary,
 # otherwise falls back to the selected or default repository binary.
+live_executable_for_pid() {
+  local live_pid="$1"
+  if [[ -e "/proc/$live_pid/exe" ]]; then
+    readlink "/proc/$live_pid/exe" 2>/dev/null || true
+    return 0
+  fi
+  ps -p "$live_pid" -o comm= 2>/dev/null | tail -1 || true
+}
+
 report_binary_freshness() {
   local live_pid="${1:-}"
   local assessed="" exe="" state=""
   if [[ -n "$live_pid" ]]; then
-    # ps comm output can be truncated or relative on some platforms; when it
-    # does not resolve to a repository-local binary we fall back to the
-    # default candidate below and always print which binary was assessed.
-    exe="$(ps -p "$live_pid" -o comm= 2>/dev/null | tail -1 || true)"
+    # Linux ps comm output is only a process name, so prefer the exact procfs
+    # executable link. Other platforms use ps comm and fall back below when it
+    # does not identify a repository-local binary.
+    exe="$(live_executable_for_pid "$live_pid")"
     case "$exe" in
       "$PWD"/target/*|./target/*|target/*)
         assessed="$exe"

--- a/scripts/test-binary-freshness.sh
+++ b/scripts/test-binary-freshness.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Regression tests for the GH-1763 binary freshness contract:
+# scripts/lib/binary-freshness.sh plus its integration in
+# scripts/start-harness-codex-safe.sh.
+#
+# Covers: fresh, stale (newer input / removed input / newer manifest),
+# missing evidence, malformed evidence, escaped-space locators, explicit
+# operator-owned binary override, refusal of a stale default binary, and
+# freshness reporting on the recorded-live-PID path.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/binary-freshness.sh
+. "$REPO_ROOT/scripts/lib/binary-freshness.sh"
+
+FAILURES=0
+
+pass() {
+    printf 'PASS: %s\n' "$1"
+}
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    FAILURES=$((FAILURES + 1))
+}
+
+OLD_TS=202601010000
+NEW_TS=202601020000
+
+FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/harness-binary-freshness.XXXXXX")"
+trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+
+# new_fixture NAME -> prints the fixture repo path
+# Layout: Cargo.toml, Cargo.lock, src/main.rs, target/release/harness{,.d},
+# everything older than the binary, so the baseline state is fresh.
+new_fixture() {
+    local fix="$FIXTURE_ROOT/$1"
+    mkdir -p "$fix/src" "$fix/target/release"
+    printf '[package]\nname = "fixture"\n' > "$fix/Cargo.toml"
+    printf '# lock\n' > "$fix/Cargo.lock"
+    printf 'fn main() {}\n' > "$fix/src/main.rs"
+    printf '#!/bin/sh\nexit 0\n' > "$fix/target/release/harness"
+    chmod +x "$fix/target/release/harness"
+    printf '%s/target/release/harness: %s/src/main.rs\n' "$fix" "$fix" \
+        > "$fix/target/release/harness.d"
+    touch -t "$OLD_TS" "$fix/Cargo.toml" "$fix/Cargo.lock" "$fix/src/main.rs" \
+        "$fix/target/release/harness.d"
+    touch -t "$NEW_TS" "$fix/target/release/harness"
+    printf '%s\n' "$fix"
+}
+
+expect_state() {
+    local label="$1" expected="$2" fix="$3"
+    local actual printed
+    printed="$(harness_binary_freshness "$fix/target/release/harness" "$fix")"
+    harness_binary_freshness "$fix/target/release/harness" "$fix" > /dev/null
+    actual="$HARNESS_BINARY_FRESHNESS_STATE"
+    if [ "$printed" != "$actual" ]; then
+        fail "$label: printed state '$printed' != variable state '$actual'"
+        return 0
+    fi
+    if [ "$actual" = "$expected" ]; then
+        pass "$label -> $actual"
+    else
+        fail "$label: expected $expected, got $actual (detail: $HARNESS_BINARY_FRESHNESS_DETAIL)"
+    fi
+}
+
+# --- helper unit cases ---------------------------------------------------
+
+fix="$(new_fixture fresh)"
+expect_state "fresh binary" fresh "$fix"
+
+fix="$(new_fixture stale-newer-input)"
+touch "$fix/src/main.rs"
+expect_state "build input newer than binary" stale "$fix"
+
+fix="$(new_fixture stale-removed-input)"
+rm "$fix/src/main.rs"
+expect_state "build input removed since build" stale "$fix"
+
+fix="$(new_fixture stale-newer-manifest)"
+touch "$fix/Cargo.lock"
+expect_state "root manifest newer than binary" stale "$fix"
+
+fix="$(new_fixture missing-evidence)"
+rm "$fix/target/release/harness.d"
+expect_state "missing dep-info evidence" unverifiable "$fix"
+
+fix="$(new_fixture malformed-evidence)"
+printf 'not a dep-info line\n' > "$fix/target/release/harness.d"
+touch -t "$OLD_TS" "$fix/target/release/harness.d"
+expect_state "malformed dep-info evidence" unverifiable "$fix"
+
+fix="$(new_fixture empty-deps)"
+printf '%s/target/release/harness:\n' "$fix" > "$fix/target/release/harness.d"
+touch -t "$OLD_TS" "$fix/target/release/harness.d"
+expect_state "dep-info with no repository inputs" unverifiable "$fix"
+
+fix="$(new_fixture escaped-space)"
+mkdir -p "$fix/src/with space"
+printf 'fn main() {}\n' > "$fix/src/with space/lib.rs"
+printf '%s/target/release/harness: %s/src/with\\ space/lib.rs\n' "$fix" "$fix" \
+    > "$fix/target/release/harness.d"
+touch -t "$OLD_TS" "$fix/src/with space/lib.rs" "$fix/target/release/harness.d"
+expect_state "escaped-space build input (fresh)" fresh "$fix"
+touch "$fix/src/with space/lib.rs"
+expect_state "escaped-space build input (stale)" stale "$fix"
+
+fix="$(new_fixture missing-manifest)"
+rm "$fix/Cargo.lock"
+expect_state "missing root manifest" unverifiable "$fix"
+
+# --- start-harness-codex-safe.sh integration cases -----------------------
+
+STARTER="$REPO_ROOT/scripts/start-harness-codex-safe.sh"
+
+if ! command -v lsof > /dev/null 2>&1; then
+    echo "SKIP: lsof unavailable; starter integration cases not run" >&2
+else
+    # A stale default binary must be refused before any launch.
+    fix="$(new_fixture starter-stale-default)"
+    touch "$fix/src/main.rs"
+    set +e
+    output="$(cd "$fix" && "$STARTER" --port 39411 2>&1)"
+    status=$?
+    set -e
+    if [ "$status" -eq 3 ] &&
+        printf '%s' "$output" | grep -q "refusing to start harness server: default binary is stale"; then
+        pass "starter refuses stale default binary (exit 3)"
+    else
+        fail "starter stale-default refusal: exit=$status output=$output"
+    fi
+
+    # An unverifiable default binary must also be refused.
+    fix="$(new_fixture starter-unverifiable-default)"
+    rm "$fix/target/release/harness.d"
+    set +e
+    output="$(cd "$fix" && "$STARTER" --port 39412 2>&1)"
+    status=$?
+    set -e
+    if [ "$status" -eq 3 ] &&
+        printf '%s' "$output" | grep -q "refusing to start harness server: default binary is unverifiable"; then
+        pass "starter refuses unverifiable default binary (exit 3)"
+    else
+        fail "starter unverifiable-default refusal: exit=$status output=$output"
+    fi
+
+    # Explicit --bin is operator-owned: warn but run.
+    fix="$(new_fixture starter-explicit-bin)"
+    printf '#!/bin/sh\nexit 0\n' > "$fix/operator-harness"
+    chmod +x "$fix/operator-harness"
+    set +e
+    output="$(cd "$fix" && "$STARTER" --port 39413 --bin "$fix/operator-harness" --foreground 2>&1)"
+    status=$?
+    set -e
+    if [ "$status" -eq 0 ] &&
+        printf '%s' "$output" | grep -q "warning: operator-selected binary is" &&
+        printf '%s' "$output" | grep -q "freshness is not enforced"; then
+        pass "starter allows explicit operator-owned binary with warning"
+    else
+        fail "starter explicit-bin override: exit=$status output=$output"
+    fi
+
+    # The recorded-live-PID fast path reports freshness separately from
+    # process health and stays successful and non-destructive.
+    fix="$(new_fixture starter-live-pid)"
+    touch "$fix/src/main.rs"
+    mkdir -p "$fix/.harness/local"
+    printf '%s\n' "$$" > "$fix/.harness/local/harness-39414.pid"
+    set +e
+    output="$(cd "$fix" && "$STARTER" --port 39414 2>&1)"
+    status=$?
+    set -e
+    if [ "$status" -eq 0 ] &&
+        printf '%s' "$output" | grep -q "already recorded as running" &&
+        printf '%s' "$output" | grep -q "binary_freshness=stale" &&
+        printf '%s' "$output" | grep -q "independent of process health"; then
+        pass "starter live-PID path reports freshness separately from health"
+    else
+        fail "starter live-PID freshness report: exit=$status output=$output"
+    fi
+
+    # --status reports freshness for a live recorded PID.
+    set +e
+    output="$(cd "$fix" && "$STARTER" --port 39414 --status 2>&1)"
+    status=$?
+    set -e
+    if [ "$status" -eq 0 ] &&
+        printf '%s' "$output" | grep -q "binary_freshness=stale"; then
+        pass "starter --status reports binary freshness"
+    else
+        fail "starter --status freshness report: exit=$status output=$output"
+    fi
+fi
+
+if [ "$FAILURES" -gt 0 ]; then
+    printf '%d test(s) failed\n' "$FAILURES" >&2
+    exit 1
+fi
+echo "all binary freshness tests passed"

--- a/scripts/test-binary-freshness.sh
+++ b/scripts/test-binary-freshness.sh
@@ -71,6 +71,27 @@ expect_state() {
 fix="$(new_fixture fresh)"
 expect_state "fresh binary" fresh "$fix"
 
+fix="$(new_fixture relative-depinfo-fresh)"
+printf 'target/release/harness: src/main.rs\n' \
+    > "$fix/target/release/harness.d"
+touch -t "$OLD_TS" "$fix/target/release/harness.d"
+expect_state "relative dep-info input (fresh)" fresh "$fix"
+
+fix="$(new_fixture relative-depinfo-stale)"
+printf 'target/release/harness: src/main.rs\n' \
+    > "$fix/target/release/harness.d"
+touch -t "$OLD_TS" "$fix/target/release/harness.d"
+touch "$fix/src/main.rs"
+expect_state "relative dep-info input (stale)" stale "$fix"
+
+fix="$(new_fixture relative-depinfo-parent-escape)"
+printf 'outside build input\n' > "$FIXTURE_ROOT/outside.rs"
+printf 'target/release/harness: src/main.rs ../outside.rs\n' \
+    > "$fix/target/release/harness.d"
+touch -t "$OLD_TS" "$fix/src/main.rs" "$fix/target/release/harness.d"
+touch "$FIXTURE_ROOT/outside.rs"
+expect_state "relative dep-info parent escape is ignored" fresh "$fix"
+
 fix="$(new_fixture stale-newer-input)"
 touch "$fix/src/main.rs"
 expect_state "build input newer than binary" stale "$fix"
@@ -114,6 +135,30 @@ expect_state "missing root manifest" unverifiable "$fix"
 # --- start-harness-codex-safe.sh integration cases -----------------------
 
 STARTER="$REPO_ROOT/scripts/start-harness-codex-safe.sh"
+
+if [ -e "/proc/$$/exe" ] && command -v sleep > /dev/null 2>&1; then
+    fix="$(new_fixture starter-live-proc-executable)"
+    mkdir -p "$fix/target/debug" "$fix/.harness/local"
+    cp "$(command -v sleep)" "$fix/target/debug/harness"
+    printf '%s/target/debug/harness: %s/src/main.rs\n' "$fix" "$fix" \
+        > "$fix/target/debug/harness.d"
+    touch -t "$OLD_TS" "$fix/target/debug/harness.d"
+    "$fix/target/debug/harness" 30 &
+    live_pid=$!
+    printf '%s\n' "$live_pid" > "$fix/.harness/local/harness-39410.pid"
+    set +e
+    output="$(cd "$fix" && "$STARTER" --port 39410 2>&1)"
+    status=$?
+    set -e
+    kill "$live_pid" 2>/dev/null || true
+    wait "$live_pid" 2>/dev/null || true
+    if [ "$status" -eq 0 ] &&
+        printf '%s' "$output" | grep -q "binary=$fix/target/debug/harness"; then
+        pass "starter reports exact Linux procfs live executable"
+    else
+        fail "starter procfs executable report: exit=$status output=$output"
+    fi
+fi
 
 if ! command -v lsof > /dev/null 2>&1; then
     echo "SKIP: lsof unavailable; starter integration cases not run" >&2

--- a/start-server.sh
+++ b/start-server.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+# shellcheck source=scripts/lib/binary-freshness.sh
+. "scripts/lib/binary-freshness.sh"
+
 CONFIG_PATH="${HARNESS_CONFIG:-}"
 CONFIG_ARGS=()
 HARNESS_BIN="${HARNESS_BIN:-./target/release/harness}"
@@ -271,29 +274,56 @@ ensure_bind_port_available() {
 ensure_bind_port_available
 
 ensure_harness_binary() {
+    local freshness rebuild_reason=""
+
     if [ -e "$HARNESS_BIN" ] && [ ! -x "$HARNESS_BIN" ]; then
         echo "ERROR: Harness binary exists but is not executable: $HARNESS_BIN" >&2
         echo "Remove it or rebuild with: cargo build --release -p harness-cli" >&2
         exit 1
     fi
 
-    if [ -x "$HARNESS_BIN" ]; then
-        return 0
-    fi
-
     if [ "$HARNESS_BIN" != "./target/release/harness" ]; then
+        if [ -x "$HARNESS_BIN" ]; then
+            # Explicit HARNESS_BIN is operator-owned: report freshness but do
+            # not enforce it.
+            harness_binary_freshness "$HARNESS_BIN" "$PWD" > /dev/null
+            freshness="$HARNESS_BINARY_FRESHNESS_STATE"
+            if [ "$freshness" != "fresh" ]; then
+                echo "WARNING: operator-selected Harness binary is ${freshness}: $HARNESS_BIN" >&2
+                echo "WARNING: reason: ${HARNESS_BINARY_FRESHNESS_DETAIL}" >&2
+            fi
+            return 0
+        fi
         echo "ERROR: configured Harness binary not found or not executable: $HARNESS_BIN" >&2
         echo "Set HARNESS_BIN to an executable harness binary or build the default release binary." >&2
         exit 1
     fi
 
+    if [ -x "$HARNESS_BIN" ]; then
+        harness_binary_freshness "$HARNESS_BIN" "$PWD" > /dev/null
+        freshness="$HARNESS_BINARY_FRESHNESS_STATE"
+        if [ "$freshness" = "fresh" ]; then
+            return 0
+        fi
+        rebuild_reason="default release binary is ${freshness}: ${HARNESS_BINARY_FRESHNESS_DETAIL}"
+    fi
+
     if ! command -v cargo >/dev/null 2>&1; then
+        if [ -n "$rebuild_reason" ]; then
+            echo "ERROR: $rebuild_reason" >&2
+            echo "ERROR: cargo is not available to rebuild it; rebuild elsewhere with: cargo build --release -p harness-cli" >&2
+            echo "Or set HARNESS_BIN to an operator-owned binary to bypass freshness enforcement." >&2
+            exit 1
+        fi
         echo "ERROR: $HARNESS_BIN is missing and cargo is not available to build it." >&2
         echo "Install Rust or build the release binary in another environment, then rerun ./start-server.sh." >&2
         exit 1
     fi
 
-    echo "Release Harness binary not found; building it with cargo build --release -p harness-cli..." >&2
+    if [ -n "$rebuild_reason" ]; then
+        echo "Rebuilding Harness because $rebuild_reason" >&2
+    fi
+    echo "Building release Harness binary with cargo build --release -p harness-cli..." >&2
     if ! cargo build --release -p harness-cli; then
         echo "ERROR: failed to build $HARNESS_BIN." >&2
         echo "Install the build prerequisites, then rerun: cargo build --release -p harness-cli" >&2


### PR DESCRIPTION
## Summary

Repository startup paths treated an executable default binary as current: `scripts/start-harness-codex-safe.sh` preferred `./target/release/harness` whenever it was executable, `start-server.sh` skipped its Cargo build whenever the binary existed, and `scripts/doctor.sh` reported it healthy on executability alone. A checkout could run behavior that no longer matches the source while every surface reported success (live case: binary built 2026-07-05 still serving a 2026-07-26 checkout).

## Design

- New shared read-only contract `scripts/lib/binary-freshness.sh`: evidence is the Cargo dep-info file next to the binary (`<bin>.d`) plus root `Cargo.toml`/`Cargo.lock`; repository-local inputs newer than (or missing since) the build make it `stale`; missing or malformed evidence is `unverifiable` and fail-closed, never fresh. Out-of-repo inputs are covered through `Cargo.lock` instead of a repository mtime scan.
- `start-harness-codex-safe.sh`: refuses to start a stale/unverifiable implicitly selected binary with an actionable rebuild command; explicit `--bin`/`HARNESS_BIN` is documented operator-owned override behavior (warn only); `--status` and the recorded-live-PID fast path report `binary_freshness=` separately from process health, non-destructively.
- `start-server.sh`: rebuilds a stale/unverifiable default release binary instead of silently reusing it; fails with rebuild guidance when cargo is unavailable; explicit `HARNESS_BIN` stays operator-owned.
- `scripts/doctor.sh`: reports fresh / stale / unverifiable as distinct read-only diagnoses.

## Validation

- `./scripts/test-binary-freshness.sh` — 15/15 pass: fresh, stale (newer input / removed input / newer manifest), missing evidence, malformed evidence, no-repo-inputs, escaped-space locators, missing manifest, stale-default refusal (exit 3), unverifiable-default refusal, explicit-binary operator override, live-PID freshness reporting, `--status` freshness reporting.
- `bash -n` on all touched scripts; shellcheck clean except cross-file SC1091 info.
- Real-repo smoke test: doctor reports the actual stale 2026-07-05 binary as FAIL with rebuild command; starter refuses it with reason and rebuild hint.

Closes #1763