### PR TITLE
fix(workflow): bind transition authority to immutable provenance (GH-1864)

### DIFF
--- a/crates/harness-server/src/workflow_runtime_submission/cancel.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/cancel.rs
@@ -238,7 +238,15 @@ async fn resolve_declarative_cancellation(
         let target_state = cancelled_state(definition.policy(), instance)?;
         return Ok(Some(DeclarativeCancellation {
             target_state,
-            validator: DecisionValidator::new(definition.registered().allowlist.clone()),
+            // The pin resolved to this exact definition, so the validator
+            // carries that identity and the store can re-verify at commit that
+            // it still governs the row it locked (GH-1864).
+            validator: DecisionValidator::for_declarative_definition(
+                &instance.definition_id,
+                definition.definition_version(),
+                definition.definition_hash(),
+                definition.registered().allowlist.clone(),
+            ),
             missing_pin: false,
         }));
     }
@@ -305,7 +313,15 @@ async fn resolve_declarative_cancellation(
     }
     Ok(Some(DeclarativeCancellation {
         target_state: cancelled_state(&policy, instance)?,
-        validator: DecisionValidator::new(definition.registered().allowlist.clone()),
+        // Rebuilt from the persisted snapshot, but only after its version and
+        // content hash were checked against the instance pin above, so the
+        // validator may claim that identity (GH-1864).
+        validator: DecisionValidator::for_declarative_definition(
+            &instance.definition_id,
+            definition.definition_version(),
+            definition.definition_hash(),
+            definition.registered().allowlist.clone(),
+        ),
         missing_pin: true,
     }))
 }

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -44,6 +44,7 @@ pub mod terminal_state;
 pub mod tier_resolution;
 pub mod transcript;
 pub mod validator;
+pub mod validator_binding;
 mod validator_progress;
 pub mod worker;
 
@@ -209,6 +210,7 @@ pub use validator::{
     DecisionValidator, TransitionAllowlist, TransitionRule, ValidationContext,
     WorkflowDecisionRejection, WorkflowDecisionRejectionKind,
 };
+pub use validator_binding::DecisionValidatorBinding;
 pub use worker::{
     RuntimeJobClaimDecision, RuntimeJobClaimGuard, RuntimeJobExecutor, RuntimeWorker,
 };

