### PR TITLE
refactor(server): centralize API error handling

### DIFF
--- a/crates/harness-server/src/handlers/repo_memory_api.rs
+++ b/crates/harness-server/src/handlers/repo_memory_api.rs
@@ -13,11 +13,9 @@ pub async fn list_project_repo_memory_route(
     State(state): State<Arc<AppState>>,
     Path(repo): Path<String>,
 ) -> (StatusCode, Json<Value>) {
-    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "workflow runtime store unavailable" })),
-        );
+    let store = match state.workflow_runtime_store() {
+        Ok(store) => store,
+        Err(error) => return error.into_status_json(),
     };
     let repo = repo.trim();
     if repo.is_empty() {
@@ -49,11 +47,9 @@ pub async fn delete_repo_memory_record_route(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<Value>) {
-    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "workflow runtime store unavailable" })),
-        );
+    let store = match state.workflow_runtime_store() {
+        Ok(store) => store,
+        Err(error) => return error.into_status_json(),
     };
     let id = match Uuid::parse_str(id.trim()) {
         Ok(id) => id,

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -171,10 +171,8 @@ pub async fn deregister_runtime_host(
                 error = %error,
                 "failed to revoke workflow runtime-job leases during deregistration"
             );
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(json!({ "error": "workflow runtime store unavailable" })),
-            );
+            return crate::http::api_error::ApiError::store_unavailable("workflow runtime store")
+                .into_status_json();
         }
         match store.count_remote_host_runtime_job_leases(&host_id).await {
             Ok(0) => {}
@@ -195,10 +193,10 @@ pub async fn deregister_runtime_host(
                     error = %error,
                     "failed to confirm workflow runtime-job revocation"
                 );
-                return (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    Json(json!({ "error": "workflow runtime store unavailable" })),
-                );
+                return crate::http::api_error::ApiError::store_unavailable(
+                    "workflow runtime store",
+                )
+                .into_status_json();
             }
         }
 
