### PR TITLE
fix(GH1788): strip nested-session markers from the effective child env

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -217,7 +217,6 @@ impl CodeAgent for ClaudeCodeAgent {
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
         crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-        crate::strip_claude_env(&mut cmd);
 
         let _provider_permit = self
             .provider_gate
@@ -376,7 +375,6 @@ impl CodeAgent for ClaudeCodeAgent {
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
         crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-        crate::strip_claude_env(&mut cmd);
 
         // ETXTBSY (error 26) occurs on Linux when a security scanner or indexer
         // briefly opens the executable for writing after it is written. Retry once.

--- a/crates/harness-agents/src/claude_adapter.rs
+++ b/crates/harness-agents/src/claude_adapter.rs
@@ -130,7 +130,6 @@ impl AgentAdapter for ClaudeAdapter {
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
         crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-        crate::strip_claude_env(&mut cmd);
 
         let provider_permit =
             acquire_provider_permit_with_event_heartbeat(&self.provider_gate, &req, &tx).await?;

--- a/crates/harness-agents/src/claude_tests.rs
+++ b/crates/harness-agents/src/claude_tests.rs
@@ -782,6 +782,45 @@ exit 0
 }
 
 #[tokio::test]
+async fn execute_strips_injected_nested_session_markers_but_keeps_claude_config() {
+    let (dir, script) = write_executable_script(
+        r#"
+printf '{"type":"result","result":"CLAUDECODE=%s ENTRYPOINT=%s CONFIG_DIR=%s"}\n' \
+    "${CLAUDECODE:-unset}" "${CLAUDE_CODE_ENTRYPOINT:-unset}" "${CLAUDE_CONFIG_DIR:-unset}"
+"#,
+    );
+    let agent = ClaudeCodeAgent::new(
+        script,
+        "test-model".to_string(),
+        SandboxMode::DangerFullAccess,
+    );
+    let mut env_vars = std::collections::HashMap::new();
+    // Injected via the request rather than inherited from the parent env —
+    // the historical bug only stripped keys present in the parent env.
+    env_vars.insert("CLAUDECODE".to_string(), "1".to_string());
+    env_vars.insert("CLAUDE_CODE_ENTRYPOINT".to_string(), "cli".to_string());
+    env_vars.insert(
+        "CLAUDE_CONFIG_DIR".to_string(),
+        "/tmp/claude-cfg".to_string(),
+    );
+    let request = AgentRequest {
+        prompt: "ignored".to_string(),
+        project_root: dir.path().to_path_buf(),
+        env_vars,
+        ..AgentRequest::default()
+    };
+
+    let response = match agent.execute(request).await {
+        Ok(response) => response,
+        Err(error) => panic!("execution should succeed, got: {error}"),
+    };
+    assert_eq!(
+        response.output,
+        "CLAUDECODE=unset ENTRYPOINT=unset CONFIG_DIR=/tmp/claude-cfg"
+    );
+}
+
+#[tokio::test]
 async fn execute_returns_token_usage_from_stream_json_result() {
     let (dir, script) = write_executable_script(
         r#"

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -207,9 +207,9 @@ impl CodexAgent {
             .kill_on_drop(true);
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
-        crate::strip_claude_env(&mut cmd);
         cmd.envs(&req.env_vars);
         crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
+        crate::spawn_contract::strip_nested_session_env(&mut cmd);
 
         if self.cloud.enabled {
             for key in &self.cloud.setup_secret_env {
@@ -416,7 +416,6 @@ impl CodeAgent for CodexAgent {
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
         crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-        crate::strip_claude_env(&mut cmd);
 
         if self.cloud.enabled {
             for key in &self.cloud.setup_secret_env {
@@ -544,7 +543,6 @@ impl CodeAgent for CodexAgent {
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
         crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-        crate::strip_claude_env(&mut cmd);
 
         if self.cloud.enabled {
             for key in &self.cloud.setup_secret_env {

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -252,7 +252,6 @@ impl CodexAdapter {
         #[cfg(unix)]
         crate::set_process_group(&mut cmd);
         crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-        crate::strip_claude_env(&mut cmd);
         crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
         if self.cloud.enabled {
             for key in &self.cloud.setup_secret_env {

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -17,18 +17,6 @@ use harness_core::run_registry::{append_binding_nonblocking, BindingRecord};
 use std::collections::HashMap;
 use std::path::Path;
 
-/// Remove all `CLAUDE`-prefixed environment variables from a command to prevent
-/// nested Claude Code detection (SIGTRAP).
-pub(crate) fn strip_claude_env(cmd: &mut tokio::process::Command) {
-    let claude_keys: Vec<String> = std::env::vars()
-        .filter(|(k, _)| k.starts_with("CLAUDE"))
-        .map(|(k, _)| k)
-        .collect();
-    for key in &claude_keys {
-        cmd.env_remove(key);
-    }
-}
-
 pub(crate) fn resolve_agent_run_identity(env_vars: &HashMap<String, String>) -> RunIdentity {
     match RunIdentity::from_env_vars(env_vars) {
         Ok(Some(identity)) => identity,

--- a/crates/harness-agents/src/spawn_contract.rs
+++ b/crates/harness-agents/src/spawn_contract.rs
@@ -15,7 +15,16 @@ use crate::scoped_token::{
 /// another Claude Code session; leaking any of them into a spawned agent
 /// causes SIGTRAP. Only these markers are stripped — legitimate `CLAUDE_*`
 /// configuration such as `CLAUDE_CONFIG_DIR` must pass through.
-pub(crate) const NESTED_SESSION_ENV_KEYS: [&str; 2] = ["CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT"];
+///
+/// Keep in sync with the wrapper-variable classification in
+/// `scripts/start-harness-codex-safe.sh`.
+pub(crate) const NESTED_SESSION_ENV_KEYS: [&str; 5] = [
+    "CLAUDECODE",
+    "CLAUDE_CODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_SESSION_ID",
+];
 
 const DEFAULT_AGENT_CONTAINER_IMAGE: &str = "harness-agent:latest";
 const AGENT_CONTAINER_IMAGE_ENV: &str = "HARNESS_AGENT_CONTAINER_IMAGE";
@@ -487,8 +496,9 @@ mod container_spawn_tests {
     fn host_spawn_filters_injected_nested_session_markers() -> anyhow::Result<()> {
         let root = tempfile::tempdir()?;
         let mut env_vars = HashMap::new();
-        env_vars.insert("CLAUDECODE".to_string(), "1".to_string());
-        env_vars.insert("CLAUDE_CODE_ENTRYPOINT".to_string(), "cli".to_string());
+        for key in NESTED_SESSION_ENV_KEYS {
+            env_vars.insert(key.to_string(), "1".to_string());
+        }
         env_vars.insert("CLAUDE_CONFIG_DIR".to_string(), "/cfg".to_string());
         let sandbox_spec = SandboxSpec::new(SandboxMode::DangerFullAccess, root.path());
 
@@ -500,8 +510,12 @@ mod container_spawn_tests {
             &env_vars,
         ))?;
 
-        assert!(!spawn.process_env.contains_key("CLAUDECODE"));
-        assert!(!spawn.process_env.contains_key("CLAUDE_CODE_ENTRYPOINT"));
+        for key in NESTED_SESSION_ENV_KEYS {
+            assert!(
+                !spawn.process_env.contains_key(key),
+                "{key} must be stripped from the host process env"
+            );
+        }
         // Legitimate CLAUDE_* configuration must pass through.
         assert_eq!(
             spawn.process_env.get("CLAUDE_CONFIG_DIR"),

--- a/crates/harness-agents/src/spawn_contract.rs
+++ b/crates/harness-agents/src/spawn_contract.rs
@@ -11,6 +11,12 @@ use crate::scoped_token::{
     CONTAINER_GH_TOKEN_ENV, CONTAINER_GITHUB_TOKEN_ENV, SCOPED_GITHUB_TOKEN_ENV,
 };
 
+/// Env keys Claude Code uses to detect that it is running nested inside
+/// another Claude Code session; leaking any of them into a spawned agent
+/// causes SIGTRAP. Only these markers are stripped — legitimate `CLAUDE_*`
+/// configuration such as `CLAUDE_CONFIG_DIR` must pass through.
+pub(crate) const NESTED_SESSION_ENV_KEYS: [&str; 2] = ["CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT"];
+
 const DEFAULT_AGENT_CONTAINER_IMAGE: &str = "harness-agent:latest";
 const AGENT_CONTAINER_IMAGE_ENV: &str = "HARNESS_AGENT_CONTAINER_IMAGE";
 const AGENT_EGRESS_PROXY_ENV: &str = "HARNESS_AGENT_EGRESS_PROXY";
@@ -137,6 +143,22 @@ pub(crate) fn apply_process_env(cmd: &mut tokio::process::Command, spawn: &Prepa
         cmd.env_clear();
     }
     cmd.envs(spawn.process_env.iter());
+    strip_nested_session_env(cmd);
+}
+
+/// Remove nested-session markers from the command's *effective* environment.
+///
+/// `env_remove` overrides both inherited parent env and explicitly set vars,
+/// so this works regardless of where the marker came from. Must be applied
+/// after all `env`/`envs` calls that could introduce the keys.
+pub(crate) fn strip_nested_session_env(cmd: &mut tokio::process::Command) {
+    for key in NESTED_SESSION_ENV_KEYS {
+        cmd.env_remove(key);
+    }
+}
+
+fn is_nested_session_env(key: &str) -> bool {
+    NESTED_SESSION_ENV_KEYS.contains(&key)
 }
 
 fn isolation_tier(env_vars: &HashMap<String, String>) -> Result<IsolationTier, HarnessError> {
@@ -166,6 +188,7 @@ fn host_process_env(env_vars: &HashMap<String, String>) -> BTreeMap<String, Stri
     env_vars
         .iter()
         .filter(|(key, _)| !is_spawn_control_env(key))
+        .filter(|(key, _)| !is_nested_session_env(key))
         .filter(|(key, _)| key.as_str() != SCOPED_GITHUB_TOKEN_ENV)
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect()
@@ -175,6 +198,7 @@ fn container_env_vars(env_vars: &HashMap<String, String>) -> BTreeMap<String, St
     let mut env = env_vars
         .iter()
         .filter(|(key, _)| !is_spawn_control_env(key))
+        .filter(|(key, _)| !is_nested_session_env(key))
         .filter(|(key, _)| key.as_str() != SCOPED_GITHUB_TOKEN_ENV)
         .filter(|(key, _)| !is_operator_secret_env(key))
         .map(|(key, value)| (key.clone(), value.clone()))
@@ -456,6 +480,63 @@ mod container_spawn_tests {
         assert!(!args.iter().any(|arg| arg.contains("operator-token")));
         assert!(!args.iter().any(|arg| arg.contains("operator-key")));
         assert!(!spawn.process_env.contains_key("GITHUB_TOKEN"));
+        Ok(())
+    }
+
+    #[test]
+    fn host_spawn_filters_injected_nested_session_markers() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut env_vars = HashMap::new();
+        env_vars.insert("CLAUDECODE".to_string(), "1".to_string());
+        env_vars.insert("CLAUDE_CODE_ENTRYPOINT".to_string(), "cli".to_string());
+        env_vars.insert("CLAUDE_CONFIG_DIR".to_string(), "/cfg".to_string());
+        let sandbox_spec = SandboxSpec::new(SandboxMode::DangerFullAccess, root.path());
+
+        let spawn = prepare_agent_spawn(input(
+            Path::new("claude"),
+            &[],
+            root.path(),
+            &sandbox_spec,
+            &env_vars,
+        ))?;
+
+        assert!(!spawn.process_env.contains_key("CLAUDECODE"));
+        assert!(!spawn.process_env.contains_key("CLAUDE_CODE_ENTRYPOINT"));
+        // Legitimate CLAUDE_* configuration must pass through.
+        assert_eq!(
+            spawn.process_env.get("CLAUDE_CONFIG_DIR"),
+            Some(&"/cfg".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn container_spawn_filters_injected_nested_session_markers() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            AGENT_ISOLATION_TIER_ENV.to_string(),
+            "container".to_string(),
+        );
+        env_vars.insert("CLAUDECODE".to_string(), "1".to_string());
+        env_vars.insert("CLAUDE_CODE_ENTRYPOINT".to_string(), "cli".to_string());
+        env_vars.insert("CLAUDE_CONFIG_DIR".to_string(), "/cfg".to_string());
+        let sandbox_spec = SandboxSpec::new(SandboxMode::WorkspaceWrite, root.path());
+
+        let spawn = ContainerSpawn.prepare(input(
+            Path::new("claude"),
+            &[],
+            root.path(),
+            &sandbox_spec,
+            &env_vars,
+        ))?;
+
+        let args = string_args(&spawn);
+        assert!(!args.iter().any(|arg| arg.starts_with("CLAUDECODE=")));
+        assert!(!args
+            .iter()
+            .any(|arg| arg.starts_with("CLAUDE_CODE_ENTRYPOINT=")));
+        assert!(args.contains(&"CLAUDE_CONFIG_DIR=/cfg".to_string()));
         Ok(())
     }
 


### PR DESCRIPTION
Closes #1788.

`strip_claude_env` scanned the **parent** process env for `CLAUDE*` keys, so markers injected via `AgentRequest.env_vars` survived (unless the parent coincidentally had the key), and the container tier forwarded `CLAUDE*` vars as `--env` args with no strip at all — both reintroduce the SIGTRAP nested-session failure. The prefix match also deleted legitimate config like `CLAUDE_CONFIG_DIR`.

- explicit allowlist (`CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`) now stripped from the effective child env in `spawn_contract` (host + container), plus unconditional `env_remove` in `apply_process_env` for inherited markers
- `execute_review` (which bypasses `prepare_agent_spawn`) strips after `cmd.envs()` instead of before
- legitimate `CLAUDE_*` configuration passes through
- old `strip_claude_env` deleted; 8 call sites collapsed into the contract

Verification: `cargo test -p harness-agents` (203 passed), `cargo clippy --workspace --all-targets -- -D warnings` clean.