### PR TITLE
fix(test): bind captured tracing subscribers to the future, not the thread

### DIFF
--- a/crates/harness-server/src/event_replay_tests.rs
+++ b/crates/harness-server/src/event_replay_tests.rs
@@ -3,6 +3,7 @@ use harness_core::types::TaskId;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tracing::field::{Field, Visit};
+use tracing::instrument::WithSubscriber;
 use tracing::span::{Attributes, Record};
 use tracing::subscriber::Interest;
 use tracing::{Event, Id, Metadata, Subscriber};
@@ -648,10 +649,9 @@ async fn replay_caller_counts_and_logs_only_applied_writes() -> anyhow::Result<(
     drop(log);
 
     let captured = ReplayCapturedSubscriber::default();
-    let updated = {
-        let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
-        replay_and_recover(&db, &log_path).await?
-    };
+    let updated = replay_and_recover(&db, &log_path)
+        .with_subscriber(captured.clone())
+        .await?;
     assert_eq!(updated, 1, "only the durable replay write is counted");
     assert_eq!(
         db.get("replay-applied")
@@ -710,12 +710,10 @@ async fn replay_conflict_preserves_terminal_log() -> anyhow::Result<()> {
     let before = std::fs::read(&log_path)?;
 
     let captured = ReplayCapturedSubscriber::default();
-    let error = {
-        let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
-        replay_and_recover(&db, &log_path)
-            .await
-            .expect_err("contradictory terminal replay must fail closed")
-    };
+    let error = replay_and_recover(&db, &log_path)
+        .with_subscriber(captured.clone())
+        .await
+        .expect_err("contradictory terminal replay must fail closed");
     assert!(
         error
             .downcast_ref::<crate::task_db::TaskRecoveryConflict>()

--- a/crates/harness-server/src/task_db/queries_recovery_tests.rs
+++ b/crates/harness-server/src/task_db/queries_recovery_tests.rs
@@ -5,6 +5,7 @@ use harness_core::types::TaskId;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tracing::field::{Field, Visit};
+use tracing::instrument::WithSubscriber;
 use tracing::span::{Attributes, Record};
 use tracing::subscriber::Interest;
 use tracing::{Event, Id, Metadata, Subscriber};
@@ -367,7 +368,6 @@ async fn exercise_real_caller_interleave(
     let interleave = TaskDb::install_recovery_write_interleave_for_test(task_id.clone());
     let captured = CapturedSubscriber::default();
     let caller = async {
-        let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
         match site {
             RecoverySite::TerminalReplay | RecoverySite::PrReplay => {
                 replay_and_recover(&db, &log_path)
@@ -383,7 +383,8 @@ async fn exercise_real_caller_interleave(
                     transient_failed: result.transient_failed,
                 }),
         }
-    };
+    }
+    .with_subscriber(captured.clone());
     let actor = async {
         interleave.wait_until_selected().await;
         let result = async {
@@ -752,10 +753,10 @@ async fn recovery_counts_and_success_logs_require_applied_write() -> anyhow::Res
     .await?;
 
     let applied_output = CapturedSubscriber::default();
-    let recovery = {
-        let _subscriber_guard = tracing::subscriber::set_default(applied_output.clone());
-        db.recover_in_progress().await?
-    };
+    let recovery = db
+        .recover_in_progress()
+        .with_subscriber(applied_output.clone())
+        .await?;
     assert_eq!(recovery.resumed, 2);
     assert_eq!(recovery.failed, 1);
     assert_eq!(recovery.transient_failed, 1);

--- a/crates/harness-server/src/task_runner/store/startup.rs
+++ b/crates/harness-server/src/task_runner/store/startup.rs
@@ -163,6 +163,7 @@ mod tests {
     use harness_core::types::TaskId;
     use std::sync::{Arc, Mutex};
     use tracing::field::{Field, Visit};
+    use tracing::instrument::WithSubscriber;
     use tracing::span::{Attributes, Record};
     use tracing::subscriber::Interest;
     use tracing::{Event, Id, Metadata, Subscriber};
@@ -240,10 +241,7 @@ mod tests {
         let pool = db.postgres_pool();
         let store_key = db.store_key().to_string();
         let captured = CapturedStartupLogs::default();
-        let startup = async {
-            let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
-            TaskStore::open(&db_path).await
-        };
+        let startup = TaskStore::open(&db_path).with_subscriber(captured.clone());
         let actor = async {
             interleave.wait_until_selected().await;
             let result = async {
@@ -327,10 +325,7 @@ mod tests {
         let pool = db.postgres_pool();
         let store_key = db.store_key().to_string();
         let captured = CapturedStartupLogs::default();
-        let startup = async {
-            let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
-            TaskStore::open(&db_path).await
-        };
+        let startup = TaskStore::open(&db_path).with_subscriber(captured.clone());
         let actor = async {
             interleave.wait_until_selected().await;
             let result = async {


### PR DESCRIPTION
## What / Why

Six tests capture tracing output with `tracing::subscriber::set_default(...)` and then `await` across the guard. That guard is **thread-local**. Tokio may migrate a future to a different worker thread at any await point, and when it does, the events the test asserts on are emitted on a thread where the captured subscriber was never installed — so the assertion sees a partial log.

This is not hypothetical. It failed CI on an unrelated PR (#1814, which touches only `harness-agents`):

```
---- event_replay::tests::replay_caller_counts_and_logs_only_applied_writes stdout ----
replay aggregate wording must report exactly the one applied task:
message=event_replay: replayed state superseded by authoritative durable state task_id="replay-superseded"
message=event_replay: compacted log, removed 2 terminal-task line(s)
```

The asserted line `event_replay: applied replayed state to 1 task(s)` is absent while *other* lines from the same call are present — the signature of a subscriber that only saw part of the run. It is scheduling-dependent, not a product defect.

## Change

`WithSubscriber::with_subscriber` attaches the subscriber to the future itself, so it travels with the work across threads:

```rust
// before — guard is thread-local, lost on migration
let updated = {
    let _subscriber_guard = tracing::subscriber::set_default(captured.clone());
    replay_and_recover(&db, &log_path).await?
};

// after — subscriber rides along with the future
let updated = replay_and_recover(&db, &log_path)
    .with_subscriber(captured.clone())
    .await?;
```

Applied to all six sites: `event_replay_tests.rs` (2), `task_db/queries_recovery_tests.rs` (2), `task_runner/store/startup.rs` (2). The last four had the same latent defect and had simply not lost the race yet.

**No assertion is changed** — this repairs how output is captured, not what is required of it (W-12).

## Proof

Characterization, run in this session against a real PostgreSQL 17 instance:

- Before the fix, in isolation: `replay_caller_counts_and_logs_only_applied_writes` passed **5/5**. It only fails under the full parallel suite, which is why it reads as flaky.
- Before the fix, full suite on clean `origin/main`: **1337 passed, 1 failed** — this test.
- CI on #1814 hit the same failure, and the job passed on a plain re-run with no code change.
- After the fix, full suite: **1338 passed, 0 failed**. Additional repeat runs were still in flight when this PR was opened; I will post their results as a comment.
- `cargo clippy -p harness-server --all-targets -- -D warnings` — clean, exit 0.

Note on the evidence: a flaky test cannot be proven fixed by passing runs alone. The argument here rests on the root cause — a thread-local guard held across an await — and on the fix removing that mechanism entirely rather than making the race less likely.

## AI Role

AI-authored. Risk: low — test-only, no production code touched, no assertions relaxed.

## Review Focus

`startup.rs` previously wrapped `TaskStore::open(&db_path)` in an `async` block; it is now the bare future with `.with_subscriber(...)`. Confirm nothing depended on that extra block's laziness — the future is still not polled until the surrounding `select`/`join` drives it.