### PR TITLE
feat(core): repository-observed agent stack inventory (GH-1731)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "libc",
+ "same-file",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +388,36 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix",
+]
 
 [[package]]
 name = "cast"
@@ -1030,6 +1066,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,8 +1337,10 @@ version = "0.6.34"
 dependencies = [
  "anyhow",
  "async-trait",
+ "cap-std",
  "chrono",
  "chrono-tz",
+ "libc",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1882,6 +1931,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2194,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
@@ -2976,6 +3047,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -4890,6 +4971,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.11.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ async-trait = "0.1"
 # Capability-scoped filesystem access (repository-observed stack inventory)
 cap-std = "3"
 libc = "0.2"
+same-file = "1.0.6"
 
 # Futures
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,10 @@ anyhow = "1"
 # Async trait
 async-trait = "0.1"
 
+# Capability-scoped filesystem access (repository-observed stack inventory)
+cap-std = "3"
+libc = "0.2"
+
 # Futures
 futures = "0.3"
 tokio-stream = "0.1"

--- a/crates/harness-core/Cargo.toml
+++ b/crates/harness-core/Cargo.toml
@@ -24,6 +24,10 @@ anyhow = { workspace = true }
 sqlx = { workspace = true }
 sha2 = { workspace = true }
 tracing = { workspace = true }
+cap-std = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/harness-core/Cargo.toml
+++ b/crates/harness-core/Cargo.toml
@@ -25,6 +25,7 @@ sqlx = { workspace = true }
 sha2 = { workspace = true }
 tracing = { workspace = true }
 cap-std = { workspace = true }
+same-file = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/harness-core/src/stack/inventory.rs
+++ b/crates/harness-core/src/stack/inventory.rs
@@ -12,11 +12,12 @@ use super::{
 };
 use cap_std::fs::{Dir, FileType, OpenOptions};
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Validated inventory options: one explicit repository root plus non-zero
 /// resource budgets that all permit a checked `+ 1` sentinel.
@@ -234,9 +235,9 @@ impl DirSelector {
     }
 
     /// Match against a native basename before any locator normalization.
-    fn matches(&self, name: &[u8], direct_level: bool) -> bool {
-        let ext_match = |ext: &&str| has_extension(name, ext.as_bytes());
-        let base_match = |base: &&str| name == base.as_bytes();
+    fn matches(&self, name: &OsStr, direct_level: bool) -> bool {
+        let ext_match = |ext: &&str| has_extension(name, ext);
+        let base_match = |base: &&str| name == OsStr::new(base);
         self.recursive_extensions.iter().any(ext_match)
             || self.recursive_basenames.iter().any(base_match)
             || (direct_level
@@ -245,9 +246,10 @@ impl DirSelector {
     }
 }
 
-fn has_extension(name: &[u8], ext: &[u8]) -> bool {
-    name.len() > ext.len() + 1 && name.ends_with(ext) && name[name.len() - ext.len() - 1] == b'.'
-}
+#[rustfmt::skip]
+fn has_extension(name: &OsStr, ext: &str) -> bool { Path::new(name).extension() == Some(OsStr::new(ext)) }
+#[rustfmt::skip]
+fn has_suffix(name: &OsStr, suffix: &str) -> bool { name.as_encoded_bytes().ends_with(suffix.as_bytes()) }
 
 /// Expected entry class for a rule target.
 #[derive(Debug, Clone, Copy)]
@@ -386,26 +388,23 @@ pub(super) fn classify_open_failure(kind: std::io::ErrorKind) -> AgentStackInven
     if kind == std::io::ErrorKind::NotFound { EK::EntryRaced } else { EK::ReadFailed }
 }
 
-#[cfg(unix)]
-#[rustfmt::skip]
-fn os_bytes(name: &OsStr) -> Option<&[u8]> {
-    use std::os::unix::ffi::OsStrExt;
-    Some(name.as_bytes())
-}
-#[cfg(not(unix))]
-#[rustfmt::skip]
-fn os_bytes(name: &OsStr) -> Option<&[u8]> { name.to_str().map(str::as_bytes) }
-
 type DerivedRule = (String, RuleTarget, AgentStackComponentKind);
 type Listing = Vec<(OsString, FileType)>;
+
+#[derive(Clone, PartialEq, Eq)]
+pub(super) struct DirectoryIdentity(Arc<same_file::Handle>);
+#[derive(Clone)]
+#[rustfmt::skip]
+struct FileObservation { bytes: Vec<u8>, digest: Sha256Digest, class: AgentStackEntryClass }
 
 #[rustfmt::skip]
 struct Scan<'a> {
     opts: &'a AgentStackInventoryOptions,
     files_used: usize, dirs_opened: usize, entries_seen: usize, bytes_used: u64,
     entries: BTreeMap<(String, &'static str), AgentStackInventoryEntry>,
+    file_observations: BTreeMap<String, FileObservation>,
     root_listing: Option<Listing>,
-    #[cfg(unix)] ancestors: Vec<(u64, u64)>,
+    ancestors: Vec<DirectoryIdentity>,
 }
 
 /// Checked budget increment: fail before a configured limit can be exceeded.
@@ -441,18 +440,10 @@ pub(crate) fn inventory_with_root(
         entries_seen: 0,
         bytes_used: 0,
         entries: BTreeMap::new(),
+        file_observations: BTreeMap::new(),
         root_listing: None,
-        #[cfg(unix)]
-        ancestors: Vec::new(),
+        ancestors: vec![directory_identity(root, "")?],
     };
-    #[cfg(unix)]
-    {
-        use cap_std::fs::MetadataExt;
-        let meta = root
-            .dir_metadata()
-            .map_err(|_| IErr::new(EK::RootOpen, None))?;
-        scan.ancestors.push((meta.dev(), meta.ino()));
-    }
     let derived = scan.load_config(root)?;
     for static_rule in STATIC_RULES {
         match static_rule.matcher {
@@ -489,7 +480,7 @@ impl Scan<'_> {
             return Ok(Vec::new());
         };
         let mut derived: Vec<DerivedRule> = Vec::new();
-        let mut seen: Vec<(String, bool)> = Vec::new();
+        let mut seen: HashSet<(String, bool)> = HashSet::new();
         let sources = rules
             .discovery_paths
             .iter()
@@ -504,10 +495,9 @@ impl Scan<'_> {
                 continue; // Absolute sources are outside the repository scope.
             };
             let key = (locator.clone(), exact_file);
-            if seen.contains(&key) {
+            if !seen.insert(key) {
                 continue;
             }
-            seen.push(key);
             let target = if exact_file {
                 RuleTarget::File
             } else {
@@ -577,24 +567,24 @@ impl Scan<'_> {
         let listing = self.root_listing.clone().unwrap_or_default();
         let mut selected = Vec::new();
         for (name, file_type) in listing {
-            let matched = os_bytes(&name).is_some_and(|bytes| {
-                bytes.len() > suffix.len() && bytes.ends_with(suffix.as_bytes())
-            });
-            if !matched || file_type.is_dir() {
+            if !has_suffix(&name, suffix) {
                 continue;
             }
+            let locator = name
+                .to_str()
+                .map(str::to_owned)
+                .ok_or_else(|| IErr::new(EK::NonUtf8Locator, None))?;
+            if file_type.is_dir() {
+                return Err(err(EK::NonRegularEntry, &locator));
+            }
             if file_type.is_symlink() {
-                let hint = name.to_str().unwrap_or("");
                 let resolved = root
                     .metadata(&name)
-                    .map_err(|error| err(classify_resolution_failure(error.kind()), hint))?;
+                    .map_err(|error| err(classify_resolution_failure(error.kind()), &locator))?;
                 if resolved.is_dir() {
-                    continue;
+                    return Err(err(EK::NonRegularEntry, &locator));
                 }
             }
-            let Some(locator) = name.to_str().map(str::to_owned) else {
-                return Err(IErr::new(EK::NonUtf8Locator, None));
-            };
             selected.push(locator);
         }
         selected.sort();
@@ -643,18 +633,12 @@ impl Scan<'_> {
             };
             err(kind, &prefix)
         })?;
-        #[cfg(unix)]
-        {
-            use cap_std::fs::MetadataExt;
-            let meta = dir.dir_metadata().map_err(|_| err(EK::EntryMetadata, &prefix))?;
-            let identity = (meta.dev(), meta.ino());
-            if self.ancestors.contains(&identity) {
-                return Err(err(EK::CycleDetected, &prefix));
-            }
-            self.ancestors.push(identity);
+        let identity = directory_identity(&dir, &prefix)?;
+        if self.ancestors.contains(&identity) {
+            return Err(err(EK::CycleDetected, &prefix));
         }
+        self.ancestors.push(identity);
         let result = self.traverse_entries(root, &dir, &prefix, selector, kind, depth);
-        #[cfg(unix)]
         self.ancestors.pop();
         result
     }
@@ -685,7 +669,7 @@ impl Scan<'_> {
             let selected = if is_dir {
                 selector.is_recursive()
             } else {
-                os_bytes(name).is_some_and(|bytes| selector.matches(bytes, direct_level))
+                selector.matches(name, direct_level)
             };
             if selected {
                 let name = name.to_str().ok_or_else(|| err(EK::NonUtf8Locator, prefix))?;
@@ -713,6 +697,10 @@ impl Scan<'_> {
     ) -> Result<Option<Vec<u8>>, IErr> {
         if self.entries.contains_key(&(locator.clone(), kind.as_str())) {
             return Ok(None);
+        }
+        if let Some(observation) = self.file_observations.get(&locator).cloned() {
+            self.emit(kind, locator, Some(observation.digest), observation.class)?;
+            return Ok(Some(observation.bytes));
         }
         charge(&mut self.files_used, self.opts.max_files, &locator)?;
         let mut open_options = OpenOptions::new();
@@ -750,6 +738,9 @@ impl Scan<'_> {
         self.bytes_used += read;
         let digest = Sha256Digest::from_bytes(&bytes);
         let class = AgentStackEntryClass::RegularFile { unix_executable };
+        self.file_observations.insert(locator.clone(), FileObservation {
+            bytes: bytes.clone(), digest: digest.clone(), class: class.clone(),
+        });
         self.emit(kind, locator, Some(digest), class)?;
         Ok(Some(bytes))
     }
@@ -782,4 +773,12 @@ impl Scan<'_> {
         self.entries.insert(key, AgentStackInventoryEntry { component, entry_class });
         Ok(())
     }
+}
+
+#[rustfmt::skip]
+pub(super) fn directory_identity(directory: &Dir, locator: &str) -> Result<DirectoryIdentity, IErr> {
+    let file = directory.try_clone().map(Dir::into_std_file)
+        .map_err(|_| err(EK::EntryMetadata, locator))?;
+    same_file::Handle::from_file(file).map(|handle| DirectoryIdentity(Arc::new(handle)))
+        .map_err(|_| err(EK::EntryMetadata, locator))
 }

--- a/crates/harness-core/src/stack/inventory.rs
+++ b/crates/harness-core/src/stack/inventory.rs
@@ -354,10 +354,19 @@ pub(super) fn classify_open_failure(kind: std::io::ErrorKind) -> AgentStackInven
 }
 
 #[rustfmt::skip]
+fn observed_non_regular(root: &Dir, path: &str) -> bool {
+    match root.symlink_metadata(path) {
+        Ok(meta) if meta.is_symlink() => root.metadata(path).ok().is_some_and(|target| !target.is_file()),
+        Ok(meta) => !meta.is_file(), Err(_) => false,
+    }
+}
+
+#[rustfmt::skip]
 pub(super) fn classify_selected_open_failure(
     root: &Dir, path: &str, kind: std::io::ErrorKind,
 ) -> AgentStackInventoryErrorKind {
-    if kind == std::io::ErrorKind::NotFound { classify_resolution_failure(root, path, kind) } else { classify_open_failure(kind) }
+    if kind == std::io::ErrorKind::NotFound { classify_resolution_failure(root, path, kind) }
+    else if observed_non_regular(root, path) { EK::NonRegularEntry } else { classify_open_failure(kind) }
 }
 
 #[rustfmt::skip]
