### PR TITLE
feat(workflow): evidence-contract primitives for completion enforcement (GH-1815)

### DIFF
--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -266,6 +266,10 @@ pub struct RuntimeWorkerPolicy {
     pub concurrency: u32,
     #[serde(default = "default_runtime_worker_lease_ttl_secs")]
     pub lease_ttl_secs: u64,
+    /// Enforce the declared completion-evidence contract on built-in workflow
+    /// transitions. Kill switch for one release; enforcement is the default.
+    #[serde(default = "default_true")]
+    pub completion_evidence_enforced: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -447,6 +451,7 @@ impl Default for RuntimeWorkerPolicy {
             interval_secs: default_runtime_worker_interval_secs(),
             concurrency: default_runtime_worker_concurrency(),
             lease_ttl_secs: default_runtime_worker_lease_ttl_secs(),
+            completion_evidence_enforced: true,
         }
     }
 }

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -61,6 +61,7 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert!(cfg.pr_scope_guard.enabled);
     assert_eq!(cfg.pr_scope_guard.max_files_changed, 30);
     assert_eq!(cfg.pr_scope_guard.max_lines_added, 1500);
+    assert!(cfg.runtime_worker.completion_evidence_enforced);
     assert_eq!(cfg.storage.schema_namespace, "workflow");
     assert!(cfg.storage.orphan_reaper_enabled);
     assert_eq!(cfg.storage.orphan_reaper_interval_secs, 3600);
@@ -195,6 +196,7 @@ runtime_worker:
   interval_secs: 3
   concurrency: 2
   lease_ttl_secs: 120
+  completion_evidence_enforced: false
 runtime_retry_policy:
   max_failed_activity_retries: 1
   retry_delay_secs: 30
@@ -384,6 +386,7 @@ Body
     assert_eq!(cfg.storage.orphan_reaper_interval_secs, 44);
     assert!(!cfg.storage.orphan_reaper_legacy_enabled);
     assert_eq!(cfg.storage.orphan_reaper_legacy_batch, 55);
