### PR TITLE
fix(core): remove prompt layer registry

### DIFF
--- a/crates/harness-cli/src/cmd/pr.rs
+++ b/crates/harness-cli/src/cmd/pr.rs
@@ -64,11 +64,10 @@ pub async fn fix(
 
     println!("[harness] Round 1 — Implementing issue #{issue} and creating PR");
 
-    let req = AgentRequest {
-        prompt: prompts::implement_from_issue(issue, None, None).to_prompt_string(),
-        project_root: project.clone(),
-        ..Default::default()
-    };
+    let req = AgentRequest::from_prompt_layers(
+        prompts::implement_from_issue(issue, None, None).into(),
+        project.clone(),
+    );
 
     let resp = agent.execute(req).await?;
     println!("{}", resp.output);

--- a/crates/harness-core/src/agent.rs
+++ b/crates/harness-core/src/agent.rs
@@ -92,10 +92,8 @@ impl AgentRequest {
         }
     }
 
-    fn effective_prompt_layers(&self) -> Option<Cow<'_, AgentPromptLayers>> {
-        self.prompt_layers.as_ref().map(Cow::Borrowed).or_else(|| {
-            crate::prompts::prompt_layers_for_flattened_prompt(&self.prompt).map(Cow::Owned)
-        })
+    fn effective_prompt_layers(&self) -> Option<&AgentPromptLayers> {
+        self.prompt_layers.as_ref()
     }
 
     pub fn claude_main_prompt(&self) -> Cow<'_, str> {
@@ -107,8 +105,8 @@ impl AgentRequest {
 
     pub fn claude_system_prompt(&self) -> Option<Cow<'_, str>> {
         self.effective_prompt_layers()
-            .and_then(|layers| layers.static_system_prompt_for_cache().map(str::to_string))
-            .map(Cow::Owned)
+            .and_then(AgentPromptLayers::static_system_prompt_for_cache)
+            .map(Cow::Borrowed)
     }
 }
 

