### PR TITLE
test(server): fix flaky log-capture tests losing events to interest-cache races

### DIFF
--- a/crates/harness-server/src/event_replay_tests.rs
+++ b/crates/harness-server/src/event_replay_tests.rs
@@ -649,6 +649,7 @@ async fn replay_caller_counts_and_logs_only_applied_writes() -> anyhow::Result<(
 
     let captured = ReplayCapturedSubscriber::default();
     let updated = {
+        crate::test_helpers::install_tracing_interest_keeper();
         let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
         replay_and_recover(&db, &log_path).await?
     };
@@ -711,6 +712,7 @@ async fn replay_conflict_preserves_terminal_log() -> anyhow::Result<()> {
 
     let captured = ReplayCapturedSubscriber::default();
     let error = {
+        crate::test_helpers::install_tracing_interest_keeper();
         let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
         replay_and_recover(&db, &log_path)
             .await

--- a/crates/harness-server/src/task_db/queries_recovery_tests.rs
+++ b/crates/harness-server/src/task_db/queries_recovery_tests.rs
@@ -367,6 +367,7 @@ async fn exercise_real_caller_interleave(
     let interleave = TaskDb::install_recovery_write_interleave_for_test(task_id.clone());
     let captured = CapturedSubscriber::default();
     let caller = async {
+        crate::test_helpers::install_tracing_interest_keeper();
         let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
         match site {
             RecoverySite::TerminalReplay | RecoverySite::PrReplay => {
@@ -753,6 +754,7 @@ async fn recovery_counts_and_success_logs_require_applied_write() -> anyhow::Res
 
     let applied_output = CapturedSubscriber::default();
     let recovery = {
+        crate::test_helpers::install_tracing_interest_keeper();
         let _subscriber_guard = tracing::subscriber::set_default(applied_output.clone());
         db.recover_in_progress().await?
     };

--- a/crates/harness-server/src/task_runner/store/startup.rs
+++ b/crates/harness-server/src/task_runner/store/startup.rs
@@ -241,6 +241,7 @@ mod tests {
         let store_key = db.store_key().to_string();
         let captured = CapturedStartupLogs::default();
         let startup = async {
+            crate::test_helpers::install_tracing_interest_keeper();
             let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
             TaskStore::open(&db_path).await
         };
@@ -328,6 +329,7 @@ mod tests {
         let store_key = db.store_key().to_string();
         let captured = CapturedStartupLogs::default();
         let startup = async {
+            crate::test_helpers::install_tracing_interest_keeper();
             let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
             TaskStore::open(&db_path).await
         };

--- a/crates/harness-server/src/test_helpers.rs
+++ b/crates/harness-server/src/test_helpers.rs
@@ -8,6 +8,53 @@ use std::time::Duration;
 use harness_core::db::{pg_open_pool, resolve_test_database_url};
 use tokio::sync::OnceCell;
 
+/// Install a process-global no-op subscriber whose only job is to keep every
+/// tracing callsite's cached `Interest` at `always`.
+///
+/// Tests that assert on captured log wording install a thread-scoped
+/// capture subscriber via `tracing::subscriber::set_default`. Under parallel
+/// test execution, other tests' scoped-subscriber guards dropping trigger
+/// interest-cache rebuilds; a rebuild that runs in the window where the
+/// registry does not include the capturing dispatcher caches `Interest::never`
+/// for a callsite, and the event macros then skip emission entirely - the
+/// capture subscriber never sees the event even though it is the thread's
+/// current dispatcher. Verified empirically: the aggregate replay log line
+/// vanished in ~30-40% of full-suite runs while `LevelFilter::current()` was
+/// `TRACE` and the scoped dispatcher was current on the emitting thread;
+/// with this keeper installed the failure did not reproduce in 15 runs.
+///
+/// The keeper reports `Interest::always` for every callsite so the macro
+/// fast path stays open, and `enabled() == false` so threads without a
+/// scoped capture subscriber pay no delivery cost.
+pub fn install_tracing_interest_keeper() {
+    use std::sync::Once;
+    use tracing::span;
+    use tracing::subscriber::Interest;
+    use tracing::{Event, Metadata};
+
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        struct InterestKeeper;
+        impl tracing::Subscriber for InterestKeeper {
+            fn register_callsite(&self, _m: &'static Metadata<'static>) -> Interest {
+                Interest::always()
+            }
+            fn enabled(&self, _m: &Metadata<'_>) -> bool {
+                false
+            }
+            fn new_span(&self, _a: &span::Attributes<'_>) -> span::Id {
+                span::Id::from_u64(1)
+            }
+            fn record(&self, _s: &span::Id, _v: &span::Record<'_>) {}
+            fn record_follows_from(&self, _s: &span::Id, _f: &span::Id) {}
+            fn event(&self, _e: &Event<'_>) {}
+            fn enter(&self, _s: &span::Id) {}
+            fn exit(&self, _s: &span::Id) {}
+        }
+        let _ = tracing::subscriber::set_global_default(InterestKeeper);
+    });
+}
+
 /// Serialises every test that reads or mutates the process-global `HOME` env
 /// var.  `tokio::test` runs tests concurrently in the same process; without
 /// this lock, a test that temporarily changes `HOME` races with any other test


### PR DESCRIPTION
Unblocks #1811 and #1822 (both red on `event_replay::tests::replay_caller_counts_and_logs_only_applied_writes`, which also fails on main — e.g. run 30213212679).

**Diagnosis** (instrumented locally with a disposable Postgres, ~35% repro rate over full-suite runs):
- probes proved the `tracing::info!` statement executes with `updated == 1`, on the capturing thread, with the capture subscriber as the current scoped dispatcher and `LevelFilter::TRACE`
- the event still never reaches the subscriber; a fresh-callsite sentinel emitted at the same point is dropped too — so it is not stale per-callsite caching but the interest-cache rebuild racing scoped-dispatcher registration: a rebuild that runs without the capturing dispatcher caches `Interest::never` and the macros skip emission
- `rebuild_interest_cache()` inside the test still failed 4/10 rounds (later rebuilds re-poison the cache)

**Fix**: a process-global no-op `InterestKeeper` subscriber (installed once per test binary from `test_helpers`) reports `Interest::always` for every callsite, keeping the macro fast path permanently open; delivery still goes to each thread's scoped capture subscriber. Wired into all six log-capture test sites (event_replay ×2, queries_recovery ×2, startup ×2), which share the same latent flake.

Verification: 24 consecutive local full-suite rounds with the fix, zero target failures; `cargo clippy --workspace --all-targets -- -D warnings` clean.