### PR TITLE
fix(workflow): validate decision transitions before persisting the instance (GH-1784)

### DIFF
--- a/crates/harness-server/src/reconciliation_apply.rs
+++ b/crates/harness-server/src/reconciliation_apply.rs
@@ -8,13 +8,31 @@ pub(super) async fn apply_runtime_workflow_transition(
     target_state: &str,
     reason: &str,
 ) -> anyhow::Result<bool> {
-    let Some(mut instance) = runtime_store.get_instance(&candidate.workflow_id).await? else {
+    let Some(instance) = runtime_store.get_instance(&candidate.workflow_id).await? else {
         return Ok(false);
     };
     if instance.is_terminal() || instance.state != candidate.state {
         return Ok(false);
     }
+    apply_loaded_runtime_workflow_transition(
+        runtime_store,
+        issue_workflows,
+        candidate,
+        instance,
+        target_state,
+        reason,
+    )
+    .await
+}
 
+pub(super) async fn apply_loaded_runtime_workflow_transition(
+    runtime_store: &WorkflowRuntimeStore,
+    issue_workflows: Option<&IssueWorkflowStore>,
+    candidate: &RuntimeWorkflowCandidate,
+    mut instance: WorkflowInstance,
+    target_state: &str,
+    reason: &str,
+) -> anyhow::Result<bool> {
     let is_pr_target = candidate.pr_number.is_some();
     let event_type = match (target_state, is_pr_target) {
         ("done", true) => "PrMerged",
@@ -90,22 +108,32 @@ pub(super) async fn apply_runtime_workflow_transition(
         reason,
         candidate,
     );
-    let Some(_record) = runtime_store
-        .apply_decision_transition(WorkflowDecisionTransition {
-            expected_state: candidate.state.as_str(),
-            create_if_missing: None,
-            event_type,
-            source: "reconciliation",
-            payload: event_payload,
-            decision: &decision,
-            final_instance: &instance,
-            command_status: WorkflowCommandStatus::Completed,
-        })
-        .await?
-    else {
+    let record = runtime_store
+        .apply_decision_transition(
+            WorkflowDecisionTransition {
+                expected_state: candidate.state.as_str(),
+                create_if_missing: None,
+                event_type,
+                source: "reconciliation",
+                payload: event_payload,
+                decision: &decision,
+                final_instance: &instance,
+                command_status: WorkflowCommandStatus::Completed,
+            },
+            "reconciliation",
+        )
+        .await?;
+    if !complete_runtime_workflow_transition(
+        record,
+        issue_workflows,
+        candidate,
+        target_state,
+        reason,
+    )
+    .await
+    {
         return Ok(false);
-    };
-    record_runtime_issue_side_effects(issue_workflows, candidate, target_state, reason).await;
+    }
     tracing::info!(
         workflow_id = %candidate.workflow_id,
         from = %candidate.state,
@@ -116,6 +144,28 @@ pub(super) async fn apply_runtime_workflow_transition(
         "workflow runtime reconciliation: applying transition"
     );
     Ok(true)
+}
+
+pub(super) async fn complete_runtime_workflow_transition(
+    record: Option<harness_workflow::runtime::WorkflowDecisionRecord>,
+    issue_workflows: Option<&IssueWorkflowStore>,
+    candidate: &RuntimeWorkflowCandidate,
+    target_state: &str,
+    reason: &str,
+) -> bool {
+    let Some(record) = record else {
+        return false;
+    };
+    if !record.accepted {
+        tracing::warn!(
+            workflow_id = %candidate.workflow_id,
+            reason = record.rejection_reason.as_deref().unwrap_or("unspecified validator rejection"),
+            "workflow runtime reconciliation transition rejected during atomic validation"
+        );
+        return false;
+    }
+    record_runtime_issue_side_effects(issue_workflows, candidate, target_state, reason).await;
+    true
 }
 
 fn remote_payload(

--- a/crates/harness-server/src/reconciliation_tests.rs
+++ b/crates/harness-server/src/reconciliation_tests.rs
@@ -355,6 +355,140 @@ fn ready_to_merge_open_alert_uses_row_age() {
 }
 
 #[tokio::test]
+async fn atomic_stale_reconciliation_does_not_record_issue_side_effects() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+    let _db_guard = crate::test_helpers::acquire_db_state_guard().await;
+    let Some(stores) = open_runtime_stores().await? else {
+        return Ok(());
+    };
+    let project_root = stores.dir.path().join("stale-reconciliation");
+    std::fs::create_dir(&project_root)?;
+    let project_id = project_root.to_string_lossy().into_owned();
+    stores
+        .issue_store
+        .record_issue_scheduled(
+            &project_id,
+            Some("owner/repo"),
+            42,
+            "stale-reconciliation-task",
+            &[],
+            false,
+        )
+        .await?;
+    stores
+        .issue_store
+        .record_implement_started(
+            &project_id,
+            Some("owner/repo"),
+            42,
+            "stale-reconciliation-task",
+        )
+        .await?;
+    let workflow_id =
+        harness_workflow::issue_lifecycle::workflow_id(&project_id, Some("owner/repo"), 42);
+    let instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:42"),
+    )
+    .with_id(&workflow_id)
+    .with_data(json!({
+        "project_id": project_id.as_str(),
+        "repo": "owner/repo",
+        "issue_number": 42,
+        "task_id": "stale-reconciliation-task",
+    }));
+    stores.runtime_store.upsert_instance(&instance).await?;
+    let stale_instance = instance.clone();
+    stores
+        .runtime_store
+        .ensure_otel_trace_context(&workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("concurrent workflow update must persist"))?;
+    let candidate = RuntimeWorkflowCandidate {
+        workflow_id: workflow_id.clone(),
+        state: "implementing".to_string(),
+        row_updated_at: chrono::Utc::now(),
+        repo: Some("owner/repo".to_string()),
+        project_root: Some(project_root),
+        issue_number: Some(42),
+        pr_number: None,
+        pr_url: None,
+    };
+
+    let applied = reconciliation_apply::apply_loaded_runtime_workflow_transition(
+        &stores.runtime_store,
+        Some(&stores.issue_store),
+        &candidate,
+        stale_instance,
+        "done",
+        "remote issue is closed",
+    )
+    .await?;
+
+    assert!(!applied, "a stale atomic transition must not be applied");
+    let stored = stores
+        .runtime_store
+        .get_instance(&workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("runtime workflow must remain"))?;
+    assert_eq!(stored.state, "implementing");
+    assert_eq!(stored.version, instance.version + 1);
+    assert!(stored.data.get("otel_trace_context").is_some());
+    assert!(stores
+        .runtime_store
+        .events_for(&workflow_id)
+        .await?
+        .is_empty());
+    assert!(stores
+        .runtime_store
+        .decisions_for(&workflow_id)
+        .await?
+        .is_empty());
+    assert!(stores
+        .runtime_store
+        .commands_for(&workflow_id)
+        .await?
+        .is_empty());
+    let rejected_record = harness_workflow::runtime::WorkflowDecisionRecord::rejected(
+        WorkflowDecision::new(
+            &workflow_id,
+            "implementing",
+            "reconcile_issue_completed",
+            "done",
+            "remote issue is closed",
+        ),
+        None,
+        "lease expired before commit",
+    );
+    let rejected_applied = reconciliation_apply::complete_runtime_workflow_transition(
+        Some(rejected_record),
+        Some(&stores.issue_store),
+        &candidate,
+        "done",
+        "remote issue is closed",
+    )
+    .await;
+    assert!(
+        !rejected_applied,
+        "an atomic rejection must not run reconciliation side effects"
+    );
+    let issue_workflow = stores
+        .issue_store
+        .get_by_issue(&project_id, Some("owner/repo"), 42)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("issue workflow must remain"))?;
+    assert_eq!(
+        issue_workflow.state,
+        harness_workflow::issue_lifecycle::IssueLifecycleState::Implementing
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn run_once_reconciles_runtime_merged_pr_workflow() -> anyhow::Result<()> {
     let _env_guard = async_env_lock().lock().await;
     if !crate::test_helpers::db_tests_enabled().await {

--- a/crates/harness-server/src/workflow_runtime_pr_feedback.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback.rs
@@ -9,9 +9,9 @@ use harness_workflow::runtime::{
     build_local_review_request_decision, build_pr_feedback_sweep_decision,
     build_pr_hygiene_repair_decision, DecisionValidator, LocalReviewDecisionInput,
     PrFeedbackSweepDecisionInput, PrHygieneRepairDecisionInput, ValidationContext,
-    WorkflowCommandStatus, WorkflowDecision, WorkflowDecisionTransition, WorkflowDefinition,
-    WorkflowEvidence, WorkflowInstance, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
-    WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY,
+    WorkflowCommandStatus, WorkflowDecision, WorkflowDecisionRecord, WorkflowDecisionTransition,
+    WorkflowDefinition, WorkflowEvidence, WorkflowInstance, WorkflowRejectedDecisionTransition,
+    WorkflowRuntimeStore, WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY,
     PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
 };
 use serde_json::json;

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/persistence.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/persistence.rs
@@ -7,6 +7,20 @@ pub(super) enum RuntimeDecisionCommitOutcome {
     Stale,
 }
 
+pub(super) fn outcome_from_atomic_record(
+    record: Option<WorkflowDecisionRecord>,
+) -> RuntimeDecisionCommitOutcome {
+    match record {
+        Some(record) if record.accepted => RuntimeDecisionCommitOutcome::Accepted,
+        Some(record) => RuntimeDecisionCommitOutcome::Rejected {
+            reason: record
+                .rejection_reason
+                .unwrap_or_else(|| "transition rejected by atomic validation".to_string()),
+        },
+        None => RuntimeDecisionCommitOutcome::Stale,
+    }
+}
+
 impl RuntimeDecisionCommitOutcome {
     #[cfg(test)]
     fn into_result(self) -> anyhow::Result<()> {
@@ -654,19 +668,19 @@ pub(super) async fn commit_runtime_decision(
     final_instance.data = merge_last_decision(accepted_data, &decision.decision);
     let create_if_missing = new_instance.then_some(&instance);
     let record = store
-        .apply_decision_transition(WorkflowDecisionTransition {
-            expected_state: &expected_state,
-            create_if_missing,
-            event_type,
-            source,
-            payload: event_payload,
-            decision: &decision,
-            final_instance: &final_instance,
-            command_status: WorkflowCommandStatus::Pending,
-        })
+        .apply_decision_transition(
+            WorkflowDecisionTransition {
+                expected_state: &expected_state,
+                create_if_missing,
+                event_type,
+                source,
+                payload: event_payload,
+                decision: &decision,
+                final_instance: &final_instance,
+                command_status: WorkflowCommandStatus::Pending,
+            },
+            "workflow-policy",
+        )
         .await?;
-    Ok(match record {
-        Some(_) => RuntimeDecisionCommitOutcome::Accepted,
-        None => RuntimeDecisionCommitOutcome::Stale,
-    })
+    Ok(outcome_from_atomic_record(record))
 }

--- a/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
+++ b/crates/harness-server/src/workflow_runtime_pr_feedback/tests.rs
@@ -282,6 +282,45 @@ async fn rejected_new_runtime_decision_persists_initial_instance() -> anyhow::Re
     Ok(())
 }
 
+#[test]
+fn atomic_validation_rejection_is_not_reported_as_accepted() {
+    let workflow_id = "atomic-validation-rejection";
+    let decision = WorkflowDecision::new(
+        workflow_id,
+        "addressing_feedback",
+        "address_feedback",
+        "local_review_gate",
+        "feedback addressed",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "run_local_review",
+        "atomic-validation-rejection-command",
+    ));
+
+    assert_eq!(
+        outcome_from_atomic_record(Some(WorkflowDecisionRecord::accepted(
+            decision.clone(),
+            Some("atomic-validation-event".to_string()),
+        ))),
+        RuntimeDecisionCommitOutcome::Accepted
+    );
+    assert_eq!(
+        outcome_from_atomic_record(None),
+        RuntimeDecisionCommitOutcome::Stale
+    );
+
+    let outcome = outcome_from_atomic_record(Some(WorkflowDecisionRecord::rejected(
+        decision,
+        Some("atomic-validation-event".to_string()),
+        "atomic validator rejected the transition",
+    )));
+
+    let RuntimeDecisionCommitOutcome::Rejected { reason } = outcome else {
+        panic!("atomic validator rejection must not be reported as success");
+    };
+    assert_eq!(reason, "atomic validator rejected the transition");
+}
+
 #[tokio::test]
 async fn pr_feedback_ready_to_merge_updates_parent_workflow_after_local_review(
 ) -> anyhow::Result<()> {

--- a/crates/harness-workflow/src/runtime/eval/mod.rs
+++ b/crates/harness-workflow/src/runtime/eval/mod.rs
@@ -9,7 +9,11 @@ pub mod manifest;
 pub mod model;
 pub mod report;
 pub mod run;
+#[cfg(test)]
+#[path = "run_concurrency_tests.rs"]
+mod run_concurrency_tests;
 pub mod scoring;
+mod transition_outcome;
 
 pub use evidence::{
     collect_eval_case_evidence, collect_eval_case_evidence_from_records, EvalCaseEvidence,

--- a/crates/harness-workflow/src/runtime/eval/run.rs
+++ b/crates/harness-workflow/src/runtime/eval/run.rs
@@ -1,4 +1,4 @@
-use super::manifest::EvalBenchmarkCase;
+use super::{manifest::EvalBenchmarkCase, transition_outcome::accepted_transition_record};
 use crate::runtime::{
     build_issue_submission_decision, IssueSubmissionDecisionInput, RuntimeCommandDispatcher,
     RuntimeJobStatus, RuntimeProfile, SubmissionMode, ValidationContext, WorkflowCommand,
@@ -160,30 +160,36 @@ pub async fn enqueue_eval_case_workflow(
     submitted_instance.state = decision.next_state.clone();
     submitted_instance.version = submitted_instance.version.saturating_add(1);
     submitted_instance.data = eval_case_submitted_data(input, &decision.decision);
-    let record = store
-        .apply_decision_transition(WorkflowDecisionTransition {
-            expected_state: &initial_instance.state,
-            create_if_missing: Some(&initial_instance),
-            event_type: "EvalCaseSubmitted",
-            source: "eval-run",
-            payload: json!({
-                "eval_run_id": input.eval_run_id,
-                "case_id": input.case.case_id,
-                "issue": input.case.issue,
-                "repo": input.case.repo,
-            }),
-            decision: &decision,
-            final_instance: &submitted_instance,
-            command_status: WorkflowCommandStatus::Pending,
-        })
-        .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "eval case workflow {} was not in the expected `{}` state",
-                initial_instance.id,
-                initial_instance.state
+    let record = accepted_transition_record(
+        store
+            .apply_decision_transition(
+                WorkflowDecisionTransition {
+                    expected_state: &initial_instance.state,
+                    create_if_missing: Some(&initial_instance),
+                    event_type: "EvalCaseSubmitted",
+                    source: "eval-run",
+                    payload: json!({
+                        "eval_run_id": input.eval_run_id,
+                        "case_id": input.case.case_id,
+                        "issue": input.case.issue,
+                        "repo": input.case.repo,
+                    }),
+                    decision: &decision,
+                    final_instance: &submitted_instance,
+                    command_status: WorkflowCommandStatus::Pending,
+                },
+                "eval-run",
             )
-        })?;
+            .await?,
+        &initial_instance.id,
+        "eval case enqueue",
+    )?
+    .ok_or_else(|| {
+        anyhow::anyhow!(
+            "eval case workflow {} changed or disappeared before commit",
+            initial_instance.id
+        )
+    })?;
     let command_ids = store
         .commands_for(&submitted_instance.id)
         .await?
@@ -287,15 +293,28 @@ pub async fn cleanup_cancelled_eval_run(
         let mut final_instance = instance.clone();
         if !instance.is_terminal() {
             match cancel_eval_workflow_instance(store, &instance, eval_run_id, case, reason).await {
-                Ok(Some(cancelled_instance)) => {
-                    summary.workflows_cancelled += 1;
-                    final_instance = cancelled_instance;
-                }
+                Ok(Some(_)) => summary.workflows_cancelled += 1,
                 Ok(None) => {}
                 Err(error) => {
                     summary.record_failure(&case.case_id, &workflow_id, "cancel_workflow", error);
                 }
             }
+            final_instance = match store.get_instance(&workflow_id).await {
+                Ok(Some(latest_instance)) => latest_instance,
+                Ok(None) => {
+                    summary.record_failure(
+                        &case.case_id,
+                        &workflow_id,
+                        "reload_workflow",
+                        "workflow disappeared after cleanup transition",
+                    );
+                    instance.clone()
+                }
+                Err(error) => {
+                    summary.record_failure(&case.case_id, &workflow_id, "reload_workflow", error);
+                    continue;
+                }
+            };
         };
 
         if let Err(error) =
@@ -356,22 +375,29 @@ async fn cancel_eval_workflow_instance(
         &ValidationContext::new("eval-cleanup", Utc::now()),
     )?;
 
-    let record = store
-        .apply_decision_transition(WorkflowDecisionTransition {
-            expected_state: &observed_state,
-            create_if_missing: None,
-            event_type: "EvalRunCancelled",
-            source: "eval-cleanup",
-            payload: json!({
-                "eval_run_id": eval_run_id,
-                "case_id": case.case_id,
-                "reason": reason,
-            }),
-            decision: &decision,
-            final_instance: &final_instance,
-            command_status: WorkflowCommandStatus::Pending,
-        })
-        .await?;
+    let record = accepted_transition_record(
+        store
+            .apply_decision_transition(
+                WorkflowDecisionTransition {
+                    expected_state: &observed_state,
+                    create_if_missing: None,
+                    event_type: "EvalRunCancelled",
+                    source: "eval-cleanup",
+                    payload: json!({
+                        "eval_run_id": eval_run_id,
+                        "case_id": case.case_id,
+                        "reason": reason,
+                    }),
+                    decision: &decision,
+                    final_instance: &final_instance,
+                    command_status: WorkflowCommandStatus::Pending,
+                },
+                "eval-cleanup",
+            )
+            .await?,
+        &instance.id,
+        "eval cleanup",
+    )?;
     Ok(record.map(|_| final_instance))
 }
 
@@ -461,7 +487,7 @@ fn active_runtime_job_status(status: RuntimeJobStatus) -> bool {
     )
 }
 
-fn eval_case_initial_instance(input: EvalCaseWorkflowInput<'_>) -> WorkflowInstance {
+pub(super) fn eval_case_initial_instance(input: EvalCaseWorkflowInput<'_>) -> WorkflowInstance {
     WorkflowInstance::new(
         GITHUB_ISSUE_PR_DEFINITION_ID,
         1,
@@ -745,7 +771,6 @@ mod tests {
             },
         )
         .await?;
-
         assert_eq!(outcome.dispatched_jobs, 1);
         assert_eq!(outcome.enqueue.command_ids.len(), 1);
         let jobs = store
@@ -762,7 +787,6 @@ mod tests {
             jobs[0].input["command"]["pull_request_mode"],
             EVAL_PR_DRAFT_MODE
         );
-
         Ok(())
     }
 }

--- a/crates/harness-workflow/src/runtime/eval/run_concurrency_tests.rs
+++ b/crates/harness-workflow/src/runtime/eval/run_concurrency_tests.rs
@@ -1,0 +1,282 @@
+use super::manifest::EvalBenchmarkCase;
+use super::run::*;
+use crate::runtime::{WorkflowCommandStatus, WorkflowRuntimeStore};
+use serde_json::json;
+use tokio::time::{sleep, timeout, Duration};
+
+fn benchmark_case(case_id: &str) -> EvalBenchmarkCase {
+    EvalBenchmarkCase {
+        case_id: case_id.to_string(),
+        repo: "owner/repo".to_string(),
+        issue: 42,
+        base_commit: "abcdef1".to_string(),
+        verify_commands: vec!["cargo test -p harness-workflow eval_run".to_string()],
+        timeout_secs: 120,
+    }
+}
+
+async fn wait_for_command_cancellation(
+    lock_tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    command_id: &str,
+) -> anyhow::Result<()> {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let status: Option<(String,)> =
+                sqlx::query_as("SELECT status FROM workflow_commands WHERE id = $1")
+                    .bind(command_id)
+                    .fetch_optional(&mut **lock_tx)
+                    .await?;
+            if status
+                .as_ref()
+                .is_some_and(|(status,)| status == WorkflowCommandStatus::Cancelled.as_str())
+            {
+                return Ok::<(), anyhow::Error>(());
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .map_err(|_| anyhow::anyhow!("cleanup did not cancel its command before the lock timeout"))?
+}
+
+#[tokio::test]
+async fn eval_enqueue_does_not_return_a_plan_for_a_same_state_stale_snapshot() -> anyhow::Result<()>
+{
+    if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime_store")).await?;
+    let case = benchmark_case("owner/repo#stale-enqueue");
+    let project_id = dir.path().to_string_lossy();
+    let input = EvalCaseWorkflowInput {
+        eval_run_id: "run-stale-enqueue",
+        case: &case,
+        project_id: project_id.as_ref(),
+        task_id: "eval-stale-enqueue-task",
+        additional_prompt: None,
+    };
+    let mut concurrent_instance = eval_case_initial_instance(input);
+    concurrent_instance.version = concurrent_instance.version.saturating_add(1);
+    concurrent_instance.data["concurrent_marker"] = json!("preserve-me");
+    store.upsert_instance(&concurrent_instance).await?;
+
+    let error = enqueue_eval_case_workflow(&store, input)
+        .await
+        .expect_err("a stale atomic transition must not return an enqueue plan");
+
+    assert!(
+        error
+            .to_string()
+            .contains("changed or disappeared before commit"),
+        "unexpected error: {error}"
+    );
+    let stored = store
+        .get_instance(&concurrent_instance.id)
+        .await?
+        .expect("the concurrent instance must remain");
+    assert_eq!(stored.version, concurrent_instance.version);
+    assert_eq!(stored.data["concurrent_marker"], "preserve-me");
+    assert!(store.events_for(&concurrent_instance.id).await?.is_empty());
+    assert!(store
+        .decisions_for(&concurrent_instance.id)
+        .await?
+        .is_empty());
+    assert!(store
+        .commands_for(&concurrent_instance.id)
+        .await?
+        .is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn eval_cleanup_reloads_latest_instance_after_a_same_state_stale_transition(
+) -> anyhow::Result<()> {
+    if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store_path = dir.path().join("workflow_runtime_store");
+    let store = WorkflowRuntimeStore::open(&store_path).await?;
+    let cleanup_store = WorkflowRuntimeStore::open(&store_path).await?;
+    let case = benchmark_case("owner/repo#stale-cleanup");
+    let enqueue = enqueue_eval_case_workflow(
+        &store,
+        EvalCaseWorkflowInput {
+            eval_run_id: "run-stale-cleanup",
+            case: &case,
+            project_id: dir.path().to_string_lossy().as_ref(),
+            task_id: "eval-stale-cleanup-task",
+            additional_prompt: None,
+        },
+    )
+    .await?;
+    let workflow_id = enqueue.plan.workflow_id.clone();
+    let command_id = enqueue
+        .command_ids
+        .first()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("eval enqueue must create a command"))?;
+    let mut concurrent_instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("eval workflow must exist"))?;
+    concurrent_instance.version = concurrent_instance
+        .version
+        .checked_add(1)
+        .ok_or_else(|| anyhow::anyhow!("test workflow version overflow"))?;
+    concurrent_instance.data["eval"]["workspace_path"] = json!("/tmp/eval-stale-worktree");
+    let concurrent_data = serde_json::to_string(&concurrent_instance)?;
+
+    let mut lock_tx = store.pool().begin().await?;
+    let _: (String,) = sqlx::query_as("SELECT id FROM workflow_instances WHERE id = $1 FOR UPDATE")
+        .bind(&workflow_id)
+        .fetch_one(&mut *lock_tx)
+        .await?;
+
+    let cleanup_case = case.clone();
+    let cleanup_task = tokio::spawn(async move {
+        cleanup_cancelled_eval_run(
+            &cleanup_store,
+            EvalRunCleanupInput {
+                eval_run_id: "run-stale-cleanup",
+                cases: std::slice::from_ref(&cleanup_case),
+                reason: "operator cancelled eval run",
+            },
+        )
+        .await
+    });
+
+    wait_for_command_cancellation(&mut lock_tx, &command_id).await?;
+
+    let updated = sqlx::query(
+        "UPDATE workflow_instances
+         SET data = $2::jsonb, version = $3, updated_at = CURRENT_TIMESTAMP
+         WHERE id = $1",
+    )
+    .bind(&workflow_id)
+    .bind(&concurrent_data)
+    .bind(i64::try_from(concurrent_instance.version)?)
+    .execute(&mut *lock_tx)
+    .await?;
+    assert_eq!(updated.rows_affected(), 1);
+    lock_tx.commit().await?;
+
+    let joined = timeout(Duration::from_secs(5), cleanup_task)
+        .await
+        .map_err(|_| anyhow::anyhow!("cleanup did not finish after releasing the row lock"))?;
+    let summary = joined??;
+
+    assert_eq!(summary.workflows_seen, 1);
+    assert_eq!(summary.commands_cancelled, 1);
+    assert_eq!(summary.workflows_cancelled, 0);
+    assert_eq!(summary.active_workflows, 1);
+    assert_eq!(summary.active_commands, 0);
+    assert_eq!(summary.orphan_workspaces, 1);
+    assert!(summary.cleanup_failures.is_empty());
+    let stored = store
+        .get_instance(&workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("concurrent workflow must remain"))?;
+    assert_eq!(stored.version, concurrent_instance.version);
+    assert_eq!(
+        stored.data["eval"]["workspace_path"],
+        "/tmp/eval-stale-worktree"
+    );
+    assert!(
+        store
+            .decisions_for(&workflow_id)
+            .await?
+            .iter()
+            .all(|record| record.decision.decision != "cancel_eval_run"),
+        "a stale cleanup transition must not record a cancellation decision"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn eval_cleanup_reports_reload_failure_when_the_workflow_disappears() -> anyhow::Result<()> {
+    if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store_path = dir.path().join("workflow_runtime_store");
+    let store = WorkflowRuntimeStore::open(&store_path).await?;
+    let cleanup_store = WorkflowRuntimeStore::open(&store_path).await?;
+    let case = benchmark_case("owner/repo#missing-cleanup");
+    let enqueue = enqueue_eval_case_workflow(
+        &store,
+        EvalCaseWorkflowInput {
+            eval_run_id: "run-missing-cleanup",
+            case: &case,
+            project_id: dir.path().to_string_lossy().as_ref(),
+            task_id: "eval-missing-cleanup-task",
+            additional_prompt: None,
+        },
+    )
+    .await?;
+    let workflow_id = enqueue.plan.workflow_id.clone();
+    let command_id = enqueue
+        .command_ids
+        .first()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("eval enqueue must create a command"))?;
+    let mut prior_instance = store
+        .get_instance(&workflow_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("eval workflow must exist"))?;
+    prior_instance.version = prior_instance
+        .version
+        .checked_add(1)
+        .ok_or_else(|| anyhow::anyhow!("test workflow version overflow"))?;
+    prior_instance.data["eval"]["workspace_path"] = json!("/tmp/eval-missing-worktree");
+    prior_instance.data["eval"]["pr_number"] = json!(99);
+    store.upsert_instance(&prior_instance).await?;
+
+    let mut lock_tx = store.pool().begin().await?;
+    let _: (String,) = sqlx::query_as("SELECT id FROM workflow_instances WHERE id = $1 FOR UPDATE")
+        .bind(&workflow_id)
+        .fetch_one(&mut *lock_tx)
+        .await?;
+
+    let cleanup_case = case.clone();
+    let cleanup_task = tokio::spawn(async move {
+        cleanup_cancelled_eval_run(
+            &cleanup_store,
+            EvalRunCleanupInput {
+                eval_run_id: "run-missing-cleanup",
+                cases: std::slice::from_ref(&cleanup_case),
+                reason: "operator cancelled eval run",
+            },
+        )
+        .await
+    });
+
+    wait_for_command_cancellation(&mut lock_tx, &command_id).await?;
+    let deleted = sqlx::query("DELETE FROM workflow_instances WHERE id = $1")
+        .bind(&workflow_id)
+        .execute(&mut *lock_tx)
+        .await?;
+    assert_eq!(deleted.rows_affected(), 1);
+    lock_tx.commit().await?;
+
+    let joined = timeout(Duration::from_secs(5), cleanup_task)
+        .await
+        .map_err(|_| anyhow::anyhow!("cleanup did not finish after releasing the row lock"))?;
+    let summary = joined??;
+
+    assert_eq!(summary.workflows_seen, 1);
+    assert_eq!(summary.commands_cancelled, 1);
+    assert_eq!(summary.workflows_cancelled, 0);
+    assert_eq!(summary.active_workflows, 1);
+    assert_eq!(summary.orphan_workspaces, 1);
+    assert_eq!(summary.orphan_pull_requests, 1);
+    assert!(!summary.is_clean());
+    assert_eq!(summary.cleanup_failures.len(), 1);
+    assert_eq!(summary.cleanup_failures[0].step, "reload_workflow");
+    assert!(summary.cleanup_failures[0]
+        .error
+        .contains("workflow disappeared"));
+    assert!(store.get_instance(&workflow_id).await?.is_none());
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/eval/run_concurrency_tests.rs
+++ b/crates/harness-workflow/src/runtime/eval/run_concurrency_tests.rs
@@ -1,6 +1,7 @@
 use super::manifest::EvalBenchmarkCase;
 use super::run::*;
 use crate::runtime::{WorkflowCommandStatus, WorkflowRuntimeStore};
+use harness_core::db::resolve_database_url;
 use serde_json::json;
 use tokio::time::{sleep, timeout, Duration};
 
@@ -42,7 +43,7 @@ async fn wait_for_command_cancellation(
 #[tokio::test]
 async fn eval_enqueue_does_not_return_a_plan_for_a_same_state_stale_snapshot() -> anyhow::Result<()>
 {
-    if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
+    if resolve_database_url(None).is_err() {
         return Ok(());
     }
     let dir = tempfile::tempdir()?;
@@ -92,7 +93,7 @@ async fn eval_enqueue_does_not_return_a_plan_for_a_same_state_stale_snapshot() -
 #[tokio::test]
 async fn eval_cleanup_reloads_latest_instance_after_a_same_state_stale_transition(
 ) -> anyhow::Result<()> {
-    if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
+    if resolve_database_url(None).is_err() {
         return Ok(());
     }
     let dir = tempfile::tempdir()?;
@@ -196,7 +197,7 @@ async fn eval_cleanup_reloads_latest_instance_after_a_same_state_stale_transitio
 
 #[tokio::test]
 async fn eval_cleanup_reports_reload_failure_when_the_workflow_disappears() -> anyhow::Result<()> {
-    if std::env::var_os("HARNESS_DATABASE_URL").is_none() {
+    if resolve_database_url(None).is_err() {
         return Ok(());
     }
     let dir = tempfile::tempdir()?;

--- a/crates/harness-workflow/src/runtime/eval/transition_outcome.rs
+++ b/crates/harness-workflow/src/runtime/eval/transition_outcome.rs
@@ -1,0 +1,59 @@
+use crate::runtime::WorkflowDecisionRecord;
+
+pub(super) fn accepted_transition_record(
+    record: Option<WorkflowDecisionRecord>,
+    workflow_id: &str,
+    operation: &str,
+) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
+    match record {
+        Some(record) if record.accepted => Ok(Some(record)),
+        Some(record) => {
+            let reason = record
+                .rejection_reason
+                .as_deref()
+                .unwrap_or("unspecified validator rejection");
+            anyhow::bail!("{operation} for workflow `{workflow_id}` was rejected: {reason}");
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::WorkflowDecision;
+
+    fn eval_decision() -> WorkflowDecision {
+        WorkflowDecision::new(
+            "eval-transition-outcome",
+            "implementing",
+            "cancel_eval_run",
+            "cancelled",
+            "operator cancelled eval run",
+        )
+    }
+
+    #[test]
+    fn accepted_transition_record_distinguishes_all_atomic_outcomes() {
+        let accepted = WorkflowDecisionRecord::accepted(eval_decision(), None);
+        assert!(
+            accepted_transition_record(Some(accepted), "workflow-1", "eval cleanup")
+                .expect("accepted transition should succeed")
+                .is_some()
+        );
+        assert!(
+            accepted_transition_record(None, "workflow-1", "eval cleanup")
+                .expect("stale transition should remain distinguishable")
+                .is_none()
+        );
+
+        let rejected =
+            WorkflowDecisionRecord::rejected(eval_decision(), None, "lease expired before commit");
+        let error = accepted_transition_record(Some(rejected), "workflow-1", "eval cleanup")
+            .expect_err("rejected transition must fail");
+        assert_eq!(
+            error.to_string(),
+            "eval cleanup for workflow `workflow-1` was rejected: lease expired before commit"
+        );
+    }
+}

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -29,6 +29,8 @@ mod command_facade;
 mod command_store;
 #[path = "store/coverage_recovery.rs"]
 mod coverage_recovery;
+#[path = "store/decision_transitions.rs"]
+mod decision_transitions;
 #[path = "store/decisions.rs"]
 mod decisions;
 #[path = "store/definitions.rs"]
@@ -65,6 +67,8 @@ mod submission_instances;
 mod terminal_instance_queries;
 #[path = "store/transaction_helpers.rs"]
 mod transaction_helpers;
+#[path = "store/transition_validation.rs"]
+mod transition_validation;
 pub use coverage_recovery::{
     WorkflowCoverageRecoveryExpected, WorkflowCoverageRecoveryOutcome,
     WorkflowCoverageRecoveryTransition,

--- a/crates/harness-workflow/src/runtime/store/decision_transitions.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions.rs
@@ -1,0 +1,177 @@
+//! Decision-driven state transitions committed from a caller-supplied final
+//! instance.
+//!
+//! Extracted from `instances.rs` so the validation funnel (GH-1784) has one
+//! home; every write here must pass `validate_transition` first.
+
+use super::{
+    command_store, insert_decision_record_tx, insert_event_tx, load_or_insert_initial_instance_tx,
+    to_jsonb_string,
+    transition_validation::{validate_transition, TransitionValidation},
+    WorkflowDecisionTransition, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
+};
+use crate::runtime::model::WorkflowDecisionRecord;
+#[cfg(test)]
+use crate::runtime::model::{WorkflowDecision, WorkflowInstance};
+use crate::runtime::status::WorkflowCommandStatus;
+
+impl WorkflowRuntimeStore {
+    pub async fn apply_decision_transition(
+        &self,
+        transition: WorkflowDecisionTransition<'_>,
+    ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
+        let final_instance = transition.final_instance;
+        let decision = transition.decision;
+        if decision.workflow_id != final_instance.id {
+            anyhow::bail!(
+                "workflow decision `{}` targets `{}` but final instance is `{}`",
+                decision.decision,
+                decision.workflow_id,
+                final_instance.id
+            );
+        }
+        let mut tx = self.pool.begin().await?;
+        let Some(current) = load_or_insert_initial_instance_tx(
+            &mut tx,
+            &final_instance.id,
+            transition.expected_state,
+            transition.create_if_missing,
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        if current.is_terminal() || current.state != transition.expected_state {
+            return Ok(None);
+        }
+
+        let event = insert_event_tx(
+            &mut tx,
+            &final_instance.id,
+            transition.event_type,
+            transition.source,
+            transition.payload,
+        )
+        .await?;
+
+        // GH-1784: this path used to write `final_instance` verbatim after only
+        // an expected-state and non-terminality check, so the transition
+        // allowlist and required commands/evidence were never consulted.
+        let record =
+            match validate_transition(&current, decision, transition.source, event.created_at) {
+                TransitionValidation::Accepted => {
+                    WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id))
+                }
+                TransitionValidation::Rejected(reason) => {
+                    let record =
+                        WorkflowDecisionRecord::rejected(decision.clone(), Some(event.id), reason);
+                    insert_decision_record_tx(&mut tx, &record).await?;
+                    tx.commit().await?;
+                    return Ok(Some(record));
+                }
+            };
+        let decision_data = to_jsonb_string(&record)?;
+        sqlx::query(
+            "INSERT INTO workflow_decisions
+                (id, workflow_id, event_id, accepted, data, rejection_reason)
+             VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+             ON CONFLICT (id) DO UPDATE SET
+                accepted = EXCLUDED.accepted,
+                data = EXCLUDED.data,
+                rejection_reason = EXCLUDED.rejection_reason",
+        )
+        .bind(&record.id)
+        .bind(&record.workflow_id)
+        .bind(&record.event_id)
+        .bind(record.accepted)
+        .bind(&decision_data)
+        .bind(&record.rejection_reason)
+        .execute(&mut *tx)
+        .await?;
+
+        for command in &decision.commands {
+            let status = if command.requires_runtime_job() {
+                transition.command_status
+            } else {
+                WorkflowCommandStatus::HandledInline
+            };
+            command_store::insert_tx(
+                &mut tx,
+                &final_instance.id,
+                Some(&record.id),
+                command,
+                status,
+            )
+            .await?;
+        }
+
+        let instance_data = to_jsonb_string(final_instance)?;
+        sqlx::query(
+            "INSERT INTO workflow_instances
+                (id, definition_id, state, subject_type, subject_key, parent_workflow_id, data, version)
+             VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+             ON CONFLICT (id) DO UPDATE SET
+                definition_id = EXCLUDED.definition_id,
+                state = EXCLUDED.state,
+                subject_type = EXCLUDED.subject_type,
+                subject_key = EXCLUDED.subject_key,
+                parent_workflow_id = EXCLUDED.parent_workflow_id,
+                data = EXCLUDED.data,
+                version = EXCLUDED.version,
+                updated_at = CURRENT_TIMESTAMP",
+        )
+        .bind(&final_instance.id)
+        .bind(&final_instance.definition_id)
+        .bind(&final_instance.state)
+        .bind(&final_instance.subject.subject_type)
+        .bind(&final_instance.subject.subject_key)
+        .bind(&final_instance.parent_workflow_id)
+        .bind(&instance_data)
+        .bind(final_instance.version as i64)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(Some(record))
+    }
+
+    pub async fn record_rejected_decision_transition(
+        &self,
+        transition: WorkflowRejectedDecisionTransition<'_>,
+    ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
+        let decision = transition.decision;
+        let mut tx = self.pool.begin().await?;
+        let Some(current) = load_or_insert_initial_instance_tx(
+            &mut tx,
+            &decision.workflow_id,
+            transition.expected_state,
+            transition.create_if_missing,
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        if current.is_terminal() || current.state != transition.expected_state {
+            return Ok(None);
+        }
+
+        let event = insert_event_tx(
+            &mut tx,
+            &decision.workflow_id,
+            transition.event_type,
+            transition.source,
+            transition.payload,
+        )
+        .await?;
+        let record =
+            WorkflowDecisionRecord::rejected(decision.clone(), Some(event.id), transition.reason);
+        insert_decision_record_tx(&mut tx, &record).await?;
+
+        tx.commit().await?;
+        Ok(Some(record))
+    }
+}
+
+#[cfg(test)]
+#[path = "decision_transitions_tests.rs"]
+mod tests;

--- a/crates/harness-workflow/src/runtime/store/decision_transitions.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions.rs
@@ -10,15 +10,54 @@ use super::{
     transition_validation::{validate_transition, TransitionValidation},
     WorkflowDecisionTransition, WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
 };
-use crate::runtime::model::WorkflowDecisionRecord;
 #[cfg(test)]
-use crate::runtime::model::{WorkflowDecision, WorkflowInstance};
+use crate::runtime::model::WorkflowDecision;
+use crate::runtime::model::{WorkflowDecisionRecord, WorkflowInstance};
 use crate::runtime::status::WorkflowCommandStatus;
 
+fn ensure_protected_instance_fields_match(
+    current: &WorkflowInstance,
+    final_instance: &WorkflowInstance,
+) -> anyhow::Result<()> {
+    let mut changed_fields = Vec::new();
+    if current.definition_id != final_instance.definition_id {
+        changed_fields.push("definition_id");
+    }
+    if current.definition_version != final_instance.definition_version {
+        changed_fields.push("definition_version");
+    }
+    if current.subject != final_instance.subject {
+        changed_fields.push("subject");
+    }
+    if current.parent_workflow_id != final_instance.parent_workflow_id {
+        changed_fields.push("parent_workflow_id");
+    }
+    if current.lease != final_instance.lease {
+        changed_fields.push("lease");
+    }
+    if current.created_at != final_instance.created_at {
+        changed_fields.push("created_at");
+    }
+    if !changed_fields.is_empty() {
+        anyhow::bail!(
+            "workflow transition final instance changes protected fields: {}",
+            changed_fields.join(", ")
+        );
+    }
+    Ok(())
+}
+
 impl WorkflowRuntimeStore {
+    /// Persist a decision attempt against the current instance.
+    ///
+    /// `Some(record)` means a decision record was committed, not necessarily
+    /// that the instance transitioned. Callers must inspect `record.accepted`
+    /// before running success side effects. `None` is reserved for a stale or
+    /// terminal instance that produced no decision record.
     pub async fn apply_decision_transition(
         &self,
         transition: WorkflowDecisionTransition<'_>,
+        validation_actor: &str,
     ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
         let final_instance = transition.final_instance;
         let decision = transition.decision;
@@ -28,6 +67,14 @@ impl WorkflowRuntimeStore {
                 decision.decision,
                 decision.workflow_id,
                 final_instance.id
+            );
+        }
+        if final_instance.state != decision.next_state {
+            anyhow::bail!(
+                "workflow decision `{}` validates next state `{}` but final instance state is `{}`",
+                decision.decision,
+                decision.next_state,
+                final_instance.state
             );
         }
         let mut tx = self.pool.begin().await?;
@@ -44,6 +91,10 @@ impl WorkflowRuntimeStore {
         if current.is_terminal() || current.state != transition.expected_state {
             return Ok(None);
         }
+        if current.version.checked_add(1) != Some(final_instance.version) {
+            return Ok(None);
+        }
+        ensure_protected_instance_fields_match(&current, final_instance)?;
 
         let event = insert_event_tx(
             &mut tx,
@@ -58,7 +109,7 @@ impl WorkflowRuntimeStore {
         // an expected-state and non-terminality check, so the transition
         // allowlist and required commands/evidence were never consulted.
         let record =
-            match validate_transition(&current, decision, transition.source, event.created_at) {
+            match validate_transition(&current, decision, validation_actor, event.created_at) {
                 TransitionValidation::Accepted => {
                     WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id))
                 }

--- a/crates/harness-workflow/src/runtime/store/decision_transitions.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions.rs
@@ -121,24 +121,7 @@ impl WorkflowRuntimeStore {
                     return Ok(Some(record));
                 }
             };
-        let decision_data = to_jsonb_string(&record)?;
-        sqlx::query(
-            "INSERT INTO workflow_decisions
-                (id, workflow_id, event_id, accepted, data, rejection_reason)
-             VALUES ($1, $2, $3, $4, $5::jsonb, $6)
-             ON CONFLICT (id) DO UPDATE SET
-                accepted = EXCLUDED.accepted,
-                data = EXCLUDED.data,
-                rejection_reason = EXCLUDED.rejection_reason",
-        )
-        .bind(&record.id)
-        .bind(&record.workflow_id)
-        .bind(&record.event_id)
-        .bind(record.accepted)
-        .bind(&decision_data)
-        .bind(&record.rejection_reason)
-        .execute(&mut *tx)
-        .await?;
+        insert_decision_record_tx(&mut tx, &record).await?;
 
         for command in &decision.commands {
             let status = if command.requires_runtime_job() {

--- a/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
@@ -1,0 +1,124 @@
+//! GH-1784 regression tests: every state-changing write must be validated.
+
+use super::*;
+use crate::runtime::{WorkflowCommand, WorkflowSubject};
+use harness_core::db::resolve_database_url;
+use serde_json::json;
+
+fn instance(id: &str, state: &str) -> WorkflowInstance {
+    WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        state,
+        WorkflowSubject::new("pr", "4242"),
+    )
+    .with_id(id)
+    .with_data(json!({ "project_id": "/project-a", "pr_number": 4242 }))
+}
+
+/// `implementing -> ready_to_merge` is absent from the github_issue_pr
+/// allowlist, so the decision must be recorded as rejected and the caller's
+/// `final_instance` must not be persisted.
+#[tokio::test]
+async fn apply_decision_transition_rejects_a_transition_outside_the_allowlist() -> anyhow::Result<()>
+{
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let initial = instance("gh1784-apply-decision-rejects", "implementing");
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "implementing",
+        "skip_the_gates",
+        "ready_to_merge",
+        "jump straight to merge",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "run_local_review",
+        "gh1784-apply-decision-command",
+    ));
+    let mut final_instance = initial.clone();
+    final_instance.state = "ready_to_merge".to_string();
+    final_instance.version = final_instance.version.saturating_add(1);
+
+    let record = store
+        .apply_decision_transition(WorkflowDecisionTransition {
+            expected_state: &initial.state,
+            create_if_missing: Some(&initial),
+            event_type: "IssueSubmitted",
+            source: "workflow-runtime-test",
+            payload: json!({}),
+            decision: &decision,
+            final_instance: &final_instance,
+            command_status: WorkflowCommandStatus::Pending,
+        })
+        .await?
+        .expect("the transition should produce a decision record");
+
+    assert!(!record.accepted, "allowlist violation must be rejected");
+    let stored = store
+        .get_instance(&initial.id)
+        .await?
+        .expect("instance should exist");
+    assert_eq!(
+        stored.state, "implementing",
+        "a rejected decision must not move the instance"
+    );
+    assert!(
+        store.commands_for(&initial.id).await?.is_empty(),
+        "a rejected decision must not enqueue its commands"
+    );
+    Ok(())
+}
+
+/// The same path must still accept an allowlisted transition.
+#[tokio::test]
+async fn apply_decision_transition_accepts_an_allowlisted_transition() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let initial = instance("gh1784-apply-decision-accepts", "addressing_feedback");
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "addressing_feedback",
+        "address_feedback",
+        "local_review_gate",
+        "feedback addressed",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "run_local_review",
+        "gh1784-accepts-command",
+    ));
+    let mut final_instance = initial.clone();
+    final_instance.state = "local_review_gate".to_string();
+    final_instance.version = final_instance.version.saturating_add(1);
+
+    let record = store
+        .apply_decision_transition(WorkflowDecisionTransition {
+            expected_state: &initial.state,
+            create_if_missing: Some(&initial),
+            event_type: "IssueSubmitted",
+            source: "workflow-runtime-test",
+            payload: json!({}),
+            decision: &decision,
+            final_instance: &final_instance,
+            command_status: WorkflowCommandStatus::Pending,
+        })
+        .await?
+        .expect("the transition should produce a decision record");
+
+    assert!(record.accepted, "allowlisted transition must be accepted");
+    let stored = store
+        .get_instance(&initial.id)
+        .await?
+        .expect("instance should exist");
+    assert_eq!(stored.state, "local_review_gate");
+    assert_eq!(store.commands_for(&initial.id).await?.len(), 1);
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
@@ -1,7 +1,8 @@
-//! GH-1784 regression tests: every state-changing write must be validated.
+//! GH-1784 regression tests for validated decision-transition writes.
 
 use super::*;
 use crate::runtime::{WorkflowCommand, WorkflowSubject};
+use chrono::{Duration, Utc};
 use harness_core::db::resolve_database_url;
 use serde_json::json;
 
@@ -45,20 +46,32 @@ async fn apply_decision_transition_rejects_a_transition_outside_the_allowlist() 
     final_instance.version = final_instance.version.saturating_add(1);
 
     let record = store
-        .apply_decision_transition(WorkflowDecisionTransition {
-            expected_state: &initial.state,
-            create_if_missing: Some(&initial),
-            event_type: "IssueSubmitted",
-            source: "workflow-runtime-test",
-            payload: json!({}),
-            decision: &decision,
-            final_instance: &final_instance,
-            command_status: WorkflowCommandStatus::Pending,
-        })
+        .apply_decision_transition(
+            WorkflowDecisionTransition {
+                expected_state: &initial.state,
+                create_if_missing: Some(&initial),
+                event_type: "IssueSubmitted",
+                source: "workflow-runtime-test",
+                payload: json!({}),
+                decision: &decision,
+                final_instance: &final_instance,
+                command_status: WorkflowCommandStatus::Pending,
+            },
+            "workflow-runtime-test",
+        )
         .await?
-        .expect("the transition should produce a decision record");
+        .expect("a rejected decision must remain durably observable");
 
-    assert!(!record.accepted, "allowlist violation must be rejected");
+    assert!(
+        !record.accepted,
+        "the returned record must distinguish rejection from an applied transition"
+    );
+    let decisions = store.decisions_for(&initial.id).await?;
+    assert_eq!(decisions.len(), 1);
+    assert!(
+        !decisions[0].accepted,
+        "allowlist violation must remain durably recorded"
+    );
     let stored = store
         .get_instance(&initial.id)
         .await?
@@ -100,16 +113,19 @@ async fn apply_decision_transition_accepts_an_allowlisted_transition() -> anyhow
     final_instance.version = final_instance.version.saturating_add(1);
 
     let record = store
-        .apply_decision_transition(WorkflowDecisionTransition {
-            expected_state: &initial.state,
-            create_if_missing: Some(&initial),
-            event_type: "IssueSubmitted",
-            source: "workflow-runtime-test",
-            payload: json!({}),
-            decision: &decision,
-            final_instance: &final_instance,
-            command_status: WorkflowCommandStatus::Pending,
-        })
+        .apply_decision_transition(
+            WorkflowDecisionTransition {
+                expected_state: &initial.state,
+                create_if_missing: Some(&initial),
+                event_type: "IssueSubmitted",
+                source: "workflow-runtime-test",
+                payload: json!({}),
+                decision: &decision,
+                final_instance: &final_instance,
+                command_status: WorkflowCommandStatus::Pending,
+            },
+            "workflow-runtime-test",
+        )
         .await?
         .expect("the transition should produce a decision record");
 
@@ -120,5 +136,247 @@ async fn apply_decision_transition_accepts_an_allowlisted_transition() -> anyhow
         .expect("instance should exist");
     assert_eq!(stored.state, "local_review_gate");
     assert_eq!(store.commands_for(&initial.id).await?.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn apply_decision_transition_uses_the_explicit_validation_actor() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let initial = instance("gh1784-explicit-validation-actor", "addressing_feedback")
+        .with_lease("workflow-policy", Utc::now() + Duration::minutes(5));
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "addressing_feedback",
+        "address_feedback",
+        "local_review_gate",
+        "feedback addressed",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "run_local_review",
+        "gh1784-explicit-actor-command",
+    ));
+    let mut final_instance = initial.clone();
+    final_instance.state = decision.next_state.clone();
+    final_instance.version = final_instance.version.saturating_add(1);
+
+    let record = store
+        .apply_decision_transition(
+            WorkflowDecisionTransition {
+                expected_state: &initial.state,
+                create_if_missing: Some(&initial),
+                event_type: "MergeApproved",
+                source: "workflow_runtime_dashboard",
+                payload: json!({}),
+                decision: &decision,
+                final_instance: &final_instance,
+                command_status: WorkflowCommandStatus::Pending,
+            },
+            "workflow-policy",
+        )
+        .await?
+        .expect("the validation actor should satisfy the active lease");
+
+    assert!(record.accepted);
+    assert_eq!(
+        store
+            .events_for(&initial.id)
+            .await?
+            .into_iter()
+            .next()
+            .expect("transition event")
+            .source,
+        "workflow_runtime_dashboard",
+        "event provenance must remain independent from validator authority"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn apply_decision_transition_rejects_a_mismatched_final_state() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let initial = instance("gh1784-final-state-mismatch", "addressing_feedback");
+    store.upsert_instance(&initial).await?;
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "addressing_feedback",
+        "address_feedback",
+        "local_review_gate",
+        "feedback addressed",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "run_local_review",
+        "gh1784-mismatched-state-command",
+    ));
+    let mut final_instance = initial.clone();
+    final_instance.state = "ready_to_merge".to_string();
+    final_instance.version = final_instance.version.saturating_add(1);
+
+    let error = store
+        .apply_decision_transition(
+            WorkflowDecisionTransition {
+                expected_state: &initial.state,
+                create_if_missing: None,
+                event_type: "FeedbackAddressed",
+                source: "workflow-runtime-test",
+                payload: json!({}),
+                decision: &decision,
+                final_instance: &final_instance,
+                command_status: WorkflowCommandStatus::Pending,
+            },
+            "workflow-runtime-test",
+        )
+        .await
+        .expect_err("the persisted state must match the validated next state");
+
+    assert!(
+        error.to_string().contains("final instance state"),
+        "unexpected error: {error}"
+    );
+    let stored = store
+        .get_instance(&initial.id)
+        .await?
+        .expect("the original instance must remain");
+    assert_eq!(stored.state, "addressing_feedback");
+    assert!(store.events_for(&initial.id).await?.is_empty());
+    assert!(store.decisions_for(&initial.id).await?.is_empty());
+    assert!(store.commands_for(&initial.id).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn apply_decision_transition_treats_a_same_state_stale_snapshot_as_stale(
+) -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let initial = instance("gh1784-same-state-stale-snapshot", "addressing_feedback");
+    store.upsert_instance(&initial).await?;
+    let stale_snapshot = initial.clone();
+    store
+        .ensure_otel_trace_context(&initial.id)
+        .await?
+        .expect("same-state writer should persist trace context");
+
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "addressing_feedback",
+        "address_feedback",
+        "local_review_gate",
+        "feedback addressed",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "run_local_review",
+        "gh1784-stale-snapshot-command",
+    ));
+    let mut stale_final_instance = stale_snapshot;
+    stale_final_instance.state = decision.next_state.clone();
+    stale_final_instance.version = stale_final_instance.version.saturating_add(1);
+
+    let record = store
+        .apply_decision_transition(
+            WorkflowDecisionTransition {
+                expected_state: &initial.state,
+                create_if_missing: None,
+                event_type: "FeedbackAddressed",
+                source: "workflow-runtime-test",
+                payload: json!({}),
+                decision: &decision,
+                final_instance: &stale_final_instance,
+                command_status: WorkflowCommandStatus::Pending,
+            },
+            "workflow-runtime-test",
+        )
+        .await?;
+
+    assert!(
+        record.is_none(),
+        "a stale version must not produce a record"
+    );
+    let stored = store
+        .get_instance(&initial.id)
+        .await?
+        .expect("concurrent instance update must remain");
+    assert_eq!(stored.state, "addressing_feedback");
+    assert_eq!(stored.version, initial.version + 1);
+    assert!(
+        stored.data.get("otel_trace_context").is_some(),
+        "the concurrent same-state update must not be overwritten"
+    );
+    assert!(store.events_for(&initial.id).await?.is_empty());
+    assert!(store.decisions_for(&initial.id).await?.is_empty());
+    assert!(store.commands_for(&initial.id).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn apply_decision_transition_rejects_definition_substitution() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let initial = instance("gh1784-definition-substitution", "addressing_feedback");
+    store.upsert_instance(&initial).await?;
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "addressing_feedback",
+        "address_feedback",
+        "local_review_gate",
+        "feedback addressed",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "run_local_review",
+        "gh1784-definition-substitution-command",
+    ));
+    let mut final_instance = initial.clone();
+    final_instance.definition_id = "prompt_task".to_string();
+    final_instance.state = decision.next_state.clone();
+    final_instance.version = final_instance.version.saturating_add(1);
+
+    let error = store
+        .apply_decision_transition(
+            WorkflowDecisionTransition {
+                expected_state: &initial.state,
+                create_if_missing: None,
+                event_type: "FeedbackAddressed",
+                source: "workflow-runtime-test",
+                payload: json!({}),
+                decision: &decision,
+                final_instance: &final_instance,
+                command_status: WorkflowCommandStatus::Pending,
+            },
+            "workflow-runtime-test",
+        )
+        .await
+        .expect_err("a transition must not substitute the workflow definition");
+
+    assert!(
+        error.to_string().contains("definition_id"),
+        "unexpected error: {error}"
+    );
+    let stored = store
+        .get_instance(&initial.id)
+        .await?
+        .expect("the original instance must remain");
+    assert_eq!(stored.definition_id, initial.definition_id);
+    assert_eq!(stored.state, initial.state);
+    assert_eq!(stored.version, initial.version);
+    assert!(store.events_for(&initial.id).await?.is_empty());
+    assert!(store.decisions_for(&initial.id).await?.is_empty());
+    assert!(store.commands_for(&initial.id).await?.is_empty());
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/store/instances.rs
+++ b/crates/harness-workflow/src/runtime/store/instances.rs
@@ -1,13 +1,10 @@
 use super::{
-    command_store, insert_decision_record_tx, insert_event_tx, insert_instance_if_absent_tx,
+    insert_instance_if_absent_tx,
     instance_helpers::{otel_trace_context_from_data, terminal_state_pairs},
-    load_or_insert_initial_instance_tx, select_instance_for_update_tx, to_jsonb_string,
-    upsert_instance_tx, workflow_instance_from_row, RuntimeHistoryPruneSummary,
-    WorkflowDecisionTransition, WorkflowInstancePage, WorkflowRejectedDecisionTransition,
-    WorkflowRuntimeStore,
+    select_instance_for_update_tx, to_jsonb_string, upsert_instance_tx, workflow_instance_from_row,
+    RuntimeHistoryPruneSummary, WorkflowInstancePage, WorkflowRuntimeStore,
 };
-use crate::runtime::model::{WorkflowDecisionRecord, WorkflowInstance};
-use crate::runtime::status::WorkflowCommandStatus;
+use crate::runtime::model::WorkflowInstance;
 use crate::runtime::WorkflowOtelTraceContext;
 use chrono::{DateTime, Utc};
 
@@ -125,146 +122,6 @@ impl WorkflowRuntimeStore {
         upsert_instance_tx(&mut tx, &instance).await?;
         tx.commit().await?;
         Ok(true)
-    }
-
-    pub async fn apply_decision_transition(
-        &self,
-        transition: WorkflowDecisionTransition<'_>,
-    ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
-        let final_instance = transition.final_instance;
-        let decision = transition.decision;
-        if decision.workflow_id != final_instance.id {
-            anyhow::bail!(
-                "workflow decision `{}` targets `{}` but final instance is `{}`",
-                decision.decision,
-                decision.workflow_id,
-                final_instance.id
-            );
-        }
-        let mut tx = self.pool.begin().await?;
-        let Some(current) = load_or_insert_initial_instance_tx(
-            &mut tx,
-            &final_instance.id,
-            transition.expected_state,
-            transition.create_if_missing,
-        )
-        .await?
-        else {
-            return Ok(None);
-        };
-        if current.is_terminal() || current.state != transition.expected_state {
-            return Ok(None);
-        }
-
-        let event = insert_event_tx(
-            &mut tx,
-            &final_instance.id,
-            transition.event_type,
-            transition.source,
-            transition.payload,
-        )
-        .await?;
-
-        let record = WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id));
-        let decision_data = to_jsonb_string(&record)?;
-        sqlx::query(
-            "INSERT INTO workflow_decisions
-                (id, workflow_id, event_id, accepted, data, rejection_reason)
-             VALUES ($1, $2, $3, $4, $5::jsonb, $6)
-             ON CONFLICT (id) DO UPDATE SET
-                accepted = EXCLUDED.accepted,
-                data = EXCLUDED.data,
-                rejection_reason = EXCLUDED.rejection_reason",
-        )
-        .bind(&record.id)
-        .bind(&record.workflow_id)
-        .bind(&record.event_id)
-        .bind(record.accepted)
-        .bind(&decision_data)
-        .bind(&record.rejection_reason)
-        .execute(&mut *tx)
-        .await?;
-
-        for command in &decision.commands {
-            let status = if command.requires_runtime_job() {
-                transition.command_status
-            } else {
-                WorkflowCommandStatus::HandledInline
-            };
-            command_store::insert_tx(
-                &mut tx,
-                &final_instance.id,
-                Some(&record.id),
-                command,
-                status,
-            )
-            .await?;
-        }
-
-        let instance_data = to_jsonb_string(final_instance)?;
-        sqlx::query(
-            "INSERT INTO workflow_instances
-                (id, definition_id, state, subject_type, subject_key, parent_workflow_id, data, version)
-             VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
-             ON CONFLICT (id) DO UPDATE SET
-                definition_id = EXCLUDED.definition_id,
-                state = EXCLUDED.state,
-                subject_type = EXCLUDED.subject_type,
-                subject_key = EXCLUDED.subject_key,
-                parent_workflow_id = EXCLUDED.parent_workflow_id,
-                data = EXCLUDED.data,
-                version = EXCLUDED.version,
-                updated_at = CURRENT_TIMESTAMP",
-        )
-        .bind(&final_instance.id)
-        .bind(&final_instance.definition_id)
-        .bind(&final_instance.state)
-        .bind(&final_instance.subject.subject_type)
-        .bind(&final_instance.subject.subject_key)
-        .bind(&final_instance.parent_workflow_id)
-        .bind(&instance_data)
-        .bind(final_instance.version as i64)
-        .execute(&mut *tx)
-        .await?;
-
-        tx.commit().await?;
-        Ok(Some(record))
-    }
-
-    pub async fn record_rejected_decision_transition(
-        &self,
-        transition: WorkflowRejectedDecisionTransition<'_>,
-    ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
-        let decision = transition.decision;
-        let mut tx = self.pool.begin().await?;
-        let Some(current) = load_or_insert_initial_instance_tx(
-            &mut tx,
-            &decision.workflow_id,
-            transition.expected_state,
-            transition.create_if_missing,
-        )
-        .await?
-        else {
-            return Ok(None);
-        };
-        if current.is_terminal() || current.state != transition.expected_state {
-            return Ok(None);
-        }
-
-        let event = insert_event_tx(
-            &mut tx,
-            &decision.workflow_id,
-            transition.event_type,
-            transition.source,
-            transition.payload,
-        )
-        .await?;
-        let record =
-            WorkflowDecisionRecord::rejected(decision.clone(), Some(event.id), transition.reason);
-        insert_decision_record_tx(&mut tx, &record).await?;
-
-        tx.commit().await?;
-        Ok(Some(record))
     }
 
     pub async fn get_instance(

--- a/crates/harness-workflow/src/runtime/store/transition_validation.rs
+++ b/crates/harness-workflow/src/runtime/store/transition_validation.rs
@@ -3,9 +3,9 @@
 //! `DecisionValidator` enforces the transition allowlist, terminal-reopen
 //! denial, lease ownership, and required commands/evidence. Historically only
 //! the runtime-completion and operator-recovery paths consulted it, so the
-//! remaining transition writers could persist a caller-supplied instance that
-//! the definition never allowed (GH-1784). Every state-changing write goes
-//! through `validate_transition` instead of calling the validator ad hoc.
+//! `apply_decision_transition` could persist a caller-supplied instance that
+//! the definition never allowed (GH-1784). That path now goes through
+//! `validate_transition` instead of calling the validator ad hoc.
 
 use chrono::{DateTime, Utc};
 
@@ -30,12 +30,12 @@ pub(super) enum TransitionValidation {
 pub(super) fn validate_transition(
     current: &WorkflowInstance,
     decision: &WorkflowDecision,
-    source: &str,
+    actor: &str,
     now: DateTime<Utc>,
 ) -> TransitionValidation {
     match validator_for_instance(current) {
         Ok(Some(validator)) => {
-            match validator.validate(current, decision, &ValidationContext::new(source, now)) {
+            match validator.validate(current, decision, &ValidationContext::new(actor, now)) {
                 Ok(()) => TransitionValidation::Accepted,
                 Err(error) => TransitionValidation::Rejected(error.to_string()),
             }

--- a/crates/harness-workflow/src/runtime/store/transition_validation.rs
+++ b/crates/harness-workflow/src/runtime/store/transition_validation.rs
@@ -1,0 +1,52 @@
+//! Shared entry point for validating a state-changing workflow decision.
+//!
+//! `DecisionValidator` enforces the transition allowlist, terminal-reopen
+//! denial, lease ownership, and required commands/evidence. Historically only
+//! the runtime-completion and operator-recovery paths consulted it, so the
+//! remaining transition writers could persist a caller-supplied instance that
+//! the definition never allowed (GH-1784). Every state-changing write goes
+//! through `validate_transition` instead of calling the validator ad hoc.
+
+use chrono::{DateTime, Utc};
+
+use super::runtime_completion::validator_for_instance;
+use crate::runtime::model::{WorkflowDecision, WorkflowInstance};
+use crate::runtime::validator::ValidationContext;
+
+/// Result of validating a decision against the definition it targets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum TransitionValidation {
+    Accepted,
+    /// The decision must not be persisted. Carries a non-secret reason
+    /// suitable for a rejected decision record.
+    Rejected(String),
+}
+
+/// Validate `decision` against the validator for `current`'s definition.
+///
+/// Fails closed: an unresolvable definition pin or an unregistered definition
+/// is a rejection, not a pass. `current` must be the instance as loaded under
+/// the row lock, before the transition is applied.
+pub(super) fn validate_transition(
+    current: &WorkflowInstance,
+    decision: &WorkflowDecision,
+    source: &str,
+    now: DateTime<Utc>,
+) -> TransitionValidation {
+    match validator_for_instance(current) {
+        Ok(Some(validator)) => {
+            match validator.validate(current, decision, &ValidationContext::new(source, now)) {
+                Ok(()) => TransitionValidation::Accepted,
+                Err(error) => TransitionValidation::Rejected(error.to_string()),
+            }
+        }
+        Ok(None) => TransitionValidation::Rejected(format!(
+            "unknown workflow definition `{}` for decision `{}`",
+            current.definition_id, decision.decision
+        )),
+        Err(error) => TransitionValidation::Rejected(format!(
+            "workflow definition could not be resolved for decision `{}`: {error}",
+            decision.decision
+        )),
+    }
+}

--- a/crates/harness-workflow/src/runtime/tests/durable_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/durable_store.rs
@@ -172,7 +172,7 @@ async fn durable_store_apply_decision_transition_can_create_initial_instance() -
             decision: &decision,
             final_instance: &final_instance,
             command_status: WorkflowCommandStatus::Pending,
-        })
+        }, "workflow-runtime-test")
         .await?
         .expect("missing initial instance should be created inside the transition");
 
@@ -249,7 +249,7 @@ async fn durable_store_apply_decision_transition_does_not_rewind_existing_instan
             decision: &decision,
             final_instance: &final_instance,
             command_status: WorkflowCommandStatus::Pending,
-        })
+        }, "workflow-runtime-test")
         .await?;
 
     assert!(record.is_none());


### PR DESCRIPTION
## What / Why

`WorkflowRuntimeStore::apply_decision_transition` validated a `WorkflowDecision` but persisted an independently caller-supplied `final_instance`. The original implementation also collapsed an accepted transition and a durable rejection into the same `Some(record)` outcome. That let callers report success or run side effects even when the transaction rejected the transition, and left stale-snapshot and state-substitution races at the persistence boundary.

## Change

This PR keeps the shared `validate_transition` funnel and hardens the complete atomic contract:

- Pass the intended validation actor explicitly; event source is audit metadata, not validation authority.
- Require `final_instance.state == decision.next_state`.
- Fence every write on the locked authoritative version: the final version must be exactly current + 1.
- Preserve protected instance identity and ownership fields across the transition.
- Keep validator rejections durable, while every production caller now distinguishes accepted, rejected, and stale outcomes.
- Gate reconciliation issue side effects on an accepted transition.
- Make PR-feedback return the real atomic outcome.
- Make eval enqueue fail visibly on rejection and remain neutral on a stale race.
- Reload the authoritative eval instance after cancellation attempts; reload errors or a concurrently missing workflow are visible cleanup failures rather than silent success.

The store implementation remains split into `store/decision_transitions.rs` and `store/transition_validation.rs` so source files stay within the repository size limits.

## Scope

Two other paths named in #1784 were investigated and deliberately left unchanged:

- **`submission_commit`** already validates every caller with the authority needed for terminal resubmission. Re-validating in the store with a default context rejects legitimate resubmissions.
- **`coverage_recovery`** reconciles from authoritative GitHub facts and intentionally uses reconciliation authority for transitions excluded from the ordinary decision allowlist.

Still open on #1784:

- privatizing the broad `upsert_instance` surface
- replacing `is_definition_pin_safety_decision` with an explicit named capability
- reviewing the remaining state-write paths under those acceptance criteria

This PR is incremental and therefore uses `Refs #1784`, not `Closes`.

## Verification

Fresh local verification on commit `5115ff1a`:

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test --workspace -- --test-threads=1` with a disposable PostgreSQL database
- `cargo clippy --workspace --all-targets -- -D warnings`
- repository pre-commit and pre-push hooks
- `python3 checks/check_workflow.py --repo .`
- `python3 checks/route_gate.py --repo . --route review_pr --issue 1784 --pr 1824 --state impl_pr_open --mode advisory --json`

All passed. The first pre-push attempt exposed an unrelated existing marker-file race in `harness-agents`; the exact test passed in isolation and the normal pre-push hook passed on retry without bypassing any gate.

New deterministic PostgreSQL coverage includes:

- accepted and durably rejected transitions
- explicit actor distinct from event source
- final-state mismatch with zero writes
- same-state stale snapshot preserving concurrent data
- protected identity substitution with zero writes
- accepted/rejected/stale PR-feedback mapping
- reconciliation side-effect gating
- stale eval enqueue
- stale and concurrently missing eval cleanup reloads

## AI Role

AI-assisted implementation, followed by an independent adversarial review. The final independent result was `safe_to_commit = true`.

Risk: medium-high. This is a workflow-runtime trust boundary and changes the outcome contract for all `apply_decision_transition` callers.

## Review Focus

1. Whether version and protected-field fencing define the right atomic boundary.
2. Whether durable rejection plus explicit caller outcome mapping is preferable to rolling rejection evidence back.
3. Whether eval cleanup should retain the old snapshot only for resource accounting when the workflow disappears concurrently.

Refs #1784

Issue: #1784
