### PR TITLE
Update PR workflow thread policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ There is no type literally named `AgentRuntime` in the codebase. The phrase is u
 - If the review bot leaves comments, address valid feedback before merge
 - If no comments or only false positives, proceed with merge
 - Resolving a review thread does not require separate user approval once its feedback has been verified as addressed.
-- Posting a new comment or reply remains an external visible action and requires explicit user approval.
+- Posting a new comment or reply remains an externally visible action and requires explicit user approval.
 
 ## Codex Integration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ There is no type literally named `AgentRuntime` in the codebase. The phrase is u
 - After creating a PR, wait for the Codex review bot before merging
 - If the review bot leaves comments, address valid feedback before merge
 - If no comments or only false positives, proceed with merge
+- Resolving a review thread does not require separate user approval once its feedback has been verified as addressed.
+- Posting a new comment or reply remains an external visible action and requires explicit user approval.
 
 ## Codex Integration
 


### PR DESCRIPTION
Summary:
- Adds two PR workflow policy bullets clarifying review-thread resolution and new comment/reply approval.

Validation:
- npx --yes markdownlint-cli AGENTS.md --disable MD013 MD032 MD060
- git diff --check origin/main...HEAD -- AGENTS.md
- env -u HARNESS_DATABASE_URL git push -u origin harness/agents-pr-workflow-thread-policy-20260729 (pre-push hook: clippy and DB-less lib tests passed)

Notes:
- Changed only AGENTS.md.
- No WORKFLOW.md or code changes.
- This PR is for mandatory human review; not merged by this activity.