--- a/crates/harness-core/src/agent.rs
+++ b/crates/harness-core/src/agent.rs
@@ -155,10 +155,13 @@ impl AgentPromptLayers {
     }
 
     pub fn to_prompt_string(&self) -> String {
-        format!(
-            "{}{}{}",
-            self.static_instructions, self.context, self.dynamic_payload
-        )
+        let mut prompt = String::with_capacity(
+            self.static_instructions.len() + self.context.len() + self.dynamic_payload.len(),
+        );
+        prompt.push_str(&self.static_instructions);
+        prompt.push_str(&self.context);
+        prompt.push_str(&self.dynamic_payload);
+        prompt
     }
 
     pub fn append_to_dynamic_payload(&mut self, text: &str) {

--- a/crates/harness-core/src/agent_tests.rs
+++ b/crates/harness-core/src/agent_tests.rs
@@ -52,25 +52,39 @@ fn claude_prompt_helpers_do_not_split_static_only_layers() {
 }
 
 #[test]
-fn agent_request_recovers_layers_from_registered_flattened_prompt_with_runtime_additions() {
+fn agent_request_does_not_infer_layers_from_flattened_prompt() {
     let flattened =
         prompts::implement_from_issue(1471, None, Some("follow the spec")).to_prompt_string();
+    let prompt = format!("Constitution\n\n{flattened}\n\n## Available Skills\n- review");
     let request = AgentRequest {
-        prompt: format!("Constitution\n\n{flattened}\n\n## Available Skills\n- review"),
+        prompt: prompt.clone(),
         project_root: PathBuf::from("/tmp/project"),
         ..AgentRequest::default()
     };
 
-    let Some(system_prompt) = request.claude_system_prompt() else {
-        panic!("registered PromptParts should provide a Claude system prompt");
-    };
-    let main_prompt = request.claude_main_prompt();
+    assert_eq!(request.claude_system_prompt().as_deref(), None);
+    assert_eq!(request.claude_main_prompt(), prompt);
+}
 
-    assert!(system_prompt.contains("Senior Engineer"));
-    assert!(!system_prompt.contains("follow the spec"));
-    assert!(main_prompt.contains("Constitution"));
-    assert!(main_prompt.contains("follow the spec"));
-    assert!(main_prompt.contains("## Available Skills"));
+#[test]
+fn explicit_layers_keep_similar_prompts_test_isolated() {
+    let short_layers = AgentPromptLayers::new("static\n", "context\n", "dynamic\n");
+    let long_layers = AgentPromptLayers::new("static\ncontext\n", "dynamic\n", "runtime\n");
+
+    let short_request =
+        AgentRequest::from_prompt_layers(short_layers, PathBuf::from("/tmp/project"));
+    let long_request = AgentRequest::from_prompt_layers(long_layers, PathBuf::from("/tmp/project"));
+
+    assert_eq!(
+        short_request.claude_system_prompt().as_deref(),
+        Some("static\n")
+    );
+    assert_eq!(short_request.claude_main_prompt(), "context\ndynamic\n");
+    assert_eq!(
+        long_request.claude_system_prompt().as_deref(),
+        Some("static\ncontext\n")
+    );
+    assert_eq!(long_request.claude_main_prompt(), "dynamic\nruntime\n");
 }
 
 #[test]

--- a/crates/harness-core/src/agent_tests.rs
+++ b/crates/harness-core/src/agent_tests.rs
@@ -86,24 +86,56 @@ fn flattened_prompt_without_layers_does_not_cross_associate_with_similar_prompt(
 }
 
 #[test]
-fn explicit_layers_keep_similar_prompts_test_isolated() {
-    let short_layers = AgentPromptLayers::new("static\n", "context\n", "dynamic\n");
-    let long_layers = AgentPromptLayers::new("static\ncontext\n", "dynamic\n", "runtime\n");
+fn concurrent_similar_prompts_keep_explicit_layer_attribution() {
+    let short_static = AgentPromptLayers::new("static\n", "context\n", "dynamic\n");
+    let long_static = AgentPromptLayers::new("static\ncontext\n", "dynamic\n", "");
+    assert_eq!(
+        short_static.to_prompt_string(),
+        long_static.to_prompt_string()
+    );
 
-    let short_request =
-        AgentRequest::from_prompt_layers(short_layers, PathBuf::from("/tmp/project"));
-    let long_request = AgentRequest::from_prompt_layers(long_layers, PathBuf::from("/tmp/project"));
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let spawn_request = |layers: AgentPromptLayers| {
+        let barrier = std::sync::Arc::clone(&barrier);
+        std::thread::spawn(move || {
+            barrier.wait();
+            let request = AgentRequest::from_prompt_layers(layers, PathBuf::from("/tmp/project"));
+            barrier.wait();
+            let system_prompt = request
+                .claude_system_prompt()
+                .map(|prompt| prompt.into_owned());
+            let main_prompt = request.claude_main_prompt().into_owned();
+            (request.prompt, system_prompt, main_prompt)
+        })
+    };
+
+    let short_static_request = spawn_request(short_static);
+    let long_static_request = spawn_request(long_static);
+    let short_static_request = match short_static_request.join() {
+        Ok(request) => request,
+        Err(payload) => std::panic::resume_unwind(payload),
+    };
+    let long_static_request = match long_static_request.join() {
+        Ok(request) => request,
+        Err(payload) => std::panic::resume_unwind(payload),
+    };
 
     assert_eq!(
-        short_request.claude_system_prompt().as_deref(),
-        Some("static\n")
+        short_static_request,
+        (
+            "static\ncontext\ndynamic\n".to_string(),
+            Some("static\n".to_string()),
+            "context\ndynamic\n".to_string(),
+        )
     );
-    assert_eq!(short_request.claude_main_prompt(), "context\ndynamic\n");
     assert_eq!(
-        long_request.claude_system_prompt().as_deref(),
-        Some("static\ncontext\n")
+        long_static_request,
+        (
+            "static\ncontext\ndynamic\n".to_string(),
+            Some("static\ncontext\n".to_string()),
+            "dynamic\n".to_string(),
+        )
     );
-    assert_eq!(long_request.claude_main_prompt(), "dynamic\nruntime\n");
 }
 
 #[test]

--- a/crates/harness-core/src/agent_tests.rs
+++ b/crates/harness-core/src/agent_tests.rs
@@ -94,23 +94,39 @@ fn concurrent_similar_prompts_keep_explicit_layer_attribution() {
         long_static.to_prompt_string()
     );
 
-    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
     let spawn_request = |layers: AgentPromptLayers| {
         let barrier = std::sync::Arc::clone(&barrier);
         std::thread::spawn(move || {
-            barrier.wait();
+            let flattened = prompts::PromptParts {
+                static_instructions: layers.static_instructions.clone(),
+                context: layers.context.clone(),
+                dynamic_payload: layers.dynamic_payload.clone(),
+            }
+            .to_prompt_string();
             let request = AgentRequest::from_prompt_layers(layers, PathBuf::from("/tmp/project"));
             barrier.wait();
             let system_prompt = request
                 .claude_system_prompt()
                 .map(|prompt| prompt.into_owned());
             let main_prompt = request.claude_main_prompt().into_owned();
-            (request.prompt, system_prompt, main_prompt)
+            (flattened, request.prompt, system_prompt, main_prompt)
         })
     };
 
     let short_static_request = spawn_request(short_static);
     let long_static_request = spawn_request(long_static);
+    barrier.wait();
+
+    let flattened_prompt = "static\ncontext\ndynamic\n".to_string();
+    let flattened_request = AgentRequest {
+        prompt: flattened_prompt.clone(),
+        project_root: PathBuf::from("/tmp/project"),
+        ..AgentRequest::default()
+    };
+    assert_eq!(flattened_request.claude_system_prompt().as_deref(), None);
+    assert_eq!(flattened_request.claude_main_prompt(), flattened_prompt);
+
     let short_static_request = match short_static_request.join() {
         Ok(request) => request,
         Err(payload) => std::panic::resume_unwind(payload),
@@ -124,6 +140,7 @@ fn concurrent_similar_prompts_keep_explicit_layer_attribution() {
         short_static_request,
         (
             "static\ncontext\ndynamic\n".to_string(),
+            "static\ncontext\ndynamic\n".to_string(),
             Some("static\n".to_string()),
             "context\ndynamic\n".to_string(),
         )
@@ -131,6 +148,7 @@ fn concurrent_similar_prompts_keep_explicit_layer_attribution() {
     assert_eq!(
         long_static_request,
         (
+            "static\ncontext\ndynamic\n".to_string(),
             "static\ncontext\ndynamic\n".to_string(),
             Some("static\ncontext\n".to_string()),
             "dynamic\n".to_string(),

--- a/crates/harness-core/src/agent_tests.rs
+++ b/crates/harness-core/src/agent_tests.rs
@@ -67,6 +67,25 @@ fn agent_request_does_not_infer_layers_from_flattened_prompt() {
 }
 
 #[test]
+fn flattened_prompt_without_layers_does_not_cross_associate_with_similar_prompt() {
+    let registered_flattened = prompts::PromptParts {
+        static_instructions: "shared static instructions\n".to_string(),
+        context: "shared request context\n".to_string(),
+        dynamic_payload: "shared dynamic payload\n".to_string(),
+    }
+    .to_prompt_string();
+    let similar_prompt = format!("{registered_flattened}runtime-specific suffix\n");
+    let request = AgentRequest {
+        prompt: similar_prompt.clone(),
+        project_root: PathBuf::from("/tmp/project"),
+        ..AgentRequest::default()
+    };
+
+    assert_eq!(request.claude_system_prompt().as_deref(), None);
+    assert_eq!(request.claude_main_prompt(), similar_prompt);
+}
+
+#[test]
 fn explicit_layers_keep_similar_prompts_test_isolated() {
     let short_layers = AgentPromptLayers::new("static\n", "context\n", "dynamic\n");
     let long_layers = AgentPromptLayers::new("static\ncontext\n", "dynamic\n", "runtime\n");

--- a/crates/harness-core/src/prompts/mod.rs
+++ b/crates/harness-core/src/prompts/mod.rs
@@ -72,10 +72,13 @@ impl PromptParts {
     /// the prompt-building function. Callers that previously stored the return value as a
     /// `String` should call this method to obtain it.
     pub fn to_prompt_string(&self) -> String {
-        format!(
-            "{}{}{}",
-            self.static_instructions, self.context, self.dynamic_payload
-        )
+        let mut prompt = String::with_capacity(
+            self.static_instructions.len() + self.context.len() + self.dynamic_payload.len(),
+        );
+        prompt.push_str(&self.static_instructions);
+        prompt.push_str(&self.context);
+        prompt.push_str(&self.dynamic_payload);
+        prompt
     }
 }
 

--- a/crates/harness-core/src/prompts/mod.rs
+++ b/crates/harness-core/src/prompts/mod.rs
@@ -1,9 +1,5 @@
 //! Prompt templates and output parsers shared across CLI and HTTP entries.
 
-use crate::agent::AgentPromptLayers;
-use std::collections::VecDeque;
-use std::sync::{Mutex, OnceLock};
-
 pub mod context;
 pub mod contract;
 pub mod cross_review;
@@ -76,73 +72,11 @@ impl PromptParts {
     /// the prompt-building function. Callers that previously stored the return value as a
     /// `String` should call this method to obtain it.
     pub fn to_prompt_string(&self) -> String {
-        let prompt = format!(
+        format!(
             "{}{}{}",
             self.static_instructions, self.context, self.dynamic_payload
-        );
-        register_prompt_layers(
-            &prompt,
-            AgentPromptLayers::new(
-                self.static_instructions.clone(),
-                self.context.clone(),
-                self.dynamic_payload.clone(),
-            ),
-        );
-        prompt
+        )
     }
-}
-
-const PROMPT_LAYER_REGISTRY_LIMIT: usize = 256;
-
-#[derive(Debug, Clone)]
-struct RegisteredPromptLayers {
-    flattened_prompt: String,
-    layers: AgentPromptLayers,
-}
-
-static PROMPT_LAYER_REGISTRY: OnceLock<Mutex<VecDeque<RegisteredPromptLayers>>> = OnceLock::new();
-
-fn prompt_layer_registry() -> &'static Mutex<VecDeque<RegisteredPromptLayers>> {
-    PROMPT_LAYER_REGISTRY.get_or_init(|| Mutex::new(VecDeque::new()))
-}
-
-fn register_prompt_layers(flattened_prompt: &str, layers: AgentPromptLayers) {
-    let mut registry = prompt_layer_registry().lock().unwrap();
-    if let Some(existing_index) = registry
-        .iter()
-        .position(|entry| entry.flattened_prompt == flattened_prompt)
-    {
-        registry.remove(existing_index);
-    }
-    registry.push_back(RegisteredPromptLayers {
-        flattened_prompt: flattened_prompt.to_string(),
-        layers,
-    });
-    while registry.len() > PROMPT_LAYER_REGISTRY_LIMIT {
-        registry.pop_front();
-    }
-}
-
-pub(crate) fn prompt_layers_for_flattened_prompt(prompt: &str) -> Option<AgentPromptLayers> {
-    let registry = prompt_layer_registry().lock().unwrap();
-    registry
-        .iter()
-        .rev()
-        .filter_map(|entry| {
-            prompt.find(&entry.flattened_prompt).map(|start| {
-                let end = start + entry.flattened_prompt.len();
-                let mut layers = entry.layers.clone();
-                if start > 0 {
-                    layers.context = format!("{}{}", &prompt[..start], layers.context);
-                }
-                if end < prompt.len() {
-                    layers.append_to_dynamic_payload(&prompt[end..]);
-                }
-                (entry.flattened_prompt.len(), layers)
-            })
-        })
-        .max_by_key(|(matched_len, _)| *matched_len)
-        .map(|(_, layers)| layers)
 }
 
 /// Wrap `s` in POSIX single quotes, escaping any embedded single quotes via `'\''`.


### PR DESCRIPTION
## Summary
- Remove the process-global prompt-layer registry and flattened-prompt heuristic re-association.
- Make Claude prompt splitting depend only on explicit AgentRequest.prompt_layers.
- Pass explicit prompt layers through the harness pr fix path and add regression coverage for similar prompts.

## Validation
- cargo test -p harness-core flattened_prompt_reassociation_can_choose_wrong_similar_layers (failed before fix, reproduced #1802)
- cargo fmt --all -- --check
- cargo check
- cargo check -p harness-core --all-targets
- cargo check -p harness-cli --all-targets
- cargo test -p harness-core
- cargo test -p harness-cli cmd::pr::tests
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- env -u HARNESS_DATABASE_URL git push -u origin harness/issue-1802-prompt-layers (pre-push clippy + database-independent workspace lib tests passed)

Note: ambient cargo test refused the inherited non-test HARNESS_DATABASE_URL (harness_self_20260729); a DB-less full cargo test later hit unrelated harness-server Postgres bootstrap pool timeouts. The scoped changed-crate tests and required workspace compile/lint gates passed.

Closes #1802