@@ -634,12 +632,10 @@ async fn persist_runtime_state(
 fn workflow_runtime_store(
     state: &Arc<AppState>,
 ) -> Result<Arc<WorkflowRuntimeStore>, (StatusCode, Json<serde_json::Value>)> {
-    state.core.workflow_runtime_store.clone().ok_or_else(|| {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "workflow runtime store unavailable" })),
-        )
-    })
+    state
+        .workflow_runtime_store()
+        .cloned()
+        .map_err(|error| error.into_status_json())
 }
 
 fn runtime_state_persistence_error_response(

--- a/crates/harness-server/src/handlers/runtime_hosts/lease.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/lease.rs
@@ -77,8 +77,9 @@ pub async fn renew_runtime_job_lease_for_runtime_host(
         Ok(value) => value,
         Err(response) => return response,
     };
-    let Some(store) = state.core.workflow_runtime_store.clone() else {
-        return workflow_store_unavailable_response();
+    let store = match state.workflow_runtime_store() {
+        Ok(store) => store.clone(),
+        Err(error) => return error.into_status_json(),
     };
     let outcome = store
         .renew_remote_host_runtime_job_lease(RuntimeJobLeaseRenewalRequest {
@@ -170,10 +171,7 @@ pub(super) fn lease_lost_response() -> (StatusCode, Json<serde_json::Value>) {
 }
 
 fn workflow_store_unavailable_response() -> (StatusCode, Json<serde_json::Value>) {
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(json!({ "error": "workflow runtime store unavailable" })),
-    )
+    crate::http::api_error::ApiError::store_unavailable("workflow runtime store").into_status_json()
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/http/api_error.rs
+++ b/crates/harness-server/src/http/api_error.rs
@@ -1,0 +1,138 @@
+use crate::services::execution::EnqueueTaskError;
+use axum::{
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::{json, Value};
+
+#[derive(Debug)]
+pub(crate) enum ApiError {
+    BadRequest(String),
+    Internal(String),
+    StoreUnavailable(&'static str),
+    MaintenanceWindow { retry_after_secs: u64 },
+}
+
+impl ApiError {
+    pub(crate) fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+
+    pub(crate) fn store_unavailable(store_name: &'static str) -> Self {
+        Self::StoreUnavailable(store_name)
+    }
+
+    pub(crate) fn status(&self) -> StatusCode {
+        match self {
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::StoreUnavailable(_) | Self::MaintenanceWindow { .. } => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+        }
+    }
+
+    pub(crate) fn body(&self) -> Value {
+        match self {
+            Self::BadRequest(message) | Self::Internal(message) => json!({ "error": message }),
+            Self::StoreUnavailable(store_name) => {
+                json!({ "error": format!("{store_name} unavailable") })
+            }
+            Self::MaintenanceWindow { retry_after_secs } => {
+                json!({ "error": "maintenance_window", "retry_after": retry_after_secs })
+            }
+        }
+    }
+
+    pub(crate) fn into_status_json(self) -> (StatusCode, Json<Value>) {
+        (self.status(), Json(self.body()))
+    }
+}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadRequest(message) => write!(f, "bad request: {message}"),
+            Self::Internal(message) => write!(f, "internal error: {message}"),
+            Self::StoreUnavailable(store_name) => write!(f, "{store_name} unavailable"),
+            Self::MaintenanceWindow { retry_after_secs } => {
+                write!(
+                    f,
+                    "maintenance window active; retry after {retry_after_secs}s"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ApiError {}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::MaintenanceWindow { retry_after_secs } => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(header::RETRY_AFTER, retry_after_secs.to_string())],
+                Json(json!({
+                    "error": "maintenance_window",
+                    "retry_after": retry_after_secs,
+                })),
+            )
+                .into_response(),
+            error => error.into_status_json().into_response(),
+        }
+    }
+}
+
+impl From<EnqueueTaskError> for ApiError {
+    fn from(error: EnqueueTaskError) -> Self {
+        match error {
+            EnqueueTaskError::BadRequest(message) => Self::BadRequest(message),
+            EnqueueTaskError::Internal(message) => Self::Internal(message),
+            EnqueueTaskError::StoreUnavailable(store_name) => Self::StoreUnavailable(store_name),
+            EnqueueTaskError::MaintenanceWindow { retry_after_secs } => {
+                Self::MaintenanceWindow { retry_after_secs }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_unavailable_uses_service_unavailable_contract() {
+        let error = ApiError::store_unavailable("workflow runtime store");
+
+        assert_eq!(error.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            error.body(),
+            json!({ "error": "workflow runtime store unavailable" })
+        );
+    }
+
+    #[test]
+    fn enqueue_task_error_maps_to_api_error_once() {
+        assert_eq!(
+            ApiError::from(EnqueueTaskError::BadRequest("bad input".to_string())).status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            ApiError::from(EnqueueTaskError::Internal("failed".to_string())).status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert_eq!(
+            ApiError::from(EnqueueTaskError::StoreUnavailable("workflow runtime store")).status(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            ApiError::from(EnqueueTaskError::MaintenanceWindow {
+                retry_after_secs: 42
+            })
+            .status(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+}

--- a/crates/harness-server/src/http/github_webhook_routes.rs
+++ b/crates/harness-server/src/http/github_webhook_routes.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use std::path::{Path as StdPath, PathBuf};
 use std::sync::Arc;
 
-use super::{state::AppState, task_routes};
+use super::{api_error::ApiError, state::AppState, task_routes};
 
 fn configured_github_webhook_project_root(
     github: Option<&harness_core::config::intake::GitHubIntakeConfig>,
@@ -209,33 +209,9 @@ pub(crate) async fn github_webhook(
                 });
                 (StatusCode::ACCEPTED, Json(response))
             }
-            Err(crate::services::execution::EnqueueTaskError::BadRequest(error)) => {
-                (StatusCode::BAD_REQUEST, Json(json!({ "error": error })))
-            }
-            Err(crate::services::execution::EnqueueTaskError::Internal(error)) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({ "error": error })),
-            ),
-            Err(crate::services::execution::EnqueueTaskError::MaintenanceWindow {
-                retry_after_secs,
-            }) => (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(json!({ "error": "maintenance_window", "retry_after": retry_after_secs })),
-            ),
+            Err(error) => error.into_status_json(),
         },
-        Err(crate::services::execution::EnqueueTaskError::BadRequest(error)) => {
-            (StatusCode::BAD_REQUEST, Json(json!({ "error": error })))
-        }
-        Err(crate::services::execution::EnqueueTaskError::Internal(error)) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": error })),
-        ),
-        Err(crate::services::execution::EnqueueTaskError::MaintenanceWindow {
-            retry_after_secs,
-        }) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "maintenance_window", "retry_after": retry_after_secs })),
-        ),
+        Err(error) => ApiError::from(error).into_status_json(),
     }
 }
 

