### PR TITLE
fix(workflow): bind cancellation cleanup to the current accepted decision (GH-1865)

### DIFF
--- a/crates/harness-server/src/intake/github_coverage_recovery_tests/atomic.rs
+++ b/crates/harness-server/src/intake/github_coverage_recovery_tests/atomic.rs
@@ -71,19 +71,38 @@ async fn cancelled_recovered_quality_gate_is_reactivated_after_terminal_job() ->
         .iter()
         .filter(|record| record.command.requires_runtime_job())
         .collect::<Vec<_>>();
-    assert_eq!(runtime_commands.len(), 1);
-    assert_eq!(runtime_commands[0].id, command.id);
-    assert_eq!(runtime_commands[0].status, WorkflowCommandStatus::Pending);
+    // Recovery re-enqueues the cancelled command as a new attempt rather than
+    // resurrecting the cancelled row, so the cancellation stays in the history
+    // and the retry carries its own identity (GH-1865).
+    assert_eq!(runtime_commands.len(), 2);
+    let superseded = runtime_commands
+        .iter()
+        .find(|record| record.id == command.id)
+        .expect("the cancelled attempt must survive recovery");
+    assert_eq!(superseded.status, WorkflowCommandStatus::Superseded);
+    assert_eq!(superseded.attempt_generation, 1);
+    let retried = runtime_commands
+        .iter()
+        .find(|record| record.id != command.id)
+        .expect("recovery must queue a new attempt");
+    assert_eq!(retried.status, WorkflowCommandStatus::Pending);
+    assert_eq!(retried.attempt_generation, 2);
+    assert_eq!(
+        superseded.superseded_by_command_id.as_deref(),
+        Some(retried.id.as_str())
+    );
     store
         .enqueue_runtime_job_for_pending_command(
-            &command.id,
+            &retried.id,
             RuntimeKind::CodexJsonrpc,
             "codex-default",
             json!({"activity": "start_child_workflow"}),
             None,
         )
         .await?;
-    assert_eq!(store.runtime_jobs_for_command(&command.id).await?.len(), 2);
+    // Each attempt owns its own runtime job; the cancelled one keeps its.
+    assert_eq!(store.runtime_jobs_for_command(&retried.id).await?.len(), 1);
+    assert_eq!(store.runtime_jobs_for_command(&command.id).await?.len(), 1);
     Ok(())
 }
 

--- a/crates/harness-server/src/workflow_runtime_submission/cancel.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/cancel.rs
@@ -348,7 +348,8 @@ mod tests {
     use chrono::{Duration, Utc};
     use harness_core::db::resolve_database_url;
     use harness_workflow::runtime::{
-        RuntimeJobStatus, RuntimeKind, WorkflowCommandStatus, WorkflowSubject,
+        RuntimeJobStatus, RuntimeKind, WorkflowCommandStatus, WorkflowDecisionRecord,
+        WorkflowSubject,
     };
 
     #[tokio::test]
@@ -396,8 +397,20 @@ mod tests {
             "retry-cancellation-cleanup-marker",
             json!({}),
         );
+        // Cleanup only honors a marker bound to the accepted cancellation
+        // decision that minted it (GH-1865), so the fixture commits one.
+        let cancellation_decision = WorkflowDecision::new(
+            &workflow.id,
+            "running",
+            "cancel_prompt_submission",
+            "cancelled",
+            "operator cancelled the runtime prompt submission",
+        )
+        .with_command(cancellation.clone());
+        let decision_record = WorkflowDecisionRecord::accepted(cancellation_decision, None);
+        store.record_decision(&decision_record).await?;
         store
-            .enqueue_command(&workflow.id, None, &cancellation)
+            .enqueue_command(&workflow.id, Some(&decision_record.id), &cancellation)
             .await?;
 
         let outcome = cancel_submission_by_workflow_id(&store, &workflow.id).await?;

--- a/crates/harness-workflow/src/runtime/command_record.rs
+++ b/crates/harness-workflow/src/runtime/command_record.rs
@@ -18,6 +18,8 @@ pub(super) type WorkflowCommandRecordRow = (
     String,
     DateTime<Utc>,
     DateTime<Utc>,
+    i32,
+    Option<String>,
 );
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -42,6 +44,14 @@ pub struct WorkflowCommandRecord {
     pub command: WorkflowCommand,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Which attempt at this dedupe key the row records. A new attempt never
+    /// rewrites an earlier one; it supersedes it and takes the next generation
+    /// (GH-1865).
+    #[serde(default)]
+    pub attempt_generation: u32,
+    /// Set on a superseded row: the attempt that replaced it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded_by_command_id: Option<String>,
 }
 
 pub(super) fn from_row(
@@ -59,11 +69,15 @@ pub(super) fn from_row(
         data,
         created_at,
         updated_at,
+        attempt_generation,
+        superseded_by_command_id,
     ): WorkflowCommandRecordRow,
 ) -> anyhow::Result<WorkflowCommandRecord> {
     use anyhow::Context;
 
     let status = WorkflowCommandStatus::try_from(status.as_str())?;
+    let attempt_generation = u32::try_from(attempt_generation)
+        .context("workflow command attempt generation is negative")?;
     let dispatch_attempt_count = u64::try_from(dispatch_attempt_count)
         .context("workflow command dispatch attempt count is negative")?;
     let dispatch_claim_generation = u64::try_from(dispatch_claim_generation)
@@ -113,5 +127,7 @@ pub(super) fn from_row(
         command: serde_json::from_str(&data)?,
         created_at,
         updated_at,
+        attempt_generation,
+        superseded_by_command_id,
     })
 }

--- a/crates/harness-workflow/src/runtime/eval/evidence.rs
+++ b/crates/harness-workflow/src/runtime/eval/evidence.rs
@@ -605,6 +605,8 @@ mod tests {
             command,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_generation: 1,
+            superseded_by_command_id: None,
         }
     }
 }

