### PR TITLE
fix(GH1783): honor Claude result is_error and surface tool_use blocks

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -285,6 +285,12 @@ impl CodeAgent for ClaudeCodeAgent {
             )));
         }
 
+        // The CLI reports terminal failures via a `result` event while still
+        // exiting 0, so the exit-status check above is not sufficient.
+        if let Some(failure) = parsed.failure {
+            return Err(harness_core::error::HarnessError::AgentExecution(failure));
+        }
+
         Ok(AgentResponse {
             output: parsed.output,
             stderr,

--- a/crates/harness-agents/src/claude_adapter.rs
+++ b/crates/harness-agents/src/claude_adapter.rs
@@ -201,10 +201,10 @@ impl AgentAdapter for ClaudeAdapter {
                 continue;
             }
 
-            let event = match parse_stream_json_line(&line) {
-                Some(ev) => ev,
-                None => continue,
-            };
+            let events = parse_stream_json_events(&line);
+            if events.is_empty() {
+                continue;
+            }
 
             if let Some(usage) = parse_stream_json_usage(&line) {
                 if tx.send(AgentEvent::TokenUsage { usage }).await.is_err() {
@@ -212,12 +212,19 @@ impl AgentAdapter for ClaudeAdapter {
                 }
             }
 
-            // Accumulate output text for TurnCompleted
-            if let AgentEvent::MessageDelta { ref text } = event {
-                output_buf.push_str(text);
-            }
+            let mut channel_closed = false;
+            for event in events {
+                // Accumulate output text for TurnCompleted
+                if let AgentEvent::MessageDelta { ref text } = event {
+                    output_buf.push_str(text);
+                }
 
-            if tx.send(event).await.is_err() {
+                if tx.send(event).await.is_err() {
+                    channel_closed = true;
+                    break;
+                }
+            }
+            if channel_closed {
                 break;
             }
         }
@@ -365,61 +372,147 @@ fn provider_wait_message(phase: ProviderPhase) -> String {
 
 /// Parse a single line of Claude Code `--output-format stream-json` output.
 ///
-/// Returns `None` for unrecognized event types (forward compatibility).
+/// Returns the first event on the line; use [`parse_stream_json_events`] when a
+/// line can carry several (e.g. an assistant message mixing text and tool_use
+/// content blocks).
 pub fn parse_stream_json_line(line: &str) -> Option<AgentEvent> {
-    let v: serde_json::Value = serde_json::from_str(line).ok()?;
-    let event_type = v.get("type")?.as_str()?;
+    parse_stream_json_events(line).into_iter().next()
+}
+
+/// Parse a single line of Claude Code `--output-format stream-json` output into
+/// every event it carries, in content-block order.
+///
+/// Returns an empty vec for unrecognized event types (forward compatibility).
+pub fn parse_stream_json_events(line: &str) -> Vec<AgentEvent> {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+        return Vec::new();
+    };
+    let Some(event_type) = v.get("type").and_then(Value::as_str) else {
+        return Vec::new();
+    };
 
     match event_type {
-        "assistant" => {
-            let text = parse_assistant_text(v.get("message")?)?;
-            Some(AgentEvent::MessageDelta { text })
-        }
+        "assistant" => v
+            .get("message")
+            .map(parse_assistant_events)
+            .unwrap_or_default(),
         "tool_use" => {
-            let name = v.get("name")?.as_str()?.to_string();
+            let Some(name) = v.get("name").and_then(Value::as_str) else {
+                return Vec::new();
+            };
             let input = v.get("input").cloned().unwrap_or(serde_json::Value::Null);
-            Some(AgentEvent::ToolCall { name, input })
+            vec![AgentEvent::ToolCall {
+                name: name.to_string(),
+                input,
+            }]
         }
-        "tool_result" => Some(AgentEvent::ItemCompleted),
-        "result" => {
-            let output = v
-                .get("result")
-                .and_then(|r| r.as_str())
-                .unwrap_or("")
-                .to_string();
-            Some(AgentEvent::TurnCompleted { output })
-        }
+        "tool_result" => vec![AgentEvent::ItemCompleted],
+        "result" => match parse_result_failure_value(&v) {
+            Some(message) => vec![AgentEvent::Error { message }],
+            None => {
+                let output = v
+                    .get("result")
+                    .and_then(|r| r.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                vec![AgentEvent::TurnCompleted { output }]
+            }
+        },
         "error" => {
             let message = v
                 .get("error")
                 .and_then(|e| e.as_str())
                 .unwrap_or("unknown error")
                 .to_string();
-            Some(AgentEvent::Error { message })
+            vec![AgentEvent::Error { message }]
         }
-        _ => None,
+        _ => Vec::new(),
     }
 }
 
-fn parse_assistant_text(message: &Value) -> Option<String> {
-    if let Some(text) = message.as_str() {
-        return Some(text.to_string());
+/// Detect a terminal `result` event that reports failure (`is_error` or an
+/// `error*` subtype). The Claude CLI emits these with exit code 0, so callers
+/// must not rely on the process status to notice the failure.
+pub(crate) fn parse_stream_json_result_failure(line: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    if v.get("type").and_then(Value::as_str) != Some("result") {
+        return None;
+    }
+    parse_result_failure_value(&v)
+}
+
+fn parse_result_failure_value(v: &Value) -> Option<String> {
+    let subtype = v.get("subtype").and_then(Value::as_str).unwrap_or("");
+    let is_error =
+        v.get("is_error").and_then(Value::as_bool) == Some(true) || subtype.starts_with("error");
+    if !is_error {
+        return None;
     }
 
-    let content = message.get("content")?.as_array()?;
-    let text = content
-        .iter()
-        .filter_map(|block| {
-            if block.get("type").and_then(Value::as_str) == Some("text") {
-                block.get("text").and_then(Value::as_str)
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("");
+    let detail = v
+        .get("result")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            v.get("error")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+        });
+    let subtype_label = if subtype.is_empty() {
+        "unknown"
+    } else {
+        subtype
+    };
+    Some(match detail {
+        Some(detail) => format!("claude result reported failure ({subtype_label}): {detail}"),
+        None => format!("claude result reported failure ({subtype_label})"),
+    })
+}
 
-    (!text.is_empty()).then_some(text)
+fn parse_assistant_events(message: &Value) -> Vec<AgentEvent> {
+    if let Some(text) = message.as_str() {
+        return vec![AgentEvent::MessageDelta {
+            text: text.to_string(),
+        }];
+    }
+
+    let Some(content) = message.get("content").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    let mut events = Vec::new();
+    let mut text_buf = String::new();
+    for block in content {
+        match block.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                if let Some(text) = block.get("text").and_then(Value::as_str) {
+                    text_buf.push_str(text);
+                }
+            }
+            Some("tool_use") => {
+                if let Some(name) = block.get("name").and_then(Value::as_str) {
+                    if !text_buf.is_empty() {
+                        events.push(AgentEvent::MessageDelta {
+                            text: std::mem::take(&mut text_buf),
+                        });
+                    }
+                    let input = block
+                        .get("input")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null);
+                    events.push(AgentEvent::ToolCall {
+                        name: name.to_string(),
+                        input,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    if !text_buf.is_empty() {
+        events.push(AgentEvent::MessageDelta { text: text_buf });
+    }
+    events
 }
 
 pub fn parse_stream_json_usage(line: &str) -> Option<TokenUsage> {

--- a/crates/harness-agents/src/claude_adapter.rs
+++ b/crates/harness-agents/src/claude_adapter.rs
@@ -195,12 +195,16 @@ impl AgentAdapter for ClaudeAdapter {
         let reader = tokio::io::BufReader::new(stdout);
         let mut lines = reader.lines();
         let mut output_buf = String::new();
+        let mut turn_failed = false;
 
         while let Ok(Some(line)) = lines.next_line().await {
             if line.trim().is_empty() {
                 continue;
             }
 
+            if parse_stream_json_result_failure(&line).is_some() {
+                turn_failed = true;
+            }
             let events = parse_stream_json_events(&line);
             if events.is_empty() {
                 continue;
@@ -277,11 +281,15 @@ impl AgentAdapter for ClaudeAdapter {
             }
         }
 
-        if let Err(e) = tx
-            .send(AgentEvent::TurnCompleted { output: output_buf })
-            .await
-        {
-            tracing::debug!("claude: event channel closed before turn completed: {e}");
+        // A terminal result failure already surfaced as AgentEvent::Error; a
+        // trailing TurnCompleted would contradict it, so skip it in that case.
+        if !turn_failed {
+            if let Err(e) = tx
+                .send(AgentEvent::TurnCompleted { output: output_buf })
+                .await
+            {
+                tracing::debug!("claude: event channel closed before turn completed: {e}");
+            }
         }
 
         // Clean up child handle

--- a/crates/harness-agents/src/claude_adapter_tests.rs
+++ b/crates/harness-agents/src/claude_adapter_tests.rs
@@ -67,6 +67,74 @@ fn parse_result_event() {
 }
 
 #[test]
+fn parse_assistant_tool_use_blocks_surface_tool_calls() {
+    let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Let me check."},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}},{"type":"text","text":"Now reading."}]}}"#;
+    let events = parse_stream_json_events(line);
+    assert_eq!(events.len(), 3, "expected delta+tool+delta, got {events:?}");
+    assert!(
+        matches!(&events[0], AgentEvent::MessageDelta { text } if text == "Let me check."),
+        "got {events:?}"
+    );
+    match &events[1] {
+        AgentEvent::ToolCall { name, input } => {
+            assert_eq!(name, "Bash");
+            assert_eq!(input["command"], "ls");
+        }
+        other => panic!("expected ToolCall, got {other:?}"),
+    }
+    assert!(
+        matches!(&events[2], AgentEvent::MessageDelta { text } if text == "Now reading."),
+        "got {events:?}"
+    );
+}
+
+#[test]
+fn parse_assistant_tool_use_only_block_is_not_dropped() {
+    let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"src/main.rs"}}]}}"#;
+    let events = parse_stream_json_events(line);
+    assert_eq!(events.len(), 1, "got {events:?}");
+    assert!(
+        matches!(&events[0], AgentEvent::ToolCall { name, .. } if name == "Read"),
+        "got {events:?}"
+    );
+}
+
+#[test]
+fn parse_result_with_is_error_reports_failure() {
+    let line = r#"{"type":"result","subtype":"error_during_execution","is_error":true,"result":"command crashed"}"#;
+    let event = parse_stream_json_line(line).unwrap();
+    match event {
+        AgentEvent::Error { message } => {
+            assert!(message.contains("error_during_execution"), "{message}");
+            assert!(message.contains("command crashed"), "{message}");
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_result_with_error_subtype_reports_failure_without_is_error() {
+    let line = r#"{"type":"result","subtype":"error_max_turns"}"#;
+    let event = parse_stream_json_line(line).unwrap();
+    match event {
+        AgentEvent::Error { message } => {
+            assert!(message.contains("error_max_turns"), "{message}");
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_result_success_subtype_still_completes() {
+    let line = r#"{"type":"result","subtype":"success","is_error":false,"result":"done"}"#;
+    let event = parse_stream_json_line(line).unwrap();
+    assert!(
+        matches!(event, AgentEvent::TurnCompleted { ref output } if output == "done"),
+        "got {event:?}"
+    );
+}
+
+#[test]
 fn parse_result_usage_with_cache_fields() {
     let line = r#"{"type":"result","result":"Done","usage":{"input_tokens":10,"output_tokens":3,"cache_read_input_tokens":4,"cache_creation_input_tokens":2}}"#;
     let usage = parse_stream_json_usage(line).expect("usage should parse");

--- a/crates/harness-agents/src/claude_stream.rs
+++ b/crates/harness-agents/src/claude_stream.rs
@@ -70,9 +70,9 @@ fn apply_claude_stream_line(
     }
 
     if let Some(failure) = parse_stream_json_result_failure(line) {
-        emitted_items.push(StreamItem::Error {
-            message: failure.clone(),
-        });
+        // Do not also emit a StreamItem::Error here: the failure is reported
+        // exactly once, through the Err path of the execution call, so the
+        // turn lifecycle does not persist the same error twice.
         parsed.failure = Some(failure);
         parsed.completed = true;
         return;

--- a/crates/harness-agents/src/claude_stream.rs
+++ b/crates/harness-agents/src/claude_stream.rs
@@ -1,4 +1,6 @@
-use crate::claude_adapter::{parse_stream_json_line, parse_stream_json_usage};
+use crate::claude_adapter::{
+    parse_stream_json_events, parse_stream_json_result_failure, parse_stream_json_usage,
+};
 use crate::streaming::send_stream_item;
 use harness_core::{
     agent::{AgentEvent, StreamItem},
@@ -15,6 +17,9 @@ pub(crate) struct ParsedClaudeStreamOutput {
     pub(crate) raw_stdout: String,
     pub(crate) output: String,
     pub(crate) token_usage: TokenUsage,
+    /// Terminal `result` failure reported by the CLI (emitted with exit code
+    /// 0), so success cannot be inferred from the process status alone.
+    pub(crate) failure: Option<String>,
     completed: bool,
 }
 
@@ -53,8 +58,8 @@ fn apply_claude_stream_line(
     }
 
     let usage = parse_stream_json_usage(line);
-    let event = parse_stream_json_line(line);
-    if usage.is_none() && event.is_none() && !is_json_line(line) {
+    let events = parse_stream_json_events(line);
+    if usage.is_none() && events.is_empty() && !is_json_line(line) {
         push_plaintext_line(line, parsed, emitted_items);
         return;
     }
@@ -64,30 +69,49 @@ fn apply_claude_stream_line(
         emitted_items.push(StreamItem::TokenUsage { usage });
     }
 
+    if let Some(failure) = parse_stream_json_result_failure(line) {
+        emitted_items.push(StreamItem::Error {
+            message: failure.clone(),
+        });
+        parsed.failure = Some(failure);
+        parsed.completed = true;
+        return;
+    }
+
+    for event in events {
+        apply_claude_stream_event(event, parsed, emitted_items);
+    }
+}
+
+fn apply_claude_stream_event(
+    event: AgentEvent,
+    parsed: &mut ParsedClaudeStreamOutput,
+    emitted_items: &mut Vec<StreamItem>,
+) {
     match event {
-        Some(AgentEvent::MessageDelta { text }) => {
+        AgentEvent::MessageDelta { text } => {
             parsed.output.push_str(&text);
             emitted_items.push(StreamItem::MessageDelta { text });
         }
-        Some(AgentEvent::ToolOutputDelta { item_id, text }) => {
+        AgentEvent::ToolOutputDelta { item_id, text } => {
             emitted_items.push(StreamItem::ToolOutputDelta { item_id, text });
         }
-        Some(AgentEvent::ItemStartedPayload { item }) => {
+        AgentEvent::ItemStartedPayload { item } => {
             emitted_items.push(StreamItem::ItemStarted { item });
         }
-        Some(AgentEvent::ItemCompletedPayload { item }) => {
+        AgentEvent::ItemCompletedPayload { item } => {
             emitted_items.push(StreamItem::ItemCompleted { item });
         }
-        Some(AgentEvent::ApprovalRequest { id, command }) => {
+        AgentEvent::ApprovalRequest { id, command } => {
             emitted_items.push(StreamItem::ApprovalRequest { id, command });
         }
-        Some(AgentEvent::Warning { message }) => {
+        AgentEvent::Warning { message } => {
             emitted_items.push(StreamItem::Warning { message });
         }
-        Some(AgentEvent::Error { message }) => {
+        AgentEvent::Error { message } => {
             emitted_items.push(StreamItem::Error { message });
         }
-        Some(AgentEvent::TurnCompleted { output }) => {
+        AgentEvent::TurnCompleted { output } => {
             if !output.is_empty() {
                 if parsed.output.is_empty() {
                     emitted_items.push(StreamItem::MessageDelta {
@@ -103,7 +127,7 @@ fn apply_claude_stream_line(
             });
             parsed.completed = true;
         }
-        Some(AgentEvent::ToolCall { name, input }) => {
+        AgentEvent::ToolCall { name, input } => {
             emitted_items.push(StreamItem::ItemCompleted {
                 item: Item::ToolCall {
                     name,
@@ -112,13 +136,10 @@ fn apply_claude_stream_line(
                 },
             });
         }
-        Some(
-            AgentEvent::TurnStarted
-            | AgentEvent::ItemStarted { .. }
-            | AgentEvent::ItemCompleted
-            | AgentEvent::TokenUsage { .. },
-        )
-        | None => {}
+        AgentEvent::TurnStarted
+        | AgentEvent::ItemStarted { .. }
+        | AgentEvent::ItemCompleted
+        | AgentEvent::TokenUsage { .. } => {}
     }
 }
 
@@ -211,6 +232,10 @@ pub(crate) async fn stream_claude_code_output(
         } else {
             format!("claude exited with {status}: stdout_tail=[{stdout_tail}]")
         }));
+    }
+
+    if let Some(failure) = &parsed.failure {
+        return Err(HarnessError::AgentExecution(failure.clone()));
     }
 
     if !parsed.completed {

--- a/crates/harness-agents/src/claude_tests.rs
+++ b/crates/harness-agents/src/claude_tests.rs
@@ -335,6 +335,29 @@ fn parse_claude_stream_output_keeps_plaintext_fallback() {
     assert_eq!(parsed.token_usage.total_tokens, 0);
 }
 
+#[test]
+fn parse_claude_stream_output_records_result_failure() {
+    let stdout = [
+        r#"{"type":"assistant","message":"working on it"}"#,
+        r#"{"type":"result","subtype":"error_during_execution","is_error":true,"usage":{"input_tokens":7,"output_tokens":1}}"#,
+    ]
+    .join("\n");
+
+    let parsed = parse_claude_stream_output(&stdout);
+
+    let failure = parsed.failure.expect("error result should record failure");
+    assert!(failure.contains("error_during_execution"), "{failure}");
+    // Usage from the failed result is still recorded for accounting.
+    assert_eq!(parsed.token_usage.input_tokens, 7);
+}
+
+#[test]
+fn parse_claude_stream_output_success_has_no_failure() {
+    let parsed = parse_claude_stream_output(r#"{"type":"result","result":"done"}"#);
+    assert!(parsed.failure.is_none());
+    assert_eq!(parsed.output, "done");
+}
+
 fn write_executable_script(script_body: &str) -> (tempfile::TempDir, PathBuf) {
     let dir = tempfile::tempdir().expect("create tempdir");
     let path = dir.path().join("mock-claude.sh");
@@ -690,6 +713,73 @@ printf '%s\n' '{"type":"result","result":"hello","usage":{"input_tokens":10,"out
     assert_eq!(usage.input_tokens, 10);
     assert_eq!(usage.output_tokens, 2);
     assert_eq!(usage.total_tokens, 15);
+}
+
+#[tokio::test]
+async fn execute_fails_on_error_result_despite_exit_zero() {
+    let (dir, script) = write_executable_script(
+        r#"
+printf '%s\n' '{"type":"assistant","message":"trying"}'
+printf '%s\n' '{"type":"result","subtype":"error_during_execution","is_error":true,"result":"tool crashed"}'
+exit 0
+"#,
+    );
+    let agent = ClaudeCodeAgent::new(
+        script,
+        "test-model".to_string(),
+        SandboxMode::DangerFullAccess,
+    );
+    let request = AgentRequest {
+        prompt: "ignored".to_string(),
+        project_root: dir.path().to_path_buf(),
+        ..AgentRequest::default()
+    };
+
+    let error = match agent.execute(request).await {
+        Ok(response) => panic!("error result must not be reported as success: {response:?}"),
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("error_during_execution"), "{error}");
+    assert!(error.contains("tool crashed"), "{error}");
+}
+
+#[tokio::test]
+async fn execute_stream_fails_on_error_result_despite_exit_zero() {
+    let (dir, script) = write_executable_script(
+        r#"
+printf '%s\n' '{"type":"result","subtype":"error_max_turns","is_error":true}'
+exit 0
+"#,
+    );
+    let agent = ClaudeCodeAgent::new(
+        script,
+        "test-model".to_string(),
+        SandboxMode::DangerFullAccess,
+    );
+    let request = AgentRequest {
+        prompt: "ignored".to_string(),
+        project_root: dir.path().to_path_buf(),
+        ..AgentRequest::default()
+    };
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+    let stream_result = agent.execute_stream(request, tx).await;
+    let error = match stream_result {
+        Ok(()) => panic!("error result must not be reported as stream success"),
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("error_max_turns"), "{error}");
+
+    let mut saw_error_item = false;
+    while let Ok(Some(item)) = timeout(Duration::from_secs(2), rx.recv()).await {
+        if matches!(item, StreamItem::Error { .. }) {
+            saw_error_item = true;
+        }
+    }
+    assert!(
+        saw_error_item,
+        "failure should surface as a stream Error item"
+    );
 }
 
 #[tokio::test]

--- a/crates/harness-agents/src/claude_tests.rs
+++ b/crates/harness-agents/src/claude_tests.rs
@@ -770,16 +770,15 @@ exit 0
     };
     assert!(error.contains("error_max_turns"), "{error}");
 
-    let mut saw_error_item = false;
+    // The failure is reported exactly once — via the Err return. A duplicate
+    // StreamItem::Error would make the turn lifecycle persist the same
+    // failure twice.
     while let Ok(Some(item)) = timeout(Duration::from_secs(2), rx.recv()).await {
-        if matches!(item, StreamItem::Error { .. }) {
-            saw_error_item = true;
-        }
+        assert!(
+            !matches!(item, StreamItem::Error { .. }),
+            "terminal failure must not also be emitted as a stream Error item"
+        );
     }
-    assert!(
-        saw_error_item,
-        "failure should surface as a stream Error item"
-    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1783.

The Claude CLI emits terminal failures as `{"type":"result","is_error":true,"subtype":"error_*"}` with exit code 0; both `execute()` and `execute_stream()` treated these as success with empty output. Tool calls never surfaced because the parser matched a top-level `tool_use` shape the CLI does not emit, while real `tool_use` content blocks in assistant messages were dropped.

- `parse_stream_json_events` parses every event on a line in content-block order (adjacent text merged into one delta, preserving output shape)
- error results become `Error` events and fail the turn on both execution paths; usage from failed results is still recorded
- fixture tests for failure results (exit 0) and tool_use blocks

Verification: `cargo test -p harness-agents` (209 passed), `cargo clippy --workspace --all-targets -- -D warnings` clean.