--- a/crates/harness-server/src/http/misc_routes_runtime_tree.rs
+++ b/crates/harness-server/src/http/misc_routes_runtime_tree.rs
@@ -169,12 +169,9 @@ pub(crate) async fn get_workflow_runtime_tree(
     State(state): State<Arc<AppState>>,
     Query(query): Query<WorkflowRuntimeTreeQuery>,
 ) -> Response {
-    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "workflow runtime store unavailable" })),
-        )
-            .into_response();
+    let store = match state.workflow_runtime_store() {
+        Ok(store) => store,
+        Err(error) => return error.into_response(),
     };
     let limit = query
         .limit

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -16,6 +16,7 @@ use axum::{
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, AtomicU64};
 
+pub(crate) mod api_error;
 pub(crate) mod auth;
 pub(crate) mod auth_routes;
 pub(crate) mod auto_merge;

--- a/crates/harness-server/src/http/runtime_submission_routes.rs
+++ b/crates/harness-server/src/http/runtime_submission_routes.rs
@@ -93,8 +93,8 @@ pub(crate) async fn get_artifacts(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Response {
-    if state.core.workflow_runtime_store.is_none() {
-        return runtime_store_unavailable();
+    if let Err(error) = state.workflow_runtime_store() {
+        return error.into_response();
     }
     let task_id = harness_core::types::TaskId(id);
     match runtime_artifacts_by_handle(&state, &task_id).await {
@@ -111,8 +111,8 @@ pub(crate) async fn get_prompts(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Response {
-    if state.core.workflow_runtime_store.is_none() {
-        return runtime_store_unavailable();
+    if let Err(error) = state.workflow_runtime_store() {
+        return error.into_response();
     }
     let task_id = harness_core::types::TaskId(id);
     match runtime_prompts_by_handle(&state, &task_id).await {
@@ -280,14 +280,6 @@ fn internal_server_error() -> Response {
     (
         StatusCode::INTERNAL_SERVER_ERROR,
         Json(json!({"error": "internal server error"})),
-    )
-        .into_response()
-}
-
-fn runtime_store_unavailable() -> Response {
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(json!({"error": "workflow runtime store unavailable"})),
     )
         .into_response()
 }

--- a/crates/harness-server/src/http/sse_routes.rs
+++ b/crates/harness-server/src/http/sse_routes.rs
@@ -22,12 +22,8 @@ pub(crate) async fn stream_runtime_submission_sse(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Response {
-    if state.core.workflow_runtime_store.is_none() {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "workflow runtime store unavailable"})),
-        )
-            .into_response();
+    if let Err(error) = state.workflow_runtime_store() {
+        return error.into_response();
     }
     let task_id = harness_core::types::TaskId(id);
     match runtime_submission_sse_stream(state, task_id).await {

--- a/crates/harness-server/src/http/state.rs
+++ b/crates/harness-server/src/http/state.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{broadcast, Mutex};
 
+use super::api_error::ApiError;
 use super::rate_limit;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -289,6 +290,33 @@ pub struct AppState {
 }
 
 impl AppState {
+    pub(crate) fn issue_workflow_store(
+        &self,
+    ) -> Result<&Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>, ApiError> {
+        self.core
+            .issue_workflow_store
+            .as_ref()
+            .ok_or_else(|| ApiError::store_unavailable("issue workflow store"))
+    }
+
+    pub(crate) fn project_workflow_store(
+        &self,
+    ) -> Result<&Arc<harness_workflow::project_lifecycle::ProjectWorkflowStore>, ApiError> {
+        self.core
+            .project_workflow_store
+            .as_ref()
+            .ok_or_else(|| ApiError::store_unavailable("project workflow store"))
+    }
+
+    pub(crate) fn workflow_runtime_store(
+        &self,
+    ) -> Result<&Arc<harness_workflow::runtime::WorkflowRuntimeStore>, ApiError> {
+        self.core
+            .workflow_runtime_store
+            .as_ref()
+            .ok_or_else(|| ApiError::store_unavailable("workflow runtime store"))
+    }
+
     fn runtime_state_persistence_required(&self) -> bool {
         self.startup_statuses
             .iter()

--- a/crates/harness-server/src/http/task_mutation_routes.rs
+++ b/crates/harness-server/src/http/task_mutation_routes.rs
@@ -77,11 +77,9 @@ pub(super) async fn merge_workflow_runtime(
     State(state): State<Arc<AppState>>,
     Json(request): Json<WorkflowRuntimeMergeRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return (
-            StatusCode::CONFLICT,
-            Json(json!({ "error": "workflow runtime store unavailable" })),
-        );
+    let store = match state.workflow_runtime_store() {
+        Ok(store) => store,
+        Err(error) => return error.into_status_json(),
     };
     match crate::workflow_runtime_pr_feedback::approve_runtime_merge_by_workflow_id(
         store,
@@ -104,11 +102,9 @@ pub(super) async fn cancel_workflow_runtime(
     State(state): State<Arc<AppState>>,
     Json(request): Json<WorkflowRuntimeCancelRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "workflow runtime store unavailable" })),
-        );
+    let store = match state.workflow_runtime_store() {
+        Ok(store) => store,
+        Err(error) => return error.into_status_json(),
     };
 
     match crate::workflow_runtime_submission::cancel_submission_by_workflow_id(
@@ -207,11 +203,9 @@ pub(super) async fn reconstruct_runtime_transcript(
             "re-exported transcript checksum does not match expected_checksum",
         );
     }
-    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return runtime_recovery_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "workflow runtime store unavailable",
-        );
+    let store = match state.workflow_runtime_store() {
+        Ok(store) => store,
+        Err(error) => return error.into_status_json(),
     };
     let sources = match store
         .command_sources_for_runtime_jobs(&[runtime_job_id.to_string()])
@@ -287,11 +281,9 @@ async fn recover_workflow_runtime(
     if reason.is_empty() {
         return runtime_recovery_error(StatusCode::BAD_REQUEST, "reason is required");
     }
-    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
-        return runtime_recovery_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "workflow runtime store unavailable",
-        );
+    let store = match state.workflow_runtime_store() {
+        Ok(store) => store,
+        Err(error) => return error.into_status_json(),
     };
 
     match store

--- a/crates/harness-server/src/http/task_query_routes.rs
+++ b/crates/harness-server/src/http/task_query_routes.rs
@@ -145,12 +145,8 @@ pub(crate) async fn list_runtime_submissions(
         Ok(query) => query,
         Err(error) => return error.into_response(),
     };
-    if state.core.workflow_runtime_store.is_none() {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "workflow runtime store unavailable"})),
-        )
-            .into_response();
+    if let Err(error) = state.workflow_runtime_store() {
+        return error.into_response();
     }
 
     let cursor = query

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -59,8 +59,8 @@ pub(crate) async fn get_runtime_submission(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Response {
-    if state.core.workflow_runtime_store.is_none() {
-        return workflow_runtime_store_unavailable_response();
+    if let Err(error) = state.workflow_runtime_store() {
+        return error.into_response();
     }
     let task_id = harness_core::types::TaskId(id);
     match runtime_task_response_by_handle(&state, &task_id).await {
@@ -172,17 +172,6 @@ async fn runtime_task_response_by_handle(
         subtask_ids: Vec::new(),
         workflow: Some(TaskWorkflowSummary::from_runtime(&workflow)),
     }))
-}
-
-fn workflow_runtime_store_unavailable_response() -> Response {
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(json!({
-            "error": "workflow runtime store unavailable",
-            "message": "workflow runtime store is unavailable",
-        })),
-    )
-        .into_response()
 }
 
 pub(crate) fn proof_from_runtime_workflow(
@@ -320,8 +309,8 @@ pub(crate) async fn get_runtime_submission_proof(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Response {
-    if state.core.workflow_runtime_store.is_none() {
-        return workflow_runtime_store_unavailable_response();
+    if let Err(error) = state.workflow_runtime_store() {
+        return error.into_response();
     }
     let task_id = harness_core::types::TaskId(id);
     match runtime_proof_by_handle(&state, &task_id).await {

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -1,5 +1,6 @@
 use super::AppState;
 use crate::{
+    http::api_error::ApiError,
     runtime_projection::RuntimeWorkflowProjection,
     services::execution::EnqueueTaskError,
     workflow_runtime_submission::{CreateTaskRequest, TaskId},
@@ -45,17 +46,14 @@ pub(crate) struct TaskResponseDetails {
 pub(crate) async fn task_response_details(
     state: &AppState,
     task_id: &TaskId,
-) -> Result<TaskResponseDetails, EnqueueTaskError> {
-    let store =
-        state.core.workflow_runtime_store.as_ref().ok_or_else(|| {
-            EnqueueTaskError::Internal("workflow runtime store unavailable".into())
-        })?;
+) -> Result<TaskResponseDetails, ApiError> {
+    let store = state.workflow_runtime_store()?;
     let workflow = store
         .get_instance_by_submission_id(task_id.as_str())
         .await
-        .map_err(|error| EnqueueTaskError::Internal(error.to_string()))?
+        .map_err(|error| ApiError::internal(error.to_string()))?
         .ok_or_else(|| {
-            EnqueueTaskError::Internal(format!(
+            ApiError::internal(format!(
                 "workflow runtime submission not found for {}",
                 task_id.as_str()
             ))
@@ -95,40 +93,8 @@ pub(super) async fn create_runtime_submission(
                 Json(task_submission_response(&task_id, details)),
             )
                 .into_response(),
-            Err(EnqueueTaskError::BadRequest(error)) => {
-                (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))).into_response()
-            }
-            Err(EnqueueTaskError::Internal(error)) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({ "error": error })),
-            )
-                .into_response(),
-            Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs }) => (
-                StatusCode::SERVICE_UNAVAILABLE,
-                [(
-                    axum::http::header::RETRY_AFTER,
-                    retry_after_secs.to_string(),
-                )],
-                Json(json!({ "error": "maintenance_window", "retry_after": retry_after_secs })),
-            )
-                .into_response(),
+            Err(error) => error.into_response(),
         },
-        Err(EnqueueTaskError::BadRequest(error)) => {
-            (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))).into_response()
-        }
-        Err(EnqueueTaskError::Internal(error)) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": error })),
-        )
-            .into_response(),
-        Err(EnqueueTaskError::MaintenanceWindow { retry_after_secs }) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            [(
-                axum::http::header::RETRY_AFTER,
-                retry_after_secs.to_string(),
-            )],
-            Json(json!({ "error": "maintenance_window", "retry_after": retry_after_secs })),
-        )
-            .into_response(),
+        Err(error) => ApiError::from(error).into_response(),
     }
 }

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -472,6 +472,50 @@ async fn workflow_runtime_cancel_endpoint_cancels_issue_workflow() -> anyhow::Re
     Ok(())
 }
 
+#[tokio::test]
+async fn workflow_runtime_mutations_share_store_unavailable_contract() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let state = make_read_only_route_test_state(dir.path()).await?;
+    let app = Router::new()
+        .route(
+            "/api/workflows/runtime/merge",
+            post(task_mutation_routes::merge_workflow_runtime),
+        )
+        .route(
+            "/api/workflows/runtime/cancel",
+            post(task_mutation_routes::cancel_workflow_runtime),
+        )
+        .with_state(state);
+
+    for route in [
+        "/api/workflows/runtime/merge",
+        "/api/workflows/runtime/cancel",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(route)
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "workflow_id": "missing-store" }).to_string(),
+                    ))?,
+            )
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = response_json(response).await?;
+        assert_eq!(body["error"], "workflow runtime store unavailable");
+    }
+
+    Ok(())
+}
+
 #[rustfmt::skip]
 #[tokio::test]
 async fn workflow_runtime_recovery_endpoints_cover_contract() -> anyhow::Result<()> {

--- a/crates/harness-server/src/http/tests/task_detail_sse_tests.rs
+++ b/crates/harness-server/src/http/tests/task_detail_sse_tests.rs
@@ -46,7 +46,6 @@ async fn get_task_returns_service_unavailable_when_required_workflow_runtime_sto
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let body = response_json(response).await?;
     assert_eq!(body["error"], "workflow runtime store unavailable");
-    assert_eq!(body["message"], "workflow runtime store is unavailable");
     Ok(())
 }
 
