### PR TITLE
fix(workflow): make decision and prompt audit writes append-only (GH-1865)

### DIFF
--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -178,12 +178,13 @@ pub use state_registry::{
     WorkflowProgressMode, WorkflowStateDefinition, WorkflowStateKey,
 };
 pub use status::WorkflowCommandStatus;
+pub use store::PromptPayloadIntegrityError;
 pub use store::{
-    cost_usd_from_micros, cost_usd_to_micros, DriverlessProgressInstance,
-    DriverlessProgressProvenanceStatus, RuntimeHistoryPruneSummary, RuntimeUsageMetrics,
-    RuntimeUsageRecord, RuntimeUsageUpsert, RuntimeUsageUpsertOutcome, RuntimeWorkflowUsage,
-    WorkflowCancellationCleanupOutcome, WorkflowChildStart, WorkflowChildStartOutcome,
-    WorkflowCoverageRecoveryExpected, WorkflowCoverageRecoveryOutcome,
+    cost_usd_from_micros, cost_usd_to_micros, DecisionProvenanceConflict,
+    DriverlessProgressInstance, DriverlessProgressProvenanceStatus, RuntimeHistoryPruneSummary,
+    RuntimeUsageMetrics, RuntimeUsageRecord, RuntimeUsageUpsert, RuntimeUsageUpsertOutcome,
+    RuntimeWorkflowUsage, WorkflowCancellationCleanupOutcome, WorkflowChildStart,
+    WorkflowChildStartOutcome, WorkflowCoverageRecoveryExpected, WorkflowCoverageRecoveryOutcome,
     WorkflowCoverageRecoveryTransition, WorkflowDecisionTransition, WorkflowPrBindingRepairOutcome,
     WorkflowRejectedDecisionTransition, WorkflowRuntimeRecoveryAction,
     WorkflowRuntimeRecoveryOutcome, WorkflowRuntimeRecoveryRequest, WorkflowRuntimeStore,

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -31,6 +31,8 @@ mod command_facade;
 mod command_store;
 #[path = "store/coverage_recovery.rs"]
 mod coverage_recovery;
+#[path = "store/decision_provenance.rs"]
+mod decision_provenance;
 #[path = "store/decision_transitions.rs"]
 mod decision_transitions;
 #[path = "store/decisions.rs"]
@@ -83,8 +85,12 @@ pub use coverage_recovery::{
     WorkflowCoverageRecoveryExpected, WorkflowCoverageRecoveryOutcome,
     WorkflowCoverageRecoveryTransition,
 };
+pub(in crate::runtime) use decision_provenance::insert_decision_record_once_tx;
+pub use decision_provenance::DecisionProvenanceConflict;
 pub use driverless_progress::{DriverlessProgressInstance, DriverlessProgressProvenanceStatus};
 pub use pr_binding_repair::WorkflowPrBindingRepairOutcome;
+pub(in crate::runtime) use prompt_payloads::insert_prompt_payload_tx;
+pub use prompt_payloads::PromptPayloadIntegrityError;
 pub use recovery::{
     WorkflowRuntimeRecoveryAction, WorkflowRuntimeRecoveryOutcome, WorkflowRuntimeRecoveryRequest,
 };
@@ -103,7 +109,7 @@ use transaction_helpers::force_upsert_lifecycle_state_for_test_tx;
 use transaction_helpers::{
     apply_inline_command_side_effect, commit_decision_instance_tx,
     commit_parent_attachment_instance_tx, commit_rejected_initial_failure_instance_tx,
-    commit_same_state_instance_tx, insert_decision_record_tx, insert_event_tx_with_id,
+    commit_same_state_instance_tx, insert_event_tx_with_id,
     insert_validated_canonical_initial_instance_tx, insert_validated_observed_instance_tx,
     load_or_insert_initial_instance_tx, runtime_job_for_command_tx, select_instance_for_update_tx,
 };

--- a/crates/harness-workflow/src/runtime/store/coverage_recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/coverage_recovery.rs
@@ -4,7 +4,7 @@ use super::{
     apply_inline_command_side_effect, command_store, commit_decision_instance_tx,
     commit_same_state_instance_tx,
     decision_transitions::ensure_protected_instance_fields_match,
-    insert_decision_record_tx, insert_event_tx_with_id, insert_validated_observed_instance_tx,
+    insert_decision_record_once_tx, insert_event_tx_with_id, insert_validated_observed_instance_tx,
     runtime_job_state::{cancel_unfinished_runtime_jobs_for_commands_tx, RuntimeJobCancellation},
     select_instance_for_update_tx,
     transition_validation::{validate_transition_with_context, TransitionValidation},
@@ -179,7 +179,7 @@ impl WorkflowRuntimeStore {
         )
         .await?;
         let record = WorkflowDecisionRecord::accepted(transition.decision.clone(), Some(event.id));
-        insert_decision_record_tx(&mut tx, &record).await?;
+        insert_decision_record_once_tx(&mut tx, &record).await?;
 
         let desired_keys = transition
             .decision

--- a/crates/harness-workflow/src/runtime/store/decision_provenance.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_provenance.rs
@@ -1,0 +1,132 @@
+//! Append-only writes for the decision audit trail (GH-1865 W1).
+//!
+//! A decision row is the record of what was authorized, by which decision, on
+//! which observed state. Writing it with an `ON CONFLICT DO UPDATE` made that
+//! record mutable: a later write reusing an existing decision id silently
+//! replaced `accepted`, the serialized decision, and the rejection reason, so
+//! the audit trail described the newest write rather than what actually
+//! happened. Retries and replays reuse decision ids by design, which is exactly
+//! when the history matters most.
+//!
+//! Every write now goes in once. A repeat of the same row is an idempotent
+//! replay; a repeat that differs is a provenance conflict and fails closed
+//! rather than overwriting the original.
+
+use super::*;
+
+/// A decision id that already exists with different content. The write is
+/// refused: the stored row is the authoritative record of what happened.
+#[derive(Debug, Clone)]
+pub struct DecisionProvenanceConflict {
+    pub decision_id: String,
+    pub workflow_id: String,
+    /// The fields that differ between the stored row and the attempted write.
+    pub changed_fields: Vec<&'static str>,
+}
+
+impl std::fmt::Display for DecisionProvenanceConflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "decision `{}` on workflow `{}` already exists with different provenance; \
+             refusing to overwrite (differs in: {})",
+            self.decision_id,
+            self.workflow_id,
+            self.changed_fields.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for DecisionProvenanceConflict {}
+
+/// The stored row a conflicting insert is compared against.
+#[derive(sqlx::FromRow)]
+struct StoredDecisionRow {
+    workflow_id: String,
+    event_id: Option<String>,
+    accepted: bool,
+    #[sqlx(rename = "data")]
+    data_json: String,
+    rejection_reason: Option<String>,
+}
+
+/// Insert a decision record once.
+///
+/// A row that already exists with identical content is an idempotent replay
+/// and succeeds without writing; one that exists with anything else is a
+/// [`DecisionProvenanceConflict`].
+pub(in crate::runtime) async fn insert_decision_record_once_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    record: &WorkflowDecisionRecord,
+) -> anyhow::Result<()> {
+    let data = to_jsonb_string(record)?;
+    let inserted = sqlx::query(
+        "INSERT INTO workflow_decisions
+            (id, workflow_id, event_id, accepted, data, rejection_reason)
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(&record.id)
+    .bind(&record.workflow_id)
+    .bind(&record.event_id)
+    .bind(record.accepted)
+    .bind(&data)
+    .bind(&record.rejection_reason)
+    .execute(&mut **tx)
+    .await?
+    .rows_affected()
+        == 1;
+    if inserted {
+        return Ok(());
+    }
+
+    let stored: Option<StoredDecisionRow> = sqlx::query_as(
+        "SELECT workflow_id, event_id, accepted, data::text AS data, rejection_reason
+         FROM workflow_decisions
+         WHERE id = $1",
+    )
+    .bind(&record.id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    // The row is inserted or read back inside this transaction, so a missing
+    // row here means the conflict was resolved by a delete that this store
+    // never performs. Fail closed rather than retrying into a race.
+    let Some(stored) = stored else {
+        anyhow::bail!(
+            "decision `{}` conflicted on insert but could not be read back",
+            record.id
+        );
+    };
+
+    let mut changed_fields = Vec::new();
+    if stored.workflow_id != record.workflow_id {
+        changed_fields.push("workflow_id");
+    }
+    if stored.event_id != record.event_id {
+        changed_fields.push("event_id");
+    }
+    if stored.accepted != record.accepted {
+        changed_fields.push("accepted");
+    }
+    if stored.rejection_reason != record.rejection_reason {
+        changed_fields.push("rejection_reason");
+    }
+    // The columns are a projection of `data`, so compare the record itself
+    // rather than its serialization: jsonb normalizes key order and numeric
+    // formatting, which would make a byte comparison report false conflicts.
+    match serde_json::from_str::<WorkflowDecisionRecord>(&stored.data_json) {
+        Ok(stored_record) if stored_record != *record => changed_fields.push("data"),
+        Ok(_) => {}
+        Err(_) => changed_fields.push("data"),
+    }
+
+    if changed_fields.is_empty() {
+        return Ok(());
+    }
+    Err(DecisionProvenanceConflict {
+        decision_id: record.id.clone(),
+        workflow_id: record.workflow_id.clone(),
+        changed_fields,
+    }
+    .into())
+}

--- a/crates/harness-workflow/src/runtime/store/decision_transitions.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions.rs
@@ -6,7 +6,7 @@
 
 use super::{
     apply_inline_command_side_effect, command_store, commit_decision_instance_tx,
-    insert_decision_record_tx, insert_event_tx, load_or_insert_initial_instance_tx,
+    insert_decision_record_once_tx, insert_event_tx, load_or_insert_initial_instance_tx,
     transition_validation::{validate_transition, TransitionValidation},
     validate_instance_for_persistence, WorkflowDecisionTransition,
     WorkflowRejectedDecisionTransition, WorkflowRuntimeStore,
@@ -179,12 +179,12 @@ impl WorkflowRuntimeStore {
             TransitionValidation::Rejected(reason) => {
                 let record =
                     WorkflowDecisionRecord::rejected(decision.clone(), Some(event.id), reason);
-                insert_decision_record_tx(&mut tx, &record).await?;
+                insert_decision_record_once_tx(&mut tx, &record).await?;
                 tx.commit().await?;
                 return Ok(Some(record));
             }
         };
-        insert_decision_record_tx(&mut tx, &record).await?;
+        insert_decision_record_once_tx(&mut tx, &record).await?;
 
         for command in &decision.commands {
             let status = if command.requires_runtime_job() {
@@ -241,7 +241,7 @@ impl WorkflowRuntimeStore {
         .await?;
         let record =
             WorkflowDecisionRecord::rejected(decision.clone(), Some(event.id), transition.reason);
-        insert_decision_record_tx(&mut tx, &record).await?;
+        insert_decision_record_once_tx(&mut tx, &record).await?;
 
         tx.commit().await?;
         Ok(Some(record))
@@ -297,7 +297,7 @@ mod submission_guard_tests {
         )
         .await?;
         let record = WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id));
-        insert_decision_record_tx(&mut tx, &record).await?;
+        insert_decision_record_once_tx(&mut tx, &record).await?;
         tx.commit().await?;
         Ok(record)
     }

--- a/crates/harness-workflow/src/runtime/store/decisions.rs
+++ b/crates/harness-workflow/src/runtime/store/decisions.rs
@@ -1,25 +1,16 @@
 use super::*;
 
 impl WorkflowRuntimeStore {
+    /// Record a decision on its own, outside a larger transition.
+    ///
+    /// Shares the append-only write with every in-transaction writer: a repeat
+    /// of the same row is an idempotent replay, and a repeat that differs is a
+    /// [`DecisionProvenanceConflict`](super::DecisionProvenanceConflict)
+    /// rather than an overwrite (GH-1865).
     pub async fn record_decision(&self, record: &WorkflowDecisionRecord) -> anyhow::Result<()> {
-        let data = to_jsonb_string(record)?;
-        sqlx::query(
-            "INSERT INTO workflow_decisions
-                (id, workflow_id, event_id, accepted, data, rejection_reason)
-             VALUES ($1, $2, $3, $4, $5::jsonb, $6)
-             ON CONFLICT (id) DO UPDATE SET
-                accepted = EXCLUDED.accepted,
-                data = EXCLUDED.data,
-                rejection_reason = EXCLUDED.rejection_reason",
-        )
-        .bind(&record.id)
-        .bind(&record.workflow_id)
-        .bind(&record.event_id)
-        .bind(record.accepted)
-        .bind(&data)
-        .bind(&record.rejection_reason)
-        .execute(&self.pool)
-        .await?;
+        let mut tx = self.pool.begin().await?;
+        insert_decision_record_once_tx(&mut tx, record).await?;
+        tx.commit().await?;
         Ok(())
     }
 

--- a/crates/harness-workflow/src/runtime/store/prompt_payloads.rs
+++ b/crates/harness-workflow/src/runtime/store/prompt_payloads.rs
@@ -1,27 +1,25 @@
 use super::*;
 
 impl WorkflowRuntimeStore {
-    pub async fn upsert_prompt_payload(
+    /// Store the prompt bytes a `prompt_ref` names.
+    ///
+    /// The ref is content-addressed by its producer, so the same ref must
+    /// always name the same bytes. Writing it once and proving equality on
+    /// repeat keeps that true: a replay is idempotent, and a second writer
+    /// claiming an existing ref for different bytes is refused instead of
+    /// silently rebinding the ref every earlier record already points at
+    /// (GH-1865).
+    pub async fn insert_prompt_payload(
         &self,
         prompt_ref: &str,
         prompt: &str,
     ) -> anyhow::Result<()> {
-        if prompt_ref.trim().is_empty() {
-            anyhow::bail!("workflow prompt payload prompt_ref must not be empty");
-        }
-        sqlx::query(
-            "INSERT INTO workflow_prompt_payloads (prompt_ref, prompt)
-             VALUES ($1, $2)
-             ON CONFLICT (prompt_ref) DO UPDATE SET
-                prompt = EXCLUDED.prompt,
-                updated_at = CURRENT_TIMESTAMP",
-        )
-        .bind(prompt_ref)
-        .bind(prompt)
-        .execute(&self.pool)
-        .await?;
+        let mut tx = self.pool.begin().await?;
+        insert_prompt_payload_tx(&mut tx, prompt_ref, prompt).await?;
+        tx.commit().await?;
         Ok(())
     }
+
     pub async fn get_prompt_payload(&self, prompt_ref: &str) -> anyhow::Result<Option<String>> {
         if prompt_ref.trim().is_empty() {
             return Ok(None);
@@ -44,4 +42,78 @@ impl WorkflowRuntimeStore {
             .await?;
         Ok(())
     }
+}
+
+/// A `prompt_ref` that already names different bytes than the ones being
+/// written. The stored payload is what every existing record resolves to, so
+/// the write is refused rather than rebinding the ref.
+#[derive(Debug, Clone)]
+pub struct PromptPayloadIntegrityError {
+    pub prompt_ref: String,
+    pub stored_len: usize,
+    pub attempted_len: usize,
+}
+
+impl std::fmt::Display for PromptPayloadIntegrityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "prompt ref `{}` already stores different prompt bytes ({} stored vs {} attempted); \
+             refusing to rebind a content-addressed ref",
+            self.prompt_ref, self.stored_len, self.attempted_len
+        )
+    }
+}
+
+impl std::error::Error for PromptPayloadIntegrityError {}
+
+/// Insert prompt bytes once.
+///
+/// Equal bytes under an existing ref are an idempotent replay; different bytes
+/// are a [`PromptPayloadIntegrityError`].
+///
+/// This checks the ref against what is stored, not against a hash of the
+/// prompt: a `prompt_ref` digests submission identity alongside the prompt, so
+/// only its producer can recompute it. The store's guarantee is narrower and
+/// still sufficient — one ref never resolves to two different payloads.
+pub(in crate::runtime) async fn insert_prompt_payload_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    prompt_ref: &str,
+    prompt: &str,
+) -> anyhow::Result<()> {
+    if prompt_ref.trim().is_empty() {
+        anyhow::bail!("workflow prompt payload prompt_ref must not be empty");
+    }
+    let inserted = sqlx::query(
+        "INSERT INTO workflow_prompt_payloads (prompt_ref, prompt)
+         VALUES ($1, $2)
+         ON CONFLICT (prompt_ref) DO NOTHING",
+    )
+    .bind(prompt_ref)
+    .bind(prompt)
+    .execute(&mut **tx)
+    .await?
+    .rows_affected()
+        == 1;
+    if inserted {
+        return Ok(());
+    }
+
+    let stored: Option<(String,)> =
+        sqlx::query_as("SELECT prompt FROM workflow_prompt_payloads WHERE prompt_ref = $1")
+            .bind(prompt_ref)
+            .fetch_optional(&mut **tx)
+            .await?;
+    let Some((stored_prompt,)) = stored else {
+        anyhow::bail!("prompt ref `{prompt_ref}` conflicted on insert but could not be read back");
+    };
+    if stored_prompt == prompt {
+        return Ok(());
+    }
+    Err(PromptPayloadIntegrityError {
+        prompt_ref: prompt_ref.to_string(),
+        stored_len: stored_prompt.len(),
+        attempted_len: prompt.len(),
+    }
+    .into())
 }

--- a/crates/harness-workflow/src/runtime/store/recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery.rs
@@ -4,7 +4,7 @@ use super::runtime_job_state::{
 };
 use super::{
     apply_inline_command_side_effect, command_store, commit_decision_instance_tx,
-    insert_decision_record_tx, insert_event_tx, select_instance_for_update_tx,
+    insert_decision_record_once_tx, insert_event_tx, select_instance_for_update_tx,
     workflow_instance_from_persisted_json, WorkflowInstance, WorkflowRuntimeStore,
 };
 use crate::runtime::model::{
@@ -199,7 +199,7 @@ impl WorkflowRuntimeStore {
         validator.validate(&instance, &decision, &validation_context)?;
         let decision_record =
             WorkflowDecisionRecord::accepted(decision.clone(), Some(event.id.clone()));
-        insert_decision_record_tx(&mut tx, &decision_record).await?;
+        insert_decision_record_once_tx(&mut tx, &decision_record).await?;
         for command in &decision.commands {
             let status = recovery_command_status(command);
             command_store::insert_tx(

--- a/crates/harness-workflow/src/runtime/store/runtime_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion.rs
@@ -1,6 +1,6 @@
 use super::{
     apply_inline_command_side_effect, command_store, commit_decision_instance_tx,
-    insert_decision_record_tx, insert_event_tx, select_instance_for_update_tx,
+    insert_decision_record_once_tx, insert_event_tx, select_instance_for_update_tx,
     WorkflowRuntimeStore,
 };
 use crate::runtime::model::{
@@ -354,7 +354,7 @@ async fn persist_runtime_completion_decision_with_context_tx(
             WorkflowDecisionRecord::rejected(decision, Some(event.id.clone()), error.to_string())
         }
     };
-    insert_decision_record_tx(tx, &record).await?;
+    insert_decision_record_once_tx(tx, &record).await?;
 
     if record.accepted {
         if apply_prompt_continuation_side_effect(tx, &mut instance, &record.decision).await?

--- a/crates/harness-workflow/src/runtime/store/submission_commit.rs
+++ b/crates/harness-workflow/src/runtime/store/submission_commit.rs
@@ -1,8 +1,8 @@
 use super::{
     command_store, commit_decision_instance_tx, commit_rejected_initial_failure_instance_tx,
     decision_transitions::ensure_protected_instance_fields_match,
-    insert_decision_record_tx, insert_event_tx_with_id, insert_validated_observed_instance_tx,
-    select_instance_for_update_tx,
+    insert_decision_record_once_tx, insert_event_tx_with_id, insert_prompt_payload_tx,
+    insert_validated_observed_instance_tx, select_instance_for_update_tx,
     transition_validation::{validate_transition_with_context, TransitionValidation},
     WorkflowRuntimeStore,
 };
@@ -212,7 +212,7 @@ impl WorkflowRuntimeStore {
                         record.event_id.clone(),
                         reason,
                     );
-                    insert_decision_record_tx(&mut tx, &rejected).await?;
+                    insert_decision_record_once_tx(&mut tx, &rejected).await?;
                     tx.commit().await?;
                     return Ok(Some(WorkflowSubmissionDecisionCommit {
                         record: rejected,
@@ -226,7 +226,7 @@ impl WorkflowRuntimeStore {
                 }
             }
         }
-        insert_decision_record_tx(&mut tx, &record).await?;
+        insert_decision_record_once_tx(&mut tx, &record).await?;
 
         let mut command_ids = Vec::new();
         if let Some(final_instance) = transition.final_instance {
@@ -240,7 +240,7 @@ impl WorkflowRuntimeStore {
                     );
                 }
                 if let Some(prompt_payload) = transition.prompt_payload {
-                    upsert_prompt_payload_tx(
+                    insert_prompt_payload_tx(
                         &mut tx,
                         prompt_payload.prompt_ref,
                         prompt_payload.prompt,
@@ -332,28 +332,6 @@ async fn load_submission_instance_tx(
     Ok(select_instance_for_update_tx(tx, transition.workflow_id)
         .await?
         .map(|instance| (instance, false)))
-}
-
-async fn upsert_prompt_payload_tx(
-    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    prompt_ref: &str,
-    prompt: &str,
-) -> anyhow::Result<()> {
-    if prompt_ref.trim().is_empty() {
-        anyhow::bail!("workflow prompt payload prompt_ref must not be empty");
-    }
-    sqlx::query(
-        "INSERT INTO workflow_prompt_payloads (prompt_ref, prompt)
-         VALUES ($1, $2)
-         ON CONFLICT (prompt_ref) DO UPDATE SET
-            prompt = EXCLUDED.prompt,
-            updated_at = CURRENT_TIMESTAMP",
-    )
-    .bind(prompt_ref)
-    .bind(prompt)
-    .execute(&mut **tx)
-    .await?;
-    Ok(())
 }
 
 async fn delete_prompt_payload_tx(

--- a/crates/harness-workflow/src/runtime/store/transaction_helpers.rs
+++ b/crates/harness-workflow/src/runtime/store/transaction_helpers.rs
@@ -29,31 +29,6 @@ pub(super) async fn runtime_job_for_command_tx(
         .map_err(Into::into)
 }
 
-pub(super) async fn insert_decision_record_tx(
-    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    record: &WorkflowDecisionRecord,
-) -> anyhow::Result<()> {
-    let data = to_jsonb_string(record)?;
-    sqlx::query(
-        "INSERT INTO workflow_decisions
-            (id, workflow_id, event_id, accepted, data, rejection_reason)
-         VALUES ($1, $2, $3, $4, $5::jsonb, $6)
-         ON CONFLICT (id) DO UPDATE SET
-            accepted = EXCLUDED.accepted,
-            data = EXCLUDED.data,
-            rejection_reason = EXCLUDED.rejection_reason",
-    )
-    .bind(&record.id)
-    .bind(&record.workflow_id)
-    .bind(&record.event_id)
-    .bind(record.accepted)
-    .bind(&data)
-    .bind(&record.rejection_reason)
-    .execute(&mut **tx)
-    .await?;
-    Ok(())
-}
-
 pub(super) async fn load_or_insert_initial_instance_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     workflow_id: &str,

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -68,6 +68,7 @@ mod lock_order_stress;
 mod otel_spans;
 mod p1_followups;
 mod pr_repair_evidence;
+mod provenance_immutability;
 mod remote_host_lease;
 mod replay_determinism;
 mod retry;

--- a/crates/harness-workflow/src/runtime/tests/provenance_immutability.rs
+++ b/crates/harness-workflow/src/runtime/tests/provenance_immutability.rs
@@ -1,0 +1,158 @@
+//! GH-1865 regression tests: workflow audit records are append-only.
+
+use super::*;
+use crate::runtime::{DecisionProvenanceConflict, PromptPayloadIntegrityError};
+
+fn workflow(id: &str, state: &str) -> WorkflowInstance {
+    WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        state,
+        WorkflowSubject::new("pr", "9101"),
+    )
+    .with_id(id)
+    .with_server_data(json!({ "project_id": "/project-a", "pr_number": 9101 }))
+}
+
+fn decision(workflow_id: &str) -> WorkflowDecision {
+    WorkflowDecision::new(
+        workflow_id,
+        "addressing_feedback",
+        "address_feedback",
+        "local_review_gate",
+        "feedback addressed",
+    )
+}
+
+/// Replaying the exact same decision row is how retries and submission replays
+/// behave, so it must stay a no-op rather than an error.
+#[tokio::test]
+async fn decision_replay_with_identical_content_is_idempotent() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = workflow("gh1865-idempotent-replay", "addressing_feedback");
+    store
+        .force_upsert_lifecycle_state_for_test(&instance)
+        .await?;
+
+    let record = WorkflowDecisionRecord::accepted(decision(&instance.id), None);
+    store.record_decision(&record).await?;
+    store.record_decision(&record).await?;
+
+    let stored = store.decisions_for(&instance.id).await?;
+    assert_eq!(stored.len(), 1, "a replay must not duplicate the audit row");
+    assert_eq!(stored[0], record);
+    Ok(())
+}
+
+/// The audit trail records what was authorized. A later write reusing a
+/// decision id must not be able to rewrite that: flipping `accepted` would
+/// turn a rejection into an authorization after the fact, and rewriting the
+/// decision content would make one id describe a transition it never
+/// authorized.
+#[tokio::test]
+async fn decision_rewrite_under_an_existing_id_is_refused() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = workflow("gh1865-rewrite-refused", "addressing_feedback");
+    store
+        .force_upsert_lifecycle_state_for_test(&instance)
+        .await?;
+
+    let original = WorkflowDecisionRecord::rejected(
+        decision(&instance.id),
+        None,
+        "transition is outside the allowlist",
+    );
+    store.record_decision(&original).await?;
+
+    let mut promoted = original.clone();
+    promoted.accepted = true;
+    promoted.rejection_reason = None;
+
+    let mut rewritten_content = original.clone();
+    rewritten_content.decision.next_state = "merging".to_string();
+
+    let mut relinked = original.clone();
+    relinked.event_id = Some("some-other-event".to_string());
+
+    for (label, attempt, expected_field) in [
+        ("a rejection promoted to accepted", promoted, "accepted"),
+        (
+            "a rewritten decision body",
+            rewritten_content,
+            "rejection_reason",
+        ),
+        ("a re-linked event", relinked, "event_id"),
+    ] {
+        let error = store
+            .record_decision(&attempt)
+            .await
+            .expect_err("rewriting an existing decision id must fail closed");
+        let conflict = error
+            .downcast_ref::<DecisionProvenanceConflict>()
+            .unwrap_or_else(|| panic!("{label} must be a provenance conflict, got: {error}"));
+        assert_eq!(conflict.decision_id, original.id);
+        assert!(
+            conflict.changed_fields.contains(&expected_field)
+                || conflict.changed_fields.contains(&"data"),
+            "{label} must name what moved, got: {:?}",
+            conflict.changed_fields
+        );
+
+        let stored = store.decisions_for(&instance.id).await?;
+        assert_eq!(stored.len(), 1);
+        assert_eq!(
+            stored[0], original,
+            "{label} must leave the original record untouched"
+        );
+    }
+    Ok(())
+}
+
+/// A `prompt_ref` is content-addressed: every record that stores one resolves
+/// through it to the prompt that was actually run. Rebinding it to different
+/// bytes would silently rewrite what those records mean, so equal bytes are an
+/// idempotent replay and different bytes are refused.
+#[tokio::test]
+async fn prompt_payload_refs_are_insert_once() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+
+    let prompt_ref = "prompt-memory:gh1865-insert-once";
+    store
+        .insert_prompt_payload(prompt_ref, "implement the fix")
+        .await?;
+    store
+        .insert_prompt_payload(prompt_ref, "implement the fix")
+        .await?;
+    assert_eq!(
+        store.get_prompt_payload(prompt_ref).await?,
+        Some("implement the fix".to_string()),
+        "an identical replay must leave the payload untouched"
+    );
+
+    let error = store
+        .insert_prompt_payload(prompt_ref, "do something else entirely")
+        .await
+        .expect_err("rebinding a prompt ref to different bytes must fail closed");
+    let integrity = error
+        .downcast_ref::<PromptPayloadIntegrityError>()
+        .unwrap_or_else(|| panic!("expected an integrity error, got: {error}"));
+    assert_eq!(integrity.prompt_ref, prompt_ref);
+    assert_eq!(
+        store.get_prompt_payload(prompt_ref).await?,
+        Some("implement the fix".to_string()),
+        "the stored prompt must survive a rejected rebind"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Closes part of #1865 (W1 + W3 of four).

## Problem

Two audit surfaces were writable after the fact:

- **Decisions** (`transaction_helpers.rs`, `decisions.rs` — byte-identical SQL) inserted with `ON CONFLICT (id) DO UPDATE`, so a later write reusing a decision id silently replaced `accepted`, the serialized decision, and the rejection reason. Retries and submission replays reuse decision ids by design, which is exactly when the original record matters.
- **Prompt payloads** (`prompt_payloads.rs` and a duplicate in `submission_commit.rs`) had the same shape, so a `prompt_ref` could be rebound to different bytes — rewriting what every record already pointing at that ref resolves to.

## Change

One shared append-only write per surface:

- `insert_decision_record_once_tx`: `DO NOTHING` + read-back. Identical row → idempotent replay; anything else → `DecisionProvenanceConflict` naming the changed fields. The comparison deserializes the stored row rather than comparing raw jsonb, since jsonb normalizes key order and would report false conflicts.
- `insert_prompt_payload_tx`: equal bytes idempotent, different bytes → `PromptPayloadIntegrityError`. The two duplicated writers collapse into one.

## Deviation from the fix plan

The plan also called for verifying `prompt_ref == hash(prompt)` at write time. That check cannot live in the store: a `prompt_ref` digests project id, external id, and task id alongside the prompt (`prompt_memory.rs:96`), so only its producer can recompute it. The store proves the narrower property it actually owns — one ref never resolves to two payloads.

## Verification

The new tests in `runtime/tests/provenance_immutability.rs` were confirmed to fail without the fix (an id rewrite commits under `DO UPDATE`).

- `harness-workflow` lib: 648 passed
- `harness-server` lib: 1439 passed
- full workspace `cargo test`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean

## Remaining on #1865

W2 (immutable command intent + explicit attempt generations, carries a schema migration) and W4 (cancellation bound to its own decision generation) follow in separate PRs.