### PR TITLE
refactor(config): consolidate env config resolution

### DIFF
--- a/crates/harness-agents/src/builder.rs
+++ b/crates/harness-agents/src/builder.rs
@@ -155,7 +155,7 @@ pub fn registry_from_config(
         )
         .map_err(|error| anyhow::anyhow!("failed to attach the codex adapter: {error}"))?;
 
-    if let Ok(api_key) = std::env::var(ANTHROPIC_API_KEY_ENV) {
+    if let Ok(api_key) = harness_core::config::process_env::var(ANTHROPIC_API_KEY_ENV) {
         registry.register(
             "anthropic-api",
             Arc::new(crate::anthropic_api::AnthropicApiAgent::from_config(

--- a/crates/harness-agents/src/compress_model.rs
+++ b/crates/harness-agents/src/compress_model.rs
@@ -168,7 +168,7 @@ fn configured_model(config: &CompressionConfig) -> Option<ApiCompressModel> {
     if !config.is_active() {
         return None;
     }
-    let api_key = std::env::var("ANTHROPIC_API_KEY").ok()?;
+    let api_key = harness_core::config::process_env::var("ANTHROPIC_API_KEY").ok()?;
     if api_key.trim().is_empty() {
         return None;
     }

--- a/crates/harness-cli/src/commands/status.rs
+++ b/crates/harness-cli/src/commands/status.rs
@@ -81,12 +81,6 @@ pub(crate) fn resolve_api_token(config: &HarnessConfig) -> Option<String> {
         .map(str::trim)
         .filter(|token| !token.is_empty())
         .map(str::to_owned)
-        .or_else(|| {
-            std::env::var("HARNESS_API_TOKEN")
-                .ok()
-                .map(|token| token.trim().to_string())
-                .filter(|token| !token.is_empty())
-        })
 }
 
 pub(crate) fn server_base_url(

--- a/crates/harness-core/src/config.rs
+++ b/crates/harness-core/src/config.rs
@@ -8,6 +8,7 @@ pub mod isolation;
 pub mod maintenance;
 pub mod misc;
 pub mod observe;
+pub mod process_env;
 pub mod project;
 pub mod resolve;
 pub mod server;
@@ -62,41 +63,87 @@ pub struct ProjectEntry {
     pub max_concurrent: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct HarnessConfig {
-    pub server: ServerConfig,
-    pub agents: AgentsConfig,
-    pub gc: GcConfig,
-    pub rules: RulesConfig,
-    pub observe: ObserveConfig,
+macro_rules! define_harness_config {
+    ($(
+        $(#[$attr:meta])*
+        $field:ident: $ty:ty,
+    )+) => {
+        #[derive(Debug, Clone, Serialize)]
+        pub struct HarnessConfig {
+            $(
+                $(#[$attr])*
+                pub $field: $ty,
+            )+
+        }
+
+        impl Default for HarnessConfig {
+            fn default() -> Self {
+                let mut config = Self {
+                    $($field: <$ty>::default(),)+
+                };
+                config.apply_derived_defaults();
+                config
+            }
+        }
+
+        impl<'de> Deserialize<'de> for HarnessConfig {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                #[derive(Deserialize)]
+                struct ParsedHarnessConfig {
+                    $(
+                        $(#[$attr])*
+                        $field: $ty,
+                    )+
+                }
+
+                let input: ParsedHarnessConfig =
+                    reserved_key_deserializer::deserialize(deserializer)?;
+                let ParsedHarnessConfig { $($field,)+ } = input;
+                let mut config = Self { $($field,)+ };
+                config.apply_derived_defaults();
+                Ok(config)
+            }
+        }
+    };
+}
+
+define_harness_config! {
+    server: ServerConfig,
+    agents: AgentsConfig,
+    gc: GcConfig,
+    rules: RulesConfig,
+    observe: ObserveConfig,
     #[serde(default)]
-    pub context: ContextConfig,
-    pub otel: OtelConfig,
+    context: ContextConfig,
+    otel: OtelConfig,
     #[serde(default)]
-    pub validation: ValidationConfig,
+    validation: ValidationConfig,
     #[serde(default)]
-    pub workspace: WorkspaceConfig,
+    workspace: WorkspaceConfig,
     #[serde(default)]
-    pub concurrency: ConcurrencyConfig,
+    concurrency: ConcurrencyConfig,
     #[serde(default)]
-    pub intake: IntakeConfig,
+    intake: IntakeConfig,
     #[serde(default)]
-    pub review: ReviewConfig,
+    review: ReviewConfig,
     #[serde(default)]
-    pub retry_scheduler: RetrySchedulerConfig,
+    retry_scheduler: RetrySchedulerConfig,
     #[serde(default)]
-    pub reconciliation: ReconciliationConfig,
+    reconciliation: ReconciliationConfig,
     #[serde(default)]
-    pub maintenance_window: MaintenanceWindowConfig,
+    maintenance_window: MaintenanceWindowConfig,
     #[serde(default)]
-    pub workflow: WorkflowRuntimeConfig,
+    workflow: WorkflowRuntimeConfig,
     #[serde(default)]
-    pub isolation: IsolationConfig,
+    isolation: IsolationConfig,
     #[serde(default)]
-    pub alerting: AlertingConfig,
+    alerting: AlertingConfig,
     /// Projects declared in the config file. Registered on server startup.
     #[serde(default)]
-    pub projects: Vec<ProjectEntry>,
+    projects: Vec<ProjectEntry>,
 }
 
 impl HarnessConfig {
@@ -168,102 +215,6 @@ impl HarnessConfig {
     }
 }
 
-impl Default for HarnessConfig {
-    fn default() -> Self {
-        let mut config = Self {
-            server: ServerConfig::default(),
-            agents: AgentsConfig::default(),
-            gc: GcConfig::default(),
-            rules: RulesConfig::default(),
-            observe: ObserveConfig::default(),
-            context: ContextConfig::default(),
-            otel: OtelConfig::default(),
-            validation: ValidationConfig::default(),
-            workspace: WorkspaceConfig::default(),
-            concurrency: ConcurrencyConfig::default(),
-            intake: IntakeConfig::default(),
-            review: ReviewConfig::default(),
-            retry_scheduler: RetrySchedulerConfig::default(),
-            reconciliation: ReconciliationConfig::default(),
-            maintenance_window: MaintenanceWindowConfig::default(),
-            workflow: WorkflowRuntimeConfig::default(),
-            isolation: IsolationConfig::default(),
-            alerting: AlertingConfig::default(),
-            projects: Vec::new(),
-        };
-        config.apply_derived_defaults();
-        config
-    }
-}
-
-impl<'de> Deserialize<'de> for HarnessConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct HarnessConfigInput {
-            server: ServerConfig,
-            agents: AgentsConfig,
-            gc: GcConfig,
-            rules: RulesConfig,
-            observe: ObserveConfig,
-            #[serde(default)]
-            context: ContextConfig,
-            otel: OtelConfig,
-            #[serde(default)]
-            validation: ValidationConfig,
-            #[serde(default)]
-            workspace: WorkspaceConfig,
-            #[serde(default)]
-            concurrency: ConcurrencyConfig,
-            #[serde(default)]
-            intake: IntakeConfig,
-            #[serde(default)]
-            review: ReviewConfig,
-            #[serde(default)]
-            retry_scheduler: RetrySchedulerConfig,
-            #[serde(default)]
-            reconciliation: ReconciliationConfig,
-            #[serde(default)]
-            maintenance_window: MaintenanceWindowConfig,
-            #[serde(default)]
-            workflow: WorkflowRuntimeConfig,
-            #[serde(default)]
-            isolation: IsolationConfig,
-            #[serde(default)]
-            alerting: AlertingConfig,
-            #[serde(default)]
-            projects: Vec<ProjectEntry>,
-        }
-
-        let input: HarnessConfigInput = reserved_key_deserializer::deserialize(deserializer)?;
-        let mut config = Self {
-            server: input.server,
-            agents: input.agents,
-            gc: input.gc,
-            rules: input.rules,
-            observe: input.observe,
-            context: input.context,
-            otel: input.otel,
-            validation: input.validation,
-            workspace: input.workspace,
-            concurrency: input.concurrency,
-            intake: input.intake,
-            review: input.review,
-            retry_scheduler: input.retry_scheduler,
-            reconciliation: input.reconciliation,
-            maintenance_window: input.maintenance_window,
-            workflow: input.workflow,
-            isolation: input.isolation,
-            alerting: input.alerting,
-            projects: input.projects,
-        };
-        config.apply_derived_defaults();
-        Ok(config)
-    }
-}
-
 #[cfg(test)]
 #[path = "config_tests.rs"]
 mod tests;
@@ -271,6 +222,10 @@ mod tests;
 #[cfg(test)]
 #[path = "config_context_tests.rs"]
 mod context_tests;
+
+#[cfg(test)]
+#[path = "config_env_audit_tests.rs"]
+mod env_audit_tests;
 
 #[cfg(test)]
 #[path = "config_workflow_circuit_breaker_tests.rs"]

--- a/crates/harness-core/src/config/alerting.rs
+++ b/crates/harness-core/src/config/alerting.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::alert::AlertClass;
 
+use super::process_env;
+
 fn default_dedup_cooldown_secs() -> u64 {
     300
 }
@@ -87,7 +89,7 @@ impl AlertChannelConfig {
         self.url
             .clone()
             .filter(|u| !u.trim().is_empty())
-            .or_else(|| std::env::var(self.url_env_var()).ok())
+            .or_else(|| process_env::non_blank_config_value(&self.url_env_var()))
             .filter(|u| !u.trim().is_empty())
     }
 }

--- a/crates/harness-core/src/config/dirs.rs
+++ b/crates/harness-core/src/config/dirs.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use super::process_env;
+
 pub fn dirs_data_dir() -> PathBuf {
     match data_local_dir() {
         Some(path) => path,
@@ -17,8 +19,8 @@ pub fn dirs_data_dir() -> PathBuf {
 }
 
 fn temp_fallback_dir() -> PathBuf {
-    let username = std::env::var("USER")
-        .or_else(|_| std::env::var("USERNAME"))
+    let username = process_env::var("USER")
+        .or_else(|_| process_env::var("USERNAME"))
         .unwrap_or_else(|_| "default".to_string());
     // Keep the directory name filesystem-safe: allow alphanumeric, '-', '_' only.
     let safe: String = username
@@ -64,7 +66,7 @@ fn config_candidates() -> Vec<PathBuf> {
     // paths relative to the process CWD, turning any directory an operator
     // starts harness from into a config boundary and potentially loading
     // attacker-controlled or accidental local config files.
-    let abs_home: Option<PathBuf> = std::env::var("HOME")
+    let abs_home: Option<PathBuf> = process_env::var("HOME")
         .ok()
         .map(PathBuf::from)
         .filter(|p| p.is_absolute());
@@ -72,13 +74,14 @@ fn config_candidates() -> Vec<PathBuf> {
     // 1. $XDG_CONFIG_HOME/harness/config.toml
     //    Per the XDG Base Directory Specification, XDG_CONFIG_HOME MUST be an
     //    absolute path. Relative values are silently discarded.
-    if let Some(xdg) = std::env::var("XDG_CONFIG_HOME")
-        .ok()
-        .map(PathBuf::from)
-        .filter(|p| p.is_absolute())
-        .or_else(|| abs_home.as_ref().map(|h| h.join(".config")))
-    {
-        candidates.push(xdg.join("harness").join("config.toml"));
+    if let Some(root) = xdg_config_harness_root(
+        process_env::var("XDG_CONFIG_HOME")
+            .ok()
+            .map(PathBuf::from)
+            .as_deref(),
+        abs_home.as_deref(),
+    ) {
+        candidates.push(root.join("config.toml"));
     }
 
     // 2. macOS: $HOME/Library/Application Support/harness/config.toml
@@ -94,7 +97,7 @@ fn config_candidates() -> Vec<PathBuf> {
     // 3. Windows: %APPDATA%\harness\config.toml
     //    APPDATA must be absolute for the same reason as XDG_CONFIG_HOME.
     #[cfg(target_os = "windows")]
-    if let Some(appdata) = std::env::var("APPDATA")
+    if let Some(appdata) = process_env::var("APPDATA")
         .ok()
         .map(PathBuf::from)
         .filter(|p| p.is_absolute())
@@ -105,27 +108,39 @@ fn config_candidates() -> Vec<PathBuf> {
     candidates
 }
 
+pub fn xdg_config_harness_root(
+    xdg_config_home: Option<&Path>,
+    home: Option<&Path>,
+) -> Option<PathBuf> {
+    if let Some(xdg) = xdg_config_home.filter(|path| path.is_absolute()) {
+        Some(xdg.join("harness"))
+    } else {
+        home.filter(|path| path.is_absolute())
+            .map(|home| home.join(".config").join("harness"))
+    }
+}
+
 fn data_local_dir() -> Option<PathBuf> {
     #[cfg(target_os = "macos")]
     {
-        std::env::var("HOME")
+        process_env::var("HOME")
             .ok()
             .map(|h| PathBuf::from(h).join("Library/Application Support"))
     }
     #[cfg(target_os = "linux")]
     {
-        std::env::var("XDG_DATA_HOME")
+        process_env::var("XDG_DATA_HOME")
             .ok()
             .map(PathBuf::from)
             .or_else(|| {
-                std::env::var("HOME")
+                process_env::var("HOME")
                     .ok()
                     .map(|h| PathBuf::from(h).join(".local/share"))
             })
     }
     #[cfg(target_os = "windows")]
     {
-        std::env::var("LOCALAPPDATA").ok().map(PathBuf::from)
+        process_env::var("LOCALAPPDATA").ok().map(PathBuf::from)
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
@@ -162,7 +177,7 @@ mod tests {
         // Save originals.
         let saved: Vec<(&str, Option<String>)> = vars
             .iter()
-            .map(|(k, _)| (*k, std::env::var(k).ok()))
+            .map(|(k, _)| (*k, process_env::var(k).ok()))
             .collect();
         for (k, v) in vars {
             // SAFETY: test-only, serialized by ENV_MUTEX.

--- a/crates/harness-core/src/config/process_env.rs
+++ b/crates/harness-core/src/config/process_env.rs
@@ -1,0 +1,38 @@
+use std::env::{var as std_var, var_os as std_var_os, VarError};
+use std::ffi::OsString;
+
+/// Single funnel for process environment reads used by config resolution.
+///
+/// Runtime code that needs general process state may read it directly, but
+/// config-driven environment overrides should go through this module so they
+/// remain auditable in one place.
+pub fn var(name: &str) -> Result<String, VarError> {
+    std_var(name)
+}
+
+pub fn var_os(name: &str) -> Option<OsString> {
+    std_var_os(name)
+}
+
+pub fn config_value(name: &str) -> Option<String> {
+    var(name).ok().filter(|value| !value.is_empty())
+}
+
+pub fn trimmed_config_value(name: &str) -> Option<String> {
+    var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+pub fn non_blank_config_value(name: &str) -> Option<String> {
+    var(name).ok().filter(|value| !value.trim().is_empty())
+}
+
+pub fn first_non_blank_config_value(names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| non_blank_config_value(name))
+}
+
+pub fn first_trimmed_config_value(names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| trimmed_config_value(name))
+}

--- a/crates/harness-core/src/config/server.rs
+++ b/crates/harness-core/src/config/server.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use super::dirs::dirs_data_dir;
+use super::process_env;
 use super::shutdown::ShutdownConfig;
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -112,66 +113,45 @@ impl ServerConfig {
     /// - `GITHUB_WEBHOOK_SECRET`   — `github_webhook_secret`
     pub fn apply_env_overrides(&mut self) -> anyhow::Result<()> {
         self.normalize_api_token();
-        if let Ok(v) = std::env::var("HARNESS_DATA_DIR") {
-            if !v.is_empty() {
-                self.data_dir = std::path::PathBuf::from(v);
-            }
+        if let Some(v) = process_env::config_value("HARNESS_DATA_DIR") {
+            self.data_dir = std::path::PathBuf::from(v);
         }
-        if let Ok(v) = std::env::var("HARNESS_PROJECT_ROOT") {
-            if !v.is_empty() {
-                self.project_root = std::path::PathBuf::from(v);
-            }
+        if let Some(v) = process_env::config_value("HARNESS_PROJECT_ROOT") {
+            self.project_root = std::path::PathBuf::from(v);
         }
-        if let Ok(v) = std::env::var("HARNESS_DATABASE_URL") {
-            if !v.is_empty() {
-                self.database_url = Some(v);
-            }
+        if let Some(v) = process_env::config_value("HARNESS_DATABASE_URL") {
+            self.database_url = Some(v);
         }
-        if let Ok(v) = std::env::var("HARNESS_DATABASE_POOL_MAX_CONNECTIONS") {
-            if !v.is_empty() {
-                self.database_pool_max_connections = Some(v.parse().map_err(|e| {
-                    anyhow::anyhow!(
-                        "HARNESS_DATABASE_POOL_MAX_CONNECTIONS={v:?} is not a valid u32: {e}"
-                    )
-                })?);
-            }
+        if let Some(v) = process_env::config_value("HARNESS_DATABASE_POOL_MAX_CONNECTIONS") {
+            self.database_pool_max_connections = Some(v.parse().map_err(|e| {
+                anyhow::anyhow!(
+                    "HARNESS_DATABASE_POOL_MAX_CONNECTIONS={v:?} is not a valid u32: {e}"
+                )
+            })?);
         }
-        if let Ok(v) = std::env::var("HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS") {
-            if !v.is_empty() {
-                self.database_pool_acquire_timeout_secs = Some(v.parse().map_err(|e| {
-                    anyhow::anyhow!(
-                        "HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS={v:?} is not a valid u64: {e}"
-                    )
-                })?);
-            }
+        if let Some(v) = process_env::config_value("HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS") {
+            self.database_pool_acquire_timeout_secs = Some(v.parse().map_err(|e| {
+                anyhow::anyhow!(
+                    "HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS={v:?} is not a valid u64: {e}"
+                )
+            })?);
         }
-        if let Ok(v) = std::env::var("HARNESS_API_TOKEN") {
-            let token = v.trim();
-            if !token.is_empty() {
-                self.api_token = Some(token.to_string());
-            }
+        if let Some(v) = process_env::trimmed_config_value("HARNESS_API_TOKEN") {
+            self.api_token = Some(v);
         }
         if self
             .github_token
             .as_deref()
             .is_none_or(|v| v.trim().is_empty())
         {
-            if let Some(v) = std::env::var("GITHUB_TOKEN")
-                .ok()
-                .filter(|v| !v.trim().is_empty())
-                .or_else(|| {
-                    std::env::var("GH_TOKEN")
-                        .ok()
-                        .filter(|v| !v.trim().is_empty())
-                })
+            if let Some(v) =
+                process_env::first_non_blank_config_value(&["GITHUB_TOKEN", "GH_TOKEN"])
             {
                 self.github_token = Some(v);
             }
         }
-        if let Ok(v) = std::env::var("GITHUB_WEBHOOK_SECRET") {
-            if !v.is_empty() {
-                self.github_webhook_secret = Some(v);
-            }
+        if let Some(v) = process_env::config_value("GITHUB_WEBHOOK_SECRET") {
+            self.github_webhook_secret = Some(v);
         }
         self.normalize_api_token();
         Ok(())
@@ -196,12 +176,10 @@ impl ServerConfig {
     /// value, or a hostname like `localhost:9800` that `SocketAddr` rejects)
     /// brick completely unrelated commands.
     pub fn apply_serve_env_overrides(&mut self) -> anyhow::Result<()> {
-        if let Ok(v) = std::env::var("HARNESS_HTTP_ADDR") {
-            if !v.is_empty() {
-                self.http_addr = v.parse().map_err(|e| {
-                    anyhow::anyhow!("HARNESS_HTTP_ADDR={v:?} is not a valid SocketAddr: {e}")
-                })?;
-            }
+        if let Some(v) = process_env::config_value("HARNESS_HTTP_ADDR") {
+            self.http_addr = v.parse().map_err(|e| {
+                anyhow::anyhow!("HARNESS_HTTP_ADDR={v:?} is not a valid SocketAddr: {e}")
+            })?;
         }
         Ok(())
     }

--- a/crates/harness-core/src/config_env_audit_tests.rs
+++ b/crates/harness-core/src/config_env_audit_tests.rs
@@ -1,0 +1,434 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+struct AllowedRawEnvRead {
+    path: &'static str,
+    expected_reads: usize,
+    reason: &'static str,
+}
+
+const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
+    allowed(
+        "crates/harness-agents/src/builder.rs",
+        1,
+        "agent provider secret discovery",
+    ),
+    allowed(
+        "crates/harness-agents/src/claude_tests.rs",
+        1,
+        "serialized env fixture",
+    ),
+    allowed(
+        "crates/harness-agents/src/cloud_setup.rs",
+        3,
+        "agent cloud setup secret passthrough",
+    ),
+    allowed(
+        "crates/harness-agents/src/codex_spawn.rs",
+        1,
+        "PATH lookup for spawning codex",
+    ),
+    allowed(
+        "crates/harness-agents/src/codex_tests.rs",
+        1,
+        "serialized env fixture",
+    ),
+    allowed(
+        "crates/harness-agents/src/compress_model.rs",
+        1,
+        "provider API key discovery",
+    ),
+    allowed(
+        "crates/harness-agents/src/run_id_tests.rs",
+        2,
+        "serialized run-id env fixture",
+    ),
+    allowed(
+        "crates/harness-agents/src/spawn_contract.rs",
+        1,
+        "PATH passthrough for child process env",
+    ),
+    allowed(
+        "crates/harness-cli/src/cmd/pr.rs",
+        1,
+        "agent review child env propagation",
+    ),
+    allowed(
+        "crates/harness-cli/src/commands/exec.rs",
+        3,
+        "operator identity and sudo process checks",
+    ),
+    allowed(
+        "crates/harness-cli/src/commands/status.rs",
+        1,
+        "CLI token fallback",
+    ),
+    allowed(
+        "crates/harness-core/src/agents_md.rs",
+        2,
+        "operator home instruction discovery",
+    ),
+    allowed(
+        "crates/harness-core/src/db_test_safety.rs",
+        1,
+        "test database safety override",
+    ),
+    allowed(
+        "crates/harness-core/src/run_id.rs",
+        11,
+        "run-id process context propagation",
+    ),
+    allowed(
+        "crates/harness-core/src/run_registry.rs",
+        2,
+        "XDG state path discovery",
+    ),
+    allowed(
+        "crates/harness-observe/src/event_store/store_tests.rs",
+        2,
+        "serialized run-id env fixture",
+    ),
+    allowed(
+        "crates/harness-observe/src/otel_export.rs",
+        1,
+        "OpenTelemetry SDK env compatibility",
+    ),
+    allowed(
+        "crates/harness-rules/src/engine/mod.rs",
+        1,
+        "operator home rule discovery",
+    ),
+    allowed(
+        "crates/harness-sandbox/src/lib.rs",
+        1,
+        "PATH lookup for sandbox command execution",
+    ),
+    allowed(
+        "crates/harness-server/build.rs",
+        5,
+        "Cargo build-script process environment",
+    ),
+    allowed(
+        "crates/harness-server/src/event_replay_tests.rs",
+        1,
+        "Postgres integration test gate",
+    ),
+    allowed(
+        "crates/harness-server/src/github_auth.rs",
+        2,
+        "GitHub token compatibility",
+    ),
+    allowed(
+        "crates/harness-server/src/github_client.rs",
+        1,
+        "GitHub API endpoint test override",
+    ),
+    allowed(
+        "crates/harness-server/src/github_pr_snapshot.rs",
+        1,
+        "GitHub GraphQL endpoint test override",
+    ),
+    allowed(
+        "crates/harness-server/src/handlers/runtime_hosts_workflow_review_tests.rs",
+        1,
+        "Postgres integration test gate",
+    ),
+    allowed(
+        "crates/harness-server/src/handlers/token_usage.rs",
+        1,
+        "operator home usage report discovery",
+    ),
+    allowed(
+        "crates/harness-server/src/handlers/usage_monitor.rs",
+        1,
+        "local usage price catalog override",
+    ),
+    allowed(
+        "crates/harness-server/src/hook_enforcer.rs",
+        2,
+        "CI process detection",
+    ),
+    allowed(
+        "crates/harness-server/src/http/background/runtime_command_dispatch.rs",
+        2,
+        "operator home fallback for spawned agents",
+    ),
+    allowed(
+        "crates/harness-server/src/http/init.rs",
+        5,
+        "operator home and Feishu credential fallback",
+    ),
+    allowed(
+        "crates/harness-server/src/http/test_fixtures.rs",
+        1,
+        "test fixture home directory",
+    ),
+    allowed(
+        "crates/harness-server/src/http/tests/route_helpers.rs",
+        1,
+        "test git binary override",
+    ),
+    allowed(
+        "crates/harness-server/src/http/tests/runtime_worker_workspace_tests.rs",
+        2,
+        "test git binary override",
+    ),
+    allowed(
+        "crates/harness-server/src/http/tests/state_support.rs",
+        1,
+        "test fixture home directory",
+    ),
+    allowed(
+        "crates/harness-server/src/intake/feishu.rs",
+        2,
+        "Feishu credential fallback",
+    ),
+    allowed(
+        "crates/harness-server/src/observation_compression.rs",
+        1,
+        "provider availability check",
+    ),
+    allowed(
+        "crates/harness-server/src/parallel_dispatch_tests.rs",
+        1,
+        "test git binary override",
+    ),
+    allowed(
+        "crates/harness-server/src/postgres_catalog.rs",
+        2,
+        "Postgres catalog env config parser",
+    ),
+    allowed(
+        "crates/harness-server/src/reconciliation_tests.rs",
+        1,
+        "serialized env fixture",
+    ),
+    allowed(
+        "crates/harness-server/src/router/tests/exec_plan.rs",
+        1,
+        "test fixture home directory",
+    ),
+    allowed(
+        "crates/harness-server/src/router/tests/observability.rs",
+        2,
+        "serialized run-id env fixture",
+    ),
+    allowed(
+        "crates/harness-server/src/stdio.rs",
+        1,
+        "stdio client home fallback",
+    ),
+    allowed(
+        "crates/harness-server/src/task_db/queries_recovery_tests.rs",
+        1,
+        "Postgres integration test gate",
+    ),
+    allowed(
+        "crates/harness-server/src/task_runner/spawn_tests/mod.rs",
+        1,
+        "test git binary override",
+    ),
+    allowed(
+        "crates/harness-server/src/task_runner/store/startup.rs",
+        2,
+        "Postgres integration test gate",
+    ),
+    allowed(
+        "crates/harness-server/src/test_helpers.rs",
+        3,
+        "test fixture home directory",
+    ),
+    allowed(
+        "crates/harness-server/src/websocket.rs",
+        1,
+        "websocket client home fallback",
+    ),
+    allowed(
+        "crates/harness-server/src/workspace.rs",
+        1,
+        "git binary compatibility override",
+    ),
+    allowed(
+        "crates/harness-server/src/workspace_test_support.rs",
+        1,
+        "serialized env fixture",
+    ),
+    allowed(
+        "crates/harness-server/tests/checkpoint_recovery.rs",
+        1,
+        "Postgres integration test gate",
+    ),
+    allowed(
+        "crates/harness-server/tests/common.rs",
+        1,
+        "test fixture home directory",
+    ),
+    allowed(
+        "crates/harness-server/tests/interceptor_enforcement.rs",
+        1,
+        "serialized env fixture",
+    ),
+    allowed(
+        "crates/harness-skills/src/store.rs",
+        2,
+        "operator home skill discovery",
+    ),
+    allowed(
+        "crates/harness-workflow/src/issue_workflow_store/maintenance.rs",
+        1,
+        "legacy DATABASE_URL migration gate",
+    ),
+    allowed(
+        "crates/harness-workflow/src/issue_workflow_store_tests.rs",
+        2,
+        "Postgres integration test gate",
+    ),
+    allowed(
+        "crates/harness-workflow/src/runtime/eval/run.rs",
+        2,
+        "Postgres integration test gate",
+    ),
+    allowed(
+        "crates/harness-workflow/src/runtime/tests/remote_host_lease.rs",
+        1,
+        "Postgres integration test gate",
+    ),
+];
+
+const fn allowed(
+    path: &'static str,
+    expected_reads: usize,
+    reason: &'static str,
+) -> AllowedRawEnvRead {
+    AllowedRawEnvRead {
+        path,
+        expected_reads,
+        reason,
+    }
+}
+
+#[test]
+fn raw_process_env_reads_stay_allowlisted() {
+    let workspace_root = workspace_root();
+    let mut actual = BTreeMap::<String, usize>::new();
+    collect_raw_env_reads(&workspace_root.join("crates"), &workspace_root, &mut actual);
+
+    let expected = ALLOWED_RAW_ENV_READS
+        .iter()
+        .map(|entry| (entry.path, entry))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut errors = Vec::new();
+    for (path, count) in &actual {
+        match expected.get(path.as_str()) {
+            Some(entry) if *count == entry.expected_reads => {}
+            Some(entry) => errors.push(format!(
+                "{path}: expected {} raw env reads for {}, found {count}",
+                entry.expected_reads, entry.reason
+            )),
+            None => errors.push(format!(
+                "{path}: {count} raw env reads are not allowlisted; route config reads through harness_core::config::process_env or document the process concern here"
+            )),
+        }
+    }
+
+    for entry in ALLOWED_RAW_ENV_READS {
+        if !actual.contains_key(entry.path) {
+            errors.push(format!(
+                "{}: allowlist entry is stale for {}",
+                entry.path, entry.reason
+            ));
+        }
+    }
+
+    assert!(
+        errors.is_empty(),
+        "raw process environment reads changed:\n{}",
+        errors.join("\n")
+    );
+}
+
+fn collect_raw_env_reads(dir: &Path, workspace_root: &Path, actual: &mut BTreeMap<String, usize>) {
+    for entry in fs::read_dir(dir)
+        .unwrap_or_else(|error| panic!("failed to read source dir {}: {error}", dir.display()))
+    {
+        let entry = entry.unwrap_or_else(|error| {
+            panic!(
+                "source dir entry under {} should be readable: {error}",
+                dir.display()
+            )
+        });
+        let path = entry.path();
+        if path.is_dir() {
+            collect_raw_env_reads(&path, workspace_root, actual);
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+
+        let contents = fs::read_to_string(&path).unwrap_or_else(|error| {
+            panic!("failed to read source file {}: {error}", path.display())
+        });
+        let count = contents.lines().map(raw_env_read_count).sum();
+        if count > 0 {
+            actual.insert(relative_path(workspace_root, &path), count);
+        }
+        assert_no_std_env_import_alias(workspace_root, &path, &contents);
+    }
+}
+
+fn raw_env_read_count(line: &str) -> usize {
+    count_substring(line, concat!("std::env::", "var("))
+        + count_substring(line, concat!("std::env::", "var_os("))
+        + count_bounded_env_call(line, concat!("env::", "var("))
+        + count_bounded_env_call(line, concat!("env::", "var_os("))
+}
+
+fn count_substring(line: &str, needle: &str) -> usize {
+    line.match_indices(needle).count()
+}
+
+fn count_bounded_env_call(line: &str, needle: &str) -> usize {
+    line.match_indices(needle)
+        .filter(|(index, _)| {
+            *index == 0
+                || !matches!(
+                    line.as_bytes()[index - 1],
+                    b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b':'
+                )
+        })
+        .count()
+}
+
+fn assert_no_std_env_import_alias(workspace_root: &Path, path: &Path, contents: &str) {
+    let rel = relative_path(workspace_root, path);
+    if rel == "crates/harness-core/src/config/process_env.rs" {
+        return;
+    }
+    assert!(
+        !contents.contains(concat!("use std::", "env")),
+        "{rel}: import std::env only inside harness_core::config::process_env so the raw env-read audit cannot be bypassed with aliases"
+    );
+}
+
+fn workspace_root() -> PathBuf {
+    let Some(root) = Path::new(env!("CARGO_MANIFEST_DIR")).ancestors().nth(2) else {
+        panic!("harness-core should be two levels below workspace root");
+    };
+    root.to_path_buf()
+}
+
+fn relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or_else(|error| {
+            panic!(
+                "source path {} should be under workspace root {}: {error}",
+                path.display(),
+                root.display()
+            )
+        })
+        .to_string_lossy()
+        .replace('\\', "/")
+}

--- a/crates/harness-core/src/config_env_audit_tests.rs
+++ b/crates/harness-core/src/config_env_audit_tests.rs
@@ -310,9 +310,12 @@ const fn allowed(
 
 #[test]
 fn raw_process_env_reads_stay_allowlisted() {
-    let workspace_root = workspace_root();
+    let Some(workspace_root) = workspace_root() else {
+        return;
+    };
+    let crates_dir = workspace_root.join("crates");
     let mut actual = BTreeMap::<String, usize>::new();
-    collect_raw_env_reads(&workspace_root.join("crates"), &workspace_root, &mut actual);
+    collect_raw_env_reads(&crates_dir, &workspace_root, &mut actual);
 
     let expected = ALLOWED_RAW_ENV_READS
         .iter()
@@ -413,11 +416,13 @@ fn assert_no_std_env_import_alias(workspace_root: &Path, path: &Path, contents: 
     );
 }
 
-fn workspace_root() -> PathBuf {
-    let Some(root) = Path::new(env!("CARGO_MANIFEST_DIR")).ancestors().nth(2) else {
-        panic!("harness-core should be two levels below workspace root");
-    };
-    root.to_path_buf()
+fn workspace_root() -> Option<PathBuf> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).ancestors().nth(2)?;
+    if root.join("Cargo.toml").is_file() && root.join("crates").is_dir() {
+        Some(root.to_path_buf())
+    } else {
+        None
+    }
 }
 
 fn relative_path(root: &Path, path: &Path) -> String {

--- a/crates/harness-core/src/config_env_audit_tests.rs
+++ b/crates/harness-core/src/config_env_audit_tests.rs
@@ -60,11 +60,6 @@ const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
         "operator identity and sudo process checks",
     ),
     allowed(
-        "crates/harness-cli/src/commands/status.rs",
-        1,
-        "CLI token fallback",
-    ),
-    allowed(
         "crates/harness-core/src/agents_md.rs",
         2,
         "operator home instruction discovery",
@@ -115,21 +110,6 @@ const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
         "Postgres integration test gate",
     ),
     allowed(
-        "crates/harness-server/src/github_auth.rs",
-        2,
-        "GitHub token compatibility",
-    ),
-    allowed(
-        "crates/harness-server/src/github_client.rs",
-        1,
-        "GitHub API endpoint test override",
-    ),
-    allowed(
-        "crates/harness-server/src/github_pr_snapshot.rs",
-        1,
-        "GitHub GraphQL endpoint test override",
-    ),
-    allowed(
         "crates/harness-server/src/handlers/runtime_hosts_workflow_review_tests.rs",
         1,
         "Postgres integration test gate",
@@ -138,11 +118,6 @@ const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
         "crates/harness-server/src/handlers/token_usage.rs",
         1,
         "operator home usage report discovery",
-    ),
-    allowed(
-        "crates/harness-server/src/handlers/usage_monitor.rs",
-        1,
-        "local usage price catalog override",
     ),
     allowed(
         "crates/harness-server/src/hook_enforcer.rs",
@@ -156,8 +131,8 @@ const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
     ),
     allowed(
         "crates/harness-server/src/http/init.rs",
-        5,
-        "operator home and Feishu credential fallback",
+        3,
+        "operator home path discovery",
     ),
     allowed(
         "crates/harness-server/src/http/test_fixtures.rs",
@@ -180,11 +155,6 @@ const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
         "test fixture home directory",
     ),
     allowed(
-        "crates/harness-server/src/intake/feishu.rs",
-        2,
-        "Feishu credential fallback",
-    ),
-    allowed(
         "crates/harness-server/src/observation_compression.rs",
         1,
         "provider availability check",
@@ -193,11 +163,6 @@ const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
         "crates/harness-server/src/parallel_dispatch_tests.rs",
         1,
         "test git binary override",
-    ),
-    allowed(
-        "crates/harness-server/src/postgres_catalog.rs",
-        2,
-        "Postgres catalog env config parser",
     ),
     allowed(
         "crates/harness-server/src/reconciliation_tests.rs",

--- a/crates/harness-core/src/config_env_audit_tests.rs
+++ b/crates/harness-core/src/config_env_audit_tests.rs
@@ -10,11 +10,6 @@ struct AllowedRawEnvRead {
 
 const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
     allowed(
-        "crates/harness-agents/src/builder.rs",
-        1,
-        "agent provider secret discovery",
-    ),
-    allowed(
         "crates/harness-agents/src/claude_tests.rs",
         1,
         "serialized env fixture",
@@ -33,11 +28,6 @@ const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
         "crates/harness-agents/src/codex_tests.rs",
         1,
         "serialized env fixture",
-    ),
-    allowed(
-        "crates/harness-agents/src/compress_model.rs",
-        1,
-        "provider API key discovery",
     ),
     allowed(
         "crates/harness-agents/src/run_id_tests.rs",
@@ -83,11 +73,6 @@ const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
         "crates/harness-observe/src/event_store/store_tests.rs",
         2,
         "serialized run-id env fixture",
-    ),
-    allowed(
-        "crates/harness-observe/src/otel_export.rs",
-        1,
-        "OpenTelemetry SDK env compatibility",
     ),
     allowed(
         "crates/harness-rules/src/engine/mod.rs",
@@ -208,11 +193,6 @@ const ALLOWED_RAW_ENV_READS: &[AllowedRawEnvRead] = &[
         "crates/harness-server/src/websocket.rs",
         1,
         "websocket client home fallback",
-    ),
-    allowed(
-        "crates/harness-server/src/workspace.rs",
-        1,
-        "git binary compatibility override",
     ),
     allowed(
         "crates/harness-server/src/workspace_test_support.rs",

--- a/crates/harness-core/src/db_pg.rs
+++ b/crates/harness-core/src/db_pg.rs
@@ -156,14 +156,14 @@ fn configured_pg_pool_config() -> anyhow::Result<PgPoolConfig> {
 }
 
 fn configured_database_url_from_env(name: &str) -> Option<String> {
-    std::env::var(name)
+    crate::config::process_env::var(name)
         .ok()
         .map(|url| url.trim().to_string())
         .filter(|url| !url.is_empty())
 }
 
 fn configured_u32_from_env(name: &str) -> anyhow::Result<Option<u32>> {
-    match std::env::var(name) {
+    match crate::config::process_env::var(name) {
         Ok(value) if !value.trim().is_empty() => value
             .trim()
             .parse()
@@ -174,7 +174,7 @@ fn configured_u32_from_env(name: &str) -> anyhow::Result<Option<u32>> {
 }
 
 fn configured_u64_from_env(name: &str) -> anyhow::Result<Option<u64>> {
-    match std::env::var(name) {
+    match crate::config::process_env::var(name) {
         Ok(value) if !value.trim().is_empty() => value
             .trim()
             .parse()
@@ -199,7 +199,7 @@ fn database_url_config_paths() -> anyhow::Result<Vec<PathBuf>> {
     // Unit tests may temporarily change the process CWD while other tests open
     // stores concurrently. The test binary path is stable, so this preserves the
     // repository config fallback without reading the generic DATABASE_URL.
-    if std::env::var_os("XDG_CONFIG_HOME").is_none() {
+    if crate::config::process_env::var_os("XDG_CONFIG_HOME").is_none() {
         if let Ok(current_exe) = std::env::current_exe() {
             if let Some(parent) = current_exe.parent() {
                 if let Some(path) = repository_default_config_from_dir(parent) {

--- a/crates/harness-core/src/stack/mod.rs
+++ b/crates/harness-core/src/stack/mod.rs
@@ -623,13 +623,8 @@ pub fn resolve_xdg_config_harness_root(
     xdg_config_home: Option<&Path>,
     home: Option<&Path>,
 ) -> Result<PathBuf, AgentStackComponentError> {
-    let root = if let Some(xdg) = xdg_config_home.filter(|path| path.is_absolute()) {
-        xdg.join("harness")
-    } else if let Some(home) = home.filter(|path| path.is_absolute()) {
-        home.join(".config").join("harness")
-    } else {
-        return Err(AgentStackComponentError::XdgConfigRootUnavailable);
-    };
+    let root = crate::config::dirs::xdg_config_harness_root(xdg_config_home, home)
+        .ok_or(AgentStackComponentError::XdgConfigRootUnavailable)?;
     normalize_absolute_path(&root)
 }
 

--- a/crates/harness-observe/src/otel_export.rs
+++ b/crates/harness-observe/src/otel_export.rs
@@ -385,7 +385,7 @@ fn resolve_endpoint(exporter: OtelExporter, config_endpoint: Option<&str>) -> St
         return endpoint.to_string();
     }
 
-    if let Ok(endpoint) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+    if let Ok(endpoint) = harness_core::config::process_env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
         if !endpoint.trim().is_empty() {
             return endpoint;
         }

--- a/crates/harness-server/src/github_auth.rs
+++ b/crates/harness-server/src/github_auth.rs
@@ -1,6 +1,6 @@
 pub(crate) fn resolve_github_token(config_token: Option<&str>) -> Option<String> {
-    let github_token = std::env::var("GITHUB_TOKEN").ok();
-    let gh_token = std::env::var("GH_TOKEN").ok();
+    let github_token = harness_core::config::process_env::var("GITHUB_TOKEN").ok();
+    let gh_token = harness_core::config::process_env::var("GH_TOKEN").ok();
     resolve_github_token_from_sources(config_token, github_token.as_deref(), gh_token.as_deref())
 }
 

--- a/crates/harness-server/src/github_client.rs
+++ b/crates/harness-server/src/github_client.rs
@@ -15,9 +15,7 @@ const GITHUB_API_VERSION: &str = "2022-11-28";
 /// Empty values fall back to the public API; a trailing slash is trimmed so
 /// callers can append `/repos/...` or `/graphql` directly.
 pub(crate) fn github_api_base_url() -> String {
-    std::env::var("HARNESS_GITHUB_API_BASE_URL")
-        .ok()
-        .filter(|s| !s.trim().is_empty())
+    harness_core::config::process_env::non_blank_config_value("HARNESS_GITHUB_API_BASE_URL")
         .unwrap_or_else(|| "https://api.github.com".to_string())
         .trim_end_matches('/')
         .to_string()

--- a/crates/harness-server/src/github_pr_snapshot.rs
+++ b/crates/harness-server/src/github_pr_snapshot.rs
@@ -156,9 +156,7 @@ pub(crate) async fn fetch_github_pr_snapshot_with_client(
 }
 
 pub(crate) fn github_graphql_url() -> String {
-    std::env::var("HARNESS_GITHUB_GRAPHQL_URL")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
+    harness_core::config::process_env::non_blank_config_value("HARNESS_GITHUB_GRAPHQL_URL")
         .unwrap_or_else(crate::github_client::graphql_url)
 }
 

--- a/crates/harness-server/src/handlers/usage_monitor.rs
+++ b/crates/harness-server/src/handlers/usage_monitor.rs
@@ -152,7 +152,8 @@ impl PriceCatalog {
     }
 
     fn from_env() -> Self {
-        let Ok(raw) = std::env::var("HARNESS_USAGE_PRICE_CATALOG_JSON") else {
+        let Ok(raw) = harness_core::config::process_env::var("HARNESS_USAGE_PRICE_CATALOG_JSON")
+        else {
             return Self::default();
         };
         let raw = raw.trim();

--- a/crates/harness-server/src/http/init.rs
+++ b/crates/harness-server/src/http/init.rs
@@ -81,10 +81,10 @@ fn feishu_alert_credentials(
     let feishu = config.intake.feishu.as_ref();
     let app_id = feishu
         .and_then(|f| f.app_id.clone())
-        .or_else(|| std::env::var("FEISHU_APP_ID").ok())?;
+        .or_else(|| harness_core::config::process_env::var("FEISHU_APP_ID").ok())?;
     let app_secret = feishu
         .and_then(|f| f.app_secret.clone())
-        .or_else(|| std::env::var("FEISHU_APP_SECRET").ok())?;
+        .or_else(|| harness_core::config::process_env::var("FEISHU_APP_SECRET").ok())?;
     Some((app_id, app_secret))
 }
 

--- a/crates/harness-server/src/intake/feishu.rs
+++ b/crates/harness-server/src/intake/feishu.rs
@@ -42,14 +42,14 @@ impl FeishuIntake {
         self.config
             .app_id
             .clone()
-            .or_else(|| std::env::var("FEISHU_APP_ID").ok())
+            .or_else(|| harness_core::config::process_env::var("FEISHU_APP_ID").ok())
     }
 
     fn app_secret(&self) -> Option<String> {
         self.config
             .app_secret
             .clone()
-            .or_else(|| std::env::var("FEISHU_APP_SECRET").ok())
+            .or_else(|| harness_core::config::process_env::var("FEISHU_APP_SECRET").ok())
     }
 
     async fn get_tenant_access_token(&self) -> anyhow::Result<String> {

--- a/crates/harness-server/src/postgres_catalog.rs
+++ b/crates/harness-server/src/postgres_catalog.rs
@@ -287,7 +287,7 @@ fn log_catalog_breach(census: &PostgresCatalogCensus) {
 }
 
 fn parse_u64_env(name: &'static str, default: u64) -> u64 {
-    let Ok(raw) = std::env::var(name) else {
+    let Ok(raw) = harness_core::config::process_env::var(name) else {
         return default;
     };
     let raw = raw.trim();
@@ -304,7 +304,7 @@ fn parse_u64_env(name: &'static str, default: u64) -> u64 {
 }
 
 fn parse_f64_env(name: &'static str, default: f64) -> f64 {
-    let Ok(raw) = std::env::var(name) else {
+    let Ok(raw) = harness_core::config::process_env::var(name) else {
         return default;
     };
     let raw = raw.trim();

--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -50,7 +50,7 @@ pub(crate) use workspace_helpers::run_hook;
 use workspace_helpers::*;
 
 fn git_binary() -> String {
-    std::env::var("HARNESS_GIT_BIN").unwrap_or_else(|_| "git".to_string())
+    harness_core::config::process_env::var("HARNESS_GIT_BIN").unwrap_or_else(|_| "git".to_string())
 }
 
 pub(crate) fn git_command() -> tokio::process::Command {

--- a/harness.toml.example
+++ b/harness.toml.example
@@ -1,4 +1,4 @@
-# harness.toml — per-project review type configuration
+# harness.toml.example - per-project review type configuration
 #
 # Each named section shows the .harness/config.toml settings for a project.
 # Copy the relevant section into {project_root}/.harness/config.toml.


### PR DESCRIPTION
## Summary
- consolidate top-level `HarnessConfig` field/default/deserialize declarations into one macro-backed field list
- add `harness_core::config::process_env` as the config environment-read funnel and route config-related env lookups through it
- add an allowlisted raw env-read audit test and rename root `harness.toml` to `harness.toml.example`

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p harness-core raw_process_env_reads_stay_allowlisted`
- `cargo check -p harness-core --all-targets`
- `cargo test -p harness-core config::`
- `cargo test -p harness-core`
- `cargo check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `env -u HARNESS_DATABASE_URL -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS XDG_CONFIG_HOME="$(mktemp -d)" cargo test --workspace --exclude harness-server --exclude harness-workflow --lib`
- `env -u HARNESS_DATABASE_URL -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS XDG_CONFIG_HOME="$(mktemp -d)" cargo test -p harness-workflow --lib -- --skip runtime::tests::remote_host_lease`
- `env -u HARNESS_DATABASE_URL -u HARNESS_DATABASE_POOL_MAX_CONNECTIONS -u HARNESS_DATABASE_POOL_ACQUIRE_TIMEOUT_SECS git push -u origin HEAD` (pre-push passed clippy plus DB-independent tests; deferred PostgreSQL suites per hook because no isolated disposable database was available)

Closes #1803