### PR TITLE
fix(server): deterministic profile locators and closed approval resolution (GH-1732)

### DIFF
--- a/crates/harness-server/src/http/background/runtime_profiles.rs
+++ b/crates/harness-server/src/http/background/runtime_profiles.rs
@@ -199,14 +199,11 @@ pub(super) fn runtime_dispatch_profile(
         .sandbox
         .clone()
         .or_else(|| base_profile.sandbox.clone());
-    profile.approval_policy = runtime_kind_supports_approval_policy(kind)
-        .then(|| {
-            policy
-                .approval_policy
-                .clone()
-                .or_else(|| base_profile.approval_policy.clone())
-        })
-        .flatten();
+    profile.approval_policy = resolve_dispatch_approval_policy(
+        kind,
+        policy.approval_policy.as_ref(),
+        base_profile.approval_policy.as_ref(),
+    )?;
     profile.max_turns = policy.max_turns.or(base_profile.max_turns);
     profile.timeout_secs = policy.timeout_secs.or(base_profile.timeout_secs);
     Ok(profile)
@@ -227,26 +224,18 @@ fn resolve_runtime_dispatch_profiles(
     inherited_profile: &RuntimeProfile,
 ) -> anyhow::Result<ResolvedRuntimeDispatchProfiles> {
     let default_profile = runtime_dispatch_profile(config, policy, inherited_profile)?;
-    let workflow_profiles = policy
-        .workflow_profiles
-        .iter()
-        .map(|(definition_id, override_policy)| {
-            (
-                definition_id.clone(),
-                apply_runtime_dispatch_profile_override(config, &default_profile, override_policy),
-            )
-        })
-        .collect::<std::collections::BTreeMap<_, _>>();
-    let activity_profiles = policy
-        .activity_profiles
-        .iter()
-        .map(|(activity, override_policy)| {
-            (
-                activity.clone(),
-                apply_runtime_dispatch_profile_override(config, &default_profile, override_policy),
-            )
-        })
-        .collect::<std::collections::BTreeMap<_, _>>();
+    let mut workflow_profiles = std::collections::BTreeMap::new();
+    for (definition_id, override_policy) in &policy.workflow_profiles {
+        let profile =
+            apply_runtime_dispatch_profile_override(config, &default_profile, override_policy)?;
+        workflow_profiles.insert(definition_id.clone(), profile);
+    }
+    let mut activity_profiles = std::collections::BTreeMap::new();
+    for (activity, override_policy) in &policy.activity_profiles {
+        let profile =
+            apply_runtime_dispatch_profile_override(config, &default_profile, override_policy)?;
+        activity_profiles.insert(activity.clone(), profile);
+    }
     let mut workflow_activity_profiles = std::collections::BTreeMap::new();
     for (definition_id, activity_overrides) in &policy.workflow_activity_profiles {
         for (activity, override_policy) in activity_overrides {
@@ -255,7 +244,7 @@ fn resolve_runtime_dispatch_profiles(
                 .or_else(|| workflow_profiles.get(definition_id))
                 .unwrap_or(&default_profile);
             let profile =
-                apply_runtime_dispatch_profile_override(config, base_profile, override_policy);
+                apply_runtime_dispatch_profile_override(config, base_profile, override_policy)?;
             workflow_activity_profiles
                 .entry(definition_id.clone())
                 .or_insert_with(std::collections::BTreeMap::new)
@@ -351,7 +340,7 @@ fn apply_runtime_dispatch_profile_override(
     config: &harness_core::config::HarnessConfig,
     default_profile: &RuntimeProfile,
     override_policy: &harness_core::config::workflow::RuntimeDispatchProfileOverride,
-) -> RuntimeProfile {
+) -> anyhow::Result<RuntimeProfile> {
     let runtime_kind_profile = override_policy
         .runtime_kind
         .as_deref()
@@ -382,28 +371,46 @@ fn apply_runtime_dispatch_profile_override(
         .sandbox
         .clone()
         .or_else(|| default_profile.sandbox.clone());
-    profile.approval_policy =
-        runtime_dispatch_approval_policy(&runtime_kind_profile, override_policy, kind);
+    profile.approval_policy = resolve_dispatch_approval_policy(
+        kind,
+        override_policy.approval_policy.as_ref(),
+        runtime_kind_profile.approval_policy.as_ref(),
+    )?;
     profile.max_turns = override_policy.max_turns.or(default_profile.max_turns);
     profile.timeout_secs = override_policy
         .timeout_secs
         .or(default_profile.timeout_secs);
-    profile
+    Ok(profile)
 }
 
-fn runtime_dispatch_approval_policy(
-    default_profile: &RuntimeProfile,
-    override_policy: &harness_core::config::workflow::RuntimeDispatchProfileOverride,
+/// Capability-aware dispatch approval-policy resolution (B-016).
+///
+/// An explicitly configured policy for a runtime kind without an
+/// approval-policy contract is invalid operator input and is rejected with a
+/// typed error naming the runtime kind; it is never silently discarded. An
+/// omitted policy inherits the base value only for Codex kinds, so switching
+/// from Codex to a non-Codex kind without declaring a policy does not carry
+/// the Codex-only value and does not report an error.
+fn resolve_dispatch_approval_policy(
     kind: RuntimeKind,
-) -> Option<String> {
-    runtime_kind_supports_approval_policy(kind)
-        .then(|| {
-            override_policy
-                .approval_policy
-                .clone()
-                .or_else(|| default_profile.approval_policy.clone())
-        })
-        .flatten()
+    explicit_policy: Option<&String>,
+    inherited_policy: Option<&String>,
+) -> anyhow::Result<Option<String>> {
+    match explicit_policy {
+        Some(policy) => {
+            if runtime_kind_supports_approval_policy(kind) {
+                Ok(Some(policy.clone()))
+            } else {
+                anyhow::bail!(
+                    "runtime dispatch approval_policy `{policy}` is only supported for Codex runtime kinds, not {}",
+                    kind.as_str()
+                )
+            }
+        }
+        None => Ok(runtime_kind_supports_approval_policy(kind)
+            .then(|| inherited_policy.cloned())
+            .flatten()),
+    }
 }
 
 fn runtime_kind_supports_approval_policy(kind: RuntimeKind) -> bool {
@@ -432,5 +439,112 @@ mod tests {
         assert_eq!(profile.name, "codex-exec-review");
         assert_eq!(profile.timeout_secs, Some(45));
         Ok(())
+    }
+
+    fn dispatch_policy(
+        value: serde_json::Value,
+    ) -> harness_core::config::workflow::RuntimeDispatchPolicy {
+        serde_json::from_value(value).expect("test dispatch policy should deserialize")
+    }
+
+    #[test]
+    fn runtime_dispatch_rejects_explicit_non_codex_approval_policy() {
+        let config = harness_core::config::HarnessConfig::default();
+        let inherited = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
+
+        for (kind_config, kind) in [
+            ("claude_code", RuntimeKind::ClaudeCode),
+            ("anthropic_api", RuntimeKind::AnthropicApi),
+            ("remote_host", RuntimeKind::RemoteHost),
+        ] {
+            // Top-level dispatch policy: explicit approval policy is invalid.
+            let policy = dispatch_policy(serde_json::json!({
+                "runtime_kind": kind_config,
+                "approval_policy": "on-request",
+            }));
+            let error = runtime_dispatch_profile(&config, &policy, &inherited)
+                .expect_err("top-level explicit non-Codex approval policy must be rejected");
+            assert!(
+                error.to_string().contains("approval_policy `on-request`"),
+                "the rejection must name the unsupported field: {error}"
+            );
+            assert!(
+                error.to_string().contains(kind.as_str()),
+                "the rejection must name the runtime kind: {error}"
+            );
+
+            // Nested profile override: explicit approval policy is invalid.
+            let override_policy = harness_core::config::workflow::RuntimeDispatchProfileOverride {
+                runtime_kind: Some(kind_config.to_string()),
+                approval_policy: Some("on-request".to_string()),
+                ..Default::default()
+            };
+            let error =
+                apply_runtime_dispatch_profile_override(&config, &inherited, &override_policy)
+                    .expect_err("nested explicit non-Codex approval policy must be rejected");
+            assert!(
+                error.to_string().contains("approval_policy `on-request`"),
+                "the rejection must name the unsupported field: {error}"
+            );
+            assert!(
+                error.to_string().contains(kind.as_str()),
+                "the rejection must name the runtime kind: {error}"
+            );
+        }
+
+        // Explicit Codex approval policy remains accepted on both paths.
+        let policy = dispatch_policy(serde_json::json!({
+            "runtime_kind": "codex_exec",
+            "approval_policy": "never",
+        }));
+        let profile = runtime_dispatch_profile(&config, &policy, &inherited)
+            .expect("explicit Codex approval policy should resolve");
+        assert_eq!(profile.approval_policy.as_deref(), Some("never"));
+        let override_policy = harness_core::config::workflow::RuntimeDispatchProfileOverride {
+            approval_policy: Some("never".to_string()),
+            ..Default::default()
+        };
+        let profile =
+            apply_runtime_dispatch_profile_override(&config, &inherited, &override_policy)
+                .expect("explicit Codex approval policy should resolve");
+        assert_eq!(profile.approval_policy.as_deref(), Some("never"));
+    }
+
+    #[test]
+    fn runtime_dispatch_kind_switch_does_not_inherit_codex_approval_policy() {
+        let config = harness_core::config::HarnessConfig::default();
+        let mut codex_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
+        codex_profile.approval_policy = Some("on-request".to_string());
+
+        // Nested override: switching from Codex to a non-Codex kind without
+        // declaring a policy drops the Codex-only value without an error.
+        let override_policy = harness_core::config::workflow::RuntimeDispatchProfileOverride {
+            runtime_kind: Some("claude_code".to_string()),
+            ..Default::default()
+        };
+        let profile =
+            apply_runtime_dispatch_profile_override(&config, &codex_profile, &override_policy)
+                .expect("an omitted policy on a kind switch must not error");
+        assert_eq!(profile.kind, RuntimeKind::ClaudeCode);
+        assert_eq!(profile.approval_policy, None);
+
+        // Top-level: selecting a non-Codex runtime kind does not carry the
+        // inherited Codex policy.
+        let policy = dispatch_policy(serde_json::json!({ "runtime_kind": "anthropic_api" }));
+        let profile = runtime_dispatch_profile(&config, &policy, &codex_profile)
+            .expect("an omitted policy on a kind switch must not error");
+        assert_eq!(profile.kind, RuntimeKind::AnthropicApi);
+        assert_eq!(profile.approval_policy, None);
+
+        // Staying on the same Codex kind still inherits the base Codex policy.
+        let override_policy = harness_core::config::workflow::RuntimeDispatchProfileOverride {
+            model: Some("override-model".to_string()),
+            ..Default::default()
+        };
+        let profile =
+            apply_runtime_dispatch_profile_override(&config, &codex_profile, &override_policy)
+                .expect("same-kind Codex inheritance should resolve");
+        assert_eq!(profile.kind, RuntimeKind::CodexJsonrpc);
+        assert_eq!(profile.approval_policy.as_deref(), Some("on-request"));
     }
 }

--- a/crates/harness-server/src/http/tests/runtime_worker_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_worker_tests.rs
@@ -349,6 +349,118 @@ async fn runtime_job_worker_cleans_on_terminal_workspace_after_failed_runtime_at
 }
 
 #[tokio::test]
+async fn provenance_failure_prevents_prompt_event_and_agent_start() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    std::fs::write(
+        project_root.join("WORKFLOW.md"),
+        "---\nworkspace:\n  strategy: source\n---\n",
+    )?;
+    let agent = RuntimeStreamAgent::new();
+    let mut registry = harness_agents::registry::AgentRegistry::new("codex");
+    registry.register("codex", agent.clone());
+    let state = make_test_state_with_workflow_runtime_config_and_registry(
+        dir.path(),
+        &project_root,
+        harness_core::config::HarnessConfig::default(),
+        registry,
+    )
+    .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = harness_workflow::runtime::WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "implementing",
+        harness_workflow::runtime::WorkflowSubject::new("issue", "issue:1732"),
+    )
+    .with_id("issue-1732")
+    .with_server_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 1732,
+    }));
+    // `implementing` is not the canonical initial state, and the public upsert
+    // is insert-only (GH-1784), so this mid-lifecycle fixture needs the
+    // lifecycle writer. The data stays classified, so the provenance guard is
+    // still active here.
+    crate::test_helpers::force_upsert_runtime_lifecycle_state_for_test(store, &workflow).await?;
+    let command = harness_workflow::runtime::WorkflowCommand::enqueue_activity(
+        "implement_issue",
+        "impl-1732",
+    );
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    let mut runtime_profile = harness_workflow::runtime::RuntimeProfile::new(
+        "codex-default",
+        harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+    );
+    runtime_profile.timeout_secs = Some(300);
+    let runtime_job = store
+        .enqueue_runtime_job(
+            &command_id,
+            harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            serde_json::json!({
+                "workflow_id": workflow.id,
+                "command_id": command_id,
+                "command_type": command.command_type,
+                "dedupe_key": command.dedupe_key,
+                "command": command.command,
+                "runtime_profile": runtime_profile,
+                // Job-scoped cfg(test) failure marker consumed by
+                // apply_context_provenance before any packet mutation.
+                "test_fail_context_provenance": true,
+            }),
+        )
+        .await?;
+
+    let tick = crate::workflow_runtime_worker::run_runtime_job_worker_tick(
+        &state,
+        "worker-test",
+        chrono::Duration::minutes(5),
+    )
+    .await?;
+
+    assert_eq!(tick.failed, 1);
+    assert_eq!(tick.succeeded, 0);
+    assert_eq!(tick.cancelled, 0);
+    let failed_job = store
+        .get_runtime_job(&runtime_job.id)
+        .await?
+        .expect("runtime job should exist");
+    assert_eq!(
+        failed_job.status,
+        harness_workflow::runtime::RuntimeJobStatus::Failed
+    );
+    let error = failed_job
+        .error
+        .expect("failed job records the injected provenance error");
+    assert!(
+        error.contains("context provenance"),
+        "job error should carry the provenance failure: {error}"
+    );
+    // The fail-closed ordering holds through the real worker boundary: no
+    // RuntimePromptPrepared event is recorded and no agent prompt is started.
+    let events = store.runtime_events_for(&runtime_job.id).await?;
+    assert!(
+        events
+            .iter()
+            .all(|event| event.event_type != "RuntimePromptPrepared"),
+        "no prompt event may be recorded when provenance construction fails: {events:?}"
+    );
+    assert!(agent.prompts.lock().await.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
 async fn runtime_job_worker_cancels_job_when_workflow_already_terminal() -> anyhow::Result<()> {
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/context_provenance.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/context_provenance.rs
@@ -30,6 +30,12 @@ pub(super) const CONTEXT_PROVENANCE_SCHEMA: &str = "harness.runtime.context_prov
 const HISTORICAL_PROMPT_PACKET_SCHEMA_V1: &str = "harness.runtime.prompt_packet.v1";
 const HISTORICAL_PROMPT_PACKET_SCHEMA_V2: &str = "harness.runtime.prompt_packet.v2";
 
+/// Job-scoped failure marker consumed only by `cfg(test)` worker tests to
+/// inject the provenance error boundary through the real executor. Production
+/// builds compile no behavior for this input key.
+#[cfg(test)]
+pub(crate) const TEST_PROVENANCE_FAILURE_MARKER: &str = "test_fail_context_provenance";
+
 /// Closed coverage markers for context Harness cannot observe. Absence of a
 /// manifest entry is never proof that such context did not exist.
 const NOT_OBSERVED_BY_HARNESS: [&str; 4] = [
@@ -92,6 +98,15 @@ pub(super) fn apply_context_provenance(
     repo_memory: &[RetrievedRepoMemoryRecord],
     prompt_task_text: Option<&str>,
 ) -> anyhow::Result<()> {
+    // Job-scoped test seam: fail the provenance boundary before any packet
+    // mutation or serialization so worker tests can prove the executor
+    // ordering without global state or parallel-test races.
+    #[cfg(test)]
+    if job.input.get(TEST_PROVENANCE_FAILURE_MARKER).is_some() {
+        anyhow::bail!(
+            "required context provenance construction failed before prompt preparation (injected test marker)"
+        );
+    }
     let provenance = build_context_provenance(resolved_settings, workflow_document, repo_memory)?;
     packet["resolved_runtime_settings"] = serde_json::to_value(resolved_settings)
         .context("failed to serialize resolved runtime settings for the prompt packet")?;
@@ -156,13 +171,19 @@ pub(super) fn validate_prompt_packet_provenance(packet: &Value) -> anyhow::Resul
     Ok(())
 }
 
-/// Remove audit-only sections from the model-facing packet clone so the
-/// agent-visible prompt bytes for unchanged inputs match the v1 rendering.
+/// Remove audit-only sections from the model-facing packet clone and restore
+/// the historical v1 schema so the agent-visible prompt bytes for unchanged
+/// inputs match the pre-v2 rendering. The durable packet is never touched and
+/// keeps the v2 schema; only this rendered clone is v1.
 pub(super) fn strip_model_facing_audit_sections(model_packet: &mut Value) {
     if let Some(object) = model_packet.as_object_mut() {
         object.remove("context_provenance");
         object.remove("resolved_runtime_settings");
         object.remove("prompt_task_request");
+        object.insert(
+            "schema".to_string(),
+            Value::String(HISTORICAL_PROMPT_PACKET_SCHEMA_V1.to_owned()),
+        );
     }
 }
 
@@ -187,6 +208,31 @@ fn build_context_provenance(
     })
 }
 
+/// Deterministic runtime-profile provenance locator (B-015).
+///
+/// The historical `runtime_profile/<exact-name>` locator is tried first so
+/// already-valid identities (including multi-segment names such as
+/// `team/codex`) keep their stable component IDs. Only names that fail
+/// ASC-001 locator validation fall back to the disjoint
+/// `runtime_profile_name_sha256/<digest>` namespace, keyed by the lowercase
+/// SHA-256 of the exact UTF-8 profile-name bytes. The fallback never trims,
+/// case-folds, or Unicode-normalizes the name: equal byte sequences produce
+/// equal locators and byte-distinct names cannot collide. The exact
+/// configured name remains in `resolved_runtime_settings.profile_name`; the
+/// fallback locator is an audit identity, not a replacement for the value.
+fn runtime_profile_source(profile_name: &str) -> anyhow::Result<AgentStackSource> {
+    let historical_locator = format!("runtime_profile/{profile_name}");
+    if let Ok(source) = AgentStackSource::new(AgentStackSourceScope::Runtime, &historical_locator) {
+        return Ok(source);
+    }
+    let name_digest = Sha256Digest::from_bytes(profile_name.as_bytes());
+    AgentStackSource::new(
+        AgentStackSourceScope::Runtime,
+        &format!("runtime_profile_name_sha256/{}", name_digest.as_str()),
+    )
+    .context("hashed runtime profile name fallback locator failed ASC-001 validation")
+}
+
 fn resolved_runtime_settings_entry(
     resolved_settings: &ResolvedRuntimeSettings,
     order: usize,
@@ -195,16 +241,7 @@ fn resolved_runtime_settings_entry(
         &serde_json::to_vec(resolved_settings)
             .context("failed to serialize resolved runtime settings for provenance hashing")?,
     );
-    let source = AgentStackSource::new(
-        AgentStackSourceScope::Runtime,
-        &format!("runtime_profile/{}", resolved_settings.profile_name),
-    )
-    .with_context(|| {
-        format!(
-            "runtime profile name `{}` cannot form a valid provenance source locator",
-            resolved_settings.profile_name
-        )
-    })?;
+    let source = runtime_profile_source(&resolved_settings.profile_name)?;
     provenance_entry(
         AgentStackComponentKind::AgentRuntime,
         source,

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/context_provenance_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/context_provenance_tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::workflow_runtime_worker::prompt_packet::{
-    build_runtime_job_prompt, build_runtime_prompt_packet, prompt_packet_digest,
-    workflow_prompt_artifact,
+    build_runtime_prompt_packet, prompt_packet_digest, workflow_prompt_artifact,
 };
 use crate::workflow_runtime_worker::runtime_profile::{
     resolve_runtime_settings, ResolvedApprovalPolicy, RuntimeSettingsResolutionError,
@@ -715,35 +714,8 @@ fn provenance_and_packet_digests_are_repeatable_and_order_sensitive() {
 #[test]
 fn invalid_required_provenance_aborts_packet_construction() {
     let job = runtime_job("implement_issue");
-    // A profile name that cannot form a valid ASC-001 locator must abort
-    // packet construction with an error instead of substituting an empty
-    // manifest; the executor therefore never hashes, records, or executes
-    // the incomplete packet.
-    let mut profile = RuntimeProfile::new("bad profile name", RuntimeKind::CodexJsonrpc);
-    profile.timeout_secs = Some(3600);
-    let resolved_settings = resolve_runtime_settings(
-        &profile,
-        RuntimeKind::CodexJsonrpc,
-        None,
-        &AgentsConfig::default(),
-        &ConcurrencyConfig::default(),
-    )
-    .unwrap_or_else(|error| panic!("settings resolve before locator construction: {error}"));
-    let error = build_runtime_prompt_packet(
-        &job,
-        None,
-        Path::new("/workspaces/job-1"),
-        Path::new("/repo"),
-        &profile,
-        &resolved_settings,
-        &WorkflowDocument::default(),
-        &[],
-        None,
-    )
-    .expect_err("invalid provenance must abort packet construction");
-    assert!(error.to_string().contains("provenance source locator"));
-
-    // A corrupted retained source digest is equally fatal.
+    // A corrupted retained source digest aborts packet construction; the
+    // executor never hashes, records, or executes the incomplete packet.
     let broken_document = WorkflowDocument {
         sources: vec![WorkflowSourceObservation {
             role: RepositoryOverride,
@@ -768,31 +740,60 @@ fn invalid_required_provenance_aborts_packet_construction() {
     assert!(error.to_string().contains("content digest"));
 }
 
+const HISTORICAL_PROFILE_ID: &str = "runtime:agent_runtime:runtime_profile/";
+const FALLBACK_PROFILE_ID: &str = "runtime:agent_runtime:runtime_profile_name_sha256/";
+fn profile_locator_component_id(name: &str) -> (String, Value) {
+    let job = runtime_job("implement_issue");
+    let mut profile = RuntimeProfile::new(name, RuntimeKind::CodexJsonrpc);
+    profile.timeout_secs = Some(3600);
+    let packet = build_packet(&job, &profile, &WorkflowDocument::default(), &[], None);
+    let id = component_id(&entries(&packet)[0]).to_owned();
+    let recorded_name = packet["resolved_runtime_settings"]["profile_name"].clone();
+    (id, recorded_name)
+}
 #[test]
-fn model_facing_prompt_strips_audit_sections_but_durable_packet_keeps_them() {
-    let mut job = runtime_job("implement_prompt");
-    job.input = json!({
-        "activity": "implement_prompt",
-        "command": { "prompt_ref": "prompt-1" },
-    });
-    let profile = codex_profile();
-    let task_text = "Implement the requested change.";
-    let packet = build_packet(
-        &job,
-        &profile,
-        &WorkflowDocument::default(),
-        &[],
-        Some(task_text),
-    );
-
-    assert!(packet.get("context_provenance").is_some());
-    assert!(packet.get("resolved_runtime_settings").is_some());
-    assert!(packet.get("prompt_task_request").is_some());
-
-    let prompt = build_runtime_job_prompt(&packet, Some(task_text));
-    assert!(!prompt.contains("context_provenance"));
-    assert!(!prompt.contains("resolved_runtime_settings"));
-    assert!(!prompt.contains("prompt_task_request"));
-    // The prompt-task text still reaches the agent exactly as before.
-    assert!(prompt.contains(task_text));
+fn profile_locator_preserves_valid_identity_and_hashes_invalid_exact_bytes() {
+    // Valid historical locators keep their stable component identity.
+    for name in ["codex-default", "team/codex"] {
+        let (id, recorded_name) = profile_locator_component_id(name);
+        assert_eq!(id, format!("{HISTORICAL_PROFILE_ID}{name}"));
+        assert_eq!(recorded_name, name);
+    }
+    // Invalid names use only the disjoint hashed namespace; digests are
+    // literal SHA-256 vectors over the exact UTF-8 name bytes, independent
+    // of the helper under test.
+    let names: &[&str] = &[
+        "",
+        " lead",
+        "trail ",
+        "Bad Profile",
+        "bad profile",
+        "double//slash",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "caf\u{e9}",
+        "cafe\u{301}",
+    ];
+    let digests: &[&str] = &[
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "e3e3c40cda282470d6ebacec8197e0c06c4334759eb8d5f8616be371fc1772bd",
+        "59413e908f3b72e4ce859bf153fffc8054615bc3e445f7ac5e7b2adb9b8bbe70",
+        "170d61a3efbe0a05dbbe03b14245c800b2ba5d1557cf70bfe2032cd89a671088",
+        "359f7ed65e4220888bd3083e6f29f2c5df1d426dcd4e233ea3ea2c11097dd7bd",
+        "ca063f40d5178dfdcbc72dd0d762745a1c45d1ba9b961d6aa37a0635f1565753",
+        "a3a9e1ed9732cab28868127be00f1ce921acaefdd5c3b23a6e9e0072bd9c1a34",
+        "850f7dc43910ff890f8879c0ed26fe697c93a067ad93a7d50f466a7028a9bf4e",
+        "81ef060bcd98adc7824eb5c1ada83c32491b16018e11e79f00ab9d09e04b015a",
+    ];
+    let mut fallbacks = std::collections::BTreeSet::new();
+    for (name, digest) in names.iter().zip(digests) {
+        let (id, recorded_name) = profile_locator_component_id(name);
+        assert_eq!(id, format!("{FALLBACK_PROFILE_ID}{digest}"));
+        assert_eq!(recorded_name, *name); // unhashed name stays byte-for-byte
+        fallbacks.insert(id);
+    }
+    // Distinct byte vectors get distinct fallbacks; equal bytes are stable.
+    assert_eq!(fallbacks.len(), names.len());
+    let repeat_a = profile_locator_component_id(" lead").0;
+    let repeat_b = profile_locator_component_id(" lead").0;
+    assert_eq!(repeat_a, repeat_b);
 }

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/fixtures/model_facing_prompt_v1.txt
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/fixtures/model_facing_prompt_v1.txt
@@ -1,0 +1,298 @@
+You are executing a Harness workflow runtime job.
+
+Runtime contract:
+- Treat the workflow database as the source of orchestration state, but do not edit workflow tables directly.
+- Harness server only manages lifecycle. You, the agent, perform repository and GitHub work when the activity requires it.
+- Follow the project instructions loaded by the runtime.
+- Use the prompt packet activity_result_schema to shape your final summary.
+- When returning structured activity output, put a JSON object in a final fenced `harness-activity-result` block matching activity_result_schema.
+- The structured result activity field must match this runtime job activity exactly.
+- Return a concise final summary appropriate to the activity. Include changed files and validation commands only when repository code changes were requested; for discovery and planning activities, report inspected inputs, emitted signals, and remaining blockers.
+
+Project root: /workspaces/job-1
+Runtime job id: runtime-job-fixture-1
+Runtime profile: codex-default
+Activity: implement_issue
+
+Prompt packet:
+{
+  "activity_result_schema": {
+    "activity": "implement_issue",
+    "activity_contract": {
+      "accepted_artifacts": [],
+      "accepted_signals": [],
+      "activity": "implement_issue",
+      "empty_success_allowed": true,
+      "explicit_noop_signals": [],
+      "required_artifacts": [],
+      "schema": "harness.runtime.activity_contract.v1",
+      "workflow_definition": "unknown"
+    },
+    "agent_summary_contract": {
+      "must_include": [
+        "summary",
+        "validation commands",
+        "remaining blockers"
+      ],
+      "must_not_include": [
+        "direct workflow table mutations"
+      ]
+    },
+    "allowed_error_kinds": [
+      "retryable",
+      "timeout",
+      "fatal",
+      "configuration",
+      "external_dependency",
+      "unknown"
+    ],
+    "allowed_statuses": [
+      "succeeded",
+      "failed",
+      "blocked",
+      "cancelled"
+    ],
+    "optional_artifacts": {
+      "workflow_decision": {
+        "allowed_confidence": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "description": "A proposed WorkflowDecision. Harness validates it before applying any transition or command.",
+        "required_fields": [
+          "workflow_id",
+          "observed_state",
+          "decision",
+          "next_state",
+          "reason",
+          "confidence"
+        ]
+      }
+    },
+    "optional_fields": [
+      "artifacts",
+      "signals",
+      "validation",
+      "error",
+      "error_kind"
+    ],
+    "required_fields": [
+      "activity",
+      "status",
+      "summary"
+    ],
+    "result_type": "ActivityResult",
+    "schema": "harness.runtime.activity_result.v1",
+    "status_contract": {
+      "blocked": "The activity cannot proceed without external input or budget.",
+      "cancelled": "The activity was intentionally stopped.",
+      "failed": "The activity hit an execution error. Use error_kind=fatal or configuration when retry would not help.",
+      "succeeded": "The activity completed and its output is ready for the workflow reducer."
+    },
+    "transition_contract": {
+      "on_succeeded": {
+        "reason": "No reducer transition is registered for this workflow/activity pair.",
+        "reducer_next_state": "unchanged"
+      }
+    },
+    "wire_format_example": {
+      "_format_rules": [
+        "`artifacts` MUST be a JSON array of {artifact_type, artifact} objects. Never emit it as a map keyed by artifact name.",
+        "`signals` MUST be a JSON array of {signal_type, signal} objects. Never use `kind` or any other discriminator name.",
+        "`validation` MUST be a JSON array of {command, status} objects. Never emit it as a map.",
+        "Inside a `workflow_decision` artifact, the next-step activity MUST be expressed as `commands: [{command_type, dedupe_key, command}]` (plural array). Never use a singular `command` field at the artifact level — that field is silently ignored, leaving the workflow stuck in the new state with no follow-up activity enqueued.",
+        "For `command_type: start_child_workflow`, the nested `command` object MUST include `definition_id` and `subject_key`; for GitHub issue workflows use `definition_id: github_issue_pr` and `subject_key: issue:<number>`.",
+        "Omit `artifacts`, `signals`, or `validation` entirely if there is nothing to report — empty arrays or missing fields are both fine."
+      ],
+      "activity": "implement_issue",
+      "artifacts": [
+        {
+          "artifact": {
+            "commands": [
+              {
+                "command": {
+                  "activity": "<next activity name>",
+                  "note": "All activity-specific payload (repo, issue_number, signals, etc.) goes INSIDE this nested `command` Value. The outer object MUST have exactly the three fields: command_type, dedupe_key, command."
+                },
+                "command_type": "enqueue_activity",
+                "dedupe_key": "<unique stable string for this command>"
+              }
+            ],
+            "confidence": "high",
+            "decision": "...",
+            "next_state": "...",
+            "observed_state": "...",
+            "reason": "...",
+            "workflow_id": "..."
+          },
+          "artifact_type": "workflow_decision"
+        }
+      ],
+      "signals": [
+        {
+          "signal": {
+            "issue_number": 123,
+            "issue_url": "https://example/issues/123",
+            "note": "Per-signal payload goes inside the `signal` object. Do NOT use `kind` as the discriminator; the wire format is `signal_type` + `signal`."
+          },
+          "signal_type": "<one of accepted_signals from transition_contract>"
+        }
+      ],
+      "status": "succeeded",
+      "summary": "Concise description of what the activity did.",
+      "validation": [
+        {
+          "command": "cargo test",
+          "status": "passed"
+        }
+      ]
+    },
+    "workflow_decision_contract": {
+      "available": false,
+      "reason": "No workflow instance was loaded for this runtime job."
+    },
+    "workflow_definition": "unknown"
+  },
+  "command_input": {
+    "activity": "implement_issue"
+  },
+  "project": {
+    "repo": null,
+    "root": "/workspaces/job-1",
+    "source_root": "/repo"
+  },
+  "required_structured_output": {
+    "changed_files": "Files changed by this runtime activity, if any.",
+    "remaining_blockers": "Any blockers that still require follow-up.",
+    "summary": "Concise final activity summary.",
+    "validation_commands": "Validation commands run and their results."
+  },
+  "runtime_contract": {
+    "agent_executes_repository_and_github_work": true,
+    "agent_must_not_edit_workflow_tables": true,
+    "follow_project_instructions": true,
+    "orchestration_source": "workflow_database"
+  },
+  "runtime_job": {
+    "activity": "implement_issue",
+    "command_id": "command-fixture-1",
+    "id": "runtime-job-fixture-1",
+    "runtime_kind": "codex_jsonrpc",
+    "runtime_profile": "codex-default"
+  },
+  "runtime_profile": {
+    "kind": "codex_jsonrpc",
+    "name": "codex-default"
+  },
+  "schema": "harness.runtime.prompt_packet.v1",
+  "workflow": null,
+  "workflow_file": {
+    "config": {
+      "activities": {},
+      "base": {
+        "branch": "main",
+        "remote": "origin",
+        "require_remote_head": true
+      },
+      "candidates": {
+        "enabled": false,
+        "n": 2,
+        "trigger_label": "best-of-n"
+      },
+      "hooks": {
+        "timeout_secs": 60
+      },
+      "issue_workflow": {
+        "auto_replan_on_plan_issue": true,
+        "force_execute_label": "force-execute",
+        "require_human_gate_before_merge": false
+      },
+      "memory": {
+        "enabled": false
+      },
+      "pr_feedback": {
+        "claim_stale_after_secs": 300,
+        "dirty_age_to_comment_secs": 604800,
+        "dirty_age_to_repair_secs": 172800,
+        "enabled": true,
+        "hygiene_batch_limit": 25,
+        "hygiene_enabled": true,
+        "hygiene_interval_secs": 1800,
+        "rebase_needed_label": "rebase-needed",
+        "sweep_interval_secs": 60
+      },
+      "pr_scope_guard": {
+        "enabled": true,
+        "max_files_changed": 30,
+        "max_lines_added": 1500
+      },
+      "runtime_completion": {
+        "quality_gate_validation_timeout_secs": 900
+      },
+      "runtime_dispatch": {
+        "activity_profiles": {},
+        "approval_policy": null,
+        "batch_limit": 25,
+        "defer_backoff_max_secs": 900,
+        "defer_backoff_secs": 30,
+        "enabled": true,
+        "interval_secs": 30,
+        "max_turns": null,
+        "model": null,
+        "reasoning_effort": null,
+        "runtime_kind": null,
+        "runtime_profile": null,
+        "sandbox": null,
+        "timeout_secs": null,
+        "workflow_activity_profiles": {},
+        "workflow_profiles": {}
+      },
+      "runtime_retry_policy": {
+        "activity_retries": {}
+      },
+      "runtime_worker": {
+        "concurrency": 10,
+        "enabled": true,
+        "interval_secs": 5,
+        "lease_ttl_secs": 3900
+      },
+      "source": {
+        "active_labels": [],
+        "ignore_labels": []
+      },
+      "storage": {
+        "orphan_reaper_enabled": true,
+        "orphan_reaper_interval_secs": 3600,
+        "orphan_reaper_legacy_batch": 200,
+        "orphan_reaper_legacy_enabled": true,
+        "runtime_retention_batch_size": 1000,
+        "runtime_retention_days": 30,
+        "runtime_retention_enabled": false,
+        "runtime_retention_interval_secs": 3600,
+        "schema_namespace": "workflow",
+        "task_retention_batch_size": 1000,
+        "task_retention_days": 30,
+        "task_retention_enabled": false,
+        "task_retention_interval_secs": 3600,
+        "workflow_watchdog_age_minutes": 240,
+        "workflow_watchdog_batch_size": 100,
+        "workflow_watchdog_enabled": false,
+        "workflow_watchdog_interval_secs": 300
+      },
+      "workflow": {
+        "version": 1
+      },
+      "workspace": {
+        "branch_prefix": "harness/",
+        "cleanup": "on_terminal",
+        "reuse_existing_workspace": false,
+        "strategy": "worktree"
+      }
+    },
+    "source_path": "/repo/WORKFLOW.md"
+  }
+}
+
+Repository workflow prompt template:
+Follow the repository workflow prompt.

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -694,6 +694,75 @@ fn memory_inject_prompt_packet_includes_fenced_repo_memory_section() {
 }
 
 #[test]
+fn model_facing_prompt_matches_frozen_v1_fixture_while_durable_packet_remains_v2() {
+    // Fixed inputs, identical to the fixture generation from pre-v2 commit
+    // f55eea8b: fixed job/command IDs, fixed roots/profile/input, no workflow,
+    // no memory, and a non-empty prompt template. The frozen fixture was
+    // rendered by that commit's genuine pre-v2 pipeline; because
+    // WorkflowConfig gained the `runtime_completion` default field after
+    // f55eea8b, generation injected exactly that default block so the fixed
+    // input bytes match the current default configuration.
+    let mut job = RuntimeJob::pending(
+        "command-fixture-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "implement_issue" }),
+    );
+    job.id = "runtime-job-fixture-1".to_string();
+    let workflow_document = WorkflowDocument {
+        prompt_template: "Follow the repository workflow prompt.".to_string(),
+        source_path: Some("/repo/WORKFLOW.md".to_string()),
+        ..Default::default()
+    };
+    let runtime_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
+    let packet = build_runtime_prompt_packet(
+        &job,
+        None,
+        Path::new("/workspaces/job-1"),
+        Path::new("/repo"),
+        &runtime_profile,
+        &resolved_settings_for_tests(&runtime_profile),
+        &workflow_document,
+        &[],
+        None,
+    )
+    .expect("fixture prompt packet should build");
+
+    // Durable evidence carries the current audit schema and keeps every audit
+    // field and template. The constant is referenced rather than pinned to a
+    // literal: this test exists to freeze the *model-facing* bytes, and the
+    // durable schema is expected to move as audit content evolves.
+    assert_eq!(packet["schema"], RUNTIME_PROMPT_PACKET_SCHEMA);
+    assert!(packet.get("context_provenance").is_some());
+    assert!(packet.get("resolved_runtime_settings").is_some());
+    assert_eq!(
+        packet["workflow_file"]["prompt_template"],
+        "Follow the repository workflow prompt."
+    );
+
+    // The complete rendered prompt matches the independent frozen pre-v2
+    // bytes; the expected value is not derived from the current v2 packet.
+    let prompt = build_runtime_job_prompt(&packet, None);
+    assert_eq!(
+        prompt,
+        include_str!("prompt_packet/fixtures/model_facing_prompt_v1.txt")
+    );
+
+    // The rendered packet JSON is v1, excludes the template and audit fields,
+    // and appends the non-empty template exactly once.
+    assert!(prompt.contains("\"schema\": \"harness.runtime.prompt_packet.v1\""));
+    assert!(!prompt.contains("prompt_template"));
+    assert!(!prompt.contains("context_provenance"));
+    assert!(!prompt.contains("resolved_runtime_settings"));
+    assert_eq!(
+        prompt
+            .matches("Repository workflow prompt template:")
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn memory_inject_fresh_repo_gets_no_repo_memory_section() {
     let job = RuntimeJob::pending(
         "command-1",

--- a/crates/harness-server/src/workflow_runtime_worker/runtime_profile.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/runtime_profile.rs
@@ -37,24 +37,28 @@ pub(super) enum RuntimeSettingsResolutionError {
     MissingTimeout { profile: String },
 }
 
-/// Final approval policy shared by provenance and agent launch.
+/// Final approval policy shared by provenance and agent launch (B-016).
 ///
 /// When a Codex profile omits `approval_policy`, the Codex CLI resolves the
 /// effective policy from configuration Harness does not observe, so the
 /// resolved settings record an explicit unobserved marker instead of a
-/// fabricated final value.
+/// fabricated final value. Claude Code and Anthropic API have no
+/// approval-policy setting at all, so an omitted policy is recorded as
+/// not applicable — a distinct audit claim from unobserved, because no
+/// approval-policy value participates in launch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "resolution", rename_all = "snake_case")]
 pub(super) enum ResolvedApprovalPolicy {
     Explicit { value: String },
     UnobservedAgentDefault,
+    NotApplicable,
 }
 
 impl ResolvedApprovalPolicy {
     pub(super) fn explicit_value(&self) -> Option<&str> {
         match self {
             Self::Explicit { value } => Some(value.as_str()),
-            Self::UnobservedAgentDefault => None,
+            Self::UnobservedAgentDefault | Self::NotApplicable => None,
         }
     }
 }
@@ -105,10 +109,7 @@ pub(super) fn resolve_runtime_settings(
         }
     };
     let sandbox_mode = runtime_profile_sandbox_mode(profile)?.unwrap_or(agents.sandbox_mode);
-    let approval_policy = match runtime_profile_approval_policy(profile, runtime_kind)? {
-        Some(value) => ResolvedApprovalPolicy::Explicit { value },
-        None => ResolvedApprovalPolicy::UnobservedAgentDefault,
-    };
+    let approval_policy = resolve_approval_policy(profile, runtime_kind)?;
     Ok(ResolvedRuntimeSettings {
         profile_name: profile.name.clone(),
         runtime_kind,
@@ -184,6 +185,32 @@ fn runtime_profile_sandbox_mode(profile: &RuntimeProfile) -> anyhow::Result<Opti
         other => anyhow::bail!("runtime profile sandbox `{other}` is not supported"),
     };
     Ok(Some(mode))
+}
+
+/// Closed runtime-kind approval resolution (B-016).
+///
+/// An explicit policy is accepted only for Codex runtime kinds and rejected
+/// with a typed error for every other kind — it is never silently discarded.
+/// An omitted policy records `UnobservedAgentDefault` for Codex runtimes
+/// (the effective value is resolved outside Harness) and `NotApplicable` for
+/// runtimes without an approval-policy contract. `RemoteHost` with an omitted
+/// policy resolves to `NotApplicable` here but never produces resolved
+/// settings: model resolution rejects remote-host jobs locally.
+fn resolve_approval_policy(
+    profile: &RuntimeProfile,
+    runtime_kind: RuntimeKind,
+) -> anyhow::Result<ResolvedApprovalPolicy> {
+    match runtime_profile_approval_policy(profile, runtime_kind)? {
+        Some(value) => Ok(ResolvedApprovalPolicy::Explicit { value }),
+        None => Ok(match runtime_kind {
+            RuntimeKind::CodexExec | RuntimeKind::CodexJsonrpc => {
+                ResolvedApprovalPolicy::UnobservedAgentDefault
+            }
+            RuntimeKind::ClaudeCode | RuntimeKind::AnthropicApi | RuntimeKind::RemoteHost => {
+                ResolvedApprovalPolicy::NotApplicable
+            }
+        }),
+    }
 }
 
 fn runtime_profile_approval_policy(
@@ -287,14 +314,79 @@ mod tests {
 
     #[test]
     fn runtime_profile_approval_policy_rejects_non_codex_runtimes() {
-        let mut profile = RuntimeProfile::new("claude-default", RuntimeKind::ClaudeCode);
-        profile.approval_policy = Some("on-request".to_string());
+        for kind in [
+            RuntimeKind::ClaudeCode,
+            RuntimeKind::AnthropicApi,
+            RuntimeKind::RemoteHost,
+        ] {
+            let mut profile = RuntimeProfile::new("non-codex", kind);
+            profile.approval_policy = Some("on-request".to_string());
 
-        let error = runtime_profile_approval_policy(&profile, RuntimeKind::ClaudeCode)
-            .expect_err("Claude approval policy should fail until it has a contract");
+            let error = runtime_profile_approval_policy(&profile, kind)
+                .expect_err("explicit approval policy must be rejected for non-Codex runtimes");
 
-        assert!(error
-            .to_string()
-            .contains("only supported for Codex runtime kinds"));
+            assert!(error
+                .to_string()
+                .contains("only supported for Codex runtime kinds"));
+            assert!(
+                error.to_string().contains(kind.as_str()),
+                "the rejection must name the unsupported runtime kind: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn approval_policy_resolution_matches_runtime_capability_matrix() {
+        let agents = AgentsConfig::default();
+        let concurrency = ConcurrencyConfig::default();
+
+        // Omitted policy for Codex runtimes: an effective value may still be
+        // selected outside Harness, so it is recorded as unobserved.
+        for kind in [RuntimeKind::CodexExec, RuntimeKind::CodexJsonrpc] {
+            let profile = profile_with_timeout("codex-default", kind);
+            let resolved = resolve_runtime_settings(&profile, kind, None, &agents, &concurrency)
+                .unwrap_or_else(|error| panic!("{kind:?} omitted policy should resolve: {error}"));
+            assert_eq!(
+                resolved.approval_policy,
+                ResolvedApprovalPolicy::UnobservedAgentDefault
+            );
+            assert_eq!(resolved.approval_policy.explicit_value(), None);
+            assert_eq!(
+                serde_json::to_value(&resolved.approval_policy)
+                    .expect("approval policy serializes"),
+                serde_json::json!({ "resolution": "unobserved_agent_default" })
+            );
+        }
+
+        // Omitted policy for runtimes without an approval-policy contract:
+        // not applicable, a distinct audit claim from unobserved.
+        for kind in [RuntimeKind::ClaudeCode, RuntimeKind::AnthropicApi] {
+            let profile = profile_with_timeout("non-codex", kind);
+            let resolved = resolve_runtime_settings(&profile, kind, None, &agents, &concurrency)
+                .unwrap_or_else(|error| panic!("{kind:?} omitted policy should resolve: {error}"));
+            assert_eq!(
+                resolved.approval_policy,
+                ResolvedApprovalPolicy::NotApplicable
+            );
+            assert_eq!(resolved.approval_policy.explicit_value(), None);
+            assert_eq!(
+                serde_json::to_value(&resolved.approval_policy)
+                    .expect("approval policy serializes"),
+                serde_json::json!({ "resolution": "not_applicable" })
+            );
+        }
+
+        // Remote Host remains rejected by local runtime-settings resolution;
+        // it never produces resolved settings.
+        let remote = profile_with_timeout("remote-host-default", RuntimeKind::RemoteHost);
+        let error = resolve_runtime_settings(
+            &remote,
+            RuntimeKind::RemoteHost,
+            None,
+            &agents,
+            &concurrency,
+        )
+        .expect_err("remote_host must be rejected by local settings resolution");
+        assert!(error.to_string().contains("remote_host"));
     }
 }


### PR DESCRIPTION
Closes the two remaining GH-1732 (ASC-003) remediation items on runtime prompt context provenance.

## B-015 — deterministic runtime-profile locator

A runtime profile whose name cannot form a valid ASC-001 provenance locator aborted packet construction. It now falls back to a disjoint `runtime_profile_name_sha256/<digest>` namespace keyed by the exact UTF-8 name bytes.

The fallback never trims, case-folds, or Unicode-normalizes: equal byte sequences produce equal locators, and byte-distinct names cannot collide. Names that already form a valid locator — including multi-segment ones such as `team/codex` — keep the historical `runtime_profile/<name>` form and their stable component IDs. The exact configured name still appears in `resolved_runtime_settings.profile_name`; the hashed locator is an audit identity, not a replacement for the value.

## B-016 — closed approval-policy resolution

An omitted `approval_policy` previously always recorded `UnobservedAgentDefault`, which claimed Harness could not observe a value that does not exist.

Resolution is now closed over runtime kind. Codex runtimes keep `UnobservedAgentDefault`, because the effective policy really is resolved by the Codex CLI from configuration Harness does not see. Claude Code and Anthropic API have no approval-policy contract at all, so an omitted policy records `NotApplicable` — a distinct audit claim, since no approval-policy value participates in launch. An explicit policy on a non-Codex runtime is still rejected with a typed error naming the unsupported kind, never silently discarded.

## Model-facing bytes

`strip_model_facing_audit_sections` now restores the historical v1 schema on the rendered clone, so agent-visible prompt bytes for unchanged inputs are unaffected by the durable packet's audit schema. A committed fixture pins those bytes; the durable packet keeps the current schema.

## Verification

- `harness-server` lib: 1439 passed
- full workspace `cargo test`: exit 0
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean

Named tests: `profile_locator_preserves_valid_identity_and_hashes_invalid_exact_bytes`, `approval_policy_resolution_matches_runtime_capability_matrix`, `runtime_profile_approval_policy_rejects_non_codex_runtimes`, `model_facing_prompt_matches_frozen_v1_fixture_while_durable_packet_remains_v2`, `provenance_failure_prevents_prompt_event_and_agent_start`.