+    assert!(!cfg.runtime_worker.completion_evidence_enforced);
     assert!(cfg.storage.workflow_watchdog_enabled);
     assert_eq!(cfg.storage.workflow_watchdog_age_minutes, 12);
     assert_eq!(cfg.storage.workflow_watchdog_interval_secs, 13);

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -107,6 +107,7 @@ impl HarnessServer {
 
     /// Start in stdio mode (JSON-RPC over stdin/stdout).
     pub async fn serve_stdio(self) -> anyhow::Result<()> {
+        self.apply_completion_evidence_policy()?;
         self.register_declarative_workflow_definitions()?;
         let state = crate::http::build_app_state(Arc::new(self)).await?;
         harness_workflow::runtime::freeze_workflow_definition_registry();
@@ -115,8 +116,31 @@ impl HarnessServer {
 
     /// Start in HTTP + WebSocket mode.
     pub async fn serve_http(self: Arc<Self>, addr: SocketAddr) -> anyhow::Result<()> {
+        self.apply_completion_evidence_policy()?;
         self.register_declarative_workflow_definitions()?;
         crate::http::serve(self, addr).await
+    }
+
+    fn apply_completion_evidence_policy(&self) -> anyhow::Result<()> {
+        // A config that cannot be read must not silently disable enforcement:
+        // the safe direction is to keep the contract on.
+        let enforced = match harness_core::config::workflow::load_workflow_config(
+            &self.config.server.project_root,
+        ) {
+            Ok(workflow_cfg) => workflow_cfg.runtime_worker.completion_evidence_enforced,
+            Err(error) => {
+                tracing::error!(
+                        "workflow config load failed ({error}); keeping completion-evidence enforcement enabled"
+                    );
+                true
+            }
+        };
+        if !enforced {
+            tracing::warn!(
+                "workflow completion-evidence enforcement is disabled; terminal transitions accept agent-claimed results without server-verified evidence"
+            );
+        }
+        harness_workflow::runtime::apply_builtin_evidence_enforcement(enforced)
     }
 
     fn register_declarative_workflow_definitions(&self) -> anyhow::Result<()> {

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -154,10 +154,10 @@ pub use repo_memory::{
     REPO_MEMORY_DEGRADATION_ARTIFACT,
 };
 pub use state_registry::{
-    current_declarative_workflow_definition, decision_validator_for_definition,
-    decision_validator_for_instance, declarative_workflow_definition_for_instance,
-    freeze_workflow_definition_registry, known_workflow_definition_ids,
-    register_declarative_workflow_definitions,
+    apply_builtin_evidence_enforcement, current_declarative_workflow_definition,
+    decision_validator_for_definition, decision_validator_for_instance,
+    declarative_workflow_definition_for_instance, freeze_workflow_definition_registry,
+    known_workflow_definition_ids, register_declarative_workflow_definitions,
     register_historical_declarative_workflow_definitions, register_workflow_definition,
     resolve_declarative_definition, workflow_declarative_definition, workflow_definition,
     workflow_definition_for_version, workflow_instance_is_declarative, workflow_state_definition,

--- a/crates/harness-workflow/src/runtime/model.rs
+++ b/crates/harness-workflow/src/runtime/model.rs
@@ -335,6 +335,18 @@ pub enum DecisionConfidence {
     High,
 }
 
+/// Evidence proving a bound PR was resolved through GitHub, not taken from the
+/// agent artifact alone.
+pub const EVIDENCE_VERIFIED_PR_BINDING: &str = "verified_pr_binding";
+
+/// Evidence carrying the digest of validation commands the server re-executed
+/// itself, rather than the agent's claim that they passed.
+pub const EVIDENCE_SERVER_VALIDATION_DIGEST: &str = "server_validation_digest";
+
+/// Evidence that a prompt task presented either a validation report or a
+/// structured no-change rationale before claiming completion.
+pub const EVIDENCE_PROMPT_COMPLETION: &str = "prompt_completion_evidence";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkflowEvidence {
     pub kind: String,

--- a/crates/harness-workflow/src/runtime/state_registry.rs
+++ b/crates/harness-workflow/src/runtime/state_registry.rs
@@ -11,7 +11,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock};
 
+mod evidence_policy;
 mod versioning;
+
+pub use evidence_policy::apply_builtin_evidence_enforcement;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeclarativeDefinitionPinError {

--- a/crates/harness-workflow/src/runtime/state_registry/evidence_policy.rs
+++ b/crates/harness-workflow/src/runtime/state_registry/evidence_policy.rs
@@ -1,0 +1,122 @@
+//! Completion-evidence enforcement policy for the built-in workflow
+//! definitions.
+//!
+//! Enforcement is the default: built-in transition tables declare the evidence
+//! each fact-minting transition requires, and the shared decision validator
+//! rejects decisions that lack it. The kill switch exists for one release, so
+//! an operator can restore the previous (claim-trusting) behavior without a
+//! rollback if agents have not yet caught up with the contract.
+
+use super::{
+    builtin_definitions, registry, RegisteredWorkflowDefinition, WorkflowDefinitionRegistry,
+};
+
+/// Apply the completion-evidence enforcement policy to the process-wide
+/// registry's built-in definitions. Must run before the registry is frozen.
+pub fn apply_builtin_evidence_enforcement(enforced: bool) -> anyhow::Result<()> {
+    registry()
+        .write()
+        .expect("workflow definition registry lock poisoned")
+        .apply_builtin_evidence_enforcement(enforced)
+}
+
+impl WorkflowDefinitionRegistry {
+    /// Re-register the built-in definitions under the given completion-evidence
+    /// policy. Disabling enforcement strips the declared evidence requirements
+    /// while leaving every other transition rule intact.
+    pub fn apply_builtin_evidence_enforcement(&mut self, enforced: bool) -> anyhow::Result<()> {
+        for definition in builtin_definitions() {
+            self.ensure_mutable(&definition.id)?;
+            if !self.definitions.contains_key(&definition.id) {
+                anyhow::bail!(
+                    "built-in workflow definition '{}' is not registered; cannot apply the completion-evidence policy",
+                    definition.id
+                );
+            }
+            let definition = if enforced {
+                definition
+            } else {
+                RegisteredWorkflowDefinition::new(
+                    definition.id.clone(),
+                    definition.states.clone(),
+                    definition.allowlist.without_required_evidence(),
+                )
+            };
+            Self::validate_registered_definition(&definition)?;
+            self.definitions
+                .insert(definition.id.clone(), std::sync::Arc::new(definition));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{builtin_definitions, WorkflowDefinitionRegistry};
+
+    fn required_evidence_kinds(registry: &WorkflowDefinitionRegistry) -> Vec<String> {
+        builtin_definitions()
+            .iter()
+            .filter_map(|builtin| registry.definition(&builtin.id))
+            .flat_map(|definition| {
+                definition
+                    .allowlist
+                    .rules()
+                    .flat_map(|rule| rule.required_evidence.iter().cloned())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn enforced_policy_preserves_the_declared_built_in_contract() {
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+        let declared = required_evidence_kinds(&registry);
+
+        registry
+            .apply_builtin_evidence_enforcement(true)
+            .expect("enforcing policy applies to a registry holding the built-ins");
+
+        assert_eq!(required_evidence_kinds(&registry), declared);
+    }
+
+    #[test]
+    fn disabled_policy_strips_every_built_in_evidence_requirement() {
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+
+        registry
+            .apply_builtin_evidence_enforcement(false)
+            .expect("kill switch applies to a registry holding the built-ins");
+
+        assert!(required_evidence_kinds(&registry).is_empty());
+        // Commands must survive the strip: only evidence is lifted.
+        for builtin in builtin_definitions() {
+            let registered = registry
+                .definition(&builtin.id)
+                .expect("built-in definition stays registered");
+            let expected = builtin.allowlist.rules().count();
+            assert_eq!(registered.allowlist.rules().count(), expected);
+        }
+    }
+
+    #[test]
+    fn policy_refuses_a_registry_missing_the_built_ins() {
+        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+
+        let error = registry
+            .apply_builtin_evidence_enforcement(true)
+            .expect_err("policy must not silently install definitions");
+
+        assert!(error.to_string().contains("is not registered"));
+    }
+
+    #[test]
+    fn frozen_registry_refuses_the_policy() {
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+        registry.freeze();
+
+        registry
+            .apply_builtin_evidence_enforcement(false)
+            .expect_err("a frozen registry must reject policy changes");
+    }
+}

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -95,6 +95,44 @@ impl TransitionAllowlist {
         self
     }
 
+    /// Attach required evidence classes to an already-allowed transition.
+    ///
+    /// Transition tables are compile-time constants, so a missing target rule
+    /// is a definition bug that must surface at registry construction rather
+    /// than silently leave the transition unguarded.
+    pub fn require_evidence(
+        mut self,
+        from_state: impl Into<String>,
+        to_state: impl Into<String>,
+        evidence: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        let from_state = from_state.into();
+        let to_state = to_state.into();
+        let rule = self
+            .rules
+            .iter_mut()
+            .find(|rule| {
+                rule.from_state.as_deref() == Some(from_state.as_str()) && rule.to_state == to_state
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "cannot require evidence for unallowed transition '{from_state}' -> '{to_state}'"
+                )
+            });
+        rule.required_evidence
+            .extend(evidence.into_iter().map(Into::into));
+        self
+    }
+
+    /// Drop every declared evidence requirement, leaving the allowed-command
+    /// contract intact. Backs the completion-evidence kill switch.
+    pub fn without_required_evidence(mut self) -> Self {
+        for rule in &mut self.rules {
+            rule.required_evidence.clear();
+        }
+        self
+    }
+
     pub fn rule_for(&self, from_state: &str, to_state: &str) -> Option<&TransitionRule> {
         self.rules
             .iter()

--- a/crates/harness-workflow/src/runtime/validator_tests.rs
+++ b/crates/harness-workflow/src/runtime/validator_tests.rs
@@ -270,3 +270,122 @@ fn github_issue_pr_validator_rejects_unevidenced_blocked_done() {
         WorkflowDecisionRejectionKind::MissingTerminalEvidence
     );
 }
+
+#[test]
+fn require_evidence_attaches_classes_to_an_allowed_transition() {
+    let allowlist = TransitionAllowlist::default()
+        .allow("implementing", "done", [WorkflowCommandType::MarkDone])
+        .require_evidence("implementing", "done", ["prompt_completion_evidence"]);
+
+    let rule = allowlist
+        .rule_for("implementing", "done")
+        .expect("transition must exist");
+    assert!(rule
+        .required_evidence
+        .contains("prompt_completion_evidence"));
+}
+
+#[test]
+fn allow_alone_leaves_a_transition_evidence_free() {
+    let allowlist = TransitionAllowlist::default().allow(
+        "implementing",
+        "done",
+        [WorkflowCommandType::MarkDone],
+    );
+
+    let rule = allowlist
+        .rule_for("implementing", "done")
+        .expect("transition must exist");
+    assert!(rule.required_evidence.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "cannot require evidence for unallowed transition")]
+fn require_evidence_rejects_a_transition_that_was_never_allowed() {
+    let _ = TransitionAllowlist::default().require_evidence(
+        "implementing",
+        "done",
+        ["prompt_completion_evidence"],
+    );
+}
+
+#[test]
+fn without_required_evidence_strips_requirements_but_keeps_commands() {
+    let allowlist = TransitionAllowlist::default()
+        .allow("implementing", "done", [WorkflowCommandType::MarkDone])
+        .require_evidence("implementing", "done", ["prompt_completion_evidence"])
+        .without_required_evidence();
+
+    let rule = allowlist
+        .rule_for("implementing", "done")
+        .expect("transition must exist");
+    assert!(rule.required_evidence.is_empty());
+    assert!(rule
+        .allowed_commands
+        .contains(&WorkflowCommandType::MarkDone));
+}
+
+#[test]
+fn declared_evidence_gates_a_decision_and_enforcement_can_be_lifted() {
+    let instance = WorkflowInstance::new(
+        "prompt_task",
+        1,
+        "implementing",
+        WorkflowSubject::new("prompt", "task-1"),
+    );
+    let decision = WorkflowDecision::new(
+        instance.id.clone(),
+        "implementing",
+        "agent_reported_done",
+        "done",
+        "agent reported completion",
+    )
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::MarkDone,
+        "task-1-done",
+        json!({ "reason": "done" }),
+    ));
+
+    let enforcing = DecisionValidator::new(
+        TransitionAllowlist::default()
+            .allow("implementing", "done", [WorkflowCommandType::MarkDone])
+            .require_evidence("implementing", "done", ["prompt_completion_evidence"]),
+    );
+    let err = enforcing
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime", Utc::now()),
+        )
+        .expect_err("decision without the declared evidence must be rejected");
+    assert_eq!(
+        err.kind,
+        WorkflowDecisionRejectionKind::MissingRequiredEvidence
+    );
+
+    let evidenced = decision.clone().with_evidence(WorkflowEvidence::new(
+        "prompt_completion_evidence",
+        "validation report attached",
+    ));
+    enforcing
+        .validate(
+            &instance,
+            &evidenced,
+            &ValidationContext::new("runtime", Utc::now()),
+        )
+        .expect("decision carrying the declared evidence must be accepted");
+
+    let lifted = DecisionValidator::new(
+        TransitionAllowlist::default()
+            .allow("implementing", "done", [WorkflowCommandType::MarkDone])
+            .require_evidence("implementing", "done", ["prompt_completion_evidence"])
+            .without_required_evidence(),
+    );
+    lifted
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime", Utc::now()),
+        )
+        .expect("kill switch must restore claim-trusting behavior");
+}

--- a/specs/GH1766/tech.md
+++ b/specs/GH1766/tech.md
@@ -154,9 +154,10 @@ digests are evidence payloads, not new tables. No migration.
 
 ## Configuration
 
-- `runtime_completion_evidence_enforced: bool` (default `true`) in the
-  runtime section of `WORKFLOW.md` config — one release of kill-switch,
-  then removed.
+- `runtime_worker.completion_evidence_enforced: bool` (default `true`) in
+  `WORKFLOW.md` — one release of kill-switch, then removed. Applied to the
+  built-in definitions at server startup, before the definition registry is
+  frozen; a config that fails to load keeps enforcement on.
 - Validation timeout: reuse the existing activity timeout configuration with
   a dedicated `quality_gate_validation_timeout_secs` override (default 900).
 


### PR DESCRIPTION
Closes #1815. First of six sub-tasks under #1766 (spec: `specs/GH1766/tech.md`).

## Why

Enforcement of `TransitionRule::required_evidence` already exists and is general — `validate_declarative_transition_metadata` rejects any decision missing a declared kind, for built-in and declarative definitions alike. What is missing is the vocabulary: no built-in transition table can *express* a requirement, and there is no way to lift one if agents have not yet caught up with the contract. The remaining #1766 sub-tasks all need both.

## What

- `TransitionAllowlist::require_evidence(from, to, [kinds])` attaches evidence classes to an already-allowed transition. Requiring evidence for a transition that was never allowed is a definition bug in a compile-time-constant table, so it panics at registry construction rather than silently leaving the transition unguarded.
- `TransitionAllowlist::without_required_evidence()` strips requirements while preserving the allowed-command contract.
- Evidence kind constants for the three classes #1766 introduces: `verified_pr_binding`, `server_validation_digest`, `prompt_completion_evidence`.
- `runtime_worker.completion_evidence_enforced` (default `true`) in `WORKFLOW.md`, applied to the built-in definitions at server startup before the registry is frozen. A config that fails to load keeps enforcement **on** and logs at error level — the kill switch cannot be flipped by an unreadable file.

No built-in allowlist declares a requirement yet, so this change is behavior-neutral by construction; #1817, #1818, #1819 and #1820 populate the contract.

## Verification

- `cargo test -p harness-workflow --lib runtime::validator` — 23 passed, including 5 new cases: requirement attachment, `.allow`-only stays evidence-free, panic on unallowed transition, strip keeps commands, and an end-to-end reject/accept/kill-switch-lifted triple.
- `cargo test -p harness-workflow --lib state_registry::evidence` — 4 passed: enforced policy preserves the declared contract, disabled policy strips every requirement while keeping all rules, policy refuses a registry missing the built-ins, frozen registry refuses the policy.
- `cargo test -p harness-core --lib config::` — 215 passed, including the new default and the YAML override.
- `cargo clippy -p harness-workflow -p harness-core -p harness-server --all-targets -- -D warnings` — clean. `cargo fmt --all` applied.

The full `harness-workflow` lib suite has 140 pre-existing failures in this checkout, all `failed to open Postgres bootstrap pool` — no `HARNESS_DATABASE_URL` is configured locally. Those suites are deferred to CI.