### PR TITLE
fix(workflow): bind PR-binding repair to accepted decisions (GH-1864)

### DIFF
--- a/crates/harness-server/src/http/background/pr_feedback.rs
+++ b/crates/harness-server/src/http/background/pr_feedback.rs
@@ -312,7 +312,11 @@ async fn recover_runtime_pr_binding_from_bind_pr_command(
     workflow: WorkflowInstance,
 ) -> anyhow::Result<Option<WorkflowInstance>> {
     match store
-        .repair_pr_binding_from_latest_command(&workflow.id, workflow.version)
+        .repair_pr_binding_from_latest_command(
+            &workflow.id,
+            workflow.version,
+            "workflow_runtime_pr_feedback",
+        )
         .await?
     {
         WorkflowPrBindingRepairOutcome::Repaired {

--- a/crates/harness-server/src/http/tests/runtime_dispatch_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_dispatch_tests.rs
@@ -669,10 +669,24 @@ async fn runtime_pr_feedback_sweep_recovers_pr_binding_from_bind_pr_command() ->
         "https://github.com/owner/repo/pull/80",
         "issue-230-bind-pr-80",
     );
+    // Repair only honors bind_pr evidence minted by an accepted decision
+    // (GH-1864), so the fixture commits one the way the production path does.
+    let bind_decision = harness_workflow::runtime::WorkflowDecisionRecord::accepted(
+        harness_workflow::runtime::WorkflowDecision::new(
+            &workflow.id,
+            "pr_open",
+            "bind_pr",
+            "pr_open",
+            "agent reported the pull request",
+        )
+        .with_command(bind_pr.clone()),
+        None,
+    );
+    store.record_decision(&bind_decision).await?;
     store
         .enqueue_command_with_status(
             &workflow.id,
-            None,
+            Some(&bind_decision.id),
             &bind_pr,
             harness_workflow::runtime::WorkflowCommandStatus::Skipped,
         )

--- a/crates/harness-workflow/src/runtime/store/pr_binding_repair.rs
+++ b/crates/harness-workflow/src/runtime/store/pr_binding_repair.rs
@@ -1,6 +1,10 @@
-use super::{commit_same_state_instance_tx, select_instance_for_update_tx, WorkflowRuntimeStore};
+use super::{
+    commit_same_state_instance_tx, insert_event_tx_with_id, select_instance_for_update_tx,
+    WorkflowRuntimeStore,
+};
 use crate::runtime::{
-    DataProvenance, WorkflowCommand, WorkflowCommandType, WorkflowDataWrite, WorkflowInstance,
+    DataProvenance, WorkflowCommand, WorkflowCommandStatus, WorkflowCommandType, WorkflowDataWrite,
+    WorkflowDecisionRecord, WorkflowInstance,
 };
 use anyhow::Context;
 use serde_json::json;
@@ -18,10 +22,22 @@ pub enum WorkflowPrBindingRepairOutcome {
 }
 
 impl WorkflowRuntimeStore {
+    /// Repair a missing `pr_number`/`pr_url` binding from command evidence.
+    ///
+    /// The evidence must be a live (non-superseded) `BindPr` command minted by
+    /// an accepted decision of the same workflow — the decision row is
+    /// append-only (GH-1865), so proving the decision carries this command's
+    /// dedupe key ties the repair to what was actually authorized (GH-1864).
+    /// A standalone command, one whose decision was rejected, or a superseded
+    /// attempt proves nothing and leaves the binding untouched.
+    ///
+    /// A successful repair records a durable `PrBindingRepaired` event in the
+    /// same transaction so the write carries its own provenance.
     pub async fn repair_pr_binding_from_latest_command(
         &self,
         workflow_id: &str,
         expected_version: u64,
+        source: &str,
     ) -> anyhow::Result<WorkflowPrBindingRepairOutcome> {
         let mut tx = self.pool.begin().await?;
         let Some(current) = select_instance_for_update_tx(&mut tx, workflow_id).await? else {
@@ -33,23 +49,48 @@ impl WorkflowRuntimeStore {
             return Ok(WorkflowPrBindingRepairOutcome::StaleInstance);
         }
 
-        let rows: Vec<(String, String)> = sqlx::query_as(
-            "SELECT id, data::text
+        let rows: Vec<(String, Option<String>, String)> = sqlx::query_as(
+            "SELECT id, decision_id, data::text
              FROM workflow_commands
              WHERE workflow_id = $1
+               AND command_type = $2
+               AND status <> $3
              ORDER BY created_at DESC, id DESC
              FOR UPDATE",
         )
         .bind(workflow_id)
+        .bind(WorkflowCommandType::BindPr.as_str())
+        .bind(WorkflowCommandStatus::Superseded.as_str())
         .fetch_all(&mut *tx)
         .await?;
-        let bind_pr = rows
-            .into_iter()
-            .map(|(id, data)| Ok((id, serde_json::from_str::<WorkflowCommand>(&data)?)))
-            .collect::<anyhow::Result<Vec<_>>>()?
-            .into_iter()
-            .find(|(_, command)| command.command_type == WorkflowCommandType::BindPr);
-        let Some((command_id, command)) = bind_pr else {
+        let mut evidence: Option<(String, WorkflowCommand, String)> = None;
+        for (command_id, decision_id, data) in rows {
+            let Some(decision_id) = decision_id else {
+                continue;
+            };
+            let decision_row: Option<(String,)> = sqlx::query_as(
+                "SELECT data::text FROM workflow_decisions
+                 WHERE id = $1 AND workflow_id = $2 AND accepted",
+            )
+            .bind(&decision_id)
+            .bind(workflow_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let Some((decision_data,)) = decision_row else {
+                continue;
+            };
+            let record: WorkflowDecisionRecord = serde_json::from_str(&decision_data)?;
+            let command: WorkflowCommand = serde_json::from_str(&data)?;
+            let decision_carries_command = record.decision.commands.iter().any(|carried| {
+                carried.command_type == WorkflowCommandType::BindPr
+                    && carried.dedupe_key == command.dedupe_key
+            });
+            if decision_carries_command {
+                evidence = Some((command_id, command, decision_id));
+                break;
+            }
+        }
+        let Some((command_id, command, decision_id)) = evidence else {
             tx.rollback().await?;
             return Ok(WorkflowPrBindingRepairOutcome::NoBindPrCommand);
         };
@@ -78,6 +119,22 @@ impl WorkflowRuntimeStore {
         ])?;
         target.version = target.version.saturating_add(1);
         commit_same_state_instance_tx(&mut tx, &current, &target).await?;
+        insert_event_tx_with_id(
+            &mut tx,
+            workflow_id,
+            "PrBindingRepaired",
+            source,
+            json!({
+                "command_id": command_id,
+                "decision_id": decision_id,
+                "pr_number": pr_number,
+                "pr_url": pr_url,
+                "previous_pr_number": current.data.get("pr_number").cloned(),
+                "previous_pr_url": current.data.get("pr_url").cloned(),
+            }),
+            None,
+        )
+        .await?;
         tx.commit().await?;
         Ok(WorkflowPrBindingRepairOutcome::Repaired {
             instance: Box::new(target),
@@ -91,7 +148,7 @@ impl WorkflowRuntimeStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::{WorkflowCommand, WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID};
+    use crate::runtime::{WorkflowDecision, WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID};
     use harness_core::db::resolve_database_url;
 
     fn workflow(id: &str) -> WorkflowInstance {
@@ -104,8 +161,39 @@ mod tests {
         .with_id(id)
     }
 
+    fn bind_pr(dedupe_key: &str) -> WorkflowCommand {
+        WorkflowCommand::bind_pr(
+            1845,
+            "https://github.com/majiayu000/harness/pull/1845",
+            dedupe_key,
+        )
+    }
+
+    fn bind_pr_decision(workflow_id: &str, command: &WorkflowCommand) -> WorkflowDecision {
+        WorkflowDecision::new(
+            workflow_id,
+            "awaiting_feedback",
+            "bind_pr",
+            "awaiting_feedback",
+            "agent reported the pull request",
+        )
+        .with_command(command.clone())
+    }
+
+    async fn repair_events(
+        store: &WorkflowRuntimeStore,
+        workflow_id: &str,
+    ) -> anyhow::Result<Vec<crate::runtime::WorkflowEvent>> {
+        Ok(store
+            .events_for(workflow_id)
+            .await?
+            .into_iter()
+            .filter(|event| event.event_type == "PrBindingRepaired")
+            .collect())
+    }
+
     #[tokio::test]
-    async fn pr_binding_repair_requires_command_evidence_and_exact_version() -> anyhow::Result<()> {
+    async fn pr_binding_repair_requires_bound_decision_evidence() -> anyhow::Result<()> {
         if resolve_database_url(None).is_err() {
             return Ok(());
         }
@@ -118,19 +206,69 @@ mod tests {
 
         assert_eq!(
             store
-                .repair_pr_binding_from_latest_command(&instance.id, 0)
+                .repair_pr_binding_from_latest_command(&instance.id, 0, "test")
                 .await?,
             WorkflowPrBindingRepairOutcome::NoBindPrCommand
         );
 
-        let bind_pr = WorkflowCommand::bind_pr(
-            1845,
-            "https://github.com/majiayu000/harness/pull/1845",
-            "bind-pr-1845",
+        // A standalone command with no decision behind it is not evidence.
+        let standalone = bind_pr("bind-pr-standalone");
+        store
+            .enqueue_command(&instance.id, None, &standalone)
+            .await?;
+        assert_eq!(
+            store
+                .repair_pr_binding_from_latest_command(&instance.id, 0, "test")
+                .await?,
+            WorkflowPrBindingRepairOutcome::NoBindPrCommand
         );
-        let command_id = store.enqueue_command(&instance.id, None, &bind_pr).await?;
+
+        // Neither is a command whose decision was rejected.
+        let rejected_command = bind_pr("bind-pr-rejected");
+        let rejected = WorkflowDecisionRecord::rejected(
+            bind_pr_decision(&instance.id, &rejected_command),
+            None,
+            "transition is outside the allowlist",
+        );
+        store.record_decision(&rejected).await?;
+        store
+            .enqueue_command(&instance.id, Some(&rejected.id), &rejected_command)
+            .await?;
+        assert_eq!(
+            store
+                .repair_pr_binding_from_latest_command(&instance.id, 0, "test")
+                .await?,
+            WorkflowPrBindingRepairOutcome::NoBindPrCommand
+        );
+        assert!(
+            repair_events(&store, &instance.id).await?.is_empty(),
+            "a refused repair must not record provenance"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pr_binding_repair_binds_accepted_evidence_and_records_event() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&dir.path().join("runtime")).await?;
+        let instance = workflow("pr-binding-repair-accepted");
+        store
+            .force_upsert_lifecycle_state_for_test(&instance)
+            .await?;
+
+        let command = bind_pr("bind-pr-1845");
+        let record =
+            WorkflowDecisionRecord::accepted(bind_pr_decision(&instance.id, &command), None);
+        store.record_decision(&record).await?;
+        let command_id = store
+            .enqueue_command(&instance.id, Some(&record.id), &command)
+            .await?;
+
         let repaired = store
-            .repair_pr_binding_from_latest_command(&instance.id, 0)
+            .repair_pr_binding_from_latest_command(&instance.id, 0, "test")
             .await?;
         let WorkflowPrBindingRepairOutcome::Repaired {
             instance: repaired,
@@ -139,7 +277,7 @@ mod tests {
             pr_url,
         } = repaired
         else {
-            anyhow::bail!("bind_pr evidence should repair the missing binding");
+            anyhow::bail!("bound bind_pr evidence should repair the missing binding");
         };
         assert_eq!(repaired_command_id, command_id);
         assert_eq!(pr_number, 1845);
@@ -147,11 +285,68 @@ mod tests {
         assert_eq!(repaired.version, 1);
         assert_eq!(repaired.data["pr_number"], 1845);
 
+        let events = repair_events(&store, &instance.id).await?;
+        assert_eq!(events.len(), 1, "a repair must record exactly one event");
+        let payload = &events[0].event;
+        assert_eq!(payload["command_id"], json!(command_id));
+        assert_eq!(payload["decision_id"], json!(record.id));
+        assert_eq!(payload["pr_number"], json!(1845));
+        assert_eq!(events[0].source, "test");
+
         assert_eq!(
             store
-                .repair_pr_binding_from_latest_command(&instance.id, 0)
+                .repair_pr_binding_from_latest_command(&instance.id, 0, "test")
                 .await?,
             WorkflowPrBindingRepairOutcome::StaleInstance
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pr_binding_repair_ignores_superseded_evidence() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&dir.path().join("runtime")).await?;
+        let instance = workflow("pr-binding-repair-superseded");
+        store
+            .force_upsert_lifecycle_state_for_test(&instance)
+            .await?;
+
+        let command = bind_pr("bind-pr-superseded");
+        let record =
+            WorkflowDecisionRecord::accepted(bind_pr_decision(&instance.id, &command), None);
+        store.record_decision(&record).await?;
+        store
+            .enqueue_command(&instance.id, Some(&record.id), &command)
+            .await?;
+
+        // A newer decision reuses the dedupe key for different work,
+        // superseding the bind_pr attempt (GH-1865 W2).
+        let replacement = WorkflowCommand::enqueue_activity("implement", "bind-pr-superseded");
+        let replacement_record = WorkflowDecisionRecord::accepted(
+            WorkflowDecision::new(
+                &instance.id,
+                "awaiting_feedback",
+                "schedule_rework",
+                "awaiting_feedback",
+                "rework scheduled over the bind attempt",
+            )
+            .with_command(replacement.clone()),
+            None,
+        );
+        store.record_decision(&replacement_record).await?;
+        store
+            .enqueue_command(&instance.id, Some(&replacement_record.id), &replacement)
+            .await?;
+
+        assert_eq!(
+            store
+                .repair_pr_binding_from_latest_command(&instance.id, 0, "test")
+                .await?,
+            WorkflowPrBindingRepairOutcome::NoBindPrCommand,
+            "a superseded bind_pr attempt is history, not evidence"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

GH-1864 W4 (final acceptance criterion): PR-binding repair accepts only a `BindPr` linked to an accepted decision, and records durable repair provenance.

- `repair_pr_binding_from_latest_command` trusted the latest `BindPr` command regardless of provenance — a standalone command (`decision_id` NULL), one whose decision was **rejected**, or a **superseded** attempt all qualified as repair evidence — and the same-state write recorded nothing about why it happened.
- Repair now requires live (non-superseded) `BindPr` evidence minted by an accepted decision of the same workflow. Because decision rows are append-only (GH-1865), proving the decision carries the command's dedupe key ties the repair to what was actually authorized.
- A successful repair records a durable `PrBindingRepaired` event (command id, decision id, previous and repaired values) in the same transaction; the event source is caller-supplied (`workflow_runtime_pr_feedback` from the sweeper).
- Sweeper fixtures now commit real accepted `bind_pr` decisions, matching the production commit path.

## Test plan

- [x] `cargo test -p harness-workflow --lib` — 650 passed (3 rewritten repair tests: accepted+event, standalone/rejected refused, superseded refused)
- [x] `cargo test -p harness-server --lib runtime_pr_feedback_sweep_recovers_pr_binding` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] CI

## Notes

- Completes GH-1864 (W1–W3 landed in #1868).

🤖 Generated with [Claude Code](https://claude.com/claude-code)