### PR TITLE
feat(stack): detect protective control weakening

### DIFF
--- a/crates/harness-core/src/stack/capability_evidence/mod.rs
+++ b/crates/harness-core/src/stack/capability_evidence/mod.rs
@@ -1,3 +1,6 @@
+use super::source_locator::{
+    normalize_absolute_path, reject_reserved_segments, validate_portable_path,
+};
 use super::{
     AgentStackCapability, AgentStackComponent, AgentStackComponentId, AgentStackComponentKind,
     AgentStackSource, AgentStackSourceScope, AgentStackTrustLevel,
@@ -96,7 +99,7 @@ impl AgentStackCapabilityScope {
     }
 
     pub fn path(path: &Path) -> Result<Self, AgentStackCapabilityEvidenceError> {
-        let normalized = super::normalize_absolute_path(path)
+        let normalized = normalize_absolute_path(path)
             .map_err(|_| AgentStackCapabilityEvidenceError::InvalidScope)?;
         let path = normalized
             .to_str()
@@ -120,14 +123,14 @@ impl AgentStackCapabilityScope {
     pub fn validate(&self) -> Result<(), AgentStackCapabilityEvidenceError> {
         match self {
             Self::Component | Self::Host => Ok(()),
-            Self::Repository { locator } => super::validate_portable_path(locator)
-                .and_then(|_| super::reject_reserved_segments(locator))
+            Self::Repository { locator } => validate_portable_path(locator)
+                .and_then(|_| reject_reserved_segments(locator))
                 .map_err(|_| AgentStackCapabilityEvidenceError::InvalidScope),
             Self::Path { path } => {
                 if path.is_empty() || path.contains('\0') || !Path::new(path).is_absolute() {
                     Err(AgentStackCapabilityEvidenceError::InvalidScope)
                 } else {
-                    let normalized = super::normalize_absolute_path(Path::new(path))
+                    let normalized = normalize_absolute_path(Path::new(path))
                         .map_err(|_| AgentStackCapabilityEvidenceError::InvalidScope)?;
                     let normalized = normalized
                         .to_str()

--- a/crates/harness-core/src/stack/mod.rs
+++ b/crates/harness-core/src/stack/mod.rs
@@ -2,14 +2,17 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use sha2::{Digest, Sha256};
 use std::fmt;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 use thiserror::Error;
-use uuid::Uuid;
 pub mod capability_evidence;
 pub mod fingerprint;
 pub mod inventory;
 #[cfg(test)]
 mod inventory_tests;
+mod protective_control_diff;
+#[cfg(test)]
+mod protective_control_diff_tests;
+mod source_locator;
 #[cfg(test)]
 mod tests;
 pub use inventory::{
@@ -17,6 +20,20 @@ pub use inventory::{
     AgentStackInventoryEntry, AgentStackInventoryError, AgentStackInventoryErrorKind,
     AgentStackInventoryOptions,
 };
+pub use protective_control_diff::{
+    protective_control_diff, AgentStackProtectionConfidence, AgentStackProtectionControl,
+    AgentStackProtectionControlDiff, AgentStackProtectionControlError,
+    AgentStackProtectionControlEvidence, AgentStackProtectionControlReason,
+    AgentStackProtectionDiffKind, AgentStackProtectionFailureMode, AgentStackProtectionRole,
+    AgentStackProtectionScope,
+};
+#[cfg(test)]
+use source_locator::root_keys_match_for_test;
+use source_locator::{
+    is_reserved, is_snake_case, is_uuid_shaped, relative_portable_path, valid_logical_segments,
+    validate_source_locator,
+};
+pub use source_locator::{resolve_xdg_config_harness_root, select_user_global_root};
 pub const AGENT_STACK_COMPONENT_SCHEMA_VERSION: &str = "agent-stack-component/v0.1";
 
 macro_rules! closed_enum {
@@ -487,309 +504,4 @@ fn validate_trust(
 
 fn has_duplicate_capabilities(capabilities: &[AgentStackCapability]) -> bool {
     (0..capabilities.len()).any(|index| capabilities[..index].contains(&capabilities[index]))
-}
-
-fn validate_source_locator(
-    scope: AgentStackSourceScope,
-    locator: &str,
-) -> Result<(), AgentStackComponentError> {
-    match scope {
-        AgentStackSourceScope::Repository | AgentStackSourceScope::Admin => {
-            validate_portable_path(locator)?;
-            reject_reserved_segments(locator)
-        }
-        AgentStackSourceScope::UserGlobal => validate_user_global_locator(locator),
-        AgentStackSourceScope::System
-        | AgentStackSourceScope::Runtime
-        | AgentStackSourceScope::Runner => validate_logical_locator(scope, locator),
-    }
-}
-
-fn validate_portable_path(value: &str) -> Result<(), AgentStackComponentError> {
-    let drive_prefixed = value
-        .as_bytes()
-        .get(0..2)
-        .is_some_and(|head| head[0].is_ascii_alphabetic() && head[1] == b':');
-    if value.is_empty()
-        || value.starts_with('/')
-        || value.contains('\\')
-        || value.contains('\0')
-        || drive_prefixed
-        || value
-            .split('/')
-            .any(|segment| segment.is_empty() || segment == "." || segment == "..")
-    {
-        Err(AgentStackComponentError::InvalidSourceLocator)
-    } else {
-        Ok(())
-    }
-}
-
-fn validate_user_global_locator(locator: &str) -> Result<(), AgentStackComponentError> {
-    validate_portable_path(locator)?;
-    let mut segments = locator.split('/');
-    match segments.next().expect("validated non-empty locator") {
-        "home_harness" | "xdg_config_harness" | "platform_config_harness" => {}
-        "configured_user" => validate_configured_user_key(
-            segments
-                .next()
-                .ok_or(AgentStackComponentError::InvalidSourceLocator)?,
-        )?,
-        _ => return Err(AgentStackComponentError::InvalidSourceLocator),
-    }
-    if segments.next().is_none() {
-        return Err(AgentStackComponentError::InvalidSourceLocator);
-    }
-    reject_reserved_segments(locator)
-}
-
-fn validate_logical_locator(
-    scope: AgentStackSourceScope,
-    locator: &str,
-) -> Result<(), AgentStackComponentError> {
-    validate_portable_path(locator)?;
-    let mut segments = locator.split('/');
-    if scope == AgentStackSourceScope::System && segments.next() != Some("builtin") {
-        return Err(AgentStackComponentError::InvalidSourceLocator);
-    }
-    let namespace = segments
-        .next()
-        .ok_or(AgentStackComponentError::InvalidSourceLocator)?;
-    let remaining = segments.collect::<Vec<_>>();
-    if !is_snake_case(namespace)
-        || is_uuid_shaped(namespace)
-        || remaining.is_empty()
-        || remaining
-            .iter()
-            .any(|segment| !valid_logical_segment(segment))
-    {
-        return Err(AgentStackComponentError::InvalidSourceLocator);
-    }
-    reject_reserved_segments(locator)
-}
-
-fn valid_logical_segments(value: &str) -> bool {
-    !value.is_empty() && value.split('/').all(valid_logical_segment)
-}
-
-fn valid_logical_segment(segment: &str) -> bool {
-    segment
-        .as_bytes()
-        .first()
-        .is_some_and(u8::is_ascii_alphanumeric)
-        && segment
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
-        && !is_reserved(segment)
-        && !is_uuid_shaped(segment)
-}
-
-fn validate_configured_user_key(key: &str) -> Result<(), AgentStackComponentError> {
-    if is_snake_case(key) && !is_reserved(key) && !is_uuid_shaped(key) {
-        Ok(())
-    } else {
-        Err(AgentStackComponentError::InvalidSourceLocator)
-    }
-}
-
-fn is_snake_case(value: &str) -> bool {
-    !value.is_empty()
-        && !value.starts_with('_')
-        && !value.ends_with('_')
-        && !value.contains("__")
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
-}
-
-fn reject_reserved_segments(value: &str) -> Result<(), AgentStackComponentError> {
-    if value.split('/').any(is_reserved) {
-        Err(AgentStackComponentError::InvalidSourceLocator)
-    } else {
-        Ok(())
-    }
-}
-
-#[rustfmt::skip]
-fn is_reserved(value: &str) -> bool {
-    ["unknown", "unknown-component", "unknown_component", "missing", "null", "none"]
-        .iter()
-        .any(|reserved| value.eq_ignore_ascii_case(reserved))
-}
-
-fn is_uuid_shaped(value: &str) -> bool {
-    Uuid::parse_str(value).is_ok()
-}
-
-pub fn resolve_xdg_config_harness_root(
-    xdg_config_home: Option<&Path>,
-    home: Option<&Path>,
-) -> Result<PathBuf, AgentStackComponentError> {
-    let root = crate::config::dirs::xdg_config_harness_root(xdg_config_home, home)
-        .ok_or(AgentStackComponentError::XdgConfigRootUnavailable)?;
-    normalize_absolute_path(&root)
-}
-
-pub fn select_user_global_root(
-    source: &Path,
-    home_harness: Option<&Path>,
-    xdg_config_harness: Option<&Path>,
-    platform_config_harness: Option<&Path>,
-    configured_user_roots: &[(&str, &Path)],
-) -> Result<(AgentStackUserGlobalRoot, AgentStackSourceLocator), AgentStackComponentError> {
-    if configured_user_roots.len() > 1 {
-        return Err(AgentStackComponentError::AmbiguousConfiguredUserRoot);
-    }
-    if let Some((key, _)) = configured_user_roots.first() {
-        validate_configured_user_key(key)?;
-    }
-    for (root_kind, namespace, root) in [
-        (
-            AgentStackUserGlobalRoot::HomeHarness,
-            "home_harness",
-            home_harness,
-        ),
-        (
-            AgentStackUserGlobalRoot::XdgConfigHarness,
-            "xdg_config_harness",
-            xdg_config_harness,
-        ),
-        (
-            AgentStackUserGlobalRoot::PlatformConfigHarness,
-            "platform_config_harness",
-            platform_config_harness,
-        ),
-    ] {
-        if let Some(root) = root {
-            if let Some(relative) = relative_portable_path_if_within(root, source)? {
-                return user_root_result(root_kind, format!("{namespace}/{relative}"));
-            }
-        }
-    }
-    if let Some((key, root)) = configured_user_roots.first() {
-        if let Some(relative) = relative_portable_path_if_within(root, source)? {
-            return user_root_result(
-                AgentStackUserGlobalRoot::ConfiguredUser,
-                format!("configured_user/{key}/{relative}"),
-            );
-        }
-    }
-    Err(AgentStackComponentError::UntypedDiscoverySource)
-}
-
-fn user_root_result(
-    root: AgentStackUserGlobalRoot,
-    locator: String,
-) -> Result<(AgentStackUserGlobalRoot, AgentStackSourceLocator), AgentStackComponentError> {
-    validate_user_global_locator(&locator)?;
-    Ok((root, AgentStackSourceLocator(locator)))
-}
-
-fn relative_portable_path(root: &Path, source: &Path) -> Result<String, AgentStackComponentError> {
-    relative_portable_path_if_within(root, source)?
-        .ok_or(AgentStackComponentError::SourceOutsideRoot)
-}
-
-fn relative_portable_path_if_within(
-    root: &Path,
-    source: &Path,
-) -> Result<Option<String>, AgentStackComponentError> {
-    let root = absolute_path_key(root, true)?;
-    let source = absolute_path_key(source, false)?;
-    if !root_key_matches(root.drive, &root.segments, source.drive, &source.segments)
-        || source.segments.len() <= root.segments.len()
-    {
-        return Ok(None);
-    }
-    let relative = source.segments[root.segments.len()..].join("/");
-    validate_portable_path(&relative)?;
-    Ok(Some(relative))
-}
-
-fn normalize_absolute_path(path: &Path) -> Result<PathBuf, AgentStackComponentError> {
-    let key = absolute_path_key(path, true)?;
-    let mut result = PathBuf::new();
-    #[cfg(unix)]
-    result.push("/");
-    #[cfg(windows)]
-    if let Some(drive) = key.drive {
-        result.push(format!("{}:\\", drive as char));
-    }
-    for segment in key.segments {
-        result.push(segment);
-    }
-    Ok(result)
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct AbsolutePathKey {
-    drive: Option<u8>,
-    segments: Vec<String>,
-}
-
-fn absolute_path_key(
-    path: &Path,
-    resolve_parent: bool,
-) -> Result<AbsolutePathKey, AgentStackComponentError> {
-    if !path.is_absolute() {
-        return Err(AgentStackComponentError::InvalidSourceLocator);
-    }
-    #[cfg(windows)]
-    let mut drive = None;
-    #[cfg(not(windows))]
-    let drive = None;
-    let mut segments = Vec::new();
-    for component in path.components() {
-        match component {
-            Component::Prefix(value) => {
-                #[cfg(windows)]
-                {
-                    use std::path::Prefix;
-                    drive = Some(match value.kind() {
-                        Prefix::Disk(drive) | Prefix::VerbatimDisk(drive) => {
-                            drive.to_ascii_uppercase()
-                        }
-                        _ => return Err(AgentStackComponentError::InvalidSourceLocator),
-                    });
-                }
-                #[cfg(not(windows))]
-                {
-                    let _ = value;
-                    return Err(AgentStackComponentError::InvalidSourceLocator);
-                }
-            }
-            Component::RootDir | Component::CurDir => {}
-            Component::ParentDir if resolve_parent && !segments.is_empty() => {
-                segments.pop();
-            }
-            Component::ParentDir => return Err(AgentStackComponentError::InvalidSourceLocator),
-            Component::Normal(value) => segments.push(
-                value
-                    .to_str()
-                    .ok_or(AgentStackComponentError::NonUtf8SourceLocator)?
-                    .to_owned(),
-            ),
-        }
-    }
-    Ok(AbsolutePathKey { drive, segments })
-}
-
-fn drives_match(left: Option<u8>, right: Option<u8>) -> bool {
-    left.map(|drive| drive.to_ascii_uppercase()) == right.map(|drive| drive.to_ascii_uppercase())
-}
-
-#[rustfmt::skip]
-fn root_key_matches<T: PartialEq>(
-    root_drive: Option<u8>, root: &[T], source_drive: Option<u8>, source: &[T],
-) -> bool {
-    drives_match(root_drive, source_drive) && source.starts_with(root)
-}
-
-#[cfg(test)]
-#[rustfmt::skip]
-fn root_keys_match_for_test(
-    drive_a: Option<u8>, segments_a: &[&str], drive_b: Option<u8>, segments_b: &[&str],
-) -> bool {
-    segments_a.len() == segments_b.len()
-        && root_key_matches(drive_a, segments_a, drive_b, segments_b)
 }

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -4,6 +4,11 @@ use super::{
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
+
+mod replacements;
+use replacements::{
+    analyze_role_replacements, replacement_candidates, replacement_use_counts, CandidateMode,
+};
 macro_rules! closed_enum {
     ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -61,6 +66,7 @@ closed_enum!(AgentStackProtectionControlReason {
     PossibleRename => "possible_rename",
     AmbiguousReplacement => "ambiguous_replacement",
     ConfidenceReduced => "confidence_reduced",
+    EnablementEvidenceLost => "enablement_evidence_lost",
     ConflictingDuplicateReport => "conflicting_duplicate_report",
 });
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -158,6 +164,13 @@ pub struct AgentStackProtectionControlDiff {
     confidence: AgentStackProtectionConfidence,
     reason: AgentStackProtectionControlReason,
 }
+
+struct ComparisonInputs<'before, 'after> {
+    after_controls: &'after [AgentStackProtectionControl],
+    before_by_id: &'before BTreeMap<String, &'before AgentStackProtectionControl>,
+    before_conflicting_component_ids: &'before BTreeSet<String>,
+    after_conflicting_component_ids: &'after BTreeSet<String>,
+}
 #[rustfmt::skip]
 impl AgentStackProtectionControlDiff {
     fn new(
@@ -199,6 +212,12 @@ pub fn protective_control_diff(
         &before_controls.conflicting_component_ids,
         &after_by_id,
     );
+    let comparison_inputs = ComparisonInputs {
+        after_controls: &after_controls.controls,
+        before_by_id: &before_by_id,
+        before_conflicting_component_ids: &before_controls.conflicting_component_ids,
+        after_conflicting_component_ids: &after_controls.conflicting_component_ids,
+    };
     let mut facts = Vec::new();
     for before_control in &before_controls.controls {
         let component_id = before_control.component.component_id().as_str();
@@ -214,9 +233,7 @@ pub fn protective_control_diff(
             Some(after_control) => compare_existing(
                 before_control,
                 after_control,
-                &after_controls.controls,
-                &before_by_id,
-                &before_controls.conflicting_component_ids,
+                &comparison_inputs,
                 has_before_conflict
                     || after_controls
                         .conflicting_component_ids
@@ -247,81 +264,115 @@ pub fn protective_control_diff(
 fn compare_existing(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
-    after_controls: &[AgentStackProtectionControl],
-    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
-    before_conflicting_component_ids: &BTreeSet<String>,
+    inputs: &ComparisonInputs<'_, '_>,
     has_conflicting_duplicate_state: bool,
     facts: &mut Vec<AgentStackProtectionControlDiff>,
 ) {
     let confidence = min_confidence(before.confidence, after.confidence);
     if after.confidence.strength() < before.confidence.strength() {
-        facts.push(AgentStackProtectionControlDiff::new(
+        push_existing_fact(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
             before.roles.clone(),
-            Some(before),
-            Some(after),
+            before,
+            after,
             confidence,
             AgentStackProtectionControlReason::ConfidenceReduced,
-        ));
+            facts,
+        );
     }
-    if before.enabled != Some(false) && after.enabled == Some(false) {
-        facts.push(AgentStackProtectionControlDiff::new(
-            AgentStackProtectionDiffKind::Disabled,
-            before.roles.clone(),
-            Some(before),
-            Some(after),
-            confidence,
-            AgentStackProtectionControlReason::ExplicitlyDisabled,
-        ));
-    }
-    let missing_roles = missing_roles_without_replacements(
-        before,
-        missing_roles(before.roles(), after.roles()),
-        after_controls,
-        before_by_id,
-        before_conflicting_component_ids,
-    );
-    if !missing_roles.is_empty() {
-        facts.push(AgentStackProtectionControlDiff::new(
-            AgentStackProtectionDiffKind::ScopeReduced,
-            missing_roles,
-            Some(before),
-            Some(after),
-            confidence,
-            AgentStackProtectionControlReason::RoleSetReduced,
-        ));
-    }
-    if before.scope.is_some() && after.scope.is_none() {
-        facts.push(AgentStackProtectionControlDiff::new(
+    match (before.enabled, after.enabled) {
+        (Some(true), None) => push_existing_fact(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
             before.roles.clone(),
-            Some(before),
-            Some(after),
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::EnablementEvidenceLost,
+            facts,
+        ),
+        (left, Some(false)) if left != Some(false) => push_existing_fact(
+            AgentStackProtectionDiffKind::Disabled,
+            before.roles.clone(),
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::ExplicitlyDisabled,
+            facts,
+        ),
+        _ => {}
+    }
+    let replacements = analyze_role_replacements(
+        before,
+        missing_roles(before.roles(), after.roles()),
+        inputs.after_controls,
+        inputs.before_by_id,
+        inputs.before_conflicting_component_ids,
+        inputs.after_conflicting_component_ids,
+    );
+    for (candidate, conflicting_roles) in replacements.conflicting_replacements {
+        push_conflicting_duplicate_fact_with_roles(
+            before,
+            Some(candidate),
+            conflicting_roles,
+            facts,
+        );
+    }
+    if !replacements.uncovered_roles.is_empty() {
+        push_existing_fact(
+            AgentStackProtectionDiffKind::ScopeReduced,
+            replacements.uncovered_roles,
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::RoleSetReduced,
+            facts,
+        );
+    }
+    if before.scope.is_some() && after.scope.is_none() {
+        push_existing_fact(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            before,
+            after,
             confidence,
             AgentStackProtectionControlReason::ScopeLevelReduced,
-        ));
+            facts,
+        );
     } else if matches!((before.scope, after.scope), (Some(left), Some(right)) if right.strength() < left.strength())
     {
-        facts.push(AgentStackProtectionControlDiff::new(
+        push_existing_fact(
             AgentStackProtectionDiffKind::ScopeReduced,
             before.roles.clone(),
-            Some(before),
-            Some(after),
+            before,
+            after,
             confidence,
             AgentStackProtectionControlReason::ScopeLevelReduced,
-        ));
+            facts,
+        );
     }
-    if before.failure_mode == Some(AgentStackProtectionFailureMode::FailClosed)
-        && after.failure_mode == Some(AgentStackProtectionFailureMode::FailOpen)
-    {
-        facts.push(AgentStackProtectionControlDiff::new(
+    match (before.failure_mode, after.failure_mode) {
+        (
+            Some(AgentStackProtectionFailureMode::FailClosed),
+            Some(AgentStackProtectionFailureMode::FailOpen),
+        ) => push_existing_fact(
             AgentStackProtectionDiffKind::FailOpen,
             before.roles.clone(),
-            Some(before),
-            Some(after),
+            before,
+            after,
             confidence,
             AgentStackProtectionControlReason::FailureModeRelaxed,
-        ));
+            facts,
+        ),
+        (Some(AgentStackProtectionFailureMode::FailClosed), None) => push_existing_fact(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::FailureModeRelaxed,
+            facts,
+        ),
+        _ => {}
     }
     if has_conflicting_duplicate_state {
         push_conflicting_duplicate_fact(before, Some(after), facts);
@@ -347,7 +398,47 @@ fn compare_removed(
         let candidate = same_integrity.remove(0);
         let component_id = candidate.component.component_id().as_str();
         if after_conflicting_component_ids.contains(component_id) {
-            push_conflicting_duplicate_fact(before, Some(candidate), facts);
+            let replacements = analyze_role_replacements(
+                before,
+                before.roles.clone(),
+                after,
+                before_by_id,
+                before_conflicting_component_ids,
+                after_conflicting_component_ids,
+            );
+            let mut uncovered_roles = replacements.uncovered_roles;
+            let mut conflicting_replacements = replacements.conflicting_replacements;
+            let overlapping_roles = before
+                .roles
+                .iter()
+                .copied()
+                .filter(|role| candidate.roles.contains(role))
+                .collect::<Vec<_>>();
+            uncovered_roles.retain(|role| !overlapping_roles.contains(role));
+            if let Some((_, roles)) =
+                conflicting_replacements
+                    .iter_mut()
+                    .find(|(conflicting, _)| {
+                        conflicting.component.component_id().as_str() == component_id
+                    })
+            {
+                *roles = merged_roles(roles, &overlapping_roles);
+            } else {
+                conflicting_replacements.push((candidate, overlapping_roles));
+            }
+            for (conflicting, roles) in conflicting_replacements {
+                push_conflicting_duplicate_fact_with_roles(before, Some(conflicting), roles, facts);
+            }
+            if !uncovered_roles.is_empty() {
+                facts.push(AgentStackProtectionControlDiff::new(
+                    AgentStackProtectionDiffKind::Removed,
+                    uncovered_roles,
+                    Some(before),
+                    None,
+                    before.confidence,
+                    AgentStackProtectionControlReason::RemovedWithoutEquivalent,
+                ));
+            }
             return;
         }
         facts.push(AgentStackProtectionControlDiff::new(
@@ -361,9 +452,12 @@ fn compare_removed(
         compare_existing(
             before,
             candidate,
-            after,
-            before_by_id,
-            before_conflicting_component_ids,
+            &ComparisonInputs {
+                after_controls: after,
+                before_by_id,
+                before_conflicting_component_ids,
+                after_conflicting_component_ids,
+            },
             false,
             facts,
         );
@@ -443,6 +537,48 @@ fn compare_removed(
         ));
         return;
     }
+    let replacements = analyze_role_replacements(
+        before,
+        before.roles.clone(),
+        after,
+        before_by_id,
+        before_conflicting_component_ids,
+        after_conflicting_component_ids,
+    );
+    let has_conflicting_replacements = !replacements.conflicting_replacements.is_empty();
+    for (candidate, conflicting_roles) in replacements.conflicting_replacements {
+        push_conflicting_duplicate_fact_with_roles(
+            before,
+            Some(candidate),
+            conflicting_roles,
+            facts,
+        );
+    }
+    if !replacements.uncovered_roles.is_empty() {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::Removed,
+            replacements.uncovered_roles,
+            Some(before),
+            None,
+            before.confidence,
+            AgentStackProtectionControlReason::RemovedWithoutEquivalent,
+        ));
+        return;
+    }
+    if has_conflicting_replacements {
+        return;
+    }
+    if replacements.replacement_ids.len() > 1 {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            Some(before),
+            None,
+            AgentStackProtectionConfidence::Low,
+            AgentStackProtectionControlReason::AmbiguousReplacement,
+        ));
+        return;
+    }
     facts.push(AgentStackProtectionControlDiff::new(
         AgentStackProtectionDiffKind::Removed,
         before.roles.clone(),
@@ -452,104 +588,9 @@ fn compare_removed(
         AgentStackProtectionControlReason::RemovedWithoutEquivalent,
     ));
 }
-#[derive(Clone, Copy)]
-enum CandidateMode {
-    SameIntegrity,
-    Equivalent,
-    WeakEquivalent,
-}
-fn replacement_candidates<'a>(
-    after: &'a [AgentStackProtectionControl],
-    before: &AgentStackProtectionControl,
-    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
-    before_conflicting_component_ids: &BTreeSet<String>,
-    mode: CandidateMode,
-) -> Vec<&'a AgentStackProtectionControl> {
-    let mut candidates = after
-        .iter()
-        .filter(|candidate| {
-            candidate_is_new_protection(
-                candidate,
-                before,
-                before_by_id,
-                before_conflicting_component_ids,
-                mode,
-            )
-        })
-        .filter(|candidate| role_overlap(before.roles(), candidate.roles()))
-        .filter(|candidate| match mode {
-            CandidateMode::SameIntegrity => same_integrity(before, candidate),
-            CandidateMode::Equivalent => equivalent_replacement(before, candidate),
-            CandidateMode::WeakEquivalent => weak_equivalent_replacement(before, candidate),
-        })
-        .collect::<Vec<_>>();
-    candidates.sort_by_key(|candidate| candidate.component.component_id().as_str());
-    candidates
-}
-fn candidate_is_new_protection(
-    candidate: &AgentStackProtectionControl,
-    removed: &AgentStackProtectionControl,
-    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
-    before_conflicting_component_ids: &BTreeSet<String>,
-    mode: CandidateMode,
-) -> bool {
-    let component_id = candidate.component.component_id().as_str();
-    match before_by_id.get(component_id).copied() {
-        Some(_) if matches!(mode, CandidateMode::SameIntegrity) => false,
-        Some(_) if before_conflicting_component_ids.contains(component_id) => true,
-        Some(previous) => match mode {
-            CandidateMode::SameIntegrity => false,
-            CandidateMode::Equivalent => !equivalent_replacement(removed, previous),
-            CandidateMode::WeakEquivalent => !weak_equivalent_replacement(removed, previous),
-        },
-        None => true,
-    }
-}
 #[rustfmt::skip]
-fn missing_roles_without_replacements(before: &AgentStackProtectionControl, missing_roles: Vec<AgentStackProtectionRole>, after: &[AgentStackProtectionControl], before_by_id: &BTreeMap<String, &AgentStackProtectionControl>, before_conflicting_component_ids: &BTreeSet<String>) -> Vec<AgentStackProtectionRole> {
-    missing_roles.into_iter().filter(|role| {
-        let mut probe = before.clone();
-        probe.roles = vec![*role];
-        replacement_candidates(after, &probe, before_by_id, before_conflicting_component_ids, CandidateMode::Equivalent).is_empty()
-    }).collect()
-}
-fn equivalent_replacement(
-    before: &AgentStackProtectionControl,
-    after: &AgentStackProtectionControl,
-) -> bool {
-    after.confidence.strength() >= before.confidence.strength()
-        && weak_equivalent_replacement(before, after)
-}
-fn weak_equivalent_replacement(
-    before: &AgentStackProtectionControl,
-    after: &AgentStackProtectionControl,
-) -> bool {
-    after.enabled != Some(false)
-        && roles_include(after.roles(), before.roles())
-        && (before.enabled != Some(true) || after.enabled == Some(true))
-        && scope_at_least(after.scope, before.scope)
-        && (before.failure_mode != Some(AgentStackProtectionFailureMode::FailClosed)
-            || after.failure_mode == Some(AgentStackProtectionFailureMode::FailClosed))
-}
-fn scope_at_least(
-    after: Option<AgentStackProtectionScope>,
-    before: Option<AgentStackProtectionScope>,
-) -> bool {
-    match before {
-        Some(before_scope) => {
-            after.is_some_and(|after_scope| after_scope.strength() >= before_scope.strength())
-        }
-        None => true,
-    }
-}
-fn same_integrity(
-    before: &AgentStackProtectionControl,
-    after: &AgentStackProtectionControl,
-) -> bool {
-    matches!(
-        (before.component.integrity(), after.component.integrity()),
-        (Some(left), Some(right)) if left.as_str() == right.as_str()
-    )
+fn push_existing_fact(kind: AgentStackProtectionDiffKind, roles: Vec<AgentStackProtectionRole>, before: &AgentStackProtectionControl, after: &AgentStackProtectionControl, confidence: AgentStackProtectionConfidence, reason: AgentStackProtectionControlReason, facts: &mut Vec<AgentStackProtectionControlDiff>) {
+    facts.push(AgentStackProtectionControlDiff::new(kind, roles, Some(before), Some(after), confidence, reason));
 }
 fn by_component_id(
     controls: &[AgentStackProtectionControl],
@@ -615,42 +656,17 @@ fn merge_control(
     existing.failure_mode = stronger_failure_mode(existing.failure_mode, control.failure_mode);
     existing.confidence = min_confidence(existing.confidence, control.confidence);
 }
-fn replacement_use_counts(
-    before: &[AgentStackProtectionControl],
-    after: &[AgentStackProtectionControl],
-    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
-    before_conflicting_component_ids: &BTreeSet<String>,
-    after_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
-) -> BTreeMap<String, usize> {
-    let mut counts = BTreeMap::new();
-    for before_control in before {
-        if before_control.roles.is_empty() || before_control.enabled == Some(false) {
-            continue;
-        }
-        if after_by_id.contains_key(before_control.component.component_id().as_str()) {
-            continue;
-        }
-        let mut used_ids = BTreeSet::new();
-        for mode in [CandidateMode::SameIntegrity, CandidateMode::Equivalent] {
-            for candidate in replacement_candidates(
-                after,
-                before_control,
-                before_by_id,
-                before_conflicting_component_ids,
-                mode,
-            ) {
-                used_ids.insert(candidate.component.component_id().as_str().to_owned());
-            }
-        }
-        for component_id in used_ids {
-            *counts.entry(component_id).or_insert(0) += 1;
-        }
-    }
-    counts
-}
 fn push_conflicting_duplicate_fact(
     before: &AgentStackProtectionControl,
     after: Option<&AgentStackProtectionControl>,
+    facts: &mut Vec<AgentStackProtectionControlDiff>,
+) {
+    push_conflicting_duplicate_fact_with_roles(before, after, before.roles.clone(), facts);
+}
+fn push_conflicting_duplicate_fact_with_roles(
+    before: &AgentStackProtectionControl,
+    after: Option<&AgentStackProtectionControl>,
+    roles: Vec<AgentStackProtectionRole>,
     facts: &mut Vec<AgentStackProtectionControlDiff>,
 ) {
     let confidence = after
@@ -658,7 +674,7 @@ fn push_conflicting_duplicate_fact(
         .unwrap_or(before.confidence);
     facts.push(AgentStackProtectionControlDiff::new(
         AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
-        before.roles.clone(),
+        roles,
         Some(before),
         after,
         confidence,
@@ -720,12 +736,6 @@ fn stronger_failure_mode(
     } else {
         left.or(right)
     }
-}
-fn role_overlap(left: &[AgentStackProtectionRole], right: &[AgentStackProtectionRole]) -> bool {
-    left.iter().any(|role| right.contains(role))
-}
-fn roles_include(left: &[AgentStackProtectionRole], right: &[AgentStackProtectionRole]) -> bool {
-    right.iter().all(|role| left.contains(role))
 }
 fn missing_roles(
     before: &[AgentStackProtectionRole],

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -174,6 +174,10 @@ struct ComparisonInputs<'before, 'after> {
     before_conflicting_component_ids: &'before BTreeSet<String>,
     after_conflicting_component_ids: &'after BTreeSet<String>,
     after_enabled_conflicting_component_ids: &'after BTreeSet<String>,
+    before_scope_conflicting_component_ids: &'before BTreeSet<String>,
+    after_scope_conflicting_component_ids: &'after BTreeSet<String>,
+    before_failure_mode_conflicting_component_ids: &'before BTreeSet<String>,
+    after_failure_mode_conflicting_component_ids: &'after BTreeSet<String>,
     replacement_use_counts: &'before BTreeMap<String, usize>,
 }
 #[rustfmt::skip]
@@ -224,6 +228,12 @@ pub fn protective_control_diff(
         before_conflicting_component_ids: &before_controls.conflicting_component_ids,
         after_conflicting_component_ids: &after_controls.conflicting_component_ids,
         after_enabled_conflicting_component_ids: &after_controls.enabled_conflicting_component_ids,
+        before_scope_conflicting_component_ids: &before_controls.scope_conflicting_component_ids,
+        after_scope_conflicting_component_ids: &after_controls.scope_conflicting_component_ids,
+        before_failure_mode_conflicting_component_ids: &before_controls
+            .failure_mode_conflicting_component_ids,
+        after_failure_mode_conflicting_component_ids: &after_controls
+            .failure_mode_conflicting_component_ids,
         replacement_use_counts: &replacement_use_counts,
     };
     let mut facts = Vec::new();
@@ -282,6 +292,13 @@ fn compare_removed(
         before_conflicting_component_ids,
         CandidateMode::SameIntegrity,
     );
+    let equivalent = replacement_candidates(
+        after,
+        before,
+        before_by_id,
+        before_conflicting_component_ids,
+        CandidateMode::Equivalent,
+    );
     if same_integrity.len() == 1 {
         let candidate = same_integrity.remove(0);
         let component_id = candidate.component.component_id().as_str();
@@ -337,6 +354,16 @@ fn compare_removed(
             rename_confidence(before, candidate),
             AgentStackProtectionControlReason::PossibleRename,
         ));
+        let has_safe_independent_equivalent = equivalent.iter().any(|replacement| {
+            let replacement_id = replacement.component.component_id().as_str();
+            replacement_id != component_id
+                && !before_conflicting_component_ids.contains(replacement_id)
+                && !after_conflicting_component_ids.contains(replacement_id)
+                && replacement_use_counts.get(replacement_id).copied() == Some(1)
+        });
+        if has_safe_independent_equivalent {
+            return;
+        }
         compare_existing(before, candidate, inputs, false, facts);
         return;
     }
@@ -370,13 +397,6 @@ fn compare_removed(
         }
         return;
     }
-    let equivalent = replacement_candidates(
-        after,
-        before,
-        before_by_id,
-        before_conflicting_component_ids,
-        CandidateMode::Equivalent,
-    );
     if equivalent.len() == 1 {
         let candidate = equivalent[0];
         let component_id = candidate.component.component_id().as_str();
@@ -492,11 +512,15 @@ struct AggregatedControls {
     controls: Vec<AgentStackProtectionControl>,
     conflicting_component_ids: BTreeSet<String>,
     enabled_conflicting_component_ids: BTreeSet<String>,
+    scope_conflicting_component_ids: BTreeSet<String>,
+    failure_mode_conflicting_component_ids: BTreeSet<String>,
 }
 fn aggregate_controls(controls: &[AgentStackProtectionControl]) -> AggregatedControls {
     let mut by_id = BTreeMap::<String, AgentStackProtectionControl>::new();
     let mut conflicting_component_ids = BTreeSet::new();
     let mut enabled_conflicting_component_ids = BTreeSet::new();
+    let mut scope_conflicting_component_ids = BTreeSet::new();
+    let mut failure_mode_conflicting_component_ids = BTreeSet::new();
     let mut integrity_conflicting_component_ids = BTreeSet::new();
     for control in controls {
         let component_id = control.component.component_id().as_str().to_owned();
@@ -506,6 +530,12 @@ fn aggregate_controls(controls: &[AgentStackProtectionControl]) -> AggregatedCon
             }
             if conflicting_values(existing.enabled, control.enabled) {
                 enabled_conflicting_component_ids.insert(component_id.clone());
+            }
+            if conflicting_values(existing.scope, control.scope) {
+                scope_conflicting_component_ids.insert(component_id.clone());
+            }
+            if conflicting_values(existing.failure_mode, control.failure_mode) {
+                failure_mode_conflicting_component_ids.insert(component_id.clone());
             }
             if conflicting_values(
                 existing.component.integrity(),
@@ -526,6 +556,8 @@ fn aggregate_controls(controls: &[AgentStackProtectionControl]) -> AggregatedCon
         controls: by_id.into_values().collect(),
         conflicting_component_ids,
         enabled_conflicting_component_ids,
+        scope_conflicting_component_ids,
+        failure_mode_conflicting_component_ids,
     }
 }
 fn duplicate_state_conflicts(
@@ -554,6 +586,10 @@ fn merge_control(
             .with_integrity(control.component.integrity().cloned());
     }
     existing.roles = merged_roles(existing.roles(), control.roles());
+    existing.component.capabilities = merged_capabilities(
+        existing.component.capabilities(),
+        control.component.capabilities(),
+    );
     existing.enabled = merged_after_enabled(existing.enabled, control.enabled);
     existing.scope = stronger_scope(existing.scope, control.scope);
     existing.failure_mode = stronger_failure_mode(existing.failure_mode, control.failure_mode);
@@ -610,6 +646,19 @@ fn merged_roles(
     }
     roles.sort_by_key(AgentStackProtectionRole::as_str);
     roles
+}
+fn merged_capabilities(
+    left: &[AgentStackCapability],
+    right: &[AgentStackCapability],
+) -> Vec<AgentStackCapability> {
+    let mut capabilities = left.to_vec();
+    for capability in right {
+        if !capabilities.contains(capability) {
+            capabilities.push(*capability);
+        }
+    }
+    capabilities.sort_by_key(AgentStackCapability::as_str);
+    capabilities
 }
 fn merged_after_enabled(left: Option<bool>, right: Option<bool>) -> Option<bool> {
     match (left, right) {

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -4,7 +4,6 @@ use super::{
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
-
 mod existing;
 mod replacements;
 use existing::compare_existing;
@@ -168,7 +167,6 @@ pub struct AgentStackProtectionControlDiff {
     confidence: AgentStackProtectionConfidence,
     reason: AgentStackProtectionControlReason,
 }
-
 struct ComparisonInputs<'before, 'after> {
     after_reports: &'after [AgentStackProtectionControl],
     after_controls: &'after [AgentStackProtectionControl],
@@ -338,7 +336,7 @@ fn compare_removed(
                     after_any: after_conflicting_component_ids,
                 },
                 &replacements.conflicting_replacements,
-                component_id,
+                std::slice::from_ref(&candidate),
             );
             let mut conflicting_replacements = replacements.conflicting_replacements;
             let overlapping_roles = before
@@ -399,15 +397,29 @@ fn compare_removed(
             min_confidence(before.confidence, AgentStackProtectionConfidence::Medium),
             AgentStackProtectionControlReason::PossibleRename,
         ));
-        let uncovered_roles = analyze_role_replacements(
+        let replacements = analyze_role_replacements(
             before,
             before.roles.clone(),
             after,
             before_by_id,
             before_conflicting_component_ids,
             after_conflicting_component_ids,
-        )
-        .uncovered_roles;
+        );
+        let uncovered_roles = conflicted_replacement_uncovered_roles(
+            before,
+            after,
+            inputs.after_reports,
+            before_by_id,
+            ReplacementCandidateConflicts {
+                before_any: before_conflicting_component_ids,
+                after_any: after_conflicting_component_ids,
+            },
+            &replacements.conflicting_replacements,
+            &same_integrity,
+        );
+        for (candidate, roles) in replacements.conflicting_replacements {
+            push_conflicting_duplicate_fact_with_roles(before, Some(candidate), roles, facts);
+        }
         if !uncovered_roles.is_empty() {
             facts.push(AgentStackProtectionControlDiff::new(
                 AgentStackProtectionDiffKind::Removed,

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -222,6 +222,7 @@ pub fn protective_control_diff(
         &before_controls.conflicting_component_ids,
         &after_by_id,
         ReplacementStateConflicts {
+            after_any: &after_controls.conflicting_component_ids,
             before_enabled: &before_controls.enabled_conflicting_component_ids,
             after_enabled: &after_controls.enabled_conflicting_component_ids,
             before_scope: &before_controls.scope_conflicting_component_ids,
@@ -252,8 +253,11 @@ pub fn protective_control_diff(
         let has_before_conflict = before_controls
             .conflicting_component_ids
             .contains(component_id);
+        let has_before_enabled_conflict = before_controls
+            .enabled_conflicting_component_ids
+            .contains(component_id);
         if before_control.roles.is_empty()
-            || (before_control.enabled == Some(false) && !has_before_conflict)
+            || (before_control.enabled == Some(false) && !has_before_enabled_conflict)
         {
             continue;
         }
@@ -407,8 +411,22 @@ fn compare_removed(
         }
         return;
     }
-    if equivalent.len() == 1 {
-        let candidate = equivalent[0];
+    let safe_equivalent = equivalent
+        .iter()
+        .copied()
+        .filter(|candidate| {
+            let component_id = candidate.component.component_id().as_str();
+            !before_conflicting_component_ids.contains(component_id)
+                && !after_conflicting_component_ids.contains(component_id)
+        })
+        .collect::<Vec<_>>();
+    let preferred_equivalent = if safe_equivalent.is_empty() {
+        &equivalent
+    } else {
+        &safe_equivalent
+    };
+    if preferred_equivalent.len() == 1 {
+        let candidate = preferred_equivalent[0];
         let component_id = candidate.component.component_id().as_str();
         let has_candidate_conflict = before_conflicting_component_ids.contains(component_id)
             || after_conflicting_component_ids.contains(component_id);
@@ -434,7 +452,7 @@ fn compare_removed(
         ));
         return;
     }
-    if let Some(candidate) = equivalent.first() {
+    if let Some(candidate) = preferred_equivalent.first() {
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
             before.roles.clone(),

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -62,6 +62,7 @@ closed_enum!(AgentStackProtectionControlReason {
     FailureModeRelaxed => "failure_mode_relaxed",
     PossibleRename => "possible_rename",
     AmbiguousReplacement => "ambiguous_replacement",
+    ConflictingDuplicateReport => "conflicting_duplicate_report",
 });
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -212,11 +213,15 @@ pub fn protective_control_diff(
     before: &[AgentStackProtectionControl],
     after: &[AgentStackProtectionControl],
 ) -> Vec<AgentStackProtectionControlDiff> {
-    let before_ids = component_ids(before);
+    let before_by_id = by_component_id(before);
     let after_controls = aggregate_controls(after);
-    let after_by_id = by_component_id(&after_controls);
-    let replacement_use_counts =
-        replacement_use_counts(before, &after_controls, &before_ids, &after_by_id);
+    let after_by_id = by_component_id(&after_controls.controls);
+    let replacement_use_counts = replacement_use_counts(
+        before,
+        &after_controls.controls,
+        &before_by_id,
+        &after_by_id,
+    );
     let mut facts = Vec::new();
 
     for before_control in before {
@@ -225,11 +230,18 @@ pub fn protective_control_diff(
         }
         let component_id = before_control.component.component_id().as_str();
         match after_by_id.get(component_id).copied() {
-            Some(after_control) => compare_existing(before_control, after_control, &mut facts),
+            Some(after_control) => compare_existing(
+                before_control,
+                after_control,
+                after_controls
+                    .conflicting_component_ids
+                    .contains(component_id),
+                &mut facts,
+            ),
             None => compare_removed(
                 before_control,
-                &after_controls,
-                &before_ids,
+                &after_controls.controls,
+                &before_by_id,
                 &replacement_use_counts,
                 &mut facts,
             ),
@@ -247,10 +259,11 @@ pub fn protective_control_diff(
 fn compare_existing(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
+    has_conflicting_duplicate_state: bool,
     facts: &mut Vec<AgentStackProtectionControlDiff>,
 ) {
     let confidence = min_confidence(before.confidence, after.confidence);
-    if before.enabled == Some(true) && after.enabled == Some(false) {
+    if before.enabled != Some(false) && after.enabled == Some(false) {
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::Disabled,
             before.roles.clone(),
@@ -294,17 +307,27 @@ fn compare_existing(
             AgentStackProtectionControlReason::FailureModeRelaxed,
         ));
     }
+    if has_conflicting_duplicate_state {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            Some(before),
+            Some(after),
+            confidence,
+            AgentStackProtectionControlReason::ConflictingDuplicateReport,
+        ));
+    }
 }
 
 fn compare_removed(
     before: &AgentStackProtectionControl,
     after: &[AgentStackProtectionControl],
-    before_ids: &BTreeSet<String>,
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
     replacement_use_counts: &BTreeMap<String, usize>,
     facts: &mut Vec<AgentStackProtectionControlDiff>,
 ) {
     let mut same_integrity =
-        replacement_candidates(after, before, before_ids, CandidateMode::SameIntegrity);
+        replacement_candidates(after, before, before_by_id, CandidateMode::SameIntegrity);
     if same_integrity.len() == 1 {
         let candidate = same_integrity.remove(0);
         facts.push(AgentStackProtectionControlDiff::new(
@@ -315,7 +338,7 @@ fn compare_removed(
             rename_confidence(before, candidate),
             AgentStackProtectionControlReason::PossibleRename,
         ));
-        compare_existing(before, candidate, facts);
+        compare_existing(before, candidate, false, facts);
         return;
     }
     if !same_integrity.is_empty() {
@@ -330,7 +353,7 @@ fn compare_removed(
         return;
     }
 
-    let equivalent = replacement_candidates(after, before, before_ids, CandidateMode::Equivalent);
+    let equivalent = replacement_candidates(after, before, before_by_id, CandidateMode::Equivalent);
     if equivalent.len() == 1 {
         let candidate = equivalent[0];
         let use_count = replacement_use_counts
@@ -363,7 +386,7 @@ fn compare_removed(
     }
 
     let weak_equivalent =
-        replacement_candidates(after, before, before_ids, CandidateMode::WeakEquivalent);
+        replacement_candidates(after, before, before_by_id, CandidateMode::WeakEquivalent);
     if let Some(candidate) = weak_equivalent.first() {
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
@@ -396,12 +419,12 @@ enum CandidateMode {
 fn replacement_candidates<'a>(
     after: &'a [AgentStackProtectionControl],
     before: &AgentStackProtectionControl,
-    before_ids: &BTreeSet<String>,
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
     mode: CandidateMode,
 ) -> Vec<&'a AgentStackProtectionControl> {
     let mut candidates = after
         .iter()
-        .filter(|candidate| !before_ids.contains(candidate.component.component_id().as_str()))
+        .filter(|candidate| candidate_is_new_protection(candidate, before, before_by_id))
         .filter(|candidate| role_overlap(before.roles(), candidate.roles()))
         .filter(|candidate| match mode {
             CandidateMode::SameIntegrity => same_integrity(before, candidate),
@@ -411,6 +434,22 @@ fn replacement_candidates<'a>(
         .collect::<Vec<_>>();
     candidates.sort_by_key(|candidate| candidate.component.component_id().as_str());
     candidates
+}
+
+fn candidate_is_new_protection(
+    candidate: &AgentStackProtectionControl,
+    removed: &AgentStackProtectionControl,
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+) -> bool {
+    match before_by_id
+        .get(candidate.component.component_id().as_str())
+        .copied()
+    {
+        Some(previous) => {
+            previous.enabled == Some(false) || !role_overlap(previous.roles(), removed.roles())
+        }
+        None => true,
+    }
 }
 
 fn equivalent_replacement(
@@ -469,18 +508,42 @@ fn by_component_id(
         .collect()
 }
 
-fn aggregate_controls(
-    controls: &[AgentStackProtectionControl],
-) -> Vec<AgentStackProtectionControl> {
+struct AggregatedControls {
+    controls: Vec<AgentStackProtectionControl>,
+    conflicting_component_ids: BTreeSet<String>,
+}
+
+fn aggregate_controls(controls: &[AgentStackProtectionControl]) -> AggregatedControls {
     let mut by_id = BTreeMap::<String, AgentStackProtectionControl>::new();
+    let mut conflicting_component_ids = BTreeSet::new();
     for control in controls {
         let component_id = control.component.component_id().as_str().to_owned();
-        by_id
-            .entry(component_id)
-            .and_modify(|existing| merge_control(existing, control))
-            .or_insert_with(|| control.clone());
+        if let Some(existing) = by_id.get_mut(&component_id) {
+            if duplicate_state_conflicts(existing, control) {
+                conflicting_component_ids.insert(component_id);
+            }
+            merge_control(existing, control);
+        } else {
+            by_id.insert(component_id, control.clone());
+        }
     }
-    by_id.into_values().collect()
+    AggregatedControls {
+        controls: by_id.into_values().collect(),
+        conflicting_component_ids,
+    }
+}
+
+fn duplicate_state_conflicts(
+    left: &AgentStackProtectionControl,
+    right: &AgentStackProtectionControl,
+) -> bool {
+    conflicting_values(left.enabled, right.enabled)
+        || conflicting_values(left.scope, right.scope)
+        || conflicting_values(left.failure_mode, right.failure_mode)
+}
+
+fn conflicting_values<T: Eq>(left: Option<T>, right: Option<T>) -> bool {
+    matches!((left, right), (Some(left), Some(right)) if left != right)
 }
 
 fn merge_control(
@@ -497,7 +560,7 @@ fn merge_control(
 fn replacement_use_counts(
     before: &[AgentStackProtectionControl],
     after: &[AgentStackProtectionControl],
-    before_ids: &BTreeSet<String>,
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
     after_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
 ) -> BTreeMap<String, usize> {
     let mut counts = BTreeMap::new();
@@ -508,22 +571,17 @@ fn replacement_use_counts(
         if after_by_id.contains_key(before_control.component.component_id().as_str()) {
             continue;
         }
-        for candidate in
-            replacement_candidates(after, before_control, before_ids, CandidateMode::Equivalent)
-        {
-            *counts
-                .entry(candidate.component.component_id().as_str().to_owned())
-                .or_insert(0) += 1;
+        let mut used_ids = BTreeSet::new();
+        for mode in [CandidateMode::SameIntegrity, CandidateMode::Equivalent] {
+            for candidate in replacement_candidates(after, before_control, before_by_id, mode) {
+                used_ids.insert(candidate.component.component_id().as_str().to_owned());
+            }
+        }
+        for component_id in used_ids {
+            *counts.entry(component_id).or_insert(0) += 1;
         }
     }
     counts
-}
-
-fn component_ids(controls: &[AgentStackProtectionControl]) -> BTreeSet<String> {
-    controls
-        .iter()
-        .map(|control| control.component.component_id().as_str().to_owned())
-        .collect()
 }
 
 fn sorted_roles(

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -173,6 +173,7 @@ struct ComparisonInputs<'before, 'after> {
     before_by_id: &'before BTreeMap<String, &'before AgentStackProtectionControl>,
     before_conflicting_component_ids: &'before BTreeSet<String>,
     after_conflicting_component_ids: &'after BTreeSet<String>,
+    after_enabled_conflicting_component_ids: &'after BTreeSet<String>,
     replacement_use_counts: &'before BTreeMap<String, usize>,
 }
 #[rustfmt::skip]
@@ -215,12 +216,14 @@ pub fn protective_control_diff(
         &before_by_id,
         &before_controls.conflicting_component_ids,
         &after_by_id,
+        &after_controls.enabled_conflicting_component_ids,
     );
     let comparison_inputs = ComparisonInputs {
         after_controls: &after_controls.controls,
         before_by_id: &before_by_id,
         before_conflicting_component_ids: &before_controls.conflicting_component_ids,
         after_conflicting_component_ids: &after_controls.conflicting_component_ids,
+        after_enabled_conflicting_component_ids: &after_controls.enabled_conflicting_component_ids,
         replacement_use_counts: &replacement_use_counts,
     };
     let mut facts = Vec::new();
@@ -250,15 +253,7 @@ pub fn protective_control_diff(
                     push_conflicting_duplicate_fact(before_control, None, &mut facts);
                 }
                 if before_control.enabled != Some(false) {
-                    compare_removed(
-                        before_control,
-                        &after_controls.controls,
-                        &before_by_id,
-                        &before_controls.conflicting_component_ids,
-                        &after_controls.conflicting_component_ids,
-                        &replacement_use_counts,
-                        &mut facts,
-                    );
+                    compare_removed(before_control, &comparison_inputs, &mut facts);
                 }
             }
         }
@@ -272,13 +267,14 @@ pub fn protective_control_diff(
 }
 fn compare_removed(
     before: &AgentStackProtectionControl,
-    after: &[AgentStackProtectionControl],
-    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
-    before_conflicting_component_ids: &BTreeSet<String>,
-    after_conflicting_component_ids: &BTreeSet<String>,
-    replacement_use_counts: &BTreeMap<String, usize>,
+    inputs: &ComparisonInputs<'_, '_>,
     facts: &mut Vec<AgentStackProtectionControlDiff>,
 ) {
+    let after = inputs.after_controls;
+    let before_by_id = inputs.before_by_id;
+    let before_conflicting_component_ids = inputs.before_conflicting_component_ids;
+    let after_conflicting_component_ids = inputs.after_conflicting_component_ids;
+    let replacement_use_counts = inputs.replacement_use_counts;
     let mut same_integrity = replacement_candidates(
         after,
         before,
@@ -341,19 +337,7 @@ fn compare_removed(
             rename_confidence(before, candidate),
             AgentStackProtectionControlReason::PossibleRename,
         ));
-        compare_existing(
-            before,
-            candidate,
-            &ComparisonInputs {
-                after_controls: after,
-                before_by_id,
-                before_conflicting_component_ids,
-                after_conflicting_component_ids,
-                replacement_use_counts,
-            },
-            false,
-            facts,
-        );
+        compare_existing(before, candidate, inputs, false, facts);
         return;
     }
     if !same_integrity.is_empty() {
@@ -507,17 +491,33 @@ fn push_existing_fact(kind: AgentStackProtectionDiffKind, roles: Vec<AgentStackP
 struct AggregatedControls {
     controls: Vec<AgentStackProtectionControl>,
     conflicting_component_ids: BTreeSet<String>,
+    enabled_conflicting_component_ids: BTreeSet<String>,
 }
 fn aggregate_controls(controls: &[AgentStackProtectionControl]) -> AggregatedControls {
     let mut by_id = BTreeMap::<String, AgentStackProtectionControl>::new();
     let mut conflicting_component_ids = BTreeSet::new();
+    let mut enabled_conflicting_component_ids = BTreeSet::new();
+    let mut integrity_conflicting_component_ids = BTreeSet::new();
     for control in controls {
         let component_id = control.component.component_id().as_str().to_owned();
         if let Some(existing) = by_id.get_mut(&component_id) {
             if duplicate_state_conflicts(existing, control) {
-                conflicting_component_ids.insert(component_id);
+                conflicting_component_ids.insert(component_id.clone());
             }
-            merge_control(existing, control);
+            if conflicting_values(existing.enabled, control.enabled) {
+                enabled_conflicting_component_ids.insert(component_id.clone());
+            }
+            if conflicting_values(
+                existing.component.integrity(),
+                control.component.integrity(),
+            ) {
+                integrity_conflicting_component_ids.insert(component_id.clone());
+            }
+            merge_control(
+                existing,
+                control,
+                integrity_conflicting_component_ids.contains(&component_id),
+            );
         } else {
             by_id.insert(component_id, control.clone());
         }
@@ -525,6 +525,7 @@ fn aggregate_controls(controls: &[AgentStackProtectionControl]) -> AggregatedCon
     AggregatedControls {
         controls: by_id.into_values().collect(),
         conflicting_component_ids,
+        enabled_conflicting_component_ids,
     }
 }
 fn duplicate_state_conflicts(
@@ -542,12 +543,15 @@ fn conflicting_values<T: Eq>(left: Option<T>, right: Option<T>) -> bool {
 fn merge_control(
     existing: &mut AgentStackProtectionControl,
     control: &AgentStackProtectionControl,
+    has_integrity_conflict: bool,
 ) {
-    if conflicting_values(
-        existing.component.integrity(),
-        control.component.integrity(),
-    ) {
+    if has_integrity_conflict {
         existing.component = existing.component.clone().with_integrity(None);
+    } else if existing.component.integrity().is_none() && control.component.integrity().is_some() {
+        existing.component = existing
+            .component
+            .clone()
+            .with_integrity(control.component.integrity().cloned());
     }
     existing.roles = merged_roles(existing.roles(), control.roles());
     existing.enabled = merged_after_enabled(existing.enabled, control.enabled);

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -60,6 +60,7 @@ closed_enum!(AgentStackProtectionControlReason {
     FailureModeRelaxed => "failure_mode_relaxed",
     PossibleRename => "possible_rename",
     AmbiguousReplacement => "ambiguous_replacement",
+    ConfidenceReduced => "confidence_reduced",
     ConflictingDuplicateReport => "conflicting_duplicate_report",
 });
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -67,11 +68,6 @@ pub enum AgentStackProtectionControlError {
     #[error("the protection role list contains a duplicate")]
     DuplicateRole,
 }
-/// Typed evidence that one Agent Stack component carries protection behavior.
-///
-/// A component is treated as protection-bearing only when explicit roles are
-/// supplied. This prevents hook or policy filenames from becoming protection
-/// claims on their own.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentStackProtectionControl {
     component: AgentStackComponent,
@@ -188,11 +184,6 @@ impl AgentStackProtectionControlDiff {
     pub fn confidence(&self) -> AgentStackProtectionConfidence { self.confidence }
     pub fn reason(&self) -> AgentStackProtectionControlReason { self.reason }
 }
-/// Emit weakening evidence for explicit protection-bearing controls.
-///
-/// The detector is intentionally evidence-driven: entries with no protection
-/// roles are ignored, renamed controls become review evidence, and equivalent
-/// replacements suppress removal facts.
 pub fn protective_control_diff(
     before: &[AgentStackProtectionControl],
     after: &[AgentStackProtectionControl],
@@ -223,6 +214,9 @@ pub fn protective_control_diff(
             Some(after_control) => compare_existing(
                 before_control,
                 after_control,
+                &after_controls.controls,
+                &before_by_id,
+                &before_controls.conflicting_component_ids,
                 has_before_conflict
                     || after_controls
                         .conflicting_component_ids
@@ -253,10 +247,23 @@ pub fn protective_control_diff(
 fn compare_existing(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
+    after_controls: &[AgentStackProtectionControl],
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
     has_conflicting_duplicate_state: bool,
     facts: &mut Vec<AgentStackProtectionControlDiff>,
 ) {
     let confidence = min_confidence(before.confidence, after.confidence);
+    if after.confidence.strength() < before.confidence.strength() {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            Some(before),
+            Some(after),
+            confidence,
+            AgentStackProtectionControlReason::ConfidenceReduced,
+        ));
+    }
     if before.enabled != Some(false) && after.enabled == Some(false) {
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::Disabled,
@@ -267,7 +274,13 @@ fn compare_existing(
             AgentStackProtectionControlReason::ExplicitlyDisabled,
         ));
     }
-    let missing_roles = missing_roles(before.roles(), after.roles());
+    let missing_roles = missing_roles_without_replacements(
+        before,
+        missing_roles(before.roles(), after.roles()),
+        after_controls,
+        before_by_id,
+        before_conflicting_component_ids,
+    );
     if !missing_roles.is_empty() {
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::ScopeReduced,
@@ -278,7 +291,16 @@ fn compare_existing(
             AgentStackProtectionControlReason::RoleSetReduced,
         ));
     }
-    if matches!((before.scope, after.scope), (Some(left), Some(right)) if right.strength() < left.strength())
+    if before.scope.is_some() && after.scope.is_none() {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            Some(before),
+            Some(after),
+            confidence,
+            AgentStackProtectionControlReason::ScopeLevelReduced,
+        ));
+    } else if matches!((before.scope, after.scope), (Some(left), Some(right)) if right.strength() < left.strength())
     {
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::ScopeReduced,
@@ -336,7 +358,15 @@ fn compare_removed(
             rename_confidence(before, candidate),
             AgentStackProtectionControlReason::PossibleRename,
         ));
-        compare_existing(before, candidate, false, facts);
+        compare_existing(
+            before,
+            candidate,
+            after,
+            before_by_id,
+            before_conflicting_component_ids,
+            false,
+            facts,
+        );
         return;
     }
     if !same_integrity.is_empty() {
@@ -467,11 +497,21 @@ fn candidate_is_new_protection(
     match before_by_id.get(component_id).copied() {
         Some(_) if matches!(mode, CandidateMode::SameIntegrity) => false,
         Some(_) if before_conflicting_component_ids.contains(component_id) => true,
-        Some(previous) => {
-            previous.enabled == Some(false) || !weak_equivalent_replacement(removed, previous)
-        }
+        Some(previous) => match mode {
+            CandidateMode::SameIntegrity => false,
+            CandidateMode::Equivalent => !equivalent_replacement(removed, previous),
+            CandidateMode::WeakEquivalent => !weak_equivalent_replacement(removed, previous),
+        },
         None => true,
     }
+}
+#[rustfmt::skip]
+fn missing_roles_without_replacements(before: &AgentStackProtectionControl, missing_roles: Vec<AgentStackProtectionRole>, after: &[AgentStackProtectionControl], before_by_id: &BTreeMap<String, &AgentStackProtectionControl>, before_conflicting_component_ids: &BTreeSet<String>) -> Vec<AgentStackProtectionRole> {
+    missing_roles.into_iter().filter(|role| {
+        let mut probe = before.clone();
+        probe.roles = vec![*role];
+        replacement_candidates(after, &probe, before_by_id, before_conflicting_component_ids, CandidateMode::Equivalent).is_empty()
+    }).collect()
 }
 fn equivalent_replacement(
     before: &AgentStackProtectionControl,

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -4,7 +4,6 @@ use super::{
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
-
 macro_rules! closed_enum {
     ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -18,7 +17,6 @@ macro_rules! closed_enum {
         }
     };
 }
-
 #[rustfmt::skip]
 closed_enum!(AgentStackProtectionRole {
     Policy => "policy",
@@ -64,13 +62,11 @@ closed_enum!(AgentStackProtectionControlReason {
     AmbiguousReplacement => "ambiguous_replacement",
     ConflictingDuplicateReport => "conflicting_duplicate_report",
 });
-
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum AgentStackProtectionControlError {
     #[error("the protection role list contains a duplicate")]
     DuplicateRole,
 }
-
 /// Typed evidence that one Agent Stack component carries protection behavior.
 ///
 /// A component is treated as protection-bearing only when explicit roles are
@@ -85,7 +81,6 @@ pub struct AgentStackProtectionControl {
     failure_mode: Option<AgentStackProtectionFailureMode>,
     confidence: AgentStackProtectionConfidence,
 }
-
 #[rustfmt::skip]
 impl AgentStackProtectionControl {
     pub fn new(
@@ -96,22 +91,18 @@ impl AgentStackProtectionControl {
         let roles = sorted_roles(roles)?;
         Ok(Self { component, roles, enabled: None, scope: None, failure_mode: None, confidence })
     }
-
     pub fn with_enabled(mut self, enabled: bool) -> Self {
         self.enabled = Some(enabled);
         self
     }
-
     pub fn with_scope(mut self, scope: AgentStackProtectionScope) -> Self {
         self.scope = Some(scope);
         self
     }
-
     pub fn with_failure_mode(mut self, failure_mode: AgentStackProtectionFailureMode) -> Self {
         self.failure_mode = Some(failure_mode);
         self
     }
-
     pub fn component(&self) -> &AgentStackComponent { &self.component }
     pub fn roles(&self) -> &[AgentStackProtectionRole] { &self.roles }
     pub fn enabled(&self) -> Option<bool> { self.enabled }
@@ -119,7 +110,6 @@ impl AgentStackProtectionControl {
     pub fn failure_mode(&self) -> Option<AgentStackProtectionFailureMode> { self.failure_mode }
     pub fn confidence(&self) -> AgentStackProtectionConfidence { self.confidence }
 }
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AgentStackProtectionControlEvidence {
     component_id: String,
@@ -134,7 +124,6 @@ pub struct AgentStackProtectionControlEvidence {
     failure_mode: Option<AgentStackProtectionFailureMode>,
     confidence: AgentStackProtectionConfidence,
 }
-
 #[rustfmt::skip]
 impl AgentStackProtectionControlEvidence {
     fn from_control(control: &AgentStackProtectionControl) -> Self {
@@ -152,7 +141,6 @@ impl AgentStackProtectionControlEvidence {
             confidence: control.confidence,
         }
     }
-
     pub fn component_id(&self) -> &str { &self.component_id }
     pub fn kind(&self) -> AgentStackComponentKind { self.kind }
     pub fn source_scope(&self) -> AgentStackSourceScope { self.source_scope }
@@ -165,7 +153,6 @@ impl AgentStackProtectionControlEvidence {
     pub fn failure_mode(&self) -> Option<AgentStackProtectionFailureMode> { self.failure_mode }
     pub fn confidence(&self) -> AgentStackProtectionConfidence { self.confidence }
 }
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AgentStackProtectionControlDiff {
     kind: AgentStackProtectionDiffKind,
@@ -175,7 +162,6 @@ pub struct AgentStackProtectionControlDiff {
     confidence: AgentStackProtectionConfidence,
     reason: AgentStackProtectionControlReason,
 }
-
 #[rustfmt::skip]
 impl AgentStackProtectionControlDiff {
     fn new(
@@ -195,7 +181,6 @@ impl AgentStackProtectionControlDiff {
             reason,
         }
     }
-
     pub fn kind(&self) -> AgentStackProtectionDiffKind { self.kind }
     pub fn roles(&self) -> &[AgentStackProtectionRole] { &self.roles }
     pub fn before(&self) -> Option<&AgentStackProtectionControlEvidence> { self.before.as_ref() }
@@ -203,7 +188,6 @@ impl AgentStackProtectionControlDiff {
     pub fn confidence(&self) -> AgentStackProtectionConfidence { self.confidence }
     pub fn reason(&self) -> AgentStackProtectionControlReason { self.reason }
 }
-
 /// Emit weakening evidence for explicit protection-bearing controls.
 ///
 /// The detector is intentionally evidence-driven: entries with no protection
@@ -213,41 +197,52 @@ pub fn protective_control_diff(
     before: &[AgentStackProtectionControl],
     after: &[AgentStackProtectionControl],
 ) -> Vec<AgentStackProtectionControlDiff> {
-    let before_by_id = by_component_id(before);
+    let before_controls = aggregate_controls(before);
+    let before_by_id = by_component_id(&before_controls.controls);
     let after_controls = aggregate_controls(after);
     let after_by_id = by_component_id(&after_controls.controls);
     let replacement_use_counts = replacement_use_counts(
-        before,
+        &before_controls.controls,
         &after_controls.controls,
         &before_by_id,
+        &before_controls.conflicting_component_ids,
         &after_by_id,
     );
     let mut facts = Vec::new();
-
-    for before_control in before {
-        if before_control.roles.is_empty() || before_control.enabled == Some(false) {
+    for before_control in &before_controls.controls {
+        let component_id = before_control.component.component_id().as_str();
+        let has_before_conflict = before_controls
+            .conflicting_component_ids
+            .contains(component_id);
+        if before_control.roles.is_empty()
+            || (before_control.enabled == Some(false) && !has_before_conflict)
+        {
             continue;
         }
-        let component_id = before_control.component.component_id().as_str();
         match after_by_id.get(component_id).copied() {
             Some(after_control) => compare_existing(
                 before_control,
                 after_control,
-                after_controls
-                    .conflicting_component_ids
-                    .contains(component_id),
+                has_before_conflict
+                    || after_controls
+                        .conflicting_component_ids
+                        .contains(component_id),
                 &mut facts,
             ),
+            None if has_before_conflict => {
+                push_conflicting_duplicate_fact(before_control, None, &mut facts);
+            }
             None => compare_removed(
                 before_control,
                 &after_controls.controls,
                 &before_by_id,
+                &before_controls.conflicting_component_ids,
+                &after_controls.conflicting_component_ids,
                 &replacement_use_counts,
                 &mut facts,
             ),
         }
     }
-
     facts.sort_by(|left, right| {
         fact_sort_key(left)
             .cmp(&fact_sort_key(right))
@@ -255,7 +250,6 @@ pub fn protective_control_diff(
     });
     facts
 }
-
 fn compare_existing(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
@@ -308,28 +302,32 @@ fn compare_existing(
         ));
     }
     if has_conflicting_duplicate_state {
-        facts.push(AgentStackProtectionControlDiff::new(
-            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
-            before.roles.clone(),
-            Some(before),
-            Some(after),
-            confidence,
-            AgentStackProtectionControlReason::ConflictingDuplicateReport,
-        ));
+        push_conflicting_duplicate_fact(before, Some(after), facts);
     }
 }
-
 fn compare_removed(
     before: &AgentStackProtectionControl,
     after: &[AgentStackProtectionControl],
     before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
+    after_conflicting_component_ids: &BTreeSet<String>,
     replacement_use_counts: &BTreeMap<String, usize>,
     facts: &mut Vec<AgentStackProtectionControlDiff>,
 ) {
-    let mut same_integrity =
-        replacement_candidates(after, before, before_by_id, CandidateMode::SameIntegrity);
+    let mut same_integrity = replacement_candidates(
+        after,
+        before,
+        before_by_id,
+        before_conflicting_component_ids,
+        CandidateMode::SameIntegrity,
+    );
     if same_integrity.len() == 1 {
         let candidate = same_integrity.remove(0);
+        let component_id = candidate.component.component_id().as_str();
+        if after_conflicting_component_ids.contains(component_id) {
+            push_conflicting_duplicate_fact(before, Some(candidate), facts);
+            return;
+        }
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
             before.roles.clone(),
@@ -352,24 +350,37 @@ fn compare_removed(
         ));
         return;
     }
-
-    let equivalent = replacement_candidates(after, before, before_by_id, CandidateMode::Equivalent);
+    let equivalent = replacement_candidates(
+        after,
+        before,
+        before_by_id,
+        before_conflicting_component_ids,
+        CandidateMode::Equivalent,
+    );
     if equivalent.len() == 1 {
         let candidate = equivalent[0];
+        let component_id = candidate.component.component_id().as_str();
+        let has_candidate_conflict = before_conflicting_component_ids.contains(component_id)
+            || after_conflicting_component_ids.contains(component_id);
         let use_count = replacement_use_counts
-            .get(candidate.component.component_id().as_str())
+            .get(component_id)
             .copied()
             .unwrap_or(0);
-        if use_count == 1 {
+        if use_count == 1 && !has_candidate_conflict {
             return;
         }
+        let reason = if has_candidate_conflict {
+            AgentStackProtectionControlReason::ConflictingDuplicateReport
+        } else {
+            AgentStackProtectionControlReason::AmbiguousReplacement
+        };
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
             before.roles.clone(),
             Some(before),
             Some(candidate),
             min_confidence(before.confidence, candidate.confidence),
-            AgentStackProtectionControlReason::AmbiguousReplacement,
+            reason,
         ));
         return;
     }
@@ -384,9 +395,13 @@ fn compare_removed(
         ));
         return;
     }
-
-    let weak_equivalent =
-        replacement_candidates(after, before, before_by_id, CandidateMode::WeakEquivalent);
+    let weak_equivalent = replacement_candidates(
+        after,
+        before,
+        before_by_id,
+        before_conflicting_component_ids,
+        CandidateMode::WeakEquivalent,
+    );
     if let Some(candidate) = weak_equivalent.first() {
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
@@ -398,7 +413,6 @@ fn compare_removed(
         ));
         return;
     }
-
     facts.push(AgentStackProtectionControlDiff::new(
         AgentStackProtectionDiffKind::Removed,
         before.roles.clone(),
@@ -408,23 +422,30 @@ fn compare_removed(
         AgentStackProtectionControlReason::RemovedWithoutEquivalent,
     ));
 }
-
 #[derive(Clone, Copy)]
 enum CandidateMode {
     SameIntegrity,
     Equivalent,
     WeakEquivalent,
 }
-
 fn replacement_candidates<'a>(
     after: &'a [AgentStackProtectionControl],
     before: &AgentStackProtectionControl,
     before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
     mode: CandidateMode,
 ) -> Vec<&'a AgentStackProtectionControl> {
     let mut candidates = after
         .iter()
-        .filter(|candidate| candidate_is_new_protection(candidate, before, before_by_id))
+        .filter(|candidate| {
+            candidate_is_new_protection(
+                candidate,
+                before,
+                before_by_id,
+                before_conflicting_component_ids,
+                mode,
+            )
+        })
         .filter(|candidate| role_overlap(before.roles(), candidate.roles()))
         .filter(|candidate| match mode {
             CandidateMode::SameIntegrity => same_integrity(before, candidate),
@@ -435,23 +456,23 @@ fn replacement_candidates<'a>(
     candidates.sort_by_key(|candidate| candidate.component.component_id().as_str());
     candidates
 }
-
 fn candidate_is_new_protection(
     candidate: &AgentStackProtectionControl,
     removed: &AgentStackProtectionControl,
     before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
+    mode: CandidateMode,
 ) -> bool {
-    match before_by_id
-        .get(candidate.component.component_id().as_str())
-        .copied()
-    {
+    let component_id = candidate.component.component_id().as_str();
+    match before_by_id.get(component_id).copied() {
+        Some(_) if matches!(mode, CandidateMode::SameIntegrity) => false,
+        Some(_) if before_conflicting_component_ids.contains(component_id) => true,
         Some(previous) => {
-            previous.enabled == Some(false) || !role_overlap(previous.roles(), removed.roles())
+            previous.enabled == Some(false) || !weak_equivalent_replacement(removed, previous)
         }
         None => true,
     }
 }
-
 fn equivalent_replacement(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
@@ -459,7 +480,6 @@ fn equivalent_replacement(
     after.confidence.strength() >= before.confidence.strength()
         && weak_equivalent_replacement(before, after)
 }
-
 fn weak_equivalent_replacement(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
@@ -471,7 +491,6 @@ fn weak_equivalent_replacement(
         && (before.failure_mode != Some(AgentStackProtectionFailureMode::FailClosed)
             || after.failure_mode == Some(AgentStackProtectionFailureMode::FailClosed))
 }
-
 fn scope_at_least(
     after: Option<AgentStackProtectionScope>,
     before: Option<AgentStackProtectionScope>,
@@ -483,7 +502,6 @@ fn scope_at_least(
         None => true,
     }
 }
-
 fn same_integrity(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
@@ -493,7 +511,6 @@ fn same_integrity(
         (Some(left), Some(right)) if left.as_str() == right.as_str()
     )
 }
-
 fn by_component_id(
     controls: &[AgentStackProtectionControl],
 ) -> BTreeMap<String, &AgentStackProtectionControl> {
@@ -507,12 +524,10 @@ fn by_component_id(
         })
         .collect()
 }
-
 struct AggregatedControls {
     controls: Vec<AgentStackProtectionControl>,
     conflicting_component_ids: BTreeSet<String>,
 }
-
 fn aggregate_controls(controls: &[AgentStackProtectionControl]) -> AggregatedControls {
     let mut by_id = BTreeMap::<String, AgentStackProtectionControl>::new();
     let mut conflicting_component_ids = BTreeSet::new();
@@ -532,7 +547,6 @@ fn aggregate_controls(controls: &[AgentStackProtectionControl]) -> AggregatedCon
         conflicting_component_ids,
     }
 }
-
 fn duplicate_state_conflicts(
     left: &AgentStackProtectionControl,
     right: &AgentStackProtectionControl,
@@ -540,27 +554,32 @@ fn duplicate_state_conflicts(
     conflicting_values(left.enabled, right.enabled)
         || conflicting_values(left.scope, right.scope)
         || conflicting_values(left.failure_mode, right.failure_mode)
+        || conflicting_values(left.component.integrity(), right.component.integrity())
 }
-
 fn conflicting_values<T: Eq>(left: Option<T>, right: Option<T>) -> bool {
     matches!((left, right), (Some(left), Some(right)) if left != right)
 }
-
 fn merge_control(
     existing: &mut AgentStackProtectionControl,
     control: &AgentStackProtectionControl,
 ) {
+    if conflicting_values(
+        existing.component.integrity(),
+        control.component.integrity(),
+    ) {
+        existing.component = existing.component.clone().with_integrity(None);
+    }
     existing.roles = merged_roles(existing.roles(), control.roles());
     existing.enabled = merged_after_enabled(existing.enabled, control.enabled);
     existing.scope = stronger_scope(existing.scope, control.scope);
     existing.failure_mode = stronger_failure_mode(existing.failure_mode, control.failure_mode);
     existing.confidence = min_confidence(existing.confidence, control.confidence);
 }
-
 fn replacement_use_counts(
     before: &[AgentStackProtectionControl],
     after: &[AgentStackProtectionControl],
     before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
     after_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
 ) -> BTreeMap<String, usize> {
     let mut counts = BTreeMap::new();
@@ -573,7 +592,13 @@ fn replacement_use_counts(
         }
         let mut used_ids = BTreeSet::new();
         for mode in [CandidateMode::SameIntegrity, CandidateMode::Equivalent] {
-            for candidate in replacement_candidates(after, before_control, before_by_id, mode) {
+            for candidate in replacement_candidates(
+                after,
+                before_control,
+                before_by_id,
+                before_conflicting_component_ids,
+                mode,
+            ) {
                 used_ids.insert(candidate.component.component_id().as_str().to_owned());
             }
         }
@@ -583,7 +608,23 @@ fn replacement_use_counts(
     }
     counts
 }
-
+fn push_conflicting_duplicate_fact(
+    before: &AgentStackProtectionControl,
+    after: Option<&AgentStackProtectionControl>,
+    facts: &mut Vec<AgentStackProtectionControlDiff>,
+) {
+    let confidence = after
+        .map(|after| min_confidence(before.confidence, after.confidence))
+        .unwrap_or(before.confidence);
+    facts.push(AgentStackProtectionControlDiff::new(
+        AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+        before.roles.clone(),
+        Some(before),
+        after,
+        confidence,
+        AgentStackProtectionControlReason::ConflictingDuplicateReport,
+    ));
+}
 fn sorted_roles(
     roles: impl IntoIterator<Item = AgentStackProtectionRole>,
 ) -> Result<Vec<AgentStackProtectionRole>, AgentStackProtectionControlError> {
@@ -598,7 +639,6 @@ fn sorted_roles(
     sorted.sort_by_key(AgentStackProtectionRole::as_str);
     Ok(sorted)
 }
-
 fn merged_roles(
     left: &[AgentStackProtectionRole],
     right: &[AgentStackProtectionRole],
@@ -612,7 +652,6 @@ fn merged_roles(
     roles.sort_by_key(AgentStackProtectionRole::as_str);
     roles
 }
-
 fn merged_after_enabled(left: Option<bool>, right: Option<bool>) -> Option<bool> {
     match (left, right) {
         (Some(false), _) | (_, Some(false)) => Some(false),
@@ -620,7 +659,6 @@ fn merged_after_enabled(left: Option<bool>, right: Option<bool>) -> Option<bool>
         _ => None,
     }
 }
-
 fn stronger_scope(
     left: Option<AgentStackProtectionScope>,
     right: Option<AgentStackProtectionScope>,
@@ -631,7 +669,6 @@ fn stronger_scope(
         (None, None) => None,
     }
 }
-
 fn stronger_failure_mode(
     left: Option<AgentStackProtectionFailureMode>,
     right: Option<AgentStackProtectionFailureMode>,
@@ -644,15 +681,12 @@ fn stronger_failure_mode(
         left.or(right)
     }
 }
-
 fn role_overlap(left: &[AgentStackProtectionRole], right: &[AgentStackProtectionRole]) -> bool {
     left.iter().any(|role| right.contains(role))
 }
-
 fn roles_include(left: &[AgentStackProtectionRole], right: &[AgentStackProtectionRole]) -> bool {
     right.iter().all(|role| left.contains(role))
 }
-
 fn missing_roles(
     before: &[AgentStackProtectionRole],
     after: &[AgentStackProtectionRole],
@@ -663,7 +697,6 @@ fn missing_roles(
         .filter(|role| !after.contains(role))
         .collect()
 }
-
 fn min_confidence(
     left: AgentStackProtectionConfidence,
     right: AgentStackProtectionConfidence,
@@ -675,7 +708,6 @@ fn min_confidence(
         _ => Confidence::High,
     }
 }
-
 fn rename_confidence(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
@@ -685,7 +717,6 @@ fn rename_confidence(
         AgentStackProtectionConfidence::Medium,
     )
 }
-
 fn fact_sort_key(fact: &AgentStackProtectionControlDiff) -> (&str, &'static str) {
     let component_id = fact
         .before
@@ -695,7 +726,6 @@ fn fact_sort_key(fact: &AgentStackProtectionControlDiff) -> (&str, &'static str)
         .unwrap_or("");
     (component_id, fact.kind.as_str())
 }
-
 impl AgentStackProtectionScope {
     const fn strength(self) -> u8 {
         match self {
@@ -706,7 +736,6 @@ impl AgentStackProtectionScope {
         }
     }
 }
-
 impl AgentStackProtectionConfidence {
     const fn strength(self) -> u8 {
         match self {

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -212,17 +212,22 @@ pub fn protective_control_diff(
     before: &[AgentStackProtectionControl],
     after: &[AgentStackProtectionControl],
 ) -> Vec<AgentStackProtectionControlDiff> {
+    let before_ids = component_ids(before);
     let after_by_id = by_component_id(after);
     let mut facts = Vec::new();
 
     for before_control in before {
-        if before_control.roles.is_empty() {
+        if before_control.roles.is_empty() || before_control.enabled == Some(false) {
             continue;
         }
         let component_id = before_control.component.component_id().as_str();
-        match after_by_id.get(component_id).copied() {
-            Some(after_control) => compare_existing(before_control, after_control, &mut facts),
-            None => compare_removed(before_control, after, &mut facts),
+        match after_by_id.get(component_id) {
+            Some(after_controls) => {
+                for after_control in after_controls {
+                    compare_existing(before_control, after_control, &mut facts);
+                }
+            }
+            None => compare_removed(before_control, after, &before_ids, &mut facts),
         }
     }
 
@@ -289,9 +294,11 @@ fn compare_existing(
 fn compare_removed(
     before: &AgentStackProtectionControl,
     after: &[AgentStackProtectionControl],
+    before_ids: &BTreeSet<String>,
     facts: &mut Vec<AgentStackProtectionControlDiff>,
 ) {
-    let mut same_integrity = replacement_candidates(after, before, CandidateMode::SameIntegrity);
+    let mut same_integrity =
+        replacement_candidates(after, before, before_ids, CandidateMode::SameIntegrity);
     if let Some(candidate) = same_integrity.pop() {
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
@@ -301,10 +308,11 @@ fn compare_removed(
             AgentStackProtectionConfidence::Medium,
             AgentStackProtectionControlReason::PossibleRename,
         ));
+        compare_existing(before, candidate, facts);
         return;
     }
 
-    let equivalent = replacement_candidates(after, before, CandidateMode::Equivalent);
+    let equivalent = replacement_candidates(after, before, before_ids, CandidateMode::Equivalent);
     if equivalent.len() == 1 {
         return;
     }
@@ -315,6 +323,20 @@ fn compare_removed(
             Some(before),
             Some(candidate),
             AgentStackProtectionConfidence::Low,
+            AgentStackProtectionControlReason::AmbiguousReplacement,
+        ));
+        return;
+    }
+
+    let weak_equivalent =
+        replacement_candidates(after, before, before_ids, CandidateMode::WeakEquivalent);
+    if let Some(candidate) = weak_equivalent.first() {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            Some(before),
+            Some(candidate),
+            min_confidence(before.confidence, candidate.confidence),
             AgentStackProtectionControlReason::AmbiguousReplacement,
         ));
         return;
@@ -334,19 +356,23 @@ fn compare_removed(
 enum CandidateMode {
     SameIntegrity,
     Equivalent,
+    WeakEquivalent,
 }
 
 fn replacement_candidates<'a>(
     after: &'a [AgentStackProtectionControl],
     before: &AgentStackProtectionControl,
+    before_ids: &BTreeSet<String>,
     mode: CandidateMode,
 ) -> Vec<&'a AgentStackProtectionControl> {
     let mut candidates = after
         .iter()
+        .filter(|candidate| !before_ids.contains(candidate.component.component_id().as_str()))
         .filter(|candidate| role_overlap(before.roles(), candidate.roles()))
         .filter(|candidate| match mode {
             CandidateMode::SameIntegrity => same_integrity(before, candidate),
             CandidateMode::Equivalent => equivalent_replacement(before, candidate),
+            CandidateMode::WeakEquivalent => weak_equivalent_replacement(before, candidate),
         })
         .collect::<Vec<_>>();
     candidates.sort_by_key(|candidate| candidate.component.component_id().as_str());
@@ -354,6 +380,14 @@ fn replacement_candidates<'a>(
 }
 
 fn equivalent_replacement(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+) -> bool {
+    confidence_at_least(after.confidence, before.confidence)
+        && weak_equivalent_replacement(before, after)
+}
+
+fn weak_equivalent_replacement(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
 ) -> bool {
@@ -388,14 +422,22 @@ fn same_integrity(
 
 fn by_component_id(
     controls: &[AgentStackProtectionControl],
-) -> BTreeMap<String, &AgentStackProtectionControl> {
+) -> BTreeMap<String, Vec<&AgentStackProtectionControl>> {
     let mut by_id = BTreeMap::new();
     for control in controls {
         by_id
             .entry(control.component.component_id().as_str().to_owned())
-            .or_insert(control);
+            .or_insert_with(Vec::new)
+            .push(control);
     }
     by_id
+}
+
+fn component_ids(controls: &[AgentStackProtectionControl]) -> BTreeSet<String> {
+    controls
+        .iter()
+        .map(|control| control.component.component_id().as_str().to_owned())
+        .collect()
 }
 
 fn sorted_roles(
@@ -442,6 +484,13 @@ fn min_confidence(
         (2, _) | (_, 2) => Confidence::Medium,
         _ => Confidence::High,
     }
+}
+
+fn confidence_at_least(
+    left: AgentStackProtectionConfidence,
+    right: AgentStackProtectionConfidence,
+) -> bool {
+    left.strength() >= right.strength()
 }
 
 fn fact_sort_key(fact: &AgentStackProtectionControlDiff) -> (&str, &'static str) {

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -1,0 +1,476 @@
+use super::{
+    AgentStackCapability, AgentStackComponent, AgentStackComponentKind, AgentStackSourceScope,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use thiserror::Error;
+
+macro_rules! closed_enum {
+    ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub enum $name { $($variant),+ }
+        impl $name {
+            pub const ALL: &'static [Self] = &[$(Self::$variant),+];
+            pub const fn as_str(&self) -> &'static str {
+                match self { $(Self::$variant => $wire),+ }
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+closed_enum!(AgentStackProtectionRole {
+    Policy => "policy",
+    Hook => "hook",
+    Validation => "validation",
+    Sandboxing => "sandboxing",
+    Check => "check",
+});
+#[rustfmt::skip]
+closed_enum!(AgentStackProtectionDiffKind {
+    Removed => "removed",
+    Disabled => "disabled",
+    ScopeReduced => "scope_reduced",
+    FailOpen => "fail_open",
+    AmbiguousReviewEvidence => "ambiguous_review_evidence",
+});
+#[rustfmt::skip]
+closed_enum!(AgentStackProtectionConfidence {
+    Low => "low",
+    Medium => "medium",
+    High => "high",
+});
+#[rustfmt::skip]
+closed_enum!(AgentStackProtectionFailureMode {
+    FailOpen => "fail_open",
+    FailClosed => "fail_closed",
+});
+#[rustfmt::skip]
+closed_enum!(AgentStackProtectionScope {
+    Advisory => "advisory",
+    Partial => "partial",
+    Required => "required",
+    Comprehensive => "comprehensive",
+});
+#[rustfmt::skip]
+closed_enum!(AgentStackProtectionControlReason {
+    RemovedWithoutEquivalent => "removed_without_equivalent",
+    ExplicitlyDisabled => "explicitly_disabled",
+    RoleSetReduced => "role_set_reduced",
+    ScopeLevelReduced => "scope_level_reduced",
+    FailureModeRelaxed => "failure_mode_relaxed",
+    PossibleRename => "possible_rename",
+    AmbiguousReplacement => "ambiguous_replacement",
+});
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum AgentStackProtectionControlError {
+    #[error("the protection role list contains a duplicate")]
+    DuplicateRole,
+}
+
+/// Typed evidence that one Agent Stack component carries protection behavior.
+///
+/// A component is treated as protection-bearing only when explicit roles are
+/// supplied. This prevents hook or policy filenames from becoming protection
+/// claims on their own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentStackProtectionControl {
+    component: AgentStackComponent,
+    roles: Vec<AgentStackProtectionRole>,
+    enabled: Option<bool>,
+    scope: Option<AgentStackProtectionScope>,
+    failure_mode: Option<AgentStackProtectionFailureMode>,
+    confidence: AgentStackProtectionConfidence,
+}
+
+#[rustfmt::skip]
+impl AgentStackProtectionControl {
+    pub fn new(
+        component: AgentStackComponent,
+        roles: impl IntoIterator<Item = AgentStackProtectionRole>,
+        confidence: AgentStackProtectionConfidence,
+    ) -> Result<Self, AgentStackProtectionControlError> {
+        let roles = sorted_roles(roles)?;
+        Ok(Self { component, roles, enabled: None, scope: None, failure_mode: None, confidence })
+    }
+
+    pub fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = Some(enabled);
+        self
+    }
+
+    pub fn with_scope(mut self, scope: AgentStackProtectionScope) -> Self {
+        self.scope = Some(scope);
+        self
+    }
+
+    pub fn with_failure_mode(mut self, failure_mode: AgentStackProtectionFailureMode) -> Self {
+        self.failure_mode = Some(failure_mode);
+        self
+    }
+
+    pub fn component(&self) -> &AgentStackComponent { &self.component }
+    pub fn roles(&self) -> &[AgentStackProtectionRole] { &self.roles }
+    pub fn enabled(&self) -> Option<bool> { self.enabled }
+    pub fn scope(&self) -> Option<AgentStackProtectionScope> { self.scope }
+    pub fn failure_mode(&self) -> Option<AgentStackProtectionFailureMode> { self.failure_mode }
+    pub fn confidence(&self) -> AgentStackProtectionConfidence { self.confidence }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AgentStackProtectionControlEvidence {
+    component_id: String,
+    kind: AgentStackComponentKind,
+    source_scope: AgentStackSourceScope,
+    source_locator: String,
+    integrity: Option<String>,
+    capabilities: Vec<AgentStackCapability>,
+    roles: Vec<AgentStackProtectionRole>,
+    enabled: Option<bool>,
+    scope: Option<AgentStackProtectionScope>,
+    failure_mode: Option<AgentStackProtectionFailureMode>,
+    confidence: AgentStackProtectionConfidence,
+}
+
+#[rustfmt::skip]
+impl AgentStackProtectionControlEvidence {
+    fn from_control(control: &AgentStackProtectionControl) -> Self {
+        Self {
+            component_id: control.component.component_id().as_str().to_owned(),
+            kind: control.component.kind(),
+            source_scope: control.component.source().scope(),
+            source_locator: control.component.source().locator().as_str().to_owned(),
+            integrity: control.component.integrity().map(|digest| digest.as_str().to_owned()),
+            capabilities: control.component.capabilities().to_vec(),
+            roles: control.roles.clone(),
+            enabled: control.enabled,
+            scope: control.scope,
+            failure_mode: control.failure_mode,
+            confidence: control.confidence,
+        }
+    }
+
+    pub fn component_id(&self) -> &str { &self.component_id }
+    pub fn kind(&self) -> AgentStackComponentKind { self.kind }
+    pub fn source_scope(&self) -> AgentStackSourceScope { self.source_scope }
+    pub fn source_locator(&self) -> &str { &self.source_locator }
+    pub fn integrity(&self) -> Option<&str> { self.integrity.as_deref() }
+    pub fn capabilities(&self) -> &[AgentStackCapability] { &self.capabilities }
+    pub fn roles(&self) -> &[AgentStackProtectionRole] { &self.roles }
+    pub fn enabled(&self) -> Option<bool> { self.enabled }
+    pub fn scope(&self) -> Option<AgentStackProtectionScope> { self.scope }
+    pub fn failure_mode(&self) -> Option<AgentStackProtectionFailureMode> { self.failure_mode }
+    pub fn confidence(&self) -> AgentStackProtectionConfidence { self.confidence }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AgentStackProtectionControlDiff {
+    kind: AgentStackProtectionDiffKind,
+    roles: Vec<AgentStackProtectionRole>,
+    before: Option<AgentStackProtectionControlEvidence>,
+    after: Option<AgentStackProtectionControlEvidence>,
+    confidence: AgentStackProtectionConfidence,
+    reason: AgentStackProtectionControlReason,
+}
+
+#[rustfmt::skip]
+impl AgentStackProtectionControlDiff {
+    fn new(
+        kind: AgentStackProtectionDiffKind,
+        roles: Vec<AgentStackProtectionRole>,
+        before: Option<&AgentStackProtectionControl>,
+        after: Option<&AgentStackProtectionControl>,
+        confidence: AgentStackProtectionConfidence,
+        reason: AgentStackProtectionControlReason,
+    ) -> Self {
+        Self {
+            kind,
+            roles,
+            before: before.map(AgentStackProtectionControlEvidence::from_control),
+            after: after.map(AgentStackProtectionControlEvidence::from_control),
+            confidence,
+            reason,
+        }
+    }
+
+    pub fn kind(&self) -> AgentStackProtectionDiffKind { self.kind }
+    pub fn roles(&self) -> &[AgentStackProtectionRole] { &self.roles }
+    pub fn before(&self) -> Option<&AgentStackProtectionControlEvidence> { self.before.as_ref() }
+    pub fn after(&self) -> Option<&AgentStackProtectionControlEvidence> { self.after.as_ref() }
+    pub fn confidence(&self) -> AgentStackProtectionConfidence { self.confidence }
+    pub fn reason(&self) -> AgentStackProtectionControlReason { self.reason }
+}
+
+/// Emit weakening evidence for explicit protection-bearing controls.
+///
+/// The detector is intentionally evidence-driven: entries with no protection
+/// roles are ignored, renamed controls become review evidence, and equivalent
+/// replacements suppress removal facts.
+pub fn protective_control_diff(
+    before: &[AgentStackProtectionControl],
+    after: &[AgentStackProtectionControl],
+) -> Vec<AgentStackProtectionControlDiff> {
+    let after_by_id = by_component_id(after);
+    let mut facts = Vec::new();
+
+    for before_control in before {
+        if before_control.roles.is_empty() {
+            continue;
+        }
+        let component_id = before_control.component.component_id().as_str();
+        match after_by_id.get(component_id).copied() {
+            Some(after_control) => compare_existing(before_control, after_control, &mut facts),
+            None => compare_removed(before_control, after, &mut facts),
+        }
+    }
+
+    facts.sort_by(|left, right| {
+        fact_sort_key(left)
+            .cmp(&fact_sort_key(right))
+            .then_with(|| left.reason.as_str().cmp(right.reason.as_str()))
+    });
+    facts
+}
+
+fn compare_existing(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+    facts: &mut Vec<AgentStackProtectionControlDiff>,
+) {
+    let confidence = min_confidence(before.confidence, after.confidence);
+    if before.enabled == Some(true) && after.enabled == Some(false) {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::Disabled,
+            before.roles.clone(),
+            Some(before),
+            Some(after),
+            confidence,
+            AgentStackProtectionControlReason::ExplicitlyDisabled,
+        ));
+    }
+    let missing_roles = missing_roles(before.roles(), after.roles());
+    if !missing_roles.is_empty() {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::ScopeReduced,
+            missing_roles,
+            Some(before),
+            Some(after),
+            confidence,
+            AgentStackProtectionControlReason::RoleSetReduced,
+        ));
+    }
+    if matches!((before.scope, after.scope), (Some(left), Some(right)) if right.strength() < left.strength())
+    {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::ScopeReduced,
+            before.roles.clone(),
+            Some(before),
+            Some(after),
+            confidence,
+            AgentStackProtectionControlReason::ScopeLevelReduced,
+        ));
+    }
+    if before.failure_mode == Some(AgentStackProtectionFailureMode::FailClosed)
+        && after.failure_mode == Some(AgentStackProtectionFailureMode::FailOpen)
+    {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::FailOpen,
+            before.roles.clone(),
+            Some(before),
+            Some(after),
+            confidence,
+            AgentStackProtectionControlReason::FailureModeRelaxed,
+        ));
+    }
+}
+
+fn compare_removed(
+    before: &AgentStackProtectionControl,
+    after: &[AgentStackProtectionControl],
+    facts: &mut Vec<AgentStackProtectionControlDiff>,
+) {
+    let mut same_integrity = replacement_candidates(after, before, CandidateMode::SameIntegrity);
+    if let Some(candidate) = same_integrity.pop() {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            Some(before),
+            Some(candidate),
+            AgentStackProtectionConfidence::Medium,
+            AgentStackProtectionControlReason::PossibleRename,
+        ));
+        return;
+    }
+
+    let equivalent = replacement_candidates(after, before, CandidateMode::Equivalent);
+    if equivalent.len() == 1 {
+        return;
+    }
+    if let Some(candidate) = equivalent.first() {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            Some(before),
+            Some(candidate),
+            AgentStackProtectionConfidence::Low,
+            AgentStackProtectionControlReason::AmbiguousReplacement,
+        ));
+        return;
+    }
+
+    facts.push(AgentStackProtectionControlDiff::new(
+        AgentStackProtectionDiffKind::Removed,
+        before.roles.clone(),
+        Some(before),
+        None,
+        before.confidence,
+        AgentStackProtectionControlReason::RemovedWithoutEquivalent,
+    ));
+}
+
+#[derive(Clone, Copy)]
+enum CandidateMode {
+    SameIntegrity,
+    Equivalent,
+}
+
+fn replacement_candidates<'a>(
+    after: &'a [AgentStackProtectionControl],
+    before: &AgentStackProtectionControl,
+    mode: CandidateMode,
+) -> Vec<&'a AgentStackProtectionControl> {
+    let mut candidates = after
+        .iter()
+        .filter(|candidate| role_overlap(before.roles(), candidate.roles()))
+        .filter(|candidate| match mode {
+            CandidateMode::SameIntegrity => same_integrity(before, candidate),
+            CandidateMode::Equivalent => equivalent_replacement(before, candidate),
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|candidate| candidate.component.component_id().as_str());
+    candidates
+}
+
+fn equivalent_replacement(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+) -> bool {
+    roles_include(after.roles(), before.roles())
+        && (before.enabled != Some(true) || after.enabled == Some(true))
+        && scope_at_least(after.scope, before.scope)
+        && (before.failure_mode != Some(AgentStackProtectionFailureMode::FailClosed)
+            || after.failure_mode == Some(AgentStackProtectionFailureMode::FailClosed))
+}
+
+fn scope_at_least(
+    after: Option<AgentStackProtectionScope>,
+    before: Option<AgentStackProtectionScope>,
+) -> bool {
+    match before {
+        Some(before_scope) => {
+            after.is_some_and(|after_scope| after_scope.strength() >= before_scope.strength())
+        }
+        None => true,
+    }
+}
+
+fn same_integrity(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+) -> bool {
+    matches!(
+        (before.component.integrity(), after.component.integrity()),
+        (Some(left), Some(right)) if left.as_str() == right.as_str()
+    )
+}
+
+fn by_component_id(
+    controls: &[AgentStackProtectionControl],
+) -> BTreeMap<String, &AgentStackProtectionControl> {
+    let mut by_id = BTreeMap::new();
+    for control in controls {
+        by_id
+            .entry(control.component.component_id().as_str().to_owned())
+            .or_insert(control);
+    }
+    by_id
+}
+
+fn sorted_roles(
+    roles: impl IntoIterator<Item = AgentStackProtectionRole>,
+) -> Result<Vec<AgentStackProtectionRole>, AgentStackProtectionControlError> {
+    let mut seen = BTreeSet::new();
+    let mut sorted = Vec::new();
+    for role in roles {
+        if !seen.insert(role.as_str()) {
+            return Err(AgentStackProtectionControlError::DuplicateRole);
+        }
+        sorted.push(role);
+    }
+    sorted.sort_by_key(AgentStackProtectionRole::as_str);
+    Ok(sorted)
+}
+
+fn role_overlap(left: &[AgentStackProtectionRole], right: &[AgentStackProtectionRole]) -> bool {
+    left.iter().any(|role| right.contains(role))
+}
+
+fn roles_include(left: &[AgentStackProtectionRole], right: &[AgentStackProtectionRole]) -> bool {
+    right.iter().all(|role| left.contains(role))
+}
+
+fn missing_roles(
+    before: &[AgentStackProtectionRole],
+    after: &[AgentStackProtectionRole],
+) -> Vec<AgentStackProtectionRole> {
+    before
+        .iter()
+        .copied()
+        .filter(|role| !after.contains(role))
+        .collect()
+}
+
+fn min_confidence(
+    left: AgentStackProtectionConfidence,
+    right: AgentStackProtectionConfidence,
+) -> AgentStackProtectionConfidence {
+    use AgentStackProtectionConfidence as Confidence;
+    match (left.strength(), right.strength()) {
+        (1, _) | (_, 1) => Confidence::Low,
+        (2, _) | (_, 2) => Confidence::Medium,
+        _ => Confidence::High,
+    }
+}
+
+fn fact_sort_key(fact: &AgentStackProtectionControlDiff) -> (&str, &'static str) {
+    let component_id = fact
+        .before
+        .as_ref()
+        .or(fact.after.as_ref())
+        .map(|evidence| evidence.component_id.as_str())
+        .unwrap_or("");
+    (component_id, fact.kind.as_str())
+}
+
+impl AgentStackProtectionScope {
+    const fn strength(self) -> u8 {
+        match self {
+            Self::Advisory => 1,
+            Self::Partial => 2,
+            Self::Required => 3,
+            Self::Comprehensive => 4,
+        }
+    }
+}
+
+impl AgentStackProtectionConfidence {
+    const fn strength(self) -> u8 {
+        match self {
+            Self::Low => 1,
+            Self::Medium => 2,
+            Self::High => 3,
+        }
+    }
+}

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -10,7 +10,7 @@ mod replacements;
 use existing::compare_existing;
 use replacements::{
     analyze_role_replacements, by_component_id, replacement_candidates, replacement_use_counts,
-    CandidateMode,
+    CandidateMode, ReplacementStateConflicts,
 };
 macro_rules! closed_enum {
     ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
@@ -173,6 +173,7 @@ struct ComparisonInputs<'before, 'after> {
     before_by_id: &'before BTreeMap<String, &'before AgentStackProtectionControl>,
     before_conflicting_component_ids: &'before BTreeSet<String>,
     after_conflicting_component_ids: &'after BTreeSet<String>,
+    before_enabled_conflicting_component_ids: &'before BTreeSet<String>,
     after_enabled_conflicting_component_ids: &'after BTreeSet<String>,
     before_scope_conflicting_component_ids: &'before BTreeSet<String>,
     after_scope_conflicting_component_ids: &'after BTreeSet<String>,
@@ -220,13 +221,22 @@ pub fn protective_control_diff(
         &before_by_id,
         &before_controls.conflicting_component_ids,
         &after_by_id,
-        &after_controls.enabled_conflicting_component_ids,
+        ReplacementStateConflicts {
+            before_enabled: &before_controls.enabled_conflicting_component_ids,
+            after_enabled: &after_controls.enabled_conflicting_component_ids,
+            before_scope: &before_controls.scope_conflicting_component_ids,
+            after_scope: &after_controls.scope_conflicting_component_ids,
+            before_failure_mode: &before_controls.failure_mode_conflicting_component_ids,
+            after_failure_mode: &after_controls.failure_mode_conflicting_component_ids,
+        },
     );
     let comparison_inputs = ComparisonInputs {
         after_controls: &after_controls.controls,
         before_by_id: &before_by_id,
         before_conflicting_component_ids: &before_controls.conflicting_component_ids,
         after_conflicting_component_ids: &after_controls.conflicting_component_ids,
+        before_enabled_conflicting_component_ids: &before_controls
+            .enabled_conflicting_component_ids,
         after_enabled_conflicting_component_ids: &after_controls.enabled_conflicting_component_ids,
         before_scope_conflicting_component_ids: &before_controls.scope_conflicting_component_ids,
         after_scope_conflicting_component_ids: &after_controls.scope_conflicting_component_ids,

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -5,9 +5,12 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
 
+mod existing;
 mod replacements;
+use existing::compare_existing;
 use replacements::{
-    analyze_role_replacements, replacement_candidates, replacement_use_counts, CandidateMode,
+    analyze_role_replacements, by_component_id, replacement_candidates, replacement_use_counts,
+    CandidateMode,
 };
 macro_rules! closed_enum {
     ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
@@ -170,6 +173,7 @@ struct ComparisonInputs<'before, 'after> {
     before_by_id: &'before BTreeMap<String, &'before AgentStackProtectionControl>,
     before_conflicting_component_ids: &'before BTreeSet<String>,
     after_conflicting_component_ids: &'after BTreeSet<String>,
+    replacement_use_counts: &'before BTreeMap<String, usize>,
 }
 #[rustfmt::skip]
 impl AgentStackProtectionControlDiff {
@@ -217,6 +221,7 @@ pub fn protective_control_diff(
         before_by_id: &before_by_id,
         before_conflicting_component_ids: &before_controls.conflicting_component_ids,
         after_conflicting_component_ids: &after_controls.conflicting_component_ids,
+        replacement_use_counts: &replacement_use_counts,
     };
     let mut facts = Vec::new();
     for before_control in &before_controls.controls {
@@ -240,18 +245,22 @@ pub fn protective_control_diff(
                         .contains(component_id),
                 &mut facts,
             ),
-            None if has_before_conflict => {
-                push_conflicting_duplicate_fact(before_control, None, &mut facts);
+            None => {
+                if has_before_conflict {
+                    push_conflicting_duplicate_fact(before_control, None, &mut facts);
+                }
+                if before_control.enabled != Some(false) {
+                    compare_removed(
+                        before_control,
+                        &after_controls.controls,
+                        &before_by_id,
+                        &before_controls.conflicting_component_ids,
+                        &after_controls.conflicting_component_ids,
+                        &replacement_use_counts,
+                        &mut facts,
+                    );
+                }
             }
-            None => compare_removed(
-                before_control,
-                &after_controls.controls,
-                &before_by_id,
-                &before_controls.conflicting_component_ids,
-                &after_controls.conflicting_component_ids,
-                &replacement_use_counts,
-                &mut facts,
-            ),
         }
     }
     facts.sort_by(|left, right| {
@@ -260,123 +269,6 @@ pub fn protective_control_diff(
             .then_with(|| left.reason.as_str().cmp(right.reason.as_str()))
     });
     facts
-}
-fn compare_existing(
-    before: &AgentStackProtectionControl,
-    after: &AgentStackProtectionControl,
-    inputs: &ComparisonInputs<'_, '_>,
-    has_conflicting_duplicate_state: bool,
-    facts: &mut Vec<AgentStackProtectionControlDiff>,
-) {
-    let confidence = min_confidence(before.confidence, after.confidence);
-    if after.confidence.strength() < before.confidence.strength() {
-        push_existing_fact(
-            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::ConfidenceReduced,
-            facts,
-        );
-    }
-    match (before.enabled, after.enabled) {
-        (Some(true), None) => push_existing_fact(
-            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::EnablementEvidenceLost,
-            facts,
-        ),
-        (left, Some(false)) if left != Some(false) => push_existing_fact(
-            AgentStackProtectionDiffKind::Disabled,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::ExplicitlyDisabled,
-            facts,
-        ),
-        _ => {}
-    }
-    let replacements = analyze_role_replacements(
-        before,
-        missing_roles(before.roles(), after.roles()),
-        inputs.after_controls,
-        inputs.before_by_id,
-        inputs.before_conflicting_component_ids,
-        inputs.after_conflicting_component_ids,
-    );
-    for (candidate, conflicting_roles) in replacements.conflicting_replacements {
-        push_conflicting_duplicate_fact_with_roles(
-            before,
-            Some(candidate),
-            conflicting_roles,
-            facts,
-        );
-    }
-    if !replacements.uncovered_roles.is_empty() {
-        push_existing_fact(
-            AgentStackProtectionDiffKind::ScopeReduced,
-            replacements.uncovered_roles,
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::RoleSetReduced,
-            facts,
-        );
-    }
-    if before.scope.is_some() && after.scope.is_none() {
-        push_existing_fact(
-            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::ScopeLevelReduced,
-            facts,
-        );
-    } else if matches!((before.scope, after.scope), (Some(left), Some(right)) if right.strength() < left.strength())
-    {
-        push_existing_fact(
-            AgentStackProtectionDiffKind::ScopeReduced,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::ScopeLevelReduced,
-            facts,
-        );
-    }
-    match (before.failure_mode, after.failure_mode) {
-        (
-            Some(AgentStackProtectionFailureMode::FailClosed),
-            Some(AgentStackProtectionFailureMode::FailOpen),
-        ) => push_existing_fact(
-            AgentStackProtectionDiffKind::FailOpen,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::FailureModeRelaxed,
-            facts,
-        ),
-        (Some(AgentStackProtectionFailureMode::FailClosed), None) => push_existing_fact(
-            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::FailureModeRelaxed,
-            facts,
-        ),
-        _ => {}
-    }
-    if has_conflicting_duplicate_state {
-        push_conflicting_duplicate_fact(before, Some(after), facts);
-    }
 }
 fn compare_removed(
     before: &AgentStackProtectionControl,
@@ -457,6 +349,7 @@ fn compare_removed(
                 before_by_id,
                 before_conflicting_component_ids,
                 after_conflicting_component_ids,
+                replacement_use_counts,
             },
             false,
             facts,
@@ -472,6 +365,25 @@ fn compare_removed(
             min_confidence(before.confidence, AgentStackProtectionConfidence::Medium),
             AgentStackProtectionControlReason::PossibleRename,
         ));
+        let uncovered_roles = analyze_role_replacements(
+            before,
+            before.roles.clone(),
+            after,
+            before_by_id,
+            before_conflicting_component_ids,
+            after_conflicting_component_ids,
+        )
+        .uncovered_roles;
+        if !uncovered_roles.is_empty() {
+            facts.push(AgentStackProtectionControlDiff::new(
+                AgentStackProtectionDiffKind::Removed,
+                uncovered_roles,
+                Some(before),
+                None,
+                before.confidence,
+                AgentStackProtectionControlReason::RemovedWithoutEquivalent,
+            ));
+        }
         return;
     }
     let equivalent = replacement_candidates(
@@ -591,19 +503,6 @@ fn compare_removed(
 #[rustfmt::skip]
 fn push_existing_fact(kind: AgentStackProtectionDiffKind, roles: Vec<AgentStackProtectionRole>, before: &AgentStackProtectionControl, after: &AgentStackProtectionControl, confidence: AgentStackProtectionConfidence, reason: AgentStackProtectionControlReason, facts: &mut Vec<AgentStackProtectionControlDiff>) {
     facts.push(AgentStackProtectionControlDiff::new(kind, roles, Some(before), Some(after), confidence, reason));
-}
-fn by_component_id(
-    controls: &[AgentStackProtectionControl],
-) -> BTreeMap<String, &AgentStackProtectionControl> {
-    controls
-        .iter()
-        .map(|control| {
-            (
-                control.component.component_id().as_str().to_owned(),
-                control,
-            )
-        })
-        .collect()
 }
 struct AggregatedControls {
     controls: Vec<AgentStackProtectionControl>,
@@ -736,16 +635,6 @@ fn stronger_failure_mode(
     } else {
         left.or(right)
     }
-}
-fn missing_roles(
-    before: &[AgentStackProtectionRole],
-    after: &[AgentStackProtectionRole],
-) -> Vec<AgentStackProtectionRole> {
-    before
-        .iter()
-        .copied()
-        .filter(|role| !after.contains(role))
-        .collect()
 }
 fn min_confidence(
     left: AgentStackProtectionConfidence,

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -9,8 +9,9 @@ mod existing;
 mod replacements;
 use existing::compare_existing;
 use replacements::{
-    analyze_role_replacements, by_component_id, replacement_candidates, replacement_use_counts,
-    CandidateMode, ReplacementStateConflicts,
+    analyze_role_replacements, by_component_id, conflicted_replacement_uncovered_roles,
+    replacement_assignments, replacement_candidates, CandidateMode, ReplacementAssignmentIndex,
+    ReplacementCandidateConflicts, ReplacementStateConflicts, RoleReplacementCoverage,
 };
 macro_rules! closed_enum {
     ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
@@ -169,6 +170,7 @@ pub struct AgentStackProtectionControlDiff {
 }
 
 struct ComparisonInputs<'before, 'after> {
+    after_reports: &'after [AgentStackProtectionControl],
     after_controls: &'after [AgentStackProtectionControl],
     before_by_id: &'before BTreeMap<String, &'before AgentStackProtectionControl>,
     before_conflicting_component_ids: &'before BTreeSet<String>,
@@ -179,7 +181,7 @@ struct ComparisonInputs<'before, 'after> {
     after_scope_conflicting_component_ids: &'after BTreeSet<String>,
     before_failure_mode_conflicting_component_ids: &'before BTreeSet<String>,
     after_failure_mode_conflicting_component_ids: &'after BTreeSet<String>,
-    replacement_use_counts: &'before BTreeMap<String, usize>,
+    replacement_assignments: &'before ReplacementAssignmentIndex,
 }
 #[rustfmt::skip]
 impl AgentStackProtectionControlDiff {
@@ -215,7 +217,7 @@ pub fn protective_control_diff(
     let before_by_id = by_component_id(&before_controls.controls);
     let after_controls = aggregate_controls(after);
     let after_by_id = by_component_id(&after_controls.controls);
-    let replacement_use_counts = replacement_use_counts(
+    let replacement_assignments = replacement_assignments(
         &before_controls.controls,
         &after_controls.controls,
         &before_by_id,
@@ -232,6 +234,7 @@ pub fn protective_control_diff(
         },
     );
     let comparison_inputs = ComparisonInputs {
+        after_reports: after,
         after_controls: &after_controls.controls,
         before_by_id: &before_by_id,
         before_conflicting_component_ids: &before_controls.conflicting_component_ids,
@@ -245,7 +248,7 @@ pub fn protective_control_diff(
             .failure_mode_conflicting_component_ids,
         after_failure_mode_conflicting_component_ids: &after_controls
             .failure_mode_conflicting_component_ids,
-        replacement_use_counts: &replacement_use_counts,
+        replacement_assignments: &replacement_assignments,
     };
     let mut facts = Vec::new();
     for before_control in &before_controls.controls {
@@ -298,7 +301,7 @@ fn compare_removed(
     let before_by_id = inputs.before_by_id;
     let before_conflicting_component_ids = inputs.before_conflicting_component_ids;
     let after_conflicting_component_ids = inputs.after_conflicting_component_ids;
-    let replacement_use_counts = inputs.replacement_use_counts;
+    let replacement_assignments = inputs.replacement_assignments;
     let mut same_integrity = replacement_candidates(
         after,
         before,
@@ -325,7 +328,18 @@ fn compare_removed(
                 before_conflicting_component_ids,
                 after_conflicting_component_ids,
             );
-            let mut uncovered_roles = replacements.uncovered_roles;
+            let uncovered_roles = conflicted_replacement_uncovered_roles(
+                before,
+                after,
+                inputs.after_reports,
+                before_by_id,
+                ReplacementCandidateConflicts {
+                    before_any: before_conflicting_component_ids,
+                    after_any: after_conflicting_component_ids,
+                },
+                &replacements.conflicting_replacements,
+                component_id,
+            );
             let mut conflicting_replacements = replacements.conflicting_replacements;
             let overlapping_roles = before
                 .roles
@@ -333,7 +347,6 @@ fn compare_removed(
                 .copied()
                 .filter(|role| candidate.roles.contains(role))
                 .collect::<Vec<_>>();
-            uncovered_roles.retain(|role| !overlapping_roles.contains(role));
             if let Some((_, roles)) =
                 conflicting_replacements
                     .iter_mut()
@@ -368,13 +381,9 @@ fn compare_removed(
             rename_confidence(before, candidate),
             AgentStackProtectionControlReason::PossibleRename,
         ));
-        let has_safe_independent_equivalent = equivalent.iter().any(|replacement| {
-            let replacement_id = replacement.component.component_id().as_str();
-            replacement_id != component_id
-                && !before_conflicting_component_ids.contains(replacement_id)
-                && !after_conflicting_component_ids.contains(replacement_id)
-                && replacement_use_counts.get(replacement_id).copied() == Some(1)
-        });
+        let has_safe_independent_equivalent = replacement_assignments
+            .unique_candidate_id(before, &before.roles)
+            .is_some_and(|replacement_id| replacement_id != component_id);
         if has_safe_independent_equivalent {
             return;
         }
@@ -425,19 +434,31 @@ fn compare_removed(
     } else {
         &safe_equivalent
     };
+    match replacement_assignments.coverage(before, &before.roles) {
+        Some(RoleReplacementCoverage::Unique) => return,
+        Some(RoleReplacementCoverage::Ambiguous) => {
+            let candidate = preferred_equivalent.first().copied();
+            let confidence = candidate.map_or(AgentStackProtectionConfidence::Low, |candidate| {
+                min_confidence(before.confidence, candidate.confidence)
+            });
+            facts.push(AgentStackProtectionControlDiff::new(
+                AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+                before.roles.clone(),
+                Some(before),
+                candidate,
+                confidence,
+                AgentStackProtectionControlReason::AmbiguousReplacement,
+            ));
+            return;
+        }
+        Some(RoleReplacementCoverage::Missing) | None => {}
+    }
     if preferred_equivalent.len() == 1 {
         let candidate = preferred_equivalent[0];
         let component_id = candidate.component.component_id().as_str();
-        let has_candidate_conflict = before_conflicting_component_ids.contains(component_id)
-            || after_conflicting_component_ids.contains(component_id);
-        let use_count = replacement_use_counts
-            .get(component_id)
-            .copied()
-            .unwrap_or(0);
-        if use_count == 1 && !has_candidate_conflict {
-            return;
-        }
-        let reason = if has_candidate_conflict {
+        let reason = if before_conflicting_component_ids.contains(component_id)
+            || after_conflicting_component_ids.contains(component_id)
+        {
             AgentStackProtectionControlReason::ConflictingDuplicateReport
         } else {
             AgentStackProtectionControlReason::AmbiguousReplacement

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -213,7 +213,10 @@ pub fn protective_control_diff(
     after: &[AgentStackProtectionControl],
 ) -> Vec<AgentStackProtectionControlDiff> {
     let before_ids = component_ids(before);
-    let after_by_id = by_component_id(after);
+    let after_controls = aggregate_controls(after);
+    let after_by_id = by_component_id(&after_controls);
+    let replacement_use_counts =
+        replacement_use_counts(before, &after_controls, &before_ids, &after_by_id);
     let mut facts = Vec::new();
 
     for before_control in before {
@@ -221,13 +224,15 @@ pub fn protective_control_diff(
             continue;
         }
         let component_id = before_control.component.component_id().as_str();
-        match after_by_id.get(component_id) {
-            Some(after_controls) => {
-                for after_control in after_controls {
-                    compare_existing(before_control, after_control, &mut facts);
-                }
-            }
-            None => compare_removed(before_control, after, &before_ids, &mut facts),
+        match after_by_id.get(component_id).copied() {
+            Some(after_control) => compare_existing(before_control, after_control, &mut facts),
+            None => compare_removed(
+                before_control,
+                &after_controls,
+                &before_ids,
+                &replacement_use_counts,
+                &mut facts,
+            ),
         }
     }
 
@@ -295,25 +300,54 @@ fn compare_removed(
     before: &AgentStackProtectionControl,
     after: &[AgentStackProtectionControl],
     before_ids: &BTreeSet<String>,
+    replacement_use_counts: &BTreeMap<String, usize>,
     facts: &mut Vec<AgentStackProtectionControlDiff>,
 ) {
     let mut same_integrity =
         replacement_candidates(after, before, before_ids, CandidateMode::SameIntegrity);
-    if let Some(candidate) = same_integrity.pop() {
+    if same_integrity.len() == 1 {
+        let candidate = same_integrity.remove(0);
         facts.push(AgentStackProtectionControlDiff::new(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
             before.roles.clone(),
             Some(before),
             Some(candidate),
-            AgentStackProtectionConfidence::Medium,
+            rename_confidence(before, candidate),
             AgentStackProtectionControlReason::PossibleRename,
         ));
         compare_existing(before, candidate, facts);
         return;
     }
+    if !same_integrity.is_empty() {
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            Some(before),
+            None,
+            min_confidence(before.confidence, AgentStackProtectionConfidence::Medium),
+            AgentStackProtectionControlReason::PossibleRename,
+        ));
+        return;
+    }
 
     let equivalent = replacement_candidates(after, before, before_ids, CandidateMode::Equivalent);
     if equivalent.len() == 1 {
+        let candidate = equivalent[0];
+        let use_count = replacement_use_counts
+            .get(candidate.component.component_id().as_str())
+            .copied()
+            .unwrap_or(0);
+        if use_count == 1 {
+            return;
+        }
+        facts.push(AgentStackProtectionControlDiff::new(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            Some(before),
+            Some(candidate),
+            min_confidence(before.confidence, candidate.confidence),
+            AgentStackProtectionControlReason::AmbiguousReplacement,
+        ));
         return;
     }
     if let Some(candidate) = equivalent.first() {
@@ -383,7 +417,7 @@ fn equivalent_replacement(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
 ) -> bool {
-    confidence_at_least(after.confidence, before.confidence)
+    after.confidence.strength() >= before.confidence.strength()
         && weak_equivalent_replacement(before, after)
 }
 
@@ -391,7 +425,8 @@ fn weak_equivalent_replacement(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
 ) -> bool {
-    roles_include(after.roles(), before.roles())
+    after.enabled != Some(false)
+        && roles_include(after.roles(), before.roles())
         && (before.enabled != Some(true) || after.enabled == Some(true))
         && scope_at_least(after.scope, before.scope)
         && (before.failure_mode != Some(AgentStackProtectionFailureMode::FailClosed)
@@ -422,15 +457,66 @@ fn same_integrity(
 
 fn by_component_id(
     controls: &[AgentStackProtectionControl],
-) -> BTreeMap<String, Vec<&AgentStackProtectionControl>> {
-    let mut by_id = BTreeMap::new();
+) -> BTreeMap<String, &AgentStackProtectionControl> {
+    controls
+        .iter()
+        .map(|control| {
+            (
+                control.component.component_id().as_str().to_owned(),
+                control,
+            )
+        })
+        .collect()
+}
+
+fn aggregate_controls(
+    controls: &[AgentStackProtectionControl],
+) -> Vec<AgentStackProtectionControl> {
+    let mut by_id = BTreeMap::<String, AgentStackProtectionControl>::new();
     for control in controls {
+        let component_id = control.component.component_id().as_str().to_owned();
         by_id
-            .entry(control.component.component_id().as_str().to_owned())
-            .or_insert_with(Vec::new)
-            .push(control);
+            .entry(component_id)
+            .and_modify(|existing| merge_control(existing, control))
+            .or_insert_with(|| control.clone());
     }
-    by_id
+    by_id.into_values().collect()
+}
+
+fn merge_control(
+    existing: &mut AgentStackProtectionControl,
+    control: &AgentStackProtectionControl,
+) {
+    existing.roles = merged_roles(existing.roles(), control.roles());
+    existing.enabled = merged_after_enabled(existing.enabled, control.enabled);
+    existing.scope = stronger_scope(existing.scope, control.scope);
+    existing.failure_mode = stronger_failure_mode(existing.failure_mode, control.failure_mode);
+    existing.confidence = min_confidence(existing.confidence, control.confidence);
+}
+
+fn replacement_use_counts(
+    before: &[AgentStackProtectionControl],
+    after: &[AgentStackProtectionControl],
+    before_ids: &BTreeSet<String>,
+    after_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for before_control in before {
+        if before_control.roles.is_empty() || before_control.enabled == Some(false) {
+            continue;
+        }
+        if after_by_id.contains_key(before_control.component.component_id().as_str()) {
+            continue;
+        }
+        for candidate in
+            replacement_candidates(after, before_control, before_ids, CandidateMode::Equivalent)
+        {
+            *counts
+                .entry(candidate.component.component_id().as_str().to_owned())
+                .or_insert(0) += 1;
+        }
+    }
+    counts
 }
 
 fn component_ids(controls: &[AgentStackProtectionControl]) -> BTreeSet<String> {
@@ -453,6 +539,52 @@ fn sorted_roles(
     }
     sorted.sort_by_key(AgentStackProtectionRole::as_str);
     Ok(sorted)
+}
+
+fn merged_roles(
+    left: &[AgentStackProtectionRole],
+    right: &[AgentStackProtectionRole],
+) -> Vec<AgentStackProtectionRole> {
+    let mut roles = left.to_vec();
+    for role in right {
+        if !roles.contains(role) {
+            roles.push(*role);
+        }
+    }
+    roles.sort_by_key(AgentStackProtectionRole::as_str);
+    roles
+}
+
+fn merged_after_enabled(left: Option<bool>, right: Option<bool>) -> Option<bool> {
+    match (left, right) {
+        (Some(false), _) | (_, Some(false)) => Some(false),
+        (Some(true), _) | (_, Some(true)) => Some(true),
+        _ => None,
+    }
+}
+
+fn stronger_scope(
+    left: Option<AgentStackProtectionScope>,
+    right: Option<AgentStackProtectionScope>,
+) -> Option<AgentStackProtectionScope> {
+    match (left, right) {
+        (Some(left), Some(right)) if right.strength() > left.strength() => Some(right),
+        (Some(scope), _) | (None, Some(scope)) => Some(scope),
+        (None, None) => None,
+    }
+}
+
+fn stronger_failure_mode(
+    left: Option<AgentStackProtectionFailureMode>,
+    right: Option<AgentStackProtectionFailureMode>,
+) -> Option<AgentStackProtectionFailureMode> {
+    if matches!(left, Some(AgentStackProtectionFailureMode::FailClosed))
+        || matches!(right, Some(AgentStackProtectionFailureMode::FailClosed))
+    {
+        Some(AgentStackProtectionFailureMode::FailClosed)
+    } else {
+        left.or(right)
+    }
 }
 
 fn role_overlap(left: &[AgentStackProtectionRole], right: &[AgentStackProtectionRole]) -> bool {
@@ -486,11 +618,14 @@ fn min_confidence(
     }
 }
 
-fn confidence_at_least(
-    left: AgentStackProtectionConfidence,
-    right: AgentStackProtectionConfidence,
-) -> bool {
-    left.strength() >= right.strength()
+fn rename_confidence(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+) -> AgentStackProtectionConfidence {
+    min_confidence(
+        min_confidence(before.confidence, after.confidence),
+        AgentStackProtectionConfidence::Medium,
+    )
 }
 
 fn fact_sort_key(fact: &AgentStackProtectionControlDiff) -> (&str, &'static str) {

--- a/crates/harness-core/src/stack/protective_control_diff/existing.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/existing.rs
@@ -1,0 +1,166 @@
+use super::replacements::{
+    analyze_role_replacements, classify_role_replacement, missing_roles, shared_replacement_roles,
+    RoleReplacementCoverage,
+};
+use super::*;
+
+pub(super) fn compare_existing(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+    inputs: &ComparisonInputs<'_, '_>,
+    has_conflicting_duplicate_state: bool,
+    facts: &mut Vec<AgentStackProtectionControlDiff>,
+) {
+    let confidence = min_confidence(before.confidence, after.confidence);
+    if after.confidence.strength() < before.confidence.strength() {
+        push_existing_fact(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::ConfidenceReduced,
+            facts,
+        );
+    }
+    match (before.enabled, after.enabled) {
+        (Some(true), None) => push_existing_fact(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::EnablementEvidenceLost,
+            facts,
+        ),
+        (left, Some(false)) if left != Some(false) => {
+            match classify_role_replacement(
+                before,
+                before.roles.clone(),
+                inputs.after_controls,
+                inputs.before_by_id,
+                inputs.before_conflicting_component_ids,
+                inputs.after_conflicting_component_ids,
+                inputs.replacement_use_counts,
+            ) {
+                RoleReplacementCoverage::Unique => {}
+                RoleReplacementCoverage::Ambiguous => push_existing_fact(
+                    AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+                    before.roles.clone(),
+                    before,
+                    after,
+                    confidence,
+                    AgentStackProtectionControlReason::AmbiguousReplacement,
+                    facts,
+                ),
+                RoleReplacementCoverage::Missing => push_existing_fact(
+                    AgentStackProtectionDiffKind::Disabled,
+                    before.roles.clone(),
+                    before,
+                    after,
+                    confidence,
+                    AgentStackProtectionControlReason::ExplicitlyDisabled,
+                    facts,
+                ),
+            }
+        }
+        _ => {}
+    }
+    let missing_roles = missing_roles(before.roles(), after.roles());
+    let shared_replacement_roles = shared_replacement_roles(
+        before,
+        missing_roles.clone(),
+        inputs.after_controls,
+        inputs.before_by_id,
+        inputs.before_conflicting_component_ids,
+        inputs.after_conflicting_component_ids,
+        inputs.replacement_use_counts,
+    );
+    let replacements = analyze_role_replacements(
+        before,
+        missing_roles,
+        inputs.after_controls,
+        inputs.before_by_id,
+        inputs.before_conflicting_component_ids,
+        inputs.after_conflicting_component_ids,
+    );
+    for (candidate, conflicting_roles) in replacements.conflicting_replacements {
+        push_conflicting_duplicate_fact_with_roles(
+            before,
+            Some(candidate),
+            conflicting_roles,
+            facts,
+        );
+    }
+    if !replacements.uncovered_roles.is_empty() {
+        push_existing_fact(
+            AgentStackProtectionDiffKind::ScopeReduced,
+            replacements.uncovered_roles,
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::RoleSetReduced,
+            facts,
+        );
+    }
+    if !shared_replacement_roles.is_empty() {
+        push_existing_fact(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            shared_replacement_roles,
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::AmbiguousReplacement,
+            facts,
+        );
+    }
+    if before.scope.is_some() && after.scope.is_none() {
+        push_existing_fact(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::ScopeLevelReduced,
+            facts,
+        );
+    } else if matches!((before.scope, after.scope), (Some(left), Some(right)) if right.strength() < left.strength())
+    {
+        push_existing_fact(
+            AgentStackProtectionDiffKind::ScopeReduced,
+            before.roles.clone(),
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::ScopeLevelReduced,
+            facts,
+        );
+    }
+    match (before.failure_mode, after.failure_mode) {
+        (
+            Some(AgentStackProtectionFailureMode::FailClosed),
+            Some(AgentStackProtectionFailureMode::FailOpen),
+        ) => push_existing_fact(
+            AgentStackProtectionDiffKind::FailOpen,
+            before.roles.clone(),
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::FailureModeRelaxed,
+            facts,
+        ),
+        (Some(AgentStackProtectionFailureMode::FailClosed), None) => push_existing_fact(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::FailureModeRelaxed,
+            facts,
+        ),
+        _ => {}
+    }
+    if has_conflicting_duplicate_state {
+        push_conflicting_duplicate_fact(before, Some(after), facts);
+    }
+}

--- a/crates/harness-core/src/stack/protective_control_diff/existing.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/existing.rs
@@ -58,20 +58,23 @@ pub(super) fn compare_existing(
     let has_scope_reduction = !has_scope_conflict && scope_is_reduced(before, after);
     let has_failure_mode_reduction =
         !has_failure_mode_conflict && failure_mode_is_reduced(before, after);
-    let standalone_state_reduction_coverage =
-        if after.enabled != Some(false) && (has_scope_reduction || has_failure_mode_reduction) {
-            Some(classify_role_replacement(
-                before,
-                before.roles.clone(),
-                inputs.after_controls,
-                inputs.before_by_id,
-                inputs.before_conflicting_component_ids,
-                inputs.after_conflicting_component_ids,
-                inputs.replacement_use_counts,
-            ))
-        } else {
-            None
-        };
+    let has_enablement_evidence_loss =
+        matches!((before.enabled, after.enabled), (Some(true), None));
+    let standalone_state_reduction_coverage = if after.enabled != Some(false)
+        && (has_enablement_evidence_loss || has_scope_reduction || has_failure_mode_reduction)
+    {
+        Some(classify_role_replacement(
+            before,
+            before.roles.clone(),
+            inputs.after_controls,
+            inputs.before_by_id,
+            inputs.before_conflicting_component_ids,
+            inputs.after_conflicting_component_ids,
+            inputs.replacement_use_counts,
+        ))
+    } else {
+        None
+    };
     let standalone_state_reduction_has_complete_coverage = matches!(
         standalone_state_reduction_coverage,
         Some(RoleReplacementCoverage::Unique | RoleReplacementCoverage::Ambiguous)
@@ -90,15 +93,18 @@ pub(super) fn compare_existing(
         );
     }
     match (before.enabled, after.enabled) {
-        (Some(true), None) => push_existing_fact(
-            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::EnablementEvidenceLost,
-            facts,
-        ),
+        (Some(true), None) => match standalone_state_reduction_coverage {
+            Some(RoleReplacementCoverage::Unique | RoleReplacementCoverage::Ambiguous) => {}
+            Some(RoleReplacementCoverage::Missing) | None => push_existing_fact(
+                AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+                before.roles.clone(),
+                before,
+                after,
+                confidence,
+                AgentStackProtectionControlReason::EnablementEvidenceLost,
+                facts,
+            ),
+        },
         (left, Some(false)) if left != Some(false) && !has_enabled_conflict => {
             match disablement_coverage {
                 Some(RoleReplacementCoverage::Unique) => {}

--- a/crates/harness-core/src/stack/protective_control_diff/existing.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/existing.rs
@@ -60,8 +60,12 @@ pub(super) fn compare_existing(
         !has_failure_mode_conflict && failure_mode_is_reduced(before, after);
     let has_enablement_evidence_loss =
         matches!((before.enabled, after.enabled), (Some(true), None));
+    let has_confidence_reduction = after.confidence.strength() < before.confidence.strength();
     let standalone_state_reduction_coverage = if after.enabled != Some(false)
-        && (has_enablement_evidence_loss || has_scope_reduction || has_failure_mode_reduction)
+        && (has_enablement_evidence_loss
+            || has_confidence_reduction
+            || has_scope_reduction
+            || has_failure_mode_reduction)
     {
         Some(classify_role_replacement(
             before,
@@ -80,7 +84,8 @@ pub(super) fn compare_existing(
         Some(RoleReplacementCoverage::Unique | RoleReplacementCoverage::Ambiguous)
     );
     if !disablement_has_complete_coverage
-        && after.confidence.strength() < before.confidence.strength()
+        && !standalone_state_reduction_has_complete_coverage
+        && has_confidence_reduction
     {
         push_existing_fact(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,

--- a/crates/harness-core/src/stack/protective_control_diff/existing.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/existing.rs
@@ -171,7 +171,14 @@ pub(super) fn compare_existing(
         standalone_state_reduction_coverage,
         Some(RoleReplacementCoverage::Ambiguous)
     );
-    if !shared_replacement_roles.is_empty() && !standalone_state_replacement_is_ambiguous {
+    let disablement_replacement_is_ambiguous = matches!(
+        disablement_coverage,
+        Some(RoleReplacementCoverage::Ambiguous)
+    );
+    if !shared_replacement_roles.is_empty()
+        && !disablement_replacement_is_ambiguous
+        && !standalone_state_replacement_is_ambiguous
+    {
         push_existing_fact(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
             shared_replacement_roles,

--- a/crates/harness-core/src/stack/protective_control_diff/existing.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/existing.rs
@@ -41,7 +41,7 @@ pub(super) fn compare_existing(
                 inputs.before_by_id,
                 inputs.before_conflicting_component_ids,
                 inputs.after_conflicting_component_ids,
-                inputs.replacement_use_counts,
+                inputs.replacement_assignments,
             ))
         } else {
             None
@@ -74,7 +74,7 @@ pub(super) fn compare_existing(
             inputs.before_by_id,
             inputs.before_conflicting_component_ids,
             inputs.after_conflicting_component_ids,
-            inputs.replacement_use_counts,
+            inputs.replacement_assignments,
         ))
     } else {
         None
@@ -143,7 +143,7 @@ pub(super) fn compare_existing(
         inputs.before_by_id,
         inputs.before_conflicting_component_ids,
         inputs.after_conflicting_component_ids,
-        inputs.replacement_use_counts,
+        inputs.replacement_assignments,
     );
     let replacements = analyze_role_replacements(
         before,

--- a/crates/harness-core/src/stack/protective_control_diff/existing.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/existing.rs
@@ -12,7 +12,31 @@ pub(super) fn compare_existing(
     facts: &mut Vec<AgentStackProtectionControlDiff>,
 ) {
     let confidence = min_confidence(before.confidence, after.confidence);
-    if after.confidence.strength() < before.confidence.strength() {
+    let component_id = after.component.component_id().as_str();
+    let has_enabled_conflict = inputs
+        .after_enabled_conflicting_component_ids
+        .contains(component_id);
+    let disablement_coverage =
+        if before.enabled != Some(false) && after.enabled == Some(false) && !has_enabled_conflict {
+            Some(classify_role_replacement(
+                before,
+                before.roles.clone(),
+                inputs.after_controls,
+                inputs.before_by_id,
+                inputs.before_conflicting_component_ids,
+                inputs.after_conflicting_component_ids,
+                inputs.replacement_use_counts,
+            ))
+        } else {
+            None
+        };
+    let disablement_has_complete_coverage = matches!(
+        disablement_coverage,
+        Some(RoleReplacementCoverage::Unique | RoleReplacementCoverage::Ambiguous)
+    );
+    if !disablement_has_complete_coverage
+        && after.confidence.strength() < before.confidence.strength()
+    {
         push_existing_fact(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
             before.roles.clone(),
@@ -33,18 +57,10 @@ pub(super) fn compare_existing(
             AgentStackProtectionControlReason::EnablementEvidenceLost,
             facts,
         ),
-        (left, Some(false)) if left != Some(false) => {
-            match classify_role_replacement(
-                before,
-                before.roles.clone(),
-                inputs.after_controls,
-                inputs.before_by_id,
-                inputs.before_conflicting_component_ids,
-                inputs.after_conflicting_component_ids,
-                inputs.replacement_use_counts,
-            ) {
-                RoleReplacementCoverage::Unique => {}
-                RoleReplacementCoverage::Ambiguous => push_existing_fact(
+        (left, Some(false)) if left != Some(false) && !has_enabled_conflict => {
+            match disablement_coverage {
+                Some(RoleReplacementCoverage::Unique) => {}
+                Some(RoleReplacementCoverage::Ambiguous) => push_existing_fact(
                     AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
                     before.roles.clone(),
                     before,
@@ -53,7 +69,7 @@ pub(super) fn compare_existing(
                     AgentStackProtectionControlReason::AmbiguousReplacement,
                     facts,
                 ),
-                RoleReplacementCoverage::Missing => push_existing_fact(
+                Some(RoleReplacementCoverage::Missing) => push_existing_fact(
                     AgentStackProtectionDiffKind::Disabled,
                     before.roles.clone(),
                     before,
@@ -62,6 +78,7 @@ pub(super) fn compare_existing(
                     AgentStackProtectionControlReason::ExplicitlyDisabled,
                     facts,
                 ),
+                None => {}
             }
         }
         _ => {}
@@ -114,51 +131,53 @@ pub(super) fn compare_existing(
             facts,
         );
     }
-    if before.scope.is_some() && after.scope.is_none() {
-        push_existing_fact(
-            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::ScopeLevelReduced,
-            facts,
-        );
-    } else if matches!((before.scope, after.scope), (Some(left), Some(right)) if right.strength() < left.strength())
-    {
-        push_existing_fact(
-            AgentStackProtectionDiffKind::ScopeReduced,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::ScopeLevelReduced,
-            facts,
-        );
-    }
-    match (before.failure_mode, after.failure_mode) {
-        (
-            Some(AgentStackProtectionFailureMode::FailClosed),
-            Some(AgentStackProtectionFailureMode::FailOpen),
-        ) => push_existing_fact(
-            AgentStackProtectionDiffKind::FailOpen,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::FailureModeRelaxed,
-            facts,
-        ),
-        (Some(AgentStackProtectionFailureMode::FailClosed), None) => push_existing_fact(
-            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
-            before.roles.clone(),
-            before,
-            after,
-            confidence,
-            AgentStackProtectionControlReason::FailureModeRelaxed,
-            facts,
-        ),
-        _ => {}
+    if !disablement_has_complete_coverage {
+        if before.scope.is_some() && after.scope.is_none() {
+            push_existing_fact(
+                AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+                before.roles.clone(),
+                before,
+                after,
+                confidence,
+                AgentStackProtectionControlReason::ScopeLevelReduced,
+                facts,
+            );
+        } else if matches!((before.scope, after.scope), (Some(left), Some(right)) if right.strength() < left.strength())
+        {
+            push_existing_fact(
+                AgentStackProtectionDiffKind::ScopeReduced,
+                before.roles.clone(),
+                before,
+                after,
+                confidence,
+                AgentStackProtectionControlReason::ScopeLevelReduced,
+                facts,
+            );
+        }
+        match (before.failure_mode, after.failure_mode) {
+            (
+                Some(AgentStackProtectionFailureMode::FailClosed),
+                Some(AgentStackProtectionFailureMode::FailOpen),
+            ) => push_existing_fact(
+                AgentStackProtectionDiffKind::FailOpen,
+                before.roles.clone(),
+                before,
+                after,
+                confidence,
+                AgentStackProtectionControlReason::FailureModeRelaxed,
+                facts,
+            ),
+            (Some(AgentStackProtectionFailureMode::FailClosed), None) => push_existing_fact(
+                AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+                before.roles.clone(),
+                before,
+                after,
+                confidence,
+                AgentStackProtectionControlReason::FailureModeRelaxed,
+                facts,
+            ),
+            _ => {}
+        }
     }
     if has_conflicting_duplicate_state {
         push_conflicting_duplicate_fact(before, Some(after), facts);

--- a/crates/harness-core/src/stack/protective_control_diff/existing.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/existing.rs
@@ -16,6 +16,19 @@ pub(super) fn compare_existing(
     let has_enabled_conflict = inputs
         .after_enabled_conflicting_component_ids
         .contains(component_id);
+    let before_component_id = before.component.component_id().as_str();
+    let has_scope_conflict = inputs
+        .before_scope_conflicting_component_ids
+        .contains(before_component_id)
+        || inputs
+            .after_scope_conflicting_component_ids
+            .contains(component_id);
+    let has_failure_mode_conflict = inputs
+        .before_failure_mode_conflicting_component_ids
+        .contains(before_component_id)
+        || inputs
+            .after_failure_mode_conflicting_component_ids
+            .contains(component_id);
     let disablement_coverage =
         if before.enabled != Some(false) && after.enabled == Some(false) && !has_enabled_conflict {
             Some(classify_role_replacement(
@@ -131,7 +144,7 @@ pub(super) fn compare_existing(
             facts,
         );
     }
-    if !disablement_has_complete_coverage {
+    if !disablement_has_complete_coverage && !has_scope_conflict {
         if before.scope.is_some() && after.scope.is_none() {
             push_existing_fact(
                 AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
@@ -154,6 +167,8 @@ pub(super) fn compare_existing(
                 facts,
             );
         }
+    }
+    if !disablement_has_complete_coverage && !has_failure_mode_conflict {
         match (before.failure_mode, after.failure_mode) {
             (
                 Some(AgentStackProtectionFailureMode::FailClosed),

--- a/crates/harness-core/src/stack/protective_control_diff/existing.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/existing.rs
@@ -1,6 +1,6 @@
 use super::replacements::{
-    analyze_role_replacements, classify_role_replacement, missing_roles, shared_replacement_roles,
-    RoleReplacementCoverage,
+    analyze_role_replacements, classify_role_replacement, failure_mode_is_reduced, missing_roles,
+    scope_is_reduced, shared_replacement_roles, RoleReplacementCoverage,
 };
 use super::*;
 
@@ -17,6 +17,9 @@ pub(super) fn compare_existing(
         .after_enabled_conflicting_component_ids
         .contains(component_id);
     let before_component_id = before.component.component_id().as_str();
+    let has_before_enabled_conflict = inputs
+        .before_enabled_conflicting_component_ids
+        .contains(before_component_id);
     let has_scope_conflict = inputs
         .before_scope_conflicting_component_ids
         .contains(before_component_id)
@@ -45,6 +48,32 @@ pub(super) fn compare_existing(
         };
     let disablement_has_complete_coverage = matches!(
         disablement_coverage,
+        Some(RoleReplacementCoverage::Unique | RoleReplacementCoverage::Ambiguous)
+    );
+    let missing_roles = if has_before_enabled_conflict {
+        Vec::new()
+    } else {
+        missing_roles(before.roles(), after.roles())
+    };
+    let has_scope_reduction = !has_scope_conflict && scope_is_reduced(before, after);
+    let has_failure_mode_reduction =
+        !has_failure_mode_conflict && failure_mode_is_reduced(before, after);
+    let standalone_state_reduction_coverage =
+        if after.enabled != Some(false) && (has_scope_reduction || has_failure_mode_reduction) {
+            Some(classify_role_replacement(
+                before,
+                before.roles.clone(),
+                inputs.after_controls,
+                inputs.before_by_id,
+                inputs.before_conflicting_component_ids,
+                inputs.after_conflicting_component_ids,
+                inputs.replacement_use_counts,
+            ))
+        } else {
+            None
+        };
+    let standalone_state_reduction_has_complete_coverage = matches!(
+        standalone_state_reduction_coverage,
         Some(RoleReplacementCoverage::Unique | RoleReplacementCoverage::Ambiguous)
     );
     if !disablement_has_complete_coverage
@@ -96,7 +125,6 @@ pub(super) fn compare_existing(
         }
         _ => {}
     }
-    let missing_roles = missing_roles(before.roles(), after.roles());
     let shared_replacement_roles = shared_replacement_roles(
         before,
         missing_roles.clone(),
@@ -133,7 +161,11 @@ pub(super) fn compare_existing(
             facts,
         );
     }
-    if !shared_replacement_roles.is_empty() {
+    let standalone_state_replacement_is_ambiguous = matches!(
+        standalone_state_reduction_coverage,
+        Some(RoleReplacementCoverage::Ambiguous)
+    );
+    if !shared_replacement_roles.is_empty() && !standalone_state_replacement_is_ambiguous {
         push_existing_fact(
             AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
             shared_replacement_roles,
@@ -144,7 +176,21 @@ pub(super) fn compare_existing(
             facts,
         );
     }
-    if !disablement_has_complete_coverage && !has_scope_conflict {
+    if standalone_state_replacement_is_ambiguous {
+        push_existing_fact(
+            AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
+            before.roles.clone(),
+            before,
+            after,
+            confidence,
+            AgentStackProtectionControlReason::AmbiguousReplacement,
+            facts,
+        );
+    }
+    if !disablement_has_complete_coverage
+        && !standalone_state_reduction_has_complete_coverage
+        && !has_scope_conflict
+    {
         if before.scope.is_some() && after.scope.is_none() {
             push_existing_fact(
                 AgentStackProtectionDiffKind::AmbiguousReviewEvidence,
@@ -168,7 +214,10 @@ pub(super) fn compare_existing(
             );
         }
     }
-    if !disablement_has_complete_coverage && !has_failure_mode_conflict {
+    if !disablement_has_complete_coverage
+        && !standalone_state_reduction_has_complete_coverage
+        && !has_failure_mode_conflict
+    {
         match (before.failure_mode, after.failure_mode) {
             (
                 Some(AgentStackProtectionFailureMode::FailClosed),

--- a/crates/harness-core/src/stack/protective_control_diff/replacements.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/replacements.rs
@@ -1,0 +1,208 @@
+use super::{
+    AgentStackProtectionControl, AgentStackProtectionFailureMode, AgentStackProtectionRole,
+    AgentStackProtectionScope,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, Copy)]
+pub(super) enum CandidateMode {
+    SameIntegrity,
+    Equivalent,
+    WeakEquivalent,
+}
+
+pub(super) struct RoleReplacementAnalysis<'a> {
+    pub(super) uncovered_roles: Vec<AgentStackProtectionRole>,
+    pub(super) conflicting_replacements: Vec<(
+        &'a AgentStackProtectionControl,
+        Vec<AgentStackProtectionRole>,
+    )>,
+    pub(super) replacement_ids: BTreeSet<String>,
+}
+
+pub(super) fn replacement_candidates<'a>(
+    after: &'a [AgentStackProtectionControl],
+    before: &AgentStackProtectionControl,
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
+    mode: CandidateMode,
+) -> Vec<&'a AgentStackProtectionControl> {
+    let mut candidates = after
+        .iter()
+        .filter(|candidate| {
+            candidate_is_new_protection(
+                candidate,
+                before,
+                before_by_id,
+                before_conflicting_component_ids,
+                mode,
+            )
+        })
+        .filter(|candidate| role_overlap(before.roles(), candidate.roles()))
+        .filter(|candidate| match mode {
+            CandidateMode::SameIntegrity => same_integrity(before, candidate),
+            CandidateMode::Equivalent => equivalent_replacement(before, candidate),
+            CandidateMode::WeakEquivalent => weak_equivalent_replacement(before, candidate),
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|candidate| candidate.component.component_id().as_str());
+    candidates
+}
+
+pub(super) fn analyze_role_replacements<'a>(
+    before: &AgentStackProtectionControl,
+    roles: Vec<AgentStackProtectionRole>,
+    after: &'a [AgentStackProtectionControl],
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
+    after_conflicting_component_ids: &BTreeSet<String>,
+) -> RoleReplacementAnalysis<'a> {
+    let mut uncovered = Vec::new();
+    let mut conflicting =
+        BTreeMap::<String, (&AgentStackProtectionControl, Vec<AgentStackProtectionRole>)>::new();
+    let mut replacement_ids = BTreeSet::new();
+    for role in roles {
+        let mut probe = before.clone();
+        probe.roles = vec![role];
+        let candidates = replacement_candidates(
+            after,
+            &probe,
+            before_by_id,
+            before_conflicting_component_ids,
+            CandidateMode::Equivalent,
+        );
+        let mut has_safe_candidate = false;
+        let mut role_conflicting_candidates = Vec::new();
+        for candidate in candidates {
+            let component_id = candidate.component.component_id().as_str();
+            if after_conflicting_component_ids.contains(component_id) {
+                role_conflicting_candidates.push(candidate);
+            } else {
+                has_safe_candidate = true;
+                replacement_ids.insert(component_id.to_owned());
+            }
+        }
+        if !has_safe_candidate {
+            if role_conflicting_candidates.is_empty() {
+                uncovered.push(role);
+            } else {
+                for candidate in role_conflicting_candidates {
+                    conflicting
+                        .entry(candidate.component.component_id().as_str().to_owned())
+                        .or_insert_with(|| (candidate, Vec::new()))
+                        .1
+                        .push(role);
+                }
+            }
+        }
+    }
+    RoleReplacementAnalysis {
+        uncovered_roles: uncovered,
+        conflicting_replacements: conflicting.into_values().collect(),
+        replacement_ids,
+    }
+}
+
+pub(super) fn replacement_use_counts(
+    before: &[AgentStackProtectionControl],
+    after: &[AgentStackProtectionControl],
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
+    after_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for before_control in before {
+        if before_control.roles.is_empty() || before_control.enabled == Some(false) {
+            continue;
+        }
+        if after_by_id.contains_key(before_control.component.component_id().as_str()) {
+            continue;
+        }
+        let mut used_ids = BTreeSet::new();
+        for mode in [CandidateMode::SameIntegrity, CandidateMode::Equivalent] {
+            for candidate in replacement_candidates(
+                after,
+                before_control,
+                before_by_id,
+                before_conflicting_component_ids,
+                mode,
+            ) {
+                used_ids.insert(candidate.component.component_id().as_str().to_owned());
+            }
+        }
+        for component_id in used_ids {
+            *counts.entry(component_id).or_insert(0) += 1;
+        }
+    }
+    counts
+}
+
+fn candidate_is_new_protection(
+    candidate: &AgentStackProtectionControl,
+    removed: &AgentStackProtectionControl,
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
+    mode: CandidateMode,
+) -> bool {
+    let component_id = candidate.component.component_id().as_str();
+    match before_by_id.get(component_id).copied() {
+        Some(_) if matches!(mode, CandidateMode::SameIntegrity) => false,
+        Some(_) if before_conflicting_component_ids.contains(component_id) => true,
+        Some(previous) => match mode {
+            CandidateMode::SameIntegrity => false,
+            CandidateMode::Equivalent => !equivalent_replacement(removed, previous),
+            CandidateMode::WeakEquivalent => !weak_equivalent_replacement(removed, previous),
+        },
+        None => true,
+    }
+}
+
+fn equivalent_replacement(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+) -> bool {
+    after.confidence.strength() >= before.confidence.strength()
+        && weak_equivalent_replacement(before, after)
+}
+
+fn weak_equivalent_replacement(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+) -> bool {
+    after.enabled != Some(false)
+        && roles_include(after.roles(), before.roles())
+        && (before.enabled != Some(true) || after.enabled == Some(true))
+        && scope_at_least(after.scope, before.scope)
+        && (before.failure_mode != Some(AgentStackProtectionFailureMode::FailClosed)
+            || after.failure_mode == Some(AgentStackProtectionFailureMode::FailClosed))
+}
+
+fn scope_at_least(
+    after: Option<AgentStackProtectionScope>,
+    before: Option<AgentStackProtectionScope>,
+) -> bool {
+    match before {
+        Some(before_scope) => {
+            after.is_some_and(|after_scope| after_scope.strength() >= before_scope.strength())
+        }
+        None => true,
+    }
+}
+
+fn same_integrity(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+) -> bool {
+    matches!(
+        (before.component.integrity(), after.component.integrity()),
+        (Some(left), Some(right)) if left.as_str() == right.as_str()
+    )
+}
+
+fn role_overlap(left: &[AgentStackProtectionRole], right: &[AgentStackProtectionRole]) -> bool {
+    left.iter().any(|role| right.contains(role))
+}
+
+fn roles_include(left: &[AgentStackProtectionRole], right: &[AgentStackProtectionRole]) -> bool {
+    right.iter().all(|role| left.contains(role))
+}

--- a/crates/harness-core/src/stack/protective_control_diff/replacements.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/replacements.rs
@@ -11,6 +11,12 @@ pub(super) enum CandidateMode {
     WeakEquivalent,
 }
 
+pub(super) enum RoleReplacementCoverage {
+    Unique,
+    Ambiguous,
+    Missing,
+}
+
 pub(super) struct RoleReplacementAnalysis<'a> {
     pub(super) uncovered_roles: Vec<AgentStackProtectionRole>,
     pub(super) conflicting_replacements: Vec<(
@@ -115,26 +121,148 @@ pub(super) fn replacement_use_counts(
         if before_control.roles.is_empty() || before_control.enabled == Some(false) {
             continue;
         }
-        if after_by_id.contains_key(before_control.component.component_id().as_str()) {
+        let component_id = before_control.component.component_id().as_str();
+        let Some(after_control) = after_by_id.get(component_id).copied() else {
+            let mut used_ids = BTreeSet::new();
+            for mode in [CandidateMode::SameIntegrity, CandidateMode::Equivalent] {
+                for candidate in replacement_candidates(
+                    after,
+                    before_control,
+                    before_by_id,
+                    before_conflicting_component_ids,
+                    mode,
+                ) {
+                    used_ids.insert(candidate.component.component_id().as_str().to_owned());
+                }
+            }
+            increment_use_counts(&mut counts, used_ids);
             continue;
-        }
+        };
+        let roles = if after_control.enabled == Some(false) {
+            before_control.roles.clone()
+        } else {
+            missing_roles(before_control.roles(), after_control.roles())
+        };
         let mut used_ids = BTreeSet::new();
-        for mode in [CandidateMode::SameIntegrity, CandidateMode::Equivalent] {
+        for role in roles {
+            let mut probe = before_control.clone();
+            probe.roles = vec![role];
             for candidate in replacement_candidates(
                 after,
-                before_control,
+                &probe,
                 before_by_id,
                 before_conflicting_component_ids,
-                mode,
+                CandidateMode::Equivalent,
             ) {
                 used_ids.insert(candidate.component.component_id().as_str().to_owned());
             }
         }
-        for component_id in used_ids {
-            *counts.entry(component_id).or_insert(0) += 1;
-        }
+        increment_use_counts(&mut counts, used_ids);
     }
     counts
+}
+
+pub(super) fn classify_role_replacement(
+    before: &AgentStackProtectionControl,
+    roles: Vec<AgentStackProtectionRole>,
+    after: &[AgentStackProtectionControl],
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
+    after_conflicting_component_ids: &BTreeSet<String>,
+    replacement_use_counts: &BTreeMap<String, usize>,
+) -> RoleReplacementCoverage {
+    let analysis = analyze_role_replacements(
+        before,
+        roles,
+        after,
+        before_by_id,
+        before_conflicting_component_ids,
+        after_conflicting_component_ids,
+    );
+    if !analysis.uncovered_roles.is_empty()
+        || !analysis.conflicting_replacements.is_empty()
+        || analysis.replacement_ids.is_empty()
+    {
+        return RoleReplacementCoverage::Missing;
+    }
+    if analysis.replacement_ids.len() == 1
+        && analysis
+            .replacement_ids
+            .iter()
+            .all(|component_id| replacement_use_counts.get(component_id).copied() == Some(1))
+    {
+        RoleReplacementCoverage::Unique
+    } else {
+        RoleReplacementCoverage::Ambiguous
+    }
+}
+
+pub(super) fn shared_replacement_roles(
+    before: &AgentStackProtectionControl,
+    roles: Vec<AgentStackProtectionRole>,
+    after: &[AgentStackProtectionControl],
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
+    after_conflicting_component_ids: &BTreeSet<String>,
+    replacement_use_counts: &BTreeMap<String, usize>,
+) -> Vec<AgentStackProtectionRole> {
+    roles
+        .into_iter()
+        .filter(|role| {
+            let mut probe = before.clone();
+            probe.roles = vec![*role];
+            let safe_candidate_ids = replacement_candidates(
+                after,
+                &probe,
+                before_by_id,
+                before_conflicting_component_ids,
+                CandidateMode::Equivalent,
+            )
+            .into_iter()
+            .map(|candidate| candidate.component.component_id().as_str())
+            .filter(|component_id| !after_conflicting_component_ids.contains(*component_id))
+            .collect::<Vec<_>>();
+            !safe_candidate_ids.is_empty()
+                && safe_candidate_ids.iter().all(|component_id| {
+                    replacement_use_counts
+                        .get(*component_id)
+                        .copied()
+                        .unwrap_or(0)
+                        > 1
+                })
+        })
+        .collect()
+}
+
+pub(super) fn by_component_id(
+    controls: &[AgentStackProtectionControl],
+) -> BTreeMap<String, &AgentStackProtectionControl> {
+    controls
+        .iter()
+        .map(|control| {
+            (
+                control.component.component_id().as_str().to_owned(),
+                control,
+            )
+        })
+        .collect()
+}
+
+pub(super) fn missing_roles(
+    before: &[AgentStackProtectionRole],
+    after: &[AgentStackProtectionRole],
+) -> Vec<AgentStackProtectionRole> {
+    before
+        .iter()
+        .copied()
+        .filter(|role| !after.contains(role))
+        .collect()
+}
+
+fn increment_use_counts(counts: &mut BTreeMap<String, usize>, component_ids: BTreeSet<String>) {
+    for component_id in component_ids {
+        *counts.entry(component_id).or_insert(0) += 1;
+    }
 }
 
 fn candidate_is_new_protection(

--- a/crates/harness-core/src/stack/protective_control_diff/replacements.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/replacements.rs
@@ -28,6 +28,7 @@ pub(super) struct RoleReplacementAnalysis<'a> {
 }
 
 pub(super) struct ReplacementStateConflicts<'a> {
+    pub(super) after_any: &'a BTreeSet<String>,
     pub(super) before_enabled: &'a BTreeSet<String>,
     pub(super) after_enabled: &'a BTreeSet<String>,
     pub(super) before_scope: &'a BTreeSet<String>,
@@ -156,8 +157,12 @@ pub(super) fn replacement_use_counts(
                 used_ids.insert(candidate.component.component_id().as_str().to_owned());
             }
             for role in before_control.roles.iter().copied().filter(|role| {
+                let mut probe = before_control.clone();
+                probe.roles = vec![*role];
                 !same_integrity.iter().any(|candidate| {
-                    candidate.roles.contains(role) && candidate.enabled != Some(false)
+                    let candidate_id = candidate.component.component_id().as_str();
+                    !conflicts.after_any.contains(candidate_id)
+                        && equivalent_replacement(&probe, candidate)
                 })
             }) {
                 let mut probe = before_control.clone();
@@ -181,8 +186,15 @@ pub(super) fn replacement_use_counts(
         let has_failure_mode_reduction = !conflicts.before_failure_mode.contains(component_id)
             && !conflicts.after_failure_mode.contains(component_id)
             && failure_mode_is_reduced(before_control, after_control);
+        let has_enablement_evidence_loss = !conflicts.before_enabled.contains(component_id)
+            && !conflicts.after_enabled.contains(component_id)
+            && matches!(
+                (before_control.enabled, after_control.enabled),
+                (Some(true), None)
+            );
         let roles = if (after_control.enabled == Some(false)
             && !conflicts.after_enabled.contains(component_id))
+            || has_enablement_evidence_loss
             || has_scope_reduction
             || has_failure_mode_reduction
         {

--- a/crates/harness-core/src/stack/protective_control_diff/replacements.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/replacements.rs
@@ -195,6 +195,11 @@ pub(super) fn conflicted_replacement_uncovered_roles(
     conflicting_component_ids.extend(
         additional_conflicting_replacements
             .iter()
+            .filter(|candidate| {
+                conflicts
+                    .after_any
+                    .contains(candidate.component.component_id().as_str())
+            })
             .map(|candidate| candidate.component.component_id().as_str().to_owned()),
     );
     before

--- a/crates/harness-core/src/stack/protective_control_diff/replacements.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/replacements.rs
@@ -192,9 +192,12 @@ pub(super) fn replacement_use_counts(
                 (before_control.enabled, after_control.enabled),
                 (Some(true), None)
             );
+        let has_confidence_reduction =
+            after_control.confidence.strength() < before_control.confidence.strength();
         let roles = if (after_control.enabled == Some(false)
             && !conflicts.after_enabled.contains(component_id))
             || has_enablement_evidence_loss
+            || has_confidence_reduction
             || has_scope_reduction
             || has_failure_mode_reduction
         {
@@ -281,14 +284,15 @@ pub(super) fn shared_replacement_roles(
             .map(|candidate| candidate.component.component_id().as_str())
             .filter(|component_id| !after_conflicting_component_ids.contains(*component_id))
             .collect::<Vec<_>>();
-            !safe_candidate_ids.is_empty()
-                && safe_candidate_ids.iter().all(|component_id| {
-                    replacement_use_counts
-                        .get(*component_id)
-                        .copied()
-                        .unwrap_or(0)
-                        > 1
-                })
+            safe_candidate_ids.len() > 1
+                || (!safe_candidate_ids.is_empty()
+                    && safe_candidate_ids.iter().all(|component_id| {
+                        replacement_use_counts
+                            .get(*component_id)
+                            .copied()
+                            .unwrap_or(0)
+                            > 1
+                    }))
         })
         .collect()
 }

--- a/crates/harness-core/src/stack/protective_control_diff/replacements.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/replacements.rs
@@ -27,6 +27,15 @@ pub(super) struct RoleReplacementAnalysis<'a> {
     pub(super) replacement_ids: BTreeSet<String>,
 }
 
+pub(super) struct ReplacementStateConflicts<'a> {
+    pub(super) before_enabled: &'a BTreeSet<String>,
+    pub(super) after_enabled: &'a BTreeSet<String>,
+    pub(super) before_scope: &'a BTreeSet<String>,
+    pub(super) after_scope: &'a BTreeSet<String>,
+    pub(super) before_failure_mode: &'a BTreeSet<String>,
+    pub(super) after_failure_mode: &'a BTreeSet<String>,
+}
+
 pub(super) fn replacement_candidates<'a>(
     after: &'a [AgentStackProtectionControl],
     before: &AgentStackProtectionControl,
@@ -116,14 +125,17 @@ pub(super) fn replacement_use_counts(
     before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
     before_conflicting_component_ids: &BTreeSet<String>,
     after_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
-    after_enabled_conflicting_component_ids: &BTreeSet<String>,
+    conflicts: ReplacementStateConflicts<'_>,
 ) -> BTreeMap<String, usize> {
     let mut counts = BTreeMap::new();
     for before_control in before {
-        if before_control.roles.is_empty() || before_control.enabled == Some(false) {
+        let component_id = before_control.component.component_id().as_str();
+        if before_control.roles.is_empty()
+            || (before_control.enabled == Some(false)
+                && !conflicts.before_enabled.contains(component_id))
+        {
             continue;
         }
-        let component_id = before_control.component.component_id().as_str();
         let Some(after_control) = after_by_id.get(component_id).copied() else {
             let mut used_ids = BTreeSet::new();
             let same_integrity = replacement_candidates(
@@ -163,8 +175,16 @@ pub(super) fn replacement_use_counts(
             increment_use_counts(&mut counts, used_ids);
             continue;
         };
-        let roles = if after_control.enabled == Some(false)
-            && !after_enabled_conflicting_component_ids.contains(component_id)
+        let has_scope_reduction = !conflicts.before_scope.contains(component_id)
+            && !conflicts.after_scope.contains(component_id)
+            && scope_is_reduced(before_control, after_control);
+        let has_failure_mode_reduction = !conflicts.before_failure_mode.contains(component_id)
+            && !conflicts.after_failure_mode.contains(component_id)
+            && failure_mode_is_reduced(before_control, after_control);
+        let roles = if (after_control.enabled == Some(false)
+            && !conflicts.after_enabled.contains(component_id))
+            || has_scope_reduction
+            || has_failure_mode_reduction
         {
             before_control.roles.clone()
         } else {
@@ -284,6 +304,30 @@ pub(super) fn missing_roles(
         .copied()
         .filter(|role| !after.contains(role))
         .collect()
+}
+
+pub(super) fn scope_is_reduced(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+) -> bool {
+    match (before.scope, after.scope) {
+        (Some(_), None) => true,
+        (Some(before), Some(after)) => after.strength() < before.strength(),
+        _ => false,
+    }
+}
+
+pub(super) fn failure_mode_is_reduced(
+    before: &AgentStackProtectionControl,
+    after: &AgentStackProtectionControl,
+) -> bool {
+    matches!(
+        (before.failure_mode, after.failure_mode),
+        (
+            Some(AgentStackProtectionFailureMode::FailClosed),
+            Some(AgentStackProtectionFailureMode::FailOpen) | None,
+        )
+    )
 }
 
 fn increment_use_counts(counts: &mut BTreeMap<String, usize>, component_ids: BTreeSet<String>) {

--- a/crates/harness-core/src/stack/protective_control_diff/replacements.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/replacements.rs
@@ -186,13 +186,17 @@ pub(super) fn conflicted_replacement_uncovered_roles(
     before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
     conflicts: ReplacementCandidateConflicts<'_>,
     conflicting_replacements: &[(&AgentStackProtectionControl, Vec<AgentStackProtectionRole>)],
-    primary_conflicting_component_id: &str,
+    additional_conflicting_replacements: &[&AgentStackProtectionControl],
 ) -> Vec<AgentStackProtectionRole> {
     let mut conflicting_component_ids = conflicting_replacements
         .iter()
         .map(|(candidate, _)| candidate.component.component_id().as_str().to_owned())
         .collect::<BTreeSet<_>>();
-    conflicting_component_ids.insert(primary_conflicting_component_id.to_owned());
+    conflicting_component_ids.extend(
+        additional_conflicting_replacements
+            .iter()
+            .map(|candidate| candidate.component.component_id().as_str().to_owned()),
+    );
     before
         .roles
         .iter()
@@ -297,7 +301,7 @@ pub(super) fn replacement_assignments(
         .map(|(component_id, demand)| (component_id.clone(), demand.full_candidate_ids.clone()))
         .collect();
     let assignment_resolutions = resolve_assignments(&candidate_edges);
-    let partial_contention = partial_candidate_contention(&demands);
+    let partial_contention = partial_candidate_contention(&demands, &assignment_resolutions);
     let resolutions = demands
         .into_iter()
         .map(|(component_id, demand)| {
@@ -406,20 +410,31 @@ fn safe_candidate_ids(
 
 fn partial_candidate_contention(
     demands: &BTreeMap<String, ReplacementDemand>,
+    assignment_resolutions: &BTreeMap<String, AssignmentResolution>,
 ) -> BTreeMap<String, BTreeSet<String>> {
     let mut contention = BTreeMap::<String, BTreeSet<String>>::new();
     for (component_id, demand) in demands {
-        let has_complete_role_plan = demand
-            .per_role_candidate_ids
-            .iter()
-            .all(|candidates| !candidates.is_empty());
+        let unique_full_candidate = match assignment_resolutions.get(component_id) {
+            Some(AssignmentResolution::Unique(candidate_id)) => Some(candidate_id.as_str()),
+            Some(AssignmentResolution::Ambiguous | AssignmentResolution::Missing) | None => None,
+        };
+        let has_complete_role_plan = unique_full_candidate.map_or_else(
+            || {
+                demand
+                    .per_role_candidate_ids
+                    .iter()
+                    .all(|candidates| !candidates.is_empty())
+            },
+            |candidate_id| has_alternative_split_plan(&demand.per_role_candidate_ids, candidate_id),
+        );
         for candidate_id in demand
             .contending_candidate_ids
             .iter()
             .filter(|candidate_id| {
                 !demand.full_candidate_ids.contains(*candidate_id)
                     && (has_complete_role_plan
-                        || demand.same_integrity_candidate_ids.contains(*candidate_id))
+                        || (unique_full_candidate.is_none()
+                            && demand.same_integrity_candidate_ids.contains(*candidate_id)))
             })
         {
             contention

--- a/crates/harness-core/src/stack/protective_control_diff/replacements.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/replacements.rs
@@ -4,6 +4,9 @@ use super::{
 };
 use std::collections::{BTreeMap, BTreeSet};
 
+mod matching;
+use matching::{resolve_assignments, AssignmentResolution};
+
 #[derive(Clone, Copy)]
 pub(super) enum CandidateMode {
     SameIntegrity,
@@ -35,6 +38,62 @@ pub(super) struct ReplacementStateConflicts<'a> {
     pub(super) after_scope: &'a BTreeSet<String>,
     pub(super) before_failure_mode: &'a BTreeSet<String>,
     pub(super) after_failure_mode: &'a BTreeSet<String>,
+}
+
+pub(super) struct ReplacementCandidateConflicts<'a> {
+    pub(super) before_any: &'a BTreeSet<String>,
+    pub(super) after_any: &'a BTreeSet<String>,
+}
+
+pub(super) struct ReplacementAssignmentIndex {
+    demands: BTreeMap<String, ReplacementDemandResolution>,
+}
+
+struct ReplacementDemandResolution {
+    roles: Vec<AgentStackProtectionRole>,
+    coverage: RoleReplacementCoverage,
+    unique_candidate_id: Option<String>,
+}
+
+struct ReplacementDemand {
+    roles: Vec<AgentStackProtectionRole>,
+    full_candidate_ids: BTreeSet<String>,
+    per_role_candidate_ids: Vec<BTreeSet<String>>,
+    same_integrity_candidate_ids: BTreeSet<String>,
+    contending_candidate_ids: BTreeSet<String>,
+}
+
+impl ReplacementAssignmentIndex {
+    pub(super) fn coverage(
+        &self,
+        before: &AgentStackProtectionControl,
+        roles: &[AgentStackProtectionRole],
+    ) -> Option<RoleReplacementCoverage> {
+        self.demand(before, roles).map(|demand| demand.coverage)
+    }
+
+    pub(super) fn unique_candidate_id(
+        &self,
+        before: &AgentStackProtectionControl,
+        roles: &[AgentStackProtectionRole],
+    ) -> Option<&str> {
+        self.demand(before, roles)
+            .and_then(|demand| demand.unique_candidate_id.as_deref())
+    }
+
+    fn demand(
+        &self,
+        before: &AgentStackProtectionControl,
+        roles: &[AgentStackProtectionRole],
+    ) -> Option<&ReplacementDemandResolution> {
+        self.demands
+            .get(before.component.component_id().as_str())
+            .filter(|demand| {
+                demand.roles == roles
+                    || (!matches!(demand.coverage, RoleReplacementCoverage::Missing)
+                        && roles.iter().all(|role| demand.roles.contains(role)))
+            })
+    }
 }
 
 pub(super) fn replacement_candidates<'a>(
@@ -120,15 +179,59 @@ pub(super) fn analyze_role_replacements<'a>(
     }
 }
 
-pub(super) fn replacement_use_counts(
+pub(super) fn conflicted_replacement_uncovered_roles(
+    before: &AgentStackProtectionControl,
+    after: &[AgentStackProtectionControl],
+    after_reports: &[AgentStackProtectionControl],
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    conflicts: ReplacementCandidateConflicts<'_>,
+    conflicting_replacements: &[(&AgentStackProtectionControl, Vec<AgentStackProtectionRole>)],
+    primary_conflicting_component_id: &str,
+) -> Vec<AgentStackProtectionRole> {
+    let mut conflicting_component_ids = conflicting_replacements
+        .iter()
+        .map(|(candidate, _)| candidate.component.component_id().as_str().to_owned())
+        .collect::<BTreeSet<_>>();
+    conflicting_component_ids.insert(primary_conflicting_component_id.to_owned());
+    before
+        .roles
+        .iter()
+        .copied()
+        .filter(|role| {
+            let mut probe = before.clone();
+            probe.roles = vec![*role];
+            let has_safe_candidate = replacement_candidates(
+                after,
+                &probe,
+                before_by_id,
+                conflicts.before_any,
+                CandidateMode::Equivalent,
+            )
+            .into_iter()
+            .any(|candidate| {
+                let component_id = candidate.component.component_id().as_str();
+                !conflicts.before_any.contains(component_id)
+                    && !conflicts.after_any.contains(component_id)
+            });
+            let has_individually_equivalent_conflicted_report =
+                after_reports.iter().any(|report| {
+                    conflicting_component_ids.contains(report.component.component_id().as_str())
+                        && equivalent_replacement(&probe, report)
+                });
+            !has_safe_candidate && !has_individually_equivalent_conflicted_report
+        })
+        .collect()
+}
+
+pub(super) fn replacement_assignments(
     before: &[AgentStackProtectionControl],
     after: &[AgentStackProtectionControl],
     before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
     before_conflicting_component_ids: &BTreeSet<String>,
     after_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
     conflicts: ReplacementStateConflicts<'_>,
-) -> BTreeMap<String, usize> {
-    let mut counts = BTreeMap::new();
+) -> ReplacementAssignmentIndex {
+    let mut demands = BTreeMap::<String, ReplacementDemand>::new();
     for before_control in before {
         let component_id = before_control.component.component_id().as_str();
         if before_control.roles.is_empty()
@@ -137,91 +240,219 @@ pub(super) fn replacement_use_counts(
         {
             continue;
         }
-        let Some(after_control) = after_by_id.get(component_id).copied() else {
-            let mut used_ids = BTreeSet::new();
-            let same_integrity = replacement_candidates(
-                after,
-                before_control,
-                before_by_id,
-                before_conflicting_component_ids,
-                CandidateMode::SameIntegrity,
-            );
-            let equivalent = replacement_candidates(
-                after,
-                before_control,
-                before_by_id,
-                before_conflicting_component_ids,
-                CandidateMode::Equivalent,
-            );
-            for candidate in same_integrity.iter().chain(equivalent.iter()) {
-                used_ids.insert(candidate.component.component_id().as_str().to_owned());
-            }
-            for role in before_control.roles.iter().copied().filter(|role| {
-                let mut probe = before_control.clone();
-                probe.roles = vec![*role];
-                !same_integrity.iter().any(|candidate| {
-                    let candidate_id = candidate.component.component_id().as_str();
-                    !conflicts.after_any.contains(candidate_id)
-                        && equivalent_replacement(&probe, candidate)
-                })
-            }) {
-                let mut probe = before_control.clone();
-                probe.roles = vec![role];
-                for candidate in replacement_candidates(
+        let roles = replacement_demand_roles(before_control, after_by_id, &conflicts);
+        if roles.is_empty() {
+            continue;
+        }
+        let full_candidate_ids = safe_candidate_ids(
+            before_control,
+            roles.clone(),
+            after,
+            before_by_id,
+            before_conflicting_component_ids,
+            conflicts.after_any,
+        );
+        let per_role_candidate_ids = roles
+            .iter()
+            .map(|role| {
+                safe_candidate_ids(
+                    before_control,
+                    vec![*role],
                     after,
-                    &probe,
                     before_by_id,
                     before_conflicting_component_ids,
-                    CandidateMode::Equivalent,
-                ) {
-                    used_ids.insert(candidate.component.component_id().as_str().to_owned());
-                }
-            }
-            increment_use_counts(&mut counts, used_ids);
-            continue;
-        };
-        let has_scope_reduction = !conflicts.before_scope.contains(component_id)
-            && !conflicts.after_scope.contains(component_id)
-            && scope_is_reduced(before_control, after_control);
-        let has_failure_mode_reduction = !conflicts.before_failure_mode.contains(component_id)
-            && !conflicts.after_failure_mode.contains(component_id)
-            && failure_mode_is_reduced(before_control, after_control);
-        let has_enablement_evidence_loss = !conflicts.before_enabled.contains(component_id)
-            && !conflicts.after_enabled.contains(component_id)
-            && matches!(
-                (before_control.enabled, after_control.enabled),
-                (Some(true), None)
-            );
-        let has_confidence_reduction =
-            after_control.confidence.strength() < before_control.confidence.strength();
-        let roles = if (after_control.enabled == Some(false)
-            && !conflicts.after_enabled.contains(component_id))
-            || has_enablement_evidence_loss
-            || has_confidence_reduction
-            || has_scope_reduction
-            || has_failure_mode_reduction
-        {
-            before_control.roles.clone()
-        } else {
-            missing_roles(before_control.roles(), after_control.roles())
-        };
-        let mut used_ids = BTreeSet::new();
-        for role in roles {
-            let mut probe = before_control.clone();
-            probe.roles = vec![role];
-            for candidate in replacement_candidates(
-                after,
-                &probe,
-                before_by_id,
-                before_conflicting_component_ids,
-                CandidateMode::Equivalent,
-            ) {
-                used_ids.insert(candidate.component.component_id().as_str().to_owned());
-            }
-        }
-        increment_use_counts(&mut counts, used_ids);
+                    conflicts.after_any,
+                )
+            })
+            .collect::<Vec<_>>();
+        let same_integrity_candidate_ids = replacement_candidates(
+            after,
+            before_control,
+            before_by_id,
+            before_conflicting_component_ids,
+            CandidateMode::SameIntegrity,
+        )
+        .into_iter()
+        .map(|candidate| candidate.component.component_id().as_str().to_owned())
+        .collect::<BTreeSet<_>>();
+        let contending_candidate_ids = same_integrity_candidate_ids
+            .iter()
+            .cloned()
+            .chain(per_role_candidate_ids.iter().flatten().cloned())
+            .collect();
+        demands.insert(
+            component_id.to_owned(),
+            ReplacementDemand {
+                roles,
+                full_candidate_ids,
+                per_role_candidate_ids,
+                same_integrity_candidate_ids,
+                contending_candidate_ids,
+            },
+        );
     }
-    counts
+
+    let candidate_edges = demands
+        .iter()
+        .map(|(component_id, demand)| (component_id.clone(), demand.full_candidate_ids.clone()))
+        .collect();
+    let assignment_resolutions = resolve_assignments(&candidate_edges);
+    let partial_contention = partial_candidate_contention(&demands);
+    let resolutions = demands
+        .into_iter()
+        .map(|(component_id, demand)| {
+            let assignment = assignment_resolutions.get(&component_id);
+            let (coverage, unique_candidate_id) = match assignment {
+                Some(AssignmentResolution::Unique(candidate_id))
+                    if !partial_contention
+                        .get(candidate_id)
+                        .is_some_and(|claimants| {
+                            claimants.iter().any(|claimant| claimant != &component_id)
+                        })
+                        && !has_alternative_split_plan(
+                            &demand.per_role_candidate_ids,
+                            candidate_id,
+                        ) =>
+                {
+                    (RoleReplacementCoverage::Unique, Some(candidate_id.clone()))
+                }
+                Some(AssignmentResolution::Unique(_) | AssignmentResolution::Ambiguous) => {
+                    (RoleReplacementCoverage::Ambiguous, None)
+                }
+                Some(AssignmentResolution::Missing)
+                    if demand
+                        .per_role_candidate_ids
+                        .iter()
+                        .all(|candidates| !candidates.is_empty()) =>
+                {
+                    (RoleReplacementCoverage::Ambiguous, None)
+                }
+                Some(AssignmentResolution::Missing) | None => {
+                    (RoleReplacementCoverage::Missing, None)
+                }
+            };
+            (
+                component_id,
+                ReplacementDemandResolution {
+                    roles: demand.roles,
+                    coverage,
+                    unique_candidate_id,
+                },
+            )
+        })
+        .collect();
+    ReplacementAssignmentIndex {
+        demands: resolutions,
+    }
+}
+
+fn replacement_demand_roles(
+    before: &AgentStackProtectionControl,
+    after_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    conflicts: &ReplacementStateConflicts<'_>,
+) -> Vec<AgentStackProtectionRole> {
+    let component_id = before.component.component_id().as_str();
+    let Some(after) = after_by_id.get(component_id).copied() else {
+        return before.roles.clone();
+    };
+    let has_scope_reduction = !conflicts.before_scope.contains(component_id)
+        && !conflicts.after_scope.contains(component_id)
+        && scope_is_reduced(before, after);
+    let has_failure_mode_reduction = !conflicts.before_failure_mode.contains(component_id)
+        && !conflicts.after_failure_mode.contains(component_id)
+        && failure_mode_is_reduced(before, after);
+    let has_enablement_evidence_loss = !conflicts.before_enabled.contains(component_id)
+        && !conflicts.after_enabled.contains(component_id)
+        && matches!((before.enabled, after.enabled), (Some(true), None));
+    let has_confidence_reduction = after.confidence.strength() < before.confidence.strength();
+    if (after.enabled == Some(false) && !conflicts.after_enabled.contains(component_id))
+        || has_enablement_evidence_loss
+        || has_confidence_reduction
+        || has_scope_reduction
+        || has_failure_mode_reduction
+    {
+        before.roles.clone()
+    } else {
+        missing_roles(before.roles(), after.roles())
+    }
+}
+
+fn safe_candidate_ids(
+    before: &AgentStackProtectionControl,
+    roles: Vec<AgentStackProtectionRole>,
+    after: &[AgentStackProtectionControl],
+    before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    before_conflicting_component_ids: &BTreeSet<String>,
+    after_conflicting_component_ids: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let mut probe = before.clone();
+    probe.roles = roles;
+    replacement_candidates(
+        after,
+        &probe,
+        before_by_id,
+        before_conflicting_component_ids,
+        CandidateMode::Equivalent,
+    )
+    .into_iter()
+    .map(|candidate| candidate.component.component_id().as_str())
+    .filter(|component_id| {
+        !before_conflicting_component_ids.contains(*component_id)
+            && !after_conflicting_component_ids.contains(*component_id)
+    })
+    .map(str::to_owned)
+    .collect()
+}
+
+fn partial_candidate_contention(
+    demands: &BTreeMap<String, ReplacementDemand>,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut contention = BTreeMap::<String, BTreeSet<String>>::new();
+    for (component_id, demand) in demands {
+        let has_complete_role_plan = demand
+            .per_role_candidate_ids
+            .iter()
+            .all(|candidates| !candidates.is_empty());
+        for candidate_id in demand
+            .contending_candidate_ids
+            .iter()
+            .filter(|candidate_id| {
+                !demand.full_candidate_ids.contains(*candidate_id)
+                    && (has_complete_role_plan
+                        || demand.same_integrity_candidate_ids.contains(*candidate_id))
+            })
+        {
+            contention
+                .entry(candidate_id.clone())
+                .or_default()
+                .insert(component_id.clone());
+        }
+    }
+    contention
+}
+
+fn has_alternative_split_plan(
+    per_role_candidate_ids: &[BTreeSet<String>],
+    excluded_candidate_id: &str,
+) -> bool {
+    let alternatives = per_role_candidate_ids
+        .iter()
+        .map(|candidates| {
+            candidates
+                .iter()
+                .filter(|candidate| candidate.as_str() != excluded_candidate_id)
+                .cloned()
+                .collect::<BTreeSet<_>>()
+        })
+        .collect::<Vec<_>>();
+    if alternatives.iter().any(BTreeSet::is_empty) {
+        return false;
+    }
+    let mut common = alternatives[0].clone();
+    for candidates in &alternatives[1..] {
+        common.retain(|candidate| candidates.contains(candidate));
+    }
+    common.is_empty() && alternatives.iter().flatten().collect::<BTreeSet<_>>().len() > 1
 }
 
 pub(super) fn classify_role_replacement(
@@ -231,8 +462,11 @@ pub(super) fn classify_role_replacement(
     before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
     before_conflicting_component_ids: &BTreeSet<String>,
     after_conflicting_component_ids: &BTreeSet<String>,
-    replacement_use_counts: &BTreeMap<String, usize>,
+    replacement_assignments: &ReplacementAssignmentIndex,
 ) -> RoleReplacementCoverage {
+    if let Some(coverage) = replacement_assignments.coverage(before, &roles) {
+        return coverage;
+    }
     let analysis = analyze_role_replacements(
         before,
         roles,
@@ -247,12 +481,7 @@ pub(super) fn classify_role_replacement(
     {
         return RoleReplacementCoverage::Missing;
     }
-    if analysis.replacement_ids.len() == 1
-        && analysis
-            .replacement_ids
-            .iter()
-            .all(|component_id| replacement_use_counts.get(component_id).copied() == Some(1))
-    {
+    if analysis.replacement_ids.len() == 1 {
         RoleReplacementCoverage::Unique
     } else {
         RoleReplacementCoverage::Ambiguous
@@ -266,8 +495,14 @@ pub(super) fn shared_replacement_roles(
     before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
     before_conflicting_component_ids: &BTreeSet<String>,
     after_conflicting_component_ids: &BTreeSet<String>,
-    replacement_use_counts: &BTreeMap<String, usize>,
+    replacement_assignments: &ReplacementAssignmentIndex,
 ) -> Vec<AgentStackProtectionRole> {
+    if let Some(coverage) = replacement_assignments.coverage(before, &roles) {
+        return match coverage {
+            RoleReplacementCoverage::Ambiguous => roles,
+            RoleReplacementCoverage::Unique | RoleReplacementCoverage::Missing => Vec::new(),
+        };
+    }
     roles
         .into_iter()
         .filter(|role| {
@@ -285,14 +520,6 @@ pub(super) fn shared_replacement_roles(
             .filter(|component_id| !after_conflicting_component_ids.contains(*component_id))
             .collect::<Vec<_>>();
             safe_candidate_ids.len() > 1
-                || (!safe_candidate_ids.is_empty()
-                    && safe_candidate_ids.iter().all(|component_id| {
-                        replacement_use_counts
-                            .get(*component_id)
-                            .copied()
-                            .unwrap_or(0)
-                            > 1
-                    }))
         })
         .collect()
 }
@@ -346,12 +573,6 @@ pub(super) fn failure_mode_is_reduced(
     )
 }
 
-fn increment_use_counts(counts: &mut BTreeMap<String, usize>, component_ids: BTreeSet<String>) {
-    for component_id in component_ids {
-        *counts.entry(component_id).or_insert(0) += 1;
-    }
-}
-
 fn candidate_is_new_protection(
     candidate: &AgentStackProtectionControl,
     removed: &AgentStackProtectionControl,
@@ -372,7 +593,7 @@ fn candidate_is_new_protection(
     }
 }
 
-fn equivalent_replacement(
+pub(super) fn equivalent_replacement(
     before: &AgentStackProtectionControl,
     after: &AgentStackProtectionControl,
 ) -> bool {

--- a/crates/harness-core/src/stack/protective_control_diff/replacements.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/replacements.rs
@@ -11,6 +11,7 @@ pub(super) enum CandidateMode {
     WeakEquivalent,
 }
 
+#[derive(Clone, Copy)]
 pub(super) enum RoleReplacementCoverage {
     Unique,
     Ambiguous,
@@ -115,6 +116,7 @@ pub(super) fn replacement_use_counts(
     before_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
     before_conflicting_component_ids: &BTreeSet<String>,
     after_by_id: &BTreeMap<String, &AgentStackProtectionControl>,
+    after_enabled_conflicting_component_ids: &BTreeSet<String>,
 ) -> BTreeMap<String, usize> {
     let mut counts = BTreeMap::new();
     for before_control in before {
@@ -124,13 +126,36 @@ pub(super) fn replacement_use_counts(
         let component_id = before_control.component.component_id().as_str();
         let Some(after_control) = after_by_id.get(component_id).copied() else {
             let mut used_ids = BTreeSet::new();
-            for mode in [CandidateMode::SameIntegrity, CandidateMode::Equivalent] {
+            let same_integrity = replacement_candidates(
+                after,
+                before_control,
+                before_by_id,
+                before_conflicting_component_ids,
+                CandidateMode::SameIntegrity,
+            );
+            let equivalent = replacement_candidates(
+                after,
+                before_control,
+                before_by_id,
+                before_conflicting_component_ids,
+                CandidateMode::Equivalent,
+            );
+            for candidate in same_integrity.iter().chain(equivalent.iter()) {
+                used_ids.insert(candidate.component.component_id().as_str().to_owned());
+            }
+            for role in before_control.roles.iter().copied().filter(|role| {
+                !same_integrity.iter().any(|candidate| {
+                    candidate.roles.contains(role) && candidate.enabled != Some(false)
+                })
+            }) {
+                let mut probe = before_control.clone();
+                probe.roles = vec![role];
                 for candidate in replacement_candidates(
                     after,
-                    before_control,
+                    &probe,
                     before_by_id,
                     before_conflicting_component_ids,
-                    mode,
+                    CandidateMode::Equivalent,
                 ) {
                     used_ids.insert(candidate.component.component_id().as_str().to_owned());
                 }
@@ -138,7 +163,9 @@ pub(super) fn replacement_use_counts(
             increment_use_counts(&mut counts, used_ids);
             continue;
         };
-        let roles = if after_control.enabled == Some(false) {
+        let roles = if after_control.enabled == Some(false)
+            && !after_enabled_conflicting_component_ids.contains(component_id)
+        {
             before_control.roles.clone()
         } else {
             missing_roles(before_control.roles(), after_control.roles())

--- a/crates/harness-core/src/stack/protective_control_diff/replacements/matching.rs
+++ b/crates/harness-core/src/stack/protective_control_diff/replacements/matching.rs
@@ -1,0 +1,303 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum AssignmentResolution {
+    Unique(String),
+    Ambiguous,
+    Missing,
+}
+
+struct MaximumMatching {
+    left_ids: Vec<String>,
+    right_ids: Vec<String>,
+    candidate_rights: Vec<Vec<usize>>,
+    left_to_right: Vec<Option<usize>>,
+    right_to_left: Vec<Option<usize>>,
+}
+
+pub(super) fn resolve_assignments(
+    candidate_edges: &BTreeMap<String, BTreeSet<String>>,
+) -> BTreeMap<String, AssignmentResolution> {
+    let matching = maximum_matching(candidate_edges);
+    let left_count = matching.left_ids.len();
+    let node_count = left_count + matching.right_ids.len();
+    let mut alternating = vec![Vec::new(); node_count];
+    let mut reverse_alternating = vec![Vec::new(); node_count];
+    for (left, candidates) in matching.candidate_rights.iter().enumerate() {
+        for right in candidates {
+            let right_node = left_count + right;
+            let (from, to) = if matching.left_to_right[left] == Some(*right) {
+                (right_node, left)
+            } else {
+                (left, right_node)
+            };
+            alternating[from].push(to);
+            reverse_alternating[to].push(from);
+        }
+    }
+
+    let unmatched_lefts = matching
+        .left_to_right
+        .iter()
+        .enumerate()
+        .filter_map(|(left, right)| right.is_none().then_some(left));
+    let reachable_from_unmatched_left = reachable(unmatched_lefts, &alternating);
+    let unmatched_rights = matching
+        .right_to_left
+        .iter()
+        .enumerate()
+        .filter_map(|(right, left)| left.is_none().then_some(left_count + right));
+    let can_reach_unmatched_right = reachable(unmatched_rights, &reverse_alternating);
+    let components = strongly_connected_components(&alternating, &reverse_alternating);
+
+    matching
+        .left_ids
+        .iter()
+        .enumerate()
+        .map(|(left, component_id)| {
+            let resolution = match matching.left_to_right[left] {
+                None if matching.candidate_rights[left].is_empty() => AssignmentResolution::Missing,
+                None => AssignmentResolution::Ambiguous,
+                Some(right) => {
+                    let right_node = left_count + right;
+                    let is_forced = !reachable_from_unmatched_left[left]
+                        && !can_reach_unmatched_right[left]
+                        && components[left] != components[right_node];
+                    if is_forced {
+                        AssignmentResolution::Unique(matching.right_ids[right].clone())
+                    } else {
+                        AssignmentResolution::Ambiguous
+                    }
+                }
+            };
+            (component_id.clone(), resolution)
+        })
+        .collect()
+}
+
+fn maximum_matching(candidate_edges: &BTreeMap<String, BTreeSet<String>>) -> MaximumMatching {
+    let left_ids = candidate_edges.keys().cloned().collect::<Vec<_>>();
+    let right_ids = candidate_edges
+        .values()
+        .flatten()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let right_indexes = right_ids
+        .iter()
+        .enumerate()
+        .map(|(index, component_id)| (component_id.as_str(), index))
+        .collect::<BTreeMap<_, _>>();
+    let candidate_rights = left_ids
+        .iter()
+        .map(|component_id| {
+            candidate_edges
+                .get(component_id)
+                .into_iter()
+                .flatten()
+                .filter_map(|candidate_id| right_indexes.get(candidate_id.as_str()).copied())
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut left_to_right = vec![None; left_ids.len()];
+    let mut right_to_left = vec![None; right_ids.len()];
+    for left in 0..left_ids.len() {
+        augment(
+            left,
+            &candidate_rights,
+            &mut left_to_right,
+            &mut right_to_left,
+        );
+    }
+    MaximumMatching {
+        left_ids,
+        right_ids,
+        candidate_rights,
+        left_to_right,
+        right_to_left,
+    }
+}
+
+fn augment(
+    start_left: usize,
+    candidate_rights: &[Vec<usize>],
+    left_to_right: &mut [Option<usize>],
+    right_to_left: &mut [Option<usize>],
+) -> bool {
+    let mut queue = VecDeque::from([start_left]);
+    let mut visited_left = vec![false; left_to_right.len()];
+    let mut predecessor_left = vec![None; right_to_left.len()];
+    visited_left[start_left] = true;
+    let mut unmatched_right = None;
+    while let Some(left) = queue.pop_front() {
+        for right in &candidate_rights[left] {
+            if predecessor_left[*right].is_some() {
+                continue;
+            }
+            predecessor_left[*right] = Some(left);
+            match right_to_left[*right] {
+                None => {
+                    unmatched_right = Some(*right);
+                    break;
+                }
+                Some(next_left) if !visited_left[next_left] => {
+                    visited_left[next_left] = true;
+                    queue.push_back(next_left);
+                }
+                Some(_) => {}
+            }
+        }
+        if unmatched_right.is_some() {
+            break;
+        }
+    }
+    let Some(mut right) = unmatched_right else {
+        return false;
+    };
+    loop {
+        let Some(left) = predecessor_left[right] else {
+            return false;
+        };
+        let previous_right = left_to_right[left].replace(right);
+        right_to_left[right] = Some(left);
+        let Some(previous_right) = previous_right else {
+            break;
+        };
+        right_to_left[previous_right] = None;
+        right = previous_right;
+    }
+    true
+}
+
+fn reachable(starts: impl IntoIterator<Item = usize>, graph: &[Vec<usize>]) -> Vec<bool> {
+    let mut reached = vec![false; graph.len()];
+    let mut queue = VecDeque::new();
+    for start in starts {
+        if !reached[start] {
+            reached[start] = true;
+            queue.push_back(start);
+        }
+    }
+    while let Some(node) = queue.pop_front() {
+        for next in &graph[node] {
+            if !reached[*next] {
+                reached[*next] = true;
+                queue.push_back(*next);
+            }
+        }
+    }
+    reached
+}
+
+fn strongly_connected_components(graph: &[Vec<usize>], reverse: &[Vec<usize>]) -> Vec<usize> {
+    let mut visited = vec![false; graph.len()];
+    let mut finish_order = Vec::with_capacity(graph.len());
+    for start in 0..graph.len() {
+        if visited[start] {
+            continue;
+        }
+        let mut stack = vec![(start, false)];
+        while let Some((node, expanded)) = stack.pop() {
+            if expanded {
+                finish_order.push(node);
+            } else if !visited[node] {
+                visited[node] = true;
+                stack.push((node, true));
+                for next in graph[node].iter().rev() {
+                    if !visited[*next] {
+                        stack.push((*next, false));
+                    }
+                }
+            }
+        }
+    }
+    let mut components = vec![usize::MAX; graph.len()];
+    let mut component = 0;
+    for start in finish_order.into_iter().rev() {
+        if components[start] != usize::MAX {
+            continue;
+        }
+        components[start] = component;
+        let mut stack = vec![start];
+        while let Some(node) = stack.pop() {
+            for next in &reverse[node] {
+                if components[*next] == usize::MAX {
+                    components[*next] = component;
+                    stack.push(*next);
+                }
+            }
+        }
+        component += 1;
+    }
+    components
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn edges(entries: &[(&str, &[&str])]) -> BTreeMap<String, BTreeSet<String>> {
+        entries
+            .iter()
+            .map(|(left, right)| {
+                (
+                    (*left).to_owned(),
+                    right.iter().map(|value| (*value).to_owned()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn forced_edges_are_unique_across_the_global_matching() {
+        let resolutions = resolve_assignments(&edges(&[("a", &["x", "y"]), ("b", &["x"])]));
+        assert_eq!(
+            resolutions.get("a"),
+            Some(&AssignmentResolution::Unique("y".to_owned()))
+        );
+        assert_eq!(
+            resolutions.get("b"),
+            Some(&AssignmentResolution::Unique("x".to_owned()))
+        );
+    }
+
+    #[test]
+    fn free_right_and_alternating_cycle_assignments_are_ambiguous() {
+        let single = resolve_assignments(&edges(&[("a", &["x", "y"])]));
+        assert_eq!(single.get("a"), Some(&AssignmentResolution::Ambiguous));
+
+        let cycle = resolve_assignments(&edges(&[("a", &["x", "y"]), ("b", &["x", "y"])]));
+        assert_eq!(cycle.get("a"), Some(&AssignmentResolution::Ambiguous));
+        assert_eq!(cycle.get("b"), Some(&AssignmentResolution::Ambiguous));
+    }
+
+    #[test]
+    fn unmatched_left_makes_a_shared_assignment_ambiguous() {
+        let resolutions = resolve_assignments(&edges(&[("a", &["x"]), ("b", &["x"])]));
+        assert_eq!(resolutions.get("a"), Some(&AssignmentResolution::Ambiguous));
+        assert_eq!(resolutions.get("b"), Some(&AssignmentResolution::Ambiguous));
+    }
+
+    #[test]
+    fn a_claim_without_candidates_is_missing() {
+        let resolutions = resolve_assignments(&edges(&[("a", &[])]));
+        assert_eq!(resolutions.get("a"), Some(&AssignmentResolution::Missing));
+    }
+
+    #[test]
+    fn dense_graph_uses_bounded_iterative_search() {
+        let candidate_ids = (0..128).map(|index| format!("r{index:03}"));
+        let all_candidates = candidate_ids.collect::<BTreeSet<_>>();
+        let graph = (0..128)
+            .map(|index| (format!("l{index:03}"), all_candidates.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        let resolutions = resolve_assignments(&graph);
+
+        assert_eq!(resolutions.len(), 128);
+        assert!(resolutions
+            .values()
+            .all(|resolution| *resolution == AssignmentResolution::Ambiguous));
+    }
+}

--- a/crates/harness-core/src/stack/protective_control_diff_tests.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests.rs
@@ -1,7 +1,25 @@
 use super::*;
+use AgentStackProtectionFailureMode as Mode;
+use AgentStackProtectionScope as Scope;
 
 const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const HASH_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const ACTIVE_REQUIRED: ControlState =
+    ControlState(Some(true), Some(Scope::Required), Some(Mode::FailClosed));
+const ACTIVE_COMPREHENSIVE: ControlState = ControlState(
+    Some(true),
+    Some(Scope::Comprehensive),
+    Some(Mode::FailClosed),
+);
+const DISABLED_PARTIAL_OPEN: ControlState =
+    ControlState(Some(false), Some(Scope::Partial), Some(Mode::FailOpen));
+const DISABLED_REQUIRED: ControlState =
+    ControlState(Some(false), Some(Scope::Required), Some(Mode::FailClosed));
+const UNKNOWN_REQUIRED: ControlState =
+    ControlState(None, Some(Scope::Required), Some(Mode::FailClosed));
+
+#[derive(Clone, Copy)]
+struct ControlState(Option<bool>, Option<Scope>, Option<Mode>);
 
 fn source(locator: &str) -> AgentStackSource {
     match AgentStackSource::new(AgentStackSourceScope::Repository, locator) {
@@ -47,28 +65,43 @@ fn control_with_confidence(
     roles: &[AgentStackProtectionRole],
     confidence: AgentStackProtectionConfidence,
 ) -> AgentStackProtectionControl {
-    match AgentStackProtectionControl::new(
-        component(kind, locator, Some(HASH_A)),
+    configured_control(
+        kind,
+        locator,
+        Some(HASH_A),
+        roles,
+        confidence,
+        ACTIVE_REQUIRED,
+    )
+}
+
+fn configured_control(
+    kind: AgentStackComponentKind,
+    locator: &str,
+    integrity: Option<&str>,
+    roles: &[AgentStackProtectionRole],
+    confidence: AgentStackProtectionConfidence,
+    state: ControlState,
+) -> AgentStackProtectionControl {
+    let mut control = match AgentStackProtectionControl::new(
+        component(kind, locator, integrity),
         roles.iter().copied(),
         confidence,
     ) {
-        Ok(control) => control
-            .with_enabled(true)
-            .with_scope(AgentStackProtectionScope::Required)
-            .with_failure_mode(AgentStackProtectionFailureMode::FailClosed),
+        Ok(control) => control,
         Err(error) => panic!("valid protection control: {error}"),
+    };
+    let ControlState(enabled, scope, failure_mode) = state;
+    if let Some(enabled) = enabled {
+        control = control.with_enabled(enabled);
     }
-}
-
-#[test]
-fn protective_control_diff_defines_all_protection_roles() {
-    assert_eq!(
-        AgentStackProtectionRole::ALL
-            .iter()
-            .map(AgentStackProtectionRole::as_str)
-            .collect::<Vec<_>>(),
-        ["policy", "hook", "validation", "sandboxing", "check"]
-    );
+    if let Some(scope) = scope {
+        control = control.with_scope(scope);
+    }
+    if let Some(failure_mode) = failure_mode {
+        control = control.with_failure_mode(failure_mode);
+    }
+    control
 }
 
 #[test]
@@ -118,21 +151,14 @@ fn protective_control_diff_reports_relaxed_existing_controls() {
             AgentStackProtectionRole::Check,
         ],
     )];
-    let relaxed = match AgentStackProtectionControl::new(
-        component(
-            AgentStackComponentKind::Validation,
-            ".github/workflows/ci.yml",
-            Some(HASH_B),
-        ),
-        [AgentStackProtectionRole::Validation],
+    let relaxed = configured_control(
+        AgentStackComponentKind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_B),
+        &[AgentStackProtectionRole::Validation],
         AgentStackProtectionConfidence::High,
-    ) {
-        Ok(control) => control
-            .with_enabled(false)
-            .with_scope(AgentStackProtectionScope::Partial)
-            .with_failure_mode(AgentStackProtectionFailureMode::FailOpen),
-        Err(error) => panic!("valid control: {error}"),
-    };
+        DISABLED_PARTIAL_OPEN,
+    );
     let after = [relaxed];
     let facts = protective_control_diff(&before, &after);
     assert_eq!(
@@ -197,21 +223,14 @@ fn protective_control_diff_suppresses_equivalent_replacement() {
         ".githooks/pre-push",
         &[AgentStackProtectionRole::Hook],
     )];
-    let replacement = match AgentStackProtectionControl::new(
-        component(
-            AgentStackComponentKind::Hook,
-            ".harness/guards/pre-push.sh",
-            Some(HASH_B),
-        ),
-        [AgentStackProtectionRole::Hook],
+    let replacement = configured_control(
+        AgentStackComponentKind::Hook,
+        ".harness/guards/pre-push.sh",
+        Some(HASH_B),
+        &[AgentStackProtectionRole::Hook],
         AgentStackProtectionConfidence::High,
-    ) {
-        Ok(control) => control
-            .with_enabled(true)
-            .with_scope(AgentStackProtectionScope::Comprehensive)
-            .with_failure_mode(AgentStackProtectionFailureMode::FailClosed),
-        Err(error) => panic!("valid replacement: {error}"),
-    };
+        ACTIVE_COMPREHENSIVE,
+    );
     let after = [replacement];
     let facts = protective_control_diff(&before, &after);
     assert!(
@@ -227,21 +246,14 @@ fn protective_control_diff_reports_weakened_rename_state() {
         ".githooks/pre-push",
         &[AgentStackProtectionRole::Hook],
     )];
-    let renamed = match AgentStackProtectionControl::new(
-        component(
-            AgentStackComponentKind::Hook,
-            ".harness/guards/pre-push.sh",
-            Some(HASH_A),
-        ),
-        [AgentStackProtectionRole::Hook],
+    let renamed = configured_control(
+        AgentStackComponentKind::Hook,
+        ".harness/guards/pre-push.sh",
+        Some(HASH_A),
+        &[AgentStackProtectionRole::Hook],
         AgentStackProtectionConfidence::High,
-    ) {
-        Ok(control) => control
-            .with_enabled(false)
-            .with_scope(AgentStackProtectionScope::Partial)
-            .with_failure_mode(AgentStackProtectionFailureMode::FailOpen),
-        Err(error) => panic!("valid renamed control: {error}"),
-    };
+        DISABLED_PARTIAL_OPEN,
+    );
     let after = [renamed];
 
     let facts = protective_control_diff(&before, &after);
@@ -314,21 +326,14 @@ fn protective_control_diff_keeps_low_confidence_replacements_ambiguous() {
         ".githooks/pre-commit",
         &[AgentStackProtectionRole::Hook],
     )];
-    let replacement = match AgentStackProtectionControl::new(
-        component(
-            AgentStackComponentKind::Hook,
-            ".harness/guards/pre-commit.sh",
-            Some(HASH_B),
-        ),
-        [AgentStackProtectionRole::Hook],
+    let replacement = configured_control(
+        AgentStackComponentKind::Hook,
+        ".harness/guards/pre-commit.sh",
+        Some(HASH_B),
+        &[AgentStackProtectionRole::Hook],
         AgentStackProtectionConfidence::Low,
-    ) {
-        Ok(control) => control
-            .with_enabled(true)
-            .with_scope(AgentStackProtectionScope::Required)
-            .with_failure_mode(AgentStackProtectionFailureMode::FailClosed),
-        Err(error) => panic!("valid low-confidence replacement: {error}"),
-    };
+        ACTIVE_REQUIRED,
+    );
     let after = [replacement];
 
     let facts = protective_control_diff(&before, &after);
@@ -346,32 +351,146 @@ fn protective_control_diff_keeps_low_confidence_replacements_ambiguous() {
 }
 
 #[test]
-fn protective_control_diff_compares_all_duplicate_after_component_ids() {
+fn protective_control_diff_aggregates_split_duplicate_after_roles() {
     let before = [control(
-        AgentStackComponentKind::Validation,
-        ".github/workflows/ci.yml",
-        &[AgentStackProtectionRole::Validation],
+        AgentStackComponentKind::Policy,
+        "rules/protect.toml",
+        &[
+            AgentStackProtectionRole::Policy,
+            AgentStackProtectionRole::Validation,
+        ],
     )];
-    let enabled = control(
-        AgentStackComponentKind::Validation,
-        ".github/workflows/ci.yml",
-        &[AgentStackProtectionRole::Validation],
-    );
-    let disabled = control(
-        AgentStackComponentKind::Validation,
-        ".github/workflows/ci.yml",
-        &[AgentStackProtectionRole::Validation],
-    )
-    .with_enabled(false);
-    let first_order = [enabled.clone(), disabled.clone()];
-    let second_order = [disabled, enabled];
+    let after = [
+        control(
+            AgentStackComponentKind::Policy,
+            "rules/protect.toml",
+            &[AgentStackProtectionRole::Policy],
+        ),
+        control(
+            AgentStackComponentKind::Policy,
+            "rules/protect.toml",
+            &[AgentStackProtectionRole::Validation],
+        ),
+    ];
 
-    for after in [&first_order, &second_order] {
-        let facts = protective_control_diff(&before, after);
-        assert_eq!(facts.len(), 1);
-        assert_eq!(
-            facts[0].reason(),
-            AgentStackProtectionControlReason::ExplicitlyDisabled
-        );
-    }
+    let facts = protective_control_diff(&before, &after);
+
+    assert!(
+        facts.is_empty(),
+        "duplicate reports for one component should be combined before diffing"
+    );
+}
+
+#[test]
+fn protective_control_diff_rejects_disabled_unknown_state_replacement() {
+    let before = [configured_control(
+        AgentStackComponentKind::Hook,
+        ".githooks/pre-commit",
+        Some(HASH_A),
+        &[AgentStackProtectionRole::Hook],
+        AgentStackProtectionConfidence::High,
+        UNKNOWN_REQUIRED,
+    )];
+    let replacement = configured_control(
+        AgentStackComponentKind::Hook,
+        ".harness/guards/pre-commit.sh",
+        Some(HASH_B),
+        &[AgentStackProtectionRole::Hook],
+        AgentStackProtectionConfidence::High,
+        DISABLED_REQUIRED,
+    );
+    let after = [replacement];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(facts.len(), 1);
+    assert_eq!(facts[0].kind(), AgentStackProtectionDiffKind::Removed);
+}
+
+#[test]
+fn protective_control_diff_caps_rename_evidence_at_source_confidence() {
+    let before = [control_with_confidence(
+        AgentStackComponentKind::Policy,
+        "rules/protect.toml",
+        &[AgentStackProtectionRole::Policy],
+        AgentStackProtectionConfidence::Low,
+    )];
+    let after = [control(
+        AgentStackComponentKind::Policy,
+        "rules/renamed.toml",
+        &[AgentStackProtectionRole::Policy],
+    )];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(facts.len(), 1);
+    assert_eq!(
+        facts[0].reason(),
+        AgentStackProtectionControlReason::PossibleRename
+    );
+    assert_eq!(facts[0].confidence(), AgentStackProtectionConfidence::Low);
+}
+
+#[test]
+fn protective_control_diff_keeps_multi_candidate_renames_ambiguous() {
+    let before = [control(
+        AgentStackComponentKind::Policy,
+        "rules/protect.toml",
+        &[AgentStackProtectionRole::Policy],
+    )];
+    let after = [
+        control(
+            AgentStackComponentKind::Policy,
+            "rules/renamed-a.toml",
+            &[AgentStackProtectionRole::Policy],
+        ),
+        control(
+            AgentStackComponentKind::Policy,
+            "rules/renamed-b.toml",
+            &[AgentStackProtectionRole::Policy],
+        )
+        .with_enabled(false),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(facts.len(), 1);
+    assert_eq!(
+        facts[0].reason(),
+        AgentStackProtectionControlReason::PossibleRename
+    );
+    assert!(facts[0].after().is_none());
+}
+
+#[test]
+fn protective_control_diff_reports_many_to_one_replacements_as_ambiguous() {
+    let before = [
+        control(
+            AgentStackComponentKind::Hook,
+            ".githooks/pre-commit",
+            &[AgentStackProtectionRole::Hook],
+        ),
+        control(
+            AgentStackComponentKind::Hook,
+            ".githooks/pre-push",
+            &[AgentStackProtectionRole::Hook],
+        ),
+    ];
+    let replacement = configured_control(
+        AgentStackComponentKind::Hook,
+        ".harness/guards/git-hooks.sh",
+        Some(HASH_B),
+        &[AgentStackProtectionRole::Hook],
+        AgentStackProtectionConfidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let after = [replacement];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(facts.len(), 2);
+    assert!(facts.iter().all(|fact| {
+        fact.reason() == AgentStackProtectionControlReason::AmbiguousReplacement
+            && fact.kind() == AgentStackProtectionDiffKind::AmbiguousReviewEvidence
+    }));
 }

--- a/crates/harness-core/src/stack/protective_control_diff_tests.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests.rs
@@ -7,6 +7,9 @@ use AgentStackProtectionDiffKind as DiffKind;
 use AgentStackProtectionFailureMode as Mode;
 use AgentStackProtectionRole as Role;
 use AgentStackProtectionScope as Scope;
+
+mod review_threads;
+
 const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const HASH_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 const ACTIVE_REQUIRED: ControlState =

--- a/crates/harness-core/src/stack/protective_control_diff_tests.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests.rs
@@ -9,6 +9,7 @@ use AgentStackProtectionRole as Role;
 use AgentStackProtectionScope as Scope;
 
 mod review_threads;
+mod review_threads_late;
 
 const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const HASH_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";

--- a/crates/harness-core/src/stack/protective_control_diff_tests.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests.rs
@@ -1,5 +1,11 @@
 use super::*;
+use AgentStackComponentKind as Kind;
+use AgentStackProtectionConfidence as Confidence;
+use AgentStackProtectionControlDiff as Diff;
+use AgentStackProtectionControlReason as Reason;
+use AgentStackProtectionDiffKind as DiffKind;
 use AgentStackProtectionFailureMode as Mode;
+use AgentStackProtectionRole as Role;
 use AgentStackProtectionScope as Scope;
 
 const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -28,11 +34,7 @@ fn source(locator: &str) -> AgentStackSource {
     }
 }
 
-fn component(
-    kind: AgentStackComponentKind,
-    locator: &str,
-    integrity: Option<&str>,
-) -> AgentStackComponent {
+fn component(kind: Kind, locator: &str, integrity: Option<&str>) -> AgentStackComponent {
     let component = match AgentStackComponent::new(
         kind,
         source(locator),
@@ -51,19 +53,15 @@ fn component(
     component.with_integrity(integrity)
 }
 
-fn control(
-    kind: AgentStackComponentKind,
-    locator: &str,
-    roles: &[AgentStackProtectionRole],
-) -> AgentStackProtectionControl {
-    control_with_confidence(kind, locator, roles, AgentStackProtectionConfidence::High)
+fn control(kind: Kind, locator: &str, roles: &[Role]) -> AgentStackProtectionControl {
+    control_with_confidence(kind, locator, roles, Confidence::High)
 }
 
 fn control_with_confidence(
-    kind: AgentStackComponentKind,
+    kind: Kind,
     locator: &str,
-    roles: &[AgentStackProtectionRole],
-    confidence: AgentStackProtectionConfidence,
+    roles: &[Role],
+    confidence: Confidence,
 ) -> AgentStackProtectionControl {
     configured_control(
         kind,
@@ -76,11 +74,11 @@ fn control_with_confidence(
 }
 
 fn configured_control(
-    kind: AgentStackComponentKind,
+    kind: Kind,
     locator: &str,
     integrity: Option<&str>,
-    roles: &[AgentStackProtectionRole],
-    confidence: AgentStackProtectionConfidence,
+    roles: &[Role],
+    confidence: Confidence,
     state: ControlState,
 ) -> AgentStackProtectionControl {
     let mut control = match AgentStackProtectionControl::new(
@@ -104,13 +102,33 @@ fn configured_control(
     control
 }
 
+fn configured_hook(
+    locator: &str,
+    integrity: Option<&str>,
+    confidence: Confidence,
+    state: ControlState,
+) -> AgentStackProtectionControl {
+    configured_control(
+        Kind::Hook,
+        locator,
+        integrity,
+        &[Role::Hook],
+        confidence,
+        state,
+    )
+}
+
+fn kinds(facts: &[Diff]) -> Vec<DiffKind> {
+    facts.iter().map(Diff::kind).collect()
+}
+
+fn reasons(facts: &[Diff]) -> Vec<Reason> {
+    facts.iter().map(Diff::reason).collect()
+}
+
 #[test]
 fn protective_control_diff_ignores_benign_hook_removal_without_role_evidence() {
-    let before = [control(
-        AgentStackComponentKind::Hook,
-        ".githooks/pre-commit",
-        &[],
-    )];
+    let before = [control(Kind::Hook, ".githooks/pre-commit", &[])];
     let facts = protective_control_diff(&before, &[]);
     assert!(
         facts.is_empty(),
@@ -120,19 +138,12 @@ fn protective_control_diff_ignores_benign_hook_removal_without_role_evidence() {
 
 #[test]
 fn protective_control_diff_reports_protective_policy_removal() {
-    let before = [control(
-        AgentStackComponentKind::Policy,
-        "rules/protect.toml",
-        &[AgentStackProtectionRole::Policy],
-    )];
+    let before = [control(Kind::Policy, "rules/protect.toml", &[Role::Policy])];
     let facts = protective_control_diff(&before, &[]);
     assert_eq!(facts.len(), 1);
-    assert_eq!(facts[0].kind(), AgentStackProtectionDiffKind::Removed);
-    assert_eq!(
-        facts[0].reason(),
-        AgentStackProtectionControlReason::RemovedWithoutEquivalent
-    );
-    assert_eq!(facts[0].confidence(), AgentStackProtectionConfidence::High);
+    assert_eq!(facts[0].kind(), DiffKind::Removed);
+    assert_eq!(facts[0].reason(), Reason::RemovedWithoutEquivalent);
+    assert_eq!(facts[0].confidence(), Confidence::High);
     let Some(before) = facts[0].before() else {
         panic!("before evidence");
     };
@@ -143,34 +154,27 @@ fn protective_control_diff_reports_protective_policy_removal() {
 #[test]
 fn protective_control_diff_reports_relaxed_existing_controls() {
     let before = [control(
-        AgentStackComponentKind::Validation,
+        Kind::Validation,
         ".github/workflows/ci.yml",
-        &[
-            AgentStackProtectionRole::Validation,
-            AgentStackProtectionRole::Sandboxing,
-            AgentStackProtectionRole::Check,
-        ],
+        &[Role::Validation, Role::Sandboxing, Role::Check],
     )];
     let relaxed = configured_control(
-        AgentStackComponentKind::Validation,
+        Kind::Validation,
         ".github/workflows/ci.yml",
         Some(HASH_B),
-        &[AgentStackProtectionRole::Validation],
-        AgentStackProtectionConfidence::High,
+        &[Role::Validation],
+        Confidence::High,
         DISABLED_PARTIAL_OPEN,
     );
     let after = [relaxed];
     let facts = protective_control_diff(&before, &after);
     assert_eq!(
-        facts
-            .iter()
-            .map(AgentStackProtectionControlDiff::kind)
-            .collect::<Vec<_>>(),
+        kinds(&facts),
         [
-            AgentStackProtectionDiffKind::Disabled,
-            AgentStackProtectionDiffKind::FailOpen,
-            AgentStackProtectionDiffKind::ScopeReduced,
-            AgentStackProtectionDiffKind::ScopeReduced,
+            DiffKind::Disabled,
+            DiffKind::FailOpen,
+            DiffKind::ScopeReduced,
+            DiffKind::ScopeReduced,
         ]
     );
     assert!(facts
@@ -178,38 +182,21 @@ fn protective_control_diff_reports_relaxed_existing_controls() {
         .all(|fact| fact.before().is_some() && fact.after().is_some()));
     assert!(facts
         .iter()
-        .any(|fact| fact.reason() == AgentStackProtectionControlReason::RoleSetReduced));
+        .any(|fact| fact.reason() == Reason::RoleSetReduced));
     assert!(facts
         .iter()
-        .any(|fact| fact.reason() == AgentStackProtectionControlReason::ScopeLevelReduced));
+        .any(|fact| fact.reason() == Reason::ScopeLevelReduced));
 }
 
 #[test]
 fn protective_control_diff_treats_rename_as_review_evidence() {
-    let before = [control(
-        AgentStackComponentKind::Policy,
-        "rules/protect.toml",
-        &[AgentStackProtectionRole::Policy],
-    )];
-    let after = [control(
-        AgentStackComponentKind::Policy,
-        "rules/renamed.toml",
-        &[AgentStackProtectionRole::Policy],
-    )];
+    let before = [control(Kind::Policy, "rules/protect.toml", &[Role::Policy])];
+    let after = [control(Kind::Policy, "rules/renamed.toml", &[Role::Policy])];
     let facts = protective_control_diff(&before, &after);
     assert_eq!(facts.len(), 1);
-    assert_eq!(
-        facts[0].kind(),
-        AgentStackProtectionDiffKind::AmbiguousReviewEvidence
-    );
-    assert_eq!(
-        facts[0].reason(),
-        AgentStackProtectionControlReason::PossibleRename
-    );
-    assert_eq!(
-        facts[0].confidence(),
-        AgentStackProtectionConfidence::Medium
-    );
+    assert_eq!(facts[0].kind(), DiffKind::AmbiguousReviewEvidence);
+    assert_eq!(facts[0].reason(), Reason::PossibleRename);
+    assert_eq!(facts[0].confidence(), Confidence::Medium);
     let Some(after) = facts[0].after() else {
         panic!("after evidence");
     };
@@ -218,17 +205,11 @@ fn protective_control_diff_treats_rename_as_review_evidence() {
 
 #[test]
 fn protective_control_diff_suppresses_equivalent_replacement() {
-    let before = [control(
-        AgentStackComponentKind::Hook,
-        ".githooks/pre-push",
-        &[AgentStackProtectionRole::Hook],
-    )];
-    let replacement = configured_control(
-        AgentStackComponentKind::Hook,
+    let before = [control(Kind::Hook, ".githooks/pre-push", &[Role::Hook])];
+    let replacement = configured_hook(
         ".harness/guards/pre-push.sh",
         Some(HASH_B),
-        &[AgentStackProtectionRole::Hook],
-        AgentStackProtectionConfidence::High,
+        Confidence::High,
         ACTIVE_COMPREHENSIVE,
     );
     let after = [replacement];
@@ -241,17 +222,11 @@ fn protective_control_diff_suppresses_equivalent_replacement() {
 
 #[test]
 fn protective_control_diff_reports_weakened_rename_state() {
-    let before = [control(
-        AgentStackComponentKind::Hook,
-        ".githooks/pre-push",
-        &[AgentStackProtectionRole::Hook],
-    )];
-    let renamed = configured_control(
-        AgentStackComponentKind::Hook,
+    let before = [control(Kind::Hook, ".githooks/pre-push", &[Role::Hook])];
+    let renamed = configured_hook(
         ".harness/guards/pre-push.sh",
         Some(HASH_A),
-        &[AgentStackProtectionRole::Hook],
-        AgentStackProtectionConfidence::High,
+        Confidence::High,
         DISABLED_PARTIAL_OPEN,
     );
     let after = [renamed];
@@ -259,57 +234,35 @@ fn protective_control_diff_reports_weakened_rename_state() {
     let facts = protective_control_diff(&before, &after);
 
     assert_eq!(
-        facts
-            .iter()
-            .map(AgentStackProtectionControlDiff::reason)
-            .collect::<Vec<_>>(),
+        reasons(&facts),
         [
-            AgentStackProtectionControlReason::PossibleRename,
-            AgentStackProtectionControlReason::ExplicitlyDisabled,
-            AgentStackProtectionControlReason::FailureModeRelaxed,
-            AgentStackProtectionControlReason::ScopeLevelReduced,
+            Reason::PossibleRename,
+            Reason::ExplicitlyDisabled,
+            Reason::FailureModeRelaxed,
+            Reason::ScopeLevelReduced,
         ]
     );
 }
 
 #[test]
 fn protective_control_diff_excludes_unchanged_controls_from_rename_candidates() {
-    let removed = control(
-        AgentStackComponentKind::Policy,
-        "rules/deleted.toml",
-        &[AgentStackProtectionRole::Policy],
-    );
-    let retained_before = control(
-        AgentStackComponentKind::Policy,
-        "rules/retained.toml",
-        &[AgentStackProtectionRole::Policy],
-    );
-    let retained_after = control(
-        AgentStackComponentKind::Policy,
-        "rules/retained.toml",
-        &[AgentStackProtectionRole::Policy],
-    );
+    let removed = control(Kind::Policy, "rules/deleted.toml", &[Role::Policy]);
+    let retained_before = control(Kind::Policy, "rules/retained.toml", &[Role::Policy]);
+    let retained_after = control(Kind::Policy, "rules/retained.toml", &[Role::Policy]);
     let before = [removed, retained_before];
     let after = [retained_after];
 
     let facts = protective_control_diff(&before, &after);
 
     assert_eq!(facts.len(), 1);
-    assert_eq!(facts[0].kind(), AgentStackProtectionDiffKind::Removed);
-    assert_eq!(
-        facts[0].reason(),
-        AgentStackProtectionControlReason::RemovedWithoutEquivalent
-    );
+    assert_eq!(facts[0].kind(), DiffKind::Removed);
+    assert_eq!(facts[0].reason(), Reason::RemovedWithoutEquivalent);
 }
 
 #[test]
 fn protective_control_diff_ignores_removed_controls_already_disabled() {
-    let before = [control(
-        AgentStackComponentKind::Policy,
-        "rules/disabled.toml",
-        &[AgentStackProtectionRole::Policy],
-    )
-    .with_enabled(false)];
+    let before =
+        [control(Kind::Policy, "rules/disabled.toml", &[Role::Policy]).with_enabled(false)];
 
     let facts = protective_control_diff(&before, &[]);
 
@@ -321,17 +274,13 @@ fn protective_control_diff_ignores_removed_controls_already_disabled() {
 
 #[test]
 fn protective_control_diff_keeps_low_confidence_replacements_ambiguous() {
-    let before = [control(
-        AgentStackComponentKind::Hook,
-        ".githooks/pre-commit",
-        &[AgentStackProtectionRole::Hook],
-    )];
+    let before = [control(Kind::Hook, ".githooks/pre-commit", &[Role::Hook])];
     let replacement = configured_control(
-        AgentStackComponentKind::Hook,
+        Kind::Hook,
         ".harness/guards/pre-commit.sh",
         Some(HASH_B),
-        &[AgentStackProtectionRole::Hook],
-        AgentStackProtectionConfidence::Low,
+        &[Role::Hook],
+        Confidence::Low,
         ACTIVE_REQUIRED,
     );
     let after = [replacement];
@@ -339,38 +288,21 @@ fn protective_control_diff_keeps_low_confidence_replacements_ambiguous() {
     let facts = protective_control_diff(&before, &after);
 
     assert_eq!(facts.len(), 1);
-    assert_eq!(
-        facts[0].kind(),
-        AgentStackProtectionDiffKind::AmbiguousReviewEvidence
-    );
-    assert_eq!(
-        facts[0].reason(),
-        AgentStackProtectionControlReason::AmbiguousReplacement
-    );
-    assert_eq!(facts[0].confidence(), AgentStackProtectionConfidence::Low);
+    assert_eq!(facts[0].kind(), DiffKind::AmbiguousReviewEvidence);
+    assert_eq!(facts[0].reason(), Reason::AmbiguousReplacement);
+    assert_eq!(facts[0].confidence(), Confidence::Low);
 }
 
 #[test]
 fn protective_control_diff_aggregates_split_duplicate_after_roles() {
     let before = [control(
-        AgentStackComponentKind::Policy,
+        Kind::Policy,
         "rules/protect.toml",
-        &[
-            AgentStackProtectionRole::Policy,
-            AgentStackProtectionRole::Validation,
-        ],
+        &[Role::Policy, Role::Validation],
     )];
     let after = [
-        control(
-            AgentStackComponentKind::Policy,
-            "rules/protect.toml",
-            &[AgentStackProtectionRole::Policy],
-        ),
-        control(
-            AgentStackComponentKind::Policy,
-            "rules/protect.toml",
-            &[AgentStackProtectionRole::Validation],
-        ),
+        control(Kind::Policy, "rules/protect.toml", &[Role::Policy]),
+        control(Kind::Policy, "rules/protect.toml", &[Role::Validation]),
     ];
 
     let facts = protective_control_diff(&before, &after);
@@ -383,20 +315,16 @@ fn protective_control_diff_aggregates_split_duplicate_after_roles() {
 
 #[test]
 fn protective_control_diff_rejects_disabled_unknown_state_replacement() {
-    let before = [configured_control(
-        AgentStackComponentKind::Hook,
+    let before = [configured_hook(
         ".githooks/pre-commit",
         Some(HASH_A),
-        &[AgentStackProtectionRole::Hook],
-        AgentStackProtectionConfidence::High,
+        Confidence::High,
         UNKNOWN_REQUIRED,
     )];
-    let replacement = configured_control(
-        AgentStackComponentKind::Hook,
+    let replacement = configured_hook(
         ".harness/guards/pre-commit.sh",
         Some(HASH_B),
-        &[AgentStackProtectionRole::Hook],
-        AgentStackProtectionConfidence::High,
+        Confidence::High,
         DISABLED_REQUIRED,
     );
     let after = [replacement];
@@ -404,84 +332,53 @@ fn protective_control_diff_rejects_disabled_unknown_state_replacement() {
     let facts = protective_control_diff(&before, &after);
 
     assert_eq!(facts.len(), 1);
-    assert_eq!(facts[0].kind(), AgentStackProtectionDiffKind::Removed);
+    assert_eq!(facts[0].kind(), DiffKind::Removed);
 }
 
 #[test]
 fn protective_control_diff_caps_rename_evidence_at_source_confidence() {
     let before = [control_with_confidence(
-        AgentStackComponentKind::Policy,
+        Kind::Policy,
         "rules/protect.toml",
-        &[AgentStackProtectionRole::Policy],
-        AgentStackProtectionConfidence::Low,
+        &[Role::Policy],
+        Confidence::Low,
     )];
-    let after = [control(
-        AgentStackComponentKind::Policy,
-        "rules/renamed.toml",
-        &[AgentStackProtectionRole::Policy],
-    )];
+    let after = [control(Kind::Policy, "rules/renamed.toml", &[Role::Policy])];
 
     let facts = protective_control_diff(&before, &after);
 
     assert_eq!(facts.len(), 1);
-    assert_eq!(
-        facts[0].reason(),
-        AgentStackProtectionControlReason::PossibleRename
-    );
-    assert_eq!(facts[0].confidence(), AgentStackProtectionConfidence::Low);
+    assert_eq!(facts[0].reason(), Reason::PossibleRename);
+    assert_eq!(facts[0].confidence(), Confidence::Low);
 }
 
 #[test]
 fn protective_control_diff_keeps_multi_candidate_renames_ambiguous() {
-    let before = [control(
-        AgentStackComponentKind::Policy,
-        "rules/protect.toml",
-        &[AgentStackProtectionRole::Policy],
-    )];
+    let before = [control(Kind::Policy, "rules/protect.toml", &[Role::Policy])];
     let after = [
-        control(
-            AgentStackComponentKind::Policy,
-            "rules/renamed-a.toml",
-            &[AgentStackProtectionRole::Policy],
-        ),
-        control(
-            AgentStackComponentKind::Policy,
-            "rules/renamed-b.toml",
-            &[AgentStackProtectionRole::Policy],
-        )
-        .with_enabled(false),
+        control(Kind::Policy, "rules/renamed-a.toml", &[Role::Policy]),
+        control(Kind::Policy, "rules/renamed-b.toml", &[Role::Policy]).with_enabled(false),
     ];
 
     let facts = protective_control_diff(&before, &after);
 
     assert_eq!(facts.len(), 1);
-    assert_eq!(
-        facts[0].reason(),
-        AgentStackProtectionControlReason::PossibleRename
-    );
+    assert_eq!(facts[0].reason(), Reason::PossibleRename);
     assert!(facts[0].after().is_none());
 }
 
 #[test]
 fn protective_control_diff_reports_many_to_one_replacements_as_ambiguous() {
     let before = [
-        control(
-            AgentStackComponentKind::Hook,
-            ".githooks/pre-commit",
-            &[AgentStackProtectionRole::Hook],
-        ),
-        control(
-            AgentStackComponentKind::Hook,
-            ".githooks/pre-push",
-            &[AgentStackProtectionRole::Hook],
-        ),
+        control(Kind::Hook, ".githooks/pre-commit", &[Role::Hook]),
+        control(Kind::Hook, ".githooks/pre-push", &[Role::Hook]),
     ];
     let replacement = configured_control(
-        AgentStackComponentKind::Hook,
+        Kind::Hook,
         ".harness/guards/git-hooks.sh",
         Some(HASH_B),
-        &[AgentStackProtectionRole::Hook],
-        AgentStackProtectionConfidence::High,
+        &[Role::Hook],
+        Confidence::High,
         ACTIVE_REQUIRED,
     );
     let after = [replacement];
@@ -490,7 +387,42 @@ fn protective_control_diff_reports_many_to_one_replacements_as_ambiguous() {
 
     assert_eq!(facts.len(), 2);
     assert!(facts.iter().all(|fact| {
-        fact.reason() == AgentStackProtectionControlReason::AmbiguousReplacement
-            && fact.kind() == AgentStackProtectionDiffKind::AmbiguousReviewEvidence
+        fact.reason() == Reason::AmbiguousReplacement
+            && fact.kind() == DiffKind::AmbiguousReviewEvidence
     }));
+}
+
+#[test]
+fn protective_control_diff_handles_review_edge_cases() {
+    let before = [configured_hook(
+        ".githooks/pre-commit",
+        Some(HASH_A),
+        Confidence::High,
+        UNKNOWN_REQUIRED,
+    )];
+    let after = [before[0].clone().with_enabled(false)];
+    assert_eq!(
+        reasons(&protective_control_diff(&before, &after)),
+        [Reason::ExplicitlyDisabled]
+    );
+
+    let before = [
+        control(Kind::Hook, ".githooks/pre-commit", &[Role::Hook]),
+        configured_hook(
+            ".githooks/pre-push",
+            Some(HASH_B),
+            Confidence::Medium,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+    let after = [configured_hook(
+        ".harness/guards/git-hooks.sh",
+        Some(HASH_A),
+        Confidence::Medium,
+        ACTIVE_REQUIRED,
+    )];
+    assert_eq!(
+        reasons(&protective_control_diff(&before, &after)),
+        [Reason::PossibleRename, Reason::AmbiguousReplacement]
+    );
 }

--- a/crates/harness-core/src/stack/protective_control_diff_tests.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests.rs
@@ -7,7 +7,6 @@ use AgentStackProtectionDiffKind as DiffKind;
 use AgentStackProtectionFailureMode as Mode;
 use AgentStackProtectionRole as Role;
 use AgentStackProtectionScope as Scope;
-
 const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const HASH_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 const ACTIVE_REQUIRED: ControlState =
@@ -23,17 +22,14 @@ const DISABLED_REQUIRED: ControlState =
     ControlState(Some(false), Some(Scope::Required), Some(Mode::FailClosed));
 const UNKNOWN_REQUIRED: ControlState =
     ControlState(None, Some(Scope::Required), Some(Mode::FailClosed));
-
 #[derive(Clone, Copy)]
 struct ControlState(Option<bool>, Option<Scope>, Option<Mode>);
-
 fn source(locator: &str) -> AgentStackSource {
     match AgentStackSource::new(AgentStackSourceScope::Repository, locator) {
         Ok(source) => source,
         Err(error) => panic!("valid source: {error}"),
     }
 }
-
 fn component(kind: Kind, locator: &str, integrity: Option<&str>) -> AgentStackComponent {
     let component = match AgentStackComponent::new(
         kind,
@@ -52,11 +48,9 @@ fn component(kind: Kind, locator: &str, integrity: Option<&str>) -> AgentStackCo
     });
     component.with_integrity(integrity)
 }
-
 fn control(kind: Kind, locator: &str, roles: &[Role]) -> AgentStackProtectionControl {
     control_with_confidence(kind, locator, roles, Confidence::High)
 }
-
 fn control_with_confidence(
     kind: Kind,
     locator: &str,
@@ -72,7 +66,6 @@ fn control_with_confidence(
         ACTIVE_REQUIRED,
     )
 }
-
 fn configured_control(
     kind: Kind,
     locator: &str,
@@ -101,7 +94,6 @@ fn configured_control(
     }
     control
 }
-
 fn configured_hook(
     locator: &str,
     integrity: Option<&str>,
@@ -117,15 +109,12 @@ fn configured_hook(
         state,
     )
 }
-
 fn kinds(facts: &[Diff]) -> Vec<DiffKind> {
     facts.iter().map(Diff::kind).collect()
 }
-
 fn reasons(facts: &[Diff]) -> Vec<Reason> {
     facts.iter().map(Diff::reason).collect()
 }
-
 #[test]
 fn protective_control_diff_ignores_benign_hook_removal_without_role_evidence() {
     let before = [control(Kind::Hook, ".githooks/pre-commit", &[])];
@@ -135,7 +124,6 @@ fn protective_control_diff_ignores_benign_hook_removal_without_role_evidence() {
         "hook kind alone must not imply protection"
     );
 }
-
 #[test]
 fn protective_control_diff_reports_protective_policy_removal() {
     let before = [control(Kind::Policy, "rules/protect.toml", &[Role::Policy])];
@@ -150,7 +138,6 @@ fn protective_control_diff_reports_protective_policy_removal() {
     assert_eq!(before.source_locator(), "rules/protect.toml");
     assert!(facts[0].after().is_none());
 }
-
 #[test]
 fn protective_control_diff_reports_relaxed_existing_controls() {
     let before = [control(
@@ -187,7 +174,6 @@ fn protective_control_diff_reports_relaxed_existing_controls() {
         .iter()
         .any(|fact| fact.reason() == Reason::ScopeLevelReduced));
 }
-
 #[test]
 fn protective_control_diff_treats_rename_as_review_evidence() {
     let before = [control(Kind::Policy, "rules/protect.toml", &[Role::Policy])];
@@ -202,7 +188,6 @@ fn protective_control_diff_treats_rename_as_review_evidence() {
     };
     assert_eq!(after.source_locator(), "rules/renamed.toml");
 }
-
 #[test]
 fn protective_control_diff_suppresses_equivalent_replacement() {
     let before = [control(Kind::Hook, ".githooks/pre-push", &[Role::Hook])];
@@ -219,7 +204,6 @@ fn protective_control_diff_suppresses_equivalent_replacement() {
         "same role with equal-or-stronger state is not a weakening fact"
     );
 }
-
 #[test]
 fn protective_control_diff_reports_weakened_rename_state() {
     let before = [control(Kind::Hook, ".githooks/pre-push", &[Role::Hook])];
@@ -230,9 +214,7 @@ fn protective_control_diff_reports_weakened_rename_state() {
         DISABLED_PARTIAL_OPEN,
     );
     let after = [renamed];
-
     let facts = protective_control_diff(&before, &after);
-
     assert_eq!(
         reasons(&facts),
         [
@@ -243,7 +225,6 @@ fn protective_control_diff_reports_weakened_rename_state() {
         ]
     );
 }
-
 #[test]
 fn protective_control_diff_excludes_unchanged_controls_from_rename_candidates() {
     let removed = control(Kind::Policy, "rules/deleted.toml", &[Role::Policy]);
@@ -251,27 +232,21 @@ fn protective_control_diff_excludes_unchanged_controls_from_rename_candidates() 
     let retained_after = control(Kind::Policy, "rules/retained.toml", &[Role::Policy]);
     let before = [removed, retained_before];
     let after = [retained_after];
-
     let facts = protective_control_diff(&before, &after);
-
     assert_eq!(facts.len(), 1);
     assert_eq!(facts[0].kind(), DiffKind::Removed);
     assert_eq!(facts[0].reason(), Reason::RemovedWithoutEquivalent);
 }
-
 #[test]
 fn protective_control_diff_ignores_removed_controls_already_disabled() {
     let before =
         [control(Kind::Policy, "rules/disabled.toml", &[Role::Policy]).with_enabled(false)];
-
     let facts = protective_control_diff(&before, &[]);
-
     assert!(
         facts.is_empty(),
         "removing an explicitly disabled control is not a weakening"
     );
 }
-
 #[test]
 fn protective_control_diff_keeps_low_confidence_replacements_ambiguous() {
     let before = [control(Kind::Hook, ".githooks/pre-commit", &[Role::Hook])];
@@ -284,15 +259,12 @@ fn protective_control_diff_keeps_low_confidence_replacements_ambiguous() {
         ACTIVE_REQUIRED,
     );
     let after = [replacement];
-
     let facts = protective_control_diff(&before, &after);
-
     assert_eq!(facts.len(), 1);
     assert_eq!(facts[0].kind(), DiffKind::AmbiguousReviewEvidence);
     assert_eq!(facts[0].reason(), Reason::AmbiguousReplacement);
     assert_eq!(facts[0].confidence(), Confidence::Low);
 }
-
 #[test]
 fn protective_control_diff_aggregates_split_duplicate_after_roles() {
     let before = [control(
@@ -304,15 +276,12 @@ fn protective_control_diff_aggregates_split_duplicate_after_roles() {
         control(Kind::Policy, "rules/protect.toml", &[Role::Policy]),
         control(Kind::Policy, "rules/protect.toml", &[Role::Validation]),
     ];
-
     let facts = protective_control_diff(&before, &after);
-
     assert!(
         facts.is_empty(),
         "duplicate reports for one component should be combined before diffing"
     );
 }
-
 #[test]
 fn protective_control_diff_rejects_disabled_unknown_state_replacement() {
     let before = [configured_hook(
@@ -328,13 +297,10 @@ fn protective_control_diff_rejects_disabled_unknown_state_replacement() {
         DISABLED_REQUIRED,
     );
     let after = [replacement];
-
     let facts = protective_control_diff(&before, &after);
-
     assert_eq!(facts.len(), 1);
     assert_eq!(facts[0].kind(), DiffKind::Removed);
 }
-
 #[test]
 fn protective_control_diff_caps_rename_evidence_at_source_confidence() {
     let before = [control_with_confidence(
@@ -344,14 +310,11 @@ fn protective_control_diff_caps_rename_evidence_at_source_confidence() {
         Confidence::Low,
     )];
     let after = [control(Kind::Policy, "rules/renamed.toml", &[Role::Policy])];
-
     let facts = protective_control_diff(&before, &after);
-
     assert_eq!(facts.len(), 1);
     assert_eq!(facts[0].reason(), Reason::PossibleRename);
     assert_eq!(facts[0].confidence(), Confidence::Low);
 }
-
 #[test]
 fn protective_control_diff_keeps_multi_candidate_renames_ambiguous() {
     let before = [control(Kind::Policy, "rules/protect.toml", &[Role::Policy])];
@@ -359,14 +322,11 @@ fn protective_control_diff_keeps_multi_candidate_renames_ambiguous() {
         control(Kind::Policy, "rules/renamed-a.toml", &[Role::Policy]),
         control(Kind::Policy, "rules/renamed-b.toml", &[Role::Policy]).with_enabled(false),
     ];
-
     let facts = protective_control_diff(&before, &after);
-
     assert_eq!(facts.len(), 1);
     assert_eq!(facts[0].reason(), Reason::PossibleRename);
     assert!(facts[0].after().is_none());
 }
-
 #[test]
 fn protective_control_diff_reports_many_to_one_replacements_as_ambiguous() {
     let before = [
@@ -382,47 +342,55 @@ fn protective_control_diff_reports_many_to_one_replacements_as_ambiguous() {
         ACTIVE_REQUIRED,
     );
     let after = [replacement];
-
     let facts = protective_control_diff(&before, &after);
-
     assert_eq!(facts.len(), 2);
     assert!(facts.iter().all(|fact| {
         fact.reason() == Reason::AmbiguousReplacement
             && fact.kind() == DiffKind::AmbiguousReviewEvidence
     }));
 }
-
 #[test]
+#[rustfmt::skip]
 fn protective_control_diff_handles_review_edge_cases() {
-    let before = [configured_hook(
-        ".githooks/pre-commit",
-        Some(HASH_A),
-        Confidence::High,
-        UNKNOWN_REQUIRED,
-    )];
+    let before = [configured_hook(".githooks/pre-commit", Some(HASH_A), Confidence::High, UNKNOWN_REQUIRED)];
     let after = [before[0].clone().with_enabled(false)];
     assert_eq!(
         reasons(&protective_control_diff(&before, &after)),
         [Reason::ExplicitlyDisabled]
     );
-
     let before = [
         control(Kind::Hook, ".githooks/pre-commit", &[Role::Hook]),
-        configured_hook(
-            ".githooks/pre-push",
-            Some(HASH_B),
-            Confidence::Medium,
-            ACTIVE_REQUIRED,
-        ),
+        configured_hook(".githooks/pre-push", Some(HASH_B), Confidence::Medium, ACTIVE_REQUIRED),
     ];
-    let after = [configured_hook(
-        ".harness/guards/git-hooks.sh",
-        Some(HASH_A),
-        Confidence::Medium,
-        ACTIVE_REQUIRED,
-    )];
+    let after = [configured_hook(".harness/guards/git-hooks.sh", Some(HASH_A), Confidence::Medium, ACTIVE_REQUIRED)];
     assert_eq!(
         reasons(&protective_control_diff(&before, &after)),
         [Reason::PossibleRename, Reason::AmbiguousReplacement]
     );
+    let before = [control(Kind::Hook, ".githooks/pre-merge", &[Role::Hook])];
+    let after = [
+        configured_hook(".harness/guards/pre-merge.sh", Some(HASH_A), Confidence::High, ACTIVE_REQUIRED),
+        configured_hook(".harness/guards/pre-merge.sh", Some(HASH_B), Confidence::High, ACTIVE_REQUIRED),
+    ];
+    assert_eq!(
+        reasons(&protective_control_diff(&before, &after)),
+        [Reason::ConflictingDuplicateReport]
+    );
+    let removed = control(Kind::Hook, ".githooks/pre-receive", &[Role::Hook]);
+    let retained_before = configured_hook(".harness/guards/git-hooks.sh", Some(HASH_B), Confidence::High, ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailOpen)));
+    let retained_after = configured_hook(".harness/guards/git-hooks.sh", Some(HASH_B), Confidence::High, ACTIVE_REQUIRED);
+    assert!(protective_control_diff(&[removed, retained_before], &[retained_after]).is_empty());
+    let before = [
+        control(Kind::Hook, ".githooks/pre-rebase", &[Role::Hook]),
+        configured_hook(".harness/guards/rebase.sh", Some(HASH_B), Confidence::High, ACTIVE_REQUIRED),
+        configured_hook(".harness/guards/rebase.sh", Some(HASH_B), Confidence::High, DISABLED_REQUIRED),
+    ];
+    let after = [configured_hook(".harness/guards/rebase.sh", Some(HASH_B), Confidence::High, ACTIVE_REQUIRED)];
+    let facts = protective_control_diff(&before, &after);
+    assert!(facts.iter().any(|fact| {
+        fact.reason() == Reason::ConflictingDuplicateReport
+            && fact
+                .before()
+                .is_some_and(|before| before.source_locator() == ".githooks/pre-rebase")
+    }));
 }

--- a/crates/harness-core/src/stack/protective_control_diff_tests.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests.rs
@@ -1,0 +1,212 @@
+use super::*;
+
+const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const HASH_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn source(locator: &str) -> AgentStackSource {
+    match AgentStackSource::new(AgentStackSourceScope::Repository, locator) {
+        Ok(source) => source,
+        Err(error) => panic!("valid source: {error}"),
+    }
+}
+
+fn component(
+    kind: AgentStackComponentKind,
+    locator: &str,
+    integrity: Option<&str>,
+) -> AgentStackComponent {
+    let component = match AgentStackComponent::new(
+        kind,
+        source(locator),
+        AgentStackObservationClass::RepositoryObserved,
+        AgentStackSelectionState::Discovered,
+        AgentStackTrustLevel::RepositoryObserved,
+        AgentStackFreshness::Fresh,
+    ) {
+        Ok(component) => component,
+        Err(error) => panic!("valid component: {error}"),
+    };
+    let integrity = integrity.map(|digest| match Sha256Digest::parse(digest) {
+        Ok(parsed) => parsed,
+        Err(error) => panic!("valid digest: {error}"),
+    });
+    component.with_integrity(integrity)
+}
+
+fn control(
+    kind: AgentStackComponentKind,
+    locator: &str,
+    roles: &[AgentStackProtectionRole],
+) -> AgentStackProtectionControl {
+    match AgentStackProtectionControl::new(
+        component(kind, locator, Some(HASH_A)),
+        roles.iter().copied(),
+        AgentStackProtectionConfidence::High,
+    ) {
+        Ok(control) => control
+            .with_enabled(true)
+            .with_scope(AgentStackProtectionScope::Required)
+            .with_failure_mode(AgentStackProtectionFailureMode::FailClosed),
+        Err(error) => panic!("valid protection control: {error}"),
+    }
+}
+
+#[test]
+fn protective_control_diff_defines_all_protection_roles() {
+    assert_eq!(
+        AgentStackProtectionRole::ALL
+            .iter()
+            .map(AgentStackProtectionRole::as_str)
+            .collect::<Vec<_>>(),
+        ["policy", "hook", "validation", "sandboxing", "check"]
+    );
+}
+
+#[test]
+fn protective_control_diff_ignores_benign_hook_removal_without_role_evidence() {
+    let before = [control(
+        AgentStackComponentKind::Hook,
+        ".githooks/pre-commit",
+        &[],
+    )];
+    let facts = protective_control_diff(&before, &[]);
+    assert!(
+        facts.is_empty(),
+        "hook kind alone must not imply protection"
+    );
+}
+
+#[test]
+fn protective_control_diff_reports_protective_policy_removal() {
+    let before = [control(
+        AgentStackComponentKind::Policy,
+        "rules/protect.toml",
+        &[AgentStackProtectionRole::Policy],
+    )];
+    let facts = protective_control_diff(&before, &[]);
+    assert_eq!(facts.len(), 1);
+    assert_eq!(facts[0].kind(), AgentStackProtectionDiffKind::Removed);
+    assert_eq!(
+        facts[0].reason(),
+        AgentStackProtectionControlReason::RemovedWithoutEquivalent
+    );
+    assert_eq!(facts[0].confidence(), AgentStackProtectionConfidence::High);
+    let Some(before) = facts[0].before() else {
+        panic!("before evidence");
+    };
+    assert_eq!(before.source_locator(), "rules/protect.toml");
+    assert!(facts[0].after().is_none());
+}
+
+#[test]
+fn protective_control_diff_reports_relaxed_existing_controls() {
+    let before = [control(
+        AgentStackComponentKind::Validation,
+        ".github/workflows/ci.yml",
+        &[
+            AgentStackProtectionRole::Validation,
+            AgentStackProtectionRole::Sandboxing,
+            AgentStackProtectionRole::Check,
+        ],
+    )];
+    let relaxed = match AgentStackProtectionControl::new(
+        component(
+            AgentStackComponentKind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_B),
+        ),
+        [AgentStackProtectionRole::Validation],
+        AgentStackProtectionConfidence::High,
+    ) {
+        Ok(control) => control
+            .with_enabled(false)
+            .with_scope(AgentStackProtectionScope::Partial)
+            .with_failure_mode(AgentStackProtectionFailureMode::FailOpen),
+        Err(error) => panic!("valid control: {error}"),
+    };
+    let after = [relaxed];
+    let facts = protective_control_diff(&before, &after);
+    assert_eq!(
+        facts
+            .iter()
+            .map(AgentStackProtectionControlDiff::kind)
+            .collect::<Vec<_>>(),
+        [
+            AgentStackProtectionDiffKind::Disabled,
+            AgentStackProtectionDiffKind::FailOpen,
+            AgentStackProtectionDiffKind::ScopeReduced,
+            AgentStackProtectionDiffKind::ScopeReduced,
+        ]
+    );
+    assert!(facts
+        .iter()
+        .all(|fact| fact.before().is_some() && fact.after().is_some()));
+    assert!(facts
+        .iter()
+        .any(|fact| fact.reason() == AgentStackProtectionControlReason::RoleSetReduced));
+    assert!(facts
+        .iter()
+        .any(|fact| fact.reason() == AgentStackProtectionControlReason::ScopeLevelReduced));
+}
+
+#[test]
+fn protective_control_diff_treats_rename_as_review_evidence() {
+    let before = [control(
+        AgentStackComponentKind::Policy,
+        "rules/protect.toml",
+        &[AgentStackProtectionRole::Policy],
+    )];
+    let after = [control(
+        AgentStackComponentKind::Policy,
+        "rules/renamed.toml",
+        &[AgentStackProtectionRole::Policy],
+    )];
+    let facts = protective_control_diff(&before, &after);
+    assert_eq!(facts.len(), 1);
+    assert_eq!(
+        facts[0].kind(),
+        AgentStackProtectionDiffKind::AmbiguousReviewEvidence
+    );
+    assert_eq!(
+        facts[0].reason(),
+        AgentStackProtectionControlReason::PossibleRename
+    );
+    assert_eq!(
+        facts[0].confidence(),
+        AgentStackProtectionConfidence::Medium
+    );
+    let Some(after) = facts[0].after() else {
+        panic!("after evidence");
+    };
+    assert_eq!(after.source_locator(), "rules/renamed.toml");
+}
+
+#[test]
+fn protective_control_diff_suppresses_equivalent_replacement() {
+    let before = [control(
+        AgentStackComponentKind::Hook,
+        ".githooks/pre-push",
+        &[AgentStackProtectionRole::Hook],
+    )];
+    let replacement = match AgentStackProtectionControl::new(
+        component(
+            AgentStackComponentKind::Hook,
+            ".harness/guards/pre-push.sh",
+            Some(HASH_B),
+        ),
+        [AgentStackProtectionRole::Hook],
+        AgentStackProtectionConfidence::High,
+    ) {
+        Ok(control) => control
+            .with_enabled(true)
+            .with_scope(AgentStackProtectionScope::Comprehensive)
+            .with_failure_mode(AgentStackProtectionFailureMode::FailClosed),
+        Err(error) => panic!("valid replacement: {error}"),
+    };
+    let after = [replacement];
+    let facts = protective_control_diff(&before, &after);
+    assert!(
+        facts.is_empty(),
+        "same role with equal-or-stronger state is not a weakening fact"
+    );
+}

--- a/crates/harness-core/src/stack/protective_control_diff_tests.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests.rs
@@ -38,10 +38,19 @@ fn control(
     locator: &str,
     roles: &[AgentStackProtectionRole],
 ) -> AgentStackProtectionControl {
+    control_with_confidence(kind, locator, roles, AgentStackProtectionConfidence::High)
+}
+
+fn control_with_confidence(
+    kind: AgentStackComponentKind,
+    locator: &str,
+    roles: &[AgentStackProtectionRole],
+    confidence: AgentStackProtectionConfidence,
+) -> AgentStackProtectionControl {
     match AgentStackProtectionControl::new(
         component(kind, locator, Some(HASH_A)),
         roles.iter().copied(),
-        AgentStackProtectionConfidence::High,
+        confidence,
     ) {
         Ok(control) => control
             .with_enabled(true)
@@ -209,4 +218,160 @@ fn protective_control_diff_suppresses_equivalent_replacement() {
         facts.is_empty(),
         "same role with equal-or-stronger state is not a weakening fact"
     );
+}
+
+#[test]
+fn protective_control_diff_reports_weakened_rename_state() {
+    let before = [control(
+        AgentStackComponentKind::Hook,
+        ".githooks/pre-push",
+        &[AgentStackProtectionRole::Hook],
+    )];
+    let renamed = match AgentStackProtectionControl::new(
+        component(
+            AgentStackComponentKind::Hook,
+            ".harness/guards/pre-push.sh",
+            Some(HASH_A),
+        ),
+        [AgentStackProtectionRole::Hook],
+        AgentStackProtectionConfidence::High,
+    ) {
+        Ok(control) => control
+            .with_enabled(false)
+            .with_scope(AgentStackProtectionScope::Partial)
+            .with_failure_mode(AgentStackProtectionFailureMode::FailOpen),
+        Err(error) => panic!("valid renamed control: {error}"),
+    };
+    let after = [renamed];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(
+        facts
+            .iter()
+            .map(AgentStackProtectionControlDiff::reason)
+            .collect::<Vec<_>>(),
+        [
+            AgentStackProtectionControlReason::PossibleRename,
+            AgentStackProtectionControlReason::ExplicitlyDisabled,
+            AgentStackProtectionControlReason::FailureModeRelaxed,
+            AgentStackProtectionControlReason::ScopeLevelReduced,
+        ]
+    );
+}
+
+#[test]
+fn protective_control_diff_excludes_unchanged_controls_from_rename_candidates() {
+    let removed = control(
+        AgentStackComponentKind::Policy,
+        "rules/deleted.toml",
+        &[AgentStackProtectionRole::Policy],
+    );
+    let retained_before = control(
+        AgentStackComponentKind::Policy,
+        "rules/retained.toml",
+        &[AgentStackProtectionRole::Policy],
+    );
+    let retained_after = control(
+        AgentStackComponentKind::Policy,
+        "rules/retained.toml",
+        &[AgentStackProtectionRole::Policy],
+    );
+    let before = [removed, retained_before];
+    let after = [retained_after];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(facts.len(), 1);
+    assert_eq!(facts[0].kind(), AgentStackProtectionDiffKind::Removed);
+    assert_eq!(
+        facts[0].reason(),
+        AgentStackProtectionControlReason::RemovedWithoutEquivalent
+    );
+}
+
+#[test]
+fn protective_control_diff_ignores_removed_controls_already_disabled() {
+    let before = [control(
+        AgentStackComponentKind::Policy,
+        "rules/disabled.toml",
+        &[AgentStackProtectionRole::Policy],
+    )
+    .with_enabled(false)];
+
+    let facts = protective_control_diff(&before, &[]);
+
+    assert!(
+        facts.is_empty(),
+        "removing an explicitly disabled control is not a weakening"
+    );
+}
+
+#[test]
+fn protective_control_diff_keeps_low_confidence_replacements_ambiguous() {
+    let before = [control(
+        AgentStackComponentKind::Hook,
+        ".githooks/pre-commit",
+        &[AgentStackProtectionRole::Hook],
+    )];
+    let replacement = match AgentStackProtectionControl::new(
+        component(
+            AgentStackComponentKind::Hook,
+            ".harness/guards/pre-commit.sh",
+            Some(HASH_B),
+        ),
+        [AgentStackProtectionRole::Hook],
+        AgentStackProtectionConfidence::Low,
+    ) {
+        Ok(control) => control
+            .with_enabled(true)
+            .with_scope(AgentStackProtectionScope::Required)
+            .with_failure_mode(AgentStackProtectionFailureMode::FailClosed),
+        Err(error) => panic!("valid low-confidence replacement: {error}"),
+    };
+    let after = [replacement];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(facts.len(), 1);
+    assert_eq!(
+        facts[0].kind(),
+        AgentStackProtectionDiffKind::AmbiguousReviewEvidence
+    );
+    assert_eq!(
+        facts[0].reason(),
+        AgentStackProtectionControlReason::AmbiguousReplacement
+    );
+    assert_eq!(facts[0].confidence(), AgentStackProtectionConfidence::Low);
+}
+
+#[test]
+fn protective_control_diff_compares_all_duplicate_after_component_ids() {
+    let before = [control(
+        AgentStackComponentKind::Validation,
+        ".github/workflows/ci.yml",
+        &[AgentStackProtectionRole::Validation],
+    )];
+    let enabled = control(
+        AgentStackComponentKind::Validation,
+        ".github/workflows/ci.yml",
+        &[AgentStackProtectionRole::Validation],
+    );
+    let disabled = control(
+        AgentStackComponentKind::Validation,
+        ".github/workflows/ci.yml",
+        &[AgentStackProtectionRole::Validation],
+    )
+    .with_enabled(false);
+    let first_order = [enabled.clone(), disabled.clone()];
+    let second_order = [disabled, enabled];
+
+    for after in [&first_order, &second_order] {
+        let facts = protective_control_diff(&before, after);
+        assert_eq!(facts.len(), 1);
+        assert_eq!(
+            facts[0].reason(),
+            AgentStackProtectionControlReason::ExplicitlyDisabled
+        );
+    }
 }

--- a/crates/harness-core/src/stack/protective_control_diff_tests.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests.rs
@@ -388,3 +388,286 @@ fn protective_control_diff_handles_review_edge_cases() {
     ];
     assert!(protective_control_diff(&before, &after).is_empty());
 }
+
+#[test]
+fn protective_control_diff_reviews_loss_of_explicit_enabled_evidence() {
+    let before = [configured_hook(
+        ".githooks/pre-commit",
+        Some(HASH_A),
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [configured_hook(
+        ".githooks/pre-commit",
+        Some(HASH_A),
+        Confidence::High,
+        ControlState(None, Some(Scope::Required), Some(Mode::FailClosed)),
+    )];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::EnablementEvidenceLost]);
+    assert!(facts[0].before().is_some() && facts[0].after().is_some());
+}
+
+#[test]
+fn protective_control_diff_reviews_loss_of_fail_closed_evidence() {
+    let before = [configured_hook(
+        ".githooks/pre-push",
+        Some(HASH_A),
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [configured_hook(
+        ".githooks/pre-push",
+        Some(HASH_A),
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Required), None),
+    )];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::FailureModeRelaxed]);
+    assert!(facts[0].before().is_some() && facts[0].after().is_some());
+}
+
+#[test]
+fn protective_control_diff_preserves_conflicts_in_partial_role_replacements() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/checks.yml",
+            Some(HASH_B),
+            &[Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/checks.yml",
+            Some(HASH_B),
+            &[Role::Check],
+            Confidence::High,
+            ControlState(Some(true), Some(Scope::Partial), Some(Mode::FailOpen)),
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::ConflictingDuplicateReport]);
+    assert_eq!(facts[0].roles(), [Role::Check]);
+    assert_eq!(
+        facts[0].after().map(|evidence| evidence.source_locator()),
+        Some(".github/workflows/checks.yml")
+    );
+}
+
+#[test]
+fn protective_control_diff_reviews_collective_multi_role_replacement() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/validation.yml",
+            Some(HASH_B),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/checks.yml",
+            Some(HASH_B),
+            &[Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::AmbiguousReplacement]);
+    assert_eq!(facts[0].roles(), [Role::Check, Role::Validation]);
+    assert!(facts[0].after().is_none());
+}
+
+#[test]
+fn protective_control_diff_keeps_conflict_and_uncovered_removal_facts() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/checks.yml",
+            Some(HASH_B),
+            &[Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/checks.yml",
+            Some(HASH_B),
+            &[Role::Check],
+            Confidence::High,
+            ControlState(Some(true), Some(Scope::Partial), Some(Mode::FailOpen)),
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(
+        kinds(&facts),
+        [DiffKind::AmbiguousReviewEvidence, DiffKind::Removed]
+    );
+    assert_eq!(facts[0].reason(), Reason::ConflictingDuplicateReport);
+    assert_eq!(facts[0].roles(), [Role::Check]);
+    assert_eq!(facts[1].reason(), Reason::RemovedWithoutEquivalent);
+    assert_eq!(facts[1].roles(), [Role::Validation]);
+}
+
+#[test]
+fn protective_control_diff_binds_conflicting_roles_to_each_candidate() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/checks.yml",
+            Some(HASH_B),
+            &[Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/checks.yml",
+            Some(HASH_B),
+            &[Role::Check],
+            Confidence::High,
+            ControlState(Some(true), Some(Scope::Partial), Some(Mode::FailOpen)),
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/validation.yml",
+            Some(HASH_B),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/validation.yml",
+            Some(HASH_B),
+            &[Role::Validation],
+            Confidence::High,
+            ControlState(Some(true), Some(Scope::Partial), Some(Mode::FailOpen)),
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(facts.len(), 2);
+    assert!(facts
+        .iter()
+        .all(|fact| fact.reason() == Reason::ConflictingDuplicateReport));
+    let Some(check_fact) = facts.iter().find(|fact| {
+        fact.after()
+            .is_some_and(|after| after.source_locator() == ".github/workflows/checks.yml")
+    }) else {
+        panic!("checks conflict fact");
+    };
+    assert_eq!(check_fact.roles(), [Role::Check]);
+    let Some(validation_fact) = facts.iter().find(|fact| {
+        fact.after()
+            .is_some_and(|after| after.source_locator() == ".github/workflows/validation.yml")
+    }) else {
+        panic!("validation conflict fact");
+    };
+    assert_eq!(validation_fact.roles(), [Role::Validation]);
+}
+
+#[test]
+fn protective_control_diff_keeps_same_integrity_conflict_and_uncovered_removal() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/renamed-checks.yml",
+            Some(HASH_A),
+            &[Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/renamed-checks.yml",
+            Some(HASH_A),
+            &[Role::Check],
+            Confidence::High,
+            ControlState(Some(true), Some(Scope::Partial), Some(Mode::FailOpen)),
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(
+        kinds(&facts),
+        [DiffKind::AmbiguousReviewEvidence, DiffKind::Removed]
+    );
+    assert_eq!(facts[0].reason(), Reason::ConflictingDuplicateReport);
+    assert_eq!(facts[0].roles(), [Role::Check]);
+    assert_eq!(
+        facts[0].after().map(|evidence| evidence.source_locator()),
+        Some(".github/workflows/renamed-checks.yml")
+    );
+    assert_eq!(facts[1].reason(), Reason::RemovedWithoutEquivalent);
+    assert_eq!(facts[1].roles(), [Role::Validation]);
+    assert!(facts[1].after().is_none());
+}

--- a/crates/harness-core/src/stack/protective_control_diff_tests.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests.rs
@@ -51,20 +51,9 @@ fn component(kind: Kind, locator: &str, integrity: Option<&str>) -> AgentStackCo
 fn control(kind: Kind, locator: &str, roles: &[Role]) -> AgentStackProtectionControl {
     control_with_confidence(kind, locator, roles, Confidence::High)
 }
-fn control_with_confidence(
-    kind: Kind,
-    locator: &str,
-    roles: &[Role],
-    confidence: Confidence,
-) -> AgentStackProtectionControl {
-    configured_control(
-        kind,
-        locator,
-        Some(HASH_A),
-        roles,
-        confidence,
-        ACTIVE_REQUIRED,
-    )
+#[rustfmt::skip]
+fn control_with_confidence(kind: Kind, locator: &str, roles: &[Role], confidence: Confidence) -> AgentStackProtectionControl {
+    configured_control(kind, locator, Some(HASH_A), roles, confidence, ACTIVE_REQUIRED)
 }
 fn configured_control(
     kind: Kind,
@@ -94,20 +83,9 @@ fn configured_control(
     }
     control
 }
-fn configured_hook(
-    locator: &str,
-    integrity: Option<&str>,
-    confidence: Confidence,
-    state: ControlState,
-) -> AgentStackProtectionControl {
-    configured_control(
-        Kind::Hook,
-        locator,
-        integrity,
-        &[Role::Hook],
-        confidence,
-        state,
-    )
+#[rustfmt::skip]
+fn configured_hook(locator: &str, integrity: Option<&str>, confidence: Confidence, state: ControlState) -> AgentStackProtectionControl {
+    configured_control(Kind::Hook, locator, integrity, &[Role::Hook], confidence, state)
 }
 fn kinds(facts: &[Diff]) -> Vec<DiffKind> {
     facts.iter().map(Diff::kind).collect()
@@ -365,7 +343,7 @@ fn protective_control_diff_handles_review_edge_cases() {
     let after = [configured_hook(".harness/guards/git-hooks.sh", Some(HASH_A), Confidence::Medium, ACTIVE_REQUIRED)];
     assert_eq!(
         reasons(&protective_control_diff(&before, &after)),
-        [Reason::PossibleRename, Reason::AmbiguousReplacement]
+        [Reason::ConfidenceReduced, Reason::PossibleRename, Reason::AmbiguousReplacement]
     );
     let before = [control(Kind::Hook, ".githooks/pre-merge", &[Role::Hook])];
     let after = [
@@ -393,4 +371,20 @@ fn protective_control_diff_handles_review_edge_cases() {
                 .before()
                 .is_some_and(|before| before.source_locator() == ".githooks/pre-rebase")
     }));
+    let removed = control(Kind::Hook, ".githooks/pre-confidence", &[Role::Hook]);
+    let retained_before = control_with_confidence(Kind::Hook, ".harness/guards/confidence.sh", &[Role::Hook], Confidence::Low);
+    let retained_after = control(Kind::Hook, ".harness/guards/confidence.sh", &[Role::Hook]);
+    assert!(protective_control_diff(&[removed, retained_before], &[retained_after]).is_empty());
+    let before = [control(Kind::Hook, ".githooks/pre-confidence-drop", &[Role::Hook])];
+    let after = [control_with_confidence(Kind::Hook, ".githooks/pre-confidence-drop", &[Role::Hook], Confidence::Low)];
+    assert_eq!(reasons(&protective_control_diff(&before, &after)), [Reason::ConfidenceReduced]);
+    let before = [configured_hook(".githooks/pre-scope", Some(HASH_A), Confidence::High, ACTIVE_REQUIRED)];
+    let after = [configured_hook(".githooks/pre-scope", Some(HASH_A), Confidence::High, ControlState(Some(true), None, Some(Mode::FailClosed)))];
+    assert_eq!(reasons(&protective_control_diff(&before, &after)), [Reason::ScopeLevelReduced]);
+    let before = [configured_control(Kind::Validation, ".github/workflows/ci.yml", Some(HASH_A), &[Role::Validation, Role::Check], Confidence::High, ACTIVE_REQUIRED)];
+    let after = [
+        configured_control(Kind::Validation, ".github/workflows/ci.yml", Some(HASH_A), &[Role::Validation], Confidence::High, ACTIVE_REQUIRED),
+        configured_control(Kind::Validation, ".github/workflows/checks.yml", Some(HASH_B), &[Role::Check], Confidence::High, ACTIVE_REQUIRED),
+    ];
+    assert!(protective_control_diff(&before, &after).is_empty());
 }

--- a/crates/harness-core/src/stack/protective_control_diff_tests.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests.rs
@@ -10,6 +10,7 @@ use AgentStackProtectionScope as Scope;
 
 mod review_threads;
 mod review_threads_late;
+mod review_threads_matching;
 
 const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const HASH_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";

--- a/crates/harness-core/src/stack/protective_control_diff_tests/review_threads.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests/review_threads.rs
@@ -1,0 +1,302 @@
+use super::*;
+
+#[test]
+fn counts_partial_role_replacement_claims() {
+    let before = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/retained.yml",
+            Some(HASH_A),
+            &[Role::Validation, Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/removed.yml",
+            Some(HASH_A),
+            &[Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/retained.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/replacement.yml",
+            Some(HASH_B),
+            &[Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(facts.len(), 2);
+    assert!(facts.iter().all(|fact| {
+        fact.kind() == DiffKind::AmbiguousReviewEvidence
+            && fact.reason() == Reason::AmbiguousReplacement
+            && fact.roles() == [Role::Check]
+    }));
+    assert!(facts.iter().any(|fact| {
+        fact.before()
+            .is_some_and(|evidence| evidence.source_locator() == ".github/workflows/removed.yml")
+    }));
+}
+
+#[test]
+fn keeps_uncovered_roles_with_ambiguous_renames() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/renamed-a.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/renamed-b.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(
+        kinds(&facts),
+        [DiffKind::AmbiguousReviewEvidence, DiffKind::Removed]
+    );
+    assert_eq!(facts[0].reason(), Reason::PossibleRename);
+    assert_eq!(facts[1].reason(), Reason::RemovedWithoutEquivalent);
+    assert_eq!(facts[1].roles(), [Role::Check]);
+}
+
+#[test]
+fn suppresses_disablement_with_unique_replacement() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/legacy.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            DISABLED_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/replacement.yml",
+            Some(HASH_B),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert!(facts.is_empty());
+}
+
+#[test]
+fn keeps_removal_with_before_conflict() {
+    let before = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ControlState(Some(true), Some(Scope::Partial), Some(Mode::FailClosed)),
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &[]);
+
+    assert_eq!(
+        kinds(&facts),
+        [DiffKind::AmbiguousReviewEvidence, DiffKind::Removed]
+    );
+    assert_eq!(facts[0].reason(), Reason::ConflictingDuplicateReport);
+    assert_eq!(facts[1].reason(), Reason::RemovedWithoutEquivalent);
+    assert_eq!(facts[1].roles(), [Role::Validation]);
+}
+
+#[test]
+fn reviews_shared_replacement_across_retained_controls() {
+    let before = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/a.yml",
+            Some(HASH_A),
+            &[Role::Validation, Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/b.yml",
+            Some(HASH_A),
+            &[Role::Policy, Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/a.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/b.yml",
+            Some(HASH_A),
+            &[Role::Policy],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/replacement.yml",
+            Some(HASH_B),
+            &[Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(facts.len(), 2);
+    assert!(facts.iter().all(|fact| {
+        fact.kind() == DiffKind::AmbiguousReviewEvidence
+            && fact.reason() == Reason::AmbiguousReplacement
+            && fact.roles() == [Role::Check]
+    }));
+}
+
+#[test]
+fn before_enablement_conflict_does_not_claim_definite_removal() {
+    let before = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            DISABLED_REQUIRED,
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &[]);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::ConflictingDuplicateReport]);
+}
+
+#[test]
+fn classifies_non_unique_disablement_replacements_as_ambiguous() {
+    let legacy = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let disabled = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        DISABLED_REQUIRED,
+    );
+    let replacement_a = configured_control(
+        Kind::Validation,
+        ".github/workflows/replacement-a.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let replacement_b = configured_control(
+        Kind::Validation,
+        ".github/workflows/replacement-b.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+
+    let facts = protective_control_diff(
+        std::slice::from_ref(&legacy),
+        &[disabled.clone(), replacement_a.clone(), replacement_b],
+    );
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::AmbiguousReplacement]);
+
+    let removed = configured_control(
+        Kind::Validation,
+        ".github/workflows/removed.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let facts = protective_control_diff(&[legacy, removed], &[disabled, replacement_a]);
+    assert_eq!(facts.len(), 2);
+    assert!(facts.iter().all(|fact| {
+        fact.kind() == DiffKind::AmbiguousReviewEvidence
+            && fact.reason() == Reason::AmbiguousReplacement
+    }));
+}

--- a/crates/harness-core/src/stack/protective_control_diff_tests/review_threads.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests/review_threads.rs
@@ -452,3 +452,180 @@ fn merges_known_integrity_independently_of_duplicate_order() {
     assert_eq!(missing_first, known_first);
     assert_eq!(reasons(&missing_first), [Reason::PossibleRename]);
 }
+
+#[test]
+fn before_scope_conflict_does_not_claim_definite_reduction() {
+    let before = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+        ),
+    ];
+    let after = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Partial), Some(Mode::FailClosed)),
+    )];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::ConflictingDuplicateReport]);
+}
+
+#[test]
+fn before_failure_mode_conflict_does_not_claim_definite_relaxation() {
+    let before = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ControlState(Some(true), Some(Scope::Required), Some(Mode::FailOpen)),
+        ),
+    ];
+    let after = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Required), Some(Mode::FailOpen)),
+    )];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::ConflictingDuplicateReport]);
+}
+
+#[test]
+fn merges_duplicate_capabilities_independently_of_order() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let shell = configured_control_with_capabilities(
+        ".github/workflows/ci.yml",
+        &[AgentStackCapability::Shell],
+    );
+    let network = configured_control_with_capabilities(
+        ".github/workflows/ci.yml",
+        &[AgentStackCapability::Network],
+    );
+
+    let shell_first = protective_control_diff(&before, &[shell.clone(), network.clone()]);
+    let network_first = protective_control_diff(&before, &[network.clone(), shell.clone()]);
+
+    assert_eq!(shell_first, network_first);
+    let Some(after) = shell_first.first().and_then(Diff::after) else {
+        panic!("scope reduction after evidence");
+    };
+    assert_eq!(
+        after.capabilities(),
+        [AgentStackCapability::Network, AgentStackCapability::Shell]
+    );
+
+    let after = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    )];
+    let shell_first = protective_control_diff(&[shell.clone(), network.clone()], &after);
+    let network_first = protective_control_diff(&[network, shell], &after);
+    assert_eq!(shell_first, network_first);
+    let Some(before) = shell_first.first().and_then(Diff::before) else {
+        panic!("scope reduction before evidence");
+    };
+    assert_eq!(
+        before.capabilities(),
+        [AgentStackCapability::Network, AgentStackCapability::Shell]
+    );
+}
+
+#[test]
+fn stronger_equivalent_replacement_precedes_weaker_rename_candidate() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/weak-rename.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::Low,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/replacement.yml",
+            Some(HASH_B),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+
+    assert_eq!(
+        reasons(&protective_control_diff(&before, &after)),
+        [Reason::PossibleRename]
+    );
+}
+
+fn configured_control_with_capabilities(
+    locator: &str,
+    capabilities: &[AgentStackCapability],
+) -> AgentStackProtectionControl {
+    let component = match component(Kind::Validation, locator, Some(HASH_A))
+        .with_capabilities(capabilities.iter().copied())
+    {
+        Ok(component) => component,
+        Err(error) => panic!("valid capabilities: {error}"),
+    };
+    let control =
+        match AgentStackProtectionControl::new(component, [Role::Validation], Confidence::High) {
+            Ok(control) => control,
+            Err(error) => panic!("valid protection control: {error}"),
+        };
+    control
+        .with_enabled(true)
+        .with_scope(Scope::Partial)
+        .with_failure_mode(Mode::FailClosed)
+}

--- a/crates/harness-core/src/stack/protective_control_diff_tests/review_threads.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests/review_threads.rs
@@ -300,3 +300,155 @@ fn classifies_non_unique_disablement_replacements_as_ambiguous() {
             && fact.reason() == Reason::AmbiguousReplacement
     }));
 }
+
+#[test]
+fn unique_replacement_suppresses_inactive_legacy_state_changes() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/legacy.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            DISABLED_PARTIAL_OPEN,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/replacement.yml",
+            Some(HASH_B),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+
+    assert!(protective_control_diff(&before, &after).is_empty());
+}
+
+#[test]
+fn after_enablement_conflict_does_not_claim_definite_disablement() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/ci.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let after = [
+        before[0].clone(),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/ci.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            DISABLED_REQUIRED,
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::ConflictingDuplicateReport]);
+}
+
+#[test]
+fn counts_supplemental_roles_used_by_partial_renames() {
+    let before = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/multi-role.yml",
+            Some(HASH_A),
+            &[Role::Validation, Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/removed-check.yml",
+            Some(HASH_A),
+            &[Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/renamed.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/supplement.yml",
+            Some(HASH_B),
+            &[Role::Check],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(facts.len(), 3);
+    assert_eq!(
+        facts
+            .iter()
+            .filter(|fact| fact.reason() == Reason::PossibleRename)
+            .count(),
+        1
+    );
+    assert_eq!(
+        facts
+            .iter()
+            .filter(|fact| fact.reason() == Reason::AmbiguousReplacement)
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn merges_known_integrity_independently_of_duplicate_order() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let missing = configured_control(
+        Kind::Validation,
+        ".github/workflows/renamed.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let known = configured_control(
+        Kind::Validation,
+        ".github/workflows/renamed.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+
+    let missing_first = protective_control_diff(&before, &[missing.clone(), known.clone()]);
+    let known_first = protective_control_diff(&before, &[known, missing]);
+
+    assert_eq!(missing_first, known_first);
+    assert_eq!(reasons(&missing_first), [Reason::PossibleRename]);
+}

--- a/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_late.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_late.rs
@@ -1,0 +1,247 @@
+use super::*;
+
+#[test]
+fn enablement_conflict_does_not_claim_role_loss_from_disabled_evidence() {
+    let before = [
+        configured_control(
+            Kind::Policy,
+            "rules/protect.toml",
+            Some(HASH_A),
+            &[Role::Policy],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+        configured_control(
+            Kind::Policy,
+            "rules/protect.toml",
+            Some(HASH_A),
+            &[Role::Hook],
+            Confidence::High,
+            DISABLED_REQUIRED,
+        ),
+    ];
+    let after = [configured_control(
+        Kind::Policy,
+        "rules/protect.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+
+    let facts = protective_control_diff(&before, &after);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::ConflictingDuplicateReport]);
+}
+
+#[test]
+fn unique_replacement_suppresses_standalone_state_reductions() {
+    let legacy = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let replacement = configured_control(
+        Kind::Validation,
+        ".github/workflows/replacement.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let advisory_legacy = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+    let fail_open_legacy = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Required), Some(Mode::FailOpen)),
+    );
+
+    assert!(protective_control_diff(
+        std::slice::from_ref(&legacy),
+        &[advisory_legacy, replacement.clone()],
+    )
+    .is_empty());
+    assert!(protective_control_diff(&[legacy], &[fail_open_legacy, replacement]).is_empty());
+}
+
+#[test]
+fn conflicted_control_counts_toward_shared_replacement_use() {
+    let normal_before = configured_control(
+        Kind::Validation,
+        ".github/workflows/normal.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let conflict_active = configured_control(
+        Kind::Validation,
+        ".github/workflows/conflict.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let conflict_disabled = configured_control(
+        Kind::Validation,
+        ".github/workflows/conflict.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        DISABLED_REQUIRED,
+    );
+    let after = [
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/normal.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/conflict.yml",
+            Some(HASH_A),
+            &[Role::Validation],
+            Confidence::High,
+            ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+        ),
+        configured_control(
+            Kind::Validation,
+            ".github/workflows/replacement.yml",
+            Some(HASH_B),
+            &[Role::Validation],
+            Confidence::High,
+            ACTIVE_REQUIRED,
+        ),
+    ];
+    let active_first = protective_control_diff(
+        &[
+            normal_before.clone(),
+            conflict_active.clone(),
+            conflict_disabled.clone(),
+        ],
+        &after,
+    );
+    let disabled_first =
+        protective_control_diff(&[normal_before, conflict_disabled, conflict_active], &after);
+
+    assert_eq!(active_first, disabled_first);
+    assert!(active_first.iter().any(|fact| {
+        fact.reason() == Reason::AmbiguousReplacement
+            && fact
+                .before()
+                .is_some_and(|before| before.source_locator() == ".github/workflows/normal.yml")
+    }));
+}
+
+#[test]
+fn full_replacement_covers_combined_role_and_scope_reduction() {
+    let before = [configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    )];
+    let retained = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+    let complete = configured_control(
+        Kind::Validation,
+        ".github/workflows/complete.yml",
+        Some(HASH_B),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    assert!(protective_control_diff(&before, &[retained.clone(), complete]).is_empty());
+
+    let partial = configured_control(
+        Kind::Validation,
+        ".github/workflows/partial.yml",
+        Some(HASH_B),
+        &[Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let facts = protective_control_diff(&before, &[retained, partial]);
+    assert!(facts.iter().any(|fact| {
+        fact.kind() == DiffKind::ScopeReduced && fact.reason() == Reason::ScopeLevelReduced
+    }));
+}
+
+#[test]
+fn shared_replacement_preserves_all_roles_for_mixed_state_reduction() {
+    let before_a = configured_control(
+        Kind::Validation,
+        ".github/workflows/a.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let before_b = configured_control(
+        Kind::Validation,
+        ".github/workflows/b.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let retained_a = configured_control(
+        Kind::Validation,
+        ".github/workflows/a.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+    let replacement = configured_control(
+        Kind::Validation,
+        ".github/workflows/replacement.yml",
+        Some(HASH_B),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let original = protective_control_diff(
+        &[before_a.clone(), before_b.clone()],
+        &[retained_a.clone(), replacement.clone()],
+    );
+    let reversed = protective_control_diff(&[before_b, before_a], &[replacement, retained_a]);
+
+    assert_eq!(original, reversed);
+    let a_facts = original
+        .iter()
+        .filter(|fact| {
+            fact.reason() == Reason::AmbiguousReplacement
+                && fact
+                    .before()
+                    .is_some_and(|before| before.source_locator() == ".github/workflows/a.yml")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(a_facts.len(), 1);
+    assert_eq!(a_facts[0].roles(), [Role::Check, Role::Validation]);
+}

--- a/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_late.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_late.rs
@@ -554,6 +554,39 @@ fn confidence_reduction_counts_replacement_as_shared() {
                 .before()
                 .is_some_and(|before| before.source_locator() == ".github/workflows/removed.yml")
     }));
+    assert!(!facts
+        .iter()
+        .any(|fact| fact.reason() == Reason::ConfidenceReduced));
+}
+
+#[test]
+fn unique_replacement_suppresses_confidence_reduction() {
+    let before = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let lower_confidence = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::Medium,
+        ACTIVE_REQUIRED,
+    );
+    let replacement = configured_control(
+        Kind::Validation,
+        ".github/workflows/replacement.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+
+    assert!(protective_control_diff(&[before], &[lower_confidence, replacement]).is_empty());
 }
 
 #[test]

--- a/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_late.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_late.rs
@@ -509,3 +509,144 @@ fn ambiguous_enablement_loss_emits_one_replacement_fact() {
     assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
     assert_eq!(reasons(&facts), [Reason::AmbiguousReplacement]);
 }
+
+#[test]
+fn confidence_reduction_counts_replacement_as_shared() {
+    let retained_before = configured_control(
+        Kind::Validation,
+        ".github/workflows/retained.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let removed = configured_control(
+        Kind::Validation,
+        ".github/workflows/removed.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let retained_after = configured_control(
+        Kind::Validation,
+        ".github/workflows/retained.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::Medium,
+        ACTIVE_REQUIRED,
+    );
+    let replacement = configured_control(
+        Kind::Validation,
+        ".github/workflows/replacement.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+
+    let facts =
+        protective_control_diff(&[retained_before, removed], &[retained_after, replacement]);
+
+    assert!(facts.iter().any(|fact| {
+        fact.reason() == Reason::AmbiguousReplacement
+            && fact
+                .before()
+                .is_some_and(|before| before.source_locator() == ".github/workflows/removed.yml")
+    }));
+}
+
+#[test]
+fn disabled_role_loss_emits_one_ambiguity_for_retained_control() {
+    let retained_before = configured_control(
+        Kind::Validation,
+        ".github/workflows/retained.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let removed = configured_control(
+        Kind::Validation,
+        ".github/workflows/removed.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let disabled_without_roles = configured_control(
+        Kind::Validation,
+        ".github/workflows/retained.yml",
+        Some(HASH_A),
+        &[],
+        Confidence::High,
+        DISABLED_REQUIRED,
+    );
+    let replacement = configured_control(
+        Kind::Validation,
+        ".github/workflows/replacement.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+
+    let facts = protective_control_diff(
+        &[retained_before, removed],
+        &[disabled_without_roles, replacement],
+    );
+    let retained_ambiguities = facts
+        .iter()
+        .filter(|fact| {
+            fact.reason() == Reason::AmbiguousReplacement
+                && fact.before().is_some_and(|before| {
+                    before.source_locator() == ".github/workflows/retained.yml"
+                })
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(retained_ambiguities.len(), 1);
+    assert_eq!(retained_ambiguities[0].roles(), [Role::Validation]);
+}
+
+#[test]
+fn alternative_partial_role_replacements_remain_ambiguous() {
+    let before = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let retained = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let replacement_a = configured_control(
+        Kind::Validation,
+        ".github/workflows/a.yml",
+        Some(HASH_B),
+        &[Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let replacement_b = configured_control(
+        Kind::Validation,
+        ".github/workflows/b.yml",
+        None,
+        &[Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+
+    let facts = protective_control_diff(&[before], &[retained, replacement_a, replacement_b]);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::AmbiguousReplacement]);
+    assert_eq!(facts[0].roles(), [Role::Check]);
+}

--- a/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_late.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_late.rs
@@ -245,3 +245,267 @@ fn shared_replacement_preserves_all_roles_for_mixed_state_reduction() {
     assert_eq!(a_facts.len(), 1);
     assert_eq!(a_facts[0].roles(), [Role::Check, Role::Validation]);
 }
+
+#[test]
+fn weakened_rename_counts_supplemental_replacements_as_shared() {
+    let renamed_before = configured_control(
+        Kind::Validation,
+        ".github/workflows/renamed-before.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let removed = configured_control(
+        Kind::Validation,
+        ".github/workflows/removed.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let weakened_rename = configured_control(
+        Kind::Validation,
+        ".github/workflows/renamed-after.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+    let shared = configured_control(
+        Kind::Validation,
+        ".github/workflows/shared.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let check_replacement = configured_control(
+        Kind::Validation,
+        ".github/workflows/check.yml",
+        None,
+        &[Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+
+    let facts = protective_control_diff(
+        &[renamed_before, removed],
+        &[weakened_rename, shared, check_replacement],
+    );
+
+    assert!(facts.iter().any(|fact| {
+        fact.reason() == Reason::AmbiguousReplacement
+            && fact
+                .before()
+                .is_some_and(|before| before.source_locator() == ".github/workflows/removed.yml")
+    }));
+}
+
+#[test]
+fn unique_replacement_suppresses_enablement_evidence_loss() {
+    let before = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let unknown_legacy = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        UNKNOWN_REQUIRED,
+    );
+    let replacement = configured_control(
+        Kind::Validation,
+        ".github/workflows/replacement.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+
+    assert!(protective_control_diff(&[before], &[unknown_legacy, replacement]).is_empty());
+}
+
+#[test]
+fn safe_replacement_wins_over_conflicted_alternative() {
+    let before = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let safe = configured_control(
+        Kind::Validation,
+        ".github/workflows/safe.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let conflicting_required = configured_control(
+        Kind::Validation,
+        ".github/workflows/conflicting.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let conflicting_advisory = configured_control(
+        Kind::Validation,
+        ".github/workflows/conflicting.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+
+    assert!(protective_control_diff(
+        &[before],
+        &[safe, conflicting_required, conflicting_advisory],
+    )
+    .is_empty());
+}
+
+#[test]
+fn unanimously_disabled_duplicates_stay_out_of_the_diff() {
+    let disabled_required = configured_control(
+        Kind::Policy,
+        "rules/disabled.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        DISABLED_REQUIRED,
+    );
+    let disabled_advisory = configured_control(
+        Kind::Policy,
+        "rules/disabled.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ControlState(Some(false), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+
+    assert!(protective_control_diff(&[disabled_required, disabled_advisory], &[]).is_empty());
+}
+
+#[test]
+fn conflicted_rename_does_not_hide_shared_supplemental_use() {
+    let renamed_before = configured_control(
+        Kind::Validation,
+        ".github/workflows/renamed-before.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let removed = configured_control(
+        Kind::Validation,
+        ".github/workflows/removed.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let rename_required = configured_control(
+        Kind::Validation,
+        ".github/workflows/renamed-after.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let rename_advisory = configured_control(
+        Kind::Validation,
+        ".github/workflows/renamed-after.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+    let shared = configured_control(
+        Kind::Validation,
+        ".github/workflows/shared.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let check_replacement = configured_control(
+        Kind::Validation,
+        ".github/workflows/check.yml",
+        None,
+        &[Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let original = protective_control_diff(
+        &[renamed_before.clone(), removed.clone()],
+        &[
+            rename_required.clone(),
+            rename_advisory.clone(),
+            shared.clone(),
+            check_replacement.clone(),
+        ],
+    );
+    let reversed = protective_control_diff(
+        &[removed, renamed_before],
+        &[check_replacement, shared, rename_advisory, rename_required],
+    );
+
+    assert_eq!(original, reversed);
+    assert!(original.iter().any(|fact| {
+        fact.reason() == Reason::AmbiguousReplacement
+            && fact
+                .before()
+                .is_some_and(|before| before.source_locator() == ".github/workflows/removed.yml")
+    }));
+}
+
+#[test]
+fn ambiguous_enablement_loss_emits_one_replacement_fact() {
+    let before = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let unknown_legacy = configured_control(
+        Kind::Validation,
+        ".github/workflows/legacy.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        UNKNOWN_REQUIRED,
+    );
+    let replacement_a = configured_control(
+        Kind::Validation,
+        ".github/workflows/a.yml",
+        Some(HASH_B),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let replacement_b = configured_control(
+        Kind::Validation,
+        ".github/workflows/b.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+
+    let facts = protective_control_diff(&[before], &[unknown_legacy, replacement_a, replacement_b]);
+
+    assert_eq!(kinds(&facts), [DiffKind::AmbiguousReviewEvidence]);
+    assert_eq!(reasons(&facts), [Reason::AmbiguousReplacement]);
+}

--- a/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_matching.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_matching.rs
@@ -119,6 +119,142 @@ fn cross_report_strengths_do_not_synthesize_an_equivalent_rename() {
     assert_conflict_and_definite_policy_removal(&original);
 }
 
+#[test]
+fn multiple_conflicted_renames_do_not_synthesize_equivalent_protection() {
+    let before = configured_control(
+        Kind::Policy,
+        "rules/legacy.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let replacement_a_scope = configured_control(
+        Kind::Policy,
+        "rules/replacement-a.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Comprehensive), Some(Mode::FailOpen)),
+    );
+    let replacement_a_mode = configured_control(
+        Kind::Policy,
+        "rules/replacement-a.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+    let replacement_b_scope = configured_control(
+        Kind::Policy,
+        "rules/replacement-b.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Comprehensive), Some(Mode::FailOpen)),
+    );
+    let replacement_b_mode = configured_control(
+        Kind::Policy,
+        "rules/replacement-b.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+
+    let original = protective_control_diff(
+        std::slice::from_ref(&before),
+        &[
+            replacement_a_scope.clone(),
+            replacement_a_mode.clone(),
+            replacement_b_scope.clone(),
+            replacement_b_mode.clone(),
+        ],
+    );
+    let reversed = protective_control_diff(
+        &[before],
+        &[
+            replacement_b_mode,
+            replacement_b_scope,
+            replacement_a_mode,
+            replacement_a_scope,
+        ],
+    );
+
+    assert_eq!(original, reversed);
+    assert_eq!(
+        original
+            .iter()
+            .filter(|fact| fact.reason() == Reason::ConflictingDuplicateReport)
+            .count(),
+        2
+    );
+    assert_conflict_and_definite_policy_removal(&original);
+}
+
+#[test]
+fn forced_full_assignment_ignores_unusable_partial_contention() {
+    let retained_before = configured_control(
+        Kind::Validation,
+        ".github/workflows/retained.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let removed = configured_control(
+        Kind::Validation,
+        ".github/workflows/removed.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_COMPREHENSIVE,
+    );
+    let retained_after = configured_control(
+        Kind::Validation,
+        ".github/workflows/retained.yml",
+        Some(HASH_A),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+    let full_replacement = configured_control(
+        Kind::Validation,
+        ".github/workflows/full.yml",
+        Some(HASH_B),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let partial_replacement = configured_control(
+        Kind::Validation,
+        ".github/workflows/partial.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_COMPREHENSIVE,
+    );
+
+    let original = protective_control_diff(
+        &[retained_before.clone(), removed.clone()],
+        &[
+            retained_after.clone(),
+            full_replacement.clone(),
+            partial_replacement.clone(),
+        ],
+    );
+    let reversed = protective_control_diff(
+        &[removed, retained_before],
+        &[partial_replacement, full_replacement, retained_after],
+    );
+
+    assert_eq!(original, reversed);
+    assert!(
+        original.is_empty(),
+        "forced assignments cover both controls"
+    );
+}
+
 fn assert_conflict_and_definite_policy_removal(facts: &[Diff]) {
     assert!(facts
         .iter()

--- a/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_matching.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_matching.rs
@@ -1,0 +1,131 @@
+use super::*;
+
+#[test]
+fn forced_global_assignment_preserves_both_removed_controls_in_any_order() {
+    let flexible = configured_control(
+        Kind::Validation,
+        ".github/workflows/flexible.yml",
+        Some(HASH_A),
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let constrained = configured_control(
+        Kind::Validation,
+        ".github/workflows/constrained.yml",
+        Some(HASH_A),
+        &[Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let shared = configured_control(
+        Kind::Validation,
+        ".github/workflows/shared.yml",
+        Some(HASH_B),
+        &[Role::Validation, Role::Check],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let flexible_only = configured_control(
+        Kind::Validation,
+        ".github/workflows/flexible-only.yml",
+        None,
+        &[Role::Validation],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+
+    let original = protective_control_diff(
+        &[flexible.clone(), constrained.clone()],
+        &[shared.clone(), flexible_only.clone()],
+    );
+    let reversed = protective_control_diff(&[constrained, flexible], &[flexible_only, shared]);
+
+    assert_eq!(original, reversed);
+    assert!(original.is_empty());
+}
+
+#[test]
+fn unanimously_disabled_conflicted_rename_keeps_definite_role_loss_in_any_order() {
+    let before = configured_control(
+        Kind::Policy,
+        "rules/legacy.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let disabled_required = configured_control(
+        Kind::Policy,
+        "rules/replacement.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        DISABLED_REQUIRED,
+    );
+    let disabled_advisory = configured_control(
+        Kind::Policy,
+        "rules/replacement.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ControlState(Some(false), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+
+    let original = protective_control_diff(
+        std::slice::from_ref(&before),
+        &[disabled_required.clone(), disabled_advisory.clone()],
+    );
+    let reversed = protective_control_diff(&[before], &[disabled_advisory, disabled_required]);
+
+    assert_eq!(original, reversed);
+    assert_conflict_and_definite_policy_removal(&original);
+}
+
+#[test]
+fn cross_report_strengths_do_not_synthesize_an_equivalent_rename() {
+    let before = configured_control(
+        Kind::Policy,
+        "rules/legacy.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let strong_scope = configured_control(
+        Kind::Policy,
+        "rules/replacement.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Comprehensive), Some(Mode::FailOpen)),
+    );
+    let strong_failure_mode = configured_control(
+        Kind::Policy,
+        "rules/replacement.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ControlState(Some(true), Some(Scope::Advisory), Some(Mode::FailClosed)),
+    );
+
+    let original = protective_control_diff(
+        std::slice::from_ref(&before),
+        &[strong_scope.clone(), strong_failure_mode.clone()],
+    );
+    let reversed = protective_control_diff(&[before], &[strong_failure_mode, strong_scope]);
+
+    assert_eq!(original, reversed);
+    assert_conflict_and_definite_policy_removal(&original);
+}
+
+fn assert_conflict_and_definite_policy_removal(facts: &[Diff]) {
+    assert!(facts
+        .iter()
+        .any(|fact| fact.reason() == Reason::ConflictingDuplicateReport));
+    assert!(facts.iter().any(|fact| {
+        fact.kind() == DiffKind::Removed
+            && fact.reason() == Reason::RemovedWithoutEquivalent
+            && fact.roles() == [Role::Policy]
+    }));
+}

--- a/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_matching.rs
+++ b/crates/harness-core/src/stack/protective_control_diff_tests/review_threads_matching.rs
@@ -255,6 +255,65 @@ fn forced_full_assignment_ignores_unusable_partial_contention() {
     );
 }
 
+#[test]
+fn confidence_only_duplicates_do_not_suppress_multi_rename_removal() {
+    let before = configured_control(
+        Kind::Policy,
+        "rules/legacy.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let high_confidence = configured_control(
+        Kind::Policy,
+        "rules/replacement-a.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        ACTIVE_REQUIRED,
+    );
+    let low_confidence = configured_control(
+        Kind::Policy,
+        "rules/replacement-a.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::Low,
+        ACTIVE_REQUIRED,
+    );
+    let disabled = configured_control(
+        Kind::Policy,
+        "rules/replacement-b.toml",
+        Some(HASH_A),
+        &[Role::Policy],
+        Confidence::High,
+        DISABLED_REQUIRED,
+    );
+
+    let original = protective_control_diff(
+        std::slice::from_ref(&before),
+        &[
+            high_confidence.clone(),
+            low_confidence.clone(),
+            disabled.clone(),
+        ],
+    );
+    let reversed = protective_control_diff(&[before], &[disabled, low_confidence, high_confidence]);
+
+    assert_eq!(original, reversed);
+    assert!(original
+        .iter()
+        .any(|fact| fact.reason() == Reason::PossibleRename));
+    assert!(original.iter().any(|fact| {
+        fact.kind() == DiffKind::Removed
+            && fact.reason() == Reason::RemovedWithoutEquivalent
+            && fact.roles() == [Role::Policy]
+    }));
+    assert!(!original
+        .iter()
+        .any(|fact| fact.reason() == Reason::ConflictingDuplicateReport));
+}
+
 fn assert_conflict_and_definite_policy_removal(facts: &[Diff]) {
     assert!(facts
         .iter()

--- a/crates/harness-core/src/stack/source_locator.rs
+++ b/crates/harness-core/src/stack/source_locator.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use std::path::{Component, Path, PathBuf};
 use uuid::Uuid;
-
 pub(super) fn validate_source_locator(
     scope: AgentStackSourceScope,
     locator: &str,
@@ -20,7 +19,6 @@ pub(super) fn validate_source_locator(
         | AgentStackSourceScope::Runner => validate_logical_locator(scope, locator),
     }
 }
-
 fn validate_portable_path(value: &str) -> Result<(), AgentStackComponentError> {
     let drive_prefixed = value
         .as_bytes()
@@ -40,7 +38,6 @@ fn validate_portable_path(value: &str) -> Result<(), AgentStackComponentError> {
         Ok(())
     }
 }
-
 fn validate_user_global_locator(locator: &str) -> Result<(), AgentStackComponentError> {
     validate_portable_path(locator)?;
     let mut segments = locator.split('/');
@@ -61,7 +58,6 @@ fn validate_user_global_locator(locator: &str) -> Result<(), AgentStackComponent
     }
     reject_reserved_segments(locator)
 }
-
 fn validate_logical_locator(
     scope: AgentStackSourceScope,
     locator: &str,
@@ -86,11 +82,9 @@ fn validate_logical_locator(
     }
     reject_reserved_segments(locator)
 }
-
 pub(super) fn valid_logical_segments(value: &str) -> bool {
     !value.is_empty() && value.split('/').all(valid_logical_segment)
 }
-
 fn valid_logical_segment(segment: &str) -> bool {
     segment
         .as_bytes()
@@ -102,7 +96,6 @@ fn valid_logical_segment(segment: &str) -> bool {
         && !is_reserved(segment)
         && !is_uuid_shaped(segment)
 }
-
 fn validate_configured_user_key(key: &str) -> Result<(), AgentStackComponentError> {
     if is_snake_case(key) && !is_reserved(key) && !is_uuid_shaped(key) {
         Ok(())
@@ -110,7 +103,6 @@ fn validate_configured_user_key(key: &str) -> Result<(), AgentStackComponentErro
         Err(AgentStackComponentError::InvalidSourceLocator)
     }
 }
-
 pub(super) fn is_snake_case(value: &str) -> bool {
     !value.is_empty()
         && !value.starts_with('_')
@@ -120,7 +112,6 @@ pub(super) fn is_snake_case(value: &str) -> bool {
             .bytes()
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
 }
-
 fn reject_reserved_segments(value: &str) -> Result<(), AgentStackComponentError> {
     if value.split('/').any(is_reserved) {
         Err(AgentStackComponentError::InvalidSourceLocator)
@@ -128,18 +119,15 @@ fn reject_reserved_segments(value: &str) -> Result<(), AgentStackComponentError>
         Ok(())
     }
 }
-
 #[rustfmt::skip]
 pub(super) fn is_reserved(value: &str) -> bool {
     ["unknown", "unknown-component", "unknown_component", "missing", "null", "none"]
         .iter()
         .any(|reserved| value.eq_ignore_ascii_case(reserved))
 }
-
 pub(super) fn is_uuid_shaped(value: &str) -> bool {
     Uuid::parse_str(value).is_ok()
 }
-
 pub fn resolve_xdg_config_harness_root(
     xdg_config_home: Option<&Path>,
     home: Option<&Path>,
@@ -153,7 +141,6 @@ pub fn resolve_xdg_config_harness_root(
     };
     normalize_absolute_path(&root)
 }
-
 pub fn select_user_global_root(
     source: &Path,
     home_harness: Option<&Path>,
@@ -200,7 +187,6 @@ pub fn select_user_global_root(
     }
     Err(AgentStackComponentError::UntypedDiscoverySource)
 }
-
 fn user_root_result(
     root: AgentStackUserGlobalRoot,
     locator: String,
@@ -208,7 +194,6 @@ fn user_root_result(
     validate_user_global_locator(&locator)?;
     Ok((root, AgentStackSourceLocator(locator)))
 }
-
 pub(super) fn relative_portable_path(
     root: &Path,
     source: &Path,
@@ -216,7 +201,6 @@ pub(super) fn relative_portable_path(
     relative_portable_path_if_within(root, source)?
         .ok_or(AgentStackComponentError::SourceOutsideRoot)
 }
-
 fn relative_portable_path_if_within(
     root: &Path,
     source: &Path,
@@ -232,7 +216,6 @@ fn relative_portable_path_if_within(
     validate_portable_path(&relative)?;
     Ok(Some(relative))
 }
-
 fn normalize_absolute_path(path: &Path) -> Result<PathBuf, AgentStackComponentError> {
     let key = absolute_path_key(path, true)?;
     let mut result = PathBuf::new();
@@ -247,13 +230,11 @@ fn normalize_absolute_path(path: &Path) -> Result<PathBuf, AgentStackComponentEr
     }
     Ok(result)
 }
-
 #[derive(Debug, PartialEq, Eq)]
 struct AbsolutePathKey {
     drive: Option<u8>,
     segments: Vec<String>,
 }
-
 fn absolute_path_key(
     path: &Path,
     resolve_parent: bool,
@@ -300,18 +281,15 @@ fn absolute_path_key(
     }
     Ok(AbsolutePathKey { drive, segments })
 }
-
 fn drives_match(left: Option<u8>, right: Option<u8>) -> bool {
     left.map(|drive| drive.to_ascii_uppercase()) == right.map(|drive| drive.to_ascii_uppercase())
 }
-
 #[rustfmt::skip]
 fn root_key_matches<T: PartialEq>(
     root_drive: Option<u8>, root: &[T], source_drive: Option<u8>, source: &[T],
 ) -> bool {
     drives_match(root_drive, source_drive) && source.starts_with(root)
 }
-
 #[cfg(test)]
 #[rustfmt::skip]
 pub(super) fn root_keys_match_for_test(

--- a/crates/harness-core/src/stack/source_locator.rs
+++ b/crates/harness-core/src/stack/source_locator.rs
@@ -19,7 +19,7 @@ pub(super) fn validate_source_locator(
         | AgentStackSourceScope::Runner => validate_logical_locator(scope, locator),
     }
 }
-fn validate_portable_path(value: &str) -> Result<(), AgentStackComponentError> {
+pub(crate) fn validate_portable_path(value: &str) -> Result<(), AgentStackComponentError> {
     let drive_prefixed = value
         .as_bytes()
         .get(0..2)
@@ -112,7 +112,7 @@ pub(super) fn is_snake_case(value: &str) -> bool {
             .bytes()
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
 }
-fn reject_reserved_segments(value: &str) -> Result<(), AgentStackComponentError> {
+pub(crate) fn reject_reserved_segments(value: &str) -> Result<(), AgentStackComponentError> {
     if value.split('/').any(is_reserved) {
         Err(AgentStackComponentError::InvalidSourceLocator)
     } else {
@@ -216,7 +216,7 @@ fn relative_portable_path_if_within(
     validate_portable_path(&relative)?;
     Ok(Some(relative))
 }
-fn normalize_absolute_path(path: &Path) -> Result<PathBuf, AgentStackComponentError> {
+pub(crate) fn normalize_absolute_path(path: &Path) -> Result<PathBuf, AgentStackComponentError> {
     let key = absolute_path_key(path, true)?;
     let mut result = PathBuf::new();
     #[cfg(unix)]

--- a/crates/harness-core/src/stack/source_locator.rs
+++ b/crates/harness-core/src/stack/source_locator.rs
@@ -1,0 +1,322 @@
+use super::{
+    AgentStackComponentError, AgentStackSourceLocator, AgentStackSourceScope,
+    AgentStackUserGlobalRoot,
+};
+use std::path::{Component, Path, PathBuf};
+use uuid::Uuid;
+
+pub(super) fn validate_source_locator(
+    scope: AgentStackSourceScope,
+    locator: &str,
+) -> Result<(), AgentStackComponentError> {
+    match scope {
+        AgentStackSourceScope::Repository | AgentStackSourceScope::Admin => {
+            validate_portable_path(locator)?;
+            reject_reserved_segments(locator)
+        }
+        AgentStackSourceScope::UserGlobal => validate_user_global_locator(locator),
+        AgentStackSourceScope::System
+        | AgentStackSourceScope::Runtime
+        | AgentStackSourceScope::Runner => validate_logical_locator(scope, locator),
+    }
+}
+
+fn validate_portable_path(value: &str) -> Result<(), AgentStackComponentError> {
+    let drive_prefixed = value
+        .as_bytes()
+        .get(0..2)
+        .is_some_and(|head| head[0].is_ascii_alphabetic() && head[1] == b':');
+    if value.is_empty()
+        || value.starts_with('/')
+        || value.contains('\\')
+        || value.contains('\0')
+        || drive_prefixed
+        || value
+            .split('/')
+            .any(|segment| segment.is_empty() || segment == "." || segment == "..")
+    {
+        Err(AgentStackComponentError::InvalidSourceLocator)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_user_global_locator(locator: &str) -> Result<(), AgentStackComponentError> {
+    validate_portable_path(locator)?;
+    let mut segments = locator.split('/');
+    let Some(root) = segments.next() else {
+        return Err(AgentStackComponentError::InvalidSourceLocator);
+    };
+    match root {
+        "home_harness" | "xdg_config_harness" | "platform_config_harness" => {}
+        "configured_user" => validate_configured_user_key(
+            segments
+                .next()
+                .ok_or(AgentStackComponentError::InvalidSourceLocator)?,
+        )?,
+        _ => return Err(AgentStackComponentError::InvalidSourceLocator),
+    }
+    if segments.next().is_none() {
+        return Err(AgentStackComponentError::InvalidSourceLocator);
+    }
+    reject_reserved_segments(locator)
+}
+
+fn validate_logical_locator(
+    scope: AgentStackSourceScope,
+    locator: &str,
+) -> Result<(), AgentStackComponentError> {
+    validate_portable_path(locator)?;
+    let mut segments = locator.split('/');
+    if scope == AgentStackSourceScope::System && segments.next() != Some("builtin") {
+        return Err(AgentStackComponentError::InvalidSourceLocator);
+    }
+    let namespace = segments
+        .next()
+        .ok_or(AgentStackComponentError::InvalidSourceLocator)?;
+    let remaining = segments.collect::<Vec<_>>();
+    if !is_snake_case(namespace)
+        || is_uuid_shaped(namespace)
+        || remaining.is_empty()
+        || remaining
+            .iter()
+            .any(|segment| !valid_logical_segment(segment))
+    {
+        return Err(AgentStackComponentError::InvalidSourceLocator);
+    }
+    reject_reserved_segments(locator)
+}
+
+pub(super) fn valid_logical_segments(value: &str) -> bool {
+    !value.is_empty() && value.split('/').all(valid_logical_segment)
+}
+
+fn valid_logical_segment(segment: &str) -> bool {
+    segment
+        .as_bytes()
+        .first()
+        .is_some_and(u8::is_ascii_alphanumeric)
+        && segment
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+        && !is_reserved(segment)
+        && !is_uuid_shaped(segment)
+}
+
+fn validate_configured_user_key(key: &str) -> Result<(), AgentStackComponentError> {
+    if is_snake_case(key) && !is_reserved(key) && !is_uuid_shaped(key) {
+        Ok(())
+    } else {
+        Err(AgentStackComponentError::InvalidSourceLocator)
+    }
+}
+
+pub(super) fn is_snake_case(value: &str) -> bool {
+    !value.is_empty()
+        && !value.starts_with('_')
+        && !value.ends_with('_')
+        && !value.contains("__")
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+}
+
+fn reject_reserved_segments(value: &str) -> Result<(), AgentStackComponentError> {
+    if value.split('/').any(is_reserved) {
+        Err(AgentStackComponentError::InvalidSourceLocator)
+    } else {
+        Ok(())
+    }
+}
+
+#[rustfmt::skip]
+pub(super) fn is_reserved(value: &str) -> bool {
+    ["unknown", "unknown-component", "unknown_component", "missing", "null", "none"]
+        .iter()
+        .any(|reserved| value.eq_ignore_ascii_case(reserved))
+}
+
+pub(super) fn is_uuid_shaped(value: &str) -> bool {
+    Uuid::parse_str(value).is_ok()
+}
+
+pub fn resolve_xdg_config_harness_root(
+    xdg_config_home: Option<&Path>,
+    home: Option<&Path>,
+) -> Result<PathBuf, AgentStackComponentError> {
+    let root = if let Some(xdg) = xdg_config_home.filter(|path| path.is_absolute()) {
+        xdg.join("harness")
+    } else if let Some(home) = home.filter(|path| path.is_absolute()) {
+        home.join(".config").join("harness")
+    } else {
+        return Err(AgentStackComponentError::XdgConfigRootUnavailable);
+    };
+    normalize_absolute_path(&root)
+}
+
+pub fn select_user_global_root(
+    source: &Path,
+    home_harness: Option<&Path>,
+    xdg_config_harness: Option<&Path>,
+    platform_config_harness: Option<&Path>,
+    configured_user_roots: &[(&str, &Path)],
+) -> Result<(AgentStackUserGlobalRoot, AgentStackSourceLocator), AgentStackComponentError> {
+    if configured_user_roots.len() > 1 {
+        return Err(AgentStackComponentError::AmbiguousConfiguredUserRoot);
+    }
+    if let Some((key, _)) = configured_user_roots.first() {
+        validate_configured_user_key(key)?;
+    }
+    for (root_kind, namespace, root) in [
+        (
+            AgentStackUserGlobalRoot::HomeHarness,
+            "home_harness",
+            home_harness,
+        ),
+        (
+            AgentStackUserGlobalRoot::XdgConfigHarness,
+            "xdg_config_harness",
+            xdg_config_harness,
+        ),
+        (
+            AgentStackUserGlobalRoot::PlatformConfigHarness,
+            "platform_config_harness",
+            platform_config_harness,
+        ),
+    ] {
+        if let Some(root) = root {
+            if let Some(relative) = relative_portable_path_if_within(root, source)? {
+                return user_root_result(root_kind, format!("{namespace}/{relative}"));
+            }
+        }
+    }
+    if let Some((key, root)) = configured_user_roots.first() {
+        if let Some(relative) = relative_portable_path_if_within(root, source)? {
+            return user_root_result(
+                AgentStackUserGlobalRoot::ConfiguredUser,
+                format!("configured_user/{key}/{relative}"),
+            );
+        }
+    }
+    Err(AgentStackComponentError::UntypedDiscoverySource)
+}
+
+fn user_root_result(
+    root: AgentStackUserGlobalRoot,
+    locator: String,
+) -> Result<(AgentStackUserGlobalRoot, AgentStackSourceLocator), AgentStackComponentError> {
+    validate_user_global_locator(&locator)?;
+    Ok((root, AgentStackSourceLocator(locator)))
+}
+
+pub(super) fn relative_portable_path(
+    root: &Path,
+    source: &Path,
+) -> Result<String, AgentStackComponentError> {
+    relative_portable_path_if_within(root, source)?
+        .ok_or(AgentStackComponentError::SourceOutsideRoot)
+}
+
+fn relative_portable_path_if_within(
+    root: &Path,
+    source: &Path,
+) -> Result<Option<String>, AgentStackComponentError> {
+    let root = absolute_path_key(root, true)?;
+    let source = absolute_path_key(source, false)?;
+    if !root_key_matches(root.drive, &root.segments, source.drive, &source.segments)
+        || source.segments.len() <= root.segments.len()
+    {
+        return Ok(None);
+    }
+    let relative = source.segments[root.segments.len()..].join("/");
+    validate_portable_path(&relative)?;
+    Ok(Some(relative))
+}
+
+fn normalize_absolute_path(path: &Path) -> Result<PathBuf, AgentStackComponentError> {
+    let key = absolute_path_key(path, true)?;
+    let mut result = PathBuf::new();
+    #[cfg(unix)]
+    result.push("/");
+    #[cfg(windows)]
+    if let Some(drive) = key.drive {
+        result.push(format!("{}:\\", drive as char));
+    }
+    for segment in key.segments {
+        result.push(segment);
+    }
+    Ok(result)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AbsolutePathKey {
+    drive: Option<u8>,
+    segments: Vec<String>,
+}
+
+fn absolute_path_key(
+    path: &Path,
+    resolve_parent: bool,
+) -> Result<AbsolutePathKey, AgentStackComponentError> {
+    if !path.is_absolute() {
+        return Err(AgentStackComponentError::InvalidSourceLocator);
+    }
+    #[cfg(windows)]
+    let mut drive = None;
+    #[cfg(not(windows))]
+    let drive = None;
+    let mut segments = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(value) => {
+                #[cfg(windows)]
+                {
+                    use std::path::Prefix;
+                    drive = Some(match value.kind() {
+                        Prefix::Disk(drive) | Prefix::VerbatimDisk(drive) => {
+                            drive.to_ascii_uppercase()
+                        }
+                        _ => return Err(AgentStackComponentError::InvalidSourceLocator),
+                    });
+                }
+                #[cfg(not(windows))]
+                {
+                    let _ = value;
+                    return Err(AgentStackComponentError::InvalidSourceLocator);
+                }
+            }
+            Component::RootDir | Component::CurDir => {}
+            Component::ParentDir if resolve_parent && !segments.is_empty() => {
+                segments.pop();
+            }
+            Component::ParentDir => return Err(AgentStackComponentError::InvalidSourceLocator),
+            Component::Normal(value) => segments.push(
+                value
+                    .to_str()
+                    .ok_or(AgentStackComponentError::NonUtf8SourceLocator)?
+                    .to_owned(),
+            ),
+        }
+    }
+    Ok(AbsolutePathKey { drive, segments })
+}
+
+fn drives_match(left: Option<u8>, right: Option<u8>) -> bool {
+    left.map(|drive| drive.to_ascii_uppercase()) == right.map(|drive| drive.to_ascii_uppercase())
+}
+
+#[rustfmt::skip]
+fn root_key_matches<T: PartialEq>(
+    root_drive: Option<u8>, root: &[T], source_drive: Option<u8>, source: &[T],
+) -> bool {
+    drives_match(root_drive, source_drive) && source.starts_with(root)
+}
+
+#[cfg(test)]
+#[rustfmt::skip]
+pub(super) fn root_keys_match_for_test(
+    drive_a: Option<u8>, segments_a: &[&str], drive_b: Option<u8>, segments_b: &[&str],
+) -> bool {
+    segments_a.len() == segments_b.len()
+        && root_key_matches(drive_a, segments_a, drive_b, segments_b)
+}


### PR DESCRIPTION
## Summary
- add typed protective-control diff facts for removal, disablement, scope reduction, fail-open changes, and ambiguous rename/replacement evidence
- split source-locator helpers out of stack/mod.rs to keep the stack module under the hard line limit

## Validation
- cargo fmt --all -- --check
- cargo check -p harness-core --all-targets
- cargo test -p harness-core protective_control_diff
- cargo test -p harness-core
- cargo check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- env -u HARNESS_DATABASE_URL git push -u origin harness/runtime-wf-github-issue-pr-f4f2c2d5 (pre-push clippy + database-independent workspace lib tests passed)

## Notes
- Inherited HARNESS_DATABASE_URL points at non-test database harness_self_20260729; full cargo test/pre-push with that env is rejected/fails outside the touched harness-core code. DB-less pre-push completed.

Closes #1740