### PR TITLE
feat(core): model agent stack capability evidence

### DIFF
--- a/crates/harness-core/src/stack/capability_evidence/mod.rs
+++ b/crates/harness-core/src/stack/capability_evidence/mod.rs
@@ -1,12 +1,13 @@
 use super::{
-    AgentStackCapability, AgentStackComponent, AgentStackComponentId, AgentStackSource,
-    AgentStackSourceScope, AgentStackTrustLevel,
+    AgentStackCapability, AgentStackComponent, AgentStackComponentId, AgentStackComponentKind,
+    AgentStackSource, AgentStackSourceScope, AgentStackTrustLevel,
 };
 use crate::capability::CapabilityToken;
 use crate::config::agents::SandboxMode;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 #[cfg(test)]
@@ -67,7 +68,7 @@ impl AgentStackCapabilityEvidenceClass {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "kind")]
+#[serde(rename_all = "snake_case", tag = "kind", deny_unknown_fields)]
 pub enum AgentStackCapabilityScope {
     Component,
     Repository {
@@ -126,9 +127,14 @@ impl AgentStackCapabilityScope {
                 if path.is_empty() || path.contains('\0') || !Path::new(path).is_absolute() {
                     Err(AgentStackCapabilityEvidenceError::InvalidScope)
                 } else {
-                    super::normalize_absolute_path(Path::new(path))
-                        .map(|_| ())
-                        .map_err(|_| AgentStackCapabilityEvidenceError::InvalidScope)
+                    let normalized = super::normalize_absolute_path(Path::new(path))
+                        .map_err(|_| AgentStackCapabilityEvidenceError::InvalidScope)?;
+                    let normalized = normalized
+                        .to_str()
+                        .ok_or(AgentStackCapabilityEvidenceError::NonUtf8Scope)?;
+                    (normalized == path)
+                        .then_some(())
+                        .ok_or(AgentStackCapabilityEvidenceError::InvalidScope)
                 }
             }
             Self::Network { endpoint } => {
@@ -140,6 +146,16 @@ impl AgentStackCapabilityScope {
                 } else {
                     Ok(())
                 }
+            }
+        }
+    }
+
+    fn canonicalized(self) -> Result<Self, AgentStackCapabilityEvidenceError> {
+        match self {
+            Self::Path { path } => Self::path(Path::new(&path)),
+            scope => {
+                scope.validate()?;
+                Ok(scope)
             }
         }
     }
@@ -239,62 +255,53 @@ impl AgentStackCapabilityEvidence {
         )
     }
 
