### PR TITLE
fix(core): default retention and watchdog sweepers on (GH-1879)

### DIFF
--- a/crates/harness-core/src/config/workflow/storage.rs
+++ b/crates/harness-core/src/config/workflow/storage.rs
@@ -19,9 +19,9 @@ pub struct WorkflowStoragePolicy {
     /// Maximum legacy unregistered path-derived schemas to drop per tick.
     #[serde(default = "default_orphan_reaper_legacy_batch")]
     pub orphan_reaper_legacy_batch: usize,
-    /// Enable workflow-runtime stuck-instance reporting. Off by default so
-    /// existing deployments keep their current background behavior on upgrade.
-    #[serde(default)]
+    /// Enable workflow-runtime stuck-instance reporting. Read-only (reports
+    /// and logs only), so it ships on; disable to silence the signal.
+    #[serde(default = "default_true")]
     pub workflow_watchdog_enabled: bool,
     /// Minimum age, in minutes, before blocked/awaiting-feedback workflows are
     /// reported as stuck.
@@ -33,9 +33,11 @@ pub struct WorkflowStoragePolicy {
     /// Maximum stuck workflow rows scanned/logged per watchdog tick.
     #[serde(default = "default_workflow_watchdog_batch_size")]
     pub workflow_watchdog_batch_size: u32,
-    /// Enable pruning of terminal workflow-runtime history. Off by default
-    /// because deleted runtime history is not recoverable.
-    #[serde(default)]
+    /// Enable pruning of terminal workflow-runtime history. On by default
+    /// with conservative bounds (30 days, 1000 families per hourly tick) so
+    /// tables cannot grow without bound; only terminal families older than
+    /// the age limit are pruned. Set false to keep history indefinitely.
+    #[serde(default = "default_true")]
     pub runtime_retention_enabled: bool,
     /// Terminal workflow families older than this many days are eligible for
     /// retention pruning.
@@ -47,9 +49,11 @@ pub struct WorkflowStoragePolicy {
     /// Interval, in seconds, between runtime-retention prune passes.
     #[serde(default = "default_runtime_retention_interval_secs")]
     pub runtime_retention_interval_secs: u64,
-    /// Enable pruning of terminal task rows and task-owned child rows. Off by
-    /// default because deleted task history is not recoverable.
-    #[serde(default)]
+    /// Enable pruning of terminal task rows and task-owned child rows. On by
+    /// default with conservative bounds (30 days, 1000 rows per hourly tick);
+    /// active, pending, dependency-blocked, and resumable tasks are never
+    /// pruned. Set false to keep task history indefinitely.
+    #[serde(default = "default_true")]
     pub task_retention_enabled: bool,
     /// Terminal tasks older than this many days are eligible for retention
     /// pruning.
@@ -71,15 +75,15 @@ impl Default for WorkflowStoragePolicy {
             orphan_reaper_interval_secs: default_orphan_reaper_interval_secs(),
             orphan_reaper_legacy_enabled: true,
             orphan_reaper_legacy_batch: default_orphan_reaper_legacy_batch(),
-            workflow_watchdog_enabled: false,
+            workflow_watchdog_enabled: true,
             workflow_watchdog_age_minutes: default_workflow_watchdog_age_minutes(),
             workflow_watchdog_interval_secs: default_workflow_watchdog_interval_secs(),
             workflow_watchdog_batch_size: default_workflow_watchdog_batch_size(),
-            runtime_retention_enabled: false,
+            runtime_retention_enabled: true,
             runtime_retention_days: default_runtime_retention_days(),
             runtime_retention_batch_size: default_runtime_retention_batch_size(),
             runtime_retention_interval_secs: default_runtime_retention_interval_secs(),
-            task_retention_enabled: false,
+            task_retention_enabled: true,
             task_retention_days: default_task_retention_days(),
             task_retention_batch_size: default_task_retention_batch_size(),
             task_retention_interval_secs: default_task_retention_interval_secs(),

--- a/crates/harness-core/src/config/workflow_tests.rs
+++ b/crates/harness-core/src/config/workflow_tests.rs
@@ -66,15 +66,15 @@ fn load_workflow_config_defaults_when_missing() -> anyhow::Result<()> {
     assert_eq!(cfg.storage.orphan_reaper_interval_secs, 3600);
     assert!(cfg.storage.orphan_reaper_legacy_enabled);
     assert_eq!(cfg.storage.orphan_reaper_legacy_batch, 200);
-    assert!(!cfg.storage.workflow_watchdog_enabled);
+    assert!(cfg.storage.workflow_watchdog_enabled);
     assert_eq!(cfg.storage.workflow_watchdog_age_minutes, 240);
     assert_eq!(cfg.storage.workflow_watchdog_interval_secs, 300);
     assert_eq!(cfg.storage.workflow_watchdog_batch_size, 100);
-    assert!(!cfg.storage.runtime_retention_enabled);
+    assert!(cfg.storage.runtime_retention_enabled);
     assert_eq!(cfg.storage.runtime_retention_days, 30);
     assert_eq!(cfg.storage.runtime_retention_batch_size, 1000);
     assert_eq!(cfg.storage.runtime_retention_interval_secs, 3600);
-    assert!(!cfg.storage.task_retention_enabled);
+    assert!(cfg.storage.task_retention_enabled);
     assert_eq!(cfg.storage.task_retention_days, 30);
     assert_eq!(cfg.storage.task_retention_batch_size, 1000);
     assert_eq!(cfg.storage.task_retention_interval_secs, 3600);

--- a/docs/workflow-runtime-operations.md
+++ b/docs/workflow-runtime-operations.md
@@ -187,7 +187,9 @@ and enqueue the correct follow-up command atomically.
 ## Watchdog And Retention Sweepers
 
 Workflow-runtime watchdog and retention sweepers are configured in
-`WORKFLOW.md` under `storage`. Both are disabled by default on first rollout:
+`WORKFLOW.md` under `storage`. All three sweepers ship on by default with
+conservative bounds (GH-1879); set the `*_enabled` flags to `false` to keep
+the pre-default behavior:
 
 ```yaml
 storage:
@@ -195,15 +197,15 @@ storage:
   orphan_reaper_interval_secs: 3600
   orphan_reaper_legacy_enabled: true
   orphan_reaper_legacy_batch: 200
-  workflow_watchdog_enabled: false
+  workflow_watchdog_enabled: true
   workflow_watchdog_age_minutes: 240
   workflow_watchdog_interval_secs: 300
   workflow_watchdog_batch_size: 100
-  runtime_retention_enabled: false
+  runtime_retention_enabled: true
   runtime_retention_days: 30
   runtime_retention_batch_size: 1000
   runtime_retention_interval_secs: 3600
-  task_retention_enabled: false
+  task_retention_enabled: true
   task_retention_days: 30
   task_retention_batch_size: 1000
   task_retention_interval_secs: 3600
@@ -214,7 +216,7 @@ path-derived schemas with dead owner paths and, in bounded batches, legacy
 unregistered `h<16-hex>` schemas that cannot be matched to a live workspace
 directory or known store path under the configured workspace root.
 
-Enable `workflow_watchdog_enabled` first. It is read-only: aged `blocked` and
+The workflow watchdog is read-only: aged `blocked` and
 `awaiting_feedback` workflow instances appear in `/api/operator-monitor` under
 `stuck_workflows` and are logged at error level.
 
@@ -224,13 +226,17 @@ reports its workflow, definition, state, age, and state-entry provenance without
 changing workflow state or history. Enabling the watchdog also emits these rows
 at error level; recovery remains an explicit operator action.
 
-Enable `runtime_retention_enabled` only after the stuck list is clean. Retention
-deletes terminal workflow families older than `runtime_retention_days` in
-bounded batches and relies on the Postgres runtime-store cascade constraints to
-remove events, decisions, commands, jobs, runtime events, and artifacts. Active
-workflow families are never pruned.
+Runtime retention deletes terminal workflow families older than
+`runtime_retention_days` in bounded batches and relies on the Postgres
+runtime-store cascade constraints to remove events, decisions, commands, jobs,
+runtime events, and artifacts. Active workflow families are never pruned. The
+first sweep after enabling (or upgrading to the on-by-default behavior) is
+bounded by `runtime_retention_batch_size` per tick, so large backlogs drain
+gradually; set `runtime_retention_enabled: false` before upgrading to keep
+history indefinitely.
 
-Enable `task_retention_enabled` only when historical task rows can be deleted.
-Retention deletes terminal tasks older than `task_retention_days` in bounded
-batches, including task-owned artifacts, prompts, and checkpoints. Active,
-pending, dependency-blocked, and resumable tasks are never pruned.
+Task retention deletes terminal tasks older than `task_retention_days` in
+bounded batches, including task-owned artifacts, prompts, and checkpoints.
+Active, pending, dependency-blocked, and resumable tasks are never pruned.
+Set `task_retention_enabled: false` before upgrading to keep task history
+indefinitely.


### PR DESCRIPTION
Closes #1879. Part of #1772.

## Summary

- `workflow_watchdog_enabled`, `runtime_retention_enabled`, `task_retention_enabled` now default to **true** — both the `Default` impl and the serde `#[serde(default)]` path, so existing configs that never mention the flags pick up the sweepers on upgrade.
- Bounds are unchanged and conservative: 30-day age minimum, 1000 rows per hourly tick, only terminal families/tasks pruned (active, pending, dependency-blocked, resumable are never touched).
- Watchdog stays read-only (reports/logs stuck workflows only).
- Ops doc updated: upgrade opt-out is `*_enabled: false` in `WORKFLOW.md` storage config.

## Behavior-change note

Upgrading deployments with >30-day terminal history will see gradual pruning (bounded per tick). Operators who want to keep history must set the flags to `false` **before** upgrading.

## Validation

- `cargo test -p harness-core --lib` — 800 passed