### PR TITLE
chore: remove defunct Gemini review bot from PR rules and workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,20 +21,3 @@ jobs:
             exit 1
           fi
           echo "PR description looks good (${#PR_BODY} chars)."
-
-  gemini-review:
-    name: Advisory Gemini Request
-    runs-on: ubuntu-latest
-    if: github.event.action == 'synchronize' && vars.GEMINI_REVIEW_ENABLED == 'true'
-    steps:
-      - name: Request Gemini re-review
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '/gemini review'
-            });
-            core.notice('Advisory Gemini review requested. This check only confirms that the request comment was posted.');

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,8 @@ There is no type literally named `AgentRuntime` in the codebase. The phrase is u
 
 ## PR Workflow
 
-- After creating a PR, wait for Gemini code review bot before merging
-- If Gemini leaves review comments, address valid feedback before merge
+- After creating a PR, wait for the Codex review bot before merging
+- If the review bot leaves comments, address valid feedback before merge
 - If no comments or only false positives, proceed with merge
 
 ## Codex Integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,8 @@ Harness is an agent orchestration layer. It constructs prompts and manages lifec
 
 ## PR Workflow
 
-- After creating a PR, wait for Gemini code review bot before merging
-- If Gemini leaves review comments, address valid feedback before merge
+- After creating a PR, wait for the Codex review bot before merging
+- If the review bot leaves comments, address valid feedback before merge
 - If no comments or only false positives, proceed with merge
 - **Squash-merge only** — enforced via GitHub ruleset (squash is the only allowed merge method; no bypass for anyone)
 - **Required CI** — the `CI Result` status check must pass before merging (enforced via ruleset)


### PR DESCRIPTION
## What

The Gemini code review bot is no longer available, so this removes it from the merge-gating rules and CI plumbing:

- `CLAUDE.md` / `AGENTS.md` PR Workflow: the "wait for Gemini before merging" rule now points at the Codex review bot, which is still active on this repo.
- `.github/workflows/pr-check.yml`: delete the `gemini-review` advisory job that posted `/gemini review` on every synchronize event.

## Not changed (follow-up decision)

Product code still models Gemini as a configurable review provider (`gemini_github_bot` in `harness-core` review config, `ReviewBotKey::Gemini`, fallback chains). That is runtime functionality with its own tests, not a repo rule — removing it is a larger change and should be its own issue if we want it.

The `GEMINI_REVIEW_ENABLED` repo variable (currently `true`) becomes unused after this merges and can be deleted.

## Validation

Docs + workflow YAML only; no Rust changes. The removed job was advisory and not part of the required `CI Result` check.