### PR TITLE
fix(workflow): make jsonb NUL stripping observable and non-corrupting (GH-1795)

### DIFF
--- a/crates/harness-server/src/event_replay_tests.rs
+++ b/crates/harness-server/src/event_replay_tests.rs
@@ -3,6 +3,7 @@ use harness_core::types::TaskId;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tracing::field::{Field, Visit};
+use tracing::instrument::WithSubscriber;
 use tracing::span::{Attributes, Record};
 use tracing::subscriber::Interest;
 use tracing::{Event, Id, Metadata, Subscriber};
@@ -648,11 +649,10 @@ async fn replay_caller_counts_and_logs_only_applied_writes() -> anyhow::Result<(
     drop(log);
 
     let captured = ReplayCapturedSubscriber::default();
-    let updated = {
-        crate::test_helpers::install_tracing_interest_keeper();
-        let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
-        replay_and_recover(&db, &log_path).await?
-    };
+    crate::test_helpers::install_tracing_interest_keeper();
+    let updated = replay_and_recover(&db, &log_path)
+        .with_subscriber(captured.clone())
+        .await?;
     assert_eq!(updated, 1, "only the durable replay write is counted");
     assert_eq!(
         db.get("replay-applied")
@@ -711,13 +711,11 @@ async fn replay_conflict_preserves_terminal_log() -> anyhow::Result<()> {
     let before = std::fs::read(&log_path)?;
 
     let captured = ReplayCapturedSubscriber::default();
-    let error = {
-        crate::test_helpers::install_tracing_interest_keeper();
-        let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
-        replay_and_recover(&db, &log_path)
-            .await
-            .expect_err("contradictory terminal replay must fail closed")
-    };
+    crate::test_helpers::install_tracing_interest_keeper();
+    let error = replay_and_recover(&db, &log_path)
+        .with_subscriber(captured.clone())
+        .await
+        .expect_err("contradictory terminal replay must fail closed");
     assert!(
         error
             .downcast_ref::<crate::task_db::TaskRecoveryConflict>()

--- a/crates/harness-workflow/src/jsonb.rs
+++ b/crates/harness-workflow/src/jsonb.rs
@@ -14,34 +14,58 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-static NUL_SANITIZATIONS: AtomicU64 = AtomicU64::new(0);
+static NUL_CHARACTERS_REMOVED: AtomicU64 = AtomicU64::new(0);
 
-/// Total number of values sanitized since process start.
-pub(crate) fn nul_sanitizations_total() -> u64 {
-    NUL_SANITIZATIONS.load(Ordering::Relaxed)
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct SanitizationStats {
+    nul_characters_removed: u64,
+    affected_nodes: u64,
+}
+
+impl SanitizationStats {
+    fn record_node(&mut self, nul_characters_removed: u64) {
+        self.nul_characters_removed = self
+            .nul_characters_removed
+            .saturating_add(nul_characters_removed);
+        self.affected_nodes = self.affected_nodes.saturating_add(1);
+    }
+}
+
+/// Total number of NUL characters removed since process start.
+#[cfg(test)]
+pub(crate) fn nul_characters_removed_total() -> u64 {
+    NUL_CHARACTERS_REMOVED.load(Ordering::Relaxed)
+}
+
+fn record_nul_characters_removed(count: u64) -> u64 {
+    match NUL_CHARACTERS_REMOVED.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(count))
+    }) {
+        Ok(previous) => previous.saturating_add(count),
+        Err(current) => current,
+    }
 }
 
 /// Serialize `value` as a JSON string safe to bind to a Postgres `jsonb` column.
 ///
 /// NUL characters are removed from string contents and object keys. Removal is
-/// data loss, so it is counted and logged at error level with the serialized
-/// type and the JSON pointers that were affected — never the values themselves,
-/// which may carry secrets.
+/// data loss, so it is counted and logged at error level. Logs contain only the
+/// serialized type and scalar counts, never values, object keys, or paths.
 pub(crate) fn to_jsonb_string<T>(value: &T) -> anyhow::Result<String>
 where
     T: Serialize + ?Sized,
 {
     let mut json = serde_json::to_value(value)?;
-    let mut affected = Vec::new();
-    strip_nul(&mut json, &mut String::new(), &mut affected);
+    let stats = strip_nul(&mut json)?;
 
-    if !affected.is_empty() {
-        NUL_SANITIZATIONS.fetch_add(affected.len() as u64, Ordering::Relaxed);
+    if stats.nul_characters_removed > 0 {
+        let total_nul_characters_removed =
+            record_nul_characters_removed(stats.nul_characters_removed);
         tracing::error!(
             entity_type = std::any::type_name::<T>(),
-            removals = affected.len(),
-            pointers = ?affected,
-            total_sanitizations = nul_sanitizations_total(),
+            nul_characters_removed = stats.nul_characters_removed,
+            affected_nodes = stats.affected_nodes,
+            total_nul_characters_removed,
             "stripped NUL characters before jsonb write; stored value differs from the input"
         );
     }
@@ -49,57 +73,53 @@ where
     Ok(serde_json::to_string(&json)?)
 }
 
-/// Remove NUL characters in place, recording an RFC 6901 pointer per affected node.
-fn strip_nul(value: &mut Value, path: &mut String, affected: &mut Vec<String>) {
+/// Remove NUL characters in place and return bounded scalar statistics.
+fn strip_nul(value: &mut Value) -> anyhow::Result<SanitizationStats> {
+    let mut stats = SanitizationStats::default();
+    strip_nul_into(value, &mut stats)?;
+    Ok(stats)
+}
+
+fn strip_nul_into(value: &mut Value, stats: &mut SanitizationStats) -> anyhow::Result<()> {
     match value {
         Value::String(text) => {
-            if text.contains('\0') {
+            let removed = text.chars().filter(|ch| *ch == '\0').count() as u64;
+            if removed > 0 {
                 text.retain(|ch| ch != '\0');
-                affected.push(path.clone());
+                stats.record_node(removed);
             }
         }
         Value::Array(items) => {
-            for (index, item) in items.iter_mut().enumerate() {
-                let restore = path.len();
-                path.push('/');
-                path.push_str(&index.to_string());
-                strip_nul(item, path, affected);
-                path.truncate(restore);
+            for item in items {
+                strip_nul_into(item, stats)?;
             }
         }
         Value::Object(entries) => {
             if entries.keys().any(|key| key.contains('\0')) {
                 let mut rekeyed = Map::with_capacity(entries.len());
                 for (key, item) in std::mem::take(entries) {
-                    if key.contains('\0') {
-                        let restore = path.len();
-                        path.push('/');
-                        path.push_str(&escape_token(&key));
-                        affected.push(path.clone());
-                        path.truncate(restore);
+                    let sanitized_key = key.replace('\0', "");
+                    if rekeyed.contains_key(&sanitized_key) {
+                        anyhow::bail!(
+                            "refusing jsonb sanitization because object keys would collide"
+                        );
                     }
-                    // A rekey can collide with an existing key; last write wins,
-                    // matching the previous textual behavior.
-                    rekeyed.insert(key.replace('\0', ""), item);
+                    let removed = key.chars().filter(|ch| *ch == '\0').count() as u64;
+                    if removed > 0 {
+                        stats.record_node(removed);
+                    }
+                    rekeyed.insert(sanitized_key, item);
                 }
                 *entries = rekeyed;
             }
 
-            for (key, item) in entries.iter_mut() {
-                let restore = path.len();
-                path.push('/');
-                path.push_str(&escape_token(key));
-                strip_nul(item, path, affected);
-                path.truncate(restore);
+            for item in entries.values_mut() {
+                strip_nul_into(item, stats)?;
             }
         }
         Value::Null | Value::Bool(_) | Value::Number(_) => {}
     }
-}
-
-/// RFC 6901 reference-token escaping.
-fn escape_token(key: &str) -> String {
-    key.replace('~', "~0").replace('/', "~1")
+    Ok(())
 }
 
 #[cfg(test)]
@@ -160,6 +180,16 @@ mod tests {
     }
 
     #[test]
+    fn every_removed_nul_is_counted() {
+        let stats = sanitization_stats(serde_json::json!({
+            "summary": "a\0b\0c"
+        }));
+
+        assert_eq!(stats.nul_characters_removed, 2);
+        assert_eq!(stats.affected_nodes, 1);
+    }
+
+    #[test]
     fn real_nul_is_stripped_from_nested_values_and_keys() {
         let value = serde_json::json!({
             "outer": { "in\0ner": ["ok", "x\0y"] }
@@ -174,41 +204,63 @@ mod tests {
         );
     }
 
-    fn affected_pointers(mut value: Value) -> Vec<String> {
-        let mut affected = Vec::new();
-        strip_nul(&mut value, &mut String::new(), &mut affected);
-        affected
+    #[test]
+    fn colliding_sanitized_keys_fail_closed() {
+        let value = serde_json::json!({
+            "ab": "original",
+            "a\0b": "would overwrite"
+        });
+
+        let error = to_jsonb_string(&value)
+            .expect_err("sanitizing colliding object keys must not discard either value");
+
+        assert!(
+            error.to_string().contains("collide"),
+            "collision error must explain the failure without revealing keys: {error}"
+        );
+        assert!(
+            !error.to_string().contains("would overwrite"),
+            "collision error must not reveal values: {error}"
+        );
+    }
+
+    fn sanitization_stats(mut value: Value) -> SanitizationStats {
+        match strip_nul(&mut value) {
+            Ok(stats) => stats,
+            Err(error) => panic!("test fixture must not contain colliding keys: {error}"),
+        }
     }
 
     #[test]
-    fn every_affected_node_is_reported_by_pointer() {
-        let affected = affected_pointers(serde_json::json!({
+    fn characters_and_affected_nodes_are_counted_separately() {
+        let stats = sanitization_stats(serde_json::json!({
             "a": "x\0y",
-            "b": ["ok", "z\0"],
+            "b": ["ok", "z\0\0"],
             "c": { "k\0": "clean" }
         }));
 
-        assert_eq!(affected, vec!["/a", "/b/1", "/c/k\0"]);
+        assert_eq!(stats.nul_characters_removed, 4);
+        assert_eq!(stats.affected_nodes, 3);
     }
 
     #[test]
     fn clean_values_report_nothing() {
-        let affected = affected_pointers(serde_json::json!({
+        let stats = sanitization_stats(serde_json::json!({
             "a": "xy",
             "b": content_with_escaped_literal()
         }));
 
-        assert!(affected.is_empty(), "unexpected reports: {affected:?}");
+        assert_eq!(stats, SanitizationStats::default());
     }
 
     /// The process-wide counter is monotonic; other tests share it, so this
     /// only asserts that a sanitization advances it.
     #[test]
-    fn sanitization_advances_the_counter() {
-        let before = nul_sanitizations_total();
+    fn sanitization_advances_the_character_counter() {
+        let before = nul_characters_removed_total();
 
         to_jsonb_string(&serde_json::json!({ "a": "x\0y", "b": "z\0" })).unwrap();
 
-        assert!(nul_sanitizations_total() >= before + 2);
+        assert!(nul_characters_removed_total() >= before + 2);
     }
 }

--- a/crates/harness-workflow/src/jsonb.rs
+++ b/crates/harness-workflow/src/jsonb.rs
@@ -1,0 +1,214 @@
+//! Shared JSONB serialization for Postgres.
+//!
+//! PostgreSQL rejects NUL characters inside `jsonb` values, so they must be
+//! removed before a write. Doing that with a textual `String::replace` over
+//! already-serialized JSON is unsafe: the six-character escape serde emits for
+//! a NUL is also a suffix of the seven-character text serde emits for a
+//! *literal* backslash followed by `u0000`. A textual replace matches inside
+//! that escaped literal and leaves a dangling backslash behind, corrupting the
+//! document. Stripping therefore happens at the JSON value level, and every
+//! removal is counted and logged.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+static NUL_SANITIZATIONS: AtomicU64 = AtomicU64::new(0);
+
+/// Total number of values sanitized since process start.
+pub(crate) fn nul_sanitizations_total() -> u64 {
+    NUL_SANITIZATIONS.load(Ordering::Relaxed)
+}
+
+/// Serialize `value` as a JSON string safe to bind to a Postgres `jsonb` column.
+///
+/// NUL characters are removed from string contents and object keys. Removal is
+/// data loss, so it is counted and logged at error level with the serialized
+/// type and the JSON pointers that were affected — never the values themselves,
+/// which may carry secrets.
+pub(crate) fn to_jsonb_string<T>(value: &T) -> anyhow::Result<String>
+where
+    T: Serialize + ?Sized,
+{
+    let mut json = serde_json::to_value(value)?;
+    let mut affected = Vec::new();
+    strip_nul(&mut json, &mut String::new(), &mut affected);
+
+    if !affected.is_empty() {
+        NUL_SANITIZATIONS.fetch_add(affected.len() as u64, Ordering::Relaxed);
+        tracing::error!(
+            entity_type = std::any::type_name::<T>(),
+            removals = affected.len(),
+            pointers = ?affected,
+            total_sanitizations = nul_sanitizations_total(),
+            "stripped NUL characters before jsonb write; stored value differs from the input"
+        );
+    }
+
+    Ok(serde_json::to_string(&json)?)
+}
+
+/// Remove NUL characters in place, recording an RFC 6901 pointer per affected node.
+fn strip_nul(value: &mut Value, path: &mut String, affected: &mut Vec<String>) {
+    match value {
+        Value::String(text) => {
+            if text.contains('\0') {
+                text.retain(|ch| ch != '\0');
+                affected.push(path.clone());
+            }
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                let restore = path.len();
+                path.push('/');
+                path.push_str(&index.to_string());
+                strip_nul(item, path, affected);
+                path.truncate(restore);
+            }
+        }
+        Value::Object(entries) => {
+            if entries.keys().any(|key| key.contains('\0')) {
+                let mut rekeyed = Map::with_capacity(entries.len());
+                for (key, item) in std::mem::take(entries) {
+                    if key.contains('\0') {
+                        let restore = path.len();
+                        path.push('/');
+                        path.push_str(&escape_token(&key));
+                        affected.push(path.clone());
+                        path.truncate(restore);
+                    }
+                    // A rekey can collide with an existing key; last write wins,
+                    // matching the previous textual behavior.
+                    rekeyed.insert(key.replace('\0', ""), item);
+                }
+                *entries = rekeyed;
+            }
+
+            for (key, item) in entries.iter_mut() {
+                let restore = path.len();
+                path.push('/');
+                path.push_str(&escape_token(key));
+                strip_nul(item, path, affected);
+                path.truncate(restore);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+/// RFC 6901 reference-token escaping.
+fn escape_token(key: &str) -> String {
+    key.replace('~', "~0").replace('/', "~1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The six characters serde emits for a NUL, built without writing the
+    /// sequence into this source file.
+    fn nul_escape() -> String {
+        format!("{}u0000", '\\')
+    }
+
+    /// Content holding a literal backslash + `u0000`, which must survive intact.
+    fn content_with_escaped_literal() -> String {
+        format!("literal {} mention", nul_escape())
+    }
+
+    /// Reproduces the defect this module replaces (GH-1795).
+    ///
+    /// The former implementation textually replaced the NUL escape in the
+    /// serialized output. When the input holds a literal backslash + `u0000`,
+    /// serde escapes the backslash, so the serialized text holds seven
+    /// characters. The replace then matches the trailing six and leaves a
+    /// dangling backslash, which is not a valid JSON escape.
+    #[test]
+    fn legacy_textual_replace_corrupts_escaped_literal() {
+        let value = serde_json::json!({ "summary": content_with_escaped_literal() });
+
+        let legacy = serde_json::to_string(&value)
+            .unwrap()
+            .replace(&nul_escape(), "");
+
+        assert!(
+            serde_json::from_str::<Value>(&legacy).is_err(),
+            "legacy replace was expected to produce invalid JSON, got: {legacy}"
+        );
+    }
+
+    #[test]
+    fn escaped_literal_survives_untouched() {
+        let value = serde_json::json!({ "summary": content_with_escaped_literal() });
+
+        let encoded = to_jsonb_string(&value).unwrap();
+        let decoded: Value = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded, value, "content without a real NUL must round-trip");
+    }
+
+    #[test]
+    fn real_nul_is_stripped_from_strings() {
+        let value = serde_json::json!({ "summary": "a\0b" });
+
+        let encoded = to_jsonb_string(&value).unwrap();
+        let decoded: Value = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded, serde_json::json!({ "summary": "ab" }));
+        assert!(!encoded.contains(&nul_escape()));
+    }
+
+    #[test]
+    fn real_nul_is_stripped_from_nested_values_and_keys() {
+        let value = serde_json::json!({
+            "outer": { "in\0ner": ["ok", "x\0y"] }
+        });
+
+        let encoded = to_jsonb_string(&value).unwrap();
+        let decoded: Value = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(
+            decoded,
+            serde_json::json!({ "outer": { "inner": ["ok", "xy"] } })
+        );
+    }
+
+    fn affected_pointers(mut value: Value) -> Vec<String> {
+        let mut affected = Vec::new();
+        strip_nul(&mut value, &mut String::new(), &mut affected);
+        affected
+    }
+
+    #[test]
+    fn every_affected_node_is_reported_by_pointer() {
+        let affected = affected_pointers(serde_json::json!({
+            "a": "x\0y",
+            "b": ["ok", "z\0"],
+            "c": { "k\0": "clean" }
+        }));
+
+        assert_eq!(affected, vec!["/a", "/b/1", "/c/k\0"]);
+    }
+
+    #[test]
+    fn clean_values_report_nothing() {
+        let affected = affected_pointers(serde_json::json!({
+            "a": "xy",
+            "b": content_with_escaped_literal()
+        }));
+
+        assert!(affected.is_empty(), "unexpected reports: {affected:?}");
+    }
+
+    /// The process-wide counter is monotonic; other tests share it, so this
+    /// only asserts that a sanitization advances it.
+    #[test]
+    fn sanitization_advances_the_counter() {
+        let before = nul_sanitizations_total();
+
+        to_jsonb_string(&serde_json::json!({ "a": "x\0y", "b": "z\0" })).unwrap();
+
+        assert!(nul_sanitizations_total() >= before + 2);
+    }
+}

--- a/crates/harness-workflow/src/lib.rs
+++ b/crates/harness-workflow/src/lib.rs
@@ -7,6 +7,7 @@ pub mod checkpoint;
 pub mod circuit_breaker;
 pub mod issue_lifecycle;
 pub mod issue_workflow_store;
+pub(crate) mod jsonb;
 pub mod plan_db;
 pub mod project_lifecycle;
 pub mod runtime;

--- a/crates/harness-workflow/src/plan_db.rs
+++ b/crates/harness-workflow/src/plan_db.rs
@@ -165,14 +165,9 @@ impl PlanDb {
     }
 
     pub async fn upsert(&self, plan: &ExecPlan) -> anyhow::Result<()> {
-        let data = serde_json::to_string(plan)?;
-        // PostgreSQL JSONB rejects \u0000; serde_json encodes NUL as the
-        // 6-char escape sequence, so strip that form (not the literal byte).
-        let data = if data.contains("\\u0000") {
-            data.replace("\\u0000", "")
-        } else {
-            data
-        };
+        // PostgreSQL JSONB rejects NUL; stripping happens at the JSON value
+        // level so escaped literals are not corrupted (see crate::jsonb).
+        let data = crate::jsonb::to_jsonb_string(plan)?;
         sqlx::query(
             "INSERT INTO exec_plans (store_key, id, data) VALUES ($1, $2, $3::jsonb)
              ON CONFLICT(store_key, id) DO UPDATE SET data = EXCLUDED.data,

--- a/crates/harness-workflow/src/plan_db.rs
+++ b/crates/harness-workflow/src/plan_db.rs
@@ -27,7 +27,7 @@ static PLAN_MIGRATIONS: &[Migration] = &[
     Migration {
         version: 3,
         description: "convert exec_plans.data from TEXT to JSONB",
-        sql: "ALTER TABLE exec_plans ALTER COLUMN data TYPE JSONB USING replace(data, '\\u0000', '')::jsonb",
+        sql: "ALTER TABLE exec_plans ALTER COLUMN data TYPE JSONB USING data::jsonb",
     },
     Migration {
         version: 4,
@@ -343,13 +343,22 @@ pub async fn migrate_legacy_plan_db_if_needed(
         return Ok(0);
     }
 
+    let legacy_data_type: Option<String> = sqlx::query_scalar(
+        "SELECT data_type
+         FROM information_schema.columns
+         WHERE table_schema = $1
+           AND table_name = 'exec_plans'
+           AND column_name = 'data'",
+    )
+    .bind(legacy_schema)
+    .fetch_optional(&target_db.pool)
+    .await?;
+    let legacy_data_type = legacy_data_type.ok_or_else(|| {
+        anyhow::anyhow!("legacy plan database schema {legacy_schema} has no exec_plans.data column")
+    })?;
+
     let mut tx = target_db.pool.begin().await?;
-    let copy_sql = format!(
-        "INSERT INTO exec_plans (store_key, id, data, created_at, updated_at)
-         SELECT $1, id, replace(data::text, '\\u0000', '')::jsonb, created_at, updated_at
-         FROM \"{legacy_schema}\".exec_plans
-         ON CONFLICT (store_key, id) DO NOTHING"
-    );
+    let copy_sql = legacy_plan_backfill_sql(legacy_schema, &legacy_data_type)?;
     let copied = sqlx::query(&copy_sql)
         .bind(target_db.store_key())
         .execute(&mut *tx)
@@ -379,6 +388,22 @@ pub async fn migrate_legacy_plan_db_if_needed(
     }
 
     Ok(copied)
+}
+
+fn legacy_plan_backfill_sql(legacy_schema: &str, legacy_data_type: &str) -> anyhow::Result<String> {
+    let data_expression = match legacy_data_type {
+        "jsonb" => "data",
+        "text" => "data::jsonb",
+        other => {
+            anyhow::bail!("unsupported legacy exec_plans.data type {other}; expected text or jsonb")
+        }
+    };
+    Ok(format!(
+        "INSERT INTO exec_plans (store_key, id, data, created_at, updated_at)
+         SELECT $1, id, {data_expression}, created_at, updated_at
+         FROM \"{legacy_schema}\".exec_plans
+         ON CONFLICT (store_key, id) DO NOTHING"
+    ))
 }
 
 #[cfg(test)]

--- a/crates/harness-workflow/src/plan_db/tests.rs
+++ b/crates/harness-workflow/src/plan_db/tests.rs
@@ -269,7 +269,8 @@ async fn legacy_plan_db_migration_backfills_once() -> anyhow::Result<()> {
 
     let result = std::panic::AssertUnwindSafe(async {
         let mut legacy_plan = ExecPlan::from_spec("# Legacy plan", &target_data_dir)?;
-        legacy_plan.purpose = "legacy plan".to_string();
+        let escaped_literal = format!("legacy {}u0000 plan", '\\');
+        legacy_plan.purpose = escaped_literal.clone();
         legacy_db.upsert(&legacy_plan).await?;
 
         let copied =
@@ -284,7 +285,7 @@ async fn legacy_plan_db_migration_backfills_once() -> anyhow::Result<()> {
             .get(&legacy_plan.id)
             .await?
             .expect("legacy plan should be present in the shared schema");
-        assert_eq!(loaded.purpose, "legacy plan");
+        assert_eq!(loaded.purpose, escaped_literal);
         assert!(
             other_db.get(&legacy_plan.id).await?.is_none(),
             "other data_dir scopes must not hydrate legacy plans"
@@ -418,5 +419,113 @@ async fn migration_contract_text_to_jsonb_gin() -> anyhow::Result<()> {
     let parsed: serde_json::Value = serde_json::from_str(&data)?;
     assert_eq!(parsed["status"], serde_json::json!("draft"));
 
+    Ok(())
+}
+
+#[test]
+fn text_to_jsonb_migration_does_not_blindly_rewrite_serialized_json() {
+    let Some(migration) = PLAN_MIGRATIONS
+        .iter()
+        .find(|migration| migration.version == 3)
+    else {
+        panic!("plan database migration v3 must exist");
+    };
+
+    assert!(
+        !migration.sql.contains("replace("),
+        "migration v3 must fail closed instead of textually rewriting serialized JSON"
+    );
+}
+
+#[test]
+fn legacy_backfill_copies_jsonb_without_a_textual_round_trip() -> anyhow::Result<()> {
+    let sql = legacy_plan_backfill_sql("h1234", "jsonb")?;
+
+    assert!(!sql.contains("replace("));
+    assert!(!sql.contains("data::text"));
+    assert!(
+        sql.contains("SELECT $1, id, data, created_at, updated_at"),
+        "legacy JSONB must be copied directly: {sql}"
+    );
+    Ok(())
+}
+
+#[test]
+fn legacy_backfill_casts_text_without_rewriting_serialized_json() -> anyhow::Result<()> {
+    let sql = legacy_plan_backfill_sql("h1234", "text")?;
+
+    assert!(!sql.contains("replace("));
+    assert!(
+        sql.contains("SELECT $1, id, data::jsonb, created_at, updated_at"),
+        "legacy TEXT must use a fail-closed JSONB cast: {sql}"
+    );
+    Ok(())
+}
+
+#[test]
+fn legacy_backfill_rejects_unknown_data_types() {
+    let error = match legacy_plan_backfill_sql("h1234", "bytea") {
+        Ok(sql) => panic!("unsupported source type produced SQL: {sql}"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("unsupported"));
+}
+
+#[tokio::test]
+async fn text_to_jsonb_migration_rejects_nul_without_rewriting_source() -> anyhow::Result<()> {
+    let Ok(database_url) = resolve_database_url(None) else {
+        return Ok(());
+    };
+    let _permit = db_gate().acquire().await?;
+    let schema = unique_test_schema("plan_db_nul_migration_test");
+    let setup = pg_open_pool(&database_url).await?;
+    sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS \"{schema}\""))
+        .execute(&setup)
+        .await?;
+    let pool = pg_open_pool_schematized(&database_url, &schema).await?;
+
+    PgMigrator::new(&pool, &PLAN_MIGRATIONS[..2]).run().await?;
+    let source = serde_json::to_string(&serde_json::json!({
+        "id": "nul-migration",
+        "purpose": "a\0b"
+    }))?;
+    sqlx::query("INSERT INTO exec_plans (id, data) VALUES ($1, $2)")
+        .bind("nul-migration")
+        .bind(&source)
+        .execute(&pool)
+        .await?;
+
+    let migration_error = match PgMigrator::new(&pool, PLAN_MIGRATIONS).run().await {
+        Ok(()) => panic!("migration must fail instead of silently rewriting a NUL escape"),
+        Err(error) => error,
+    };
+    assert!(
+        migration_error.to_string().contains("migration v3"),
+        "migration failure must identify the rejected step: {migration_error}"
+    );
+
+    let column_type: String = sqlx::query_scalar(
+        "SELECT data_type
+         FROM information_schema.columns
+         WHERE table_schema = current_schema()
+           AND table_name = 'exec_plans'
+           AND column_name = 'data'",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(column_type, "text", "failed migration must roll back DDL");
+
+    let stored: String = sqlx::query_scalar("SELECT data FROM exec_plans WHERE id = $1")
+        .bind("nul-migration")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(stored, source, "failed migration must preserve source data");
+
+    pool.close().await;
+    sqlx::query(&format!("DROP SCHEMA IF EXISTS \"{schema}\" CASCADE"))
+        .execute(&setup)
+        .await?;
+    setup.close().await;
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/store/transaction_helpers.rs
+++ b/crates/harness-workflow/src/runtime/store/transaction_helpers.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub(in crate::runtime) fn to_jsonb_string(value: &impl Serialize) -> anyhow::Result<String> {
-    Ok(serde_json::to_string(value)?.replace("\\u0000", ""))
+    crate::jsonb::to_jsonb_string(value)
 }
 
 pub(in crate::runtime) fn enum_str(value: &impl Serialize) -> anyhow::Result<String> {


### PR DESCRIPTION
## What / Why

Every JSONB write used to remove `\u0000` textually after serialization. That had two defects:

1. **Silent data loss.** Removal was neither logged nor counted.
2. **Corruption of escaped literals.** The six-character escape emitted for a real NUL is a suffix of the representation for a literal backslash followed by `u0000`; blind replacement could leave invalid JSON.

## Change

- centralize JSONB serialization in `crate::jsonb`
- sanitize real NUL characters at the `serde_json::Value` level
- log only the compile-time entity type and bounded scalar counts:
  - `nul_characters_removed`
  - `affected_nodes`
  - process-wide `total_nul_characters_removed`
- never collect or log JSON pointers, object keys, or values
- fail closed when sanitizing object keys would create a collision
- remove blind textual replacement from the historical TEXT-to-JSONB migration
- preserve migration safety:
  - migration v3 uses `data::jsonb`, so unsupported legacy NUL data fails visibly and transactionally instead of being rewritten
  - legacy JSONB backfills copy `data` directly
  - legacy TEXT backfills use the same fail-closed `data::jsonb` cast
  - unsupported source column types return an error

The issue's proposed direction also mentioned a stored-record marker. That would require a schema and public persistence-contract change, so it remains out of scope. The acceptance criteria are covered by error-level observability, a cumulative counter, structurally safe handling, and one shared write-path implementation.

Closes #1795

## Review findings addressed

- count each removed NUL rather than each affected node
- remove user-controlled path data from logs
- remove the unbounded pointer vector
- reject sanitized-key collisions without exposing the keys
- eliminate the two remaining blind SQL replacement paths

## Verification

Fresh local verification for the JSONB fix:

- `cargo fmt --all -- --check`
- `cargo check -p harness-workflow --all-targets`
- `cargo test -p harness-workflow --lib 'jsonb::tests::'` — 9 passed
- three database-independent legacy-backfill branch tests — 3 passed
- migration v3 no-blind-replace test — 1 passed
- repository DB-independent `harness-workflow` lib profile — 536 passed, 0 failed, 4 ignored, 7 PostgreSQL tests filtered
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 checks/check_workflow.py --repo .`
- repository pre-commit and pre-push hooks

The new configured-PostgreSQL tests cover fail-closed v3 rollback and escaped-literal legacy backfill. Local configured-DB execution was unavailable because the configured pool timed out before test logic; the repository hook therefore deferred PostgreSQL-backed suites to CI according to project policy.

## CI repair

The first two CI attempts on `28212984` exposed an existing async tracing-capture defect in `event_replay_tests.rs`: durable-state assertions passed, but one aggregate log event was not captured. The test held a thread-local subscriber across `.await`.

Commit `24695883` binds the existing subscriber to every future poll with `WithSubscriber`. All original business, persistence, typed-error, byte-preservation, and log assertions remain unchanged; no production code was modified.

Current-head CI on `24695883` is green, including the full configured-PostgreSQL `harness-server` profile and the new migration tests.

## Independent review

A read-only reviewer rechecked all hosted findings plus the collision and migration/backfill paths and returned `safe_to_commit` with no blocking findings.

## AI Role

Implementation and tests were AI-generated and independently reviewed. Human authorization, current-head CI, hosted review, and merge gates remain required.