--- a/crates/harness-workflow/src/runtime/status.rs
+++ b/crates/harness-workflow/src/runtime/status.rs
@@ -14,6 +14,10 @@ pub enum WorkflowCommandStatus {
     Blocked,
     Cancelled,
     Skipped,
+    /// A pending or cancelled attempt that a newer attempt replaced. The row
+    /// stays as the historical record of that attempt and is never dispatched
+    /// again (GH-1865).
+    Superseded,
 }
 
 impl WorkflowCommandStatus {
@@ -29,6 +33,7 @@ impl WorkflowCommandStatus {
             Self::Blocked => "blocked",
             Self::Cancelled => "cancelled",
             Self::Skipped => "skipped",
+            Self::Superseded => "superseded",
         }
     }
 }
@@ -60,6 +65,7 @@ impl TryFrom<&str> for WorkflowCommandStatus {
             "blocked" => Ok(Self::Blocked),
             "cancelled" => Ok(Self::Cancelled),
             "skipped" => Ok(Self::Skipped),
+            "superseded" => Ok(Self::Superseded),
             other => anyhow::bail!("unknown workflow command status: {other}"),
         }
     }

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -25,6 +25,8 @@ mod activity_completion;
 mod artifacts;
 #[path = "store/child_instance_start.rs"]
 mod child_instance_start;
+#[path = "store/command_attempts.rs"]
+mod command_attempts;
 #[path = "store/command_facade.rs"]
 mod command_facade;
 #[path = "store/commands.rs"]

