### PR TITLE
fix(GH1789): bound non-streaming agent output and enforce an idle timeout

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -260,7 +260,8 @@ impl CodeAgent for ClaudeCodeAgent {
         }
         let mut child = crate::ManagedChild::new(child, "claude execute");
 
-        let output = child.wait_with_output().await.map_err(|e| {
+        let limits = crate::OutputLimits::from_stream_timeout_secs(self.stream_timeout_secs);
+        let output = child.wait_with_output(&limits).await.map_err(|e| {
             harness_core::error::HarnessError::AgentExecution(format!(
                 "failed to wait for claude: {e}"
             ))

--- a/crates/harness-agents/src/claude_tests.rs
+++ b/crates/harness-agents/src/claude_tests.rs
@@ -821,6 +821,35 @@ printf '{"type":"result","result":"CLAUDECODE=%s ENTRYPOINT=%s CONFIG_DIR=%s"}\n
 }
 
 #[tokio::test]
+async fn execute_times_out_on_hung_agent() {
+    let (dir, script) = write_executable_script("sleep 30");
+    let agent = ClaudeCodeAgent::new(
+        script,
+        "test-model".to_string(),
+        SandboxMode::DangerFullAccess,
+    )
+    .with_stream_timeout(Some(1));
+    let request = AgentRequest {
+        prompt: "ignored".to_string(),
+        project_root: dir.path().to_path_buf(),
+        ..AgentRequest::default()
+    };
+
+    let started = std::time::Instant::now();
+    let error = match timeout(Duration::from_secs(10), agent.execute(request)).await {
+        Ok(Ok(response)) => panic!("hung agent must not report success: {response:?}"),
+        Ok(Err(error)) => error.to_string(),
+        Err(_) => panic!("execute must fail at the configured timeout, not hang"),
+    };
+    assert!(error.contains("idle timeout"), "{error}");
+    assert!(
+        started.elapsed() < Duration::from_secs(8),
+        "took {:?}",
+        started.elapsed()
+    );
+}
+
+#[tokio::test]
 async fn execute_returns_token_usage_from_stream_json_result() {
     let (dir, script) = write_executable_script(
         r#"

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -268,7 +268,9 @@ impl CodexAgent {
                 })?;
         }
 
-        let output = child.wait_with_output().await.map_err(|error| {
+        let mut child = crate::ManagedChild::new(child, "codex review");
+        let limits = crate::OutputLimits::from_stream_timeout_secs(self.stream_timeout_secs);
+        let output = child.wait_with_output(&limits).await.map_err(|error| {
             harness_core::error::HarnessError::AgentExecution(format!(
                 "failed to wait for codex review: {error}"
             ))
@@ -455,7 +457,8 @@ impl CodeAgent for CodexAgent {
             );
         }
         let mut child = crate::ManagedChild::new(child, "codex execute");
-        let output = child.wait_with_output().await.map_err(|err| {
+        let limits = crate::OutputLimits::from_stream_timeout_secs(self.stream_timeout_secs);
+        let output = child.wait_with_output(&limits).await.map_err(|err| {
             harness_core::error::HarnessError::AgentExecution(format!(
                 "failed to wait for codex: {err}"
             ))

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -192,35 +192,116 @@ impl ManagedChild {
         Ok(())
     }
 
-    pub(crate) async fn wait_with_output(&mut self) -> std::io::Result<std::process::Output> {
-        use tokio::io::AsyncReadExt;
+    /// Wait for the child while capturing bounded output with an idle timeout.
+    ///
+    /// Unlike `Child::wait_with_output`, this never buffers unbounded process
+    /// output (only the tail up to `limits.max_captured_bytes` per stream is
+    /// kept, which preserves the trailing result line agents emit) and it
+    /// declares the child a zombie when neither pipe produces data for
+    /// `limits.idle_timeout`, killing the process group instead of hanging
+    /// the caller forever.
+    pub(crate) async fn wait_with_output(
+        &mut self,
+        limits: &OutputLimits,
+    ) -> std::io::Result<BoundedOutput> {
+        let mut stdout_pipe = self.child_mut().stdout.take();
+        let mut stderr_pipe = self.child_mut().stderr.take();
+        let mut stdout_buf = TailBuffer::new(limits.max_captured_bytes);
+        let mut stderr_buf = TailBuffer::new(limits.max_captured_bytes);
+        let mut stdout_chunk = vec![0u8; OUTPUT_READ_CHUNK_BYTES];
+        let mut stderr_chunk = vec![0u8; OUTPUT_READ_CHUNK_BYTES];
 
-        let stdout = self.child_mut().stdout.take();
-        let stderr = self.child_mut().stderr.take();
-        let stdout_task = tokio::spawn(async move {
-            let mut bytes = Vec::new();
-            if let Some(mut pipe) = stdout {
-                pipe.read_to_end(&mut bytes).await?;
+        let mut exit_status: Option<std::process::ExitStatus> = None;
+        while stdout_pipe.is_some() || stderr_pipe.is_some() {
+            let child_running = exit_status.is_none();
+            let read = async {
+                tokio::select! {
+                    result = read_from_pipe(&mut stdout_pipe, &mut stdout_chunk) => {
+                        PipeRead::Stdout(result)
+                    }
+                    result = read_from_pipe(&mut stderr_pipe, &mut stderr_chunk) => {
+                        PipeRead::Stderr(result)
+                    }
+                    // Watch for root exit while pipes stay open: a descendant
+                    // holding the pipe must be killed so the reads reach EOF
+                    // instead of hanging until the idle timeout.
+                    result = self.child.as_mut().expect(
+                        "ManagedChild is only vacated during drop",
+                    ).wait(), if child_running => {
+                        PipeRead::Exited(result)
+                    }
+                }
+            };
+            let event = if let Some(idle) = limits.idle_timeout {
+                match tokio::time::timeout(idle, read).await {
+                    Ok(event) => event,
+                    Err(_) => {
+                        self.terminate_now();
+                        return Err(self.idle_timeout_error(idle));
+                    }
+                }
+            } else {
+                read.await
+            };
+            match event {
+                PipeRead::Stdout(Ok(0)) => stdout_pipe = None,
+                PipeRead::Stderr(Ok(0)) => stderr_pipe = None,
+                PipeRead::Stdout(Ok(n)) => stdout_buf.push(&stdout_chunk[..n]),
+                PipeRead::Stderr(Ok(n)) => stderr_buf.push(&stderr_chunk[..n]),
+                PipeRead::Stdout(Err(error)) | PipeRead::Stderr(Err(error)) => {
+                    self.terminate_now();
+                    return Err(error);
+                }
+                PipeRead::Exited(result) => {
+                    exit_status = Some(result?);
+                    self.cleanup_after_child_exit().await?;
+                }
             }
-            Ok::<_, std::io::Error>(bytes)
-        });
-        let stderr_task = tokio::spawn(async move {
-            let mut bytes = Vec::new();
-            if let Some(mut pipe) = stderr {
-                pipe.read_to_end(&mut bytes).await?;
+        }
+
+        let status = match exit_status {
+            Some(status) => status,
+            None => {
+                if let Some(idle) = limits.idle_timeout {
+                    match tokio::time::timeout(idle, self.wait_and_cleanup_descendants()).await {
+                        Ok(result) => result?,
+                        Err(_) => {
+                            self.terminate_now();
+                            return Err(self.idle_timeout_error(idle));
+                        }
+                    }
+                } else {
+                    self.wait_and_cleanup_descendants().await?
+                }
             }
-            Ok::<_, std::io::Error>(bytes)
-        });
+        };
 
-        let status = self.wait_and_cleanup_descendants().await?;
-        let stdout = join_reader(stdout_task).await?;
-        let stderr = join_reader(stderr_task).await?;
+        if stdout_buf.truncated || stderr_buf.truncated {
+            tracing::warn!(
+                agent_process = self.label,
+                max_captured_bytes = limits.max_captured_bytes,
+                stdout_truncated = stdout_buf.truncated,
+                stderr_truncated = stderr_buf.truncated,
+                "agent output exceeded the capture limit; kept only the tail"
+            );
+        }
 
-        Ok(std::process::Output {
+        Ok(BoundedOutput {
             status,
-            stdout,
-            stderr,
+            stdout: stdout_buf.data,
+            stderr: stderr_buf.data,
         })
+    }
+
+    fn idle_timeout_error(&self, idle: std::time::Duration) -> std::io::Error {
+        std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!(
+                "{} idle timeout after {}s: zombie process terminated",
+                self.label,
+                idle.as_secs()
+            ),
+        )
     }
 
     #[cfg(unix)]
@@ -261,11 +342,89 @@ impl ManagedChild {
     }
 }
 
-async fn join_reader(
-    task: tokio::task::JoinHandle<std::io::Result<Vec<u8>>>,
-) -> std::io::Result<Vec<u8>> {
-    task.await
-        .map_err(|error| std::io::Error::other(error.to_string()))?
+/// Default per-stream capture ceiling for non-streaming execution. Generous
+/// enough for any legitimate agent transcript while preventing a runaway
+/// child (e.g. one that dumps a build log) from holding gigabytes in RAM.
+pub(crate) const DEFAULT_MAX_CAPTURED_OUTPUT_BYTES: usize = 32 * 1024 * 1024;
+
+const OUTPUT_READ_CHUNK_BYTES: usize = 64 * 1024;
+
+/// Limits applied by [`ManagedChild::wait_with_output`].
+pub(crate) struct OutputLimits {
+    /// Kill the child when neither pipe produces data for this long.
+    pub(crate) idle_timeout: Option<std::time::Duration>,
+    /// Per-stream capture ceiling; only the tail is kept beyond it.
+    pub(crate) max_captured_bytes: usize,
+}
+
+impl OutputLimits {
+    /// Build limits from an agent's `stream_timeout_secs` configuration so the
+    /// non-streaming path shares the streaming path's zombie detection.
+    pub(crate) fn from_stream_timeout_secs(secs: Option<u64>) -> Self {
+        Self {
+            idle_timeout: secs.map(std::time::Duration::from_secs),
+            max_captured_bytes: DEFAULT_MAX_CAPTURED_OUTPUT_BYTES,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BoundedOutput {
+    pub(crate) status: std::process::ExitStatus,
+    pub(crate) stdout: Vec<u8>,
+    pub(crate) stderr: Vec<u8>,
+}
+
+/// Fixed-capacity byte buffer that keeps the most recent bytes pushed into it.
+struct TailBuffer {
+    data: Vec<u8>,
+    cap: usize,
+    truncated: bool,
+}
+
+impl TailBuffer {
+    fn new(cap: usize) -> Self {
+        Self {
+            data: Vec::new(),
+            cap,
+            truncated: false,
+        }
+    }
+
+    fn push(&mut self, chunk: &[u8]) {
+        if chunk.len() >= self.cap {
+            self.truncated = self.truncated || !self.data.is_empty() || chunk.len() > self.cap;
+            self.data.clear();
+            self.data
+                .extend_from_slice(&chunk[chunk.len() - self.cap..]);
+            return;
+        }
+        let overflow = (self.data.len() + chunk.len()).saturating_sub(self.cap);
+        if overflow > 0 {
+            self.data.drain(..overflow);
+            self.truncated = true;
+        }
+        self.data.extend_from_slice(chunk);
+    }
+}
+
+enum PipeRead {
+    Stdout(std::io::Result<usize>),
+    Stderr(std::io::Result<usize>),
+    Exited(std::io::Result<std::process::ExitStatus>),
+}
+
+/// Read from an optional pipe; a vacated pipe never resolves, letting
+/// `select!` wait solely on the remaining stream.
+async fn read_from_pipe<R>(pipe: &mut Option<R>, buf: &mut [u8]) -> std::io::Result<usize>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use tokio::io::AsyncReadExt;
+    match pipe {
+        Some(reader) => reader.read(buf).await,
+        None => std::future::pending().await,
+    }
 }
 
 impl Drop for ManagedChild {
@@ -428,6 +587,78 @@ fn drain_killed_child_blocking(
 #[cfg(unix)]
 mod managed_child_tests {
     use super::*;
+
+    fn spawn_shell(script: &str) -> ManagedChild {
+        let mut cmd = tokio::process::Command::new("/bin/sh");
+        cmd.arg("-c")
+            .arg(script)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        set_process_group(&mut cmd);
+        ManagedChild::new(
+            cmd.spawn().expect("spawn shell child"),
+            "managed child test",
+        )
+    }
+
+    #[test]
+    fn tail_buffer_keeps_only_most_recent_bytes() {
+        let mut buf = TailBuffer::new(4);
+        buf.push(b"ab");
+        assert_eq!(buf.data, b"ab");
+        assert!(!buf.truncated);
+        buf.push(b"cdef");
+        assert_eq!(buf.data, b"cdef");
+        assert!(buf.truncated);
+
+        let mut big = TailBuffer::new(4);
+        big.push(b"0123456789");
+        assert_eq!(big.data, b"6789");
+        assert!(big.truncated);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wait_with_output_times_out_on_silent_child() {
+        let mut child = spawn_shell("sleep 30");
+        let limits = OutputLimits {
+            idle_timeout: Some(std::time::Duration::from_millis(300)),
+            max_captured_bytes: DEFAULT_MAX_CAPTURED_OUTPUT_BYTES,
+        };
+
+        let start = std::time::Instant::now();
+        let error = child
+            .wait_with_output(&limits)
+            .await
+            .expect_err("a silent child must trip the idle timeout");
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut, "{error}");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(5),
+            "timeout must fire near the configured deadline, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wait_with_output_caps_capture_to_the_tail() {
+        let mut child = spawn_shell("printf 'a%.0s' $(seq 1 8000); printf 'END-MARKER'; exit 0");
+        let limits = OutputLimits {
+            idle_timeout: Some(std::time::Duration::from_secs(10)),
+            max_captured_bytes: 512,
+        };
+
+        let output = child
+            .wait_with_output(&limits)
+            .await
+            .expect("bounded wait should succeed");
+        assert!(output.status.success());
+        assert!(output.stdout.len() <= 512, "len={}", output.stdout.len());
+        assert!(
+            output.stdout.ends_with(b"END-MARKER"),
+            "the trailing bytes must survive truncation"
+        );
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drop_of_running_child_returns_promptly_and_reaps_in_background() {


### PR DESCRIPTION
Closes #1789.

Non-streaming `execute()` called `wait_with_output` with no deadline and buffered output unbounded (`read_to_end`) — `harness exec` could hang forever on a stuck agent, and a child dumping a huge log was held entirely in RAM.

- `ManagedChild::wait_with_output` now enforces the agent's `stream_timeout_secs` as an idle deadline on both pipes (same zombie semantics as the streaming path), killing the process group when it fires
- per-stream capture is capped (32 MiB, tail-retained so the trailing result line survives; truncation logged)
- the read loop selects on root exit, so descendants holding pipes are killed immediately rather than stalling reads
- `execute_review` now runs under `ManagedChild` supervision (was a raw `Child`)

Verification: `cargo test -p harness-agents` (218 passed), `cargo clippy --workspace --all-targets -- -D warnings` clean.