@@ -434,7 +443,6 @@ pub(crate) fn inventory_with_root(
         if let Some(rule) = exact_rules.iter_mut()
             .find(|rule| rule.0 == locator && rule.2.as_str() == kind.as_str())
         {
-            rule.1 = target;
             rule.3 = true;
         } else {
             exact_rules.push((locator, target, kind, true));
@@ -522,9 +530,11 @@ impl Scan<'_> {
     #[rustfmt::skip]
     fn has_exact_case(&mut self, root: &Dir, path: &str) -> Result<bool, IErr> {
         let mut parent = String::new();
+        let components = path.split('/').count();
         for (depth, segment) in path.split('/').enumerate() {
             if !self.listings.contains_key(&parent) {
                 if parent.is_empty() { self.enumerate(root, "")?; } else {
+                    if root.symlink_metadata(&parent).ok().is_some_and(|meta| meta.is_symlink()) && root.metadata(&parent).ok().is_some_and(|meta| !meta.is_dir()) { return Ok(false); }
                     if depth > self.opts.max_depth { return Err(err(EK::LimitExceeded, &parent)); }
                     charge(&mut self.dirs_opened, self.opts.max_directories, &parent)?;
                     let dir = root.open_dir(&parent).map_err(|error| {
@@ -536,9 +546,10 @@ impl Scan<'_> {
                     self.enumerate(&dir, &parent)?;
                 }
             }
-            let exact = self.listings.get(&parent)
-                .is_some_and(|listing| listing.iter().any(|(name, _)| name == OsStr::new(segment)));
-            if !exact { return Ok(false); }
+            let exact = self.listings.get(&parent).and_then(|listing| listing.iter()
+                .find(|(name, _)| name == OsStr::new(segment)).map(|(_, kind)| (kind.is_dir(), kind.is_symlink())));
+            let Some((is_dir, is_symlink)) = exact else { return Ok(false); };
+            if depth + 1 < components && !is_dir && !is_symlink { return Ok(false); }
             parent = if parent.is_empty() { segment.to_owned() } else { format!("{parent}/{segment}") };
         }
         Ok(true)
@@ -626,9 +637,6 @@ impl Scan<'_> {
         Ok(listing)
     }
 
-    /// Recursive selector-filtered traversal; `depth` counts directory opens
-    /// below the repository root (the root itself is depth 0). All opens and
-    /// symlink resolutions stay relative to the one root capability.
     #[rustfmt::skip]
     fn traverse(
         &mut self, root: &Dir, prefix: String,
@@ -659,8 +667,6 @@ impl Scan<'_> {
     ) -> Result<(), IErr> {
         let direct_level = depth == 1;
         let listing = self.enumerate(dir, prefix)?;
-        // Every symlink is resolved through the root capability before any
-        // file selector applies; broken or escaping targets fail typed.
         let mut candidates: Vec<(bool, String)> = Vec::new();
         for (name, file_type) in &listing {
             let is_dir = if file_type.is_symlink() {
@@ -698,9 +704,6 @@ impl Scan<'_> {
         Ok(())
     }
 
-    /// Open one selected candidate capability-relatively (nonblocking on
-    /// Unix), validate the opened handle type, read within remaining budgets,
-    /// and emit its component; `None` means the binding was deduplicated.
     #[rustfmt::skip]
     fn read_selected(
         &mut self, root: &Dir, locator: String, kind: Kind,
@@ -740,7 +743,6 @@ impl Scan<'_> {
         #[cfg(not(unix))]
         let unix_executable: Option<bool> = None;
         let remaining = self.opts.max_total_bytes - self.bytes_used;
-        // Sentinels are safe: validation keeps byte limits below `u64::MAX`.
         let limit = (self.opts.max_file_bytes + 1).min(remaining + 1);
         let mut bytes = Vec::new();
         file.take(limit)
@@ -760,7 +762,6 @@ impl Scan<'_> {
         Ok(Some(bytes))
     }
 
-    /// Build and validate one ASC-001 component and record its typed entry.
     #[rustfmt::skip]
     fn emit(
         &mut self, kind: Kind, locator: String,

--- a/crates/harness-core/src/stack/inventory.rs
+++ b/crates/harness-core/src/stack/inventory.rs
@@ -374,11 +374,17 @@ fn normalize_configured_source(raw: &str) -> Result<Option<String>, AgentStackIn
     }
 }
 
-/// `NotFound` on symlink-target resolution is a broken symlink; every other
-/// failure (including escape) rejects without leaking ambient targets.
 #[rustfmt::skip]
-fn classify_resolution_failure(kind: std::io::ErrorKind) -> AgentStackInventoryErrorKind {
-    if kind == std::io::ErrorKind::NotFound { EK::BrokenSymlink } else { EK::RootEscape }
+pub(super) fn classify_resolution_failure(
+    root: &Dir, path: impl AsRef<Path>, kind: std::io::ErrorKind,
+) -> AgentStackInventoryErrorKind {
+    if kind != std::io::ErrorKind::NotFound { return EK::RootEscape; }
+    match root.symlink_metadata(path) {
+        Ok(meta) if meta.is_symlink() => EK::BrokenSymlink,
+        Ok(_) => EK::EntryRaced,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => EK::EntryRaced,
+        Err(_) => EK::EntryMetadata,
+    }
 }
 
 /// A selected entry that disappeared before open is a race; any other open
@@ -395,7 +401,7 @@ type Listing = Vec<(OsString, FileType)>;
 pub(super) struct DirectoryIdentity(Arc<same_file::Handle>);
 #[derive(Clone)]
 #[rustfmt::skip]
-struct FileObservation { bytes: Vec<u8>, digest: Sha256Digest, class: AgentStackEntryClass }
+struct FileObservation { digest: Sha256Digest, class: AgentStackEntryClass }
 
 #[rustfmt::skip]
 struct Scan<'a> {
@@ -521,7 +527,7 @@ impl Scan<'_> {
         };
         let is_dir = if meta.is_symlink() {
             root.metadata(path)
-                .map_err(|error| err(classify_resolution_failure(error.kind()), path))?
+                .map_err(|error| err(classify_resolution_failure(root, path, error.kind()), path))?
                 .is_dir()
         } else {
             meta.is_dir()
@@ -578,9 +584,12 @@ impl Scan<'_> {
                 return Err(err(EK::NonRegularEntry, &locator));
             }
             if file_type.is_symlink() {
-                let resolved = root
-                    .metadata(&name)
-                    .map_err(|error| err(classify_resolution_failure(error.kind()), &locator))?;
+                let resolved = root.metadata(&name).map_err(|error| {
+                    err(
+                        classify_resolution_failure(root, &name, error.kind()),
+                        &locator,
+                    )
+                })?;
                 if resolved.is_dir() {
                     return Err(err(EK::NonRegularEntry, &locator));
                 }
@@ -660,7 +669,8 @@ impl Scan<'_> {
                         let hint = name
                             .to_str()
                             .map_or_else(|| prefix.to_owned(), |n| format!("{prefix}/{n}"));
-                        err(classify_resolution_failure(error.kind()), &hint)
+                        let path = Path::new(prefix).join(name);
+                        err(classify_resolution_failure(root, path, error.kind()), &hint)
                     })?
                     .is_dir()
             } else {
@@ -700,9 +710,8 @@ impl Scan<'_> {
         }
         if let Some(observation) = self.file_observations.get(&locator).cloned() {
             self.emit(kind, locator, Some(observation.digest), observation.class)?;
-            return Ok(Some(observation.bytes));
+            return Ok(None);
         }
-        charge(&mut self.files_used, self.opts.max_files, &locator)?;
         let mut open_options = OpenOptions::new();
         open_options.read(true);
         #[cfg(unix)]
@@ -717,6 +726,7 @@ impl Scan<'_> {
         if !meta.is_file() {
             return Err(err(EK::NonRegularEntry, &locator));
         }
+        charge(&mut self.files_used, self.opts.max_files, &locator)?;
         #[cfg(unix)]
         let unix_executable = {
             use cap_std::fs::MetadataExt;
@@ -739,7 +749,7 @@ impl Scan<'_> {
         let digest = Sha256Digest::from_bytes(&bytes);
         let class = AgentStackEntryClass::RegularFile { unix_executable };
         self.file_observations.insert(locator.clone(), FileObservation {
-            bytes: bytes.clone(), digest: digest.clone(), class: class.clone(),
+            digest: digest.clone(), class: class.clone(),
         });
         self.emit(kind, locator, Some(digest), class)?;
         Ok(Some(bytes))

--- a/crates/harness-core/src/stack/inventory.rs
+++ b/crates/harness-core/src/stack/inventory.rs
@@ -1,9 +1,4 @@
-//! Repository-observed Agent Stack inventory (GH-1731): discovers a closed
-//! allowlist of stack surfaces beneath one explicit repository root and emits
-//! validated ASC-001 components. All traversal is capability-scoped through
-//! one opened root directory handle, so path or symlink races cannot grant
-//! access outside the repository; discovery proves that content exists under
-//! the root and never claims runtime selection.
+//! Capability-scoped repository Agent Stack inventory (GH-1731).
 
 use super::{
     AgentStackComponent, AgentStackComponentKind, AgentStackFreshnessEvidence,
@@ -19,8 +14,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-/// Validated inventory options: one explicit repository root plus non-zero
-/// resource budgets that all permit a checked `+ 1` sentinel.
+/// Validated root and resource budgets for one inventory.
 #[derive(Debug, Clone)]
 pub struct AgentStackInventoryOptions {
     root: PathBuf,
@@ -60,7 +54,6 @@ impl AgentStackInventoryOptions {
         with_max_entries_per_directory => max_entries_per_directory: usize,
     );
 
-    /// Limits must be non-zero and permit `+ 1` sentinels; fails pre-open.
     fn validated(self) -> Result<Self, AgentStackInventoryError> {
         let bytes_ok = |v: u64| v > 0 && v < u64::MAX;
         let count_ok = |v: usize| v > 0 && v < usize::MAX;
@@ -79,15 +72,13 @@ impl AgentStackInventoryOptions {
     }
 }
 
-/// A regular file read through the opened handle (with its Unix executable
-/// bit when observed), or the non-recursive `spec` directory-presence probe.
+/// Observed file or directory-presence class.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentStackEntryClass {
     RegularFile { unix_executable: Option<bool> },
     DirectoryPresence,
 }
 
-/// One inventoried surface: a validated ASC-001 component plus entry class.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentStackInventoryEntry {
     component: AgentStackComponent,
@@ -100,8 +91,7 @@ impl AgentStackInventoryEntry {
     pub fn entry_class(&self) -> &AgentStackEntryClass { &self.entry_class }
 }
 
-/// Ordered repository-observed inventory, sorted by normalized locator; no
-/// ambient canonical root path is claimed or exposed.
+/// Repository-observed inventory sorted by normalized locator.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentStackInventory {
     entries: Vec<AgentStackInventoryEntry>,
@@ -138,9 +128,7 @@ error_kinds!(
 use AgentStackComponentKind as Kind;
 use AgentStackInventoryErrorKind as EK;
 
-/// Typed inventory error: a stable category plus, when representable, a safe
-/// repository-relative locator. Evidence never carries file bytes, ambient
-/// target paths, configured absolute paths, or OS error strings.
+/// Stable failure category with an optional repository-relative locator.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentStackInventoryError {
     kind: AgentStackInventoryErrorKind,
@@ -174,9 +162,6 @@ fn err(kind: AgentStackInventoryErrorKind, locator: &str) -> IErr {
     IErr::new(kind, (!locator.is_empty()).then(|| locator.to_owned()))
 }
 
-/// Closed per-directory entry selector: pure rule-table data, never content
-/// sniffing. Direct selectors apply only to a rule root's immediate children;
-/// recursive selectors apply at every depth.
 #[derive(Debug, Clone, Copy)]
 struct DirSelector {
     direct_extensions: &'static [&'static str],
@@ -197,9 +182,6 @@ const fn sel(
     DirSelector { direct_extensions, direct_basenames, recursive_extensions, recursive_basenames }
 }
 
-/// General skill roots select direct `*.md` plus recursive exact `SKILL.md`;
-/// `.harness/skills` selects direct `*.md` only, so usage sidecars and
-/// package support files are never stack units.
 #[rustfmt::skip]
 mod selectors {
     use super::{sel, DirSelector, NONE};
@@ -217,8 +199,6 @@ mod selectors {
 }
 use selectors::*;
 
-/// Documented Git lifecycle hook basenames: the only direct `.githooks`
-/// children that can carry the ASC-001 `hook` kind.
 #[rustfmt::skip]
 const GIT_LIFECYCLE_HOOKS: &[&str] = &[
     "applypatch-msg", "pre-applypatch", "post-applypatch", "pre-commit", "pre-merge-commit",
@@ -234,7 +214,6 @@ impl DirSelector {
         !self.recursive_extensions.is_empty() || !self.recursive_basenames.is_empty()
     }
 
-    /// Match against a native basename before any locator normalization.
     fn matches(&self, name: &OsStr, direct_level: bool) -> bool {
         let ext_match = |ext: &&str| has_extension(name, ext);
         let base_match = |base: &&str| name == OsStr::new(base);
@@ -251,7 +230,6 @@ fn has_extension(name: &OsStr, ext: &str) -> bool { Path::new(name).extension() 
 #[rustfmt::skip]
 fn has_suffix(name: &OsStr, suffix: &str) -> bool { name.as_encoded_bytes().ends_with(suffix.as_bytes()) }
 
-/// Expected entry class for a rule target.
 #[derive(Debug, Clone, Copy)]
 enum RuleTarget {
     File,
@@ -286,50 +264,36 @@ const fn sfx(suffix: &'static str, kind: Kind) -> StaticRule {
     StaticRule { matcher: Matcher::RootSuffix(suffix), target: RuleTarget::File, kind }
 }
 
-/// The single typed representation of the B-003 v0.1 allowlist. Table order
-/// is stable; output order is lexicographic over normalized locators.
 #[rustfmt::skip]
 const STATIC_RULES: &[StaticRule] = &[
     fr("AGENTS.md", Kind::Instructions), fr("AGENTS.override.md", Kind::Instructions),
     fr("CLAUDE.md", Kind::Instructions), fr("WORKFLOW.md", Kind::Workflow),
     fr("MEMORY.md", Kind::Memory),
-    fr("src/AGENTS.md", Kind::Instructions), fr("src/AGENTS.override.md", Kind::Instructions),
-    fr("src/CLAUDE.md", Kind::Instructions), fr("crates/AGENTS.md", Kind::Instructions),
-    fr("crates/AGENTS.override.md", Kind::Instructions), fr("crates/CLAUDE.md", Kind::Instructions),
-    fr("lib/AGENTS.md", Kind::Instructions), fr("lib/AGENTS.override.md", Kind::Instructions),
-    fr("lib/CLAUDE.md", Kind::Instructions), fr("pkg/AGENTS.md", Kind::Instructions),
-    fr("pkg/AGENTS.override.md", Kind::Instructions), fr("pkg/CLAUDE.md", Kind::Instructions),
-    dr(".claude/skills", SKILL_ROOT, Kind::Skill), dr(".codex/skills", SKILL_ROOT, Kind::Skill),
-    dr(".agents/skills", SKILL_ROOT, Kind::Skill), dr("skills", SKILL_ROOT, Kind::Skill),
-    dr(".harness/skills", HARNESS_SKILLS, Kind::Skill),
-    dr(".harness/guards", GUARDS, Kind::Hook), dr(".githooks", GITHOOKS, Kind::Hook),
-    fr(".mcp.json", Kind::McpServer), fr("mcp.json", Kind::McpServer),
+    fr("src/AGENTS.md", Kind::Instructions), fr("src/AGENTS.override.md", Kind::Instructions), fr("src/CLAUDE.md", Kind::Instructions),
+    fr("crates/AGENTS.md", Kind::Instructions), fr("crates/AGENTS.override.md", Kind::Instructions), fr("crates/CLAUDE.md", Kind::Instructions),
+    fr("lib/AGENTS.md", Kind::Instructions), fr("lib/AGENTS.override.md", Kind::Instructions), fr("lib/CLAUDE.md", Kind::Instructions),
+    fr("pkg/AGENTS.md", Kind::Instructions), fr("pkg/AGENTS.override.md", Kind::Instructions), fr("pkg/CLAUDE.md", Kind::Instructions),
+    dr(".claude/skills", SKILL_ROOT, Kind::Skill), dr(".codex/skills", SKILL_ROOT, Kind::Skill), dr(".agents/skills", SKILL_ROOT, Kind::Skill),
+    dr("skills", SKILL_ROOT, Kind::Skill), dr(".harness/skills", HARNESS_SKILLS, Kind::Skill),
+    dr(".harness/guards", GUARDS, Kind::Hook), dr(".githooks", GITHOOKS, Kind::Hook), fr(".mcp.json", Kind::McpServer), fr("mcp.json", Kind::McpServer),
     dr(".vibeguard", VIBEGUARD, Kind::Policy), fr(".vibeguard/run-guards.sh", Kind::Validation),
-    dr("rules", MD_TOML, Kind::Policy), fr("requirements.toml", Kind::Policy),
-    dr(".remem", REMEM, Kind::Memory), fr("remem.toml", Kind::Memory),
+    dr("rules", MD_TOML, Kind::Policy), fr("requirements.toml", Kind::Policy), dr(".remem", REMEM, Kind::Memory), fr("remem.toml", Kind::Memory),
     fr(".harness/config.toml", Kind::Validation), dr(".harness/rules", MD_TOML, Kind::Policy),
     dr(".harness/sg", SG, Kind::Policy), fr("harness.toml", Kind::Validation),
     dr(".github/workflows", WORKFLOWS, Kind::Workflow), dr(".cursor/rules", CURSOR_RULES, Kind::Policy),
-    // Toolchain and validation selectors mirrored from `lang_detect.rs`.
-    fr("Cargo.toml", Kind::Validation), fr("go.mod", Kind::Validation),
-    fr("package.json", Kind::Validation), fr("pyproject.toml", Kind::Validation),
-    fr("setup.py", Kind::Validation), fr("requirements.txt", Kind::Validation),
-    fr("build.gradle", Kind::Validation), fr("build.gradle.kts", Kind::Validation),
-    fr("pom.xml", Kind::Validation), fr("Gemfile", Kind::Validation),
-    fr("yarn.lock", Kind::Validation), fr("pnpm-lock.yaml", Kind::Validation),
-    fr(".eslintrc", Kind::Validation), fr(".eslintrc.js", Kind::Validation),
-    fr(".eslintrc.cjs", Kind::Validation), fr(".eslintrc.json", Kind::Validation),
-    fr(".eslintrc.yaml", Kind::Validation), fr(".eslintrc.yml", Kind::Validation),
-    fr("eslint.config.js", Kind::Validation), fr("eslint.config.mjs", Kind::Validation),
-    fr("eslint.config.cjs", Kind::Validation), fr("biome.json", Kind::Validation),
-    fr(".rubocop.yml", Kind::Validation),
+    fr("Cargo.toml", Kind::Validation), fr("go.mod", Kind::Validation), fr("package.json", Kind::Validation),
+    fr("pyproject.toml", Kind::Validation), fr("setup.py", Kind::Validation), fr("requirements.txt", Kind::Validation),
+    fr("build.gradle", Kind::Validation), fr("build.gradle.kts", Kind::Validation), fr("pom.xml", Kind::Validation),
+    fr("Gemfile", Kind::Validation), fr("yarn.lock", Kind::Validation), fr("pnpm-lock.yaml", Kind::Validation),
+    fr(".eslintrc", Kind::Validation), fr(".eslintrc.js", Kind::Validation), fr(".eslintrc.cjs", Kind::Validation),
+    fr(".eslintrc.json", Kind::Validation), fr(".eslintrc.yaml", Kind::Validation), fr(".eslintrc.yml", Kind::Validation),
+    fr("eslint.config.js", Kind::Validation), fr("eslint.config.mjs", Kind::Validation), fr("eslint.config.cjs", Kind::Validation),
+    fr("biome.json", Kind::Validation), fr(".rubocop.yml", Kind::Validation),
     sfx(".csproj", Kind::Validation), sfx(".sln", Kind::Validation),
     StaticRule { matcher: Matcher::Exact("spec"), target: RuleTarget::DirectoryPresence, kind: Kind::Validation },
     fr("Makefile", Kind::Validation), fr("justfile", Kind::Validation),
 ];
 
-/// Minimal `harness.toml` shape: only repository-relative rule sources are
-/// deserialized; unrelated Harness settings are ignored, never validated.
 #[rustfmt::skip]
 #[derive(Debug, Default, Deserialize)]
 struct ConfigShape {
@@ -345,9 +309,6 @@ struct ConfigRules {
     #[serde(default)] requirements_path: Option<String>,
 }
 
-/// Lexically normalize a configured repository-relative source. Absolute
-/// sources are out of scope (`Ok(None)`); empty, parent-traversing, or
-/// otherwise unportable sources are invalid.
 fn normalize_configured_source(raw: &str) -> Result<Option<String>, AgentStackInventoryErrorKind> {
     let bytes = raw.as_bytes();
     if raw.starts_with('/')
@@ -387,11 +348,21 @@ pub(super) fn classify_resolution_failure(
     }
 }
 
-/// A selected entry that disappeared before open is a race; any other open
-/// failure of an already-selected candidate is a read failure.
 #[rustfmt::skip]
 pub(super) fn classify_open_failure(kind: std::io::ErrorKind) -> AgentStackInventoryErrorKind {
     if kind == std::io::ErrorKind::NotFound { EK::EntryRaced } else { EK::ReadFailed }
+}
+
+#[rustfmt::skip]
+pub(super) fn classify_selected_open_failure(
+    root: &Dir, path: &str, kind: std::io::ErrorKind,
+) -> AgentStackInventoryErrorKind {
+    if kind == std::io::ErrorKind::NotFound { classify_resolution_failure(root, path, kind) } else { classify_open_failure(kind) }
+}
+
+#[rustfmt::skip]
+pub(super) fn classify_entry_metadata_failure(kind: std::io::ErrorKind) -> AgentStackInventoryErrorKind {
+    if kind == std::io::ErrorKind::NotFound { EK::EntryRaced } else { EK::EntryMetadata }
 }
 
 #[rustfmt::skip]
@@ -400,6 +371,7 @@ pub(super) fn classify_directory_open_failure(kind: std::io::ErrorKind) -> Agent
 }
 
 type DerivedRule = (String, RuleTarget, AgentStackComponentKind);
+type ExactRule = (String, RuleTarget, AgentStackComponentKind, bool);
 type Listing = Vec<(OsString, FileType)>;
 
 #[derive(Clone, PartialEq, Eq)]
@@ -414,11 +386,10 @@ struct Scan<'a> {
     files_used: usize, dirs_opened: usize, entries_seen: usize, bytes_used: u64,
     entries: BTreeMap<(String, &'static str), AgentStackInventoryEntry>,
     file_observations: BTreeMap<String, FileObservation>,
-    root_listing: Option<Listing>,
+    listings: BTreeMap<String, Listing>,
     ancestors: Vec<DirectoryIdentity>,
 }
 
-/// Checked budget increment: fail before a configured limit can be exceeded.
 fn charge(counter: &mut usize, max: usize, locator: &str) -> Result<(), IErr> {
     match counter.checked_add(1) {
         Some(next) if next <= max => {
@@ -429,7 +400,7 @@ fn charge(counter: &mut usize, max: usize, locator: &str) -> Result<(), IErr> {
     }
 }
 
-/// Run the repository-observed stack inventory for one explicit root.
+/// Inventory one explicit repository root.
 pub fn inventory_repository_stack(
     options: &AgentStackInventoryOptions,
 ) -> Result<AgentStackInventory, AgentStackInventoryError> {
@@ -438,8 +409,7 @@ pub fn inventory_repository_stack(
     inventory_with_root(&root, options)
 }
 
-/// Inventory against an already-opened root capability; all discovery stays
-/// relative to this handle and no ambient path is reconstructed from it.
+#[rustfmt::skip]
 pub(crate) fn inventory_with_root(
     root: &Dir,
     options: &AgentStackInventoryOptions,
@@ -452,20 +422,31 @@ pub(crate) fn inventory_with_root(
         bytes_used: 0,
         entries: BTreeMap::new(),
         file_observations: BTreeMap::new(),
-        root_listing: None,
+        listings: BTreeMap::new(),
         ancestors: vec![directory_identity(root, "")?],
     };
     let derived = scan.load_config(root)?;
-    for static_rule in STATIC_RULES {
-        match static_rule.matcher {
-            Matcher::Exact(path) => {
-                scan.apply_exact(root, path, static_rule.target, static_rule.kind, false)?;
-            }
-            Matcher::RootSuffix(suffix) => scan.apply_suffix(root, suffix, static_rule.kind)?,
+    let mut exact_rules: Vec<ExactRule> = STATIC_RULES.iter().filter_map(|rule| match rule.matcher {
+        Matcher::Exact(path) => Some((path.to_owned(), rule.target, rule.kind, false)),
+        Matcher::RootSuffix(_) => None,
+    }).collect();
+    for (locator, target, kind) in derived {
+        if let Some(rule) = exact_rules.iter_mut()
+            .find(|rule| rule.0 == locator && rule.2.as_str() == kind.as_str())
+        {
+            rule.1 = target;
+            rule.3 = true;
+        } else {
+            exact_rules.push((locator, target, kind, true));
         }
     }
-    for (locator, target, kind) in derived {
-        scan.apply_exact(root, &locator, target, kind, true)?;
+    for (locator, target, kind, derived) in exact_rules {
+        scan.apply_exact(root, &locator, target, kind, derived)?;
+    }
+    for static_rule in STATIC_RULES {
+        if let Matcher::RootSuffix(suffix) = static_rule.matcher {
+            scan.apply_suffix(root, suffix, static_rule.kind)?;
+        }
     }
     Ok(AgentStackInventory {
         entries: scan.entries.into_values().collect(),
@@ -473,8 +454,6 @@ pub(crate) fn inventory_with_root(
 }
 
 impl Scan<'_> {
-    /// Read `harness.toml` at most once through the bounded handle-first path
-    /// and derive typed `policy` rules from the four documented rule sources.
     fn load_config(&mut self, root: &Dir) -> Result<Vec<DerivedRule>, IErr> {
         const CONFIG: &str = "harness.toml";
         match self.lookup_exact(root, CONFIG)? {
@@ -519,12 +498,12 @@ impl Scan<'_> {
         Ok(derived)
     }
 
-    /// Non-following lookup of one exact path, resolving a symlink target
-    /// through the root capability: `None` is absent, `Some(is_dir)` present.
-    fn lookup_exact(&self, root: &Dir, path: &str) -> Result<Option<bool>, IErr> {
+    #[rustfmt::skip]
+    fn lookup_exact(&mut self, root: &Dir, path: &str) -> Result<Option<bool>, IErr> {
+        if !self.has_exact_case(root, path)? { return Ok(None); }
         let meta = match root.symlink_metadata(path) {
             Ok(meta) => meta,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Err(err(EK::EntryRaced, path)),
             Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
                 return Err(err(EK::RootEscape, path))
             }
@@ -538,6 +517,31 @@ impl Scan<'_> {
             meta.is_dir()
         };
         Ok(Some(is_dir))
+    }
+
+    #[rustfmt::skip]
+    fn has_exact_case(&mut self, root: &Dir, path: &str) -> Result<bool, IErr> {
+        let mut parent = String::new();
+        for (depth, segment) in path.split('/').enumerate() {
+            if !self.listings.contains_key(&parent) {
+                if parent.is_empty() { self.enumerate(root, "")?; } else {
+                    if depth > self.opts.max_depth { return Err(err(EK::LimitExceeded, &parent)); }
+                    charge(&mut self.dirs_opened, self.opts.max_directories, &parent)?;
+                    let dir = root.open_dir(&parent).map_err(|error| {
+                        let kind = if error.kind() == std::io::ErrorKind::NotFound {
+                            classify_resolution_failure(root, &parent, error.kind())
+                        } else { classify_directory_open_failure(error.kind()) };
+                        err(kind, &parent)
+                    })?;
+                    self.enumerate(&dir, &parent)?;
+                }
+            }
+            let exact = self.listings.get(&parent)
+                .is_some_and(|listing| listing.iter().any(|(name, _)| name == OsStr::new(segment)));
+            if !exact { return Ok(false); }
+            parent = if parent.is_empty() { segment.to_owned() } else { format!("{parent}/{segment}") };
+        }
+        Ok(true)
     }
 
     #[rustfmt::skip]
@@ -568,14 +572,8 @@ impl Scan<'_> {
         }
     }
 
-    /// Root-only suffix rules (`*.csproj`, `*.sln`) select regular-file
-    /// children of the repository root from one charged root enumeration.
     fn apply_suffix(&mut self, root: &Dir, suffix: &str, kind: Kind) -> Result<(), IErr> {
-        if self.root_listing.is_none() {
-            let listing = self.enumerate(root, "")?;
-            self.root_listing = Some(listing);
-        }
-        let listing = self.root_listing.clone().unwrap_or_default();
+        let listing = self.enumerate(root, "")?;
         let mut selected = Vec::new();
         for (name, file_type) in listing {
             if !has_suffix(&name, suffix) {
@@ -608,9 +606,9 @@ impl Scan<'_> {
         Ok(())
     }
 
-    /// Enumerate one directory with the checked `N + 1` sentinel, charging
-    /// every yielded item to the encountered-entry budget pre-classification.
+    #[rustfmt::skip]
     fn enumerate(&mut self, dir: &Dir, prefix: &str) -> Result<Listing, IErr> {
+        if let Some(listing) = self.listings.get(prefix) { return Ok(listing.clone()); }
         let iter = dir.entries().map_err(|_| err(EK::EntryMetadata, prefix))?;
         let mut listing = Vec::new();
         for entry in iter {
@@ -621,9 +619,10 @@ impl Scan<'_> {
             charge(&mut self.entries_seen, self.opts.max_total_entries, prefix)?;
             let file_type = entry
                 .file_type()
-                .map_err(|_| err(EK::EntryMetadata, prefix))?;
+                .map_err(|error| err(classify_entry_metadata_failure(error.kind()), prefix))?;
             listing.push((entry.file_name(), file_type));
         }
+        self.listings.insert(prefix.to_owned(), listing.clone());
         Ok(listing)
     }
 
@@ -722,7 +721,12 @@ impl Scan<'_> {
         }
         let file = root
             .open_with(&locator, &open_options)
-            .map_err(|error| err(classify_open_failure(error.kind()), &locator))?;
+            .map_err(|error| {
+                err(
+                    classify_selected_open_failure(root, &locator, error.kind()),
+                    &locator,
+                )
+            })?;
         let meta = file.metadata().map_err(|_| err(EK::EntryMetadata, &locator))?;
         if !meta.is_file() {
             return Err(err(EK::NonRegularEntry, &locator));

--- a/crates/harness-core/src/stack/inventory.rs
+++ b/crates/harness-core/src/stack/inventory.rs
@@ -1,0 +1,785 @@
+//! Repository-observed Agent Stack inventory (GH-1731): discovers a closed
+//! allowlist of stack surfaces beneath one explicit repository root and emits
+//! validated ASC-001 components. All traversal is capability-scoped through
+//! one opened root directory handle, so path or symlink races cannot grant
+//! access outside the repository; discovery proves that content exists under
+//! the root and never claims runtime selection.
+
+use super::{
+    AgentStackComponent, AgentStackComponentKind, AgentStackFreshnessEvidence,
+    AgentStackObservationClass, AgentStackSelectionState, AgentStackSource, AgentStackSourceScope,
+    AgentStackTrustLevel, Sha256Digest,
+};
+use cap_std::fs::{Dir, FileType, OpenOptions};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+/// Validated inventory options: one explicit repository root plus non-zero
+/// resource budgets that all permit a checked `+ 1` sentinel.
+#[derive(Debug, Clone)]
+pub struct AgentStackInventoryOptions {
+    root: PathBuf,
+    max_file_bytes: u64,
+    max_total_bytes: u64,
+    max_files: usize,
+    max_directories: usize,
+    max_total_entries: usize,
+    max_depth: usize,
+    max_entries_per_directory: usize,
+}
+
+macro_rules! limit_setters {
+    ($($setter:ident => $field:ident: $ty:ty),+ $(,)?) => {
+        $(pub fn $setter(mut self, value: $ty) -> Result<Self, AgentStackInventoryError> {
+            self.$field = value;
+            self.validated()
+        })+
+    };
+}
+
+impl AgentStackInventoryOptions {
+    #[rustfmt::skip]
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root,
+            max_file_bytes: 1024 * 1024, max_total_bytes: 64 * 1024 * 1024,
+            max_files: 10_000, max_directories: 1_000, max_total_entries: 50_000,
+            max_depth: 32, max_entries_per_directory: 10_000,
+        }
+    }
+
+    limit_setters!(
+        with_max_file_bytes => max_file_bytes: u64, with_max_total_bytes => max_total_bytes: u64,
+        with_max_files => max_files: usize, with_max_directories => max_directories: usize,
+        with_max_total_entries => max_total_entries: usize, with_max_depth => max_depth: usize,
+        with_max_entries_per_directory => max_entries_per_directory: usize,
+    );
+
+    /// Limits must be non-zero and permit `+ 1` sentinels; fails pre-open.
+    fn validated(self) -> Result<Self, AgentStackInventoryError> {
+        let bytes_ok = |v: u64| v > 0 && v < u64::MAX;
+        let count_ok = |v: usize| v > 0 && v < usize::MAX;
+        if bytes_ok(self.max_file_bytes)
+            && bytes_ok(self.max_total_bytes)
+            && count_ok(self.max_files)
+            && count_ok(self.max_directories)
+            && count_ok(self.max_total_entries)
+            && count_ok(self.max_depth)
+            && count_ok(self.max_entries_per_directory)
+        {
+            Ok(self)
+        } else {
+            Err(AgentStackInventoryError::new(EK::InvalidOptions, None))
+        }
+    }
+}
+
+/// A regular file read through the opened handle (with its Unix executable
+/// bit when observed), or the non-recursive `spec` directory-presence probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentStackEntryClass {
+    RegularFile { unix_executable: Option<bool> },
+    DirectoryPresence,
+}
+
+/// One inventoried surface: a validated ASC-001 component plus entry class.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentStackInventoryEntry {
+    component: AgentStackComponent,
+    entry_class: AgentStackEntryClass,
+}
+
+#[rustfmt::skip]
+impl AgentStackInventoryEntry {
+    pub fn component(&self) -> &AgentStackComponent { &self.component }
+    pub fn entry_class(&self) -> &AgentStackEntryClass { &self.entry_class }
+}
+
+/// Ordered repository-observed inventory, sorted by normalized locator; no
+/// ambient canonical root path is claimed or exposed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentStackInventory {
+    entries: Vec<AgentStackInventoryEntry>,
+}
+
+#[rustfmt::skip]
+impl AgentStackInventory {
+    pub fn entries(&self) -> &[AgentStackInventoryEntry] { &self.entries }
+}
+
+macro_rules! error_kinds {
+    ($($variant:ident => $wire:literal),+ $(,)?) => {
+        /// Closed inventory failure categories.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum AgentStackInventoryErrorKind { $($variant),+ }
+        impl AgentStackInventoryErrorKind {
+            pub const fn as_str(&self) -> &'static str {
+                match self { $(Self::$variant => $wire),+ }
+            }
+        }
+    };
+}
+#[rustfmt::skip]
+error_kinds!(
+    InvalidOptions => "invalid_options", RootOpen => "root_open",
+    EntryMetadata => "entry_metadata", BrokenSymlink => "broken_symlink",
+    RootEscape => "root_escape", NonRegularEntry => "non_regular_entry",
+    NonUtf8Locator => "non_utf8_locator", ReadFailed => "read_failed",
+    EntryRaced => "entry_raced", CycleDetected => "cycle_detected",
+    ConfigParse => "config_parse", ConfiguredSourceInvalid => "configured_source_invalid",
+    ConfiguredSourceMissing => "configured_source_missing", LimitExceeded => "limit_exceeded",
+    ComponentValidation => "component_validation",
+);
+use AgentStackComponentKind as Kind;
+use AgentStackInventoryErrorKind as EK;
+
+/// Typed inventory error: a stable category plus, when representable, a safe
+/// repository-relative locator. Evidence never carries file bytes, ambient
+/// target paths, configured absolute paths, or OS error strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentStackInventoryError {
+    kind: AgentStackInventoryErrorKind,
+    locator: Option<String>,
+}
+
+#[rustfmt::skip]
+impl AgentStackInventoryError {
+    fn new(kind: AgentStackInventoryErrorKind, locator: Option<String>) -> Self {
+        Self { kind, locator }
+    }
+    pub const fn kind(&self) -> AgentStackInventoryErrorKind { self.kind }
+    pub fn locator(&self) -> Option<&str> { self.locator.as_deref() }
+}
+
+impl fmt::Display for AgentStackInventoryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "agent stack inventory {}", self.kind.as_str())?;
+        if let Some(locator) = &self.locator {
+            write!(f, ": {locator}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for AgentStackInventoryError {}
+
+type IErr = AgentStackInventoryError;
+
+fn err(kind: AgentStackInventoryErrorKind, locator: &str) -> IErr {
+    IErr::new(kind, Some(locator.to_owned()))
+}
+
+/// Closed per-directory entry selector: pure rule-table data, never content
+/// sniffing. Direct selectors apply only to a rule root's immediate children;
+/// recursive selectors apply at every depth.
+#[derive(Debug, Clone, Copy)]
+struct DirSelector {
+    direct_extensions: &'static [&'static str],
+    direct_basenames: &'static [&'static str],
+    recursive_extensions: &'static [&'static str],
+    recursive_basenames: &'static [&'static str],
+}
+
+const NONE: &[&str] = &[];
+
+#[rustfmt::skip]
+const fn sel(
+    direct_extensions: &'static [&'static str],
+    direct_basenames: &'static [&'static str],
+    recursive_extensions: &'static [&'static str],
+    recursive_basenames: &'static [&'static str],
+) -> DirSelector {
+    DirSelector { direct_extensions, direct_basenames, recursive_extensions, recursive_basenames }
+}
+
+/// General skill roots select direct `*.md` plus recursive exact `SKILL.md`;
+/// `.harness/skills` selects direct `*.md` only, so usage sidecars and
+/// package support files are never stack units.
+#[rustfmt::skip]
+mod selectors {
+    use super::{sel, DirSelector, NONE};
+    pub(super) const SKILL_ROOT: DirSelector = sel(&["md"], NONE, NONE, &["SKILL.md"]);
+    pub(super) const HARNESS_SKILLS: DirSelector = sel(&["md"], NONE, NONE, NONE);
+    pub(super) const GUARDS: DirSelector = sel(&["sh"], NONE, NONE, NONE);
+    pub(super) const WORKFLOWS: DirSelector = sel(&["yml", "yaml"], NONE, NONE, NONE);
+    pub(super) const MD_TOML: DirSelector = sel(NONE, NONE, &["md", "toml"], NONE);
+    pub(super) const SG: DirSelector = sel(NONE, NONE, &["yml", "yaml"], NONE);
+    pub(super) const CURSOR_RULES: DirSelector = sel(NONE, NONE, &["md", "mdc"], NONE);
+    pub(super) const VIBEGUARD: DirSelector =
+        sel(NONE, NONE, &["md", "toml", "yaml", "yml", "json", "json5"], NONE);
+    pub(super) const REMEM: DirSelector = sel(NONE, NONE, &["toml", "yaml", "yml", "json"], NONE);
+    pub(super) const GITHOOKS: DirSelector = sel(NONE, super::GIT_LIFECYCLE_HOOKS, NONE, NONE);
+}
+use selectors::*;
+
+/// Documented Git lifecycle hook basenames: the only direct `.githooks`
+/// children that can carry the ASC-001 `hook` kind.
+#[rustfmt::skip]
+const GIT_LIFECYCLE_HOOKS: &[&str] = &[
+    "applypatch-msg", "pre-applypatch", "post-applypatch", "pre-commit", "pre-merge-commit",
+    "prepare-commit-msg", "commit-msg", "post-commit", "pre-rebase", "post-checkout",
+    "post-merge", "pre-push", "pre-receive", "update", "proc-receive", "post-receive",
+    "post-update", "reference-transaction", "push-to-checkout", "pre-auto-gc", "post-rewrite",
+    "sendemail-validate", "fsmonitor-watchman", "p4-changelist", "p4-prepare-changelist",
+    "p4-post-changelist", "p4-pre-submit", "post-index-change",
+];
+
+impl DirSelector {
+    const fn is_recursive(&self) -> bool {
+        !self.recursive_extensions.is_empty() || !self.recursive_basenames.is_empty()
+    }
+
+    /// Match against a native basename before any locator normalization.
+    fn matches(&self, name: &[u8], direct_level: bool) -> bool {
+        let ext_match = |ext: &&str| has_extension(name, ext.as_bytes());
+        let base_match = |base: &&str| name == base.as_bytes();
+        self.recursive_extensions.iter().any(ext_match)
+            || self.recursive_basenames.iter().any(base_match)
+            || (direct_level
+                && (self.direct_extensions.iter().any(ext_match)
+                    || self.direct_basenames.iter().any(base_match)))
+    }
+}
+
+fn has_extension(name: &[u8], ext: &[u8]) -> bool {
+    name.len() > ext.len() + 1 && name.ends_with(ext) && name[name.len() - ext.len() - 1] == b'.'
+}
+
+/// Expected entry class for a rule target.
+#[derive(Debug, Clone, Copy)]
+enum RuleTarget {
+    File,
+    Directory(DirSelector),
+    FileOrDirectory(DirSelector),
+    DirectoryPresence,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Matcher {
+    Exact(&'static str),
+    RootSuffix(&'static str),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StaticRule {
+    matcher: Matcher,
+    target: RuleTarget,
+    kind: AgentStackComponentKind,
+}
+
+#[rustfmt::skip]
+const fn fr(path: &'static str, kind: Kind) -> StaticRule {
+    StaticRule { matcher: Matcher::Exact(path), target: RuleTarget::File, kind }
+}
+#[rustfmt::skip]
+const fn dr(path: &'static str, sel: DirSelector, kind: Kind) -> StaticRule {
+    StaticRule { matcher: Matcher::Exact(path), target: RuleTarget::Directory(sel), kind }
+}
+#[rustfmt::skip]
+const fn sfx(suffix: &'static str, kind: Kind) -> StaticRule {
+    StaticRule { matcher: Matcher::RootSuffix(suffix), target: RuleTarget::File, kind }
+}
+
+/// The single typed representation of the B-003 v0.1 allowlist. Table order
+/// is stable; output order is lexicographic over normalized locators.
+#[rustfmt::skip]
+const STATIC_RULES: &[StaticRule] = &[
+    fr("AGENTS.md", Kind::Instructions), fr("AGENTS.override.md", Kind::Instructions),
+    fr("CLAUDE.md", Kind::Instructions), fr("WORKFLOW.md", Kind::Workflow),
+    fr("MEMORY.md", Kind::Memory),
+    fr("src/AGENTS.md", Kind::Instructions), fr("src/AGENTS.override.md", Kind::Instructions),
+    fr("src/CLAUDE.md", Kind::Instructions), fr("crates/AGENTS.md", Kind::Instructions),
+    fr("crates/AGENTS.override.md", Kind::Instructions), fr("crates/CLAUDE.md", Kind::Instructions),
+    fr("lib/AGENTS.md", Kind::Instructions), fr("lib/AGENTS.override.md", Kind::Instructions),
+    fr("lib/CLAUDE.md", Kind::Instructions), fr("pkg/AGENTS.md", Kind::Instructions),
+    fr("pkg/AGENTS.override.md", Kind::Instructions), fr("pkg/CLAUDE.md", Kind::Instructions),
+    dr(".claude/skills", SKILL_ROOT, Kind::Skill), dr(".codex/skills", SKILL_ROOT, Kind::Skill),
+    dr(".agents/skills", SKILL_ROOT, Kind::Skill), dr("skills", SKILL_ROOT, Kind::Skill),
+    dr(".harness/skills", HARNESS_SKILLS, Kind::Skill),
+    dr(".harness/guards", GUARDS, Kind::Hook), dr(".githooks", GITHOOKS, Kind::Hook),
+    fr(".mcp.json", Kind::McpServer), fr("mcp.json", Kind::McpServer),
+    dr(".vibeguard", VIBEGUARD, Kind::Policy), fr(".vibeguard/run-guards.sh", Kind::Validation),
+    dr("rules", MD_TOML, Kind::Policy), fr("requirements.toml", Kind::Policy),
+    dr(".remem", REMEM, Kind::Memory), fr("remem.toml", Kind::Memory),
+    fr(".harness/config.toml", Kind::Validation), dr(".harness/rules", MD_TOML, Kind::Policy),
+    dr(".harness/sg", SG, Kind::Policy), fr("harness.toml", Kind::Validation),
+    dr(".github/workflows", WORKFLOWS, Kind::Workflow), dr(".cursor/rules", CURSOR_RULES, Kind::Policy),
+    // Toolchain and validation selectors mirrored from `lang_detect.rs`.
+    fr("Cargo.toml", Kind::Validation), fr("go.mod", Kind::Validation),
+    fr("package.json", Kind::Validation), fr("pyproject.toml", Kind::Validation),
+    fr("setup.py", Kind::Validation), fr("requirements.txt", Kind::Validation),
+    fr("build.gradle", Kind::Validation), fr("build.gradle.kts", Kind::Validation),
+    fr("pom.xml", Kind::Validation), fr("Gemfile", Kind::Validation),
+    fr("yarn.lock", Kind::Validation), fr("pnpm-lock.yaml", Kind::Validation),
+    fr(".eslintrc", Kind::Validation), fr(".eslintrc.js", Kind::Validation),
+    fr(".eslintrc.cjs", Kind::Validation), fr(".eslintrc.json", Kind::Validation),
+    fr(".eslintrc.yaml", Kind::Validation), fr(".eslintrc.yml", Kind::Validation),
+    fr("eslint.config.js", Kind::Validation), fr("eslint.config.mjs", Kind::Validation),
+    fr("eslint.config.cjs", Kind::Validation), fr("biome.json", Kind::Validation),
+    fr(".rubocop.yml", Kind::Validation),
+    sfx(".csproj", Kind::Validation), sfx(".sln", Kind::Validation),
+    StaticRule { matcher: Matcher::Exact("spec"), target: RuleTarget::DirectoryPresence, kind: Kind::Validation },
+    fr("Makefile", Kind::Validation), fr("justfile", Kind::Validation),
+];
+
+/// Minimal `harness.toml` shape: only repository-relative rule sources are
+/// deserialized; unrelated Harness settings are ignored, never validated.
+#[rustfmt::skip]
+#[derive(Debug, Default, Deserialize)]
+struct ConfigShape {
+    #[serde(default)] rules: Option<ConfigRules>,
+}
+
+#[rustfmt::skip]
+#[derive(Debug, Default, Deserialize)]
+struct ConfigRules {
+    #[serde(default)] discovery_paths: Vec<String>,
+    #[serde(default)] builtin_path: Option<String>,
+    #[serde(default)] exec_policy_paths: Vec<String>,
+    #[serde(default)] requirements_path: Option<String>,
+}
+
+/// Lexically normalize a configured repository-relative source. Absolute
+/// sources are out of scope (`Ok(None)`); empty, parent-traversing, or
+/// otherwise unportable sources are invalid.
+fn normalize_configured_source(raw: &str) -> Result<Option<String>, AgentStackInventoryErrorKind> {
+    let bytes = raw.as_bytes();
+    if raw.starts_with('/')
+        || raw.starts_with('\\')
+        || (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+    {
+        return Ok(None);
+    }
+    if raw.is_empty() || raw.contains('\0') || raw.contains('\\') {
+        return Err(EK::ConfiguredSourceInvalid);
+    }
+    let mut segments = Vec::new();
+    for segment in raw.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => return Err(EK::ConfiguredSourceInvalid),
+            other => segments.push(other),
+        }
+    }
+    if segments.is_empty() {
+        Err(EK::ConfiguredSourceInvalid)
+    } else {
+        Ok(Some(segments.join("/")))
+    }
+}
+
+/// `NotFound` on symlink-target resolution is a broken symlink; every other
+/// failure (including escape) rejects without leaking ambient targets.
+#[rustfmt::skip]
+fn classify_resolution_failure(kind: std::io::ErrorKind) -> AgentStackInventoryErrorKind {
+    if kind == std::io::ErrorKind::NotFound { EK::BrokenSymlink } else { EK::RootEscape }
+}
+
+/// A selected entry that disappeared before open is a race; any other open
+/// failure of an already-selected candidate is a read failure.
+#[rustfmt::skip]
+pub(super) fn classify_open_failure(kind: std::io::ErrorKind) -> AgentStackInventoryErrorKind {
+    if kind == std::io::ErrorKind::NotFound { EK::EntryRaced } else { EK::ReadFailed }
+}
+
+#[cfg(unix)]
+#[rustfmt::skip]
+fn os_bytes(name: &OsStr) -> Option<&[u8]> {
+    use std::os::unix::ffi::OsStrExt;
+    Some(name.as_bytes())
+}
+#[cfg(not(unix))]
+#[rustfmt::skip]
+fn os_bytes(name: &OsStr) -> Option<&[u8]> { name.to_str().map(str::as_bytes) }
+
+type DerivedRule = (String, RuleTarget, AgentStackComponentKind);
+type Listing = Vec<(OsString, FileType)>;
+
+#[rustfmt::skip]
+struct Scan<'a> {
+    opts: &'a AgentStackInventoryOptions,
+    files_used: usize, dirs_opened: usize, entries_seen: usize, bytes_used: u64,
+    entries: BTreeMap<(String, &'static str), AgentStackInventoryEntry>,
+    root_listing: Option<Listing>,
+    #[cfg(unix)] ancestors: Vec<(u64, u64)>,
+}
+
+/// Checked budget increment: fail before a configured limit can be exceeded.
+fn charge(counter: &mut usize, max: usize, locator: &str) -> Result<(), IErr> {
+    match counter.checked_add(1) {
+        Some(next) if next <= max => {
+            *counter = next;
+            Ok(())
+        }
+        _ => Err(err(EK::LimitExceeded, locator)),
+    }
+}
+
+/// Run the repository-observed stack inventory for one explicit root.
+pub fn inventory_repository_stack(
+    options: &AgentStackInventoryOptions,
+) -> Result<AgentStackInventory, AgentStackInventoryError> {
+    let root = Dir::open_ambient_dir(&options.root, cap_std::ambient_authority())
+        .map_err(|_| IErr::new(EK::RootOpen, None))?;
+    inventory_with_root(&root, options)
+}
+
+/// Inventory against an already-opened root capability; all discovery stays
+/// relative to this handle and no ambient path is reconstructed from it.
+pub(crate) fn inventory_with_root(
+    root: &Dir,
+    options: &AgentStackInventoryOptions,
+) -> Result<AgentStackInventory, AgentStackInventoryError> {
+    let mut scan = Scan {
+        opts: options,
+        files_used: 0,
+        dirs_opened: 1, // The opened repository root counts as directory 1.
+        entries_seen: 0,
+        bytes_used: 0,
+        entries: BTreeMap::new(),
+        root_listing: None,
+        #[cfg(unix)]
+        ancestors: Vec::new(),
+    };
+    #[cfg(unix)]
+    {
+        use cap_std::fs::MetadataExt;
+        let meta = root
+            .dir_metadata()
+            .map_err(|_| IErr::new(EK::RootOpen, None))?;
+        scan.ancestors.push((meta.dev(), meta.ino()));
+    }
+    let derived = scan.load_config(root)?;
+    for static_rule in STATIC_RULES {
+        match static_rule.matcher {
+            Matcher::Exact(path) => {
+                scan.apply_exact(root, path, static_rule.target, static_rule.kind, false)?;
+            }
+            Matcher::RootSuffix(suffix) => scan.apply_suffix(root, suffix, static_rule.kind)?,
+        }
+    }
+    for (locator, target, kind) in derived {
+        scan.apply_exact(root, &locator, target, kind, true)?;
+    }
+    Ok(AgentStackInventory {
+        entries: scan.entries.into_values().collect(),
+    })
+}
+
+impl Scan<'_> {
+    /// Read `harness.toml` at most once through the bounded handle-first path
+    /// and derive typed `policy` rules from the four documented rule sources.
+    fn load_config(&mut self, root: &Dir) -> Result<Vec<DerivedRule>, IErr> {
+        const CONFIG: &str = "harness.toml";
+        match self.lookup_exact(root, CONFIG)? {
+            None => return Ok(Vec::new()),
+            Some(true) => return Err(err(EK::NonRegularEntry, CONFIG)),
+            Some(false) => {}
+        }
+        let bytes = self
+            .read_selected(root, CONFIG.to_owned(), Kind::Validation)?
+            .unwrap_or_default();
+        let text = std::str::from_utf8(&bytes).map_err(|_| err(EK::ConfigParse, CONFIG))?;
+        let shape: ConfigShape = toml::from_str(text).map_err(|_| err(EK::ConfigParse, CONFIG))?;
+        let Some(rules) = shape.rules else {
+            return Ok(Vec::new());
+        };
+        let mut derived: Vec<DerivedRule> = Vec::new();
+        let mut seen: Vec<(String, bool)> = Vec::new();
+        let sources = rules
+            .discovery_paths
+            .iter()
+            .map(|raw| (raw, false))
+            .chain(rules.builtin_path.iter().map(|raw| (raw, false)))
+            .chain(rules.exec_policy_paths.iter().map(|raw| (raw, true)))
+            .chain(rules.requirements_path.iter().map(|raw| (raw, true)));
+        for (raw, exact_file) in sources {
+            let Some(locator) =
+                normalize_configured_source(raw).map_err(|kind| err(kind, CONFIG))?
+            else {
+                continue; // Absolute sources are outside the repository scope.
+            };
+            let key = (locator.clone(), exact_file);
+            if seen.contains(&key) {
+                continue;
+            }
+            seen.push(key);
+            let target = if exact_file {
+                RuleTarget::File
+            } else {
+                RuleTarget::FileOrDirectory(MD_TOML)
+            };
+            derived.push((locator, target, Kind::Policy));
+        }
+        Ok(derived)
+    }
+
+    /// Non-following lookup of one exact path, resolving a symlink target
+    /// through the root capability: `None` is absent, `Some(is_dir)` present.
+    fn lookup_exact(&self, root: &Dir, path: &str) -> Result<Option<bool>, IErr> {
+        let meta = match root.symlink_metadata(path) {
+            Ok(meta) => meta,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                return Err(err(EK::RootEscape, path))
+            }
+            Err(_) => return Err(err(EK::EntryMetadata, path)),
+        };
+        let is_dir = if meta.is_symlink() {
+            root.metadata(path)
+                .map_err(|error| err(classify_resolution_failure(error.kind()), path))?
+                .is_dir()
+        } else {
+            meta.is_dir()
+        };
+        Ok(Some(is_dir))
+    }
+
+    #[rustfmt::skip]
+    fn apply_exact(
+        &mut self, root: &Dir, path: &str, target: RuleTarget, kind: Kind, derived: bool,
+    ) -> Result<(), IErr> {
+        let is_dir = match self.lookup_exact(root, path)? {
+            None if derived => return Err(err(EK::ConfiguredSourceMissing, path)),
+            None => return Ok(()),
+            Some(is_dir) => is_dir,
+        };
+        match target {
+            RuleTarget::DirectoryPresence => {
+                if is_dir {
+                    let class = AgentStackEntryClass::DirectoryPresence;
+                    self.emit(kind, path.to_owned(), None, class)?;
+                }
+                Ok(())
+            }
+            RuleTarget::Directory(selector) | RuleTarget::FileOrDirectory(selector) if is_dir => {
+                self.traverse(root, path.to_owned(), &selector, kind, 1)
+            }
+            RuleTarget::File if is_dir => Err(err(EK::NonRegularEntry, path)),
+            RuleTarget::Directory(_) => Err(err(EK::NonRegularEntry, path)),
+            RuleTarget::File | RuleTarget::FileOrDirectory(_) => {
+                self.read_selected(root, path.to_owned(), kind).map(drop)
+            }
+        }
+    }
+
+    /// Root-only suffix rules (`*.csproj`, `*.sln`) select regular-file
+    /// children of the repository root from one charged root enumeration.
+    fn apply_suffix(&mut self, root: &Dir, suffix: &str, kind: Kind) -> Result<(), IErr> {
+        if self.root_listing.is_none() {
+            let listing = self.enumerate(root, "")?;
+            self.root_listing = Some(listing);
+        }
+        let listing = self.root_listing.clone().unwrap_or_default();
+        let mut selected = Vec::new();
+        for (name, file_type) in listing {
+            let matched = os_bytes(&name).is_some_and(|bytes| {
+                bytes.len() > suffix.len() && bytes.ends_with(suffix.as_bytes())
+            });
+            if !matched || file_type.is_dir() {
+                continue;
+            }
+            if file_type.is_symlink() {
+                let hint = name.to_str().unwrap_or("");
+                let resolved = root
+                    .metadata(&name)
+                    .map_err(|error| err(classify_resolution_failure(error.kind()), hint))?;
+                if resolved.is_dir() {
+                    continue;
+                }
+            }
+            let Some(locator) = name.to_str().map(str::to_owned) else {
+                return Err(IErr::new(EK::NonUtf8Locator, None));
+            };
+            selected.push(locator);
+        }
+        selected.sort();
+        for locator in selected {
+            self.read_selected(root, locator, kind)?;
+        }
+        Ok(())
+    }
+
+    /// Enumerate one directory with the checked `N + 1` sentinel, charging
+    /// every yielded item to the encountered-entry budget pre-classification.
+    fn enumerate(&mut self, dir: &Dir, prefix: &str) -> Result<Listing, IErr> {
+        let iter = dir.entries().map_err(|_| err(EK::EntryMetadata, prefix))?;
+        let mut listing = Vec::new();
+        for entry in iter {
+            let entry = entry.map_err(|_| err(EK::EntryMetadata, prefix))?;
+            if listing.len() + 1 > self.opts.max_entries_per_directory {
+                return Err(err(EK::LimitExceeded, prefix));
+            }
+            charge(&mut self.entries_seen, self.opts.max_total_entries, prefix)?;
+            let file_type = entry
+                .file_type()
+                .map_err(|_| err(EK::EntryMetadata, prefix))?;
+            listing.push((entry.file_name(), file_type));
+        }
+        Ok(listing)
+    }
+
+    /// Recursive selector-filtered traversal; `depth` counts directory opens
+    /// below the repository root (the root itself is depth 0). All opens and
+    /// symlink resolutions stay relative to the one root capability.
+    #[rustfmt::skip]
+    fn traverse(
+        &mut self, root: &Dir, prefix: String,
+        selector: &DirSelector, kind: Kind, depth: usize,
+    ) -> Result<(), IErr> {
+        if depth > self.opts.max_depth {
+            return Err(err(EK::LimitExceeded, &prefix));
+        }
+        charge(&mut self.dirs_opened, self.opts.max_directories, &prefix)?;
+        let dir = root.open_dir(&prefix).map_err(|error| {
+            let kind = match error.kind() {
+                std::io::ErrorKind::NotFound => EK::EntryRaced,
+                std::io::ErrorKind::PermissionDenied => EK::RootEscape,
+                _ => EK::EntryMetadata,
+            };
+            err(kind, &prefix)
+        })?;
+        #[cfg(unix)]
+        {
+            use cap_std::fs::MetadataExt;
+            let meta = dir.dir_metadata().map_err(|_| err(EK::EntryMetadata, &prefix))?;
+            let identity = (meta.dev(), meta.ino());
+            if self.ancestors.contains(&identity) {
+                return Err(err(EK::CycleDetected, &prefix));
+            }
+            self.ancestors.push(identity);
+        }
+        let result = self.traverse_entries(root, &dir, &prefix, selector, kind, depth);
+        #[cfg(unix)]
+        self.ancestors.pop();
+        result
+    }
+
+    #[rustfmt::skip]
+    fn traverse_entries(
+        &mut self, root: &Dir, dir: &Dir, prefix: &str,
+        selector: &DirSelector, kind: Kind, depth: usize,
+    ) -> Result<(), IErr> {
+        let direct_level = depth == 1;
+        let listing = self.enumerate(dir, prefix)?;
+        // Every symlink is resolved through the root capability before any
+        // file selector applies; broken or escaping targets fail typed.
+        let mut candidates: Vec<(bool, String)> = Vec::new();
+        for (name, file_type) in &listing {
+            let is_dir = if file_type.is_symlink() {
+                root.metadata(Path::new(prefix).join(name))
+                    .map_err(|error| {
+                        let hint = name
+                            .to_str()
+                            .map_or_else(|| prefix.to_owned(), |n| format!("{prefix}/{n}"));
+                        err(classify_resolution_failure(error.kind()), &hint)
+                    })?
+                    .is_dir()
+            } else {
+                file_type.is_dir()
+            };
+            let selected = if is_dir {
+                selector.is_recursive()
+            } else {
+                os_bytes(name).is_some_and(|bytes| selector.matches(bytes, direct_level))
+            };
+            if selected {
+                let name = name.to_str().ok_or_else(|| err(EK::NonUtf8Locator, prefix))?;
+                candidates.push((is_dir, name.to_owned()));
+            }
+        }
+        candidates.sort_by(|a, b| a.1.cmp(&b.1));
+        for (is_dir, name) in candidates {
+            let locator = format!("{prefix}/{name}");
+            if is_dir {
+                self.traverse(root, locator, selector, kind, depth + 1)?;
+            } else {
+                self.read_selected(root, locator, kind)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Open one selected candidate capability-relatively (nonblocking on
+    /// Unix), validate the opened handle type, read within remaining budgets,
+    /// and emit its component; `None` means the binding was deduplicated.
+    #[rustfmt::skip]
+    fn read_selected(
+        &mut self, root: &Dir, locator: String, kind: Kind,
+    ) -> Result<Option<Vec<u8>>, IErr> {
+        if self.entries.contains_key(&(locator.clone(), kind.as_str())) {
+            return Ok(None);
+        }
+        charge(&mut self.files_used, self.opts.max_files, &locator)?;
+        let mut open_options = OpenOptions::new();
+        open_options.read(true);
+        #[cfg(unix)]
+        {
+            use cap_std::fs::OpenOptionsExt;
+            open_options.custom_flags(libc::O_NONBLOCK);
+        }
+        let file = root
+            .open_with(&locator, &open_options)
+            .map_err(|error| err(classify_open_failure(error.kind()), &locator))?;
+        let meta = file.metadata().map_err(|_| err(EK::EntryMetadata, &locator))?;
+        if !meta.is_file() {
+            return Err(err(EK::NonRegularEntry, &locator));
+        }
+        #[cfg(unix)]
+        let unix_executable = {
+            use cap_std::fs::MetadataExt;
+            Some(meta.mode() & 0o111 != 0)
+        };
+        #[cfg(not(unix))]
+        let unix_executable: Option<bool> = None;
+        let remaining = self.opts.max_total_bytes - self.bytes_used;
+        // Sentinels are safe: validation keeps byte limits below `u64::MAX`.
+        let limit = (self.opts.max_file_bytes + 1).min(remaining + 1);
+        let mut bytes = Vec::new();
+        file.take(limit)
+            .read_to_end(&mut bytes)
+            .map_err(|_| err(EK::ReadFailed, &locator))?;
+        let read = bytes.len() as u64;
+        if read > self.opts.max_file_bytes || read > remaining {
+            return Err(err(EK::LimitExceeded, &locator));
+        }
+        self.bytes_used += read;
+        let digest = Sha256Digest::from_bytes(&bytes);
+        let class = AgentStackEntryClass::RegularFile { unix_executable };
+        self.emit(kind, locator, Some(digest), class)?;
+        Ok(Some(bytes))
+    }
+
+    /// Build and validate one ASC-001 component and record its typed entry.
+    #[rustfmt::skip]
+    fn emit(
+        &mut self, kind: Kind, locator: String,
+        integrity: Option<Sha256Digest>, entry_class: AgentStackEntryClass,
+    ) -> Result<(), IErr> {
+        let key = (locator.clone(), kind.as_str());
+        if self.entries.contains_key(&key) {
+            return Ok(());
+        }
+        let validation = |_| err(EK::ComponentValidation, &locator);
+        let source = AgentStackSource::new(AgentStackSourceScope::Repository, &locator)
+            .map_err(validation)?;
+        let freshness = AgentStackFreshnessEvidence::new(false, None, None, true, false).classify();
+        let component = AgentStackComponent::new(
+            kind,
+            source,
+            AgentStackObservationClass::RepositoryObserved,
+            AgentStackSelectionState::Discovered,
+            AgentStackTrustLevel::RepositoryObserved,
+            freshness,
+        )
+        .map_err(validation)?
+        .with_integrity(integrity);
+        component.validate().map_err(validation)?;
+        self.entries.insert(key, AgentStackInventoryEntry { component, entry_class });
+        Ok(())
+    }
+}

--- a/crates/harness-core/src/stack/inventory.rs
+++ b/crates/harness-core/src/stack/inventory.rs
@@ -171,7 +171,7 @@ impl std::error::Error for AgentStackInventoryError {}
 type IErr = AgentStackInventoryError;
 
 fn err(kind: AgentStackInventoryErrorKind, locator: &str) -> IErr {
-    IErr::new(kind, Some(locator.to_owned()))
+    IErr::new(kind, (!locator.is_empty()).then(|| locator.to_owned()))
 }
 
 /// Closed per-directory entry selector: pure rule-table data, never content
@@ -392,6 +392,11 @@ pub(super) fn classify_resolution_failure(
 #[rustfmt::skip]
 pub(super) fn classify_open_failure(kind: std::io::ErrorKind) -> AgentStackInventoryErrorKind {
     if kind == std::io::ErrorKind::NotFound { EK::EntryRaced } else { EK::ReadFailed }
+}
+
+#[rustfmt::skip]
+pub(super) fn classify_directory_open_failure(kind: std::io::ErrorKind) -> AgentStackInventoryErrorKind {
+    match kind { std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory => EK::EntryRaced, std::io::ErrorKind::PermissionDenied => EK::RootEscape, _ => EK::EntryMetadata }
 }
 
 type DerivedRule = (String, RuleTarget, AgentStackComponentKind);
@@ -635,11 +640,7 @@ impl Scan<'_> {
         }
         charge(&mut self.dirs_opened, self.opts.max_directories, &prefix)?;
         let dir = root.open_dir(&prefix).map_err(|error| {
-            let kind = match error.kind() {
-                std::io::ErrorKind::NotFound => EK::EntryRaced,
-                std::io::ErrorKind::PermissionDenied => EK::RootEscape,
-                _ => EK::EntryMetadata,
-            };
+            let kind = classify_directory_open_failure(error.kind());
             err(kind, &prefix)
         })?;
         let identity = directory_identity(&dir, &prefix)?;

--- a/crates/harness-core/src/stack/inventory_tests.rs
+++ b/crates/harness-core/src/stack/inventory_tests.rs
@@ -508,14 +508,14 @@ fn symlink_swaps_remain_root_confined_and_hash_the_opened_target() {
     symlink("b.txt", root.join("CLAUDE.md")).expect("relink");
     let swapped = run_ok(&root);
     assert_eq!(entry_digest(find(&swapped, "CLAUDE.md")), digest_of(b"target b"));
-    // An escaping target is rejected by the root capability.
     write_file(outer.path(), "outside.txt", b"outside");
     fs::remove_file(root.join("CLAUDE.md")).expect("remove link");
     symlink("../outside.txt", root.join("CLAUDE.md")).expect("escape link");
     let error = assert_fail(&root, EK::RootEscape);
     assert_eq!(error.locator(), Some("CLAUDE.md"));
-    // A dangling in-root target is a broken symlink, not a silent omission.
     fs::remove_file(root.join("CLAUDE.md")).expect("remove link");
+    let cap = cap_std::fs::Dir::open_ambient_dir(&root, cap_std::ambient_authority()).expect("root");
+    assert_eq!(classify_resolution_failure(&cap, "CLAUDE.md", std::io::ErrorKind::NotFound), EK::EntryRaced);
     symlink("gone.txt", root.join("CLAUDE.md")).expect("broken link");
     assert_fail(&root, EK::BrokenSymlink);
 }
@@ -724,10 +724,12 @@ fn selected_fifo_targets_fail_without_blocking() {
         .status()
         .expect("spawn mkfifo");
     assert!(status.success(), "mkfifo must succeed");
+    write_file(dir.path(), "AGENTS.md", b"regular file consumes the budget");
     let root = dir.path().to_path_buf();
+    let options = opts(&root).with_max_files(1).expect("one regular file");
     let (sender, receiver) = mpsc::channel();
     std::thread::spawn(move || {
-        let _ = sender.send(run(&root));
+        let _ = sender.send(inventory_repository_stack(&options));
     });
     let result = receiver
         .recv_timeout(Duration::from_secs(10))
@@ -739,7 +741,6 @@ fn selected_fifo_targets_fail_without_blocking() {
 #[cfg(not(unix))]
 #[test]
 fn selected_fifo_targets_fail_without_blocking() {
-    // FIFOs are Unix-specific; assert the typed rejection category directly.
     assert_eq!(EK::NonRegularEntry.as_str(), "non_regular_entry");
 }
 

--- a/crates/harness-core/src/stack/inventory_tests.rs
+++ b/crates/harness-core/src/stack/inventory_tests.rs
@@ -256,19 +256,20 @@ fn configured_repository_rule_sources_are_inventoried_once() {
     let dir = tmp();
     let root = dir.path();
     write_file(root, "harness.toml", br#"[rules]
-discovery_paths = ["policies", "policies", "./policies", "/absolute/outside"]
+discovery_paths = ["rules", "rules", "./rules", "/absolute/outside"]
 builtin_path = "builtin.toml"
 exec_policy_paths = ["exec.policy.toml"]
 requirements_path = "reqs.toml"
 "#);
-    write_file(root, "policies/p.md", b"p");
-    write_file(root, "policies/p.toml", b"q = 1");
-    write_file(root, "policies/skip.txt", b"not selected");
+    write_file(root, "rules/p.md", b"p");
+    write_file(root, "rules/p.toml", b"q = 1");
+    write_file(root, "rules/skip.txt", b"not selected");
     write_file(root, "builtin.toml", b"b = 1");
     write_file(root, "exec.policy.toml", b"e = 1");
     write_file(root, "reqs.toml", b"r = 1");
-    let listed = pairs(&run_ok(root));
-    let expected = ["builtin.toml", "exec.policy.toml", "policies/p.md", "policies/p.toml", "reqs.toml"];
+    let options = opts(root).with_max_directories(2).expect("root plus rules");
+    let listed = pairs(&inventory_repository_stack(&options).expect("merged static and derived rules"));
+    let expected = ["builtin.toml", "exec.policy.toml", "reqs.toml", "rules/p.md", "rules/p.toml"];
     assert_eq!(of_kind(&listed, "policy"), expected, "each binding is inventoried once");
     assert!(listed.contains(&("harness.toml".to_owned(), "validation")));
     assert!(!listed.iter().any(|(l, _)| l.contains("absolute") || l.contains("outside")));
@@ -301,6 +302,9 @@ fn missing_allowlisted_entries_emit_no_placeholders() {
     write_file(dir.path(), "WORKFLOW.md", b"w");
     let listed = pairs(&run_ok(dir.path()));
     assert_eq!(listed, vec![("WORKFLOW.md".to_owned(), "workflow")]);
+    let wrong_case = tmp();
+    write_file(wrong_case.path(), "agents.md", b"wrong case");
+    assert!(run_ok(wrong_case.path()).entries().is_empty());
 }
 
 // ── B-005 ────────────────────────────────────────────────────────────────────
@@ -517,13 +521,13 @@ fn symlink_swaps_remain_root_confined_and_hash_the_opened_target() {
     let cap = cap_std::fs::Dir::open_ambient_dir(&root, cap_std::ambient_authority()).expect("root");
     assert_eq!(classify_resolution_failure(&cap, "CLAUDE.md", std::io::ErrorKind::NotFound), EK::EntryRaced);
     symlink("gone.txt", root.join("CLAUDE.md")).expect("broken link");
+    assert_eq!(classify_selected_open_failure(&cap, "CLAUDE.md", std::io::ErrorKind::NotFound), EK::BrokenSymlink);
     assert_fail(&root, EK::BrokenSymlink);
 }
 
 #[cfg(not(unix))]
 #[test]
 fn symlink_swaps_remain_root_confined_and_hash_the_opened_target() {
-    // Symlink fixtures are Unix-only; assert digests bind to opened bytes.
     let dir = tmp();
     write_file(dir.path(), "CLAUDE.md", b"target a");
     let inventory = run_ok(dir.path());
@@ -605,17 +609,15 @@ fn unreadable_and_non_utf8_entries_fail_without_lossy_locators() {
         assert!(!error.locator().unwrap_or_default().contains('\u{FFFD}'), "no lossy locator");
     }
     fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("chmod back");
-    // Deterministic injected failure mapping covers privileged environments
-    // where permission bits cannot produce an unreadable file.
     assert_eq!(classify_open_failure(std::io::ErrorKind::PermissionDenied), EK::ReadFailed);
     assert_eq!(classify_open_failure(std::io::ErrorKind::NotFound), EK::EntryRaced);
+    assert_eq!(classify_entry_metadata_failure(std::io::ErrorKind::NotFound), EK::EntryRaced);
     assert_eq!(classify_directory_open_failure(std::io::ErrorKind::NotADirectory), EK::EntryRaced);
 }
 
 #[cfg(not(unix))]
 #[test]
 fn unreadable_and_non_utf8_entries_fail_without_lossy_locators() {
-    // Deterministic injected failure mapping replaces permission fixtures.
     let denied = classify_open_failure(std::io::ErrorKind::PermissionDenied);
     assert_eq!(denied, EK::ReadFailed);
     let raced = classify_open_failure(std::io::ErrorKind::NotFound);
@@ -661,7 +663,6 @@ fn every_traversal_limit_has_an_exact_boundary_fixture() {
     assert!(run_with(base(files.path()).with_max_files(2)).is_ok());
     let error = run_with(base(files.path()).with_max_files(1)).expect_err("file budget");
     assert_eq!((error.kind(), error.locator()), (EK::LimitExceeded, Some("CLAUDE.md")));
-    // max_file_bytes: a 4-byte file passes at 4 and fails at 3.
     assert!(run_with(base(files.path()).with_max_file_bytes(4)).is_ok());
     let error = run_with(base(files.path()).with_max_file_bytes(3)).expect_err("per-file bytes");
     assert_eq!(error.kind(), EK::LimitExceeded);
@@ -691,7 +692,7 @@ fn every_traversal_limit_has_an_exact_boundary_fixture() {
     // suffix enumeration yields 1 (the `skills` directory itself): 4 exactly.
     assert!(run_with(base(wide.path()).with_max_total_entries(4)).is_ok());
     let error = run_with(base(wide.path()).with_max_total_entries(3)).expect_err("entries");
-    assert_eq!((error.kind(), error.locator()), (EK::LimitExceeded, None));
+    assert_eq!((error.kind(), error.locator()), (EK::LimitExceeded, Some("skills")));
 }
 
 #[test]
@@ -702,8 +703,6 @@ fn reads_never_exceed_remaining_aggregate_or_per_file_budget() {
     let options = opts(dir.path()).with_max_file_bytes(4).expect("options");
     let error = inventory_repository_stack(&options).expect_err("oversized file");
     assert_eq!((error.kind(), error.locator()), (EK::LimitExceeded, Some("AGENTS.md")));
-    // The second file exceeds the remaining aggregate budget even though it
-    // stays within the per-file budget.
     let pair = tmp();
     write_file(pair.path(), "AGENTS.md", b"aaaa");
     write_file(pair.path(), "CLAUDE.md", b"bbbb");

--- a/crates/harness-core/src/stack/inventory_tests.rs
+++ b/crates/harness-core/src/stack/inventory_tests.rs
@@ -1,0 +1,778 @@
+//! Behavior-invariant tests for the repository-observed Agent Stack
+//! inventory (GH-1731, B-001..B-012).
+
+use super::inventory::*;
+use super::{AgentStackFreshness, Sha256Digest};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use AgentStackInventoryErrorKind as EK;
+
+#[cfg(unix)]
+use std::os::unix::fs::{symlink, PermissionsExt};
+
+fn tmp() -> TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+fn write_file(root: &Path, rel: &str, contents: &[u8]) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("mkdir");
+    }
+    fs::write(path, contents).expect("write");
+}
+
+fn opts(root: &Path) -> AgentStackInventoryOptions {
+    AgentStackInventoryOptions::new(root.to_path_buf())
+}
+
+fn run(root: &Path) -> Result<AgentStackInventory, AgentStackInventoryError> {
+    inventory_repository_stack(&opts(root))
+}
+
+fn run_ok(root: &Path) -> AgentStackInventory {
+    run(root).expect("inventory must succeed")
+}
+
+/// Assert the scan fails with `kind` and return the error for locator checks.
+fn assert_fail(root: &Path, kind: EK) -> AgentStackInventoryError {
+    let error = run(root).expect_err("inventory must fail");
+    assert_eq!(error.kind(), kind);
+    error
+}
+
+fn pairs(inventory: &AgentStackInventory) -> Vec<(String, &'static str)> {
+    inventory
+        .entries()
+        .iter()
+        .map(|entry| {
+            let component = entry.component();
+            let locator = component.source().locator().as_str().to_owned();
+            (locator, component.kind().as_str())
+        })
+        .collect()
+}
+
+fn of_kind<'a>(listed: &'a [(String, &'static str)], kind: &str) -> Vec<&'a str> {
+    listed
+        .iter()
+        .filter(|(_, entry_kind)| *entry_kind == kind)
+        .map(|(locator, _)| locator.as_str())
+        .collect()
+}
+
+fn find<'a>(inventory: &'a AgentStackInventory, locator: &str) -> &'a AgentStackInventoryEntry {
+    inventory
+        .entries()
+        .iter()
+        .find(|entry| entry.component().source().locator().as_str() == locator)
+        .unwrap_or_else(|| panic!("missing inventory entry for {locator}"))
+}
+
+fn digest_of(bytes: &[u8]) -> String {
+    Sha256Digest::from_bytes(bytes).as_str().to_owned()
+}
+
+fn entry_digest(entry: &AgentStackInventoryEntry) -> String {
+    entry
+        .component()
+        .integrity()
+        .expect("regular file entries carry a digest")
+        .as_str()
+        .to_owned()
+}
+
+// ── B-001 ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[rustfmt::skip]
+fn invalid_limits_fail_before_root_open() {
+    // Invalid limits are rejected at construction, before any root open, even
+    // when the root itself does not exist.
+    let missing = PathBuf::from("/nonexistent/harness-gh1731");
+    let base = || AgentStackInventoryOptions::new(missing.clone());
+    for result in [
+        base().with_max_file_bytes(0), base().with_max_file_bytes(u64::MAX),
+        base().with_max_total_bytes(0), base().with_max_files(0),
+        base().with_max_directories(0), base().with_max_total_entries(0),
+        base().with_max_depth(0), base().with_max_entries_per_directory(0),
+        base().with_max_entries_per_directory(usize::MAX),
+    ] {
+        let error = result.expect_err("invalid limit must be rejected");
+        assert_eq!(error.kind(), EK::InvalidOptions);
+        assert_eq!(error.locator(), None);
+    }
+    // A missing, unreadable, or non-directory root fails as `root_open`.
+    assert_eq!(run(&missing).expect_err("missing root").kind(), EK::RootOpen);
+    let dir = tmp();
+    write_file(dir.path(), "not-a-directory", b"x");
+    let error = run(&dir.path().join("not-a-directory")).expect_err("file root must fail");
+    assert_eq!(error.kind(), EK::RootOpen);
+}
+
+#[cfg(unix)]
+#[test]
+#[rustfmt::skip]
+fn inventory_stays_bound_to_the_opened_root_handle() {
+    // Replace the root path after opening the handle: traversal must keep
+    // observing the originally opened directory, not the new path occupant.
+    let outer = tmp();
+    let root = outer.path().join("repo");
+    fs::create_dir(&root).expect("mkdir root");
+    write_file(&root, "AGENTS.md", b"original");
+    let dir = cap_std::fs::Dir::open_ambient_dir(&root, cap_std::ambient_authority())
+        .expect("open root capability");
+    fs::rename(&root, outer.path().join("moved")).expect("rename root away");
+    fs::create_dir(&root).expect("recreate root path");
+    write_file(&root, "AGENTS.md", b"replacement");
+    let inventory = inventory_with_root(&dir, &opts(&root)).expect("inventory");
+    assert_eq!(entry_digest(find(&inventory, "AGENTS.md")), digest_of(b"original"));
+}
+
+#[cfg(not(unix))]
+#[test]
+fn inventory_stays_bound_to_the_opened_root_handle() {
+    // Handle replacement cannot be raced portably here; assert the service
+    // only reports repository-relative locators.
+    let dir = tmp();
+    write_file(dir.path(), "AGENTS.md", b"original");
+    let inventory = run_ok(dir.path());
+    assert!(pairs(&inventory).iter().all(|(l, _)| !l.starts_with('/')));
+}
+
+// ── B-002 ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[rustfmt::skip]
+fn inventory_never_reads_user_global_or_sibling_paths() {
+    let outer = tmp();
+    let root = outer.path().join("repo");
+    fs::create_dir(&root).expect("mkdir");
+    write_file(outer.path(), "sibling/AGENTS.md", b"sibling instructions");
+    write_file(outer.path(), "AGENTS.md", b"parent instructions");
+    assert!(run_ok(&root).entries().is_empty(), "sibling content must not leak");
+    write_file(&root, "AGENTS.md", b"repo instructions");
+    let listed = pairs(&run_ok(&root));
+    assert_eq!(listed, vec![("AGENTS.md".to_owned(), "instructions")]);
+    assert!(listed.iter().all(|(l, _)| !l.starts_with('/') && !l.contains("..")));
+}
+
+// ── B-003 ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[rustfmt::skip]
+fn inventory_discovers_every_stack_and_language_validation_selector() {
+    let dir = tmp();
+    let root = dir.path();
+    let files: &[&str] = &[
+        "AGENTS.md", "AGENTS.override.md", "CLAUDE.md", "WORKFLOW.md", "MEMORY.md",
+        "src/AGENTS.md", "src/AGENTS.override.md", "src/CLAUDE.md",
+        "crates/AGENTS.md", "crates/AGENTS.override.md", "crates/CLAUDE.md",
+        "lib/AGENTS.md", "lib/AGENTS.override.md", "lib/CLAUDE.md",
+        "pkg/AGENTS.md", "pkg/AGENTS.override.md", "pkg/CLAUDE.md",
+        ".claude/skills/a.md", ".codex/skills/b.md", ".agents/skills/c.md",
+        "skills/d.md", "skills/pack/SKILL.md", ".harness/skills/e.md",
+        ".harness/guards/guard.sh", ".githooks/pre-commit",
+        ".mcp.json", "mcp.json",
+        ".vibeguard/rules.md", ".vibeguard/run-guards.sh",
+        "rules/r.md", "requirements.toml", ".remem/mem.json", "remem.toml",
+        ".harness/config.toml", ".harness/rules/hr.toml", ".harness/sg/scan.yml",
+        ".github/workflows/ci.yml", ".cursor/rules/c.mdc",
+        "Cargo.toml", "go.mod", "package.json", "pyproject.toml", "setup.py",
+        "requirements.txt", "build.gradle", "build.gradle.kts", "pom.xml", "Gemfile",
+        "yarn.lock", "pnpm-lock.yaml", ".eslintrc", ".eslintrc.js", ".eslintrc.cjs",
+        ".eslintrc.json", ".eslintrc.yaml", ".eslintrc.yml", "eslint.config.js",
+        "eslint.config.mjs", "eslint.config.cjs", "biome.json", ".rubocop.yml",
+        "App.csproj", "App.sln", "Makefile", "justfile",
+        // Unrelated files that must stay excluded.
+        "README.md", "src/main.rs", "docs/notes.md", ".vibeguard/helper.sh",
+        ".harness/local/run.log", "hooks/x.sh", ".claude/hooks/y.sh",
+        "spec/models/user_spec.rb",
+    ];
+    for rel in files {
+        write_file(root, rel, rel.as_bytes());
+    }
+    // Keep `harness.toml` valid TOML so configured-rule parsing succeeds.
+    write_file(root, "harness.toml", b"# empty harness config\n");
+    let expected: &[(&str, &str)] = &[
+        ("AGENTS.md", "instructions"), ("AGENTS.override.md", "instructions"),
+        ("CLAUDE.md", "instructions"), ("WORKFLOW.md", "workflow"), ("MEMORY.md", "memory"),
+        ("src/AGENTS.md", "instructions"), ("src/AGENTS.override.md", "instructions"),
+        ("src/CLAUDE.md", "instructions"), ("crates/AGENTS.md", "instructions"),
+        ("crates/AGENTS.override.md", "instructions"), ("crates/CLAUDE.md", "instructions"),
+        ("lib/AGENTS.md", "instructions"), ("lib/AGENTS.override.md", "instructions"),
+        ("lib/CLAUDE.md", "instructions"), ("pkg/AGENTS.md", "instructions"),
+        ("pkg/AGENTS.override.md", "instructions"), ("pkg/CLAUDE.md", "instructions"),
+        (".claude/skills/a.md", "skill"), (".codex/skills/b.md", "skill"),
+        (".agents/skills/c.md", "skill"), ("skills/d.md", "skill"),
+        ("skills/pack/SKILL.md", "skill"), (".harness/skills/e.md", "skill"),
+        (".harness/guards/guard.sh", "hook"), (".githooks/pre-commit", "hook"),
+        (".mcp.json", "mcp_server"), ("mcp.json", "mcp_server"),
+        (".vibeguard/rules.md", "policy"), (".vibeguard/run-guards.sh", "validation"),
+        ("rules/r.md", "policy"), ("requirements.toml", "policy"),
+        (".remem/mem.json", "memory"), ("remem.toml", "memory"),
+        (".harness/config.toml", "validation"), (".harness/rules/hr.toml", "policy"),
+        (".harness/sg/scan.yml", "policy"), ("harness.toml", "validation"),
+        (".github/workflows/ci.yml", "workflow"), (".cursor/rules/c.mdc", "policy"),
+        ("Cargo.toml", "validation"), ("go.mod", "validation"),
+        ("package.json", "validation"), ("pyproject.toml", "validation"),
+        ("setup.py", "validation"), ("requirements.txt", "validation"),
+        ("build.gradle", "validation"), ("build.gradle.kts", "validation"),
+        ("pom.xml", "validation"), ("Gemfile", "validation"),
+        ("yarn.lock", "validation"), ("pnpm-lock.yaml", "validation"),
+        (".eslintrc", "validation"), (".eslintrc.js", "validation"),
+        (".eslintrc.cjs", "validation"), (".eslintrc.json", "validation"),
+        (".eslintrc.yaml", "validation"), (".eslintrc.yml", "validation"),
+        ("eslint.config.js", "validation"), ("eslint.config.mjs", "validation"),
+        ("eslint.config.cjs", "validation"), ("biome.json", "validation"),
+        (".rubocop.yml", "validation"),
+        ("App.csproj", "validation"), ("App.sln", "validation"),
+        ("spec", "validation"), ("Makefile", "validation"), ("justfile", "validation"),
+    ];
+    let mut expected: Vec<(String, &'static str)> =
+        expected.iter().map(|(l, k)| ((*l).to_owned(), *k)).collect();
+    expected.sort();
+    assert_eq!(pairs(&run_ok(root)), expected);
+}
+
+#[test]
+#[rustfmt::skip]
+fn vibeguard_runner_is_inventoried_as_validation() {
+    let dir = tmp();
+    write_file(dir.path(), ".vibeguard/run-guards.sh", b"#!/bin/sh\n");
+    write_file(dir.path(), ".vibeguard/helper.sh", b"#!/bin/sh\n");
+    write_file(dir.path(), ".vibeguard/rules.md", b"rule");
+    let listed = pairs(&run_ok(dir.path()));
+    assert!(listed.contains(&(".vibeguard/run-guards.sh".to_owned(), "validation")));
+    assert!(listed.contains(&(".vibeguard/rules.md".to_owned(), "policy")));
+    assert!(!listed.iter().any(|(l, _)| l == ".vibeguard/helper.sh"));
+}
+
+#[test]
+#[rustfmt::skip]
+fn configured_repository_rule_sources_are_inventoried_once() {
+    let dir = tmp();
+    let root = dir.path();
+    write_file(root, "harness.toml", br#"[rules]
+discovery_paths = ["policies", "policies", "./policies", "/absolute/outside"]
+builtin_path = "builtin.toml"
+exec_policy_paths = ["exec.policy.toml"]
+requirements_path = "reqs.toml"
+"#);
+    write_file(root, "policies/p.md", b"p");
+    write_file(root, "policies/p.toml", b"q = 1");
+    write_file(root, "policies/skip.txt", b"not selected");
+    write_file(root, "builtin.toml", b"b = 1");
+    write_file(root, "exec.policy.toml", b"e = 1");
+    write_file(root, "reqs.toml", b"r = 1");
+    let listed = pairs(&run_ok(root));
+    let expected = ["builtin.toml", "exec.policy.toml", "policies/p.md", "policies/p.toml", "reqs.toml"];
+    assert_eq!(of_kind(&listed, "policy"), expected, "each binding is inventoried once");
+    assert!(listed.contains(&("harness.toml".to_owned(), "validation")));
+    assert!(!listed.iter().any(|(l, _)| l.contains("absolute") || l.contains("outside")));
+    assert!(!listed.iter().any(|(l, _)| l == "policies/skip.txt"));
+}
+
+#[test]
+#[rustfmt::skip]
+fn same_locator_with_distinct_kinds_is_preserved() {
+    let dir = tmp();
+    write_file(dir.path(), "harness.toml", b"[rules]\ndiscovery_paths = [\"Cargo.toml\"]\n");
+    write_file(dir.path(), "Cargo.toml", b"[package]\nname = \"fixture\"\n");
+    let listed = pairs(&run_ok(dir.path()));
+    let kinds: Vec<&str> = listed.iter()
+        .filter(|(l, _)| l == "Cargo.toml")
+        .map(|(_, k)| *k)
+        .collect();
+    assert_eq!(kinds, ["policy", "validation"], "one component per kind");
+}
+
+// ── B-004 ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn missing_allowlisted_entries_emit_no_placeholders() {
+    let dir = tmp();
+    assert!(run_ok(dir.path()).entries().is_empty());
+    write_file(dir.path(), "WORKFLOW.md", b"w");
+    let listed = pairs(&run_ok(dir.path()));
+    assert_eq!(listed, vec![("WORKFLOW.md".to_owned(), "workflow")]);
+}
+
+// ── B-005 ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[rustfmt::skip]
+fn entries_bind_content_mode_and_directory_presence_to_valid_components() {
+    let dir = tmp();
+    let root = dir.path();
+    write_file(root, "AGENTS.md", b"hello world");
+    write_file(root, ".githooks/pre-commit", b"#!/bin/sh\n");
+    write_file(root, "spec/user_spec.rb", b"inside");
+    let inventory = run_ok(root);
+    let agents = find(&inventory, "AGENTS.md");
+    assert_eq!(entry_digest(agents), digest_of(b"hello world"));
+    assert_eq!(agents.component().component_id().as_str(), "repository:instructions:AGENTS.md");
+    let spec = find(&inventory, "spec");
+    assert_eq!(*spec.entry_class(), AgentStackEntryClass::DirectoryPresence);
+    assert!(spec.component().integrity().is_none());
+    assert_eq!(spec.component().kind().as_str(), "validation");
+    assert!(!pairs(&inventory).iter().any(|(l, _)| l.starts_with("spec/")), "no spec recursion");
+    for entry in inventory.entries() {
+        entry.component().validate().expect("every component validates under ASC-001");
+    }
+    #[cfg(unix)]
+    {
+        let hook_path = root.join(".githooks/pre-commit");
+        fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755)).expect("chmod");
+        let enabled = run_ok(root);
+        fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o644)).expect("chmod");
+        let disabled = run_ok(root);
+        let on = find(&enabled, ".githooks/pre-commit");
+        let off = find(&disabled, ".githooks/pre-commit");
+        assert_eq!(entry_digest(on), entry_digest(off), "bytes unchanged");
+        let exec = |entry: &AgentStackInventoryEntry| match entry.entry_class() {
+            AgentStackEntryClass::RegularFile { unix_executable } => *unix_executable,
+            AgentStackEntryClass::DirectoryPresence => panic!("hook is a file"),
+        };
+        assert_eq!(exec(on), Some(true));
+        assert_eq!(exec(off), Some(false));
+        assert_ne!(on, off, "executable-bit change alters entry evidence");
+    }
+    #[cfg(not(unix))]
+    match find(&inventory, "AGENTS.md").entry_class() {
+        AgentStackEntryClass::RegularFile { unix_executable } => {
+            assert_eq!(*unix_executable, None, "mode is explicitly unobserved");
+        }
+        AgentStackEntryClass::DirectoryPresence => panic!("AGENTS.md is a file"),
+    }
+}
+
+#[test]
+fn current_observations_are_fresh() {
+    let dir = tmp();
+    write_file(dir.path(), "AGENTS.md", b"a");
+    fs::create_dir(dir.path().join("spec")).expect("mkdir spec");
+    let inventory = run_ok(dir.path());
+    assert_eq!(inventory.entries().len(), 2);
+    for entry in inventory.entries() {
+        assert_eq!(entry.component().freshness(), AgentStackFreshness::Fresh);
+    }
+}
+
+// ── B-006 ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[rustfmt::skip]
+fn sidecars_and_support_files_do_not_emit_stack_units() {
+    let dir = tmp();
+    let root = dir.path();
+    write_file(root, ".harness/skills/skill.md", b"s");
+    write_file(root, ".harness/skills/skill.usage.json", b"{}");
+    write_file(root, ".harness/skills/nested/pkg.md", b"nested");
+    write_file(root, "skills/direct.md", b"d");
+    write_file(root, "skills/pack/SKILL.md", b"entry");
+    write_file(root, "skills/pack/helper.py", b"print()");
+    write_file(root, "skills/pack/notes.md", b"support");
+    write_file(root, "skills/pack/refs.usage.json", b"{}");
+    let listed = pairs(&run_ok(root));
+    let expected = [".harness/skills/skill.md", "skills/direct.md", "skills/pack/SKILL.md"];
+    assert_eq!(of_kind(&listed, "skill"), expected);
+    for excluded in [
+        ".harness/skills/skill.usage.json", ".harness/skills/nested/pkg.md",
+        "skills/pack/helper.py", "skills/pack/notes.md", "skills/pack/refs.usage.json",
+    ] {
+        assert!(!listed.iter().any(|(l, _)| l == excluded), "{excluded} must be excluded");
+    }
+}
+
+#[test]
+#[rustfmt::skip]
+fn only_lifecycle_bound_hook_entrypoints_are_inventoried() {
+    let dir = tmp();
+    let root = dir.path();
+    write_file(root, ".githooks/pre-commit", b"#!/bin/sh\n");
+    write_file(root, ".githooks/pre-push", b"#!/bin/sh\n");
+    write_file(root, ".githooks/README.md", b"docs");
+    write_file(root, ".githooks/helper.sh", b"#!/bin/sh\n");
+    write_file(root, ".githooks/nested/pre-commit", b"#!/bin/sh\n");
+    write_file(root, ".harness/guards/check.sh", b"#!/bin/sh\n");
+    write_file(root, ".harness/guards/README.md", b"docs");
+    write_file(root, ".harness/guards/nested/x.sh", b"#!/bin/sh\n");
+    let listed = pairs(&run_ok(root));
+    let expected = [".githooks/pre-commit", ".githooks/pre-push", ".harness/guards/check.sh"];
+    assert_eq!(of_kind(&listed, "hook"), expected);
+    assert!(!listed.iter().any(|(l, _)| {
+        l.contains("README") || l.contains("helper") || l.contains("nested")
+    }));
+}
+
+#[test]
+#[rustfmt::skip]
+fn component_kind_comes_from_matching_rule() {
+    let dir = tmp();
+    let root = dir.path();
+    // Identical bytes everywhere: the kind must come from the matched rule.
+    for rel in ["skills/same.md", "rules/same.md", "MEMORY.md", "WORKFLOW.md", ".mcp.json"] {
+        write_file(root, rel, b"identical contents");
+    }
+    let listed = pairs(&run_ok(root));
+    assert!(listed.contains(&("skills/same.md".to_owned(), "skill")));
+    assert!(listed.contains(&("rules/same.md".to_owned(), "policy")));
+    assert!(listed.contains(&("MEMORY.md".to_owned(), "memory")));
+    assert!(listed.contains(&("WORKFLOW.md".to_owned(), "workflow")));
+    assert!(listed.contains(&(".mcp.json".to_owned(), "mcp_server")));
+}
+
+// ── B-007 ────────────────────────────────────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+#[rustfmt::skip]
+fn unsupported_non_utf8_entries_are_filtered_before_locator_normalization() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    let dir = tmp();
+    let root = dir.path();
+    write_file(root, "skills/ok.md", b"ok");
+    // Unmatched non-UTF-8 basename (no selector extension): excluded before
+    // portable locator normalization, without failing the scan.
+    let unmatched = root.join("skills").join(OsStr::from_bytes(b"raw-\xFF-bytes.bin"));
+    if fs::write(&unmatched, b"binary").is_err() {
+        // This filesystem (for example APFS) rejects non-UTF-8 names, so the
+        // fixture is unrepresentable; assert the typed category directly.
+        assert_eq!(EK::NonUtf8Locator.as_str(), "non_utf8_locator");
+        return;
+    }
+    assert_eq!(pairs(&run_ok(root)), vec![("skills/ok.md".to_owned(), "skill")]);
+    // A selected non-UTF-8 name fails typed with the representable ancestor.
+    let selected = root.join("skills").join(OsStr::from_bytes(b"bad-\xFF.md"));
+    fs::write(&selected, b"selected").expect("write non-utf8 md");
+    let error = assert_fail(root, EK::NonUtf8Locator);
+    assert_eq!(error.locator(), Some("skills"), "only the representable ancestor is reported");
+}
+
+#[cfg(not(unix))]
+#[test]
+fn unsupported_non_utf8_entries_are_filtered_before_locator_normalization() {
+    // Non-UTF-8 basenames cannot be constructed portably here; assert the
+    // typed category directly and that ordinary discovery is unaffected.
+    assert_eq!(EK::NonUtf8Locator.as_str(), "non_utf8_locator");
+    let dir = tmp();
+    write_file(dir.path(), "skills/ok.md", b"ok");
+    let listed = pairs(&run_ok(dir.path()));
+    assert_eq!(listed, vec![("skills/ok.md".to_owned(), "skill")]);
+}
+
+#[test]
+#[rustfmt::skip]
+fn filesystem_enumeration_order_does_not_change_inventory() {
+    let dir = tmp();
+    let root = dir.path();
+    // Create in deliberately non-sorted order.
+    for rel in ["skills/zz.md", "skills/aa.md", "skills/mm.md", "rules/z.toml", "rules/a.md"] {
+        write_file(root, rel, rel.as_bytes());
+    }
+    let first = run_ok(root);
+    let second = run_ok(root);
+    let listed = pairs(&first);
+    let mut sorted = listed.clone();
+    sorted.sort();
+    assert_eq!(listed, sorted, "output is sorted by normalized locator");
+    assert_eq!(first, second, "enumeration order cannot change output");
+}
+
+// ── B-008 ────────────────────────────────────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+#[rustfmt::skip]
+fn symlink_swaps_remain_root_confined_and_hash_the_opened_target() {
+    let outer = tmp();
+    let root = outer.path().join("repo");
+    fs::create_dir(&root).expect("mkdir");
+    write_file(&root, "a.txt", b"target a");
+    write_file(&root, "b.txt", b"target b");
+    symlink("a.txt", root.join("CLAUDE.md")).expect("symlink");
+    let inventory = run_ok(&root);
+    assert_eq!(entry_digest(find(&inventory, "CLAUDE.md")), digest_of(b"target a"));
+    fs::remove_file(root.join("CLAUDE.md")).expect("remove link");
+    symlink("b.txt", root.join("CLAUDE.md")).expect("relink");
+    let swapped = run_ok(&root);
+    assert_eq!(entry_digest(find(&swapped, "CLAUDE.md")), digest_of(b"target b"));
+    // An escaping target is rejected by the root capability.
+    write_file(outer.path(), "outside.txt", b"outside");
+    fs::remove_file(root.join("CLAUDE.md")).expect("remove link");
+    symlink("../outside.txt", root.join("CLAUDE.md")).expect("escape link");
+    let error = assert_fail(&root, EK::RootEscape);
+    assert_eq!(error.locator(), Some("CLAUDE.md"));
+    // A dangling in-root target is a broken symlink, not a silent omission.
+    fs::remove_file(root.join("CLAUDE.md")).expect("remove link");
+    symlink("gone.txt", root.join("CLAUDE.md")).expect("broken link");
+    assert_fail(&root, EK::BrokenSymlink);
+}
+
+#[cfg(not(unix))]
+#[test]
+fn symlink_swaps_remain_root_confined_and_hash_the_opened_target() {
+    // Symlink fixtures are Unix-only; assert digests bind to opened bytes.
+    let dir = tmp();
+    write_file(dir.path(), "CLAUDE.md", b"target a");
+    let inventory = run_ok(dir.path());
+    let digest = entry_digest(find(&inventory, "CLAUDE.md"));
+    assert_eq!(digest, digest_of(b"target a"));
+}
+
+#[cfg(unix)]
+#[test]
+#[rustfmt::skip]
+fn in_root_directory_symlinks_are_traversed_and_cycles_fail() {
+    let dir = tmp();
+    let root = dir.path();
+    write_file(root, "rules-src/a.md", b"a");
+    symlink("rules-src", root.join("rules")).expect("dir symlink");
+    assert!(pairs(&run_ok(root)).contains(&("rules/a.md".to_owned(), "policy")));
+    // A directory identity already on the active ancestor stack is a cycle.
+    let cyclic = tmp();
+    write_file(cyclic.path(), ".vibeguard/sub/rule.md", b"r");
+    symlink("../../.vibeguard", cyclic.path().join(".vibeguard/sub/loop")).expect("cycle link");
+    assert_fail(cyclic.path(), EK::CycleDetected);
+}
+
+#[cfg(not(unix))]
+#[test]
+fn in_root_directory_symlinks_are_traversed_and_cycles_fail() {
+    // Cycle fixtures require symlinks; assert the typed category directly.
+    assert_eq!(EK::CycleDetected.as_str(), "cycle_detected");
+}
+
+#[cfg(unix)]
+#[test]
+fn file_rules_reject_directory_symlink_targets() {
+    let dir = tmp();
+    let root = dir.path();
+    fs::create_dir(root.join("somewhere")).expect("mkdir");
+    symlink("somewhere", root.join("CLAUDE.md")).expect("symlink");
+    let error = assert_fail(root, EK::NonRegularEntry);
+    assert_eq!(error.locator(), Some("CLAUDE.md"));
+}
+
+#[cfg(not(unix))]
+#[test]
+fn file_rules_reject_directory_symlink_targets() {
+    // Without symlinks, assert the same rejection for a plain directory that
+    // occupies an exact-file rule path.
+    let dir = tmp();
+    fs::create_dir(dir.path().join("CLAUDE.md")).expect("mkdir");
+    assert_fail(dir.path(), EK::NonRegularEntry);
+}
+
+// ── B-009 ────────────────────────────────────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+#[rustfmt::skip]
+fn unreadable_and_non_utf8_entries_fail_without_lossy_locators() {
+    let dir = tmp();
+    let root = dir.path();
+    write_file(root, "CLAUDE.md", b"secret");
+    let path = root.join("CLAUDE.md");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).expect("chmod 000");
+    if fs::File::open(&path).is_err() {
+        let error = assert_fail(root, EK::ReadFailed);
+        assert_eq!(error.locator(), Some("CLAUDE.md"));
+        assert!(!error.locator().unwrap_or_default().contains('\u{FFFD}'), "no lossy locator");
+    }
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("chmod back");
+    // Deterministic injected failure mapping covers privileged environments
+    // where permission bits cannot produce an unreadable file.
+    assert_eq!(classify_open_failure(std::io::ErrorKind::PermissionDenied), EK::ReadFailed);
+    assert_eq!(classify_open_failure(std::io::ErrorKind::NotFound), EK::EntryRaced);
+}
+
+#[cfg(not(unix))]
+#[test]
+fn unreadable_and_non_utf8_entries_fail_without_lossy_locators() {
+    // Deterministic injected failure mapping replaces permission fixtures.
+    let denied = classify_open_failure(std::io::ErrorKind::PermissionDenied);
+    assert_eq!(denied, EK::ReadFailed);
+    let raced = classify_open_failure(std::io::ErrorKind::NotFound);
+    assert_eq!(raced, EK::EntryRaced);
+}
+
+#[test]
+#[rustfmt::skip]
+fn invalid_configured_rule_sources_fail_typed() {
+    let invalid = tmp();
+    write_file(invalid.path(), "harness.toml", b"[rules]\ndiscovery_paths = [\"../escape\"]\n");
+    let error = assert_fail(invalid.path(), EK::ConfiguredSourceInvalid);
+    assert_eq!(error.locator(), Some("harness.toml"));
+    let empty = tmp();
+    write_file(empty.path(), "harness.toml", b"[rules]\nexec_policy_paths = [\"\"]\n");
+    assert_fail(empty.path(), EK::ConfiguredSourceInvalid);
+    let missing = tmp();
+    write_file(missing.path(), "harness.toml", b"[rules]\nrequirements_path = \"nope.toml\"\n");
+    let error = assert_fail(missing.path(), EK::ConfiguredSourceMissing);
+    assert_eq!(error.locator(), Some("nope.toml"));
+    let bad_toml = tmp();
+    write_file(bad_toml.path(), "harness.toml", b"rules = [not toml");
+    assert_fail(bad_toml.path(), EK::ConfigParse);
+    let dir_target = tmp();
+    write_file(dir_target.path(), "harness.toml", b"[rules]\nexec_policy_paths = [\"adir\"]\n");
+    fs::create_dir(dir_target.path().join("adir")).expect("mkdir");
+    assert_fail(dir_target.path(), EK::NonRegularEntry);
+}
+
+// ── B-010 ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[rustfmt::skip]
+fn every_traversal_limit_has_an_exact_boundary_fixture() {
+    let base = |root: &Path| AgentStackInventoryOptions::new(root.to_path_buf());
+    let run_with = |options: Result<AgentStackInventoryOptions, AgentStackInventoryError>| {
+        inventory_repository_stack(&options.expect("valid boundary options"))
+    };
+    let files = tmp();
+    write_file(files.path(), "AGENTS.md", b"aaaa");
+    write_file(files.path(), "CLAUDE.md", b"bbbb");
+    // max_files: two regular files fit exactly; one fails on the second read.
+    assert!(run_with(base(files.path()).with_max_files(2)).is_ok());
+    let error = run_with(base(files.path()).with_max_files(1)).expect_err("file budget");
+    assert_eq!((error.kind(), error.locator()), (EK::LimitExceeded, Some("CLAUDE.md")));
+    // max_file_bytes: a 4-byte file passes at 4 and fails at 3.
+    assert!(run_with(base(files.path()).with_max_file_bytes(4)).is_ok());
+    let error = run_with(base(files.path()).with_max_file_bytes(3)).expect_err("per-file bytes");
+    assert_eq!(error.kind(), EK::LimitExceeded);
+    // max_total_bytes: 4 + 4 bytes pass at 8 and fail at 7.
+    assert!(run_with(base(files.path()).with_max_total_bytes(8)).is_ok());
+    let error = run_with(base(files.path()).with_max_total_bytes(7)).expect_err("total bytes");
+    assert_eq!((error.kind(), error.locator()), (EK::LimitExceeded, Some("CLAUDE.md")));
+    // Depth and opened-directory budgets: skills/a/SKILL.md needs depth 2 and
+    // three opened directories (root, skills, skills/a).
+    let deep = tmp();
+    write_file(deep.path(), "skills/a/SKILL.md", b"s");
+    assert!(run_with(base(deep.path()).with_max_depth(2)).is_ok());
+    let error = run_with(base(deep.path()).with_max_depth(1)).expect_err("depth budget");
+    assert_eq!((error.kind(), error.locator()), (EK::LimitExceeded, Some("skills/a")));
+    assert!(run_with(base(deep.path()).with_max_directories(3)).is_ok());
+    let error = run_with(base(deep.path()).with_max_directories(2)).expect_err("dir budget");
+    assert_eq!(error.kind(), EK::LimitExceeded);
+    // max_entries_per_directory: three children fit exactly at 3, fail at 2.
+    let wide = tmp();
+    for rel in ["skills/a.md", "skills/b.md", "skills/c.md"] {
+        write_file(wide.path(), rel, b"x");
+    }
+    assert!(run_with(base(wide.path()).with_max_entries_per_directory(3)).is_ok());
+    let error = run_with(base(wide.path()).with_max_entries_per_directory(2))
+        .expect_err("per-directory entries");
+    assert_eq!(error.kind(), EK::LimitExceeded);
+    // max_total_entries: the skills traversal yields 3 entries and the root
+    // suffix enumeration yields 1 (the `skills` directory itself): 4 exactly.
+    assert!(run_with(base(wide.path()).with_max_total_entries(4)).is_ok());
+    let error = run_with(base(wide.path()).with_max_total_entries(3)).expect_err("entries");
+    assert_eq!(error.kind(), EK::LimitExceeded);
+}
+
+#[test]
+#[rustfmt::skip]
+fn reads_never_exceed_remaining_aggregate_or_per_file_budget() {
+    let dir = tmp();
+    write_file(dir.path(), "AGENTS.md", b"0123456789");
+    let options = opts(dir.path()).with_max_file_bytes(4).expect("options");
+    let error = inventory_repository_stack(&options).expect_err("oversized file");
+    assert_eq!((error.kind(), error.locator()), (EK::LimitExceeded, Some("AGENTS.md")));
+    // The second file exceeds the remaining aggregate budget even though it
+    // stays within the per-file budget.
+    let pair = tmp();
+    write_file(pair.path(), "AGENTS.md", b"aaaa");
+    write_file(pair.path(), "CLAUDE.md", b"bbbb");
+    let options = opts(pair.path()).with_max_total_bytes(6).expect("options");
+    let error = inventory_repository_stack(&options).expect_err("aggregate budget");
+    assert_eq!((error.kind(), error.locator()), (EK::LimitExceeded, Some("CLAUDE.md")));
+}
+
+#[cfg(unix)]
+#[test]
+#[rustfmt::skip]
+fn selected_fifo_targets_fail_without_blocking() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+    let dir = tmp();
+    let status = std::process::Command::new("mkfifo")
+        .arg(dir.path().join("Makefile"))
+        .status()
+        .expect("spawn mkfifo");
+    assert!(status.success(), "mkfifo must succeed");
+    let root = dir.path().to_path_buf();
+    let (sender, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = sender.send(run(&root));
+    });
+    let result = receiver
+        .recv_timeout(Duration::from_secs(10))
+        .expect("inventory must not block on a writer-less FIFO");
+    let error = result.expect_err("fifo is a non-regular entry");
+    assert_eq!((error.kind(), error.locator()), (EK::NonRegularEntry, Some("Makefile")));
+}
+
+#[cfg(not(unix))]
+#[test]
+fn selected_fifo_targets_fail_without_blocking() {
+    // FIFOs are Unix-specific; assert the typed rejection category directly.
+    assert_eq!(EK::NonRegularEntry.as_str(), "non_regular_entry");
+}
+
+// ── B-011 ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn unchanged_repository_inventory_is_repeatable() {
+    let dir = tmp();
+    let root = dir.path();
+    write_file(root, "AGENTS.md", b"stable");
+    write_file(root, "skills/pack/SKILL.md", b"skill");
+    write_file(root, ".githooks/pre-commit", b"#!/bin/sh\n");
+    fs::create_dir(root.join("spec")).expect("mkdir spec");
+    let first = run_ok(root);
+    let second = run_ok(root);
+    assert_eq!(first, second, "unchanged bytes produce identical output");
+    assert_eq!(first.entries().len(), 4);
+}
+
+// ── B-012 ────────────────────────────────────────────────────────────────────
+
+fn snapshot(root: &Path) -> Vec<(PathBuf, Option<Vec<u8>>)> {
+    fn walk(dir: &Path, out: &mut Vec<(PathBuf, Option<Vec<u8>>)>) {
+        let mut children: Vec<_> = fs::read_dir(dir)
+            .expect("read_dir")
+            .map(|entry| entry.expect("entry").path())
+            .collect();
+        children.sort();
+        for child in children {
+            if child.is_dir() {
+                out.push((child.clone(), None));
+                walk(&child, out);
+            } else {
+                out.push((child.clone(), Some(fs::read(&child).expect("read"))));
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, &mut out);
+    out
+}
+
+#[test]
+#[rustfmt::skip]
+fn inventory_is_read_only_and_invokes_no_external_behavior() {
+    let dir = tmp();
+    let root = dir.path();
+    write_file(root, "AGENTS.md", b"a");
+    write_file(root, "harness.toml", b"[rules]\ndiscovery_paths = [\"policies\"]\n");
+    write_file(root, "policies/p.md", b"p");
+    write_file(root, ".githooks/pre-commit", b"#!/bin/sh\n");
+    fs::create_dir(root.join("spec")).expect("mkdir spec");
+    let before = snapshot(root);
+    let inventory = run_ok(root);
+    assert!(!inventory.entries().is_empty());
+    assert_eq!(snapshot(root), before, "inventory performs no repository writes");
+}

--- a/crates/harness-core/src/stack/inventory_tests.rs
+++ b/crates/harness-core/src/stack/inventory_tests.rs
@@ -83,8 +83,6 @@ fn entry_digest(entry: &AgentStackInventoryEntry) -> String {
         .to_owned()
 }
 
-// ── B-001 ────────────────────────────────────────────────────────────────────
-
 #[test]
 #[rustfmt::skip]
 fn invalid_limits_fail_before_root_open() {
@@ -141,8 +139,6 @@ fn inventory_stays_bound_to_the_opened_root_handle() {
     assert!(pairs(&inventory).iter().all(|(l, _)| !l.starts_with('/')));
 }
 
-// ── B-002 ────────────────────────────────────────────────────────────────────
-
 #[test]
 #[rustfmt::skip]
 fn inventory_never_reads_user_global_or_sibling_paths() {
@@ -157,8 +153,6 @@ fn inventory_never_reads_user_global_or_sibling_paths() {
     assert_eq!(listed, vec![("AGENTS.md".to_owned(), "instructions")]);
     assert!(listed.iter().all(|(l, _)| !l.starts_with('/') && !l.contains("..")));
 }
-
-// ── B-003 ────────────────────────────────────────────────────────────────────
 
 #[test]
 #[rustfmt::skip]
@@ -256,7 +250,7 @@ fn configured_repository_rule_sources_are_inventoried_once() {
     let dir = tmp();
     let root = dir.path();
     write_file(root, "harness.toml", br#"[rules]
-discovery_paths = ["rules", "rules", "./rules", "/absolute/outside"]
+discovery_paths = ["rules", "rules", "./rules", ".vibeguard", "/absolute/outside"]
 builtin_path = "builtin.toml"
 exec_policy_paths = ["exec.policy.toml"]
 requirements_path = "reqs.toml"
@@ -264,16 +258,21 @@ requirements_path = "reqs.toml"
     write_file(root, "rules/p.md", b"p");
     write_file(root, "rules/p.toml", b"q = 1");
     write_file(root, "rules/skip.txt", b"not selected");
+    write_file(root, ".vibeguard/rule.json", b"{}");
     write_file(root, "builtin.toml", b"b = 1");
     write_file(root, "exec.policy.toml", b"e = 1");
     write_file(root, "reqs.toml", b"r = 1");
-    let options = opts(root).with_max_directories(2).expect("root plus rules");
+    let options = opts(root).with_max_directories(3).expect("root plus two rule directories");
     let listed = pairs(&inventory_repository_stack(&options).expect("merged static and derived rules"));
-    let expected = ["builtin.toml", "exec.policy.toml", "reqs.toml", "rules/p.md", "rules/p.toml"];
+    let expected = [".vibeguard/rule.json", "builtin.toml", "exec.policy.toml", "reqs.toml", "rules/p.md", "rules/p.toml"];
     assert_eq!(of_kind(&listed, "policy"), expected, "each binding is inventoried once");
     assert!(listed.contains(&("harness.toml".to_owned(), "validation")));
     assert!(!listed.iter().any(|(l, _)| l.contains("absolute") || l.contains("outside")));
-    assert!(!listed.iter().any(|(l, _)| l == "policies/skip.txt"));
+    assert!(!listed.iter().any(|(l, _)| l == "rules/skip.txt"));
+    let mismatch = tmp();
+    write_file(mismatch.path(), "harness.toml", b"[rules]\ndiscovery_paths = [\"requirements.toml\"]\n");
+    fs::create_dir(mismatch.path().join("requirements.toml")).expect("mkdir");
+    assert_fail(mismatch.path(), EK::NonRegularEntry);
 }
 
 #[test]
@@ -293,8 +292,6 @@ fn same_locator_with_distinct_kinds_is_preserved() {
     }
 }
 
-// ── B-004 ────────────────────────────────────────────────────────────────────
-
 #[test]
 fn missing_allowlisted_entries_emit_no_placeholders() {
     let dir = tmp();
@@ -305,9 +302,17 @@ fn missing_allowlisted_entries_emit_no_placeholders() {
     let wrong_case = tmp();
     write_file(wrong_case.path(), "agents.md", b"wrong case");
     assert!(run_ok(wrong_case.path()).entries().is_empty());
+    let file_ancestor = tmp();
+    write_file(file_ancestor.path(), "src", b"not a directory");
+    assert!(run_ok(file_ancestor.path()).entries().is_empty());
+    #[cfg(unix)]
+    {
+        let linked = tmp();
+        write_file(linked.path(), "target", b"not a directory");
+        symlink("target", linked.path().join("src")).expect("symlink");
+        assert!(run_ok(linked.path()).entries().is_empty());
+    }
 }
-
-// ── B-005 ────────────────────────────────────────────────────────────────────
 
 #[test]
 #[rustfmt::skip]
@@ -367,8 +372,6 @@ fn current_observations_are_fresh() {
         assert_eq!(entry.component().freshness(), AgentStackFreshness::Fresh);
     }
 }
-
-// ── B-006 ────────────────────────────────────────────────────────────────────
 
 #[test]
 #[rustfmt::skip]
@@ -432,8 +435,6 @@ fn component_kind_comes_from_matching_rule() {
     assert!(listed.contains(&(".mcp.json".to_owned(), "mcp_server")));
 }
 
-// ── B-007 ────────────────────────────────────────────────────────────────────
-
 #[cfg(unix)]
 #[test]
 #[rustfmt::skip]
@@ -493,8 +494,6 @@ fn filesystem_enumeration_order_does_not_change_inventory() {
     assert_eq!(listed, sorted, "output is sorted by normalized locator");
     assert_eq!(first, second, "enumeration order cannot change output");
 }
-
-// ── B-008 ────────────────────────────────────────────────────────────────────
 
 #[cfg(unix)]
 #[test]
@@ -592,8 +591,6 @@ fn file_rules_reject_directory_symlink_targets() {
     assert_fail(dir.path(), EK::NonRegularEntry);
 }
 
-// ── B-009 ────────────────────────────────────────────────────────────────────
-
 #[cfg(unix)]
 #[test]
 #[rustfmt::skip]
@@ -646,8 +643,6 @@ fn invalid_configured_rule_sources_fail_typed() {
     fs::create_dir(dir_target.path().join("adir")).expect("mkdir");
     assert_fail(dir_target.path(), EK::NonRegularEntry);
 }
-
-// ── B-010 ────────────────────────────────────────────────────────────────────
 
 #[test]
 #[rustfmt::skip]
@@ -735,6 +730,10 @@ fn selected_fifo_targets_fail_without_blocking() {
         .expect("inventory must not block on a writer-less FIFO");
     let error = result.expect_err("fifo is a non-regular entry");
     assert_eq!((error.kind(), error.locator()), (EK::NonRegularEntry, Some("Makefile")));
+    let socket = tmp();
+    let _listener = std::os::unix::net::UnixListener::bind(socket.path().join("Makefile"))
+        .expect("bind socket");
+    assert_fail(socket.path(), EK::NonRegularEntry);
 }
 
 #[cfg(not(unix))]
@@ -742,8 +741,6 @@ fn selected_fifo_targets_fail_without_blocking() {
 fn selected_fifo_targets_fail_without_blocking() {
     assert_eq!(EK::NonRegularEntry.as_str(), "non_regular_entry");
 }
-
-// ── B-011 ────────────────────────────────────────────────────────────────────
 
 #[test]
 fn unchanged_repository_inventory_is_repeatable() {
@@ -758,8 +755,6 @@ fn unchanged_repository_inventory_is_repeatable() {
     assert_eq!(first, second, "unchanged bytes produce identical output");
     assert_eq!(first.entries().len(), 4);
 }
-
-// ── B-012 ────────────────────────────────────────────────────────────────────
 
 fn snapshot(root: &Path) -> Vec<(PathBuf, Option<Vec<u8>>)> {
     fn walk(dir: &Path, out: &mut Vec<(PathBuf, Option<Vec<u8>>)>) {

--- a/crates/harness-core/src/stack/inventory_tests.rs
+++ b/crates/harness-core/src/stack/inventory_tests.rs
@@ -609,6 +609,7 @@ fn unreadable_and_non_utf8_entries_fail_without_lossy_locators() {
     // where permission bits cannot produce an unreadable file.
     assert_eq!(classify_open_failure(std::io::ErrorKind::PermissionDenied), EK::ReadFailed);
     assert_eq!(classify_open_failure(std::io::ErrorKind::NotFound), EK::EntryRaced);
+    assert_eq!(classify_directory_open_failure(std::io::ErrorKind::NotADirectory), EK::EntryRaced);
 }
 
 #[cfg(not(unix))]
@@ -687,11 +688,10 @@ fn every_traversal_limit_has_an_exact_boundary_fixture() {
     let error = run_with(base(wide.path()).with_max_entries_per_directory(2))
         .expect_err("per-directory entries");
     assert_eq!(error.kind(), EK::LimitExceeded);
-    // max_total_entries: the skills traversal yields 3 entries and the root
     // suffix enumeration yields 1 (the `skills` directory itself): 4 exactly.
     assert!(run_with(base(wide.path()).with_max_total_entries(4)).is_ok());
     let error = run_with(base(wide.path()).with_max_total_entries(3)).expect_err("entries");
-    assert_eq!(error.kind(), EK::LimitExceeded);
+    assert_eq!((error.kind(), error.locator()), (EK::LimitExceeded, None));
 }
 
 #[test]

--- a/crates/harness-core/src/stack/inventory_tests.rs
+++ b/crates/harness-core/src/stack/inventory_tests.rs
@@ -184,7 +184,7 @@ fn inventory_discovers_every_stack_and_language_validation_selector() {
         "yarn.lock", "pnpm-lock.yaml", ".eslintrc", ".eslintrc.js", ".eslintrc.cjs",
         ".eslintrc.json", ".eslintrc.yaml", ".eslintrc.yml", "eslint.config.js",
         "eslint.config.mjs", "eslint.config.cjs", "biome.json", ".rubocop.yml",
-        "App.csproj", "App.sln", "Makefile", "justfile",
+        "App.csproj", "App.sln", ".csproj", ".sln", "Makefile", "justfile",
         // Unrelated files that must stay excluded.
         "README.md", "src/main.rs", "docs/notes.md", ".vibeguard/helper.sh",
         ".harness/local/run.log", "hooks/x.sh", ".claude/hooks/y.sh",
@@ -228,6 +228,7 @@ fn inventory_discovers_every_stack_and_language_validation_selector() {
         ("eslint.config.cjs", "validation"), ("biome.json", "validation"),
         (".rubocop.yml", "validation"),
         ("App.csproj", "validation"), ("App.sln", "validation"),
+        (".csproj", "validation"), (".sln", "validation"),
         ("spec", "validation"), ("Makefile", "validation"), ("justfile", "validation"),
     ];
     let mut expected: Vec<(String, &'static str)> =
@@ -278,14 +279,17 @@ requirements_path = "reqs.toml"
 #[rustfmt::skip]
 fn same_locator_with_distinct_kinds_is_preserved() {
     let dir = tmp();
-    write_file(dir.path(), "harness.toml", b"[rules]\ndiscovery_paths = [\"Cargo.toml\"]\n");
+    write_file(dir.path(), "harness.toml",
+        b"[rules]\ndiscovery_paths = [\"Cargo.toml\", \"harness.toml\"]\n");
     write_file(dir.path(), "Cargo.toml", b"[package]\nname = \"fixture\"\n");
-    let listed = pairs(&run_ok(dir.path()));
-    let kinds: Vec<&str> = listed.iter()
-        .filter(|(l, _)| l == "Cargo.toml")
-        .map(|(_, k)| *k)
-        .collect();
-    assert_eq!(kinds, ["policy", "validation"], "one component per kind");
+    let options = opts(dir.path()).with_max_files(2).expect("two physical files");
+    let inventory = inventory_repository_stack(&options).expect("reuse observations by locator");
+    for locator in ["Cargo.toml", "harness.toml"] {
+        let entries: Vec<_> = inventory.entries().iter()
+            .filter(|entry| entry.component().source().locator().as_str() == locator).collect();
+        assert_eq!(entries.len(), 2, "one component per kind");
+        assert_eq!(entry_digest(entries[0]), entry_digest(entries[1]), "one opened observation");
+    }
 }
 
 // ── B-004 ────────────────────────────────────────────────────────────────────
@@ -435,8 +439,6 @@ fn unsupported_non_utf8_entries_are_filtered_before_locator_normalization() {
     let dir = tmp();
     let root = dir.path();
     write_file(root, "skills/ok.md", b"ok");
-    // Unmatched non-UTF-8 basename (no selector extension): excluded before
-    // portable locator normalization, without failing the scan.
     let unmatched = root.join("skills").join(OsStr::from_bytes(b"raw-\xFF-bytes.bin"));
     if fs::write(&unmatched, b"binary").is_err() {
         // This filesystem (for example APFS) rejects non-UTF-8 names, so the
@@ -452,16 +454,22 @@ fn unsupported_non_utf8_entries_are_filtered_before_locator_normalization() {
     assert_eq!(error.locator(), Some("skills"), "only the representable ancestor is reported");
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 #[test]
 fn unsupported_non_utf8_entries_are_filtered_before_locator_normalization() {
-    // Non-UTF-8 basenames cannot be constructed portably here; assert the
-    // typed category directly and that ordinary discovery is unaffected.
-    assert_eq!(EK::NonUtf8Locator.as_str(), "non_utf8_locator");
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
     let dir = tmp();
-    write_file(dir.path(), "skills/ok.md", b"ok");
-    let listed = pairs(&run_ok(dir.path()));
-    assert_eq!(listed, vec![("skills/ok.md".to_owned(), "skill")]);
+    fs::create_dir(dir.path().join("skills")).expect("mkdir");
+    let name = OsString::from_wide(&[0xD800, b'.' as u16, b'm' as u16, b'd' as u16]);
+    fs::write(dir.path().join("skills").join(name), b"selected").expect("write invalid UTF-16");
+    assert_fail(dir.path(), EK::NonUtf8Locator);
+}
+
+#[cfg(all(not(unix), not(windows)))]
+#[test]
+fn unsupported_non_utf8_entries_are_filtered_before_locator_normalization() {
+    assert_eq!(EK::NonUtf8Locator.as_str(), "non_utf8_locator");
 }
 
 #[test]
@@ -542,7 +550,15 @@ fn in_root_directory_symlinks_are_traversed_and_cycles_fail() {
 #[cfg(not(unix))]
 #[test]
 fn in_root_directory_symlinks_are_traversed_and_cycles_fail() {
-    // Cycle fixtures require symlinks; assert the typed category directly.
+    let dir = tmp();
+    let first = cap_std::fs::Dir::open_ambient_dir(dir.path(), cap_std::ambient_authority())
+        .expect("first handle");
+    let second = cap_std::fs::Dir::open_ambient_dir(dir.path(), cap_std::ambient_authority())
+        .expect("second handle");
+    assert!(
+        directory_identity(&first, "").expect("identity")
+            == directory_identity(&second, "").expect("identity")
+    );
     assert_eq!(EK::CycleDetected.as_str(), "cycle_detected");
 }
 
@@ -555,6 +571,11 @@ fn file_rules_reject_directory_symlink_targets() {
     symlink("somewhere", root.join("CLAUDE.md")).expect("symlink");
     let error = assert_fail(root, EK::NonRegularEntry);
     assert_eq!(error.locator(), Some("CLAUDE.md"));
+    let suffix = tmp();
+    fs::create_dir(suffix.path().join("target")).expect("mkdir");
+    symlink("target", suffix.path().join("App.csproj")).expect("suffix symlink");
+    let error = assert_fail(suffix.path(), EK::NonRegularEntry);
+    assert_eq!(error.locator(), Some("App.csproj"));
 }
 
 #[cfg(not(unix))]

--- a/crates/harness-core/src/stack/mod.rs
+++ b/crates/harness-core/src/stack/mod.rs
@@ -5,8 +5,16 @@ use std::fmt;
 use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 use uuid::Uuid;
+pub mod inventory;
+#[cfg(test)]
+mod inventory_tests;
 #[cfg(test)]
 mod tests;
+pub use inventory::{
+    inventory_repository_stack, AgentStackEntryClass, AgentStackInventory,
+    AgentStackInventoryEntry, AgentStackInventoryError, AgentStackInventoryErrorKind,
+    AgentStackInventoryOptions,
+};
 pub const AGENT_STACK_COMPONENT_SCHEMA_VERSION: &str = "agent-stack-component/v0.1";
 
 macro_rules! closed_enum {
@@ -600,17 +608,11 @@ fn reject_reserved_segments(value: &str) -> Result<(), AgentStackComponentError>
     }
 }
 
+#[rustfmt::skip]
 fn is_reserved(value: &str) -> bool {
-    [
-        "unknown",
-        "unknown-component",
-        "unknown_component",
-        "missing",
-        "null",
-        "none",
-    ]
-    .iter()
-    .any(|reserved| value.eq_ignore_ascii_case(reserved))
+    ["unknown", "unknown-component", "unknown_component", "missing", "null", "none"]
+        .iter()
+        .any(|reserved| value.eq_ignore_ascii_case(reserved))
 }
 
 fn is_uuid_shaped(value: &str) -> bool {
@@ -779,21 +781,17 @@ fn drives_match(left: Option<u8>, right: Option<u8>) -> bool {
     left.map(|drive| drive.to_ascii_uppercase()) == right.map(|drive| drive.to_ascii_uppercase())
 }
 
+#[rustfmt::skip]
 fn root_key_matches<T: PartialEq>(
-    root_drive: Option<u8>,
-    root: &[T],
-    source_drive: Option<u8>,
-    source: &[T],
+    root_drive: Option<u8>, root: &[T], source_drive: Option<u8>, source: &[T],
 ) -> bool {
     drives_match(root_drive, source_drive) && source.starts_with(root)
 }
 
 #[cfg(test)]
+#[rustfmt::skip]
 fn root_keys_match_for_test(
-    drive_a: Option<u8>,
-    segments_a: &[&str],
-    drive_b: Option<u8>,
-    segments_b: &[&str],
+    drive_a: Option<u8>, segments_a: &[&str], drive_b: Option<u8>, segments_b: &[&str],
 ) -> bool {
     segments_a.len() == segments_b.len()
         && root_key_matches(drive_a, segments_a, drive_b, segments_b)


### PR DESCRIPTION
Closes #1731

## Summary

- add `stack::inventory`, a repository-observed Agent Stack inventory service that discovers the closed GH-1731 allowlist beneath one explicit repository root and emits validated ASC-001 components
- perform all traversal, metadata, and file opens relative to one `cap-std` root directory capability so absolute paths, `..`, and symlink races cannot escape the repository; Unix candidate opens use `O_NONBLOCK` with handle-first type validation
- represent the full B-003 allowlist as one constant typed rule table (exact files, root-only suffixes, selector-filtered recursive directories, and the non-recursive `spec` directory-presence predicate) and derive typed `policy` rules from repository-relative `harness.toml` rule sources
- enforce checked per-file byte, aggregate byte, regular-file, opened-directory, aggregate-encountered-entry, depth, and entries-per-directory budgets with `+ 1` sentinels that fail closed
- return a closed typed error vocabulary (`invalid_options` .. `component_validation`) with sanitized repository-relative locators only; missing allowlisted entries emit no placeholders
- keep output deterministic: native basename/extension prefiltering before locator normalization, sorted traversal, and locator-sorted entries with `(locator, kind)` deduplication

## Verification

- cargo audit (baseline before manifest edits, and again after adding cap-std and promoting libc): no vulnerabilities, 1 pre-existing allowed warning
- cargo check -p harness-core --all-targets
- cargo test -p harness-core stack::inventory_tests (25 passed)
- cargo test -p harness-core (672 passed)
- cargo fmt --all and cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- python3 checks/check_workflow.py --repo . --spec-dir specs/GH1731 (SpecRail check passed)
- git diff --name-only origin/main...HEAD matches the six planned-changes manifest paths exactly

## Notes

- library-only service: no CLI command, persistence, runtime consumer, or prompt-loader behavior changes (ASC-026 owns CLI exposure)
- `libc` is used only for Unix `O_NONBLOCK`; `Cargo.lock` only adds new crates and downgrades nothing
- the inventory exposes no ambient canonical root; the opened handle is the observation and authorization boundary
