### PR TITLE
chore(repo): refresh specs index state

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -75,7 +75,7 @@ Lifecycle status per spec directory. Generated 2026-07-29 from GitHub issue stat
 | [GH1716](./GH1716) | #1716 | implemented (issue closed) |
 | [GH1717](./GH1717) | #1717 | implemented (issue closed) |
 | [GH1730](./GH1730) | #1730 | implemented (issue closed) |
-| [GH1731](./GH1731) | #1731 | open |
+| [GH1731](./GH1731) | #1731 | implemented (issue closed) |
 | [GH1732](./GH1732) | #1732 | open |
 | [GH1765](./GH1765) | #1765 | open |
 | [GH1766](./GH1766) | #1766 | implemented (issue closed) |


### PR DESCRIPTION
Refs #1805.

## Summary
- Refresh `specs/INDEX.md` after #1731 closed on 2026-07-28.
- Keep the change scoped to the remaining accepted repository metadata/index cleanup.

## Validation
- `ruby -rjson -e ...` — `specs/INDEX.md` matches GitHub issue states for indexed GH specs.
- `git diff --check` — passed.
- `cargo fmt --all -- --check` — passed.
- `cargo check` — passed.
- `bash -n scripts/doctor.sh` — passed.
- `scripts/doctor.sh --dry-run` — exited 0; reported an existing port 9800 listener in the local environment.
- `env -u HARNESS_DATABASE_URL -u DATABASE_URL git push -u origin harness/issue-1805-specs-index-refresh` — pre-push clippy and DB-less lib tests passed; PostgreSQL-backed suites were deferred because no isolated test `HARNESS_DATABASE_URL` was supplied.

## Scope guard
- Base: `origin/main`
- Files changed: 1
- Lines added: 1
- Thresholds: 30 files / 1500 added lines

## Remaining #1805 blocker
This PR intentionally does not close #1805. The remaining `.yaml` rename / single-location workflow-config criterion is a configuration contract change, not a metadata-only cleanup. Current `origin/main` still treats `WORKFLOW.md` as an established repo/base configuration contract across loader, CLI registration, tests, stack inventory/provenance, runtime worker paths, and `scripts/doctor.sh`; `config/WORKFLOW.md` is documented as the central base that is deep-merged with per-repo `WORKFLOW.md` overrides. Resolving that remaining criterion needs a separate contract-change issue with migration scope beyond this lane.