### PR TITLE
fix(agents): consolidate agent spawn supervision (GH-1785)

### DIFF
--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -218,8 +218,8 @@ impl CodeAgent for ClaudeCodeAgent {
             .await?;
 
         let spawn_project_root = req.project_root.clone();
-        let supervised =
-            crate::spawn_supervisor::spawn_agent(crate::spawn_supervisor::AgentSpawnPlan {
+        let supervised = crate::spawn_supervisor::spawn_agent(
+            crate::spawn_supervisor::AgentSpawnPlan {
                 prepared_spawn,
                 run_identity,
                 native_kind: "claude-code",
@@ -234,8 +234,10 @@ impl CodeAgent for ClaudeCodeAgent {
                     );
                     harness_core::error::HarnessError::AgentExecution(message)
                 }),
-            })
-            .await?;
+            },
+            req.capability_token.as_ref(),
+        )
+        .await?;
         let mut child = supervised.child;
 
         let limits = crate::OutputLimits::from_stream_timeout_secs(self.stream_timeout_secs);
@@ -346,8 +348,8 @@ impl CodeAgent for ClaudeCodeAgent {
         );
 
         let spawn_project_root = req.project_root.clone();
-        let supervised =
-            crate::spawn_supervisor::spawn_agent(crate::spawn_supervisor::AgentSpawnPlan {
+        let supervised = crate::spawn_supervisor::spawn_agent(
+            crate::spawn_supervisor::AgentSpawnPlan {
                 prepared_spawn,
                 run_identity,
                 native_kind: "claude-code",
@@ -362,8 +364,10 @@ impl CodeAgent for ClaudeCodeAgent {
                     );
                     harness_core::error::HarnessError::AgentExecution(message)
                 }),
-            })
-            .await?;
+            },
+            req.capability_token.as_ref(),
+        )
+        .await?;
         let mut child = supervised.child;
 
         let stderr_capture = Arc::new(Mutex::new(String::new()));

--- a/crates/harness-agents/src/claude.rs
+++ b/crates/harness-agents/src/claude.rs
@@ -20,7 +20,6 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
-use tokio::process::Command;
 use tokio::sync::mpsc;
 
 pub struct ClaudeCodeAgent {
@@ -209,17 +208,6 @@ impl CodeAgent for ClaudeCodeAgent {
             "spawning claude agent"
         );
 
-        let mut cmd = Command::new(&prepared_spawn.program);
-        cmd.args(&prepared_spawn.args)
-            .current_dir(&prepared_spawn.current_dir)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
-        #[cfg(unix)]
-        crate::set_process_group(&mut cmd);
-        crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-
         let _provider_permit = self
             .provider_gate
             .acquire(
@@ -229,38 +217,26 @@ impl CodeAgent for ClaudeCodeAgent {
             )
             .await?;
 
-        let spawn_result = cmd.spawn();
-        let child = match spawn_result {
-            Ok(child) => child,
-            Err(ref error) if error.raw_os_error() == Some(26) => {
-                tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-                cmd.spawn().map_err(|error| {
+        let spawn_project_root = req.project_root.clone();
+        let supervised =
+            crate::spawn_supervisor::spawn_agent(crate::spawn_supervisor::AgentSpawnPlan {
+                prepared_spawn,
+                run_identity,
+                native_kind: "claude-code",
+                process_label: "claude execute",
+                stdio: crate::spawn_supervisor::AgentStdio::piped_output(Stdio::null()),
+                extra_env_removals: Vec::new(),
+                map_spawn_error: Box::new(move |error, _spawn| {
                     let message = crate::classify_missing_workspace_spawn_failure(
-                        &error,
-                        &req.project_root,
+                        error,
+                        &spawn_project_root,
                         format!("failed to run claude: {error}"),
                     );
                     harness_core::error::HarnessError::AgentExecution(message)
-                })?
-            }
-            Err(error) => {
-                let message = crate::classify_missing_workspace_spawn_failure(
-                    &error,
-                    &req.project_root,
-                    format!("failed to run claude: {error}"),
-                );
-                return Err(harness_core::error::HarnessError::AgentExecution(message));
-            }
-        };
-        if let Some(pid) = child.id() {
-            crate::write_provisional_agent_run_binding(
-                &run_identity,
-                "claude-code",
-                pid,
-                &prepared_spawn.current_dir,
-            );
-        }
-        let mut child = crate::ManagedChild::new(child, "claude execute");
+                }),
+            })
+            .await?;
+        let mut child = supervised.child;
 
         let limits = crate::OutputLimits::from_stream_timeout_secs(self.stream_timeout_secs);
         let output = child.wait_with_output(&limits).await.map_err(|e| {
@@ -369,51 +345,26 @@ impl CodeAgent for ClaudeCodeAgent {
             "claude execute_stream admitted by provider gate"
         );
 
-        let mut cmd = Command::new(&prepared_spawn.program);
-        cmd.args(&prepared_spawn.args)
-            .current_dir(&prepared_spawn.current_dir)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
-        #[cfg(unix)]
-        crate::set_process_group(&mut cmd);
-        crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-
-        // ETXTBSY (error 26) occurs on Linux when a security scanner or indexer
-        // briefly opens the executable for writing after it is written. Retry once.
-        let spawn_result = cmd.spawn();
-        let child = match spawn_result {
-            Ok(child) => child,
-            Err(ref e) if e.raw_os_error() == Some(26) => {
-                tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-                cmd.spawn().map_err(|error| {
+        let spawn_project_root = req.project_root.clone();
+        let supervised =
+            crate::spawn_supervisor::spawn_agent(crate::spawn_supervisor::AgentSpawnPlan {
+                prepared_spawn,
+                run_identity,
+                native_kind: "claude-code",
+                process_label: "claude execute_stream",
+                stdio: crate::spawn_supervisor::AgentStdio::piped_output(Stdio::null()),
+                extra_env_removals: Vec::new(),
+                map_spawn_error: Box::new(move |error, _spawn| {
                     let message = crate::classify_missing_workspace_spawn_failure(
-                        &error,
-                        &req.project_root,
+                        error,
+                        &spawn_project_root,
                         format!("failed to run claude: {error}"),
                     );
                     harness_core::error::HarnessError::AgentExecution(message)
-                })?
-            }
-            Err(error) => {
-                let message = crate::classify_missing_workspace_spawn_failure(
-                    &error,
-                    &req.project_root,
-                    format!("failed to run claude: {error}"),
-                );
-                return Err(harness_core::error::HarnessError::AgentExecution(message));
-            }
-        };
-        if let Some(pid) = child.id() {
-            crate::write_provisional_agent_run_binding(
-                &run_identity,
-                "claude-code",
-                pid,
-                &prepared_spawn.current_dir,
-            );
-        }
-        let mut child = crate::ManagedChild::new(child, "claude execute_stream");
+                }),
+            })
+            .await?;
+        let mut child = supervised.child;
 
         let stderr_capture = Arc::new(Mutex::new(String::new()));
         let mut stderr_task = None;

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -265,6 +265,7 @@ impl CodexAgent {
                     harness_core::error::HarnessError::AgentExecution(message)
                 }),
             },
+            None,
         )
         .await?;
         let mut child = supervised.child;
@@ -444,8 +445,8 @@ impl CodeAgent for CodexAgent {
             "execute",
         );
         let spawn_error_req = req.clone();
-        let supervised =
-            crate::spawn_supervisor::spawn_agent(crate::spawn_supervisor::AgentSpawnPlan {
+        let supervised = crate::spawn_supervisor::spawn_agent(
+            crate::spawn_supervisor::AgentSpawnPlan {
                 prepared_spawn,
                 run_identity,
                 native_kind: "codex",
@@ -461,8 +462,10 @@ impl CodeAgent for CodexAgent {
                         "execute",
                     ))
                 }),
-            })
-            .await?;
+            },
+            req.capability_token.as_ref(),
+        )
+        .await?;
         let mut child = supervised.child;
         let limits = crate::OutputLimits::from_stream_timeout_secs(self.stream_timeout_secs);
         let output = child.wait_with_output(&limits).await.map_err(|err| {
@@ -552,8 +555,8 @@ impl CodeAgent for CodexAgent {
             "execute_stream",
         );
         let spawn_error_req = req.clone();
-        let supervised =
-            crate::spawn_supervisor::spawn_agent(crate::spawn_supervisor::AgentSpawnPlan {
+        let supervised = crate::spawn_supervisor::spawn_agent(
+            crate::spawn_supervisor::AgentSpawnPlan {
                 prepared_spawn,
                 run_identity,
                 native_kind: "codex",
@@ -569,8 +572,10 @@ impl CodeAgent for CodexAgent {
                         "execute_stream",
                     ))
                 }),
-            })
-            .await?;
+            },
+            req.capability_token.as_ref(),
+        )
+        .await?;
         let mut child = supervised.child;
 
         let stderr_capture = Arc::new(Mutex::new(String::new()));

--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -15,7 +15,6 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use tokio::io::AsyncWriteExt;
-use tokio::process::Command;
 
 #[path = "codex_exec_parser.rs"]
 mod codex_exec_parser;
