### PR TITLE
fix(context): demote composer to preview-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,7 +1323,6 @@ dependencies = [
  "anyhow",
  "harness-core",
  "harness-exec",
- "harness-gc",
  "harness-rules",
  "harness-skills",
  "serde",

--- a/crates/harness-context/Cargo.toml
+++ b/crates/harness-context/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 harness-core = { workspace = true }
 harness-rules = { workspace = true }
 harness-skills = { workspace = true }
-harness-gc = { workspace = true }
 harness-exec = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/harness-context/src/composer.rs
+++ b/crates/harness-context/src/composer.rs
@@ -643,10 +643,11 @@ fn provider_precedence(provider_id: &ProviderId) -> u8 {
     match provider_id.as_str() {
         "rules" => 0,
         "contract" => 1,
-        "skills" => 2,
-        "brief" => 3,
-        "gc-drafts" => 4,
-        "supplied" => 5,
-        _ => 6,
+        "exec-plan" => 2,
+        "skills" => 3,
+        "brief" => 4,
+        "gc-drafts" => 5,
+        "supplied" => 6,
+        _ => 7,
     }
 }

--- a/crates/harness-context/src/providers.rs
+++ b/crates/harness-context/src/providers.rs
@@ -143,7 +143,7 @@ impl ExecPlanProvider {
 
 impl ContextProvider for ExecPlanProvider {
     fn id(&self) -> ProviderId {
-        ProviderId::new("contract")
+        ProviderId::new("exec-plan")
     }
 
     fn propose(&self, req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {

--- a/crates/harness-context/src/tests.rs
+++ b/crates/harness-context/src/tests.rs
@@ -38,6 +38,14 @@ fn types_bytes_div_four_estimator_documents_v1_behavior() {
 }
 
 #[test]
+fn compose_config_is_preview_only() {
+    let core_config = harness_core::config::misc::ContextConfig::default();
+
+    assert_eq!(ComposeConfig::default().mode, ComposeMode::Preview);
+    assert_eq!(ComposeConfig::from(&core_config).mode, ComposeMode::Preview);
+}
+
+#[test]
 fn pipeline_is_deterministic_for_identical_inputs() {
     let items = vec![
         item("rule:b", ItemClass::Rule, 20, Priority::P1),
@@ -251,6 +259,8 @@ fn providers_include_active_exec_plans_for_matching_project() {
     let mut request = req();
     request.project = ProjectId::from_path(dir.path());
 
+    assert_eq!(provider.id().as_str(), "exec-plan");
+
     let items = provider.propose(&request).expect("provider succeeds");
 
     assert_eq!(items.len(), 1);
@@ -261,4 +271,22 @@ fn providers_include_active_exec_plans_for_matching_project() {
     assert_eq!(items[0].class, ItemClass::Contract);
     assert_eq!(items[0].priority, Priority::P0);
     assert!(items[0].content.contains("Ship context composer"));
+
+    let composition = match ContextComposer::new(ComposeConfig::default())
+        .with_provider(Box::new(provider))
+        .compose(&request)
+    {
+        Ok(composition) => composition,
+        Err(error) => panic!("composition succeeds: {error}"),
+    };
+    let manifest_item = match composition
+        .manifest
+        .items
+        .iter()
+        .find(|item| item.id.as_str() == format!("contract:exec-plan:{}", plan.id))
+    {
+        Some(item) => item,
+        None => panic!("exec plan appears in manifest"),
+    };
+    assert_eq!(manifest_item.provider_id.as_str(), "exec-plan");
 }

--- a/crates/harness-context/src/types.rs
+++ b/crates/harness-context/src/types.rs
@@ -222,18 +222,7 @@ impl Estimator for BytesDivFourEstimator {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ComposeMode {
-    Shadow,
-    Enforce,
     Preview,
-}
-
-impl From<harness_core::config::misc::ContextMode> for ComposeMode {
-    fn from(value: harness_core::config::misc::ContextMode) -> Self {
-        match value {
-            harness_core::config::misc::ContextMode::Shadow => Self::Shadow,
-            harness_core::config::misc::ContextMode::Enforce => Self::Enforce,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -281,7 +270,7 @@ pub struct ComposeConfig {
 impl Default for ComposeConfig {
     fn default() -> Self {
         Self {
-            mode: ComposeMode::Shadow,
+            mode: ComposeMode::Preview,
             budget_tokens: 24_000,
             reserved_headroom: 0.20,
             provider_timeout_ms: 2_000,
@@ -293,7 +282,7 @@ impl Default for ComposeConfig {
 impl From<&harness_core::config::misc::ContextConfig> for ComposeConfig {
     fn from(value: &harness_core::config::misc::ContextConfig) -> Self {
         Self {
-            mode: value.mode.into(),
+            mode: ComposeMode::Preview,
             budget_tokens: value.budget_tokens,
             reserved_headroom: value.reserved_headroom,
             provider_timeout_ms: value.provider_timeout_ms,

--- a/crates/harness-core/src/config/misc.rs
+++ b/crates/harness-core/src/config/misc.rs
@@ -316,14 +316,6 @@ pub struct RulesConfig {
     pub hook_enforcement: bool,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ContextMode {
-    #[default]
-    Shadow,
-    Enforce,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextQuotasConfig {
     #[serde(default = "default_context_rule_quota")]
@@ -372,8 +364,6 @@ impl Default for ContextQuotasConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextConfig {
-    #[serde(default)]
-    pub mode: ContextMode,
     #[serde(default = "default_context_budget_tokens")]
     pub budget_tokens: u32,
     #[serde(default = "default_context_reserved_headroom")]
@@ -401,7 +391,6 @@ fn default_context_provider_timeout_ms() -> u64 {
 impl Default for ContextConfig {
     fn default() -> Self {
         Self {
-            mode: ContextMode::Shadow,
             budget_tokens: default_context_budget_tokens(),
             reserved_headroom: default_context_reserved_headroom(),
             provider_timeout_ms: default_context_provider_timeout_ms(),

--- a/crates/harness-core/src/config_context_tests.rs
+++ b/crates/harness-core/src/config_context_tests.rs
@@ -1,11 +1,10 @@
-use super::misc::{ContextConfig, ContextMode};
+use super::misc::ContextConfig;
 use super::HarnessConfig;
 
 #[test]
-fn harness_config_defaults_include_context_shadow_mode() {
+fn harness_config_defaults_include_context_preview_budgeting() {
     let config = HarnessConfig::default();
 
-    assert_eq!(config.context.mode, ContextMode::Shadow);
     assert_eq!(config.context.budget_tokens, 24_000);
     assert_eq!(config.context.reserved_headroom, 0.20);
     assert_eq!(config.context.provider_timeout_ms, 2_000);
@@ -19,7 +18,6 @@ fn harness_config_defaults_include_context_shadow_mode() {
 #[test]
 fn context_config_deserializes_from_toml() {
     let toml_str = r#"
-        mode = "enforce"
         budget_tokens = 12000
         reserved_headroom = 0.10
         provider_timeout_ms = 500
@@ -34,7 +32,6 @@ fn context_config_deserializes_from_toml() {
 
     let config: ContextConfig = toml::from_str(toml_str).expect("context config should parse");
 
-    assert_eq!(config.mode, ContextMode::Enforce);
     assert_eq!(config.budget_tokens, 12_000);
     assert_eq!(config.reserved_headroom, 0.10);
     assert_eq!(config.provider_timeout_ms, 500);
@@ -43,4 +40,19 @@ fn context_config_deserializes_from_toml() {
     assert_eq!(config.quotas.contract, 0.20);
     assert_eq!(config.quotas.brief, 0.15);
     assert_eq!(config.quotas.draft, 0.05);
+}
+
+#[test]
+fn context_config_ignores_legacy_mode_field() {
+    let toml_str = r#"
+        mode = "enforce"
+        budget_tokens = 8000
+    "#;
+
+    let config: ContextConfig = match toml::from_str(toml_str) {
+        Ok(config) => config,
+        Err(error) => panic!("legacy mode is ignored: {error}"),
+    };
+
+    assert_eq!(config.budget_tokens, 8_000);
 }

--- a/specs/context-composer/product.md
+++ b/specs/context-composer/product.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-A single owner for the context harness injects when it starts an agent thread. Today rules, skills, ExecPlan contracts, task briefs, and GC drafts are injected by independent code paths with no shared token budget and no record of what the agent actually received. The Context Composer collects typed proposals from these sources, arbitrates them inside an explicit budget, and emits an auditable manifest for every composition. It ships in shadow mode first: observe and log what it *would* do before it changes anything.
+The context composer is a preview/debug tool for inspecting the context Harness could assemble from registered providers. Today rules, skills, ExecPlan contracts, task briefs, and GC drafts are still injected by independent production paths; wiring the composer into agent execution requires a separate integration design. The composer collects typed proposals from these sources, arbitrates them inside an explicit budget, and returns an auditable manifest from `context/preview`.
 
 ## User Problem
 
@@ -13,22 +13,23 @@ Two failure modes, both invisible today:
 
 ## Product Behavior
 
-- At `thread/start` (and on resume), registered providers propose typed context items with a declared size, priority, and degrade ladder (full text → summary → one-line pointer).
+- For `context/preview`, registered providers propose typed context items with a declared size, priority, and degrade ladder (full text -> summary -> one-line pointer).
 - The composer deduplicates, scores, and fits items into a configured token budget. Items that don't fit are degraded down their ladder before being excluded; every exclusion has a recorded reason.
-- Every composition emits a **manifest**: what was included, degraded, excluded, and why, with size accounting — stored as a harness-observe event, queryable later.
-- `context/preview` lets a human dry-run the composition for a task before running it.
-- **Shadow mode (default at launch):** the composer runs and logs manifests, but injection continues through the existing code paths, byte-identical to today. **Enforce mode** switches injection over to the composed output.
+- Every preview composition returns a **manifest**: what was included, degraded, excluded, and why, with size accounting.
+- The composer does not run at `thread/start`, `thread/resume`, or `turn/steer`, and it does not write to `AgentRequest.context`.
+- There is no active shadow or enforce mode in the composer surface. Existing Harness injection paths remain authoritative for execution.
 
 ## MVP Scope
 
-- New `harness-context` crate with the provider trait and deterministic arbitration pipeline.
-- Five v1 providers, all sources harness already owns: rules (harness-rules), skills (harness-skills), ExecPlan/spec contract (harness-exec), task brief, GC remediation drafts (harness-gc).
-- Shadow mode + manifest logging + `context/preview` and `context/manifest/get` RPC methods.
-- Config: per-project budget, per-class quotas, mode flag.
+- `harness-context` crate with the provider trait and deterministic arbitration pipeline.
+- Preview providers, all sources Harness already owns: rules (harness-rules), skills (harness-skills), task contract, ExecPlan contracts (harness-exec), task brief, GC remediation drafts.
+- `context/preview` RPC method returning rendered context plus the manifest.
+- Config: per-project budget, per-class quotas, reserved headroom, and provider timeout. No mode flag.
 
 ## Follow-Up Scope
 
-- Enforce mode rollout after shadow-mode manifests are reviewed against real tasks.
+- Execution integration after a dedicated design decides how composed output replaces or augments existing prompt assembly.
+- Manifest persistence, if needed, after preview manifests prove useful enough to query outside the immediate RPC response.
 - Measure **unmanaged injectors** (CLI-side hooks: remem, vibeguard, user hooks) by joining session JSONL to manifests via the run id (depends on the session-identity spec), so the reserved headroom becomes measured instead of guessed.
 - Outcome-driven tuning: correlate manifests with harness-observe quality grades; propose weight adjustments as adoptable drafts (same pattern as GC), never auto-applied.
 - Memory provider — explicitly deferred until the remem × harness integration question is decided; the design must not assume it.
@@ -41,14 +42,17 @@ Two failure modes, both invisible today:
 
 ## Acceptance Criteria
 
-- Shadow mode produces a manifest for 100% of thread starts; injection remains byte-identical to the pre-composer baseline (verified by integration test).
+- `context/preview` returns rendered context and a manifest without changing production agent requests.
 - Determinism: identical inputs produce byte-identical composition and manifest.
 - The budget is never exceeded; mandatory items that cannot fit fail the composition loudly rather than being silently trimmed.
 - Every excluded or degraded item appears in the manifest with a reason. No silent drops.
 - A count of instruction-bearing items > 15 raises a recorded warning in the manifest.
+- Contract and ExecPlan providers use distinct provider IDs, so manifest attribution is unambiguous.
+- `harness-context` does not depend on crates it does not use.
 
 ## Decisions
 
-- Class quotas ship with the proposed defaults (rule 30 / skill 25 / contract 25 / brief 15 / draft 5). They are configuration, and shadow-mode manifests are the instrument for revising them — no further quota debate before that data exists.
-- v1 token estimation is `bytes / 4` behind the `Estimator` trait: deterministic, dependency-free, and shadow mode makes its error harmless. A real tokenizer is a drop-in replacement later.
-- Recomposition happens at `thread/start` and `thread/resume` only. `turn/steer` never recomposes mid-turn — steering text is user intent, not managed context.
+- GH1806 records the active product decision: keep `harness-context` preview-only. Do not expose shadow/enforce modes or route composed output into `AgentRequest.context` until a future execution-integration spec owns that blast radius.
+- Class quotas ship with the proposed defaults (rule 30 / skill 25 / contract 25 / brief 15 / draft 5). They are configuration, and preview manifests are the instrument for revising them.
+- v1 token estimation is `bytes / 4` behind the `Estimator` trait: deterministic and dependency-free. A real tokenizer is a drop-in replacement later.
+- Recomposition is preview-only. `turn/steer` never recomposes mid-turn; steering text is user intent, not managed context.

--- a/specs/context-composer/tasks.md
+++ b/specs/context-composer/tasks.md
@@ -4,7 +4,7 @@ Spec: `specs/context-composer/` (PR #1426)
 
 ## Thread Lane Map
 
-- `CC-L1`: implementation worker. Owns the new `harness-context` crate, provider adapters, server wiring, and their tests.
+- `CC-L1`: implementation worker. Owns the `harness-context` crate, provider adapters, preview RPC wiring, and their tests.
 - `CC-L2`: reviewer, read-only. Owns post-implementation diff review against this spec, with special attention to determinism and no-silent-drop guarantees.
 
 No two writable lanes may edit the same file. `AGENTS.md`, `.claude/*`, hooks, settings, and global config are forbidden files unless explicitly requested.
@@ -63,7 +63,7 @@ Verify:
 cargo test -p harness-context manifest
 ```
 
-### CC-T4: Five v1 providers
+### CC-T4: Preview providers
 
 Owner: CC-L1
 
@@ -71,8 +71,9 @@ Dependencies: CC-T1
 
 Done when:
 
-- Providers wrapping existing crates: rules (harness-rules), skills (harness-skills), contract (harness-exec ExecPlan), task brief, GC drafts (harness-gc).
+- Providers wrapping existing sources: rules (harness-rules), skills (harness-skills), task contract, ExecPlan contracts (harness-exec), task brief, and GC drafts supplied by the server.
 - Providers reuse existing selection logic; they add only sizing, relevance, degrade ladders, and dedupe keys.
+- Contract and ExecPlan providers use distinct provider IDs.
 
 Verify:
 
@@ -80,7 +81,7 @@ Verify:
 cargo test -p harness-context providers
 ```
 
-### CC-T5: Shadow-mode server wiring
+### CC-T5: Preview-only server wiring
 
 Owner: CC-L1
 
@@ -88,15 +89,15 @@ Dependencies: CC-T2, CC-T3, CC-T4
 
 Done when:
 
-- `harness-server` invokes the composer at `thread/start` and `thread/resume` when `context.mode = "shadow"` (default); `turn/steer` never recomposes.
-- Injection remains byte-identical to the pre-composer baseline (integration test against a captured baseline).
-- Composer failure in shadow mode produces an error event only and never affects thread start.
+- `harness-server` invokes the composer only for `context/preview`; `thread/start`, `thread/resume`, and `turn/steer` never compose.
+- Production agent requests remain on existing prompt assembly paths.
 - Config surface: `budget_tokens` (per agent kind), `reserved_headroom` (default 0.20), `provider_timeout_ms`, `quotas` (defaults: rule 0.30 / skill 0.25 / contract 0.25 / brief 0.15 / draft 0.05).
+- Legacy `context.mode` config is ignored for compatibility and is no longer part of typed config.
 
 Verify:
 
 ```sh
-cargo test -p harness-server context_shadow
+cargo test -p harness-server context_preview
 ```
 
 ### CC-T6: RPC methods
@@ -107,7 +108,7 @@ Dependencies: CC-T5
 
 Done when:
 
-- `context/preview` dry-runs a composition for a hypothetical request; `context/manifest/get` returns a thread's manifest.
+- `context/preview` dry-runs a composition for a hypothetical request and returns rendered context plus its manifest.
 - Both registered in the JSON-RPC router with protocol tests.
 
 Verify:
@@ -118,18 +119,6 @@ cargo test -p harness-server context_rpc
 
 ### CC-T7: Enforce mode (gated)
 
-Owner: CC-L1
+Status: superseded by GH1806 preview-only decision.
 
-Dependencies: CC-T5 plus a shadow-mode review period on real tasks
-
-Done when:
-
-- Per-project `context.mode = "enforce"` disables the five legacy injection paths behind the same flag and makes the composed block the single harness-side injection.
-- Integration test asserts the legacy paths inject nothing under enforce.
-- Rollback documented: flip the flag back to `shadow`; legacy paths are disabled, not deleted, until enforce has run stably.
-
-Verify:
-
-```sh
-cargo test -p harness-server context_enforce
-```
+Future execution integration must be planned in a new task or spec that owns prompt assembly, agent request wiring, migration behavior, and rollback.

--- a/specs/context-composer/tech.md
+++ b/specs/context-composer/tech.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-harness injects context into agent threads from at least five code paths: harness-rules (loaded rule text), harness-skills (skill projection), harness-exec (ExecPlan/spec contract), the task brief itself, and harness-gc (remediation drafts). Each path decides independently what to include. This spec centralizes those decisions in a new `harness-context` crate, invoked by `harness-server` at `thread/start` and `thread/resume`.
+Harness injects context into agent threads from at least five production code paths: harness-rules (loaded rule text), harness-skills (skill projection), harness-exec (ExecPlan/spec contract), the task brief itself, and harness-gc (remediation drafts). Each path decides independently what to include. GH1806 records the current decision: `harness-context` remains a preview/debug composer invoked by `context/preview`; it does not run at `thread/start` or `thread/resume`, and it does not write to `AgentRequest.context`.
 
 CLI-side hook injections (remem, vibeguard, user hooks) are outside the composer's control by design; they are accounted for with reserved headroom (see Budget).
 
@@ -12,7 +12,7 @@ CLI-side hook injections (remem, vibeguard, user hooks) are outside the composer
 
 ```rust
 pub trait ContextProvider: Send + Sync {
-    fn id(&self) -> ProviderId;                       // "rules", "skills", "contract", "brief", "gc-drafts"
+    fn id(&self) -> ProviderId;                       // "rules", "skills", "contract", "exec-plan", "brief", "gc-drafts"
     fn propose(&self, req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError>;
 }
 
@@ -46,8 +46,8 @@ collect → dedupe → mandatory → quota fill → redistribute → guards → 
 ```
 
 1. **Collect.** Run providers with a per-provider timeout (config, default 2s). A provider error or timeout contributes nothing, is logged at error level, and is recorded in the manifest as `provider_error` — the composition is marked degraded, never silently complete.
-2. **Dedupe.** Items sharing a `dedupe_key` collapse to one survivor: highest priority wins, ties broken by configured provider precedence (`rules > contract > skills > brief > gc-drafts`), then lexicographic item id (for determinism).
-3. **Mandatory.** All P0 items are placed first. If P0 alone exceeds the budget, composition **fails loudly** (`compose_error`), failing the thread start in enforce mode — mandatory context must never be silently trimmed.
+2. **Dedupe.** Items sharing a `dedupe_key` collapse to one survivor: highest priority wins, ties broken by configured provider precedence (`rules > contract > exec-plan > skills > brief > gc-drafts`), then lexicographic item id (for determinism).
+3. **Mandatory.** All P0 items are placed first. If P0 alone exceeds the budget, composition **fails loudly** (`compose_error`) rather than silently trimming mandatory context.
 4. **Quota fill.** Remaining budget splits into class quotas (default: Rule 30%, Skill 25%, Contract 25%, Brief 15%, Draft 5%). Within each class, items sort by `score = relevance × class_weight`, ties by item id. Each item is placed at the highest degrade level that fits its class's remaining quota: full content, else ladder steps in order, else deferred to step 5.
 5. **Redistribute.** Unused quota pools globally; deferred items compete in global score order, same degrade-to-fit rule.
 6. **Guards.**
@@ -59,7 +59,6 @@ collect → dedupe → mandatory → quota fill → redistribute → guards → 
 
 ```toml
 [context]
-mode = "shadow"                  # shadow | enforce
 budget_tokens = 24000            # per agent kind overridable: [context.claude-code] / [context.codex]
 reserved_headroom = 0.20         # fraction left free for CLI-hook injections the composer cannot see
 provider_timeout_ms = 2000
@@ -70,10 +69,10 @@ Effective budget = `budget_tokens × (1 − reserved_headroom)`. Token estimatio
 
 ### Manifest
 
-Logged through harness-observe as event kind `context_manifest`:
+Returned by `context/preview`:
 
 ```json
-{"v":1,"thread_id":"...","run_id":"ar-01j1...","mode":"shadow","ts":"...",
+{"v":1,"thread_id":"...","run_id":"ar-01j1...","mode":"preview",
  "budget":{"total":24000,"effective":19200,"used":14730},
  "items":[
    {"id":"rule:U-29","class":"rule","decision":"included","tokens":410},
@@ -83,12 +82,11 @@ Logged through harness-observe as event kind `context_manifest`:
  "provider_errors":[],"warnings":["constraint_overload:17"]}
 ```
 
-`context/manifest/get` returns the manifest for a thread; `context/preview` runs steps 1–7 for a hypothetical `ComposeRequest` without starting a thread.
+`context/preview` runs steps 1-7 for a hypothetical `ComposeRequest` without starting a thread. Manifests are returned to the caller and are not persisted by the composer.
 
 ### Modes
 
-- **Shadow (default):** pipeline runs, manifest is logged, existing injection paths remain the sole writers of agent context. Zero behavioral risk; produces the data needed to validate quotas and headroom.
-- **Enforce:** the five v1 providers' legacy direct-injection paths are disabled behind the same config flag and the composed block becomes the single injection. The flag flips per project, not globally.
+There is one active mode: `preview`. The former shadow/enforce rollout surface was removed because no production call site constructed those modes or consumed composed output. Future execution integration must introduce its own spec, tests, and migration path before composed context can affect agent requests.
 
 ### Interaction with unmanaged injectors
 
@@ -100,22 +98,22 @@ harness-observe already grades task quality. Manifests give every graded task a 
 
 ## Data Model
 
-No new store. Manifests are harness-observe events; config lives in the existing TOML. The crate is stateless between compositions.
+No new store. Preview manifests are returned in the RPC response; config lives in the existing TOML. The crate is stateless between compositions.
 
 ## Privacy and Failure Behavior
 
 - Manifests record item ids, sizes, and decisions — not full item content (content is recoverable from providers by id).
 - Provider failure: error-level log + degraded manifest, never a silent partial composition (U-29).
-- In shadow mode, composer panics/errors must never affect thread start: the composer call is isolated and its failure only produces an error event.
+- Composer errors affect only the preview RPC response. Production thread start remains on the existing prompt assembly paths.
 
 ## Verification Plan
 
 - Golden tests: fixture proposals → snapshot of composition + manifest (byte-exact, guards determinism).
 - Property tests: `used ≤ effective budget` for arbitrary item sets; every input item appears in the manifest exactly once with a decision.
 - Pipeline unit tests: dedupe precedence, P0-overflow hard failure, degrade-ladder fitting, redistribution order, constraint-count guard.
-- Integration (shadow): run a real task; assert manifest event exists and the injected context is byte-identical to a pre-composer baseline capture.
-- Integration (enforce, gated): same task with enforce on; assert the five legacy paths injected nothing and the composed block is present.
+- Preview RPC integration: assert rendered context and manifest are returned for a hypothetical request.
+- Config regression: legacy `context.mode` TOML is ignored for compatibility, and the typed config no longer exposes a mode field.
 
 ## Rollback
 
-Shadow mode is inert by construction. Enforce mode rolls back by flipping `context.mode` back to `shadow` per project — legacy injection paths are disabled behind the flag, not deleted, until enforce has run stably for an agreed period.
+Preview-only composition is inert for production execution. Roll back by disabling or removing the preview RPC route; there is no production injection flag to flip.


### PR DESCRIPTION
## Summary

- record the GH1806 decision that harness-context is preview-only until a future execution integration owns prompt/request wiring
- remove the inert shadow/enforce typed config surface and keep legacy context.mode TOML ignored for compatibility
- fix ExecPlan provider attribution to use a distinct exec-plan provider ID
- remove the unused harness-gc dependency from harness-context

## Validation

- cargo fmt --all -- --check
- cargo test -p harness-context
- cargo test -p harness-core config::context_tests
- cargo check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- pre-push DB-less hook passed; PostgreSQL suites deferred without HARNESS_DATABASE_URL

Closes #1806