-    pub fn granted_by_capability_token(
-        component: &AgentStackComponent,
-        token: &CapabilityToken,
-        source: AgentStackSource,
-        observed_at: DateTime<Utc>,
-    ) -> Result<Vec<Self>, AgentStackCapabilityEvidenceError> {
-        let trust_level = runtime_trust_for_source(source.scope())?;
-        token
-            .allowed_write_paths
-            .iter()
-            .map(|path| {
-                Self::granted(
-                    component,
-                    AgentStackCapability::FileWrite,
-                    source.clone(),
-                    observed_at,
-                    trust_level,
-                    AgentStackCapabilityScope::path(path)?,
-                )
-            })
-            .collect()
-    }
-
     pub fn granted_by_sandbox_mode(
         component: &AgentStackComponent,
         sandbox_mode: SandboxMode,
         project_root: &Path,
+        capability_token: Option<&CapabilityToken>,
         source: AgentStackSource,
         observed_at: DateTime<Utc>,
     ) -> Result<Vec<Self>, AgentStackCapabilityEvidenceError> {
         let trust_level = runtime_trust_for_source(source.scope())?;
-        let grants = match sandbox_mode {
-            SandboxMode::ReadOnly => Vec::new(),
-            SandboxMode::ReadOnlyWithNetwork => vec![(
+        if let Some(token) = capability_token {
+            validate_capability_token_time(token, &observed_at)?;
+        }
+
+        let mut grants = vec![
+            (AgentStackCapability::Shell, AgentStackCapabilityScope::Host),
+            (
+                AgentStackCapability::SecretRead,
+                AgentStackCapabilityScope::Host,
+            ),
+        ];
+        match (sandbox_mode, capability_token) {
+            (SandboxMode::ReadOnly, _) => {}
+            (SandboxMode::ReadOnlyWithNetwork, _) => grants.push((
                 AgentStackCapability::Network,
                 AgentStackCapabilityScope::network(None::<String>)?,
-            )],
-            SandboxMode::WorkspaceWrite => vec![
-                (
+            )),
+            (SandboxMode::WorkspaceWrite | SandboxMode::DangerFullAccess, Some(token)) => {
+                grants.push((
                     AgentStackCapability::Network,
                     AgentStackCapabilityScope::network(None::<String>)?,
-                ),
-                (
-                    AgentStackCapability::FileWrite,
-                    AgentStackCapabilityScope::path(project_root)?,
-                ),
-            ],
-            SandboxMode::DangerFullAccess => vec![
-                (
-                    AgentStackCapability::Destructive,
-                    AgentStackCapabilityScope::Host,
-                ),
-                (
-                    AgentStackCapability::SecretRead,
-                    AgentStackCapabilityScope::Host,
-                ),
+                ));
+                for path in &token.allowed_write_paths {
+                    let scope = AgentStackCapabilityScope::path(path)?;
+                    grants.push((AgentStackCapability::FileWrite, scope.clone()));
+                    grants.push((AgentStackCapability::Destructive, scope));
+                }
+            }
+            (SandboxMode::WorkspaceWrite, None) => {
+                let scope = AgentStackCapabilityScope::path(project_root)?;
+                grants.push((
+                    AgentStackCapability::Network,
+                    AgentStackCapabilityScope::network(None::<String>)?,
+                ));
+                grants.push((AgentStackCapability::FileWrite, scope.clone()));
+                grants.push((AgentStackCapability::Destructive, scope));
+            }
+            (SandboxMode::DangerFullAccess, None) => grants.extend([
                 (
                     AgentStackCapability::Network,
                     AgentStackCapabilityScope::Host,
@@ -307,8 +314,12 @@ impl AgentStackCapabilityEvidence {
                     AgentStackCapability::FileWrite,
                     AgentStackCapabilityScope::Host,
                 ),
-            ],
-        };
+                (
+                    AgentStackCapability::Destructive,
+                    AgentStackCapabilityScope::Host,
+                ),
+            ]),
+        }
         grants
             .into_iter()
             .map(|(capability, scope)| {
@@ -328,11 +339,12 @@ impl AgentStackCapabilityEvidence {
         if self.schema_version != AGENT_STACK_CAPABILITY_EVIDENCE_SCHEMA_VERSION {
             return Err(AgentStackCapabilityEvidenceError::UnsupportedSchemaVersion);
         }
-        validate_component_id(self.component_id.as_str())?;
+        validate_component_id(&self.component_id)?;
         validate_source_for_class(self.evidence_class, self.source.scope())?;
         validate_time_for_class(self.evidence_class, self.observed_at.as_ref())?;
-        validate_trust_for_class(self.evidence_class, self.trust_level)?;
-        self.scope.validate()
+        validate_trust_for_source(self.evidence_class, self.source.scope(), self.trust_level)?;
+        self.scope.validate()?;
+        validate_scope_for_capability(self.capability, &self.scope)
     }
 
     pub fn from_json(value: &str) -> Result<Self, AgentStackCapabilityEvidenceParseError> {
@@ -397,6 +409,10 @@ pub enum AgentStackCapabilityEvidenceError {
     InvalidScope,
     #[error("the Agent Stack capability evidence scope contains non-UTF-8 data")]
     NonUtf8Scope,
+    #[error("the Agent Stack capability evidence scope is incompatible with its capability")]
+    IncompatibleCapabilityScope,
+    #[error("the capability token is not effective at the evidence observation time")]
+    CapabilityTokenNotEffectiveAtEvidenceTime,
 }
 
 #[derive(Debug, Error)]
@@ -442,6 +458,7 @@ impl TryFrom<V01WireCapabilityEvidence> for AgentStackCapabilityEvidence {
         }
         let source = AgentStackSource::new(wire.source.scope, &wire.source.locator)
             .map_err(|_| AgentStackCapabilityEvidenceError::InvalidEvidenceSource)?;
+        let scope = wire.scope.canonicalized()?;
         AgentStackCapabilityEvidence::new(
             wire.evidence_class,
             wire.capability,
@@ -449,7 +466,7 @@ impl TryFrom<V01WireCapabilityEvidence> for AgentStackCapabilityEvidence {
             source,
             wire.observed_at,
             wire.trust_level,
-            wire.scope,
+            scope,
         )
     }
 }
@@ -469,19 +486,37 @@ fn runtime_trust_for_source(
     }
 }
 
-fn validate_component_id(value: &str) -> Result<(), AgentStackCapabilityEvidenceError> {
-    let mut segments = value.splitn(3, ':');
-    let source_scope = segments.next();
-    let component_kind = segments.next();
-    let locator = segments.next();
-    if source_scope.is_some_and(|value| !value.is_empty())
-        && component_kind.is_some_and(|value| !value.is_empty())
-        && locator.is_some_and(|value| !value.is_empty() && !value.contains('\0'))
-    {
-        Ok(())
-    } else {
-        Err(AgentStackCapabilityEvidenceError::InvalidComponentId)
-    }
+fn validate_component_id(
+    component_id: &AgentStackComponentId,
+) -> Result<(), AgentStackCapabilityEvidenceError> {
+    let mut segments = component_id.as_str().splitn(3, ':');
+    let source_scope = segments
+        .next()
+        .and_then(|value| {
+            AgentStackSourceScope::ALL
+                .iter()
+                .copied()
+                .find(|scope| scope.as_str() == value)
+        })
+        .ok_or(AgentStackCapabilityEvidenceError::InvalidComponentId)?;
+    let component_kind = segments
+        .next()
+        .and_then(|value| {
+            AgentStackComponentKind::ALL
+                .iter()
+                .copied()
+                .find(|kind| kind.as_str() == value)
+        })
+        .ok_or(AgentStackCapabilityEvidenceError::InvalidComponentId)?;
+    let locator = segments
+        .next()
+        .ok_or(AgentStackCapabilityEvidenceError::InvalidComponentId)?;
+    let parsed_source = AgentStackSource::new(source_scope, locator)
+        .map_err(|_| AgentStackCapabilityEvidenceError::InvalidComponentId)?;
+    let canonical_id = AgentStackComponentId::from_source(component_kind, &parsed_source);
+    (canonical_id.as_str() == component_id.as_str())
+        .then_some(())
+        .ok_or(AgentStackCapabilityEvidenceError::InvalidComponentId)
 }
 
 fn validate_source_for_class(
@@ -520,8 +555,9 @@ fn validate_time_for_class(
     }
 }
 
-fn validate_trust_for_class(
+fn validate_trust_for_source(
     evidence_class: AgentStackCapabilityEvidenceClass,
+    source_scope: AgentStackSourceScope,
     trust_level: AgentStackTrustLevel,
 ) -> Result<(), AgentStackCapabilityEvidenceError> {
     let valid = match evidence_class {
@@ -530,14 +566,63 @@ fn validate_trust_for_class(
             AgentStackTrustLevel::SelfDeclared | AgentStackTrustLevel::RepositoryObserved
         ),
         AgentStackCapabilityEvidenceClass::Granted
-        | AgentStackCapabilityEvidenceClass::Observed => {
-            matches!(
-                trust_level,
-                AgentStackTrustLevel::RuntimeObserved | AgentStackTrustLevel::RunnerObserved
-            )
-        }
+        | AgentStackCapabilityEvidenceClass::Observed => match source_scope {
+            AgentStackSourceScope::Runtime => trust_level == AgentStackTrustLevel::RuntimeObserved,
+            AgentStackSourceScope::Runner => trust_level == AgentStackTrustLevel::RunnerObserved,
+            AgentStackSourceScope::Repository
+            | AgentStackSourceScope::UserGlobal
+            | AgentStackSourceScope::Admin
+            | AgentStackSourceScope::System => false,
+        },
     };
     valid
         .then_some(())
         .ok_or(AgentStackCapabilityEvidenceError::TrustNotSupported)
+}
+
+fn validate_scope_for_capability(
+    capability: AgentStackCapability,
+    scope: &AgentStackCapabilityScope,
+) -> Result<(), AgentStackCapabilityEvidenceError> {
+    let valid = !matches!(
+        (capability, scope),
+        (
+            AgentStackCapability::FileWrite,
+            AgentStackCapabilityScope::Network { .. }
+        ) | (
+            AgentStackCapability::Network,
+            AgentStackCapabilityScope::Repository { .. } | AgentStackCapabilityScope::Path { .. }
+        )
+    );
+    valid
+        .then_some(())
+        .ok_or(AgentStackCapabilityEvidenceError::IncompatibleCapabilityScope)
+}
+
+fn validate_capability_token_time(
+    token: &CapabilityToken,
+    observed_at: &DateTime<Utc>,
+) -> Result<(), AgentStackCapabilityEvidenceError> {
+    let issued_at = system_time_unix_nanos(token.issued_at);
+    let expires_at = system_time_unix_nanos(token.expires_at);
+    let observed_at = datetime_unix_nanos(observed_at);
+    (issued_at <= expires_at && issued_at <= observed_at && observed_at <= expires_at)
+        .then_some(())
+        .ok_or(AgentStackCapabilityEvidenceError::CapabilityTokenNotEffectiveAtEvidenceTime)
+}
+
+fn system_time_unix_nanos(value: SystemTime) -> i128 {
+    match value.duration_since(UNIX_EPOCH) {
+        Ok(duration) => {
+            i128::from(duration.as_secs()) * 1_000_000_000 + i128::from(duration.subsec_nanos())
+        }
+        Err(error) => {
+            let duration = error.duration();
+            -(i128::from(duration.as_secs()) * 1_000_000_000 + i128::from(duration.subsec_nanos()))
+        }
+    }
+}
+
+fn datetime_unix_nanos(value: &DateTime<Utc>) -> i128 {
+    i128::from(value.timestamp()) * 1_000_000_000 + i128::from(value.timestamp_subsec_nanos())
 }

--- a/crates/harness-core/src/stack/capability_evidence/mod.rs
+++ b/crates/harness-core/src/stack/capability_evidence/mod.rs
@@ -1,0 +1,543 @@
+use super::{
+    AgentStackCapability, AgentStackComponent, AgentStackComponentId, AgentStackSource,
+    AgentStackSourceScope, AgentStackTrustLevel,
+};
+use crate::capability::CapabilityToken;
+use crate::config::agents::SandboxMode;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use thiserror::Error;
+
+#[cfg(test)]
+mod tests;
+
+pub const AGENT_STACK_CAPABILITY_EVIDENCE_SCHEMA_VERSION: &str =
+    "agent-stack-capability-evidence/v0.1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentStackCapabilityDefinition {
+    pub capability: AgentStackCapability,
+    pub summary: &'static str,
+}
+
+#[rustfmt::skip]
+pub const AGENT_STACK_CAPABILITY_DEFINITIONS: &[AgentStackCapabilityDefinition] = &[
+    AgentStackCapabilityDefinition { capability: AgentStackCapability::Destructive, summary: "May delete, overwrite, or irreversibly mutate local or remote state." },
+    AgentStackCapabilityDefinition { capability: AgentStackCapability::SecretRead, summary: "May read credentials, tokens, private configuration, or sensitive material." },
+    AgentStackCapabilityDefinition { capability: AgentStackCapability::Network, summary: "May initiate outbound network calls or access remote resources." },
+    AgentStackCapabilityDefinition { capability: AgentStackCapability::Privileged, summary: "May bypass normal sandbox, permission, or isolation boundaries." },
+    AgentStackCapabilityDefinition { capability: AgentStackCapability::ProductionWrite, summary: "May write to production infrastructure, deployments, or customer-affecting systems." },
+    AgentStackCapabilityDefinition { capability: AgentStackCapability::Shell, summary: "May execute shell commands or arbitrary local programs." },
+    AgentStackCapabilityDefinition { capability: AgentStackCapability::FileWrite, summary: "May create, modify, or delete filesystem content." },
+];
+
+impl AgentStackCapability {
+    pub const fn definition(self) -> &'static str {
+        match self {
+            Self::Destructive => "May delete, overwrite, or irreversibly mutate local or remote state.",
+            Self::SecretRead => "May read credentials, tokens, private configuration, or sensitive material.",
+            Self::Network => "May initiate outbound network calls or access remote resources.",
+            Self::Privileged => "May bypass normal sandbox, permission, or isolation boundaries.",
+            Self::ProductionWrite => "May write to production infrastructure, deployments, or customer-affecting systems.",
+            Self::Shell => "May execute shell commands or arbitrary local programs.",
+            Self::FileWrite => "May create, modify, or delete filesystem content.",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentStackCapabilityEvidenceClass {
+    Declared,
+    Granted,
+    Observed,
+}
+
+impl AgentStackCapabilityEvidenceClass {
+    pub const ALL: &'static [Self] = &[Self::Declared, Self::Granted, Self::Observed];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Declared => "declared",
+            Self::Granted => "granted",
+            Self::Observed => "observed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum AgentStackCapabilityScope {
+    Component,
+    Repository {
+        locator: String,
+    },
+    Path {
+        path: String,
+    },
+    Network {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        endpoint: Option<String>,
+    },
+    Host,
+}
+
+impl AgentStackCapabilityScope {
+    pub fn repository(
+        locator: impl Into<String>,
+    ) -> Result<Self, AgentStackCapabilityEvidenceError> {
+        let scope = Self::Repository {
+            locator: locator.into(),
+        };
+        scope.validate()?;
+        Ok(scope)
+    }
+
+    pub fn path(path: &Path) -> Result<Self, AgentStackCapabilityEvidenceError> {
+        let normalized = super::normalize_absolute_path(path)
+            .map_err(|_| AgentStackCapabilityEvidenceError::InvalidScope)?;
+        let path = normalized
+            .to_str()
+            .ok_or(AgentStackCapabilityEvidenceError::NonUtf8Scope)?
+            .to_owned();
+        let scope = Self::Path { path };
+        scope.validate()?;
+        Ok(scope)
+    }
+
+    pub fn network(
+        endpoint: Option<impl Into<String>>,
+    ) -> Result<Self, AgentStackCapabilityEvidenceError> {
+        let scope = Self::Network {
+            endpoint: endpoint.map(Into::into),
+        };
+        scope.validate()?;
+        Ok(scope)
+    }
+
+    pub fn validate(&self) -> Result<(), AgentStackCapabilityEvidenceError> {
+        match self {
+            Self::Component | Self::Host => Ok(()),
+            Self::Repository { locator } => super::validate_portable_path(locator)
+                .and_then(|_| super::reject_reserved_segments(locator))
+                .map_err(|_| AgentStackCapabilityEvidenceError::InvalidScope),
+            Self::Path { path } => {
+                if path.is_empty() || path.contains('\0') || !Path::new(path).is_absolute() {
+                    Err(AgentStackCapabilityEvidenceError::InvalidScope)
+                } else {
+                    super::normalize_absolute_path(Path::new(path))
+                        .map(|_| ())
+                        .map_err(|_| AgentStackCapabilityEvidenceError::InvalidScope)
+                }
+            }
+            Self::Network { endpoint } => {
+                if endpoint
+                    .as_deref()
+                    .is_some_and(|value| value.trim().is_empty() || value.contains('\0'))
+                {
+                    Err(AgentStackCapabilityEvidenceError::InvalidScope)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AgentStackCapabilityEvidence {
+    schema_version: &'static str,
+    evidence_class: AgentStackCapabilityEvidenceClass,
+    capability: AgentStackCapability,
+    component_id: AgentStackComponentId,
+    source: AgentStackSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    observed_at: Option<DateTime<Utc>>,
+    trust_level: AgentStackTrustLevel,
+    scope: AgentStackCapabilityScope,
+}
+
+impl AgentStackCapabilityEvidence {
+    pub fn new(
+        evidence_class: AgentStackCapabilityEvidenceClass,
+        capability: AgentStackCapability,
+        component_id: AgentStackComponentId,
+        source: AgentStackSource,
+        observed_at: Option<DateTime<Utc>>,
+        trust_level: AgentStackTrustLevel,
+        scope: AgentStackCapabilityScope,
+    ) -> Result<Self, AgentStackCapabilityEvidenceError> {
+        let evidence = Self {
+            schema_version: AGENT_STACK_CAPABILITY_EVIDENCE_SCHEMA_VERSION,
+            evidence_class,
+            capability,
+            component_id,
+            source,
+            observed_at,
+            trust_level,
+            scope,
+        };
+        evidence.validate()?;
+        Ok(evidence)
+    }
+
+    pub fn declared(
+        component: &AgentStackComponent,
+        capability: AgentStackCapability,
+        source: AgentStackSource,
+        observed_at: Option<DateTime<Utc>>,
+        trust_level: AgentStackTrustLevel,
+        scope: AgentStackCapabilityScope,
+    ) -> Result<Self, AgentStackCapabilityEvidenceError> {
+        Self::new(
+            AgentStackCapabilityEvidenceClass::Declared,
+            capability,
+            component.component_id().clone(),
+            source,
+            observed_at,
+            trust_level,
+            scope,
+        )
+    }
+
+    pub fn granted(
+        component: &AgentStackComponent,
+        capability: AgentStackCapability,
+        source: AgentStackSource,
+        observed_at: DateTime<Utc>,
+        trust_level: AgentStackTrustLevel,
+        scope: AgentStackCapabilityScope,
+    ) -> Result<Self, AgentStackCapabilityEvidenceError> {
+        Self::new(
+            AgentStackCapabilityEvidenceClass::Granted,
+            capability,
+            component.component_id().clone(),
+            source,
+            Some(observed_at),
+            trust_level,
+            scope,
+        )
+    }
+
+    pub fn observed(
+        component: &AgentStackComponent,
+        capability: AgentStackCapability,
+        source: AgentStackSource,
+        observed_at: DateTime<Utc>,
+        trust_level: AgentStackTrustLevel,
+        scope: AgentStackCapabilityScope,
+    ) -> Result<Self, AgentStackCapabilityEvidenceError> {
+        Self::new(
+            AgentStackCapabilityEvidenceClass::Observed,
+            capability,
+            component.component_id().clone(),
+            source,
+            Some(observed_at),
+            trust_level,
+            scope,
+        )
+    }
+
+    pub fn granted_by_capability_token(
+        component: &AgentStackComponent,
+        token: &CapabilityToken,
+        source: AgentStackSource,
+        observed_at: DateTime<Utc>,
+    ) -> Result<Vec<Self>, AgentStackCapabilityEvidenceError> {
+        let trust_level = runtime_trust_for_source(source.scope())?;
+        token
+            .allowed_write_paths
+            .iter()
+            .map(|path| {
+                Self::granted(
+                    component,
+                    AgentStackCapability::FileWrite,
+                    source.clone(),
+                    observed_at,
+                    trust_level,
+                    AgentStackCapabilityScope::path(path)?,
+                )
+            })
+            .collect()
+    }
+
+    pub fn granted_by_sandbox_mode(
+        component: &AgentStackComponent,
+        sandbox_mode: SandboxMode,
+        project_root: &Path,
+        source: AgentStackSource,
+        observed_at: DateTime<Utc>,
+    ) -> Result<Vec<Self>, AgentStackCapabilityEvidenceError> {
+        let trust_level = runtime_trust_for_source(source.scope())?;
+        let grants = match sandbox_mode {
+            SandboxMode::ReadOnly => Vec::new(),
+            SandboxMode::ReadOnlyWithNetwork => vec![(
+                AgentStackCapability::Network,
+                AgentStackCapabilityScope::network(None::<String>)?,
+            )],
+            SandboxMode::WorkspaceWrite => vec![
+                (
+                    AgentStackCapability::Network,
+                    AgentStackCapabilityScope::network(None::<String>)?,
+                ),
+                (
+                    AgentStackCapability::FileWrite,
+                    AgentStackCapabilityScope::path(project_root)?,
+                ),
+            ],
+            SandboxMode::DangerFullAccess => vec![
+                (
+                    AgentStackCapability::Destructive,
+                    AgentStackCapabilityScope::Host,
+                ),
+                (
+                    AgentStackCapability::SecretRead,
+                    AgentStackCapabilityScope::Host,
+                ),
+                (
+                    AgentStackCapability::Network,
+                    AgentStackCapabilityScope::Host,
+                ),
+                (
+                    AgentStackCapability::Privileged,
+                    AgentStackCapabilityScope::Host,
+                ),
+                (
+                    AgentStackCapability::FileWrite,
+                    AgentStackCapabilityScope::Host,
+                ),
+            ],
+        };
+        grants
+            .into_iter()
+            .map(|(capability, scope)| {
+                Self::granted(
+                    component,
+                    capability,
+                    source.clone(),
+                    observed_at,
+                    trust_level,
+                    scope,
+                )
+            })
+            .collect()
+    }
+
+    pub fn validate(&self) -> Result<(), AgentStackCapabilityEvidenceError> {
+        if self.schema_version != AGENT_STACK_CAPABILITY_EVIDENCE_SCHEMA_VERSION {
+            return Err(AgentStackCapabilityEvidenceError::UnsupportedSchemaVersion);
+        }
+        validate_component_id(self.component_id.as_str())?;
+        validate_source_for_class(self.evidence_class, self.source.scope())?;
+        validate_time_for_class(self.evidence_class, self.observed_at.as_ref())?;
+        validate_trust_for_class(self.evidence_class, self.trust_level)?;
+        self.scope.validate()
+    }
+
+    pub fn from_json(value: &str) -> Result<Self, AgentStackCapabilityEvidenceParseError> {
+        let envelope: VersionEnvelope =
+            serde_json::from_str(value).map_err(AgentStackCapabilityEvidenceParseError::Syntax)?;
+        if envelope.schema_version.as_deref()
+            != Some(AGENT_STACK_CAPABILITY_EVIDENCE_SCHEMA_VERSION)
+        {
+            return Err(AgentStackCapabilityEvidenceError::UnsupportedSchemaVersion.into());
+        }
+        let wire: V01WireCapabilityEvidence =
+            serde_json::from_str(value).map_err(AgentStackCapabilityEvidenceParseError::Syntax)?;
+        wire.try_into().map_err(Into::into)
+    }
+
+    pub fn schema_version(&self) -> &str {
+        self.schema_version
+    }
+
+    pub const fn evidence_class(&self) -> AgentStackCapabilityEvidenceClass {
+        self.evidence_class
+    }
+
+    pub const fn capability(&self) -> AgentStackCapability {
+        self.capability
+    }
+
+    pub fn component_id(&self) -> &AgentStackComponentId {
+        &self.component_id
+    }
+
+    pub fn source(&self) -> &AgentStackSource {
+        &self.source
+    }
+
+    pub fn observed_at(&self) -> Option<&DateTime<Utc>> {
+        self.observed_at.as_ref()
+    }
+
+    pub const fn trust_level(&self) -> AgentStackTrustLevel {
+        self.trust_level
+    }
+
+    pub fn scope(&self) -> &AgentStackCapabilityScope {
+        &self.scope
+    }
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum AgentStackCapabilityEvidenceError {
+    #[error("the Agent Stack capability evidence schema version is unsupported")]
+    UnsupportedSchemaVersion,
+    #[error("the Agent Stack capability evidence component ID is invalid")]
+    InvalidComponentId,
+    #[error("the Agent Stack capability evidence source is invalid for its evidence class")]
+    InvalidEvidenceSource,
+    #[error("granted and observed capability evidence require an observation time")]
+    MissingEvidenceTime,
+    #[error("the Agent Stack capability evidence trust level is invalid for its evidence class")]
+    TrustNotSupported,
+    #[error("the Agent Stack capability evidence scope is invalid")]
+    InvalidScope,
+    #[error("the Agent Stack capability evidence scope contains non-UTF-8 data")]
+    NonUtf8Scope,
+}
+
+#[derive(Debug, Error)]
+pub enum AgentStackCapabilityEvidenceParseError {
+    #[error("the Agent Stack capability evidence JSON has invalid syntax or shape")]
+    Syntax(#[source] serde_json::Error),
+    #[error(transparent)]
+    Validation(#[from] AgentStackCapabilityEvidenceError),
+}
+
+#[derive(Deserialize)]
+struct VersionEnvelope {
+    schema_version: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct V01WireSource {
+    scope: AgentStackSourceScope,
+    locator: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct V01WireCapabilityEvidence {
+    schema_version: String,
+    evidence_class: AgentStackCapabilityEvidenceClass,
+    capability: AgentStackCapability,
+    component_id: String,
+    source: V01WireSource,
+    #[serde(default)]
+    observed_at: Option<DateTime<Utc>>,
+    trust_level: AgentStackTrustLevel,
+    scope: AgentStackCapabilityScope,
+}
+
+impl TryFrom<V01WireCapabilityEvidence> for AgentStackCapabilityEvidence {
+    type Error = AgentStackCapabilityEvidenceError;
+
+    fn try_from(wire: V01WireCapabilityEvidence) -> Result<Self, Self::Error> {
+        if wire.schema_version != AGENT_STACK_CAPABILITY_EVIDENCE_SCHEMA_VERSION {
+            return Err(AgentStackCapabilityEvidenceError::UnsupportedSchemaVersion);
+        }
+        let source = AgentStackSource::new(wire.source.scope, &wire.source.locator)
+            .map_err(|_| AgentStackCapabilityEvidenceError::InvalidEvidenceSource)?;
+        AgentStackCapabilityEvidence::new(
+            wire.evidence_class,
+            wire.capability,
+            AgentStackComponentId(wire.component_id),
+            source,
+            wire.observed_at,
+            wire.trust_level,
+            wire.scope,
+        )
+    }
+}
+
+fn runtime_trust_for_source(
+    source_scope: AgentStackSourceScope,
+) -> Result<AgentStackTrustLevel, AgentStackCapabilityEvidenceError> {
+    match source_scope {
+        AgentStackSourceScope::Runtime => Ok(AgentStackTrustLevel::RuntimeObserved),
+        AgentStackSourceScope::Runner => Ok(AgentStackTrustLevel::RunnerObserved),
+        AgentStackSourceScope::Repository
+        | AgentStackSourceScope::UserGlobal
+        | AgentStackSourceScope::Admin
+        | AgentStackSourceScope::System => {
+            Err(AgentStackCapabilityEvidenceError::InvalidEvidenceSource)
+        }
+    }
+}
+
+fn validate_component_id(value: &str) -> Result<(), AgentStackCapabilityEvidenceError> {
+    let mut segments = value.splitn(3, ':');
+    let source_scope = segments.next();
+    let component_kind = segments.next();
+    let locator = segments.next();
+    if source_scope.is_some_and(|value| !value.is_empty())
+        && component_kind.is_some_and(|value| !value.is_empty())
+        && locator.is_some_and(|value| !value.is_empty() && !value.contains('\0'))
+    {
+        Ok(())
+    } else {
+        Err(AgentStackCapabilityEvidenceError::InvalidComponentId)
+    }
+}
+
+fn validate_source_for_class(
+    evidence_class: AgentStackCapabilityEvidenceClass,
+    source_scope: AgentStackSourceScope,
+) -> Result<(), AgentStackCapabilityEvidenceError> {
+    let valid = match evidence_class {
+        AgentStackCapabilityEvidenceClass::Declared => !matches!(
+            source_scope,
+            AgentStackSourceScope::Runtime | AgentStackSourceScope::Runner
+        ),
+        AgentStackCapabilityEvidenceClass::Granted
+        | AgentStackCapabilityEvidenceClass::Observed => {
+            matches!(
+                source_scope,
+                AgentStackSourceScope::Runtime | AgentStackSourceScope::Runner
+            )
+        }
+    };
+    valid
+        .then_some(())
+        .ok_or(AgentStackCapabilityEvidenceError::InvalidEvidenceSource)
+}
+
+fn validate_time_for_class(
+    evidence_class: AgentStackCapabilityEvidenceClass,
+    observed_at: Option<&DateTime<Utc>>,
+) -> Result<(), AgentStackCapabilityEvidenceError> {
+    match evidence_class {
+        AgentStackCapabilityEvidenceClass::Declared => Ok(()),
+        AgentStackCapabilityEvidenceClass::Granted
+        | AgentStackCapabilityEvidenceClass::Observed => observed_at
+            .is_some()
+            .then_some(())
+            .ok_or(AgentStackCapabilityEvidenceError::MissingEvidenceTime),
+    }
+}
+
+fn validate_trust_for_class(
+    evidence_class: AgentStackCapabilityEvidenceClass,
+    trust_level: AgentStackTrustLevel,
+) -> Result<(), AgentStackCapabilityEvidenceError> {
+    let valid = match evidence_class {
+        AgentStackCapabilityEvidenceClass::Declared => matches!(
+            trust_level,
+            AgentStackTrustLevel::SelfDeclared | AgentStackTrustLevel::RepositoryObserved
+        ),
+        AgentStackCapabilityEvidenceClass::Granted
+        | AgentStackCapabilityEvidenceClass::Observed => {
+            matches!(
+                trust_level,
+                AgentStackTrustLevel::RuntimeObserved | AgentStackTrustLevel::RunnerObserved
+            )
+        }
+    };
+    valid
+        .then_some(())
+        .ok_or(AgentStackCapabilityEvidenceError::TrustNotSupported)
+}

--- a/crates/harness-core/src/stack/capability_evidence/tests.rs
+++ b/crates/harness-core/src/stack/capability_evidence/tests.rs
@@ -53,6 +53,43 @@ fn observed_at() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 0).unwrap()
 }
 
+fn system_time(value: DateTime<Utc>) -> SystemTime {
+    SystemTime::UNIX_EPOCH + Duration::from_secs(value.timestamp().try_into().unwrap())
+}
+
+fn capability_token(
+    issued_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+    allowed_write_paths: Vec<PathBuf>,
+) -> CapabilityToken {
+    CapabilityToken {
+        token_id: Uuid::nil(),
+        subtask_index: 0,
+        allowed_write_paths,
+        issued_at: system_time(issued_at),
+        expires_at: system_time(expires_at),
+    }
+}
+
+fn assert_grants(
+    actual: &[AgentStackCapabilityEvidence],
+    expected: &[(AgentStackCapability, AgentStackCapabilityScope)],
+) {
+    assert_eq!(actual.len(), expected.len(), "{actual:#?}");
+    for (capability, scope) in expected {
+        assert!(
+            actual
+                .iter()
+                .any(|item| item.capability() == *capability && item.scope() == scope),
+            "missing {capability:?} at {scope:?} in {actual:#?}"
+        );
+    }
+    assert!(actual.iter().all(|item| {
+        item.evidence_class() == AgentStackCapabilityEvidenceClass::Granted
+            && item.observed_at() == Some(&observed_at())
+    }));
+}
+
 #[test]
 fn capability_evidence_defines_complete_initial_vocabulary() {
     let defined = AGENT_STACK_CAPABILITY_DEFINITIONS
@@ -250,92 +287,391 @@ fn observed_evidence_rejects_repository_source_and_weak_trust() {
 }
 
 #[test]
-fn capability_token_grants_file_write_path_evidence_only() {
+fn evidence_json_rejects_noncanonical_component_ids() {
     let component = component();
-    let token = CapabilityToken {
-        token_id: Uuid::nil(),
-        subtask_index: 0,
-        allowed_write_paths: vec![
-            PathBuf::from("/tmp/harness-worktree-0"),
-            PathBuf::from("/tmp/harness-worktree-1/src"),
-        ],
-        issued_at: SystemTime::UNIX_EPOCH,
-        expires_at: SystemTime::UNIX_EPOCH + Duration::from_secs(60),
-    };
-
-    let evidence = AgentStackCapabilityEvidence::granted_by_capability_token(
-        &component,
-        &token,
-        runtime_source(),
-        observed_at(),
+    let mut wire = serde_json::to_value(
+        AgentStackCapabilityEvidence::granted(
+            &component,
+            AgentStackCapability::Shell,
+            runtime_source(),
+            observed_at(),
+            AgentStackTrustLevel::RuntimeObserved,
+            AgentStackCapabilityScope::Host,
+        )
+        .unwrap(),
     )
     .unwrap();
+    wire["component_id"] = json!("bogus:bogus:anything");
 
-    assert_eq!(evidence.len(), 2);
-    assert!(evidence.iter().all(|item| {
-        item.evidence_class() == AgentStackCapabilityEvidenceClass::Granted
-            && item.capability() == AgentStackCapability::FileWrite
-            && matches!(item.scope(), AgentStackCapabilityScope::Path { .. })
-    }));
+    assert!(matches!(
+        AgentStackCapabilityEvidence::from_json(&wire.to_string()),
+        Err(AgentStackCapabilityEvidenceParseError::Validation(
+            AgentStackCapabilityEvidenceError::InvalidComponentId
+        ))
+    ));
 }
 
 #[test]
-fn sandbox_mode_grants_evidence_without_claiming_runtime_use() {
+fn runtime_evidence_requires_trust_exactly_matching_its_source() {
     let component = component();
+    for evidence_class in [
+        AgentStackCapabilityEvidenceClass::Granted,
+        AgentStackCapabilityEvidenceClass::Observed,
+    ] {
+        for (source, trust_level) in [
+            (runtime_source(), AgentStackTrustLevel::RunnerObserved),
+            (runner_source(), AgentStackTrustLevel::RuntimeObserved),
+        ] {
+            let error = AgentStackCapabilityEvidence::new(
+                evidence_class,
+                AgentStackCapability::Shell,
+                component.component_id().clone(),
+                source,
+                Some(observed_at()),
+                trust_level,
+                AgentStackCapabilityScope::Host,
+            )
+            .unwrap_err();
+            assert_eq!(error, AgentStackCapabilityEvidenceError::TrustNotSupported);
+        }
+    }
+}
+
+#[test]
+fn evidence_json_rejects_unknown_nested_scope_fields() {
+    let component = component();
+    let mut wire = serde_json::to_value(
+        AgentStackCapabilityEvidence::granted(
+            &component,
+            AgentStackCapability::Network,
+            runtime_source(),
+            observed_at(),
+            AgentStackTrustLevel::RuntimeObserved,
+            AgentStackCapabilityScope::network(None::<String>).unwrap(),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    wire["scope"]["allow_all"] = json!(true);
+
+    assert!(matches!(
+        AgentStackCapabilityEvidence::from_json(&wire.to_string()),
+        Err(AgentStackCapabilityEvidenceParseError::Syntax(_))
+    ));
+}
+
+#[test]
+fn evidence_json_normalizes_path_scopes_before_storage() {
+    let component = component();
+    let mut wire = serde_json::to_value(
+        AgentStackCapabilityEvidence::granted(
+            &component,
+            AgentStackCapability::FileWrite,
+            runtime_source(),
+            observed_at(),
+            AgentStackTrustLevel::RuntimeObserved,
+            AgentStackCapabilityScope::path(Path::new("/tmp/evidence/canonical")).unwrap(),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    wire["scope"] = json!({
+        "kind": "path",
+        "path": "/tmp/evidence/a/../canonical"
+    });
+
+    let decoded = AgentStackCapabilityEvidence::from_json(&wire.to_string()).unwrap();
+    assert_eq!(
+        decoded.scope(),
+        &AgentStackCapabilityScope::path(Path::new("/tmp/evidence/canonical")).unwrap()
+    );
+}
+
+#[test]
+fn capability_scope_compatibility_rejects_cross_domain_pairs() {
+    let component = component();
+    let incompatible = [
+        (
+            AgentStackCapability::FileWrite,
+            AgentStackCapabilityScope::network(None::<String>).unwrap(),
+        ),
+        (
+            AgentStackCapability::Network,
+            AgentStackCapabilityScope::repository("deploy/production").unwrap(),
+        ),
+        (
+            AgentStackCapability::Network,
+            AgentStackCapabilityScope::path(Path::new("/tmp/capability-scope")).unwrap(),
+        ),
+    ];
+
+    for (capability, scope) in incompatible {
+        let error = AgentStackCapabilityEvidence::granted(
+            &component,
+            capability,
+            runtime_source(),
+            observed_at(),
+            AgentStackTrustLevel::RuntimeObserved,
+            scope,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            AgentStackCapabilityEvidenceError::IncompatibleCapabilityScope
+        );
+    }
+}
+
+#[test]
+fn cross_boundary_risk_capabilities_accept_specific_scopes() {
+    let component = component();
+    let compatible = [
+        (
+            AgentStackCapability::ProductionWrite,
+            AgentStackCapabilityScope::path(Path::new("/srv/production")).unwrap(),
+        ),
+        (
+            AgentStackCapability::ProductionWrite,
+            AgentStackCapabilityScope::repository("deploy/production").unwrap(),
+        ),
+        (
+            AgentStackCapability::Destructive,
+            AgentStackCapabilityScope::network(Some("production.example.com")).unwrap(),
+        ),
+        (
+            AgentStackCapability::SecretRead,
+            AgentStackCapabilityScope::path(Path::new("/run/secrets")).unwrap(),
+        ),
+        (
+            AgentStackCapability::Shell,
+            AgentStackCapabilityScope::repository("scripts/release").unwrap(),
+        ),
+        (
+            AgentStackCapability::Privileged,
+            AgentStackCapabilityScope::network(None::<String>).unwrap(),
+        ),
+    ];
+
+    for (capability, scope) in compatible {
+        AgentStackCapabilityEvidence::granted(
+            &component,
+            capability,
+            runtime_source(),
+            observed_at(),
+            AgentStackTrustLevel::RuntimeObserved,
+            scope,
+        )
+        .unwrap();
+    }
+}
+
+#[test]
+fn capability_token_lifetime_is_inclusive_and_validated() {
+    let component = component();
+    let path = PathBuf::from("/tmp/harness-token");
+    let at = observed_at();
+
+    for token in [
+        capability_token(at, at, vec![path.clone()]),
+        capability_token(at - chrono::Duration::seconds(60), at, vec![path.clone()]),
+        capability_token(at, at + chrono::Duration::seconds(60), vec![path.clone()]),
+    ] {
+        assert!(AgentStackCapabilityEvidence::granted_by_sandbox_mode(
+            &component,
+            SandboxMode::WorkspaceWrite,
+            Path::new("/tmp/project"),
+            Some(&token),
+            runtime_source(),
+            at,
+        )
+        .is_ok());
+    }
+
+    for token in [
+        capability_token(
+            at + chrono::Duration::seconds(1),
+            at - chrono::Duration::seconds(1),
+            vec![path.clone()],
+        ),
+        capability_token(
+            at + chrono::Duration::seconds(1),
+            at + chrono::Duration::seconds(60),
+            vec![path.clone()],
+        ),
+        capability_token(
+            at - chrono::Duration::seconds(60),
+            at - chrono::Duration::seconds(1),
+            vec![path.clone()],
+        ),
+    ] {
+        let error = AgentStackCapabilityEvidence::granted_by_sandbox_mode(
+            &component,
+            SandboxMode::WorkspaceWrite,
+            Path::new("/tmp/project"),
+            Some(&token),
+            runtime_source(),
+            at,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            AgentStackCapabilityEvidenceError::CapabilityTokenNotEffectiveAtEvidenceTime
+        );
+    }
+}
+
+#[test]
+fn sandbox_modes_without_token_report_effective_authority() {
+    let component = component();
+    let project_scope =
+        AgentStackCapabilityScope::path(Path::new("/tmp/harness-workspace")).unwrap();
+    let network_scope = AgentStackCapabilityScope::network(None::<String>).unwrap();
+
+    for (sandbox_mode, expected) in [
+        (
+            SandboxMode::ReadOnly,
+            vec![
+                (AgentStackCapability::Shell, AgentStackCapabilityScope::Host),
+                (
+                    AgentStackCapability::SecretRead,
+                    AgentStackCapabilityScope::Host,
+                ),
+            ],
+        ),
+        (
+            SandboxMode::ReadOnlyWithNetwork,
+            vec![
+                (AgentStackCapability::Shell, AgentStackCapabilityScope::Host),
+                (
+                    AgentStackCapability::SecretRead,
+                    AgentStackCapabilityScope::Host,
+                ),
+                (AgentStackCapability::Network, network_scope.clone()),
+            ],
+        ),
+        (
+            SandboxMode::WorkspaceWrite,
+            vec![
+                (AgentStackCapability::Shell, AgentStackCapabilityScope::Host),
+                (
+                    AgentStackCapability::SecretRead,
+                    AgentStackCapabilityScope::Host,
+                ),
+                (AgentStackCapability::Network, network_scope.clone()),
+                (AgentStackCapability::FileWrite, project_scope.clone()),
+                (AgentStackCapability::Destructive, project_scope.clone()),
+            ],
+        ),
+        (
+            SandboxMode::DangerFullAccess,
+            [
+                AgentStackCapability::Shell,
+                AgentStackCapability::SecretRead,
+                AgentStackCapability::Network,
+                AgentStackCapability::Privileged,
+                AgentStackCapability::FileWrite,
+                AgentStackCapability::Destructive,
+            ]
+            .into_iter()
+            .map(|capability| (capability, AgentStackCapabilityScope::Host))
+            .collect(),
+        ),
+    ] {
+        let actual = AgentStackCapabilityEvidence::granted_by_sandbox_mode(
+            &component,
+            sandbox_mode,
+            Path::new("/tmp/harness-workspace"),
+            None,
+            runtime_source(),
+            observed_at(),
+        )
+        .unwrap();
+        assert_grants(&actual, &expected);
+    }
+}
+
+#[test]
+fn capability_token_narrows_writable_sandboxes_without_upgrading_read_only_modes() {
+    let component = component();
+    let at = observed_at();
+    let token_paths = [
+        PathBuf::from("/tmp/harness-token-a"),
+        PathBuf::from("/tmp/harness-token-b/child/.."),
+    ];
+    let token = capability_token(
+        at - chrono::Duration::seconds(60),
+        at + chrono::Duration::seconds(60),
+        token_paths.to_vec(),
+    );
+    let network_scope = AgentStackCapabilityScope::network(None::<String>).unwrap();
+    let baseline = vec![
+        (AgentStackCapability::Shell, AgentStackCapabilityScope::Host),
+        (
+            AgentStackCapability::SecretRead,
+            AgentStackCapabilityScope::Host,
+        ),
+    ];
+    let mut networked = baseline.clone();
+    networked.push((AgentStackCapability::Network, network_scope));
+    let mut token_scoped = networked.clone();
+    for path in token_paths {
+        let scope = AgentStackCapabilityScope::path(&path).unwrap();
+        token_scoped.push((AgentStackCapability::FileWrite, scope.clone()));
+        token_scoped.push((AgentStackCapability::Destructive, scope));
+    }
+
+    for (sandbox_mode, expected) in [
+        (SandboxMode::ReadOnly, baseline),
+        (SandboxMode::ReadOnlyWithNetwork, networked.clone()),
+        (SandboxMode::WorkspaceWrite, token_scoped.clone()),
+        (SandboxMode::DangerFullAccess, token_scoped),
+    ] {
+        let actual = AgentStackCapabilityEvidence::granted_by_sandbox_mode(
+            &component,
+            sandbox_mode,
+            Path::new("/tmp/harness-workspace"),
+            Some(&token),
+            runtime_source(),
+            observed_at(),
+        )
+        .unwrap();
+        assert_grants(&actual, &expected);
+        assert!(!actual.iter().any(|item| {
+            item.capability() == AgentStackCapability::Privileged
+                || matches!(
+                    (item.capability(), item.scope()),
+                    (
+                        AgentStackCapability::FileWrite | AgentStackCapability::Destructive,
+                        AgentStackCapabilityScope::Host
+                    )
+                )
+        }));
+    }
+}
+
+#[test]
+fn sandbox_evidence_preserves_runtime_source_and_trust() {
+    let component = component();
+    let token = capability_token(
+        observed_at(),
+        observed_at(),
+        vec![PathBuf::from("/tmp/harness-token")],
+    );
     let evidence = AgentStackCapabilityEvidence::granted_by_sandbox_mode(
         &component,
         SandboxMode::WorkspaceWrite,
         Path::new("/tmp/harness-workspace"),
+        Some(&token),
         runtime_source(),
         observed_at(),
     )
     .unwrap();
 
-    let capabilities = evidence
-        .iter()
-        .map(AgentStackCapabilityEvidence::capability)
-        .collect::<Vec<_>>();
-    assert_eq!(
-        capabilities,
-        [
-            AgentStackCapability::Network,
-            AgentStackCapability::FileWrite
-        ]
-    );
-    assert!(evidence
-        .iter()
-        .all(|item| item.evidence_class() == AgentStackCapabilityEvidenceClass::Granted));
-}
-
-#[test]
-fn danger_full_access_sandbox_grants_host_boundary_evidence() {
-    let component = component();
-    let evidence = AgentStackCapabilityEvidence::granted_by_sandbox_mode(
-        &component,
-        SandboxMode::DangerFullAccess,
-        Path::new("/tmp/harness-workspace"),
-        runtime_source(),
-        observed_at(),
-    )
-    .unwrap();
-
-    let capabilities = evidence
-        .iter()
-        .map(AgentStackCapabilityEvidence::capability)
-        .collect::<Vec<_>>();
-    assert_eq!(
-        capabilities,
-        [
-            AgentStackCapability::Destructive,
-            AgentStackCapability::SecretRead,
-            AgentStackCapability::Network,
-            AgentStackCapability::Privileged,
-            AgentStackCapability::FileWrite,
-        ]
-    );
-    assert!(evidence
-        .iter()
-        .all(|item| matches!(item.scope(), AgentStackCapabilityScope::Host)));
+    assert!(evidence.iter().all(|item| {
+        item.component_id() == component.component_id()
+            && item.source() == &runtime_source()
+            && item.trust_level() == AgentStackTrustLevel::RuntimeObserved
+    }));
 }
 
 #[test]

--- a/crates/harness-core/src/stack/capability_evidence/tests.rs
+++ b/crates/harness-core/src/stack/capability_evidence/tests.rs
@@ -1,0 +1,379 @@
+use super::*;
+use crate::stack::{
+    AgentStackComponentKind, AgentStackFreshness, AgentStackObservationClass,
+    AgentStackSelectionState,
+};
+use chrono::TimeZone;
+use serde_json::json;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use uuid::Uuid;
+
+fn component() -> AgentStackComponent {
+    let source = AgentStackSource::logical(
+        AgentStackSourceScope::System,
+        "harness",
+        "agent_runtime/codex",
+    )
+    .unwrap();
+    AgentStackComponent::new(
+        AgentStackComponentKind::AgentRuntime,
+        source,
+        AgentStackObservationClass::RuntimeObserved,
+        AgentStackSelectionState::Loaded,
+        AgentStackTrustLevel::RuntimeObserved,
+        AgentStackFreshness::Fresh,
+    )
+    .unwrap()
+}
+
+fn repository_source() -> AgentStackSource {
+    AgentStackSource::new(AgentStackSourceScope::Repository, "AGENTS.md").unwrap()
+}
+
+fn runtime_source() -> AgentStackSource {
+    AgentStackSource::logical(
+        AgentStackSourceScope::Runtime,
+        "workflow_runtime",
+        "job/capability_evidence",
+    )
+    .unwrap()
+}
+
+fn runner_source() -> AgentStackSource {
+    AgentStackSource::logical(
+        AgentStackSourceScope::Runner,
+        "codex",
+        "sandbox/capability_evidence",
+    )
+    .unwrap()
+}
+
+fn observed_at() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 0).unwrap()
+}
+
+#[test]
+fn capability_evidence_defines_complete_initial_vocabulary() {
+    let defined = AGENT_STACK_CAPABILITY_DEFINITIONS
+        .iter()
+        .map(|definition| definition.capability)
+        .collect::<Vec<_>>();
+    assert_eq!(defined, AgentStackCapability::ALL);
+    for capability in AgentStackCapability::ALL {
+        assert!(!capability.definition().is_empty());
+    }
+}
+
+#[test]
+fn capability_evidence_classes_round_trip_in_closed_wire_order() {
+    let actual = AgentStackCapabilityEvidenceClass::ALL
+        .iter()
+        .map(|class| {
+            serde_json::to_value(class)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_owned()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(actual, ["declared", "granted", "observed"]);
+    assert!(serde_json::from_str::<AgentStackCapabilityEvidenceClass>("\"runtime\"").is_err());
+}
+
+#[test]
+fn declared_granted_and_observed_evidence_remain_distinct() {
+    let component = component();
+    let declared = AgentStackCapabilityEvidence::declared(
+        &component,
+        AgentStackCapability::Shell,
+        repository_source(),
+        None,
+        AgentStackTrustLevel::RepositoryObserved,
+        AgentStackCapabilityScope::Component,
+    )
+    .unwrap();
+    let granted = AgentStackCapabilityEvidence::granted(
+        &component,
+        AgentStackCapability::Network,
+        runtime_source(),
+        observed_at(),
+        AgentStackTrustLevel::RuntimeObserved,
+        AgentStackCapabilityScope::network(None::<String>).unwrap(),
+    )
+    .unwrap();
+    let observed = AgentStackCapabilityEvidence::observed(
+        &component,
+        AgentStackCapability::FileWrite,
+        runner_source(),
+        observed_at(),
+        AgentStackTrustLevel::RunnerObserved,
+        AgentStackCapabilityScope::path(Path::new("/tmp/harness-output")).unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        declared.evidence_class(),
+        AgentStackCapabilityEvidenceClass::Declared
+    );
+    assert_eq!(
+        granted.evidence_class(),
+        AgentStackCapabilityEvidenceClass::Granted
+    );
+    assert_eq!(
+        observed.evidence_class(),
+        AgentStackCapabilityEvidenceClass::Observed
+    );
+    assert_eq!(declared.observed_at(), None);
+    assert!(granted.observed_at().is_some());
+    assert!(observed.observed_at().is_some());
+}
+
+#[test]
+fn capability_evidence_json_round_trips_through_validation() {
+    let component = component();
+    let evidence = AgentStackCapabilityEvidence::observed(
+        &component,
+        AgentStackCapability::ProductionWrite,
+        runner_source(),
+        observed_at(),
+        AgentStackTrustLevel::RunnerObserved,
+        AgentStackCapabilityScope::Host,
+    )
+    .unwrap();
+
+    let encoded = serde_json::to_string(&evidence).unwrap();
+    let decoded = AgentStackCapabilityEvidence::from_json(&encoded).unwrap();
+
+    assert_eq!(decoded, evidence);
+    assert_eq!(
+        decoded.schema_version(),
+        AGENT_STACK_CAPABILITY_EVIDENCE_SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn granted_evidence_requires_runtime_source_time_and_trust() {
+    let component = component();
+    let missing_time = AgentStackCapabilityEvidence::new(
+        AgentStackCapabilityEvidenceClass::Granted,
+        AgentStackCapability::Network,
+        component.component_id().clone(),
+        runtime_source(),
+        None,
+        AgentStackTrustLevel::RuntimeObserved,
+        AgentStackCapabilityScope::Host,
+    )
+    .unwrap_err();
+    assert_eq!(
+        missing_time,
+        AgentStackCapabilityEvidenceError::MissingEvidenceTime
+    );
+
+    let repository_source = AgentStackCapabilityEvidence::granted(
+        &component,
+        AgentStackCapability::Network,
+        repository_source(),
+        observed_at(),
+        AgentStackTrustLevel::RuntimeObserved,
+        AgentStackCapabilityScope::Host,
+    )
+    .unwrap_err();
+    assert_eq!(
+        repository_source,
+        AgentStackCapabilityEvidenceError::InvalidEvidenceSource
+    );
+
+    let weak_trust = AgentStackCapabilityEvidence::granted(
+        &component,
+        AgentStackCapability::Network,
+        runtime_source(),
+        observed_at(),
+        AgentStackTrustLevel::SelfDeclared,
+        AgentStackCapabilityScope::Host,
+    )
+    .unwrap_err();
+    assert_eq!(
+        weak_trust,
+        AgentStackCapabilityEvidenceError::TrustNotSupported
+    );
+}
+
+#[test]
+fn declared_evidence_rejects_runtime_observation_source() {
+    let component = component();
+    let error = AgentStackCapabilityEvidence::declared(
+        &component,
+        AgentStackCapability::Shell,
+        runtime_source(),
+        None,
+        AgentStackTrustLevel::SelfDeclared,
+        AgentStackCapabilityScope::Component,
+    )
+    .unwrap_err();
+    assert_eq!(
+        error,
+        AgentStackCapabilityEvidenceError::InvalidEvidenceSource
+    );
+}
+
+#[test]
+fn observed_evidence_rejects_repository_source_and_weak_trust() {
+    let component = component();
+    let repository_source = AgentStackCapabilityEvidence::observed(
+        &component,
+        AgentStackCapability::Shell,
+        repository_source(),
+        observed_at(),
+        AgentStackTrustLevel::RuntimeObserved,
+        AgentStackCapabilityScope::Component,
+    )
+    .unwrap_err();
+    assert_eq!(
+        repository_source,
+        AgentStackCapabilityEvidenceError::InvalidEvidenceSource
+    );
+
+    let weak_trust = AgentStackCapabilityEvidence::observed(
+        &component,
+        AgentStackCapability::Shell,
+        runtime_source(),
+        observed_at(),
+        AgentStackTrustLevel::RepositoryObserved,
+        AgentStackCapabilityScope::Component,
+    )
+    .unwrap_err();
+    assert_eq!(
+        weak_trust,
+        AgentStackCapabilityEvidenceError::TrustNotSupported
+    );
+}
+
+#[test]
+fn capability_token_grants_file_write_path_evidence_only() {
+    let component = component();
+    let token = CapabilityToken {
+        token_id: Uuid::nil(),
+        subtask_index: 0,
+        allowed_write_paths: vec![
+            PathBuf::from("/tmp/harness-worktree-0"),
+            PathBuf::from("/tmp/harness-worktree-1/src"),
+        ],
+        issued_at: SystemTime::UNIX_EPOCH,
+        expires_at: SystemTime::UNIX_EPOCH + Duration::from_secs(60),
+    };
+
+    let evidence = AgentStackCapabilityEvidence::granted_by_capability_token(
+        &component,
+        &token,
+        runtime_source(),
+        observed_at(),
+    )
+    .unwrap();
+
+    assert_eq!(evidence.len(), 2);
+    assert!(evidence.iter().all(|item| {
+        item.evidence_class() == AgentStackCapabilityEvidenceClass::Granted
+            && item.capability() == AgentStackCapability::FileWrite
+            && matches!(item.scope(), AgentStackCapabilityScope::Path { .. })
+    }));
+}
+
+#[test]
+fn sandbox_mode_grants_evidence_without_claiming_runtime_use() {
+    let component = component();
+    let evidence = AgentStackCapabilityEvidence::granted_by_sandbox_mode(
+        &component,
+        SandboxMode::WorkspaceWrite,
+        Path::new("/tmp/harness-workspace"),
+        runtime_source(),
+        observed_at(),
+    )
+    .unwrap();
+
+    let capabilities = evidence
+        .iter()
+        .map(AgentStackCapabilityEvidence::capability)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        capabilities,
+        [
+            AgentStackCapability::Network,
+            AgentStackCapability::FileWrite
+        ]
+    );
+    assert!(evidence
+        .iter()
+        .all(|item| item.evidence_class() == AgentStackCapabilityEvidenceClass::Granted));
+}
+
+#[test]
+fn danger_full_access_sandbox_grants_host_boundary_evidence() {
+    let component = component();
+    let evidence = AgentStackCapabilityEvidence::granted_by_sandbox_mode(
+        &component,
+        SandboxMode::DangerFullAccess,
+        Path::new("/tmp/harness-workspace"),
+        runtime_source(),
+        observed_at(),
+    )
+    .unwrap();
+
+    let capabilities = evidence
+        .iter()
+        .map(AgentStackCapabilityEvidence::capability)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        capabilities,
+        [
+            AgentStackCapability::Destructive,
+            AgentStackCapability::SecretRead,
+            AgentStackCapability::Network,
+            AgentStackCapability::Privileged,
+            AgentStackCapability::FileWrite,
+        ]
+    );
+    assert!(evidence
+        .iter()
+        .all(|item| matches!(item.scope(), AgentStackCapabilityScope::Host)));
+}
+
+#[test]
+fn invalid_scope_and_schema_are_rejected() {
+    let component = component();
+    let invalid_path = AgentStackCapabilityEvidence::observed(
+        &component,
+        AgentStackCapability::FileWrite,
+        runner_source(),
+        observed_at(),
+        AgentStackTrustLevel::RunnerObserved,
+        AgentStackCapabilityScope::Path {
+            path: "relative/path".to_string(),
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        invalid_path,
+        AgentStackCapabilityEvidenceError::InvalidScope
+    );
+
+    let mut wire = serde_json::to_value(
+        AgentStackCapabilityEvidence::declared(
+            &component,
+            AgentStackCapability::SecretRead,
+            repository_source(),
+            None,
+            AgentStackTrustLevel::SelfDeclared,
+            AgentStackCapabilityScope::Component,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    wire["schema_version"] = json!("agent-stack-capability-evidence/v9");
+    assert!(matches!(
+        AgentStackCapabilityEvidence::from_json(&wire.to_string()),
+        Err(AgentStackCapabilityEvidenceParseError::Validation(
+            AgentStackCapabilityEvidenceError::UnsupportedSchemaVersion
+        ))
+    ));
+}

--- a/crates/harness-core/src/stack/mod.rs
+++ b/crates/harness-core/src/stack/mod.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 use uuid::Uuid;
+pub mod capability_evidence;
 pub mod fingerprint;
 pub mod inventory;
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- add a typed Agent Stack capability evidence model for declared, granted, and observed capability facts
- define the initial capability vocabulary and trace each evidence item to source, time, trust, scope, and component
- add evidence-only helpers for CapabilityToken write grants and SandboxMode grants without changing enforcement behavior

## Validation

- cargo fmt --all -- --check
- cargo check
- cargo check -p harness-core -p harness-agents --all-targets
- cargo test -p harness-core capability_evidence
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- env -u HARNESS_DATABASE_URL git push -u origin harness/runtime-wf-github-issue-pr-7deb4bbb (pre-push clippy + DB-independent workspace lib tests passed; DB-backed tests deferred by hook)

Note: plain cargo test was attempted with the ambient HARNESS_DATABASE_URL and failed in unrelated harness-observe event-store tests with Postgres timestamp type errors. Re-running with HARNESS_DATABASE_URL unset progressed further but failed in harness-server DB-backed tests with Postgres pool timeouts; the repository pre-push DB-less hook passed.

Closes #1737