--- a/crates/harness-workflow/src/runtime/store/activity_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/activity_completion.rs
@@ -199,7 +199,8 @@ impl WorkflowRuntimeStore {
             "SELECT id, workflow_id, decision_id, status, dispatch_owner,
                     dispatch_lease_expires_at, dispatch_not_before,
                     dispatch_attempt_count, dispatch_claim_generation,
-                    dispatch_barrier::text, data::text, created_at, updated_at
+                    dispatch_barrier::text, data::text, created_at, updated_at,
+                    attempt_generation, superseded_by_command_id
              FROM workflow_commands
              WHERE id = $1
              FOR UPDATE",

--- a/crates/harness-workflow/src/runtime/store/artifacts.rs
+++ b/crates/harness-workflow/src/runtime/store/artifacts.rs
@@ -147,6 +147,9 @@ pub(super) async fn insert_runtime_transcript_tx(
     Ok(())
 }
 
+/// Keep the transcript retention set aligned with the commands that can still
+/// use it. A superseded attempt is history: it will never be dispatched again,
+/// so it does not hold a transcript alive (GH-1865).
 pub(super) async fn reconcile_runtime_transcript_dependencies_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     workflow_id: &str,
@@ -158,6 +161,7 @@ pub(super) async fn reconcile_runtime_transcript_dependencies_tx(
                SELECT 1
                FROM workflow_commands AS command
                WHERE command.workflow_id = $1
+                 AND command.status <> 'superseded'
                  AND jsonb_typeof(
                      command.data #> '{command,exact_replay,transcript_artifact_ref}'
                  ) = 'string'
@@ -170,6 +174,7 @@ pub(super) async fn reconcile_runtime_transcript_dependencies_tx(
                FROM runtime_jobs AS job
                JOIN workflow_commands AS command ON command.id = job.command_id
                WHERE command.workflow_id = $1
+                 AND command.status <> 'superseded'
                  AND jsonb_typeof(
                      job.data #> '{input,command,exact_replay,transcript_artifact_ref}'
                  ) = 'string'
@@ -190,6 +195,7 @@ pub(super) async fn reconcile_runtime_transcript_dependencies_tx(
              ) AS artifact_ref
              FROM workflow_commands AS command
              WHERE command.workflow_id = $1
+                 AND command.status <> 'superseded'
                AND jsonb_typeof(
                    command.data #> '{command,exact_replay,transcript_artifact_ref}'
                ) = 'string'
@@ -200,6 +206,7 @@ pub(super) async fn reconcile_runtime_transcript_dependencies_tx(
              FROM runtime_jobs AS job
              JOIN workflow_commands AS command ON command.id = job.command_id
              WHERE command.workflow_id = $1
+                 AND command.status <> 'superseded'
                AND jsonb_typeof(
                    job.data #> '{input,command,exact_replay,transcript_artifact_ref}'
                ) = 'string'

--- a/crates/harness-workflow/src/runtime/store/command_attempts.rs
+++ b/crates/harness-workflow/src/runtime/store/command_attempts.rs
@@ -1,0 +1,192 @@
+//! Command attempts supersede each other instead of being rewritten in place
+//! (GH-1865 W2).
+//!
+//! A command row records an intent: this decision asked for this command with
+//! this payload. Enqueueing on top of a live row used to rewrite `decision_id`,
+//! `command_type`, and `data` under the same row id, so one command id could
+//! describe an intent it was never minted for — and a cancelled row could be
+//! fully resurrected, dispatch fields nulled, with nothing recording that it
+//! had been cancelled at all.
+//!
+//! Intent fields are now write-once per row. A new attempt for the same dedupe
+//! key marks the live row `superseded`, links it to its replacement, and
+//! inserts a fresh row with the next `attempt_generation`. Dispatch status
+//! stays mutable on the row that owns it.
+
+use super::*;
+use uuid::Uuid;
+
+/// How a live row for the same dedupe key is treated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AttemptReplacement {
+    /// Only a pending row may be replaced, and an identical re-enqueue is an
+    /// idempotent replay rather than a new attempt.
+    PendingIntent,
+    /// A cancelled row is being re-enqueued. Re-enqueueing is itself the new
+    /// attempt, so it supersedes even when the intent is unchanged — the
+    /// cancelled row must stay cancelled in the history.
+    ReactivateCancelled,
+}
+
+impl AttemptReplacement {
+    fn replaceable_status(self) -> WorkflowCommandStatus {
+        match self {
+            Self::PendingIntent => WorkflowCommandStatus::Pending,
+            Self::ReactivateCancelled => WorkflowCommandStatus::Cancelled,
+        }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct LiveAttemptRow {
+    id: String,
+    status: String,
+    decision_id: Option<String>,
+    command_type: String,
+    #[sqlx(rename = "data")]
+    data_json: String,
+    attempt_generation: i32,
+}
+
+/// Insert a command attempt, superseding the live attempt it replaces.
+///
+/// Returns the id of the row that now carries the intent: the existing row when
+/// this was an idempotent replay or a row in a status that cannot be replaced,
+/// and the new row when an attempt was superseded.
+pub(super) async fn insert_command_attempt_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workflow_id: &str,
+    decision_id: Option<&str>,
+    command: &WorkflowCommand,
+    status: WorkflowCommandStatus,
+    replacement: AttemptReplacement,
+) -> anyhow::Result<String> {
+    let data = to_jsonb_string(command)?;
+    let command_type = enum_str(&command.command_type)?;
+
+    let live: Option<LiveAttemptRow> = sqlx::query_as(
+        "SELECT id, status, decision_id, command_type, data::text AS data, attempt_generation
+         FROM workflow_commands
+         WHERE workflow_id = $1 AND dedupe_key = $2 AND status <> $3
+         FOR UPDATE",
+    )
+    .bind(workflow_id)
+    .bind(&command.dedupe_key)
+    .bind(WorkflowCommandStatus::Superseded.as_str())
+    .fetch_optional(&mut **tx)
+    .await?;
+
+    let Some(live) = live else {
+        return insert_attempt_row_tx(
+            tx,
+            &Uuid::new_v4().to_string(),
+            workflow_id,
+            decision_id,
+            &command_type,
+            &command.dedupe_key,
+            status,
+            &data,
+            1,
+        )
+        .await;
+    };
+
+    if live.status != replacement.replaceable_status().as_str() {
+        // Dispatched, completed, failed, blocked, skipped: the attempt is
+        // already past the point where its intent could be restated, so the
+        // enqueue resolves to the row that owns it.
+        return Ok(live.id);
+    }
+
+    if replacement == AttemptReplacement::PendingIntent
+        && intent_is_unchanged(&live, decision_id, &command_type, command)
+    {
+        // Same intent from the same decision. The row already carries it; only
+        // its dispatch status may advance.
+        if live.status != status.as_str() {
+            sqlx::query(
+                "UPDATE workflow_commands
+                 SET status = $2, updated_at = CURRENT_TIMESTAMP
+                 WHERE id = $1",
+            )
+            .bind(&live.id)
+            .bind(status.as_str())
+            .execute(&mut **tx)
+            .await?;
+        }
+        return Ok(live.id);
+    }
+
+    // Retire the live row first: the dedupe key is unique across every row
+    // that is not superseded, so the replacement cannot be inserted while the
+    // row it replaces still holds that key.
+    let new_id = Uuid::new_v4().to_string();
+    sqlx::query(
+        "UPDATE workflow_commands
+         SET status = $2, superseded_by_command_id = $3, updated_at = CURRENT_TIMESTAMP
+         WHERE id = $1",
+    )
+    .bind(&live.id)
+    .bind(WorkflowCommandStatus::Superseded.as_str())
+    .bind(&new_id)
+    .execute(&mut **tx)
+    .await?;
+    insert_attempt_row_tx(
+        tx,
+        &new_id,
+        workflow_id,
+        decision_id,
+        &command_type,
+        &command.dedupe_key,
+        status,
+        &data,
+        live.attempt_generation.saturating_add(1),
+    )
+    .await
+}
+
+/// Compare the stored payload as a command rather than as raw jsonb, which
+/// normalizes key order and would report identical intents as different.
+fn intent_is_unchanged(
+    live: &LiveAttemptRow,
+    decision_id: Option<&str>,
+    command_type: &str,
+    command: &WorkflowCommand,
+) -> bool {
+    if live.decision_id.as_deref() != decision_id || live.command_type != command_type {
+        return false;
+    }
+    serde_json::from_str::<WorkflowCommand>(&live.data_json).is_ok_and(|stored| stored == *command)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_attempt_row_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    id: &str,
+    workflow_id: &str,
+    decision_id: Option<&str>,
+    command_type: &str,
+    dedupe_key: &str,
+    status: WorkflowCommandStatus,
+    data: &str,
+    attempt_generation: i32,
+) -> anyhow::Result<String> {
+    let (id,): (String,) = sqlx::query_as(
+        "INSERT INTO workflow_commands
+            (id, workflow_id, decision_id, command_type, dedupe_key, status, data,
+             attempt_generation)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+         RETURNING id",
+    )
+    .bind(id)
+    .bind(workflow_id)
+    .bind(decision_id)
+    .bind(command_type)
+    .bind(dedupe_key)
+    .bind(status.as_str())
+    .bind(data)
+    .bind(attempt_generation)
+    .fetch_one(&mut **tx)
+    .await?;
+    Ok(id)
+}

--- a/crates/harness-workflow/src/runtime/store/command_facade.rs
+++ b/crates/harness-workflow/src/runtime/store/command_facade.rs
@@ -34,7 +34,8 @@ impl WorkflowRuntimeStore {
             "SELECT id, workflow_id, decision_id, status, dispatch_owner,
                     dispatch_lease_expires_at, dispatch_not_before,
                     dispatch_attempt_count, dispatch_claim_generation,
-                    dispatch_barrier::text, data::text, created_at, updated_at
+                    dispatch_barrier::text, data::text, created_at, updated_at,
+                    attempt_generation, superseded_by_command_id
                  FROM workflow_commands
                  WHERE workflow_id = $1
                  ORDER BY created_at ASC",
@@ -58,7 +59,8 @@ impl WorkflowRuntimeStore {
             "SELECT id, workflow_id, decision_id, status, dispatch_owner,
                     dispatch_lease_expires_at, dispatch_not_before,
                     dispatch_attempt_count, dispatch_claim_generation,
-                    dispatch_barrier::text, data::text, created_at, updated_at
+                    dispatch_barrier::text, data::text, created_at, updated_at,
+                    attempt_generation, superseded_by_command_id
              FROM workflow_commands
              WHERE workflow_id = ANY($1::text[])
              ORDER BY workflow_id ASC, created_at ASC",
@@ -92,14 +94,16 @@ impl WorkflowRuntimeStore {
                     command.dispatch_not_before, command.dispatch_attempt_count,
                     command.dispatch_claim_generation, command.dispatch_barrier,
                     command.data,
-                    command.created_at, command.updated_at
+                    command.created_at, command.updated_at,
+                    command.attempt_generation, command.superseded_by_command_id
              FROM unnest($1::text[]) AS selected(workflow_id)
              JOIN LATERAL (
                  SELECT id, workflow_id, decision_id, status, dispatch_owner,
                         dispatch_lease_expires_at, dispatch_not_before,
                         dispatch_attempt_count, dispatch_claim_generation,
                         dispatch_barrier::text AS dispatch_barrier,
-                        data::text AS data, created_at, updated_at
+                        data::text AS data, created_at, updated_at,
+                        attempt_generation, superseded_by_command_id
                  FROM workflow_commands
                  WHERE workflow_id = selected.workflow_id
                  ORDER BY created_at DESC
@@ -130,7 +134,8 @@ impl WorkflowRuntimeStore {
             "SELECT id, workflow_id, decision_id, status, dispatch_owner,
                     dispatch_lease_expires_at, dispatch_not_before,
                     dispatch_attempt_count, dispatch_claim_generation,
-                    dispatch_barrier::text, data::text, created_at, updated_at
+                    dispatch_barrier::text, data::text, created_at, updated_at,
+                    attempt_generation, superseded_by_command_id
              FROM workflow_commands
              WHERE id = $1",
         )
@@ -147,7 +152,8 @@ impl WorkflowRuntimeStore {
                     command.dispatch_owner, command.dispatch_lease_expires_at,
                     command.dispatch_not_before, command.dispatch_attempt_count,
                     command.dispatch_claim_generation, command.dispatch_barrier::text,
-                    command.data::text, command.created_at, command.updated_at
+                    command.data::text, command.created_at, command.updated_at,
+                    command.attempt_generation, command.superseded_by_command_id
              FROM workflow_commands AS command
              JOIN workflow_instances AS workflow ON workflow.id = command.workflow_id
              WHERE command.status = 'pending'
@@ -218,7 +224,8 @@ impl WorkflowRuntimeStore {
                        command.dispatch_owner, command.dispatch_lease_expires_at,
                        command.dispatch_not_before, command.dispatch_attempt_count,
                        command.dispatch_claim_generation, command.dispatch_barrier::text,
-                       command.data::text, command.created_at, command.updated_at",
+                       command.data::text, command.created_at, command.updated_at,
+                       command.attempt_generation, command.superseded_by_command_id",
         )
         .bind(owner)
         .bind(expires_at)
@@ -244,12 +251,17 @@ impl WorkflowRuntimeStore {
         Ok(records)
     }
 
+    /// Move a command's dispatch status.
+    ///
+    /// A superseded attempt is history and cannot be moved: reviving it would
+    /// put two live rows on one dedupe key and let a replaced attempt dispatch
+    /// (GH-1865).
     pub async fn mark_command_status(
         &self,
         command_id: &str,
         status: WorkflowCommandStatus,
     ) -> anyhow::Result<()> {
-        sqlx::query(
+        let updated = sqlx::query(
             "UPDATE workflow_commands
              SET status = $1,
                  dispatch_owner = NULL,
@@ -257,13 +269,31 @@ impl WorkflowRuntimeStore {
                  dispatch_not_before = NULL,
                  dispatch_barrier = NULL,
                  updated_at = CURRENT_TIMESTAMP
-             WHERE id = $2",
+             WHERE id = $2 AND status <> $3",
         )
         .bind(status.as_str())
         .bind(command_id)
+        .bind(WorkflowCommandStatus::Superseded.as_str())
         .execute(&self.pool)
-        .await?;
-        Ok(())
+        .await?
+        .rows_affected()
+            == 1;
+        if updated {
+            return Ok(());
+        }
+        let existing: Option<(String,)> =
+            sqlx::query_as("SELECT status FROM workflow_commands WHERE id = $1")
+                .bind(command_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        match existing {
+            Some((current,)) if current == WorkflowCommandStatus::Superseded.as_str() => {
+                anyhow::bail!(
+                    "workflow command `{command_id}` was superseded by a newer attempt and cannot be moved to `{status}`"
+                )
+            }
+            _ => Ok(()),
+        }
     }
 
     pub async fn mark_pending_command_status(

--- a/crates/harness-workflow/src/runtime/store/commands.rs
+++ b/crates/harness-workflow/src/runtime/store/commands.rs
@@ -1,4 +1,5 @@
 use super::{
+    command_attempts::{insert_command_attempt_tx, AttemptReplacement},
     enum_str, runtime_job_for_command_tx, to_jsonb_string, workflow_instance_from_persisted_json,
     ClaimedCommandTerminalOutcome, RuntimeJobEnqueueOutcome, WorkflowRuntimeStore,
 };
@@ -9,7 +10,6 @@ use crate::runtime::{
 use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
 use sqlx::postgres::PgPool;
-use uuid::Uuid;
 
 impl WorkflowRuntimeStore {
     pub async fn skip_claimed_command_if_owned(
@@ -136,19 +136,15 @@ pub(super) async fn insert_tx(
     command: &WorkflowCommand,
     status: WorkflowCommandStatus,
 ) -> anyhow::Result<String> {
-    let data = to_jsonb_string(command)?;
-    let command_type = enum_str(&command.command_type)?;
-    let (id,): (String,) = sqlx::query_as(insert_sql())
-        .bind(Uuid::new_v4().to_string())
-        .bind(workflow_id)
-        .bind(decision_id)
-        .bind(&command_type)
-        .bind(&command.dedupe_key)
-        .bind(status.as_str())
-        .bind(&data)
-        .bind(WorkflowCommandStatus::Pending.as_str())
-        .fetch_one(&mut **tx)
-        .await?;
+    let id = insert_command_attempt_tx(
+        tx,
+        workflow_id,
+        decision_id,
+        command,
+        status,
+        AttemptReplacement::PendingIntent,
+    )
+    .await?;
     super::artifacts::reconcile_runtime_transcript_dependencies_tx(tx, workflow_id).await?;
     Ok(id)
 }
@@ -160,70 +156,15 @@ pub(super) async fn insert_or_reactivate_cancelled_tx(
     command: &WorkflowCommand,
     status: WorkflowCommandStatus,
 ) -> anyhow::Result<String> {
-    let data = to_jsonb_string(command)?;
-    let command_type = enum_str(&command.command_type)?;
-    let (id,): (String,) = sqlx::query_as(
-        "INSERT INTO workflow_commands
-            (id, workflow_id, decision_id, command_type, dedupe_key, status, data)
-         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
-         ON CONFLICT (workflow_id, dedupe_key) DO UPDATE SET
-            decision_id = CASE WHEN workflow_commands.status = $8 THEN EXCLUDED.decision_id ELSE workflow_commands.decision_id END,
-            command_type = CASE WHEN workflow_commands.status = $8 THEN EXCLUDED.command_type ELSE workflow_commands.command_type END,
-            data = CASE WHEN workflow_commands.status = $8 THEN EXCLUDED.data ELSE workflow_commands.data END,
-            status = CASE WHEN workflow_commands.status = $8 THEN EXCLUDED.status ELSE workflow_commands.status END,
-            dispatch_owner = CASE WHEN workflow_commands.status = $8 THEN NULL ELSE workflow_commands.dispatch_owner END,
-            dispatch_lease_expires_at = CASE WHEN workflow_commands.status = $8 THEN NULL ELSE workflow_commands.dispatch_lease_expires_at END,
-            dispatch_not_before = CASE WHEN workflow_commands.status = $8 THEN NULL ELSE workflow_commands.dispatch_not_before END,
-            dispatch_barrier = CASE WHEN workflow_commands.status = $8 THEN NULL ELSE workflow_commands.dispatch_barrier END,
-            updated_at = CASE WHEN workflow_commands.status = $8 THEN CURRENT_TIMESTAMP ELSE workflow_commands.updated_at END
-         RETURNING id",
+    insert_command_attempt_tx(
+        tx,
+        workflow_id,
+        decision_id,
+        command,
+        status,
+        AttemptReplacement::ReactivateCancelled,
     )
-    .bind(Uuid::new_v4().to_string())
-    .bind(workflow_id)
-    .bind(decision_id)
-    .bind(command_type)
-    .bind(&command.dedupe_key)
-    .bind(status.as_str())
-    .bind(data)
-    .bind(WorkflowCommandStatus::Cancelled.as_str())
-    .fetch_one(&mut **tx)
-    .await?;
-    Ok(id)
-}
-
-fn insert_sql() -> &'static str {
-    "INSERT INTO workflow_commands
-        (id, workflow_id, decision_id, command_type, dedupe_key, status, data)
-     VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
-     ON CONFLICT (workflow_id, dedupe_key) DO UPDATE SET
-        decision_id = CASE
-            WHEN workflow_commands.status = $8 THEN EXCLUDED.decision_id
-            ELSE workflow_commands.decision_id
-        END,
-        command_type = CASE
-            WHEN workflow_commands.status = $8 THEN EXCLUDED.command_type
-            ELSE workflow_commands.command_type
-        END,
-        data = CASE
-            WHEN workflow_commands.status = $8 THEN EXCLUDED.data
-            ELSE workflow_commands.data
-        END,
-        status = CASE
-            WHEN workflow_commands.status = $8 THEN EXCLUDED.status
-            ELSE workflow_commands.status
-        END,
-        updated_at = CASE
-            WHEN workflow_commands.status = $8
-                 AND (
-                     workflow_commands.status <> EXCLUDED.status
-                     OR workflow_commands.decision_id IS DISTINCT FROM EXCLUDED.decision_id
-                     OR workflow_commands.command_type <> EXCLUDED.command_type
-                     OR workflow_commands.data <> EXCLUDED.data
-                 )
-            THEN CURRENT_TIMESTAMP
-            ELSE workflow_commands.updated_at
-        END
-     RETURNING id"
+    .await
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/harness-workflow/src/runtime/store/runtime_job_state.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_job_state.rs
@@ -300,9 +300,15 @@ impl WorkflowRuntimeStore {
                 Ok((id, status, serde_json::from_str::<WorkflowCommand>(&data)?))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
-        if !commands
-            .iter()
-            .any(|(_, _, command)| command.command_type == WorkflowCommandType::MarkCancelled)
+        // The marker authorizing cleanup must belong to the exact accepted
+        // decision that placed the instance in its current state (GH-1865).
+        // Accepting any historical MarkCancelled row lets a stale generation's
+        // cancellation — or a detached marker with no decision behind it, or a
+        // superseded attempt — authorize cancelling the current generation's
+        // live commands.
+        if !self
+            .cancellation_marker_is_current_tx(&mut tx, &current)
+            .await?
         {
             tx.rollback().await?;
             return Ok(WorkflowCancellationCleanupOutcome::NoCancellationCommand);
@@ -367,6 +373,64 @@ impl WorkflowRuntimeStore {
         Ok(WorkflowCancellationCleanupOutcome::Cleaned(Box::new(
             current,
         )))
+    }
+
+    /// Prove that the workflow's live cancellation marker was minted by the
+    /// exact accepted decision that placed the instance in its current state.
+    ///
+    /// The latest accepted decision must target the instance's current state
+    /// and carry a `MarkCancelled` command, and a live (non-superseded)
+    /// command row linking that decision to the marker's dedupe key must
+    /// exist. Anything weaker lets an older generation's marker — replayed,
+    /// detached, or superseded — speak for the current generation.
+    async fn cancellation_marker_is_current_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        current: &WorkflowInstance,
+    ) -> anyhow::Result<bool> {
+        let latest: Option<(String, String)> = sqlx::query_as(
+            "SELECT id, data::text FROM workflow_decisions
+             WHERE workflow_id = $1 AND accepted
+             ORDER BY created_at DESC, id DESC
+             LIMIT 1",
+        )
+        .bind(&current.id)
+        .fetch_optional(&mut **tx)
+        .await?;
+        let Some((decision_id, data)) = latest else {
+            return Ok(false);
+        };
+        let record: WorkflowDecisionRecord = serde_json::from_str(&data)?;
+        let decision = record.decision;
+        if decision.next_state != current.state {
+            return Ok(false);
+        }
+        let marker_keys: Vec<String> = decision
+            .commands
+            .iter()
+            .filter(|command| command.command_type == WorkflowCommandType::MarkCancelled)
+            .map(|command| command.dedupe_key.clone())
+            .collect();
+        if marker_keys.is_empty() {
+            return Ok(false);
+        }
+        let bound: Option<(String,)> = sqlx::query_as(
+            "SELECT id FROM workflow_commands
+             WHERE workflow_id = $1
+               AND decision_id = $2
+               AND command_type = $3
+               AND dedupe_key = ANY($4::text[])
+               AND status <> $5
+             LIMIT 1",
+        )
+        .bind(&current.id)
+        .bind(&decision_id)
+        .bind(WorkflowCommandType::MarkCancelled.as_str())
+        .bind(&marker_keys)
+        .bind(WorkflowCommandStatus::Superseded.as_str())
+        .fetch_optional(&mut **tx)
+        .await?;
+        Ok(bound.is_some())
     }
 }
 

--- a/crates/harness-workflow/src/runtime/store_migrations.rs
+++ b/crates/harness-workflow/src/runtime/store_migrations.rs
@@ -593,4 +593,28 @@ pub(super) static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
         CREATE INDEX IF NOT EXISTS idx_workflow_artifact_dependencies_workflow
           ON workflow_artifact_dependencies (workflow_id)",
     },
+    Migration {
+        version: 24,
+        description: "supersede workflow command attempts instead of rewriting them",
+        sql: "ALTER TABLE workflow_commands
+                ADD COLUMN IF NOT EXISTS attempt_generation INTEGER NOT NULL DEFAULT 1;
+              ALTER TABLE workflow_commands
+                ADD COLUMN IF NOT EXISTS superseded_by_command_id TEXT;
+              ALTER TABLE workflow_commands
+                DROP CONSTRAINT IF EXISTS workflow_commands_status_check;
+              ALTER TABLE workflow_commands
+                ADD CONSTRAINT workflow_commands_status_check
+                CHECK (status IN (
+                  'pending', 'dispatching', 'deferred', 'dispatched', 'handled_inline',
+                  'completed', 'failed', 'blocked', 'cancelled', 'skipped', 'superseded'
+                ));
+              -- Dedupe identity now covers only live attempts: a superseded row
+              -- keeps its dedupe_key as the record of the attempt it was, while
+              -- the replacement attempt takes over that key.
+              ALTER TABLE workflow_commands
+                DROP CONSTRAINT IF EXISTS workflow_commands_workflow_id_dedupe_key_key;
+              CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_commands_live_dedupe
+                ON workflow_commands (workflow_id, dedupe_key)
+                WHERE status <> 'superseded'",
+    },
 ];

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -20,12 +20,12 @@ use super::{
     PrFeedbackWorkflowAction, PromptContinuationPolicy, PromptContinuationState,
     PromptSubmissionDecisionInput, QualityGateDecisionInput, QualityGateWorkflowAction,
     RuntimeCommandDispatcher, RuntimeJobExecutor, RuntimeProfileSelector, RuntimeWorker,
-    SubmissionMode, WorkflowCommandStatus, WorkflowDataWrite, WorkflowDecisionTransition,
-    WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY,
-    PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
-    PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL,
-    QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
-    RUNTIME_JOB_COMPLETED_EVENT, SCOPE_TOO_LARGE_SIGNAL,
+    SubmissionMode, WorkflowCancellationCleanupOutcome, WorkflowCommandStatus, WorkflowDataWrite,
+    WorkflowDecisionTransition, WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID,
+    LOCAL_REVIEW_ACTIVITY, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, QUALITY_BLOCKED_SIGNAL,
+    QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID,
+    QUALITY_PASSED_SIGNAL, RUNTIME_JOB_COMPLETED_EVENT, SCOPE_TOO_LARGE_SIGNAL,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Timelike, Utc};

--- a/crates/harness-workflow/src/runtime/tests/p1_followups.rs
+++ b/crates/harness-workflow/src/runtime/tests/p1_followups.rs
@@ -93,7 +93,7 @@ async fn runtime_worker_completes_job_when_workflow_already_done() -> anyhow::Re
 }
 
 #[tokio::test]
-async fn runtime_store_pending_dedupe_refreshes_command_payload() -> anyhow::Result<()> {
+async fn runtime_store_pending_dedupe_supersedes_instead_of_rewriting() -> anyhow::Result<()> {
     if resolve_database_url(None).is_err() {
         return Ok(());
     }
@@ -139,23 +139,64 @@ async fn runtime_store_pending_dedupe_refreshes_command_payload() -> anyhow::Res
     );
     new_decision.id = "decision-new".to_string();
     store.record_decision(&new_decision).await?;
-    let duplicate_id = store
+    let superseding_id = store
         .enqueue_command(&instance.id, Some("decision-new"), &updated)
         .await?;
 
-    assert_eq!(duplicate_id, command_id);
+    // A different intent under the same dedupe key is a new attempt, not a
+    // rewrite of the old row (GH-1865).
+    assert_ne!(superseding_id, command_id);
     let commands = store.commands_for(&instance.id).await?;
-    assert_eq!(commands.len(), 1);
-    let command = &commands[0];
-    assert_eq!(command.id, command_id);
-    assert_eq!(command.status, "pending");
-    assert_eq!(command.decision_id.as_deref(), Some("decision-new"));
+    assert_eq!(commands.len(), 2, "the replaced attempt must survive");
+
+    let superseded = commands
+        .iter()
+        .find(|command| command.id == command_id)
+        .expect("the original attempt must still be readable");
+    assert_eq!(superseded.status, WorkflowCommandStatus::Superseded);
+    assert_eq!(superseded.decision_id.as_deref(), Some("decision-old"));
     assert_eq!(
-        command.command.command_type,
+        superseded.command.command_type,
+        WorkflowCommandType::EnqueueActivity,
+        "the replaced attempt must keep the intent it was minted for"
+    );
+    assert_eq!(superseded.attempt_generation, 1);
+    assert_eq!(
+        superseded.superseded_by_command_id.as_deref(),
+        Some(superseding_id.as_str())
+    );
+
+    let live = commands
+        .iter()
+        .find(|command| command.id == superseding_id)
+        .expect("the new attempt must be readable");
+    assert_eq!(live.status, WorkflowCommandStatus::Pending);
+    assert_eq!(live.decision_id.as_deref(), Some("decision-new"));
+    assert_eq!(
+        live.command.command_type,
         WorkflowCommandType::StartChildWorkflow
     );
-    assert_eq!(command.command.command["definition_id"], "github_issue_pr");
-    assert_eq!(command.command.command["subject_key"], "issue:1200");
+    assert_eq!(live.command.command["definition_id"], "github_issue_pr");
+    assert_eq!(live.command.command["subject_key"], "issue:1200");
+    assert_eq!(live.attempt_generation, 2);
+    assert!(live.superseded_by_command_id.is_none());
+
+    // A replayed enqueue of the live intent stays idempotent.
+    let replayed = store
+        .enqueue_command(&instance.id, Some("decision-new"), &updated)
+        .await?;
+    assert_eq!(replayed, superseding_id);
+    assert_eq!(store.commands_for(&instance.id).await?.len(), 2);
+
+    // A superseded attempt can never be moved back into a dispatchable state.
+    let error = store
+        .mark_command_status(&command_id, WorkflowCommandStatus::Pending)
+        .await
+        .expect_err("a superseded attempt must not be revivable");
+    assert!(
+        error.to_string().contains("superseded"),
+        "unexpected error: {error}"
+    );
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/tests/provenance_immutability.rs
+++ b/crates/harness-workflow/src/runtime/tests/provenance_immutability.rs
@@ -156,3 +156,253 @@ async fn prompt_payload_refs_are_insert_once() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+fn cancellation_marker(dedupe_key: &str) -> WorkflowCommand {
+    WorkflowCommand::new(WorkflowCommandType::MarkCancelled, dedupe_key, json!({}))
+}
+
+fn cancellation_decision(workflow_id: &str, marker: &WorkflowCommand) -> WorkflowDecision {
+    WorkflowDecision::new(
+        workflow_id,
+        "running",
+        "cancel_submission",
+        "cancelled",
+        "operator cancelled the submission",
+    )
+    .with_command(marker.clone())
+}
+
+/// Cleanup may proceed: the live marker was minted by the latest accepted
+/// decision, and that decision is what placed the instance in `cancelled`.
+#[tokio::test]
+async fn cancellation_cleanup_honors_marker_bound_to_current_decision() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = workflow("gh1865-cancel-bound", "cancelled");
+    store
+        .force_upsert_lifecycle_state_for_test(&instance)
+        .await?;
+
+    let marker = cancellation_marker("gh1865-cancel-bound-marker");
+    let record =
+        WorkflowDecisionRecord::accepted(cancellation_decision(&instance.id, &marker), None);
+    store.record_decision(&record).await?;
+    store
+        .enqueue_command(&instance.id, Some(&record.id), &marker)
+        .await?;
+
+    let stored = store
+        .get_instance(&instance.id)
+        .await?
+        .expect("instance must exist");
+    let outcome = store
+        .finish_cancellation_cleanup_if_current(&stored, "test", "cleanup")
+        .await?;
+    let WorkflowCancellationCleanupOutcome::Cleaned(cleaned) = outcome else {
+        panic!("a marker bound to the current decision must authorize cleanup, got: {outcome:?}");
+    };
+    assert_eq!(cleaned.data["cancelled"], true);
+    Ok(())
+}
+
+/// A marker row with no decision behind it proves nothing about what was
+/// authorized, so it must not authorize cancelling the generation's work.
+#[tokio::test]
+async fn cancellation_cleanup_rejects_detached_marker() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = workflow("gh1865-cancel-detached", "cancelled");
+    store
+        .force_upsert_lifecycle_state_for_test(&instance)
+        .await?;
+
+    let activity = WorkflowCommand::enqueue_activity("implement", "gh1865-detached-activity");
+    let activity_id = store.enqueue_command(&instance.id, None, &activity).await?;
+    let marker = cancellation_marker("gh1865-cancel-detached-marker");
+    store.enqueue_command(&instance.id, None, &marker).await?;
+
+    let stored = store
+        .get_instance(&instance.id)
+        .await?
+        .expect("instance must exist");
+    let outcome = store
+        .finish_cancellation_cleanup_if_current(&stored, "test", "cleanup")
+        .await?;
+    assert_eq!(
+        outcome,
+        WorkflowCancellationCleanupOutcome::NoCancellationCommand
+    );
+
+    let activity = store
+        .get_command(&activity_id)
+        .await?
+        .expect("activity command must remain queryable");
+    assert_eq!(
+        activity.status,
+        WorkflowCommandStatus::Pending,
+        "a detached marker must not cancel the generation's live commands"
+    );
+    Ok(())
+}
+
+/// A rejection never authorized anything; a marker pointing at a rejected
+/// decision must not authorize cleanup either.
+#[tokio::test]
+async fn cancellation_cleanup_rejects_marker_for_rejected_decision() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = workflow("gh1865-cancel-rejected", "cancelled");
+    store
+        .force_upsert_lifecycle_state_for_test(&instance)
+        .await?;
+
+    let marker = cancellation_marker("gh1865-cancel-rejected-marker");
+    let record = WorkflowDecisionRecord::rejected(
+        cancellation_decision(&instance.id, &marker),
+        None,
+        "transition is outside the allowlist",
+    );
+    store.record_decision(&record).await?;
+    store
+        .enqueue_command(&instance.id, Some(&record.id), &marker)
+        .await?;
+
+    let stored = store
+        .get_instance(&instance.id)
+        .await?
+        .expect("instance must exist");
+    let outcome = store
+        .finish_cancellation_cleanup_if_current(&stored, "test", "cleanup")
+        .await?;
+    assert_eq!(
+        outcome,
+        WorkflowCancellationCleanupOutcome::NoCancellationCommand
+    );
+    Ok(())
+}
+
+/// The marker belongs to the generation that was cancelled. Once a newer
+/// accepted decision moved the workflow on, the old marker is history and
+/// must not authorize cleaning up the new generation.
+#[tokio::test]
+async fn cancellation_cleanup_rejects_marker_from_older_generation() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = workflow("gh1865-cancel-old-generation", "cancelled");
+    store
+        .force_upsert_lifecycle_state_for_test(&instance)
+        .await?;
+
+    let marker = cancellation_marker("gh1865-cancel-old-generation-marker");
+    let cancelled_record =
+        WorkflowDecisionRecord::accepted(cancellation_decision(&instance.id, &marker), None);
+    store.record_decision(&cancelled_record).await?;
+    store
+        .enqueue_command(&instance.id, Some(&cancelled_record.id), &marker)
+        .await?;
+
+    // A newer accepted decision reopened the workflow; the instance row in
+    // this fixture still says `cancelled`, which is exactly the stale view a
+    // racing cleanup would hold.
+    let mut reopened = WorkflowDecisionRecord::accepted(
+        WorkflowDecision::new(
+            &instance.id,
+            "cancelled",
+            "reopen_submission",
+            "planning",
+            "operator reopened the submission",
+        ),
+        None,
+    );
+    reopened.created_at = cancelled_record.created_at + chrono::Duration::seconds(1);
+    store.record_decision(&reopened).await?;
+
+    let stored = store
+        .get_instance(&instance.id)
+        .await?
+        .expect("instance must exist");
+    let outcome = store
+        .finish_cancellation_cleanup_if_current(&stored, "test", "cleanup")
+        .await?;
+    assert_eq!(
+        outcome,
+        WorkflowCancellationCleanupOutcome::NoCancellationCommand
+    );
+    Ok(())
+}
+
+/// Superseding retires an attempt (GH-1865 W2). A superseded marker is part
+/// of the historical record and must not authorize cleanup, even when it was
+/// bound to an accepted cancellation decision when it was live.
+#[tokio::test]
+async fn cancellation_cleanup_rejects_superseded_marker() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let instance = workflow("gh1865-cancel-superseded", "cancelled");
+    store
+        .force_upsert_lifecycle_state_for_test(&instance)
+        .await?;
+
+    let marker = cancellation_marker("gh1865-cancel-superseded-marker");
+    let cancelled_record =
+        WorkflowDecisionRecord::accepted(cancellation_decision(&instance.id, &marker), None);
+    store.record_decision(&cancelled_record).await?;
+    let marker_id = store
+        .enqueue_command(&instance.id, Some(&cancelled_record.id), &marker)
+        .await?;
+
+    // A newer decision reuses the marker's dedupe key for different work,
+    // superseding the marker attempt.
+    let replacement =
+        WorkflowCommand::enqueue_activity("implement", "gh1865-cancel-superseded-marker");
+    let mut replacement_record = WorkflowDecisionRecord::accepted(
+        WorkflowDecision::new(
+            &instance.id,
+            "cancelled",
+            "schedule_rework",
+            "cancelled",
+            "rework scheduled over the cancelled attempt",
+        )
+        .with_command(replacement.clone()),
+        None,
+    );
+    replacement_record.created_at = cancelled_record.created_at + chrono::Duration::seconds(1);
+    store.record_decision(&replacement_record).await?;
+    store
+        .enqueue_command(&instance.id, Some(&replacement_record.id), &replacement)
+        .await?;
+
+    let marker = store
+        .get_command(&marker_id)
+        .await?
+        .expect("marker command must remain queryable");
+    assert_eq!(marker.status, WorkflowCommandStatus::Superseded);
+
+    let stored = store
+        .get_instance(&instance.id)
+        .await?
+        .expect("instance must exist");
+    let outcome = store
+        .finish_cancellation_cleanup_if_current(&stored, "test", "cleanup")
+        .await?;
+    assert_eq!(
+        outcome,
+        WorkflowCancellationCleanupOutcome::NoCancellationCommand
+    );
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/tests/transcript_durability.rs
+++ b/crates/harness-workflow/src/runtime/tests/transcript_durability.rs
@@ -651,10 +651,12 @@ async fn transcript_dependencies_follow_the_persisted_dedupe_command() -> anyhow
         )
     };
 
-    let command_id = store
+    store
         .enqueue_command(&workflow.id, None, &replay("runtime-transcript:old"))
         .await?;
-    store
+    // The second enqueue supersedes the first attempt, so retention follows the
+    // live attempt and drops the superseded one (GH-1865).
+    let command_id = store
         .enqueue_command(&workflow.id, None, &replay("runtime-transcript:current"))
         .await?;
     let mut dependencies: Vec<(String,)> = sqlx::query_as(


### PR DESCRIPTION
## Summary

GH-1865 W4: cancellation cleanup is bound to the exact accepted cancellation decision/generation.

- `finish_cancellation_cleanup_if_current` accepted **any** historical `MarkCancelled` row. After W2 made attempts supersedeable, that check also honored superseded markers; it likewise honored detached markers (`decision_id` NULL), markers minted for **rejected** decisions, and markers left over from an older generation after a reopen — each could authorize cancelling the current generation's live commands.
- Cleanup now requires the marker to belong to the exact accepted decision that placed the instance in its current state: the latest accepted decision must target the instance's current state and carry a `MarkCancelled` command, and a live (non-superseded) command row must link that decision id to the marker's dedupe key. Anything else returns `NoCancellationCommand` and rolls back.
- The `harness-server` terminal-cancellation retry fixture now commits a real accepted cancellation decision instead of a detached marker, matching the production commit path.

## Test plan

- [x] `cargo test -p harness-workflow --lib` — 653 passed (5 new regression tests: bound happy path, detached, rejected, older-generation, superseded)
- [x] `cargo test -p harness-server --lib terminal_cancellation_retry` — pass
- [x] Full `harness-server` lib suite against `HARNESS_DATABASE_URL` — 1439 passed on the W2 base; re-running on this delta (result before merge)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] CI

## Notes

- Lands the final acceptance criterion of GH-1865 (W1/W3 in #1871, W2 in #1872). With this, old decisions, commands, prompts, and cancellation markers cannot authorize or overwrite a newer generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)