@@ -77,7 +76,6 @@ async fn get_task_proof_returns_service_unavailable_when_required_workflow_runti
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let body = response_json(response).await?;
     assert_eq!(body["error"], "workflow runtime store unavailable");
-    assert_eq!(body["message"], "workflow runtime store is unavailable");
     Ok(())
 }
 

--- a/crates/harness-server/src/http/tests/webhook_runtime_tests.rs
+++ b/crates/harness-server/src/http/tests/webhook_runtime_tests.rs
@@ -193,12 +193,9 @@ async fn webhook_issues_opened_requires_workflow_runtime_store() -> anyhow::Resu
         )
         .await?;
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let json = response_json(response).await?;
-    assert_eq!(
-        json["error"],
-        "workflow runtime store is required for submissions"
-    );
+    assert_eq!(json["error"], "workflow runtime store unavailable");
     assert_eq!(state.core.tasks.count(), before_count);
     Ok(())
 }

--- a/crates/harness-server/src/http/tests/webhook_task_tests.rs
+++ b/crates/harness-server/src/http/tests/webhook_task_tests.rs
@@ -443,12 +443,9 @@ async fn create_task_with_prompt_requires_workflow_runtime_store() -> anyhow::Re
         )
         .await?;
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let resp = response_json(response).await?;
-    assert_eq!(
-        resp["error"],
-        "workflow runtime store is required for submissions"
-    );
+    assert_eq!(resp["error"], "workflow runtime store unavailable");
     assert_eq!(state.core.tasks.count(), before_count);
     Ok(())
 }