--- a/crates/harness-workflow/src/runtime/state_registry.rs
+++ b/crates/harness-workflow/src/runtime/state_registry.rs
@@ -258,9 +258,14 @@ impl WorkflowDefinitionRegistry {
         instance: &WorkflowInstance,
     ) -> Result<Option<DecisionValidator>, DeclarativeDefinitionPinError> {
         match self.resolve_declarative_definition(instance) {
+            // Carry the exact version and content hash the pin resolved to, so
+            // the store can re-verify at commit that this validator still
+            // governs the row it loaded (GH-1864).
             DeclarativeDefinitionResolution::Resolved(definition) => {
-                Ok(Some(DecisionValidator::for_definition(
+                Ok(Some(DecisionValidator::for_declarative_definition(
                     &instance.definition_id,
+                    definition.definition_version(),
+                    definition.definition_hash(),
                     definition.registered().allowlist.clone(),
                 )))
             }

--- a/crates/harness-workflow/src/runtime/store/decision_transitions.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions.rs
@@ -96,6 +96,14 @@ impl WorkflowRuntimeStore {
         validation_context: ValidationContext,
     ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
         self.apply_decision_transition_inner(transition, |current, decision, event| {
+            // The caller resolved this validator before the row was locked, so
+            // re-verify under lock that it still governs the instance being
+            // written. A validator from another definition, version, or content
+            // hash authorizes transitions this workflow's own definition never
+            // allowed (GH-1864).
+            if let Err(error) = validator.binding().ensure_governs(current) {
+                return TransitionValidation::Rejected(error.to_string());
+            }
             let mut context = validation_context.clone();
             context.now = event.created_at;
             match validator.validate(current, decision, &context) {

--- a/crates/harness-workflow/src/runtime/store/decision_transitions.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions.rs
@@ -17,6 +17,17 @@ use crate::runtime::model::{
 use crate::runtime::status::WorkflowCommandStatus;
 use crate::runtime::{DecisionValidator, ValidationContext};
 
+/// The declarative definition pin carried in `workflow.data`.
+///
+/// Declarative resolution treats this hash as pinned identity: it decides
+/// which definition — and therefore which validator and which legal
+/// transitions — govern the workflow. It is established when the instance is
+/// created and must never move afterwards, so it is a protected field even
+/// though it lives inside `data` rather than in a column.
+pub(super) fn definition_hash_pin(instance: &WorkflowInstance) -> Option<&serde_json::Value> {
+    instance.data.get("definition_hash")
+}
+
 pub(super) fn ensure_protected_instance_fields_match(
     current: &WorkflowInstance,
     final_instance: &WorkflowInstance,
@@ -27,6 +38,12 @@ pub(super) fn ensure_protected_instance_fields_match(
     }
     if current.definition_version != final_instance.definition_version {
         changed_fields.push("definition_version");
+    }
+    // Covers substitution, removal, and introducing a pin on a workflow that
+    // never had one -- each of them re-points the instance at a different
+    // definition than the one it was validated against.
+    if definition_hash_pin(current) != definition_hash_pin(final_instance) {
+        changed_fields.push("data.definition_hash");
     }
     if current.subject != final_instance.subject {
         changed_fields.push("subject");

--- a/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
@@ -325,6 +325,93 @@ async fn apply_decision_transition_treats_a_same_state_stale_snapshot_as_stale(
     Ok(())
 }
 
+/// The declarative pin in `workflow.data` decides which definition — and so
+/// which validator and which legal transitions — govern the instance. A
+/// transition that moves it re-points the workflow at a definition it was
+/// never validated against, so `definition_hash` is protected exactly like the
+/// definition id and version (GH-1864).
+#[tokio::test]
+async fn apply_decision_transition_rejects_definition_hash_substitution() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let mut initial = instance("gh1864-definition-hash-substitution", "addressing_feedback");
+    initial.set_data_field(
+        "definition_hash",
+        json!("a".repeat(64)),
+        crate::runtime::DataProvenance::Server,
+    )?;
+    store
+        .force_upsert_lifecycle_state_for_test(&initial)
+        .await?;
+
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "addressing_feedback",
+        "address_feedback",
+        "local_review_gate",
+        "feedback addressed",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "run_local_review",
+        "gh1864-definition-hash-substitution-command",
+    ));
+
+    // Substituting the pin and removing it are both identity changes.
+    let mut substituted = initial.clone();
+    substituted.set_data_field(
+        "definition_hash",
+        json!("b".repeat(64)),
+        crate::runtime::DataProvenance::Server,
+    )?;
+    let mut removed = initial.clone();
+    removed.remove_data_field("definition_hash", crate::runtime::DataProvenance::Server)?;
+
+    for (label, mut final_instance) in [("substituted", substituted), ("removed", removed)] {
+        final_instance.state = decision.next_state.clone();
+        final_instance.version = final_instance.version.saturating_add(1);
+
+        let error = store
+            .apply_decision_transition(
+                WorkflowDecisionTransition {
+                    expected_state: &initial.state,
+                    create_if_missing: None,
+                    event_type: "FeedbackAddressed",
+                    source: "workflow-runtime-test",
+                    payload: json!({}),
+                    decision: &decision,
+                    final_instance: &final_instance,
+                    command_status: WorkflowCommandStatus::Pending,
+                },
+                "workflow-runtime-test",
+            )
+            .await
+            .expect_err("a transition must not move the declarative definition pin");
+        assert!(
+            error.to_string().contains("data.definition_hash"),
+            "the {label} pin must be named in the rejection: {error}"
+        );
+
+        let stored = store
+            .get_instance(&initial.id)
+            .await?
+            .expect("the original instance must remain");
+        assert_eq!(
+            stored.data["definition_hash"],
+            initial.data["definition_hash"]
+        );
+        assert_eq!(stored.state, initial.state);
+        assert_eq!(stored.version, initial.version);
+        assert!(store.events_for(&initial.id).await?.is_empty());
+        assert!(store.decisions_for(&initial.id).await?.is_empty());
+        assert!(store.commands_for(&initial.id).await?.is_empty());
+    }
+    Ok(())
+}
+
 #[tokio::test]
 async fn apply_decision_transition_rejects_definition_substitution() -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {

--- a/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
@@ -1,7 +1,8 @@
 //! GH-1784 regression tests for validated decision-transition writes.
 
 use super::*;
-use crate::runtime::{WorkflowCommand, WorkflowSubject};
+use crate::runtime::validator::TransitionAllowlist;
+use crate::runtime::{WorkflowCommand, WorkflowCommandType, WorkflowSubject};
 use chrono::{Duration, Utc};
 use harness_core::db::resolve_database_url;
 use serde_json::json;
@@ -409,6 +410,188 @@ async fn apply_decision_transition_rejects_definition_hash_substitution() -> any
         assert!(store.decisions_for(&initial.id).await?.is_empty());
         assert!(store.commands_for(&initial.id).await?.is_empty());
     }
+    Ok(())
+}
+
+/// A validator resolved before the row was locked must be re-checked against
+/// the row actually loaded: one built from another definition, another version,
+/// another content hash, or from no definition at all authorizes transitions
+/// this workflow's own definition never allowed (GH-1864).
+#[tokio::test]
+async fn apply_decision_transition_with_validator_rejects_a_foreign_validator() -> anyhow::Result<()>
+{
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let initial = instance("gh1864-foreign-validator", "addressing_feedback");
+    store
+        .force_upsert_lifecycle_state_for_test(&initial)
+        .await?;
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "addressing_feedback",
+        "address_feedback",
+        "local_review_gate",
+        "feedback addressed",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "run_local_review",
+        "gh1864-foreign-validator-command",
+    ));
+    let mut final_instance = initial.clone();
+    final_instance.state = decision.next_state.clone();
+    final_instance.version = final_instance.version.saturating_add(1);
+
+    // The permissive allowlist proves the rejection comes from the binding
+    // check rather than from the transition rules: this decision satisfies
+    // every rule it carries.
+    let permissive = TransitionAllowlist::default().allow_from_any(
+        "local_review_gate",
+        [
+            WorkflowCommandType::EnqueueActivity,
+            WorkflowCommandType::Wait,
+        ],
+    );
+    let cases = [
+        (
+            "another definition",
+            DecisionValidator::for_definition("prompt_task", permissive.clone()),
+        ),
+        (
+            "another version",
+            DecisionValidator::for_declarative_definition(
+                &initial.definition_id,
+                initial.definition_version.saturating_add(1),
+                &"a".repeat(64),
+                permissive.clone(),
+            ),
+        ),
+        (
+            "another content hash",
+            DecisionValidator::for_declarative_definition(
+                &initial.definition_id,
+                initial.definition_version,
+                &"a".repeat(64),
+                permissive.clone(),
+            ),
+        ),
+        ("no definition", DecisionValidator::new(permissive.clone())),
+    ];
+
+    for (label, validator) in cases {
+        let record = store
+            .apply_decision_transition_with_validator(
+                WorkflowDecisionTransition {
+                    expected_state: &initial.state,
+                    create_if_missing: None,
+                    event_type: "FeedbackAddressed",
+                    source: "workflow-runtime-test",
+                    payload: json!({}),
+                    decision: &decision,
+                    final_instance: &final_instance,
+                    command_status: WorkflowCommandStatus::Pending,
+                },
+                &validator,
+                ValidationContext::new("workflow-runtime-test", Utc::now()),
+            )
+            .await?
+            .expect("a rejected decision must remain durably observable");
+
+        assert!(
+            !record.accepted,
+            "a validator bound to {label} must not authorize this transition"
+        );
+        let reason = record
+            .rejection_reason
+            .clone()
+            .unwrap_or_else(|| "<none>".to_string());
+        assert!(
+            reason.contains("decision validator is"),
+            "the {label} case must be rejected by the binding check, not incidentally: {reason}"
+        );
+        let stored = store
+            .get_instance(&initial.id)
+            .await?
+            .expect("the original instance must remain");
+        assert_eq!(
+            stored.state, initial.state,
+            "the {label} case must not move the instance"
+        );
+        assert_eq!(stored.version, initial.version);
+    }
+    Ok(())
+}
+
+/// `data.definition_hash` is a definition pin only for declarative workflows.
+/// A built-in workflow may carry that key as ordinary payload, and its
+/// built-in validator — which makes no content claim — must still govern it.
+#[tokio::test]
+async fn apply_decision_transition_with_validator_ignores_unpinned_definition_hash_data(
+) -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let mut initial = instance("gh1864-builtin-hash-payload", "addressing_feedback");
+    initial.set_data_field(
+        "definition_hash",
+        json!("c".repeat(64)),
+        crate::runtime::DataProvenance::Server,
+    )?;
+    store
+        .force_upsert_lifecycle_state_for_test(&initial)
+        .await?;
+
+    let decision = WorkflowDecision::new(
+        &initial.id,
+        "addressing_feedback",
+        "address_feedback",
+        "local_review_gate",
+        "feedback addressed",
+    )
+    .with_command(WorkflowCommand::enqueue_activity(
+        "run_local_review",
+        "gh1864-builtin-hash-payload-command",
+    ));
+    let mut final_instance = initial.clone();
+    final_instance.state = decision.next_state.clone();
+    final_instance.version = final_instance.version.saturating_add(1);
+
+    let record = store
+        .apply_decision_transition_with_validator(
+            WorkflowDecisionTransition {
+                expected_state: &initial.state,
+                create_if_missing: None,
+                event_type: "FeedbackAddressed",
+                source: "workflow-runtime-test",
+                payload: json!({}),
+                decision: &decision,
+                final_instance: &final_instance,
+                command_status: WorkflowCommandStatus::Pending,
+            },
+            &DecisionValidator::github_issue_pr(),
+            ValidationContext::new("workflow-runtime-test", Utc::now()),
+        )
+        .await?
+        .expect("the transition should produce a decision record");
+
+    assert!(
+        record.accepted,
+        "a built-in validator must not read data.definition_hash as a pin"
+    );
+    assert_eq!(
+        store
+            .get_instance(&initial.id)
+            .await?
+            .expect("instance should exist")
+            .state,
+        "local_review_gate"
+    );
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/store/instances.rs
+++ b/crates/harness-workflow/src/runtime/store/instances.rs
@@ -1,5 +1,5 @@
 use super::{
-    commit_parent_attachment_instance_tx, commit_same_state_instance_tx,
+    commit_parent_attachment_instance_tx, commit_same_state_instance_tx, insert_event_tx,
     insert_validated_canonical_initial_instance_tx,
     instance_helpers::{otel_trace_context_from_data, terminal_state_pairs},
     select_instance_for_update_tx, validate_instance_for_persistence,
@@ -9,14 +9,29 @@ use super::{
 use crate::runtime::model::WorkflowInstance;
 use crate::runtime::WorkflowOtelTraceContext;
 use chrono::{DateTime, Utc};
+use serde_json::json;
+
+/// Event recorded when a workflow row is created outside a decision
+/// transition, so no creation is eventless (GH-1864).
+pub const WORKFLOW_INSTANCE_CREATED_EVENT: &str = "WorkflowInstanceCreated";
 
 impl WorkflowRuntimeStore {
+    /// Create a workflow at its canonical initial state if it does not exist.
+    ///
+    /// Creation records a `WorkflowInstanceCreated` event in the same
+    /// transaction, so a row can never appear with no provenance for how it
+    /// came to exist. Decision-driven creation carries its own event and
+    /// decision and does not come through here.
     pub async fn insert_instance_if_absent(
         &self,
         instance: &WorkflowInstance,
     ) -> anyhow::Result<bool> {
+        validate_instance_for_persistence(instance)?;
         let mut tx = self.pool.begin().await?;
         let inserted = insert_validated_canonical_initial_instance_tx(&mut tx, instance).await?;
+        if inserted {
+            record_instance_created_event_tx(&mut tx, instance).await?;
+        }
         tx.commit().await?;
         Ok(inserted)
     }
@@ -27,6 +42,7 @@ impl WorkflowRuntimeStore {
         let current = match select_instance_for_update_tx(&mut tx, &instance.id).await? {
             Some(current) => current,
             None if insert_validated_canonical_initial_instance_tx(&mut tx, instance).await? => {
+                record_instance_created_event_tx(&mut tx, instance).await?;
                 tx.commit().await?;
                 return Ok(());
             }
@@ -687,6 +703,27 @@ impl WorkflowRuntimeStore {
     }
 }
 
+async fn record_instance_created_event_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    instance: &WorkflowInstance,
+) -> anyhow::Result<()> {
+    insert_event_tx(
+        tx,
+        &instance.id,
+        WORKFLOW_INSTANCE_CREATED_EVENT,
+        "workflow_runtime_store",
+        json!({
+            "definition_id": instance.definition_id,
+            "definition_version": instance.definition_version,
+            "state": instance.state,
+            "subject": instance.subject,
+            "parent_workflow_id": instance.parent_workflow_id,
+        }),
+    )
+    .await?;
+    Ok(())
+}
+
 fn ensure_public_upsert_preserves_instance_boundary(
     current: &WorkflowInstance,
     target: &WorkflowInstance,
@@ -697,6 +734,11 @@ fn ensure_public_upsert_preserves_instance_boundary(
     }
     if current.definition_version != target.definition_version {
         changed_fields.push("definition_version");
+    }
+    if super::decision_transitions::definition_hash_pin(current)
+        != super::decision_transitions::definition_hash_pin(target)
+    {
+        changed_fields.push("data.definition_hash");
     }
     if current.state != target.state {
         changed_fields.push("state");

--- a/crates/harness-workflow/src/runtime/store/instances_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/instances_tests.rs
@@ -171,3 +171,39 @@ async fn public_upsert_rejects_version_jump() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+/// No workflow row may appear with no record of how it came to exist
+/// (GH-1864). Decision-driven creation carries its own event and decision;
+/// creation through the public insert APIs records a `WorkflowInstanceCreated`
+/// event in the same transaction.
+#[tokio::test]
+async fn public_creation_records_an_initial_event_atomically() -> anyhow::Result<()> {
+    let Some(store) = test_store().await? else {
+        return Ok(());
+    };
+
+    let instance = discovered_instance("gh1864-eventless-creation");
+    assert!(store.insert_instance_if_absent(&instance).await?);
+
+    let events = store.events_for(&instance.id).await?;
+    assert_eq!(
+        events.len(),
+        1,
+        "creation must record exactly one provenance event"
+    );
+    assert_eq!(events[0].event_type, WORKFLOW_INSTANCE_CREATED_EVENT);
+    assert_eq!(events[0].event["definition_id"], instance.definition_id);
+    assert_eq!(events[0].event["state"], instance.state);
+
+    // A losing concurrent insert must not append a second creation event.
+    assert!(!store.insert_instance_if_absent(&instance).await?);
+    assert_eq!(store.events_for(&instance.id).await?.len(), 1);
+
+    // The other public creation entry point is held to the same rule.
+    let upserted = discovered_instance("gh1864-eventless-creation-upsert");
+    store.upsert_instance(&upserted).await?;
+    let events = store.events_for(&upserted.id).await?;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_type, WORKFLOW_INSTANCE_CREATED_EVENT);
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/store/transaction_helpers.rs
+++ b/crates/harness-workflow/src/runtime/store/transaction_helpers.rs
@@ -458,6 +458,15 @@ fn ensure_instance_identity_fields_match(
     if current.definition_version != target.definition_version {
         changed_fields.push("definition_version");
     }
+    // The declarative pin decides which definition governs the workflow, so it
+    // is identity even though it lives in `data`. Checking it at this
+    // chokepoint covers every row write that compares against a loaded row:
+    // decision commits, same-state writes, recovery, and child start.
+    if super::decision_transitions::definition_hash_pin(current)
+        != super::decision_transitions::definition_hash_pin(target)
+    {
+        changed_fields.push("data.definition_hash");
+    }
     if current.subject != target.subject {
         changed_fields.push("subject");
     }

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -1,4 +1,5 @@
 use super::model::{WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowInstance};
+use super::validator_binding::DecisionValidatorBinding;
 use super::validator_progress;
 use chrono::{DateTime, Utc};
 use std::collections::BTreeSet;
@@ -422,6 +423,7 @@ impl std::error::Error for WorkflowDecisionRejection {}
 pub struct DecisionValidator {
     allowlist: TransitionAllowlist,
     kind: DecisionValidatorKind,
+    binding: DecisionValidatorBinding,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -432,11 +434,36 @@ enum DecisionValidatorKind {
 }
 
 impl DecisionValidator {
+    /// A validator over a bare allowlist, bound to no definition. The store
+    /// refuses such a validator; callers that persist transitions must build a
+    /// bound one instead.
     pub fn new(allowlist: TransitionAllowlist) -> Self {
         Self {
             allowlist,
             kind: DecisionValidatorKind::Generic,
+            binding: DecisionValidatorBinding::unbound(),
         }
+    }
+
+    /// A validator bound to the exact declarative definition a pin resolved to.
+    pub fn for_declarative_definition(
+        definition_id: &str,
+        definition_version: u32,
+        definition_hash: &str,
+        allowlist: TransitionAllowlist,
+    ) -> Self {
+        let mut validator = Self::for_definition(definition_id, allowlist);
+        validator.binding = DecisionValidatorBinding::for_declarative(
+            definition_id,
+            definition_version,
+            definition_hash,
+        );
+        validator
+    }
+
+    /// The definition identity this validator was resolved from.
+    pub fn binding(&self) -> &DecisionValidatorBinding {
+        &self.binding
     }
 
     pub fn github_issue_pr() -> Self {
@@ -473,7 +500,11 @@ impl DecisionValidator {
             super::prompt_task::PROMPT_TASK_DEFINITION_ID => DecisionValidatorKind::PromptTask,
             _ => DecisionValidatorKind::Generic,
         };
-        Self { allowlist, kind }
+        Self {
+            allowlist,
+            kind,
+            binding: DecisionValidatorBinding::for_definition(definition_id),
+        }
     }
 
     pub fn validate(

--- a/crates/harness-workflow/src/runtime/validator_binding.rs
+++ b/crates/harness-workflow/src/runtime/validator_binding.rs
@@ -1,0 +1,107 @@
+//! The definition identity a [`DecisionValidator`] speaks for (GH-1864).
+//!
+//! [`DecisionValidator`]: super::validator::DecisionValidator
+
+use super::WorkflowInstance;
+
+/// The definition identity a validator was built from.
+///
+/// A validator encodes which transitions are legal, so applying one that was
+/// resolved from a different definition — or from a different version or
+/// content hash of the same definition — authorizes transitions the instance's
+/// own definition never allowed. The store re-checks this binding against the
+/// row it loaded under lock, which also closes the window between a caller
+/// resolving a validator and the commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecisionValidatorBinding {
+    /// `None` means the validator was built from a bare allowlist and claims no
+    /// definition. Such a validator cannot be shown to govern any instance, so
+    /// the store refuses it rather than guessing.
+    pub definition_id: Option<String>,
+    /// Declarative definitions pin an exact version; built-ins do not carry
+    /// one, and `None` means "this validator makes no version claim".
+    pub definition_version: Option<u32>,
+    /// The content hash the declarative pin resolved to. `None` for built-in
+    /// definitions, which are addressed by id alone and whose instances may
+    /// carry a `data.definition_hash` the validator has no claim over.
+    pub definition_hash: Option<String>,
+}
+
+impl DecisionValidatorBinding {
+    /// A validator that claims no definition and therefore governs nothing.
+    pub fn unbound() -> Self {
+        Self {
+            definition_id: None,
+            definition_version: None,
+            definition_hash: None,
+        }
+    }
+
+    /// A validator bound to a definition by id, with no version or content
+    /// claim — the built-in case.
+    pub fn for_definition(definition_id: &str) -> Self {
+        Self {
+            definition_id: Some(definition_id.to_string()),
+            definition_version: None,
+            definition_hash: None,
+        }
+    }
+
+    /// A validator bound to the exact declarative definition a pin resolved to.
+    pub fn for_declarative(definition_id: &str, definition_version: u32, hash: &str) -> Self {
+        Self {
+            definition_id: Some(definition_id.to_string()),
+            definition_version: Some(definition_version),
+            definition_hash: Some(hash.to_string()),
+        }
+    }
+
+    /// Reject a validator that does not govern this instance.
+    pub fn ensure_governs(&self, instance: &WorkflowInstance) -> anyhow::Result<()> {
+        let Some(definition_id) = self.definition_id.as_deref() else {
+            anyhow::bail!(
+                "decision validator is not bound to a workflow definition and cannot govern workflow `{}`",
+                instance.id
+            );
+        };
+        if definition_id != instance.definition_id {
+            anyhow::bail!(
+                "decision validator is bound to definition `{}` but workflow `{}` uses `{}`",
+                definition_id,
+                instance.id,
+                instance.definition_id
+            );
+        }
+        if let Some(version) = self.definition_version {
+            if version != instance.definition_version {
+                anyhow::bail!(
+                    "decision validator is bound to definition `{}` version {} but workflow `{}` is at version {}",
+                    definition_id,
+                    version,
+                    instance.id,
+                    instance.definition_version
+                );
+            }
+        }
+        // Only a validator resolved through a declarative pin makes a claim
+        // about content, so only it compares hashes. A built-in validator must
+        // not read `data.definition_hash`: for a built-in definition that field
+        // is ordinary payload, not a definition pin.
+        if let Some(hash) = self.definition_hash.as_deref() {
+            let pinned = instance
+                .data
+                .get("definition_hash")
+                .and_then(serde_json::Value::as_str);
+            if pinned != Some(hash) {
+                anyhow::bail!(
+                    "decision validator is bound to definition `{}` content hash `{}` but workflow `{}` pins `{}`",
+                    definition_id,
+                    hash,
+                    instance.id,
+                    pinned.unwrap_or("<none>")
+                );
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes two of the four provenance boundaries in #1864. Follow-up to #1784.

## W1 — no eventless creation

`insert_instance_if_absent` and the creation branch of the public `upsert_instance` inserted a workflow row with no record of how it came to exist. Both now record a `WorkflowInstanceCreated` event in the same transaction.

Every creation path is now provenance-bearing:

| Path | Provenance |
|---|---|
| Decision-driven (`create_if_missing`) | its own event + decision record |
| Child start | `ChildWorkflowStarted` |
| `insert_instance_if_absent` / `upsert_instance` | `WorkflowInstanceCreated` (new) |

A losing concurrent insert appends nothing.

## W2 — `data.definition_hash` is protected

The declarative pin decides which definition — and therefore which validator and which legal transitions — govern the instance. It was absent from every protected-field check because it lives inside `data` rather than in a column, so a transition could re-point a workflow at a definition it was never validated against.

It is now compared in `ensure_instance_identity_fields_match`, the chokepoint every row write that compares against a loaded row passes through, so decision commits, same-state writes, recovery, and child start are all covered at once. It is also named explicitly in the decision-transition and public-upsert boundary checks so the rejection reports which field moved.

Three cases are all treated as identity changes:
- substituting the pin
- removing the pin
- introducing a pin on a workflow that never had one

## Not in this PR

The remaining two items from #1864 — binding a supplied `DecisionValidator` to exact definition id/version/hash, and requiring PR-binding repair to link to an accepted decision and record durable repair provenance — are still open.

## Verification

- `harness-workflow` lib: 643 passed
- `harness-server` lib: 1439 passed
- full workspace `cargo test`: exit 0
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean

New tests: `public_creation_records_an_initial_event_atomically`, `apply_decision_transition_rejects_definition_hash_substitution`.