@@ -225,27 +224,6 @@ impl CodexAgent {
         let use_stdin_prompt = review_uses_stdin_prompt(&req);
         let (prepared_spawn, run_identity) = self.prepare_review_spawn(&req)?;
 
-        let mut cmd = Command::new(&prepared_spawn.program);
-        cmd.args(&prepared_spawn.args)
-            .current_dir(&prepared_spawn.current_dir)
-            .stdin(if use_stdin_prompt {
-                Stdio::piped()
-            } else {
-                Stdio::null()
-            })
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
-        #[cfg(unix)]
-        crate::set_process_group(&mut cmd);
-        crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-
-        if self.cloud.enabled {
-            for key in &self.cloud.setup_secret_env {
-                cmd.env_remove(key);
-            }
-        }
-
         tracing::debug!(
             agent = "codex",
             mode = "review",
@@ -256,33 +234,46 @@ impl CodexAgent {
             has_stdin_instructions = use_stdin_prompt,
             "codex review spawn prepared"
         );
-        let mut child = cmd.spawn().map_err(|error| {
-            let message = format!(
-                "failed to run codex review: {error}; mode=review; program={}; current_dir={}; sandbox_engine={:?}; arg_count={}",
-                prepared_spawn.program.display(),
-                prepared_spawn.current_dir.display(),
-                prepared_spawn.sandbox_engine,
-                prepared_spawn.args.len()
-            );
-            let message =
-                crate::classify_missing_workspace_spawn_failure(&error, &req.project_root, message);
-            tracing::error!(agent = "codex", mode = "review", error_kind = ?error.kind(), "{message}");
-            harness_core::error::HarnessError::AgentExecution(message)
-        })?;
-        if let Some(pid) = child.id() {
-            crate::write_provisional_agent_run_binding(
-                &run_identity,
-                "codex",
-                pid,
-                &prepared_spawn.current_dir,
-            );
-        }
+        let spawn_project_root = req.project_root.clone();
+        let supervised = crate::spawn_supervisor::spawn_agent(
+            crate::spawn_supervisor::AgentSpawnPlan {
+                prepared_spawn,
+                run_identity,
+                native_kind: "codex",
+                process_label: "codex review",
+                stdio: crate::spawn_supervisor::AgentStdio::piped_output(
+                    if use_stdin_prompt {
+                        Stdio::piped()
+                    } else {
+                        Stdio::null()
+                    },
+                ),
+                extra_env_removals: cloud_setup_env_removals(&self.cloud),
+                map_spawn_error: Box::new(move |error, spawn| {
+                    let message = format!(
+                        "failed to run codex review: {error}; mode=review; program={}; current_dir={}; sandbox_engine={:?}; arg_count={}",
+                        spawn.program.display(),
+                        spawn.current_dir.display(),
+                        spawn.sandbox_engine,
+                        spawn.args.len()
+                    );
+                    let message = crate::classify_missing_workspace_spawn_failure(
+                        error,
+                        &spawn_project_root,
+                        message,
+                    );
+                    harness_core::error::HarnessError::AgentExecution(message)
+                }),
+            },
+        )
+        .await?;
+        let mut child = supervised.child;
 
         if use_stdin_prompt {
             let Some(instructions) = req.instructions.as_deref() else {
                 unreachable!("review stdin prompt requires instructions");
             };
-            let Some(mut stdin) = child.stdin.take() else {
+            let Some(mut stdin) = child.inner_mut().stdin.take() else {
                 return Err(harness_core::error::HarnessError::AgentExecution(
                     "failed to open stdin for codex review instructions".to_string(),
                 ));
@@ -297,7 +288,6 @@ impl CodexAgent {
                 })?;
         }
 
-        let mut child = crate::ManagedChild::new(child, "codex review");
         let limits = crate::OutputLimits::from_stream_timeout_secs(self.stream_timeout_secs);
         let output = child.wait_with_output(&limits).await.map_err(|error| {
             harness_core::error::HarnessError::AgentExecution(format!(
@@ -341,6 +331,14 @@ fn review_uses_stdin_prompt(req: &CodexReviewRequest) -> bool {
 
 fn review_uses_config_instructions(req: &CodexReviewRequest) -> bool {
     req.instructions.is_some() && !review_uses_stdin_prompt(req)
+}
+
+fn cloud_setup_env_removals(cloud: &CodexCloudConfig) -> Vec<String> {
+    if cloud.enabled {
+        cloud.setup_secret_env.clone()
+    } else {
+        Vec::new()
+    }
 }
 
 fn codex_structured_error_from_stdout(stdout: &str) -> Option<String> {
@@ -438,23 +436,6 @@ impl CodeAgent for CodexAgent {
                 forward_stdin: false,
             })?;
 
-        let mut cmd = Command::new(&prepared_spawn.program);
-        cmd.args(&prepared_spawn.args)
-            .current_dir(&prepared_spawn.current_dir)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
-        #[cfg(unix)]
-        crate::set_process_group(&mut cmd);
-        crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-
-        if self.cloud.enabled {
-            for key in &self.cloud.setup_secret_env {
-                cmd.env_remove(key);
-            }
-        }
-
         log_codex_spawn_attempt(
             &prepared_spawn.program,
             prepared_spawn.args.len(),
@@ -462,31 +443,27 @@ impl CodeAgent for CodexAgent {
             prepared_spawn.sandbox_engine,
             "execute",
         );
-        let child = cmd.spawn().map_err(|err| {
-            let message = codex_spawn_failure_message(
-                &err,
-                &prepared_spawn.program,
-                &req,
-                prepared_spawn.sandbox_engine,
-                "execute",
-            );
-            tracing::error!(
-                agent = "codex",
-                mode = "execute",
-                error_kind = ?err.kind(),
-                "{message}"
-            );
-            harness_core::error::HarnessError::AgentExecution(message)
-        })?;
-        if let Some(pid) = child.id() {
-            crate::write_provisional_agent_run_binding(
-                &run_identity,
-                "codex",
-                pid,
-                &prepared_spawn.current_dir,
-            );
-        }
-        let mut child = crate::ManagedChild::new(child, "codex execute");
+        let spawn_error_req = req.clone();
+        let supervised =
+            crate::spawn_supervisor::spawn_agent(crate::spawn_supervisor::AgentSpawnPlan {
+                prepared_spawn,
+                run_identity,
+                native_kind: "codex",
+                process_label: "codex execute",
+                stdio: crate::spawn_supervisor::AgentStdio::piped_output(Stdio::null()),
+                extra_env_removals: cloud_setup_env_removals(&self.cloud),
+                map_spawn_error: Box::new(move |error, spawn| {
+                    harness_core::error::HarnessError::AgentExecution(codex_spawn_failure_message(
+                        error,
+                        &spawn.program,
+                        &spawn_error_req,
+                        spawn.sandbox_engine,
+                        "execute",
+                    ))
+                }),
+            })
+            .await?;
+        let mut child = supervised.child;
         let limits = crate::OutputLimits::from_stream_timeout_secs(self.stream_timeout_secs);
         let output = child.wait_with_output(&limits).await.map_err(|err| {
             harness_core::error::HarnessError::AgentExecution(format!(
@@ -567,23 +544,6 @@ impl CodeAgent for CodexAgent {
                 forward_stdin: false,
             })?;
 
-        let mut cmd = Command::new(&prepared_spawn.program);
-        cmd.args(&prepared_spawn.args)
-            .current_dir(&prepared_spawn.current_dir)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
-        #[cfg(unix)]
-        crate::set_process_group(&mut cmd);
-        crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-
-        if self.cloud.enabled {
-            for key in &self.cloud.setup_secret_env {
-                cmd.env_remove(key);
-            }
-        }
-
         log_codex_spawn_attempt(
             &prepared_spawn.program,
             prepared_spawn.args.len(),
@@ -591,31 +551,27 @@ impl CodeAgent for CodexAgent {
             prepared_spawn.sandbox_engine,
             "execute_stream",
         );
-        let child = cmd.spawn().map_err(|error| {
-            let message = codex_spawn_failure_message(
-                &error,
-                &prepared_spawn.program,
-                &req,
-                prepared_spawn.sandbox_engine,
-                "execute_stream",
-            );
-            tracing::error!(
-                agent = "codex",
-                mode = "execute_stream",
-                error_kind = ?error.kind(),
-                "{message}"
-            );
-            harness_core::error::HarnessError::AgentExecution(message)
-        })?;
-        if let Some(pid) = child.id() {
-            crate::write_provisional_agent_run_binding(
-                &run_identity,
-                "codex",
-                pid,
-                &prepared_spawn.current_dir,
-            );
-        }
-        let mut child = crate::ManagedChild::new(child, "codex execute_stream");
+        let spawn_error_req = req.clone();
+        let supervised =
+            crate::spawn_supervisor::spawn_agent(crate::spawn_supervisor::AgentSpawnPlan {
+                prepared_spawn,
+                run_identity,
+                native_kind: "codex",
+                process_label: "codex execute_stream",
+                stdio: crate::spawn_supervisor::AgentStdio::piped_output(Stdio::null()),
+                extra_env_removals: cloud_setup_env_removals(&self.cloud),
+                map_spawn_error: Box::new(move |error, spawn| {
+                    harness_core::error::HarnessError::AgentExecution(codex_spawn_failure_message(
+                        error,
+                        &spawn.program,
+                        &spawn_error_req,
+                        spawn.sandbox_engine,
+                        "execute_stream",
+                    ))
+                }),
+            })
+            .await?;
+        let mut child = supervised.child;
 
         let stderr_capture = Arc::new(Mutex::new(String::new()));
         let mut stderr_task = None;

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -287,7 +287,7 @@ impl CodexAdapter {
         let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
         let prepared_spawn = prepare_app_server_spawn(&self.cli_path, req)?;
         let spawn_project_root = req.project_root.clone();
-        let supervised = crate::spawn_supervisor::spawn_agent_with_capability(
+        let supervised = crate::spawn_supervisor::spawn_agent(
             crate::spawn_supervisor::AgentSpawnPlan {
                 prepared_spawn,
                 run_identity,
@@ -555,12 +555,15 @@ impl AgentAdapter for CodexAdapter {
             ));
         }
 
-        self.state.lock().await.stdout_lines = Some(lines);
         if receiver_closed {
+            drop(lines);
+            let mut state = self.state.lock().await;
+            state.reset_child().await;
             return Err(harness_core::error::HarnessError::AgentExecution(
                 "codex event receiver closed before turn/completed".into(),
             ));
         }
+        self.state.lock().await.stdout_lines = Some(lines);
         Ok(())
     }
 
@@ -628,3 +631,7 @@ impl AgentAdapter for CodexAdapter {
 #[cfg(test)]
 #[path = "codex_adapter_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "codex_adapter_receiver_tests.rs"]
+mod receiver_tests;

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -14,9 +14,17 @@ use tokio::sync::{mpsc, Mutex};
 type StdoutLines = Lines<BufReader<ChildStdout>>;
 const MAX_PROTOCOL_LINE_PREVIEW: usize = 240;
 mod protocol;
+/// Parse one Codex app-server JSON-RPC line.
+///
+/// ```
+/// use harness_agents::codex_adapter::parse_codex_message;
+///
+/// assert!(parse_codex_message(r#"{"method":"custom/unknown","params":{}}"#).is_some());
+/// ```
+pub use self::protocol::parse_codex_message;
 use self::protocol::{
-    approval_decision_result, notification_payload, parse_codex_message, protocol_line_preview,
-    response_id_matches, thread_id_from_result, thread_start_params, turn_start_params,
+    approval_decision_result, notification_payload, protocol_line_preview, response_id_matches,
+    thread_id_from_result, thread_start_params, turn_start_params,
 };
 #[cfg(test)]
 use self::protocol::{sandbox_mode_value, sandbox_policy_value};
@@ -256,8 +264,7 @@ impl CodexAdapter {
         match tokio::time::timeout(stall_timeout, read).await {
             Ok(result) => result,
             Err(_) => Err(harness_core::error::HarnessError::AgentExecution(format!(
-                "codex app-server {phase} stalled for {}s without stdout",
-                stall_timeout.as_secs()
+                "codex app-server {phase} stalled for {stall_timeout:?} without stdout"
             ))),
         }
     }
@@ -280,8 +287,8 @@ impl CodexAdapter {
         let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
         let prepared_spawn = prepare_app_server_spawn(&self.cli_path, req)?;
         let spawn_project_root = req.project_root.clone();
-        let supervised =
-            crate::spawn_supervisor::spawn_agent(crate::spawn_supervisor::AgentSpawnPlan {
+        let supervised = crate::spawn_supervisor::spawn_agent_with_capability(
+            crate::spawn_supervisor::AgentSpawnPlan {
                 prepared_spawn,
                 run_identity,
                 native_kind: "codex",
@@ -298,8 +305,10 @@ impl CodexAdapter {
                     );
                     harness_core::error::HarnessError::AgentExecution(message)
                 }),
-            })
-            .await?;
+            },
+            req.capability_token.as_ref(),
+        )
+        .await?;
         let child_workspace = supervised.prepared_spawn.child_workspace.clone();
         let mut child = supervised.child;
 
@@ -320,7 +329,7 @@ impl CodexAdapter {
         state.child_workspace = Some(child_workspace.clone());
         let stall_timeout = app_server_stall_timeout(req);
 
-        let init_id = Self::send_request(
+        let init_id = match Self::send_request(
             state,
             "initialize",
             json!({
@@ -333,80 +342,103 @@ impl CodexAdapter {
                 }
             }),
         )
-        .await?;
+        .await
+        {
+            Ok(id) => id,
+            Err(error) => {
+                state.reset_child().await;
+                return Err(error);
+            }
+        };
 
         let mut lines = state.stdout_lines.take().ok_or_else(|| {
             harness_core::error::HarnessError::AgentExecution(
                 "codex stdout reader not available".into(),
             )
         })?;
-        loop {
-            match Self::read_next_message_with_timeout(&mut lines, stall_timeout, "initialize")
-                .await?
-            {
-                Some(ParsedCodexMessage::Response { id, .. })
-                    if response_id_matches(&id, init_id) =>
+        let protocol_result = async {
+            loop {
+                match Self::read_next_message_with_timeout(&mut lines, stall_timeout, "initialize")
+                    .await?
                 {
-                    break;
-                }
-                Some(ParsedCodexMessage::Event(AgentEvent::Warning { message })) => {
-                    tracing::warn!(agent = "codex", "{message}");
-                }
-                Some(ParsedCodexMessage::Event(AgentEvent::Error { message })) => {
-                    return Err(harness_core::error::HarnessError::AgentExecution(message));
-                }
-                Some(_) => {}
-                None => {
-                    return Err(harness_core::error::HarnessError::AgentExecution(
-                        "codex app-server exited during initialize".into(),
-                    ));
+                    Some(ParsedCodexMessage::Response { id, .. })
+                        if response_id_matches(&id, init_id) =>
+                    {
+                        break;
+                    }
+                    Some(ParsedCodexMessage::Event(AgentEvent::Warning { message })) => {
+                        tracing::warn!(agent = "codex", "{message}");
+                    }
+                    Some(ParsedCodexMessage::Event(AgentEvent::Error { message })) => {
+                        return Err(harness_core::error::HarnessError::AgentExecution(message));
+                    }
+                    Some(_) => {}
+                    None => {
+                        return Err(harness_core::error::HarnessError::AgentExecution(
+                            "codex app-server exited during initialize".into(),
+                        ));
+                    }
                 }
             }
-        }
 
-        Self::send_notification(state, "initialized", Value::Null).await?;
+            Self::send_notification(state, "initialized", Value::Null).await?;
 
-        let thread_id_request = Self::send_request(
-            state,
-            "thread/start",
-            thread_start_params(req, &child_workspace),
-        )
-        .await?;
+            let thread_id_request = Self::send_request(
+                state,
+                "thread/start",
+                thread_start_params(req, &child_workspace),
+            )
+            .await?;
 
-        loop {
-            match Self::read_next_message_with_timeout(&mut lines, stall_timeout, "thread/start")
+            loop {
+                match Self::read_next_message_with_timeout(
+                    &mut lines,
+                    stall_timeout,
+                    "thread/start",
+                )
                 .await?
-            {
-                Some(ParsedCodexMessage::ThreadStarted { thread_id }) => {
-                    state.thread_id = Some(thread_id);
-                    break;
-                }
-                Some(ParsedCodexMessage::Response { id, result })
-                    if response_id_matches(&id, thread_id_request) =>
                 {
-                    if let Some(thread_id) = thread_id_from_result(&result) {
+                    Some(ParsedCodexMessage::ThreadStarted { thread_id }) => {
                         state.thread_id = Some(thread_id);
                         break;
                     }
-                }
-                Some(ParsedCodexMessage::Event(AgentEvent::Warning { message })) => {
-                    tracing::warn!(agent = "codex", "{message}");
-                }
-                Some(ParsedCodexMessage::Event(AgentEvent::Error { message })) => {
-                    return Err(harness_core::error::HarnessError::AgentExecution(message));
-                }
-                Some(_) => {}
-                None => {
-                    return Err(harness_core::error::HarnessError::AgentExecution(
-                        "codex app-server exited before thread/start completed".into(),
-                    ));
+                    Some(ParsedCodexMessage::Response { id, result })
+                        if response_id_matches(&id, thread_id_request) =>
+                    {
+                        if let Some(thread_id) = thread_id_from_result(&result) {
+                            state.thread_id = Some(thread_id);
+                            break;
+                        }
+                    }
+                    Some(ParsedCodexMessage::Event(AgentEvent::Warning { message })) => {
+                        tracing::warn!(agent = "codex", "{message}");
+                    }
+                    Some(ParsedCodexMessage::Event(AgentEvent::Error { message })) => {
+                        return Err(harness_core::error::HarnessError::AgentExecution(message));
+                    }
+                    Some(_) => {}
+                    None => {
+                        return Err(harness_core::error::HarnessError::AgentExecution(
+                            "codex app-server exited before thread/start completed".into(),
+                        ));
+                    }
                 }
             }
+            Ok(())
         }
+        .await;
 
-        state.stdout_lines = Some(lines);
-
-        Ok(())
+        match protocol_result {
+            Ok(()) => {
+                state.stdout_lines = Some(lines);
+                Ok(())
+            }
+            Err(error) => {
+                drop(lines);
+                state.reset_child().await;
+                Err(error)
+            }
+        }
     }
 
     async fn clear_active_turn_id(&self) {
@@ -426,6 +458,7 @@ impl AgentAdapter for CodexAdapter {
         tx: mpsc::Sender<AgentEvent>,
     ) -> harness_core::error::Result<()> {
         let req = self.effective_turn_request(req);
+        crate::spawn_supervisor::validate_capability_token(req.capability_token.as_ref())?;
         crate::cloud_setup::run_setup_phase(&self.cloud, &req.project_root).await?;
         let mut state = self.state.lock().await;
         self.ensure_child(&req, &mut state).await?;
@@ -441,12 +474,16 @@ impl AgentAdapter for CodexAdapter {
             )
         })?;
 
-        Self::send_request(
+        if let Err(error) = Self::send_request(
             &mut state,
             "turn/start",
             turn_start_params(&req, &thread_id, &child_workspace),
         )
-        .await?;
+        .await
+        {
+            state.reset_child().await;
+            return Err(error);
+        }
 
         let mut lines = state.stdout_lines.take().ok_or_else(|| {
             harness_core::error::HarnessError::AgentExecution(
@@ -459,41 +496,51 @@ impl AgentAdapter for CodexAdapter {
         let mut receiver_closed = false;
         let mut stdout_closed = false;
         let stall_timeout = app_server_stall_timeout(&req);
-        while let Some(message) =
-            Self::read_next_message_with_timeout(&mut lines, stall_timeout, "turn").await?
-        {
-            match message {
-                ParsedCodexMessage::TurnStarted { turn_id } => {
-                    let mut guard = self.state.lock().await;
-                    guard.active_turn_id = Some(turn_id);
-                    drop(guard);
-                    if tx.send(AgentEvent::TurnStarted).await.is_err() {
-                        receiver_closed = true;
-                        break;
+        let read_result = async {
+            while let Some(message) =
+                Self::read_next_message_with_timeout(&mut lines, stall_timeout, "turn").await?
+            {
+                match message {
+                    ParsedCodexMessage::TurnStarted { turn_id } => {
+                        let mut guard = self.state.lock().await;
+                        guard.active_turn_id = Some(turn_id);
+                        drop(guard);
+                        if tx.send(AgentEvent::TurnStarted).await.is_err() {
+                            receiver_closed = true;
+                            break;
+                        }
                     }
-                }
-                ParsedCodexMessage::ThreadStarted { thread_id } => {
-                    self.state.lock().await.thread_id = Some(thread_id);
-                }
-                ParsedCodexMessage::Response { .. } | ParsedCodexMessage::Ignore => {}
-                ParsedCodexMessage::Event(event) => {
-                    let is_terminal = matches!(
-                        event,
-                        AgentEvent::TurnCompleted { .. } | AgentEvent::Error { .. }
-                    );
-                    if is_terminal {
-                        self.clear_active_turn_id().await;
+                    ParsedCodexMessage::ThreadStarted { thread_id } => {
+                        self.state.lock().await.thread_id = Some(thread_id);
                     }
-                    if tx.send(event).await.is_err() {
-                        receiver_closed = true;
-                        break;
-                    }
-                    if is_terminal {
-                        turn_completed = true;
-                        break;
+                    ParsedCodexMessage::Response { .. } | ParsedCodexMessage::Ignore => {}
+                    ParsedCodexMessage::Event(event) => {
+                        let is_terminal = matches!(
+                            event,
+                            AgentEvent::TurnCompleted { .. } | AgentEvent::Error { .. }
+                        );
+                        if is_terminal {
+                            self.clear_active_turn_id().await;
+                        }
+                        if tx.send(event).await.is_err() {
+                            receiver_closed = true;
+                            break;
+                        }
+                        if is_terminal {
+                            turn_completed = true;
+                            break;
+                        }
                     }
                 }
             }
+            Ok(())
+        }
+        .await;
+        if let Err(error) = read_result {
+            drop(lines);
+            let mut state = self.state.lock().await;
+            state.reset_child().await;
+            return Err(error);
         }
         if !turn_completed && !receiver_closed {
             stdout_closed = true;

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -1,4 +1,3 @@
-use crate::codex::{parse_codex_error_item_message, parse_codex_item, parse_codex_token_usage};
 use crate::streaming::capture_agent_stderr_diagnostics;
 use async_trait::async_trait;
 use harness_core::agent::{AgentAdapter, AgentEvent, ApprovalDecision, TurnRequest};
@@ -8,11 +7,19 @@ use serde_json::{json, Value};
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::ChildStdout;
 use tokio::sync::{mpsc, Mutex};
 type StdoutLines = Lines<BufReader<ChildStdout>>;
 const MAX_PROTOCOL_LINE_PREVIEW: usize = 240;
+mod protocol;
+use self::protocol::{
+    approval_decision_result, notification_payload, parse_codex_message, protocol_line_preview,
+    response_id_matches, thread_id_from_result, thread_start_params, turn_start_params,
+};
+#[cfg(test)]
+use self::protocol::{sandbox_mode_value, sandbox_policy_value};
 fn prepare_app_server_spawn(
     cli_path: &std::path::Path,
     req: &TurnRequest,
@@ -48,7 +55,7 @@ pub struct CodexAdapter {
     state: Arc<Mutex<AdapterState>>,
 }
 struct AdapterState {
-    child: Option<tokio::process::Child>,
+    child: Option<crate::ManagedChild>,
     stdin: Option<tokio::process::ChildStdin>,
     stdout_lines: Option<StdoutLines>,
     next_id: u64,
@@ -78,8 +85,10 @@ impl AdapterState {
     }
     async fn reset_child(&mut self) {
         if let Some(mut child) = self.child.take() {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
+            child.terminate_now();
+            if let Err(error) = child.wait_and_cleanup_descendants().await {
+                tracing::warn!("failed to clean up codex app-server child: {error}");
+            }
         }
         self.stdin = None;
         self.stdout_lines = None;
@@ -88,6 +97,21 @@ impl AdapterState {
         self.child_workspace = None;
     }
 }
+
+fn cloud_setup_env_removals(cloud: &CodexCloudConfig) -> Vec<String> {
+    if cloud.enabled {
+        cloud.setup_secret_env.clone()
+    } else {
+        Vec::new()
+    }
+}
+
+fn app_server_stall_timeout(req: &TurnRequest) -> Option<Duration> {
+    req.timeout_secs
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParsedCodexMessage {
     Event(AgentEvent),
@@ -220,6 +244,24 @@ impl CodexAdapter {
         })
     }
 
+    async fn read_next_message_with_timeout(
+        lines: &mut StdoutLines,
+        stall_timeout: Option<Duration>,
+        phase: &str,
+    ) -> harness_core::error::Result<Option<ParsedCodexMessage>> {
+        let read = Self::read_next_message(lines);
+        let Some(stall_timeout) = stall_timeout else {
+            return read.await;
+        };
+        match tokio::time::timeout(stall_timeout, read).await {
+            Ok(result) => result,
+            Err(_) => Err(harness_core::error::HarnessError::AgentExecution(format!(
+                "codex app-server {phase} stalled for {}s without stdout",
+                stall_timeout.as_secs()
+            ))),
+        }
+    }
+
     async fn ensure_child(
         &self,
         req: &TurnRequest,
@@ -237,55 +279,46 @@ impl CodexAdapter {
 
         let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
         let prepared_spawn = prepare_app_server_spawn(&self.cli_path, req)?;
-        let mut cmd = tokio::process::Command::new(&prepared_spawn.program);
-        cmd.args(&prepared_spawn.args)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .current_dir(&prepared_spawn.current_dir)
-            .kill_on_drop(true);
-        #[cfg(unix)]
-        crate::set_process_group(&mut cmd);
-        crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
-        crate::apply_agent_run_identity_env(&mut cmd, &run_identity);
-        if self.cloud.enabled {
-            for key in &self.cloud.setup_secret_env {
-                cmd.env_remove(key);
-            }
-        }
+        let spawn_project_root = req.project_root.clone();
+        let supervised =
+            crate::spawn_supervisor::spawn_agent(crate::spawn_supervisor::AgentSpawnPlan {
+                prepared_spawn,
+                run_identity,
+                native_kind: "codex",
+                process_label: "codex app-server",
+                stdio: crate::spawn_supervisor::AgentStdio::piped_output(
+                    std::process::Stdio::piped(),
+                ),
+                extra_env_removals: cloud_setup_env_removals(&self.cloud),
+                map_spawn_error: Box::new(move |error, _spawn| {
+                    let message = crate::classify_missing_workspace_spawn_failure(
+                        error,
+                        &spawn_project_root,
+                        format!("failed to spawn codex app-server: {error}"),
+                    );
+                    harness_core::error::HarnessError::AgentExecution(message)
+                }),
+            })
+            .await?;
+        let child_workspace = supervised.prepared_spawn.child_workspace.clone();
+        let mut child = supervised.child;
 
-        let mut child = cmd.spawn().map_err(|error| {
-            let message = crate::classify_missing_workspace_spawn_failure(
-                &error,
-                &req.project_root,
-                format!("failed to spawn codex app-server: {error}"),
-            );
-            harness_core::error::HarnessError::AgentExecution(message)
-        })?;
-        if let Some(pid) = child.id() {
-            crate::write_provisional_agent_run_binding(
-                &run_identity,
-                "codex",
-                pid,
-                &req.project_root,
-            );
-        }
-
-        if let Some(stderr) = child.stderr.take() {
+        if let Some(stderr) = child.inner_mut().stderr.take() {
             tokio::spawn(async move {
                 capture_agent_stderr_diagnostics(stderr, "codex", None).await;
             });
         }
 
-        let stdout = child.stdout.take().ok_or_else(|| {
+        let stdout = child.inner_mut().stdout.take().ok_or_else(|| {
             harness_core::error::HarnessError::AgentExecution(
                 "codex app-server stdout unavailable".into(),
             )
         })?;
-        state.stdin = child.stdin.take();
+        state.stdin = child.inner_mut().stdin.take();
         state.stdout_lines = Some(BufReader::new(stdout).lines());
         state.child = Some(child);
-        state.child_workspace = Some(prepared_spawn.child_workspace.clone());
+        state.child_workspace = Some(child_workspace.clone());
+        let stall_timeout = app_server_stall_timeout(req);
 
         let init_id = Self::send_request(
             state,
@@ -308,7 +341,9 @@ impl CodexAdapter {
             )
         })?;
         loop {
-            match Self::read_next_message(&mut lines).await? {
+            match Self::read_next_message_with_timeout(&mut lines, stall_timeout, "initialize")
+                .await?
+            {
                 Some(ParsedCodexMessage::Response { id, .. })
                     if response_id_matches(&id, init_id) =>
                 {
@@ -334,12 +369,14 @@ impl CodexAdapter {
         let thread_id_request = Self::send_request(
             state,
             "thread/start",
-            thread_start_params(req, &prepared_spawn.child_workspace),
+            thread_start_params(req, &child_workspace),
         )
         .await?;
 
         loop {
-            match Self::read_next_message(&mut lines).await? {
+            match Self::read_next_message_with_timeout(&mut lines, stall_timeout, "thread/start")
+                .await?
+            {
                 Some(ParsedCodexMessage::ThreadStarted { thread_id }) => {
                     state.thread_id = Some(thread_id);
                     break;
@@ -421,7 +458,10 @@ impl AgentAdapter for CodexAdapter {
         let mut turn_completed = false;
         let mut receiver_closed = false;
         let mut stdout_closed = false;
-        while let Some(message) = Self::read_next_message(&mut lines).await? {
+        let stall_timeout = app_server_stall_timeout(&req);
+        while let Some(message) =
+            Self::read_next_message_with_timeout(&mut lines, stall_timeout, "turn").await?
+        {
             match message {
                 ParsedCodexMessage::TurnStarted { turn_id } => {
                     let mut guard = self.state.lock().await;
@@ -536,257 +576,6 @@ impl AgentAdapter for CodexAdapter {
         let result = approval_decision_result(decision);
         Self::send_response(&mut state, request_id, result).await
     }
-}
-
-fn protocol_line_preview(line: &str) -> String {
-    let mut chars = line.chars();
-    let mut preview: String = chars.by_ref().take(MAX_PROTOCOL_LINE_PREVIEW).collect();
-    if chars.next().is_some() {
-        preview.push_str("...");
-    }
-    preview
-}
-
-fn notification_payload(method: &str, params: Value) -> Value {
-    json!({
-        "method": method,
-        "params": params,
-    })
-}
-
-fn approval_decision_result(decision: ApprovalDecision) -> Value {
-    match decision {
-        ApprovalDecision::Accept => json!({ "decision": "accept" }),
-        ApprovalDecision::Reject { reason } => json!({
-            "decision": "decline",
-            "reason": reason,
-        }),
-    }
-}
-
-fn sandbox_mode_value(mode: Option<SandboxMode>) -> Option<String> {
-    mode.map(|value| {
-        match value {
-            SandboxMode::ReadOnly | SandboxMode::ReadOnlyWithNetwork => "read-only",
-            SandboxMode::WorkspaceWrite => "workspace-write",
-            SandboxMode::DangerFullAccess => "danger-full-access",
-        }
-        .to_string()
-    })
-}
-
-fn sandbox_policy_value(mode: Option<SandboxMode>, project_root: &PathBuf) -> Option<Value> {
-    mode.map(|value| match value {
-        SandboxMode::ReadOnly => json!({ "type": "readOnly" }),
-        SandboxMode::ReadOnlyWithNetwork => json!({
-            "type": "readOnly",
-            "networkAccess": true,
-        }),
-        SandboxMode::WorkspaceWrite => json!({
-            "type": "workspaceWrite",
-            "writableRoots": [project_root],
-        }),
-        SandboxMode::DangerFullAccess => json!({ "type": "dangerFullAccess" }),
-    })
-}
-
-fn thread_start_params(req: &TurnRequest, child_workspace: &PathBuf) -> Value {
-    json!({
-        "cwd": child_workspace,
-        "model": req.model,
-        "sandbox": sandbox_mode_value(req.sandbox_mode),
-        "approvalPolicy": req.approval_policy,
-        "ephemeral": true,
-    })
-}
-
-fn turn_start_params(req: &TurnRequest, thread_id: &str, child_workspace: &PathBuf) -> Value {
-    json!({
-        "threadId": thread_id,
-        "cwd": child_workspace,
-        "model": req.model,
-        "effort": req.reasoning_effort,
-        "sandboxPolicy": sandbox_policy_value(req.sandbox_mode, child_workspace),
-        "approvalPolicy": req.approval_policy,
-        "input": [
-            {
-                "type": "text",
-                "text": req.prompt,
-            }
-        ],
-    })
-}
-
-fn response_id_matches(actual: &Value, expected: u64) -> bool {
-    actual.as_u64() == Some(expected) || actual.as_str() == Some(&expected.to_string())
-}
-
-fn request_id_string(id: &Value) -> String {
-    match id {
-        Value::String(value) => value.clone(),
-        other => other.to_string(),
-    }
-}
-
-fn thread_id_from_result(result: &Value) -> Option<String> {
-    result
-        .get("thread")
-        .and_then(|thread| thread.get("id"))
-        .and_then(Value::as_str)
-        .map(ToString::to_string)
-        .or_else(|| {
-            result
-                .get("id")
-                .and_then(Value::as_str)
-                .map(ToString::to_string)
-        })
-}
-
-fn parse_app_server_agent_event(
-    method: &str,
-    params: &Value,
-    id: Option<&Value>,
-) -> ParsedCodexMessage {
-    match method {
-        "thread/started" => {
-            let thread_id = params
-                .get("thread")
-                .and_then(|thread| thread.get("id"))
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_string();
-            ParsedCodexMessage::ThreadStarted { thread_id }
-        }
-        "turn/started" => {
-            let turn_id = params
-                .get("turn")
-                .and_then(|turn| turn.get("id"))
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_string();
-            ParsedCodexMessage::TurnStarted { turn_id }
-        }
-        "item/agentMessage/delta" => ParsedCodexMessage::Event(AgentEvent::MessageDelta {
-            text: params
-                .get("delta")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_string(),
-        }),
-        "item/commandExecution/outputDelta" => {
-            ParsedCodexMessage::Event(AgentEvent::ToolOutputDelta {
-                item_id: params
-                    .get("itemId")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string(),
-                text: params
-                    .get("delta")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string(),
-            })
-        }
-        "item/started" => params
-            .get("item")
-            .and_then(parse_codex_item)
-            .map(|item| ParsedCodexMessage::Event(AgentEvent::ItemStartedPayload { item }))
-            .unwrap_or(ParsedCodexMessage::Ignore),
-        "item/completed" => params
-            .get("item")
-            .map(|item| {
-                if let Some(message) = parse_codex_error_item_message(item) {
-                    ParsedCodexMessage::Event(AgentEvent::Error { message })
-                } else {
-                    parse_codex_item(item)
-                        .map(|item| {
-                            ParsedCodexMessage::Event(AgentEvent::ItemCompletedPayload { item })
-                        })
-                        .unwrap_or(ParsedCodexMessage::Ignore)
-                }
-            })
-            .unwrap_or(ParsedCodexMessage::Ignore),
-        "thread/tokenUsage/updated" => params
-            .get("tokenUsage")
-            .and_then(|usage| usage.get("total"))
-            .and_then(parse_codex_token_usage)
-            .map(|usage| ParsedCodexMessage::Event(AgentEvent::TokenUsage { usage }))
-            .unwrap_or(ParsedCodexMessage::Ignore),
-        "warning" => ParsedCodexMessage::Event(AgentEvent::Warning {
-            message: params
-                .get("message")
-                .and_then(Value::as_str)
-                .unwrap_or("unknown warning")
-                .to_string(),
-        }),
-        "error" => ParsedCodexMessage::Event(AgentEvent::Error {
-            message: params
-                .get("error")
-                .and_then(|error| error.get("message"))
-                .and_then(Value::as_str)
-                .or_else(|| params.get("message").and_then(Value::as_str))
-                .unwrap_or("unknown error")
-                .to_string(),
-        }),
-        "turn/completed" => ParsedCodexMessage::Event(AgentEvent::TurnCompleted {
-            output: params
-                .get("turn")
-                .and_then(|turn| turn.get("items"))
-                .and_then(Value::as_array)
-                .and_then(|items| items.iter().rev().find_map(parse_codex_item))
-                .and_then(|item| match item {
-                    harness_core::types::Item::AgentReasoning { content } => Some(content),
-                    _ => None,
-                })
-                .unwrap_or_default(),
-        }),
-        "item/commandExecution/requestApproval"
-        | "item/fileChange/requestApproval"
-        | "item/permissions/requestApproval" => {
-            ParsedCodexMessage::Event(AgentEvent::ApprovalRequest {
-                id: id.map(request_id_string).unwrap_or_default(),
-                command: params
-                    .get("command")
-                    .and_then(Value::as_str)
-                    .or_else(|| params.get("reason").and_then(Value::as_str))
-                    .unwrap_or(method)
-                    .to_string(),
-            })
-        }
-        _ => ParsedCodexMessage::Ignore,
-    }
-}
-
-pub fn parse_codex_message(line: &str) -> Option<ParsedCodexMessage> {
-    let value: Value = serde_json::from_str(line).ok()?;
-
-    if let Some(method) = value.get("method").and_then(Value::as_str) {
-        let params = value.get("params").cloned().unwrap_or(Value::Null);
-        return Some(parse_app_server_agent_event(
-            method,
-            &params,
-            value.get("id"),
-        ));
-    }
-
-    if let Some(id) = value.get("id") {
-        if let Some(error) = value.get("error") {
-            let message = error
-                .get("message")
-                .and_then(Value::as_str)
-                .unwrap_or("unknown error")
-                .to_string();
-            return Some(ParsedCodexMessage::Event(AgentEvent::Error { message }));
-        }
-        if let Some(result) = value.get("result") {
-            return Some(ParsedCodexMessage::Response {
-                id: id.clone(),
-                result: result.clone(),
-            });
-        }
-    }
-
-    Some(ParsedCodexMessage::Ignore)
 }
 
 #[cfg(test)]

--- a/crates/harness-agents/src/codex_adapter/protocol.rs
+++ b/crates/harness-agents/src/codex_adapter/protocol.rs
@@ -1,0 +1,265 @@
+use crate::codex::{parse_codex_error_item_message, parse_codex_item, parse_codex_token_usage};
+use harness_core::agent::{AgentEvent, ApprovalDecision, TurnRequest};
+use harness_core::config::agents::SandboxMode;
+use serde_json::{json, Value};
+use std::path::PathBuf;
+
+use super::{ParsedCodexMessage, MAX_PROTOCOL_LINE_PREVIEW};
+
+pub(super) fn protocol_line_preview(line: &str) -> String {
+    let mut chars = line.chars();
+    let mut preview: String = chars.by_ref().take(MAX_PROTOCOL_LINE_PREVIEW).collect();
+    if chars.next().is_some() {
+        preview.push_str("...");
+    }
+    preview
+}
+
+pub(super) fn notification_payload(method: &str, params: Value) -> Value {
+    json!({
+        "method": method,
+        "params": params,
+    })
+}
+
+pub(super) fn approval_decision_result(decision: ApprovalDecision) -> Value {
+    match decision {
+        ApprovalDecision::Accept => json!({ "decision": "accept" }),
+        ApprovalDecision::Reject { reason } => json!({
+            "decision": "decline",
+            "reason": reason,
+        }),
+    }
+}
+
+pub(super) fn sandbox_mode_value(mode: Option<SandboxMode>) -> Option<String> {
+    mode.map(|value| {
+        match value {
+            SandboxMode::ReadOnly | SandboxMode::ReadOnlyWithNetwork => "read-only",
+            SandboxMode::WorkspaceWrite => "workspace-write",
+            SandboxMode::DangerFullAccess => "danger-full-access",
+        }
+        .to_string()
+    })
+}
+
+pub(super) fn sandbox_policy_value(
+    mode: Option<SandboxMode>,
+    project_root: &PathBuf,
+) -> Option<Value> {
+    mode.map(|value| match value {
+        SandboxMode::ReadOnly => json!({ "type": "readOnly" }),
+        SandboxMode::ReadOnlyWithNetwork => json!({
+            "type": "readOnly",
+            "networkAccess": true,
+        }),
+        SandboxMode::WorkspaceWrite => json!({
+            "type": "workspaceWrite",
+            "writableRoots": [project_root],
+        }),
+        SandboxMode::DangerFullAccess => json!({ "type": "dangerFullAccess" }),
+    })
+}
+
+pub(super) fn thread_start_params(req: &TurnRequest, child_workspace: &PathBuf) -> Value {
+    json!({
+        "cwd": child_workspace,
+        "model": req.model,
+        "sandbox": sandbox_mode_value(req.sandbox_mode),
+        "approvalPolicy": req.approval_policy,
+        "ephemeral": true,
+    })
+}
+
+pub(super) fn turn_start_params(
+    req: &TurnRequest,
+    thread_id: &str,
+    child_workspace: &PathBuf,
+) -> Value {
+    json!({
+        "threadId": thread_id,
+        "cwd": child_workspace,
+        "model": req.model,
+        "effort": req.reasoning_effort,
+        "sandboxPolicy": sandbox_policy_value(req.sandbox_mode, child_workspace),
+        "approvalPolicy": req.approval_policy,
+        "input": [
+            {
+                "type": "text",
+                "text": req.prompt,
+            }
+        ],
+    })
+}
+
+pub(super) fn response_id_matches(actual: &Value, expected: u64) -> bool {
+    actual.as_u64() == Some(expected) || actual.as_str() == Some(&expected.to_string())
+}
+
+fn request_id_string(id: &Value) -> String {
+    match id {
+        Value::String(value) => value.clone(),
+        other => other.to_string(),
+    }
+}
+
+pub(super) fn thread_id_from_result(result: &Value) -> Option<String> {
+    result
+        .get("thread")
+        .and_then(|thread| thread.get("id"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .or_else(|| {
+            result
+                .get("id")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+}
+
+fn parse_app_server_agent_event(
+    method: &str,
+    params: &Value,
+    id: Option<&Value>,
+) -> ParsedCodexMessage {
+    match method {
+        "thread/started" => {
+            let thread_id = params
+                .get("thread")
+                .and_then(|thread| thread.get("id"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            ParsedCodexMessage::ThreadStarted { thread_id }
+        }
+        "turn/started" => {
+            let turn_id = params
+                .get("turn")
+                .and_then(|turn| turn.get("id"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            ParsedCodexMessage::TurnStarted { turn_id }
+        }
+        "item/agentMessage/delta" => ParsedCodexMessage::Event(AgentEvent::MessageDelta {
+            text: params
+                .get("delta")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        }),
+        "item/commandExecution/outputDelta" => {
+            ParsedCodexMessage::Event(AgentEvent::ToolOutputDelta {
+                item_id: params
+                    .get("itemId")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                text: params
+                    .get("delta")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+        }
+        "item/started" => params
+            .get("item")
+            .and_then(parse_codex_item)
+            .map(|item| ParsedCodexMessage::Event(AgentEvent::ItemStartedPayload { item }))
+            .unwrap_or(ParsedCodexMessage::Ignore),
+        "item/completed" => params
+            .get("item")
+            .map(|item| {
+                if let Some(message) = parse_codex_error_item_message(item) {
+                    ParsedCodexMessage::Event(AgentEvent::Error { message })
+                } else {
+                    parse_codex_item(item)
+                        .map(|item| {
+                            ParsedCodexMessage::Event(AgentEvent::ItemCompletedPayload { item })
+                        })
+                        .unwrap_or(ParsedCodexMessage::Ignore)
+                }
+            })
+            .unwrap_or(ParsedCodexMessage::Ignore),
+        "thread/tokenUsage/updated" => params
+            .get("tokenUsage")
+            .and_then(|usage| usage.get("total"))
+            .and_then(parse_codex_token_usage)
+            .map(|usage| ParsedCodexMessage::Event(AgentEvent::TokenUsage { usage }))
+            .unwrap_or(ParsedCodexMessage::Ignore),
+        "warning" => ParsedCodexMessage::Event(AgentEvent::Warning {
+            message: params
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown warning")
+                .to_string(),
+        }),
+        "error" => ParsedCodexMessage::Event(AgentEvent::Error {
+            message: params
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+                .or_else(|| params.get("message").and_then(Value::as_str))
+                .unwrap_or("unknown error")
+                .to_string(),
+        }),
+        "turn/completed" => ParsedCodexMessage::Event(AgentEvent::TurnCompleted {
+            output: params
+                .get("turn")
+                .and_then(|turn| turn.get("items"))
+                .and_then(Value::as_array)
+                .and_then(|items| items.iter().rev().find_map(parse_codex_item))
+                .and_then(|item| match item {
+                    harness_core::types::Item::AgentReasoning { content } => Some(content),
+                    _ => None,
+                })
+                .unwrap_or_default(),
+        }),
+        "item/commandExecution/requestApproval"
+        | "item/fileChange/requestApproval"
+        | "item/permissions/requestApproval" => {
+            ParsedCodexMessage::Event(AgentEvent::ApprovalRequest {
+                id: id.map(request_id_string).unwrap_or_default(),
+                command: params
+                    .get("command")
+                    .and_then(Value::as_str)
+                    .or_else(|| params.get("reason").and_then(Value::as_str))
+                    .unwrap_or(method)
+                    .to_string(),
+            })
+        }
+        _ => ParsedCodexMessage::Ignore,
+    }
+}
+
+pub(super) fn parse_codex_message(line: &str) -> Option<ParsedCodexMessage> {
+    let value: Value = serde_json::from_str(line).ok()?;
+
+    if let Some(method) = value.get("method").and_then(Value::as_str) {
+        let params = value.get("params").cloned().unwrap_or(Value::Null);
+        return Some(parse_app_server_agent_event(
+            method,
+            &params,
+            value.get("id"),
+        ));
+    }
+
+    if let Some(id) = value.get("id") {
+        if let Some(error) = value.get("error") {
+            let message = error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown error")
+                .to_string();
+            return Some(ParsedCodexMessage::Event(AgentEvent::Error { message }));
+        }
+        if let Some(result) = value.get("result") {
+            return Some(ParsedCodexMessage::Response {
+                id: id.clone(),
+                result: result.clone(),
+            });
+        }
+    }
+
+    Some(ParsedCodexMessage::Ignore)
+}

--- a/crates/harness-agents/src/codex_adapter/protocol.rs
+++ b/crates/harness-agents/src/codex_adapter/protocol.rs
@@ -2,7 +2,7 @@ use crate::codex::{parse_codex_error_item_message, parse_codex_item, parse_codex
 use harness_core::agent::{AgentEvent, ApprovalDecision, TurnRequest};
 use harness_core::config::agents::SandboxMode;
 use serde_json::{json, Value};
-use std::path::PathBuf;
+use std::path::Path;
 
 use super::{ParsedCodexMessage, MAX_PROTOCOL_LINE_PREVIEW};
 
@@ -45,7 +45,7 @@ pub(super) fn sandbox_mode_value(mode: Option<SandboxMode>) -> Option<String> {
 
 pub(super) fn sandbox_policy_value(
     mode: Option<SandboxMode>,
-    project_root: &PathBuf,
+    project_root: &Path,
 ) -> Option<Value> {
     mode.map(|value| match value {
         SandboxMode::ReadOnly => json!({ "type": "readOnly" }),
@@ -61,7 +61,7 @@ pub(super) fn sandbox_policy_value(
     })
 }
 
-pub(super) fn thread_start_params(req: &TurnRequest, child_workspace: &PathBuf) -> Value {
+pub(super) fn thread_start_params(req: &TurnRequest, child_workspace: &Path) -> Value {
     json!({
         "cwd": child_workspace,
         "model": req.model,
@@ -74,7 +74,7 @@ pub(super) fn thread_start_params(req: &TurnRequest, child_workspace: &PathBuf) 
 pub(super) fn turn_start_params(
     req: &TurnRequest,
     thread_id: &str,
-    child_workspace: &PathBuf,
+    child_workspace: &Path,
 ) -> Value {
     json!({
         "threadId": thread_id,
@@ -232,7 +232,7 @@ fn parse_app_server_agent_event(
     }
 }
 
-pub(super) fn parse_codex_message(line: &str) -> Option<ParsedCodexMessage> {
+pub fn parse_codex_message(line: &str) -> Option<ParsedCodexMessage> {
     let value: Value = serde_json::from_str(line).ok()?;
 
     if let Some(method) = value.get("method").and_then(Value::as_str) {

--- a/crates/harness-agents/src/codex_adapter_receiver_tests.rs
+++ b/crates/harness-agents/src/codex_adapter_receiver_tests.rs
@@ -1,0 +1,79 @@
+use super::*;
+use harness_core::agent::AgentAdapter;
+use std::collections::HashMap;
+
+#[tokio::test]
+#[cfg(unix)]
+async fn closed_event_receiver_kills_and_reaps_app_server_process_group() -> anyhow::Result<()> {
+    let mut command = tokio::process::Command::new("sh");
+    command
+        .arg("-c")
+        .arg(
+            r#"printf '%s\n' '{"method":"turn/started","params":{"threadId":"thread-1","turn":{"id":"turn-1"}}}'; sleep 60 & wait"#,
+        )
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped());
+    crate::set_process_group(&mut command);
+    let mut child = command.spawn()?;
+    let pid = child
+        .id()
+        .ok_or_else(|| anyhow::anyhow!("stub app-server should have a pid"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("stdout should be piped"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("stdin should be piped"))?;
+
+    let adapter = CodexAdapter::new(PathBuf::from("codex"));
+    {
+        let mut state = adapter.state.lock().await;
+        state.child = Some(crate::ManagedChild::new(
+            child,
+            "codex app-server receiver test",
+        ));
+        state.stdin = Some(stdin);
+        state.stdout_lines = Some(BufReader::new(stdout).lines());
+        state.thread_id = Some("thread-1".into());
+        state.child_workspace = Some(PathBuf::from("/tmp/project"));
+    }
+    let request = TurnRequest {
+        prompt: "ping".into(),
+        prompt_layers: None,
+        project_root: PathBuf::from("/tmp/project"),
+        model: None,
+        reasoning_effort: None,
+        execution_phase: None,
+        sandbox_mode: None,
+        approval_policy: None,
+        allowed_tools: None,
+        context: Vec::new(),
+        timeout_secs: Some(5),
+        env_vars: HashMap::new(),
+        capability_token: None,
+    };
+    let (tx, rx) = mpsc::channel(1);
+    drop(rx);
+
+    let error = adapter
+        .start_turn(request, tx)
+        .await
+        .expect_err("closed receiver must fail and reset the app-server");
+    assert!(format!("{error}").contains("event receiver closed"));
+
+    let state = adapter.state.lock().await;
+    assert!(state.child.is_none());
+    assert!(state.stdin.is_none());
+    assert!(state.stdout_lines.is_none());
+    assert!(state.thread_id.is_none());
+    assert!(state.active_turn_id.is_none());
+    assert!(state.child_workspace.is_none());
+    drop(state);
+    assert!(
+        !crate::process_group_has_members(pid),
+        "app-server process group {pid} survived receiver closure"
+    );
+    Ok(())
+}

--- a/crates/harness-agents/src/codex_adapter_tests.rs
+++ b/crates/harness-agents/src/codex_adapter_tests.rs
@@ -20,6 +20,16 @@ fn test_turn_request(project_root: PathBuf) -> TurnRequest {
     }
 }
 
+#[cfg(unix)]
+fn write_app_server_stub(dir: &std::path::Path, body: &str) -> anyhow::Result<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = dir.join("codex-app-server-stub");
+    std::fs::write(&path, format!("#!/bin/sh\n{body}\nsleep 60\n"))?;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))?;
+    Ok(path)
+}
+
 #[test]
 fn parse_no_jsonrpc_thread_started_notification() {
     let line = r#"{"method":"thread/started","params":{"thread":{"id":"thread-1"}}}"#;
@@ -503,7 +513,7 @@ fn sandbox_policy_value_preserves_network_for_read_only_with_network() {
     assert_eq!(
         sandbox_policy_value(
             Some(SandboxMode::ReadOnlyWithNetwork),
-            &PathBuf::from("/tmp/project")
+            std::path::Path::new("/tmp/project")
         ),
         Some(json!({
             "type": "readOnly",
@@ -526,6 +536,7 @@ fn protocol_line_preview_truncates_without_full_count_scan() {
 }
 
 #[tokio::test]
+#[cfg(unix)]
 async fn app_server_read_times_out_when_stdout_stalls() -> anyhow::Result<()> {
     let mut child = tokio::process::Command::new("sleep")
         .arg("60")
@@ -547,7 +558,101 @@ async fn app_server_read_times_out_when_stdout_stalls() -> anyhow::Result<()> {
 
     child.kill().await?;
     child.wait().await?;
-    assert!(format!("{error}").contains("initialize stalled"));
+    assert!(format!("{error}").contains("initialize stalled for 50ms"));
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn app_server_protocol_failures_reset_and_reap_child() -> anyhow::Result<()> {
+    let scenarios = [
+        ("", "initialize stalled"),
+        (
+            r#"printf '%s\n' '{"method":"error","params":{"message":"init failed"}}'"#,
+            "init failed",
+        ),
+        (
+            r#"printf '%s\n' '{"id":1,"result":{}}'"#,
+            "thread/start stalled",
+        ),
+        (
+            concat!(
+                r#"printf '%s\n' '{"id":1,"result":{}}'"#,
+                "\n",
+                r#"printf '%s\n' '{"method":"error","params":{"message":"thread failed"}}'"#,
+            ),
+            "thread failed",
+        ),
+        (
+            concat!(
+                r#"printf '%s\n' '{"id":1,"result":{}}'"#,
+                "\n",
+                r#"printf '%s\n' '{"id":2,"result":{"thread":{"id":"thread-1"}}}'"#,
+            ),
+            "turn stalled",
+        ),
+        (
+            concat!(
+                r#"printf '%s\n' '{"id":1,"result":{}}'"#,
+                "\n",
+                r#"printf '%s\n' '{"id":2,"result":{"thread":{"id":"thread-1"}}}'"#,
+                "\n",
+                r#"printf '%s\n' 'not-json'"#,
+            ),
+            "invalid JSON-RPC",
+        ),
+    ];
+
+    for (body, expected) in scenarios {
+        let dir = tempfile::tempdir()?;
+        let adapter = CodexAdapter::new(write_app_server_stub(dir.path(), body)?);
+        let mut request = test_turn_request(dir.path().to_path_buf());
+        request.timeout_secs = Some(if expected.contains("stalled") { 3 } else { 10 });
+        let (tx, _rx) = mpsc::channel(4);
+
+        let error = adapter.start_turn(request, tx).await.expect_err(expected);
+        assert!(format!("{error}").contains(expected), "{expected}: {error}");
+        let state = adapter.state.lock().await;
+        assert!(state.child.is_none(), "{expected}: child was not reaped");
+        assert!(state.stdin.is_none());
+        assert!(state.stdout_lines.is_none());
+        assert!(state.thread_id.is_none());
+        assert!(state.active_turn_id.is_none());
+        assert!(state.child_workspace.is_none());
+    }
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn expired_capability_token_never_spawns_app_server() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let marker = dir.path().join("spawned");
+    let adapter = CodexAdapter::new(write_app_server_stub(
+        dir.path(),
+        r#"printf spawned > "$SPAWN_MARKER""#,
+    )?);
+    let mut request = test_turn_request(dir.path().to_path_buf());
+    request
+        .env_vars
+        .insert("SPAWN_MARKER".into(), marker.display().to_string());
+    let mut token = harness_core::capability::CapabilityToken::new(
+        7,
+        vec![dir.path().to_path_buf()],
+        std::time::Duration::from_secs(60),
+    );
+    token.expires_at = std::time::SystemTime::UNIX_EPOCH;
+    request.capability_token = Some(token);
+    request.timeout_secs = Some(1);
+    let (tx, _rx) = mpsc::channel(4);
+
+    let error = adapter
+        .start_turn(request, tx)
+        .await
+        .expect_err("expired token must fail before spawn");
+    assert!(format!("{error}").contains("subtask 7 has expired"));
+    assert!(!marker.exists(), "expired token spawned the app-server");
+    assert!(adapter.state.lock().await.child.is_none());
     Ok(())
 }
 
@@ -662,6 +767,7 @@ async fn start_turn_fails_when_stdout_eofs_before_terminal_event() {
 }
 
 #[tokio::test]
+#[cfg(unix)]
 async fn adapter_state_reports_incomplete_child_when_stdout_reader_is_missing() {
     let mut child = tokio::process::Command::new("sleep")
         .arg("60")

--- a/crates/harness-agents/src/codex_adapter_tests.rs
+++ b/crates/harness-agents/src/codex_adapter_tests.rs
@@ -526,6 +526,32 @@ fn protocol_line_preview_truncates_without_full_count_scan() {
 }
 
 #[tokio::test]
+async fn app_server_read_times_out_when_stdout_stalls() -> anyhow::Result<()> {
+    let mut child = tokio::process::Command::new("sleep")
+        .arg("60")
+        .stdout(std::process::Stdio::piped())
+        .spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("stdout should be piped"))?;
+    let mut lines = BufReader::new(stdout).lines();
+
+    let error = CodexAdapter::read_next_message_with_timeout(
+        &mut lines,
+        Some(std::time::Duration::from_millis(50)),
+        "initialize",
+    )
+    .await
+    .expect_err("silent app-server stdout must hit the stall timeout");
+
+    child.kill().await?;
+    child.wait().await?;
+    assert!(format!("{error}").contains("initialize stalled"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn interrupt_noop_when_no_child() {
     let adapter = CodexAdapter::new(PathBuf::from("codex"));
     adapter.interrupt().await.unwrap();
@@ -596,7 +622,7 @@ async fn start_turn_fails_when_stdout_eofs_before_terminal_event() {
     let stdin = child.stdin.take().expect("stdin should be piped");
     {
         let mut state = adapter.state.lock().await;
-        state.child = Some(child);
+        state.child = Some(crate::ManagedChild::new(child, "codex app-server test"));
         state.stdin = Some(stdin);
         state.stdout_lines = Some(BufReader::new(stdout).lines());
         state.thread_id = Some("thread-1".into());
@@ -646,7 +672,7 @@ async fn adapter_state_reports_incomplete_child_when_stdout_reader_is_missing() 
     let stdout = child.stdout.take().expect("stdout should be piped");
     let stdin = child.stdin.take().expect("stdin should be piped");
     let mut state = AdapterState::new();
-    state.child = Some(child);
+    state.child = Some(crate::ManagedChild::new(child, "codex app-server test"));
     state.stdin = Some(stdin);
     state.stdout_lines = Some(BufReader::new(stdout).lines());
 

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -11,9 +11,12 @@ pub mod provider_backpressure;
 pub mod registry;
 pub mod scoped_token;
 mod spawn_contract;
+mod spawn_supervisor;
 mod streaming;
 
-use harness_core::run_id::{RunIdentity, AGENT_RUN_ID_ENV, AGENT_RUN_PARENT_ENV};
+use harness_core::run_id::RunIdentity;
+#[cfg(test)]
+use harness_core::run_id::{AGENT_RUN_ID_ENV, AGENT_RUN_PARENT_ENV};
 use harness_core::run_registry::{append_binding_nonblocking, BindingRecord};
 use std::collections::HashMap;
 use std::path::Path;
@@ -28,18 +31,6 @@ pub(crate) fn resolve_agent_run_identity(env_vars: &HashMap<String, String>) -> 
             );
             RunIdentity::mint()
         }
-    }
-}
-
-pub(crate) fn apply_agent_run_identity_env(
-    cmd: &mut tokio::process::Command,
-    identity: &RunIdentity,
-) {
-    cmd.env(AGENT_RUN_ID_ENV, identity.run_id.as_str());
-    if let Some(parent) = &identity.parent {
-        cmd.env(AGENT_RUN_PARENT_ENV, parent.as_str());
-    } else {
-        cmd.env_remove(AGENT_RUN_PARENT_ENV);
     }
 }
 

--- a/crates/harness-agents/src/spawn_supervisor.rs
+++ b/crates/harness-agents/src/spawn_supervisor.rs
@@ -1,5 +1,6 @@
 use crate::spawn_contract::PreparedAgentSpawn;
 use crate::ManagedChild;
+use harness_core::capability::CapabilityToken;
 use harness_core::error::HarnessError;
 use harness_core::run_id::RunIdentity;
 use std::process::Stdio;
@@ -44,6 +45,34 @@ pub(crate) struct SupervisedAgentProcess {
 pub(crate) async fn spawn_agent(
     plan: AgentSpawnPlan<'_>,
 ) -> harness_core::error::Result<SupervisedAgentProcess> {
+    spawn_agent_inner(plan, None).await
+}
+
+pub(crate) async fn spawn_agent_with_capability(
+    plan: AgentSpawnPlan<'_>,
+    capability_token: Option<&CapabilityToken>,
+) -> harness_core::error::Result<SupervisedAgentProcess> {
+    spawn_agent_inner(plan, capability_token).await
+}
+
+pub(crate) fn validate_capability_token(
+    capability_token: Option<&CapabilityToken>,
+) -> harness_core::error::Result<()> {
+    if let Some(token) = capability_token {
+        if token.is_expired() {
+            return Err(HarnessError::AgentExecution(format!(
+                "capability token for subtask {} has expired",
+                token.subtask_index
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn spawn_agent_inner(
+    plan: AgentSpawnPlan<'_>,
+    capability_token: Option<&CapabilityToken>,
+) -> harness_core::error::Result<SupervisedAgentProcess> {
     let AgentSpawnPlan {
         prepared_spawn,
         run_identity,
@@ -68,18 +97,31 @@ pub(crate) async fn spawn_agent(
         cmd.env_remove(key);
     }
 
-    let child = spawn_with_etxtbsy_retry(|| cmd.spawn())
-        .await
-        .map_err(|error| {
-            let mapped = (map_spawn_error)(&error, &prepared_spawn);
-            tracing::error!(
-                agent = native_kind,
-                process = process_label,
-                error_kind = ?error.kind(),
-                "{mapped}"
-            );
-            mapped
-        })?;
+    let mut capability_error = None;
+    let child_result = spawn_with_etxtbsy_retry(|| {
+        if let Err(error) = validate_capability_token(capability_token) {
+            capability_error = Some(error);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "capability token expired before agent spawn",
+            ));
+        }
+        cmd.spawn()
+    })
+    .await;
+    if let Some(error) = capability_error {
+        return Err(error);
+    }
+    let child = child_result.map_err(|error| {
+        let mapped = (map_spawn_error)(&error, &prepared_spawn);
+        tracing::error!(
+            agent = native_kind,
+            process = process_label,
+            error_kind = ?error.kind(),
+            "{mapped}"
+        );
+        mapped
+    })?;
 
     if let Some(pid) = child.id() {
         crate::write_provisional_agent_run_binding(

--- a/crates/harness-agents/src/spawn_supervisor.rs
+++ b/crates/harness-agents/src/spawn_supervisor.rs
@@ -1,0 +1,154 @@
+use crate::spawn_contract::PreparedAgentSpawn;
+use crate::ManagedChild;
+use harness_core::error::HarnessError;
+use harness_core::run_id::RunIdentity;
+use std::process::Stdio;
+use tokio::process::Command;
+
+const ETXTBSY_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(150);
+
+pub(crate) struct AgentStdio {
+    pub(crate) stdin: Stdio,
+    pub(crate) stdout: Stdio,
+    pub(crate) stderr: Stdio,
+}
+
+impl AgentStdio {
+    pub(crate) fn piped_output(stdin: Stdio) -> Self {
+        Self {
+            stdin,
+            stdout: Stdio::piped(),
+            stderr: Stdio::piped(),
+        }
+    }
+}
+
+pub(crate) type SpawnErrorMapper<'a> =
+    Box<dyn Fn(&std::io::Error, &PreparedAgentSpawn) -> HarnessError + Send + 'a>;
+
+pub(crate) struct AgentSpawnPlan<'a> {
+    pub(crate) prepared_spawn: PreparedAgentSpawn,
+    pub(crate) run_identity: RunIdentity,
+    pub(crate) native_kind: &'static str,
+    pub(crate) process_label: &'static str,
+    pub(crate) stdio: AgentStdio,
+    pub(crate) extra_env_removals: Vec<String>,
+    pub(crate) map_spawn_error: SpawnErrorMapper<'a>,
+}
+
+pub(crate) struct SupervisedAgentProcess {
+    pub(crate) prepared_spawn: PreparedAgentSpawn,
+    pub(crate) child: ManagedChild,
+}
+
+pub(crate) async fn spawn_agent(
+    plan: AgentSpawnPlan<'_>,
+) -> harness_core::error::Result<SupervisedAgentProcess> {
+    let AgentSpawnPlan {
+        prepared_spawn,
+        run_identity,
+        native_kind,
+        process_label,
+        stdio,
+        extra_env_removals,
+        map_spawn_error,
+    } = plan;
+
+    let mut cmd = Command::new(&prepared_spawn.program);
+    cmd.args(&prepared_spawn.args)
+        .current_dir(&prepared_spawn.current_dir)
+        .stdin(stdio.stdin)
+        .stdout(stdio.stdout)
+        .stderr(stdio.stderr)
+        .kill_on_drop(true);
+    #[cfg(unix)]
+    crate::set_process_group(&mut cmd);
+    crate::spawn_contract::apply_process_env(&mut cmd, &prepared_spawn);
+    for key in &extra_env_removals {
+        cmd.env_remove(key);
+    }
+
+    let child = spawn_with_etxtbsy_retry(|| cmd.spawn())
+        .await
+        .map_err(|error| {
+            let mapped = (map_spawn_error)(&error, &prepared_spawn);
+            tracing::error!(
+                agent = native_kind,
+                process = process_label,
+                error_kind = ?error.kind(),
+                "{mapped}"
+            );
+            mapped
+        })?;
+
+    if let Some(pid) = child.id() {
+        crate::write_provisional_agent_run_binding(
+            &run_identity,
+            native_kind,
+            pid,
+            &prepared_spawn.current_dir,
+        );
+    }
+
+    Ok(SupervisedAgentProcess {
+        prepared_spawn,
+        child: ManagedChild::new(child, process_label),
+    })
+}
+
+async fn spawn_with_etxtbsy_retry<F, T>(mut spawn: F) -> std::io::Result<T>
+where
+    F: FnMut() -> std::io::Result<T>,
+{
+    match spawn() {
+        Err(error) if is_etxtbsy(&error) => {
+            tokio::time::sleep(ETXTBSY_RETRY_DELAY).await;
+            spawn()
+        }
+        result => result,
+    }
+}
+
+fn is_etxtbsy(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(26)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn spawn_retry_retries_once_for_etxtbsy() {
+        let attempts = AtomicUsize::new(0);
+
+        let result = spawn_with_etxtbsy_retry(|| {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt == 0 {
+                Err(std::io::Error::from_raw_os_error(26))
+            } else {
+                Ok("spawned")
+            }
+        })
+        .await
+        .expect("ETXTBSY retry should use the second spawn result");
+
+        assert_eq!(result, "spawned");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn spawn_retry_does_not_retry_other_errors() {
+        let attempts = AtomicUsize::new(0);
+
+        let error = spawn_with_etxtbsy_retry(|| -> std::io::Result<()> {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Err(std::io::Error::from_raw_os_error(2))
+        })
+        .await
+        .expect_err("non-ETXTBSY errors must not be retried");
+
+        assert_eq!(error.raw_os_error(), Some(2));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/harness-agents/src/spawn_supervisor.rs
+++ b/crates/harness-agents/src/spawn_supervisor.rs
@@ -44,33 +44,6 @@ pub(crate) struct SupervisedAgentProcess {
 
 pub(crate) async fn spawn_agent(
     plan: AgentSpawnPlan<'_>,
-) -> harness_core::error::Result<SupervisedAgentProcess> {
-    spawn_agent_inner(plan, None).await
-}
-
-pub(crate) async fn spawn_agent_with_capability(
-    plan: AgentSpawnPlan<'_>,
-    capability_token: Option<&CapabilityToken>,
-) -> harness_core::error::Result<SupervisedAgentProcess> {
-    spawn_agent_inner(plan, capability_token).await
-}
-
-pub(crate) fn validate_capability_token(
-    capability_token: Option<&CapabilityToken>,
-) -> harness_core::error::Result<()> {
-    if let Some(token) = capability_token {
-        if token.is_expired() {
-            return Err(HarnessError::AgentExecution(format!(
-                "capability token for subtask {} has expired",
-                token.subtask_index
-            )));
-        }
-    }
-    Ok(())
-}
-
-async fn spawn_agent_inner(
-    plan: AgentSpawnPlan<'_>,
     capability_token: Option<&CapabilityToken>,
 ) -> harness_core::error::Result<SupervisedAgentProcess> {
     let AgentSpawnPlan {
@@ -97,31 +70,25 @@ async fn spawn_agent_inner(
         cmd.env_remove(key);
     }
 
-    let mut capability_error = None;
-    let child_result = spawn_with_etxtbsy_retry(|| {
-        if let Err(error) = validate_capability_token(capability_token) {
-            capability_error = Some(error);
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::PermissionDenied,
-                "capability token expired before agent spawn",
-            ));
+    let child = match spawn_with_etxtbsy_retry(
+        || validate_capability_token(capability_token),
+        || cmd.spawn(),
+    )
+    .await
+    {
+        Ok(child) => child,
+        Err(SpawnAttemptError::Authorization(error)) => return Err(error),
+        Err(SpawnAttemptError::Io(error)) => {
+            let mapped = (map_spawn_error)(&error, &prepared_spawn);
+            tracing::error!(
+                agent = native_kind,
+                process = process_label,
+                error_kind = ?error.kind(),
+                "{mapped}"
+            );
+            return Err(mapped);
         }
-        cmd.spawn()
-    })
-    .await;
-    if let Some(error) = capability_error {
-        return Err(error);
-    }
-    let child = child_result.map_err(|error| {
-        let mapped = (map_spawn_error)(&error, &prepared_spawn);
-        tracing::error!(
-            agent = native_kind,
-            process = process_label,
-            error_kind = ?error.kind(),
-            "{mapped}"
-        );
-        mapped
-    })?;
+    };
 
     if let Some(pid) = child.id() {
         crate::write_provisional_agent_run_binding(
@@ -138,14 +105,47 @@ async fn spawn_agent_inner(
     })
 }
 
-async fn spawn_with_etxtbsy_retry<F, T>(mut spawn: F) -> std::io::Result<T>
+pub(crate) fn validate_capability_token(
+    capability_token: Option<&CapabilityToken>,
+) -> harness_core::error::Result<()> {
+    if let Some(token) = capability_token {
+        if token.is_expired() {
+            return Err(HarnessError::AgentExecution(format!(
+                "capability token for subtask {} has expired",
+                token.subtask_index
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+enum SpawnAttemptError {
+    Authorization(HarnessError),
+    Io(std::io::Error),
+}
+
+fn authorized_spawn<A, F, T>(authorize: &mut A, spawn: &mut F) -> Result<T, SpawnAttemptError>
 where
+    A: FnMut() -> harness_core::error::Result<()>,
     F: FnMut() -> std::io::Result<T>,
 {
-    match spawn() {
-        Err(error) if is_etxtbsy(&error) => {
+    authorize().map_err(SpawnAttemptError::Authorization)?;
+    spawn().map_err(SpawnAttemptError::Io)
+}
+
+async fn spawn_with_etxtbsy_retry<A, F, T>(
+    mut authorize: A,
+    mut spawn: F,
+) -> Result<T, SpawnAttemptError>
+where
+    A: FnMut() -> harness_core::error::Result<()>,
+    F: FnMut() -> std::io::Result<T>,
+{
+    match authorized_spawn(&mut authorize, &mut spawn) {
+        Err(SpawnAttemptError::Io(error)) if is_etxtbsy(&error) => {
             tokio::time::sleep(ETXTBSY_RETRY_DELAY).await;
-            spawn()
+            authorized_spawn(&mut authorize, &mut spawn)
         }
         result => result,
     }
@@ -164,14 +164,17 @@ mod tests {
     async fn spawn_retry_retries_once_for_etxtbsy() {
         let attempts = AtomicUsize::new(0);
 
-        let result = spawn_with_etxtbsy_retry(|| {
-            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-            if attempt == 0 {
-                Err(std::io::Error::from_raw_os_error(26))
-            } else {
-                Ok("spawned")
-            }
-        })
+        let result = spawn_with_etxtbsy_retry(
+            || Ok(()),
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    Err(std::io::Error::from_raw_os_error(26))
+                } else {
+                    Ok("spawned")
+                }
+            },
+        )
         .await
         .expect("ETXTBSY retry should use the second spawn result");
 
@@ -183,14 +186,50 @@ mod tests {
     async fn spawn_retry_does_not_retry_other_errors() {
         let attempts = AtomicUsize::new(0);
 
-        let error = spawn_with_etxtbsy_retry(|| -> std::io::Result<()> {
-            attempts.fetch_add(1, Ordering::SeqCst);
-            Err(std::io::Error::from_raw_os_error(2))
-        })
+        let error = spawn_with_etxtbsy_retry(
+            || Ok(()),
+            || -> std::io::Result<()> {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(std::io::Error::from_raw_os_error(2))
+            },
+        )
         .await
         .expect_err("non-ETXTBSY errors must not be retried");
 
-        assert_eq!(error.raw_os_error(), Some(2));
+        assert!(matches!(
+            error,
+            SpawnAttemptError::Io(error) if error.raw_os_error() == Some(2)
+        ));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn token_expiring_during_etxtbsy_delay_blocks_second_spawn() {
+        let attempts = AtomicUsize::new(0);
+        let authorization_checks = AtomicUsize::new(0);
+        let mut token = CapabilityToken::new(9, Vec::new(), std::time::Duration::from_secs(60));
+
+        let error = spawn_with_etxtbsy_retry(
+            || {
+                if authorization_checks.fetch_add(1, Ordering::SeqCst) == 1 {
+                    token.expires_at = std::time::SystemTime::UNIX_EPOCH;
+                }
+                validate_capability_token(Some(&token))
+            },
+            || -> std::io::Result<()> {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(std::io::Error::from_raw_os_error(26))
+            },
+        )
+        .await
+        .expect_err("expiry during retry delay must block the second spawn attempt");
+
+        assert!(matches!(
+            error,
+            SpawnAttemptError::Authorization(HarnessError::AgentExecution(message))
+                if message.contains("subtask 9 has expired")
+        ));
+        assert_eq!(authorization_checks.load(Ordering::SeqCst), 2);
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## What

- Added a shared spawn supervisor that owns command construction, process-group setup, prepared environment application, ETXTBSY retry, provisional run binding, and ManagedChild wrapping.
- Routed Claude execute/stream, Codex review/execute/stream, and the Codex app-server adapter through the supervisor while leaving each backend responsible for argv/env planning and response parsing.
- Split Codex app-server protocol helpers into a submodule and added a stall-timeout regression for silent app-server stdout.

## Scope

This implements the remaining accepted scope of #1785 after the merged partial review isolation fix in f2b133c7 / #1814. It does not rework workflow state transitions, repository cleanup, docs metadata, or active PRs #1845-#1847.

## Scope guard

- Base: origin/main
- Files changed: 7 / 30
- Added lines: 653 / 1500

## Verification

- cargo fmt --all
- cargo fmt --all -- --check
- cargo check -p harness-agents --all-targets
- cargo test -p harness-agents
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- env -u HARNESS_DATABASE_URL -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS .githooks/pre-push

Note: running .githooks/pre-push without unsetting HARNESS_DATABASE_URL selected DB-backed harness-server tests and the test safety guard refused the configured non-test database (harness_self_20260729). The DB-less pre-push path above passed and deferred the DB-backed suites as designed.

Closes #1785