@@ -598,12 +595,9 @@ async fn create_task_with_issue_requires_workflow_runtime_store() -> anyhow::Res
         )
         .await?;
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     let resp = response_json(response).await?;
-    assert_eq!(
-        resp["error"],
-        "workflow runtime store is required for submissions"
-    );
+    assert_eq!(resp["error"], "workflow runtime store unavailable");
     assert_eq!(state.core.tasks.count(), before_count);
 
     Ok(())

--- a/crates/harness-server/src/http/workflow_routes.rs
+++ b/crates/harness-server/src/http/workflow_routes.rs
@@ -56,20 +56,13 @@ where
     }
 }
 
-fn workflow_lookup_store_unavailable(entity: &'static str) -> Response {
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(json!({ "error": format!("{entity} store unavailable") })),
-    )
-        .into_response()
-}
-
 pub(crate) async fn get_issue_workflow_by_issue(
     State(state): State<Arc<AppState>>,
     Query(query): Query<IssueWorkflowByIssueQuery>,
 ) -> Response {
-    let Some(store) = state.core.issue_workflow_store.as_ref() else {
-        return workflow_lookup_store_unavailable("issue workflow");
+    let store = match state.issue_workflow_store() {
+        Ok(store) => store,
+        Err(error) => return error.into_response(),
     };
     workflow_lookup_response(
         "issue workflow",
@@ -82,8 +75,9 @@ pub(crate) async fn get_issue_workflow_by_pr(
     State(state): State<Arc<AppState>>,
     Query(query): Query<IssueWorkflowByPrQuery>,
 ) -> Response {
-    let Some(store) = state.core.issue_workflow_store.as_ref() else {
-        return workflow_lookup_store_unavailable("issue workflow");
+    let store = match state.issue_workflow_store() {
+        Ok(store) => store,
+        Err(error) => return error.into_response(),
     };
     workflow_lookup_response(
         "issue workflow",
@@ -96,8 +90,9 @@ pub(crate) async fn get_project_workflow_by_project(
     State(state): State<Arc<AppState>>,
     Query(query): Query<ProjectWorkflowByProjectQuery>,
 ) -> Response {
-    let Some(store) = state.core.project_workflow_store.as_ref() else {
-        return workflow_lookup_store_unavailable("project workflow");
+    let store = match state.project_workflow_store() {
+        Ok(store) => store,
+        Err(error) => return error.into_response(),
     };
     workflow_lookup_response(
         "project workflow",

--- a/crates/harness-server/src/services/execution.rs
+++ b/crates/harness-server/src/services/execution.rs
@@ -24,6 +24,7 @@ pub use crate::workflow_runtime_submission::runtime_models::QueueDomain;
 pub enum EnqueueTaskError {
     BadRequest(String),
     Internal(String),
+    StoreUnavailable(&'static str),
     MaintenanceWindow { retry_after_secs: u64 },
 }
 
@@ -32,6 +33,7 @@ impl std::fmt::Display for EnqueueTaskError {
         match self {
             Self::BadRequest(message) => write!(f, "bad request: {message}"),
             Self::Internal(message) => write!(f, "internal error: {message}"),
+            Self::StoreUnavailable(store_name) => write!(f, "{store_name} unavailable"),
             Self::MaintenanceWindow { retry_after_secs } => {
                 write!(
                     f,
@@ -387,9 +389,7 @@ impl DefaultExecutionService {
             ));
         }
         if self.workflow_runtime_store.is_none() {
-            return Err(EnqueueTaskError::Internal(
-                "workflow runtime store is required for submissions".to_string(),
-            ));
+            return Err(EnqueueTaskError::StoreUnavailable("workflow runtime store"));
         }
 
         if let Some(definition_id) = req.definition_id.as_deref() {


### PR DESCRIPTION
## Summary
- Add a shared HTTP ApiError with IntoResponse and centralized EnqueueTaskError mapping.
- Add AppState store accessors and migrate duplicated workflow-store unavailable responses to a consistent 503 contract.
- Update submission/webhook/runtime mutation tests for the unified store-unavailable response.

## Validation
- cargo fmt --all
- cargo fmt --all -- --check
- cargo check
- cargo check -p harness-server --all-targets
- cargo test -p harness-server api_error
- cargo test -p harness-server workflow_runtime_mutations_share_store_unavailable_contract
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- env -u HARNESS_DATABASE_URL git push -u origin harness/issue-1796-api-error (pre-push DB-less checks passed)

Note: env -u HARNESS_DATABASE_URL cargo test was also attempted; it failed in this local environment on DB-backed tests with Postgres bootstrap pool timeouts. The hook DB-less validation path passed.

Closes #1796