### PR TITLE
fix(context): finish preview-only cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,6 @@ dependencies = [
 name = "harness-context"
 version = "0.6.34"
 dependencies = [
- "anyhow",
  "harness-core",
  "harness-exec",
  "harness-rules",

--- a/config/default.toml.example
+++ b/config/default.toml.example
@@ -152,8 +152,8 @@ log_retention_max_files = 30
 log_retention_days = 90
 
 [context]
-# Shadow mode records composition manifests without changing injected context.
-mode = "shadow"
+# Context composition is preview-only; it is used by context/preview and does
+# not change production agent requests.
 budget_tokens = 24000
 reserved_headroom = 0.20
 provider_timeout_ms = 2000

--- a/crates/harness-context/Cargo.toml
+++ b/crates/harness-context/Cargo.toml
@@ -15,10 +15,9 @@ harness-rules = { workspace = true }
 harness-skills = { workspace = true }
 harness-exec = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
-anyhow = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/harness-context/src/tests.rs
+++ b/crates/harness-context/src/tests.rs
@@ -46,6 +46,20 @@ fn compose_config_is_preview_only() {
 }
 
 #[test]
+fn compose_mode_normalizes_legacy_values_to_preview() {
+    for legacy_mode in ["shadow", "enforce"] {
+        let mode: ComposeMode = serde_json::from_str(&format!("\"{legacy_mode}\""))
+            .expect("legacy compose mode remains readable");
+        assert_eq!(mode, ComposeMode::Preview);
+    }
+
+    assert_eq!(
+        serde_json::to_string(&ComposeMode::Preview).expect("preview mode serializes"),
+        "\"preview\""
+    );
+}
+
+#[test]
 fn pipeline_is_deterministic_for_identical_inputs() {
     let items = vec![
         item("rule:b", ItemClass::Rule, 20, Priority::P1),

--- a/crates/harness-context/src/types.rs
+++ b/crates/harness-context/src/types.rs
@@ -222,6 +222,7 @@ impl Estimator for BytesDivFourEstimator {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ComposeMode {
+    #[serde(alias = "shadow", alias = "enforce")]
     Preview,
 }
 

--- a/specs/context-composer/product.md
+++ b/specs/context-composer/product.md
@@ -48,7 +48,7 @@ Two failure modes, both invisible today:
 - Every excluded or degraded item appears in the manifest with a reason. No silent drops.
 - A count of instruction-bearing items > 15 raises a recorded warning in the manifest.
 - Contract and ExecPlan providers use distinct provider IDs, so manifest attribution is unambiguous.
-- `harness-context` does not depend on crates it does not use.
+- `harness-context` production dependencies are limited to crates used by library code; test-only helpers are kept in dev-dependencies.
 
 ## Decisions
 

--- a/specs/context-composer/tasks.md
+++ b/specs/context-composer/tasks.md
@@ -54,7 +54,7 @@ Dependencies: CC-T2
 
 Done when:
 
-- Manifest schema (v1) rendered per composition and logged through harness-observe as event kind `context_manifest`.
+- Manifest schema (v1) is rendered per composition and returned in the `context/preview` response. It is response-only and is not persisted through harness-observe.
 - Manifests record item ids, sizes, and decisions — never full item content.
 
 Verify:


### PR DESCRIPTION
## Summary
- accept legacy `shadow` and `enforce` compose-mode values as preview-only data while serializing only `preview`
- remove the retired shadow-mode setting from the default config example
- make the context-composer task contract explicit that preview manifests are response-only
- remove the unused production `anyhow` dependency and keep `serde_json` test-only

## Why

PR #1853 was merged while its latest review feedback was still being addressed. These changes preserve the intended preview-only behavior and finish the dependency and documentation cleanup without reopening production composition.

## Impact

Legacy serialized compose modes remain readable but safely degrade to preview behavior. Operators no longer see a retired `mode = "shadow"` setting, and the production crate has no unused `anyhow` dependency.

## Validation
- `cargo test -p harness-context` (11 passed)
- `cargo check -p harness-context --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook passed
