### PR TITLE
feat(agents): add OpenCode runtime over ACP and exec backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ The `anthropic-api` adapter is for text generation: it sends the prompt without
 repository context or tools, so it cannot inspect or modify the project in this
 coding example.
 
-Useful flags: `--project <dir>`, `--agent claude|codex|anthropic-api`,
+The `opencode` adapter runs OpenCode (`opencode run` / `opencode acp`), a
+provider-agnostic coding agent. On macOS it must run outside the Seatbelt
+sandbox like Claude Code: `--agent opencode --sandbox-mode danger-full-access`.
+
+Useful flags: `--project <dir>`, `--agent claude|codex|anthropic-api|opencode`,
 `--model <id>`, `--sandbox-mode <mode>`, `--output-file result.md`. Supported
 sandbox modes are `read-only`, `read-only-with-network`, `workspace-write`, and
 `danger-full-access`.

--- a/crates/harness-agents/src/builder.rs
+++ b/crates/harness-agents/src/builder.rs
@@ -14,6 +14,8 @@
 use crate::claude::ClaudeCodeAgent;
 use crate::codex::CodexAgent;
 use crate::codex_adapter::CodexAdapter;
+use crate::opencode::OpenCodeAgent;
+use crate::opencode_adapter::OpenCodeAcpAdapter;
 use crate::provider_backpressure::ProviderBackpressureGate;
 use crate::registry::{AdapterExecutionStrategy, AgentRegistry};
 use async_trait::async_trait;
@@ -154,6 +156,27 @@ pub fn registry_from_config(
             AdapterExecutionStrategy::ExecuteTurns,
         )
         .map_err(|error| anyhow::anyhow!("failed to attach the codex adapter: {error}"))?;
+
+    registry.register(
+        "opencode",
+        Arc::new(
+            OpenCodeAgent::from_config(config.opencode.clone(), sandbox_mode)
+                .with_stream_timeout(config.stream_timeout_secs),
+        ),
+    );
+    let opencode_config = config.opencode.clone();
+    registry
+        .register_adapter_factory_with_strategy(
+            "opencode",
+            move || {
+                Arc::new(OpenCodeAcpAdapter::from_config(
+                    opencode_config.clone(),
+                    sandbox_mode,
+                ))
+            },
+            AdapterExecutionStrategy::ExecuteTurns,
+        )
+        .map_err(|error| anyhow::anyhow!("failed to attach the opencode adapter: {error}"))?;
 
     if let Ok(api_key) = harness_core::config::process_env::var(ANTHROPIC_API_KEY_ENV) {
         registry.register(

--- a/crates/harness-agents/src/lib.rs
+++ b/crates/harness-agents/src/lib.rs
@@ -7,6 +7,8 @@ mod cloud_setup;
 pub mod codex;
 pub mod codex_adapter;
 pub mod compress_model;
+pub mod opencode;
+pub mod opencode_adapter;
 pub mod provider_backpressure;
 pub mod registry;
 pub mod runtime_fingerprint;

--- a/crates/harness-agents/src/opencode.rs
+++ b/crates/harness-agents/src/opencode.rs
@@ -23,9 +23,18 @@ const OPENCODE_PERMISSION_ENV: &str = "OPENCODE_PERMISSION";
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum OpenCodeRunEvent {
-    Text { text: String },
-    ToolUse { command: String, output: String },
-    StepFinish { reason: String, tokens: TokenUsage },
+    Text {
+        text: String,
+    },
+    ToolUse {
+        command: String,
+        exit_code: Option<i32>,
+        output: String,
+    },
+    StepFinish {
+        reason: String,
+        tokens: TokenUsage,
+    },
 }
 
 /// Parse one line of `opencode run --format json` output.
@@ -57,7 +66,16 @@ pub fn parse_opencode_run_line(line: &str) -> Option<OpenCodeRunEvent> {
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string();
-            Some(OpenCodeRunEvent::ToolUse { command, output })
+            let exit_code = match value.pointer("/part/state/status").and_then(Value::as_str) {
+                Some("completed") => Some(0),
+                Some("error") => Some(1),
+                _ => None,
+            };
+            Some(OpenCodeRunEvent::ToolUse {
+                command,
+                exit_code,
+                output,
+            })
         }
         Some("step_finish") => {
             let reason = value
@@ -101,15 +119,15 @@ fn parse_step_finish_tokens(value: &Value) -> TokenUsage {
 ///
 /// `None` = full profile (opencode `--auto`). An explicitly empty list means
 /// deny-all, mirroring `AgentRequest::allowed_tools` semantics.
-fn permission_env_value(tools: &[String]) -> Option<String> {
+fn permission_env_value(tools: &[String]) -> String {
     if tools.is_empty() {
-        return Some(r#"{"*":"deny"}"#.to_string());
+        return r#"{"*":"deny"}"#.to_string();
     }
     let mut map = serde_json::Map::new();
     for tool in tools {
         map.insert(tool.clone(), Value::String("allow".to_string()));
     }
-    Some(serde_json::Value::Object(map).to_string())
+    serde_json::Value::Object(map).to_string()
 }
 
 pub struct OpenCodeAgent {
@@ -162,18 +180,23 @@ impl OpenCodeAgent {
     fn spawn_env_vars(&self, req: &AgentRequest) -> Vec<(String, String)> {
         let mut vars = Vec::new();
         if let Some(tools) = req.allowed_tools.as_ref() {
-            if let Some(value) = permission_env_value(tools) {
-                vars.push((OPENCODE_PERMISSION_ENV.to_string(), value));
-            }
+            vars.push((
+                OPENCODE_PERMISSION_ENV.to_string(),
+                permission_env_value(tools),
+            ));
         }
         vars
     }
 
     fn item_from_tool_use(&self, event: &OpenCodeRunEvent) -> Option<Item> {
         match event {
-            OpenCodeRunEvent::ToolUse { command, output } => Some(Item::ShellCommand {
+            OpenCodeRunEvent::ToolUse {
+                command,
+                exit_code,
+                output,
+            } => Some(Item::ShellCommand {
                 command: command.clone(),
-                exit_code: Some(0),
+                exit_code: *exit_code,
                 stdout: output.clone(),
                 stderr: String::new(),
             }),
@@ -429,10 +452,14 @@ impl CodeAgent for OpenCodeAgent {
                         break;
                     }
                 }
-                OpenCodeRunEvent::ToolUse { command, output } => {
+                OpenCodeRunEvent::ToolUse {
+                    command,
+                    exit_code,
+                    output,
+                } => {
                     let item = Item::ShellCommand {
                         command: command.clone(),
-                        exit_code: Some(0),
+                        exit_code,
                         stdout: output.clone(),
                         stderr: String::new(),
                     };
@@ -557,7 +584,18 @@ mod tests {
             parse_opencode_run_line(line),
             Some(OpenCodeRunEvent::ToolUse {
                 command: "ls /tmp".to_string(),
+                exit_code: Some(0),
                 output: "a.txt".to_string()
+            })
+        );
+
+        let failed = r#"{"type":"tool_use","part":{"type":"tool","tool":"bash","callID":"c2","state":{"status":"error","input":{"command":"ls /nope"},"output":""}}}"#;
+        assert_eq!(
+            parse_opencode_run_line(failed),
+            Some(OpenCodeRunEvent::ToolUse {
+                command: "ls /nope".to_string(),
+                exit_code: Some(1),
+                output: String::new()
             })
         );
     }
@@ -588,9 +626,9 @@ mod tests {
     #[test]
     fn permission_env_mapping() {
         assert_eq!(
-            permission_env_value(&["bash".to_string(), "edit".to_string()]).unwrap(),
+            permission_env_value(&["bash".to_string(), "edit".to_string()]),
             r#"{"bash":"allow","edit":"allow"}"#
         );
-        assert_eq!(permission_env_value(&[]).unwrap(), r#"{"*":"deny"}"#);
+        assert_eq!(permission_env_value(&[]), r#"{"*":"deny"}"#);
     }
 }

--- a/crates/harness-agents/src/opencode.rs
+++ b/crates/harness-agents/src/opencode.rs
@@ -1,0 +1,596 @@
+use crate::streaming::{
+    capture_agent_stderr_diagnostics, captured_stderr_tail, log_captured_stderr_diagnostics,
+    send_stream_item,
+};
+use async_trait::async_trait;
+use harness_core::agent::{AgentRequest, AgentResponse, CodeAgent, StreamItem};
+use harness_core::config::agents::{OpenCodeAgentConfig, SandboxMode};
+use harness_core::types::{Capability, Item, TokenUsage};
+use harness_sandbox::SandboxSpec;
+use serde_json::Value;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncBufReadExt, BufReader, Lines};
+use tokio::process::ChildStdout;
+
+/// Environment variable holding an inlined JSON permissions config.
+///
+/// opencode merges this on top of the user/global config, mirroring the
+/// `AgentRequest::allowed_tools` restriction surface.
+const OPENCODE_PERMISSION_ENV: &str = "OPENCODE_PERMISSION";
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OpenCodeRunEvent {
+    Text { text: String },
+    ToolUse { command: String, output: String },
+    StepFinish { reason: String, tokens: TokenUsage },
+}
+
+/// Parse one line of `opencode run --format json` output.
+///
+/// Emitted line shapes (verified against opencode 1.18.14):
+/// - `{"type":"step_start","part":{...}}`
+/// - `{"type":"text","part":{"type":"text","text":"..."}}`
+/// - `{"type":"tool_use","part":{"type":"tool","tool":"bash","state":{...}}}`
+/// - `{"type":"step_finish","part":{"reason":"stop","tokens":{...}}}`
+pub fn parse_opencode_run_line(line: &str) -> Option<OpenCodeRunEvent> {
+    let value: Value = serde_json::from_str(line).ok()?;
+    match value.get("type").and_then(Value::as_str) {
+        Some("text") => {
+            let text = value
+                .pointer("/part/text")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            Some(OpenCodeRunEvent::Text { text })
+        }
+        Some("tool_use") => {
+            let command = value
+                .pointer("/part/state/input/command")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let output = value
+                .pointer("/part/state/output")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            Some(OpenCodeRunEvent::ToolUse { command, output })
+        }
+        Some("step_finish") => {
+            let reason = value
+                .pointer("/part/reason")
+                .and_then(Value::as_str)
+                .unwrap_or("stop")
+                .to_string();
+            let tokens = parse_step_finish_tokens(&value);
+            Some(OpenCodeRunEvent::StepFinish { reason, tokens })
+        }
+        _ => None,
+    }
+}
+
+fn parse_step_finish_tokens(value: &Value) -> TokenUsage {
+    let input = value
+        .pointer("/part/tokens/input")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let output = value
+        .pointer("/part/tokens/output")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let total = value
+        .pointer("/part/tokens/total")
+        .and_then(Value::as_u64)
+        .unwrap_or(input.saturating_add(output));
+    let cost = value
+        .pointer("/part/cost")
+        .and_then(Value::as_f64)
+        .unwrap_or(0.0);
+    TokenUsage {
+        input_tokens: input,
+        output_tokens: output,
+        total_tokens: total,
+        cost_usd: cost,
+    }
+}
+
+/// Build the permission env value for an explicit allowlist.
+///
+/// `None` = full profile (opencode `--auto`). An explicitly empty list means
+/// deny-all, mirroring `AgentRequest::allowed_tools` semantics.
+fn permission_env_value(tools: &[String]) -> Option<String> {
+    if tools.is_empty() {
+        return Some(r#"{"*":"deny"}"#.to_string());
+    }
+    let mut map = serde_json::Map::new();
+    for tool in tools {
+        map.insert(tool.clone(), Value::String("allow".to_string()));
+    }
+    Some(serde_json::Value::Object(map).to_string())
+}
+
+pub struct OpenCodeAgent {
+    pub cli_path: PathBuf,
+    pub default_model: String,
+    pub sandbox_mode: SandboxMode,
+    /// Maximum seconds of idle silence on the output stream before the
+    /// subprocess is declared a zombie and terminated. `None` = no timeout.
+    pub stream_timeout_secs: Option<u64>,
+}
+
+impl OpenCodeAgent {
+    pub fn from_config(config: OpenCodeAgentConfig, sandbox_mode: SandboxMode) -> Self {
+        Self {
+            cli_path: config.cli_path,
+            default_model: config.default_model,
+            sandbox_mode,
+            stream_timeout_secs: None,
+        }
+    }
+
+    pub fn with_stream_timeout(mut self, stream_timeout_secs: Option<u64>) -> Self {
+        self.stream_timeout_secs = stream_timeout_secs;
+        self
+    }
+
+    fn effective_model(&self, req: &AgentRequest) -> Option<String> {
+        req.model
+            .clone()
+            .or_else(|| (!self.default_model.is_empty()).then(|| self.default_model.clone()))
+    }
+
+    fn base_args(&self, req: &AgentRequest) -> Vec<OsString> {
+        let mut args = vec![
+            OsString::from("run"),
+            OsString::from("--format"),
+            OsString::from("json"),
+        ];
+        if let Some(model) = self.effective_model(req) {
+            args.push(OsString::from("--model"));
+            args.push(OsString::from(model));
+        }
+        if req.allowed_tools.is_none() {
+            args.push(OsString::from("--auto"));
+        }
+        args.push(OsString::from(req.prompt.clone()));
+        args
+    }
+
+    fn spawn_env_vars(&self, req: &AgentRequest) -> Vec<(String, String)> {
+        let mut vars = Vec::new();
+        if let Some(tools) = req.allowed_tools.as_ref() {
+            if let Some(value) = permission_env_value(tools) {
+                vars.push((OPENCODE_PERMISSION_ENV.to_string(), value));
+            }
+        }
+        vars
+    }
+
+    fn item_from_tool_use(&self, event: &OpenCodeRunEvent) -> Option<Item> {
+        match event {
+            OpenCodeRunEvent::ToolUse { command, output } => Some(Item::ShellCommand {
+                command: command.clone(),
+                exit_code: Some(0),
+                stdout: output.clone(),
+                stderr: String::new(),
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[async_trait]
+impl CodeAgent for OpenCodeAgent {
+    fn name(&self) -> &str {
+        "opencode"
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![Capability::Read, Capability::Write, Capability::Execute]
+    }
+
+    async fn execute(&self, req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+        if let Some(ref token) = req.capability_token {
+            if token.is_expired() {
+                return Err(harness_core::error::HarnessError::AgentExecution(format!(
+                    "capability token for subtask {} has expired",
+                    token.subtask_index
+                )));
+            }
+        }
+
+        let base_args = self.base_args(&req);
+        let sandbox_spec = if let Some(ref token) = req.capability_token {
+            SandboxSpec::new(self.sandbox_mode, &req.project_root)
+                .with_allowed_write_paths(token.allowed_write_paths.clone())
+        } else {
+            SandboxSpec::new(self.sandbox_mode, &req.project_root)
+        };
+        let mut spawn_env_vars = req.env_vars.clone();
+        for (key, value) in self.spawn_env_vars(&req) {
+            spawn_env_vars.insert(key, value);
+        }
+        let run_identity = crate::resolve_agent_run_identity(&spawn_env_vars);
+        run_identity.write_env_vars(&mut spawn_env_vars);
+        let prepared_spawn =
+            crate::spawn_contract::prepare_agent_spawn(crate::spawn_contract::AgentSpawnInput {
+                program: &self.cli_path,
+                args: &base_args,
+                project_root: &req.project_root,
+                sandbox_spec: &sandbox_spec,
+                env_vars: &spawn_env_vars,
+                forward_stdin: false,
+            })?;
+
+        let spawn_error_req = req.clone();
+        let supervised = crate::spawn_supervisor::spawn_agent(
+            crate::spawn_supervisor::AgentSpawnPlan {
+                prepared_spawn,
+                run_identity,
+                native_kind: "opencode",
+                process_label: "opencode run",
+                stdio: crate::spawn_supervisor::AgentStdio::piped_output(Stdio::null()),
+                extra_env_removals: Vec::new(),
+                map_spawn_error: Box::new(move |error, spawn| {
+                    let message = crate::classify_missing_workspace_spawn_failure(
+                        error,
+                        &spawn_error_req.project_root,
+                        format!(
+                            "failed to spawn opencode run: {error}; program={}; current_dir={}; sandbox_engine={:?}",
+                            spawn.program.display(),
+                            spawn.current_dir.display(),
+                            spawn.sandbox_engine,
+                        ),
+                    );
+                    harness_core::error::HarnessError::AgentExecution(message)
+                }),
+            },
+            req.capability_token.as_ref(),
+        )
+        .await?;
+        let mut child = supervised.child;
+        let limits = crate::OutputLimits::from_stream_timeout_secs(self.stream_timeout_secs);
+        let output = child.wait_with_output(&limits).await.map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to wait for opencode: {error}"
+            ))
+        })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        log_captured_stderr_diagnostics(&stderr, self.name());
+
+        if !output.status.success() {
+            let error_output = if stderr.trim().is_empty() {
+                stdout.clone()
+            } else {
+                stderr.clone()
+            };
+            return Err(harness_core::error::HarnessError::AgentExecution(format!(
+                "opencode exited with {status}: {error_output}",
+                status = output.status
+            )));
+        }
+
+        let mut items = Vec::new();
+        let mut message_text = String::new();
+        let mut token_usage = TokenUsage::default();
+        for line in stdout.lines() {
+            match parse_opencode_run_line(line) {
+                Some(OpenCodeRunEvent::Text { text }) => message_text.push_str(&text),
+                Some(event @ OpenCodeRunEvent::ToolUse { .. }) => {
+                    if let Some(item) = self.item_from_tool_use(&event) {
+                        items.push(item);
+                    }
+                }
+                Some(OpenCodeRunEvent::StepFinish { reason, tokens }) => {
+                    token_usage = tokens;
+                    if reason != "stop" {
+                        return Err(harness_core::error::HarnessError::AgentExecution(format!(
+                            "opencode run finished with reason `{reason}`"
+                        )));
+                    }
+                }
+                None => {}
+            }
+        }
+
+        Ok(AgentResponse {
+            output: message_text,
+            stderr,
+            items,
+            token_usage,
+            model: "opencode".to_string(),
+            exit_code: output.status.code(),
+        })
+    }
+
+    async fn execute_stream(
+        &self,
+        req: AgentRequest,
+        tx: tokio::sync::mpsc::Sender<StreamItem>,
+    ) -> harness_core::error::Result<()> {
+        if let Some(ref token) = req.capability_token {
+            if token.is_expired() {
+                return Err(harness_core::error::HarnessError::AgentExecution(format!(
+                    "capability token for subtask {} has expired",
+                    token.subtask_index
+                )));
+            }
+        }
+
+        let base_args = self.base_args(&req);
+        let sandbox_spec = if let Some(ref token) = req.capability_token {
+            SandboxSpec::new(self.sandbox_mode, &req.project_root)
+                .with_allowed_write_paths(token.allowed_write_paths.clone())
+        } else {
+            SandboxSpec::new(self.sandbox_mode, &req.project_root)
+        };
+        let mut spawn_env_vars = req.env_vars.clone();
+        for (key, value) in self.spawn_env_vars(&req) {
+            spawn_env_vars.insert(key, value);
+        }
+        let run_identity = crate::resolve_agent_run_identity(&spawn_env_vars);
+        run_identity.write_env_vars(&mut spawn_env_vars);
+        let prepared_spawn =
+            crate::spawn_contract::prepare_agent_spawn(crate::spawn_contract::AgentSpawnInput {
+                program: &self.cli_path,
+                args: &base_args,
+                project_root: &req.project_root,
+                sandbox_spec: &sandbox_spec,
+                env_vars: &spawn_env_vars,
+                forward_stdin: false,
+            })?;
+
+        let spawn_error_req = req.clone();
+        let supervised = crate::spawn_supervisor::spawn_agent(
+            crate::spawn_supervisor::AgentSpawnPlan {
+                prepared_spawn,
+                run_identity,
+                native_kind: "opencode",
+                process_label: "opencode run (streamed)",
+                stdio: crate::spawn_supervisor::AgentStdio::piped_output(Stdio::null()),
+                extra_env_removals: Vec::new(),
+                map_spawn_error: Box::new(move |error, spawn| {
+                    let message = crate::classify_missing_workspace_spawn_failure(
+                        error,
+                        &spawn_error_req.project_root,
+                        format!(
+                            "failed to spawn opencode run: {error}; program={}; current_dir={}; sandbox_engine={:?}",
+                            spawn.program.display(),
+                            spawn.current_dir.display(),
+                            spawn.sandbox_engine,
+                        ),
+                    );
+                    harness_core::error::HarnessError::AgentExecution(message)
+                }),
+            },
+            req.capability_token.as_ref(),
+        )
+        .await?;
+        let mut child = supervised.child;
+
+        let stderr_capture = Arc::new(Mutex::new(String::new()));
+        let mut stderr_task = None;
+        if let Some(stderr) = child.inner_mut().stderr.take() {
+            let agent = self.name().to_string();
+            let captured = Arc::clone(&stderr_capture);
+            stderr_task = Some(tokio::spawn(async move {
+                capture_agent_stderr_diagnostics(stderr, &agent, Some(captured)).await;
+            }));
+        }
+
+        let stdout = child.inner_mut().stdout.take().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution("opencode stdout unavailable".into())
+        })?;
+        let mut lines: Lines<BufReader<ChildStdout>> = BufReader::new(stdout).lines();
+        let idle_timeout = self
+            .stream_timeout_secs
+            .filter(|&s| s > 0)
+            .map(std::time::Duration::from_secs);
+
+        let mut stream_result: harness_core::error::Result<()> = Ok(());
+        loop {
+            let read = match idle_timeout {
+                Some(duration) => match tokio::time::timeout(duration, lines.next_line()).await {
+                    Ok(result) => result,
+                    Err(_) => Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "opencode stream idle timeout",
+                    )),
+                },
+                None => lines.next_line().await,
+            };
+            let line = match read {
+                Ok(Some(line)) => line,
+                Ok(None) => break,
+                Err(error) => {
+                    stream_result = Err(harness_core::error::HarnessError::AgentExecution(
+                        format!("failed reading opencode stdout: {error}"),
+                    ));
+                    break;
+                }
+            };
+            let Some(event) = parse_opencode_run_line(&line) else {
+                continue;
+            };
+            match event {
+                OpenCodeRunEvent::Text { text } => {
+                    if send_stream_item(&tx, StreamItem::MessageDelta { text }, self.name(), "text")
+                        .await
+                        .is_err()
+                    {
+                        stream_result = Err(harness_core::error::HarnessError::AgentExecution(
+                            "opencode stream send failed".into(),
+                        ));
+                        break;
+                    }
+                }
+                OpenCodeRunEvent::ToolUse { command, output } => {
+                    let item = Item::ShellCommand {
+                        command: command.clone(),
+                        exit_code: Some(0),
+                        stdout: output.clone(),
+                        stderr: String::new(),
+                    };
+                    if send_stream_item(
+                        &tx,
+                        StreamItem::ItemStarted { item: item.clone() },
+                        self.name(),
+                        "tool",
+                    )
+                    .await
+                    .is_err()
+                    {
+                        stream_result = Err(harness_core::error::HarnessError::AgentExecution(
+                            "opencode stream send failed".into(),
+                        ));
+                        break;
+                    }
+                    if send_stream_item(
+                        &tx,
+                        StreamItem::ToolOutputDelta {
+                            item_id: command,
+                            text: output,
+                        },
+                        self.name(),
+                        "tool output",
+                    )
+                    .await
+                    .is_err()
+                    {
+                        stream_result = Err(harness_core::error::HarnessError::AgentExecution(
+                            "opencode stream send failed".into(),
+                        ));
+                        break;
+                    }
+                    if send_stream_item(
+                        &tx,
+                        StreamItem::ItemCompleted { item },
+                        self.name(),
+                        "tool completed",
+                    )
+                    .await
+                    .is_err()
+                    {
+                        stream_result = Err(harness_core::error::HarnessError::AgentExecution(
+                            "opencode stream send failed".into(),
+                        ));
+                        break;
+                    }
+                }
+                OpenCodeRunEvent::StepFinish { reason, tokens } => {
+                    if send_stream_item(
+                        &tx,
+                        StreamItem::TokenUsage { usage: tokens },
+                        self.name(),
+                        "usage",
+                    )
+                    .await
+                    .is_err()
+                    {
+                        stream_result = Err(harness_core::error::HarnessError::AgentExecution(
+                            "opencode stream send failed".into(),
+                        ));
+                        break;
+                    }
+                    if reason != "stop" {
+                        stream_result = Err(harness_core::error::HarnessError::AgentExecution(
+                            format!("opencode run finished with reason `{reason}`"),
+                        ));
+                    }
+                    break;
+                }
+            }
+        }
+
+        let status = child
+            .wait_and_cleanup_descendants()
+            .await
+            .map_err(|error| {
+                harness_core::error::HarnessError::AgentExecution(format!(
+                    "failed waiting for opencode process: {error}"
+                ))
+            })?;
+        if let Some(stderr_task) = stderr_task {
+            let _ = stderr_task.await;
+        }
+        if let Err(error) = stream_result {
+            let stderr = captured_stderr_tail(&stderr_capture);
+            return Err(harness_core::error::HarnessError::AgentExecution(format!(
+                "{error}; stderr=[{stderr}]"
+            )));
+        }
+        if !status.success() {
+            let stderr = captured_stderr_tail(&stderr_capture);
+            return Err(harness_core::error::HarnessError::AgentExecution(format!(
+                "opencode exited with {status}: {stderr}"
+            )));
+        }
+        send_stream_item(&tx, StreamItem::Done, self.name(), "done").await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_text_line() {
+        let line = r#"{"type":"text","timestamp":1,"part":{"type":"text","text":"OK"}}"#;
+        assert_eq!(
+            parse_opencode_run_line(line),
+            Some(OpenCodeRunEvent::Text {
+                text: "OK".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn parses_tool_use_line() {
+        let line = r#"{"type":"tool_use","part":{"type":"tool","tool":"bash","callID":"c1","state":{"status":"completed","input":{"command":"ls /tmp"},"output":"a.txt"}}}"#;
+        assert_eq!(
+            parse_opencode_run_line(line),
+            Some(OpenCodeRunEvent::ToolUse {
+                command: "ls /tmp".to_string(),
+                output: "a.txt".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn parses_step_finish_tokens() {
+        let line = r#"{"type":"step_finish","part":{"reason":"stop","tokens":{"total":100,"input":90,"output":10,"reasoning":0,"cache":{"write":0,"read":0}},"cost":0.001}}"#;
+        let event = parse_opencode_run_line(line).unwrap();
+        match event {
+            OpenCodeRunEvent::StepFinish { reason, tokens } => {
+                assert_eq!(reason, "stop");
+                assert_eq!(tokens.input_tokens, 90);
+                assert_eq!(tokens.output_tokens, 10);
+                assert_eq!(tokens.total_tokens, 100);
+                assert!((tokens.cost_usd - 0.001).abs() < f64::EPSILON);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ignores_unknown_lines() {
+        assert!(parse_opencode_run_line("not json").is_none());
+        assert!(parse_opencode_run_line(r#"{"type":"step_start","part":{}}"#).is_none());
+        assert!(parse_opencode_run_line("").is_none());
+    }
+
+    #[test]
+    fn permission_env_mapping() {
+        assert_eq!(
+            permission_env_value(&["bash".to_string(), "edit".to_string()]).unwrap(),
+            r#"{"bash":"allow","edit":"allow"}"#
+        );
+        assert_eq!(permission_env_value(&[]).unwrap(), r#"{"*":"deny"}"#);
+    }
+}

--- a/crates/harness-agents/src/opencode_adapter.rs
+++ b/crates/harness-agents/src/opencode_adapter.rs
@@ -583,6 +583,21 @@ impl AgentAdapter for OpenCodeAcpAdapter {
             {
                 match message {
                     ParsedAcpMessage::Response { result, .. } => {
+                        // A JSON-RPC error response (e.g. -32602 invalid
+                        // params) must fail the turn, not be treated as a
+                        // successful completion.
+                        if result.get("error").is_some() || result.get("code").is_some() {
+                            let message = result
+                                .get("message")
+                                .and_then(Value::as_str)
+                                .unwrap_or("opencode acp request failed")
+                                .to_string();
+                            if tx.send(AgentEvent::Error { message }).await.is_err() {
+                                receiver_closed = true;
+                            }
+                            turn_completed = true;
+                            break;
+                        }
                         let stop_reason = result.get("stopReason").and_then(Value::as_str);
                         if stop_reason == Some("cancelled")
                             && tx

--- a/crates/harness-agents/src/opencode_adapter.rs
+++ b/crates/harness-agents/src/opencode_adapter.rs
@@ -1,0 +1,689 @@
+use crate::streaming::capture_agent_stderr_diagnostics;
+use async_trait::async_trait;
+use harness_core::agent::{AgentAdapter, AgentEvent, ApprovalDecision, TurnRequest};
+use harness_core::config::agents::{OpenCodeAgentConfig, SandboxMode};
+use harness_core::types::TokenUsage;
+use harness_sandbox::SandboxSpec;
+use serde_json::{json, Value};
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::ChildStdout;
+use tokio::sync::{mpsc, Mutex};
+
+type StdoutLines = Lines<BufReader<ChildStdout>>;
+const MAX_PROTOCOL_LINE_PREVIEW: usize = 240;
+
+fn protocol_line_preview(line: &str) -> String {
+    let mut chars = line.chars();
+    let mut preview: String = chars.by_ref().take(MAX_PROTOCOL_LINE_PREVIEW).collect();
+    if chars.next().is_some() {
+        preview.push_str("...");
+    }
+    preview
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedAcpMessage {
+    Event(AgentEvent),
+    Response { id: Value, result: Value },
+    Ignore,
+}
+
+/// Parse one ACP JSON-RPC line from `opencode acp` stdout.
+pub fn parse_acp_message(line: &str) -> Option<ParsedAcpMessage> {
+    let value: Value = serde_json::from_str(line).ok()?;
+    if value.get("method").is_some() {
+        return parse_acp_notification(&value);
+    }
+    if value.get("id").is_some() {
+        if value.get("error").is_some() {
+            return Some(ParsedAcpMessage::Response {
+                id: value.get("id").cloned()?,
+                result: value.get("error").cloned()?,
+            });
+        }
+        return Some(ParsedAcpMessage::Response {
+            id: value.get("id").cloned()?,
+            result: value.get("result").cloned()?,
+        });
+    }
+    None
+}
+
+fn parse_acp_notification(value: &Value) -> Option<ParsedAcpMessage> {
+    let method = value.get("method")?.as_str()?;
+    let params = value.get("params").cloned().unwrap_or(Value::Null);
+    match method {
+        "session/update" => {
+            let update = params.get("update")?;
+            let session_update = update.get("sessionUpdate")?.as_str()?;
+            match session_update {
+                "agent_message_chunk" => {
+                    let text = update
+                        .pointer("/content/text")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    Some(ParsedAcpMessage::Event(AgentEvent::MessageDelta { text }))
+                }
+                "tool_call" => {
+                    let name = update
+                        .get("title")
+                        .and_then(Value::as_str)
+                        .unwrap_or("tool")
+                        .to_string();
+                    let tool_call_id = update
+                        .get("toolCallId")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let input = json!({ "toolCallId": tool_call_id });
+                    Some(ParsedAcpMessage::Event(AgentEvent::ToolCall {
+                        name,
+                        input,
+                    }))
+                }
+                "tool_call_update" => {
+                    let status = update
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    match status {
+                        "in_progress" => Some(ParsedAcpMessage::Event(AgentEvent::ItemStarted {
+                            item_type: "tool_call".into(),
+                        })),
+                        "completed" | "error" => {
+                            Some(ParsedAcpMessage::Event(AgentEvent::ItemCompleted))
+                        }
+                        _ => Some(ParsedAcpMessage::Ignore),
+                    }
+                }
+                "usage_update" => {
+                    let used = update.get("used").and_then(Value::as_u64).unwrap_or(0);
+                    let size = update.get("size").and_then(Value::as_u64).unwrap_or(0);
+                    let cost = update
+                        .pointer("/cost/amount")
+                        .and_then(Value::as_f64)
+                        .unwrap_or(0.0);
+                    let usage = TokenUsage {
+                        input_tokens: used,
+                        output_tokens: 0,
+                        total_tokens: size,
+                        cost_usd: cost,
+                    };
+                    Some(ParsedAcpMessage::Event(AgentEvent::TokenUsage { usage }))
+                }
+                _ => Some(ParsedAcpMessage::Ignore),
+            }
+        }
+        "session/request_permission" => {
+            let id = value.get("id")?.clone();
+            let command = params
+                .get("prompt")
+                .and_then(Value::as_str)
+                .unwrap_or("permission requested")
+                .to_string();
+            Some(ParsedAcpMessage::Event(AgentEvent::ApprovalRequest {
+                id: request_id_string(&id),
+                command,
+            }))
+        }
+        _ => Some(ParsedAcpMessage::Ignore),
+    }
+}
+
+fn request_id_string(id: &Value) -> String {
+    match id {
+        Value::String(value) => value.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn response_id_matches(actual: &Value, expected: u64) -> bool {
+    actual.as_u64() == Some(expected) || actual.as_str() == Some(&expected.to_string())
+}
+
+fn request_id_from_string(id: &str) -> Value {
+    serde_json::from_str(id).unwrap_or_else(|_| Value::String(id.to_string()))
+}
+
+fn stall_timeout_for(req: &TurnRequest) -> Option<Duration> {
+    req.timeout_secs
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+}
+
+fn prepare_acp_spawn(
+    cli_path: &std::path::Path,
+    req: &TurnRequest,
+) -> harness_core::error::Result<crate::spawn_contract::PreparedAgentSpawn> {
+    let args = [OsString::from("acp"), OsString::from("--cwd")];
+    let sandbox_mode = req.sandbox_mode.unwrap_or(SandboxMode::DangerFullAccess);
+    let mut args = args.to_vec();
+    args.push(OsString::from(&req.project_root));
+    let sandbox_spec = if let Some(token) = req.capability_token.as_ref() {
+        SandboxSpec::new(sandbox_mode, &req.project_root)
+            .with_allowed_write_paths(token.allowed_write_paths.clone())
+    } else {
+        SandboxSpec::new(sandbox_mode, &req.project_root)
+    };
+    crate::spawn_contract::prepare_agent_spawn(crate::spawn_contract::AgentSpawnInput {
+        program: cli_path,
+        args: &args,
+        project_root: &req.project_root,
+        sandbox_spec: &sandbox_spec,
+        env_vars: &req.env_vars,
+        forward_stdin: true,
+    })
+}
+
+pub struct OpenCodeAcpAdapter {
+    cli_path: PathBuf,
+    default_model: String,
+    sandbox_mode: SandboxMode,
+    state: Arc<Mutex<AdapterState>>,
+}
+
+struct AdapterState {
+    child: Option<crate::ManagedChild>,
+    stdin: Option<tokio::process::ChildStdin>,
+    stdout_lines: Option<StdoutLines>,
+    next_id: u64,
+    session_id: Option<String>,
+}
+
+impl AdapterState {
+    fn new() -> Self {
+        Self {
+            child: None,
+            stdin: None,
+            stdout_lines: None,
+            next_id: 1,
+            session_id: None,
+        }
+    }
+
+    fn next_request_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    fn child_ready(&self) -> bool {
+        self.child.is_some() && self.stdin.is_some() && self.stdout_lines.is_some()
+    }
+
+    async fn reset_child(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            child.terminate_now();
+            if let Err(error) = child.wait_and_cleanup_descendants().await {
+                tracing::warn!("failed to clean up opencode acp child: {error}");
+            }
+        }
+        self.stdin = None;
+        self.stdout_lines = None;
+        self.session_id = None;
+    }
+}
+
+impl OpenCodeAcpAdapter {
+    pub fn new(cli_path: PathBuf) -> Self {
+        let config = OpenCodeAgentConfig {
+            cli_path,
+            ..OpenCodeAgentConfig::default()
+        };
+        Self::from_config(config, SandboxMode::DangerFullAccess)
+    }
+
+    pub fn from_config(config: OpenCodeAgentConfig, sandbox_mode: SandboxMode) -> Self {
+        Self {
+            cli_path: config.cli_path,
+            default_model: config.default_model,
+            sandbox_mode,
+            state: Arc::new(Mutex::new(AdapterState::new())),
+        }
+    }
+
+    fn effective_turn_request(&self, mut req: TurnRequest) -> TurnRequest {
+        if req.model.is_none() && !self.default_model.is_empty() {
+            req.model = Some(self.default_model.clone());
+        }
+        if req.sandbox_mode.is_none() {
+            req.sandbox_mode = Some(self.sandbox_mode);
+        }
+        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
+        run_identity.write_env_vars(&mut req.env_vars);
+        req
+    }
+
+    async fn send_json_line(
+        state: &mut AdapterState,
+        payload: &Value,
+    ) -> harness_core::error::Result<()> {
+        let stdin = state.stdin.as_mut().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution("opencode stdin not available".into())
+        })?;
+        let mut line = serde_json::to_string(payload).map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to serialize opencode payload: {error}"
+            ))
+        })?;
+        line.push('\n');
+        stdin.write_all(line.as_bytes()).await.map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to write to opencode: {error}"
+            ))
+        })?;
+        stdin.flush().await.map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed to flush opencode stdin: {error}"
+            ))
+        })
+    }
+
+    async fn send_request(
+        state: &mut AdapterState,
+        method: &str,
+        params: Value,
+    ) -> harness_core::error::Result<u64> {
+        let id = state.next_request_id();
+        let payload = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        Self::send_json_line(state, &payload).await?;
+        Ok(id)
+    }
+
+    async fn send_notification(
+        state: &mut AdapterState,
+        method: &str,
+        params: Value,
+    ) -> harness_core::error::Result<()> {
+        let payload = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        Self::send_json_line(state, &payload).await
+    }
+
+    async fn read_next_message(
+        lines: &mut StdoutLines,
+    ) -> harness_core::error::Result<Option<ParsedAcpMessage>> {
+        let Some(line) = lines.next_line().await.map_err(|error| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "failed reading opencode acp stdout: {error}"
+            ))
+        })?
+        else {
+            return Ok(None);
+        };
+        if line.trim().is_empty() {
+            return Ok(Some(ParsedAcpMessage::Ignore));
+        }
+        parse_acp_message(&line).map(Some).ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(format!(
+                "opencode acp emitted invalid JSON-RPC stdout: {}",
+                protocol_line_preview(&line)
+            ))
+        })
+    }
+
+    async fn read_next_message_with_timeout(
+        lines: &mut StdoutLines,
+        stall_timeout: Option<Duration>,
+        phase: &str,
+    ) -> harness_core::error::Result<Option<ParsedAcpMessage>> {
+        let read = Self::read_next_message(lines);
+        let Some(stall_timeout) = stall_timeout else {
+            return read.await;
+        };
+        match tokio::time::timeout(stall_timeout, read).await {
+            Ok(result) => result,
+            Err(_) => Err(harness_core::error::HarnessError::AgentExecution(format!(
+                "opencode acp {phase} stalled for {stall_timeout:?} without stdout"
+            ))),
+        }
+    }
+
+    async fn ensure_child(
+        &self,
+        req: &TurnRequest,
+        state: &mut AdapterState,
+    ) -> harness_core::error::Result<()> {
+        if state.child_ready() {
+            return Ok(());
+        }
+        if state.child.is_some() {
+            tracing::warn!(
+                "opencode acp state is incomplete; restarting before starting a new turn"
+            );
+            state.reset_child().await;
+        }
+
+        let run_identity = crate::resolve_agent_run_identity(&req.env_vars);
+        let prepared_spawn = prepare_acp_spawn(&self.cli_path, req)?;
+        let spawn_project_root = req.project_root.clone();
+        let supervised = crate::spawn_supervisor::spawn_agent(
+            crate::spawn_supervisor::AgentSpawnPlan {
+                prepared_spawn,
+                run_identity,
+                native_kind: "opencode",
+                process_label: "opencode acp",
+                stdio: crate::spawn_supervisor::AgentStdio::piped_output(
+                    std::process::Stdio::piped(),
+                ),
+                extra_env_removals: Vec::new(),
+                map_spawn_error: Box::new(move |error, _spawn| {
+                    let message = crate::classify_missing_workspace_spawn_failure(
+                        error,
+                        &spawn_project_root,
+                        format!("failed to spawn opencode acp: {error}"),
+                    );
+                    harness_core::error::HarnessError::AgentExecution(message)
+                }),
+            },
+            req.capability_token.as_ref(),
+        )
+        .await?;
+        let mut child = supervised.child;
+
+        if let Some(stderr) = child.inner_mut().stderr.take() {
+            tokio::spawn(async move {
+                capture_agent_stderr_diagnostics(stderr, "opencode", None).await;
+            });
+        }
+
+        let stdout = child.inner_mut().stdout.take().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(
+                "opencode acp stdout unavailable".into(),
+            )
+        })?;
+        state.stdin = child.inner_mut().stdin.take();
+        state.stdout_lines = Some(BufReader::new(stdout).lines());
+        state.child = Some(child);
+        let stall_timeout = stall_timeout_for(req);
+
+        let init_id = match Self::send_request(
+            state,
+            "initialize",
+            json!({
+                "protocolVersion": 1,
+                "clientInfo": {
+                    "name": "harness",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }),
+        )
+        .await
+        {
+            Ok(id) => id,
+            Err(error) => {
+                state.reset_child().await;
+                return Err(error);
+            }
+        };
+
+        let mut lines = state.stdout_lines.take().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(
+                "opencode stdout reader not available".into(),
+            )
+        })?;
+        let protocol_result = async {
+            loop {
+                match Self::read_next_message_with_timeout(&mut lines, stall_timeout, "initialize")
+                    .await?
+                {
+                    Some(ParsedAcpMessage::Response { id, .. })
+                        if response_id_matches(&id, init_id) =>
+                    {
+                        break;
+                    }
+                    Some(ParsedAcpMessage::Event(AgentEvent::Warning { message })) => {
+                        tracing::warn!(agent = "opencode", "{message}");
+                    }
+                    Some(ParsedAcpMessage::Event(AgentEvent::Error { message })) => {
+                        return Err(harness_core::error::HarnessError::AgentExecution(message));
+                    }
+                    Some(_) => {}
+                    None => {
+                        return Err(harness_core::error::HarnessError::AgentExecution(
+                            "opencode acp exited during initialize".into(),
+                        ));
+                    }
+                }
+            }
+
+            Self::send_notification(state, "notifications/initialized", Value::Null).await?;
+
+            let session_request = Self::send_request(
+                state,
+                "session/new",
+                json!({
+                    "cwd": req.project_root,
+                    "mcpServers": [],
+                    "configOptions": session_config_options(req),
+                }),
+            )
+            .await?;
+
+            loop {
+                match Self::read_next_message_with_timeout(&mut lines, stall_timeout, "session/new")
+                    .await?
+                {
+                    Some(ParsedAcpMessage::Response { id, result })
+                        if response_id_matches(&id, session_request) =>
+                    {
+                        if let Some(session_id) = result.get("sessionId").and_then(Value::as_str) {
+                            state.session_id = Some(session_id.to_string());
+                            break;
+                        }
+                    }
+                    Some(ParsedAcpMessage::Event(AgentEvent::Warning { message })) => {
+                        tracing::warn!(agent = "opencode", "{message}");
+                    }
+                    Some(ParsedAcpMessage::Event(AgentEvent::Error { message })) => {
+                        return Err(harness_core::error::HarnessError::AgentExecution(message));
+                    }
+                    Some(_) => {}
+                    None => {
+                        return Err(harness_core::error::HarnessError::AgentExecution(
+                            "opencode acp exited before session/new completed".into(),
+                        ));
+                    }
+                }
+            }
+            Ok(())
+        }
+        .await;
+
+        match protocol_result {
+            Ok(()) => {
+                state.stdout_lines = Some(lines);
+                Ok(())
+            }
+            Err(error) => {
+                drop(lines);
+                state.reset_child().await;
+                Err(error)
+            }
+        }
+    }
+}
+
+fn session_config_options(req: &TurnRequest) -> Vec<Value> {
+    let mut options = Vec::new();
+    if let Some(model) = req.model.as_deref().filter(|value| !value.is_empty()) {
+        options.push(json!({ "id": "model", "value": model }));
+    }
+    options
+}
+
+#[async_trait]
+impl AgentAdapter for OpenCodeAcpAdapter {
+    fn name(&self) -> &str {
+        "opencode"
+    }
+
+    async fn start_turn(
+        &self,
+        req: TurnRequest,
+        tx: mpsc::Sender<AgentEvent>,
+    ) -> harness_core::error::Result<()> {
+        let req = self.effective_turn_request(req);
+        crate::spawn_supervisor::validate_capability_token(req.capability_token.as_ref())?;
+        let mut state = self.state.lock().await;
+        self.ensure_child(&req, &mut state).await?;
+
+        let session_id = state.session_id.clone().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(
+                "opencode session/new did not yield a session id".into(),
+            )
+        })?;
+
+        if let Err(error) = Self::send_request(
+            &mut state,
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [
+                    {
+                        "type": "text",
+                        "text": req.prompt,
+                    }
+                ],
+            }),
+        )
+        .await
+        {
+            state.reset_child().await;
+            return Err(error);
+        }
+
+        let mut lines = state.stdout_lines.take().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution(
+                "opencode stdout reader not available".into(),
+            )
+        })?;
+        drop(state);
+
+        let mut turn_completed = false;
+        let mut receiver_closed = false;
+        let mut stdout_closed = false;
+        let stall_timeout = stall_timeout_for(&req);
+        let read_result = async {
+            while let Some(message) =
+                Self::read_next_message_with_timeout(&mut lines, stall_timeout, "turn").await?
+            {
+                match message {
+                    ParsedAcpMessage::Response { result, .. } => {
+                        let stop_reason = result.get("stopReason").and_then(Value::as_str);
+                        if stop_reason == Some("cancelled")
+                            && tx
+                                .send(AgentEvent::Error {
+                                    message: "opencode turn cancelled by agent".into(),
+                                })
+                                .await
+                                .is_err()
+                        {
+                            receiver_closed = true;
+                        }
+                        turn_completed = true;
+                        break;
+                    }
+                    ParsedAcpMessage::Ignore => {}
+                    ParsedAcpMessage::Event(event) => {
+                        let is_terminal = matches!(
+                            event,
+                            AgentEvent::TurnCompleted { .. } | AgentEvent::Error { .. }
+                        );
+                        if tx.send(event).await.is_err() {
+                            receiver_closed = true;
+                            break;
+                        }
+                        if is_terminal {
+                            turn_completed = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(error) = read_result {
+            drop(lines);
+            let mut state = self.state.lock().await;
+            state.reset_child().await;
+            return Err(error);
+        }
+        if !turn_completed && !receiver_closed {
+            stdout_closed = true;
+        }
+
+        if stdout_closed {
+            drop(lines);
+            let mut state = self.state.lock().await;
+            state.reset_child().await;
+            return Err(harness_core::error::HarnessError::AgentExecution(
+                "opencode acp stdout closed before turn/completed".into(),
+            ));
+        }
+
+        if receiver_closed {
+            drop(lines);
+            let mut state = self.state.lock().await;
+            state.reset_child().await;
+            return Err(harness_core::error::HarnessError::AgentExecution(
+                "opencode event receiver closed before turn/completed".into(),
+            ));
+        }
+        self.state.lock().await.stdout_lines = Some(lines);
+        Ok(())
+    }
+
+    async fn interrupt(&self) -> harness_core::error::Result<()> {
+        let mut state = self.state.lock().await;
+        let Some(session_id) = state.session_id.clone() else {
+            return Ok(());
+        };
+        Self::send_notification(
+            &mut state,
+            "session/cancel",
+            json!({ "sessionId": session_id }),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn respond_approval(
+        &self,
+        id: String,
+        decision: ApprovalDecision,
+    ) -> harness_core::error::Result<()> {
+        let mut state = self.state.lock().await;
+        let request_id = request_id_from_string(&id);
+        let result = match decision {
+            ApprovalDecision::Accept => json!({ "outcome": "approved" }),
+            ApprovalDecision::Reject { reason } => {
+                json!({ "outcome": "rejected", "reason": reason })
+            }
+        };
+        let payload = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": result,
+        });
+        Self::send_json_line(&mut state, &payload).await
+    }
+}
+
+#[cfg(test)]
+#[path = "opencode_adapter_tests.rs"]
+mod tests;

--- a/crates/harness-agents/src/opencode_adapter_tests.rs
+++ b/crates/harness-agents/src/opencode_adapter_tests.rs
@@ -1,0 +1,151 @@
+use super::*;
+use harness_core::agent::AgentEvent;
+
+#[test]
+fn parse_message_chunk_notification() {
+    let line = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","messageId":"m1","content":{"type":"text","text":"hello"}}}}"#;
+    let message = parse_acp_message(line).unwrap();
+    assert_eq!(
+        message,
+        ParsedAcpMessage::Event(AgentEvent::MessageDelta {
+            text: "hello".into()
+        })
+    );
+}
+
+#[test]
+fn parse_tool_call_notification() {
+    let line = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call","toolCallId":"call_1","title":"bash","kind":"execute","status":"pending"}}}"#;
+    let message = parse_acp_message(line).unwrap();
+    match message {
+        ParsedAcpMessage::Event(AgentEvent::ToolCall { name, input }) => {
+            assert_eq!(name, "bash");
+            assert_eq!(input["toolCallId"], "call_1");
+        }
+        other => panic!("unexpected message: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_tool_call_update_status_transitions() {
+    let in_progress = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call_update","toolCallId":"call_1","status":"in_progress"}}}"#;
+    assert_eq!(
+        parse_acp_message(in_progress).unwrap(),
+        ParsedAcpMessage::Event(AgentEvent::ItemStarted {
+            item_type: "tool_call".into()
+        })
+    );
+
+    let completed = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call_update","toolCallId":"call_1","status":"completed"}}}"#;
+    assert_eq!(
+        parse_acp_message(completed).unwrap(),
+        ParsedAcpMessage::Event(AgentEvent::ItemCompleted)
+    );
+}
+
+#[test]
+fn parse_usage_update_notification() {
+    let line = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"usage_update","used":53000,"size":200000,"cost":{"amount":0.045,"currency":"USD"}}}}"#;
+    let message = parse_acp_message(line).unwrap();
+    match message {
+        ParsedAcpMessage::Event(AgentEvent::TokenUsage { usage }) => {
+            assert_eq!(usage.input_tokens, 53000);
+            assert_eq!(usage.total_tokens, 200000);
+            assert!((usage.cost_usd - 0.045).abs() < f64::EPSILON);
+        }
+        other => panic!("unexpected message: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_permission_request() {
+    let line = r#"{"jsonrpc":"2.0","id":7,"method":"session/request_permission","params":{"sessionId":"s1","prompt":"run git push"}}"#;
+    let message = parse_acp_message(line).unwrap();
+    assert_eq!(
+        message,
+        ParsedAcpMessage::Event(AgentEvent::ApprovalRequest {
+            id: "7".into(),
+            command: "run git push".into()
+        })
+    );
+}
+
+#[test]
+fn parse_response() {
+    let line = r#"{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn","usage":{"inputTokens":100,"outputTokens":5,"totalTokens":105}}}"#;
+    let message = parse_acp_message(line).unwrap();
+    match message {
+        ParsedAcpMessage::Response { id, result } => {
+            assert_eq!(id, 3);
+            assert_eq!(result["stopReason"], "end_turn");
+        }
+        other => panic!("unexpected message: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_error_response() {
+    let line = r#"{"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"Invalid params"}}"#;
+    let message = parse_acp_message(line).unwrap();
+    match message {
+        ParsedAcpMessage::Response { id, result } => {
+            assert_eq!(id, 2);
+            assert_eq!(result["message"], "Invalid params");
+        }
+        other => panic!("unexpected message: {other:?}"),
+    }
+}
+
+#[test]
+fn ignores_unknown_updates_and_garbage() {
+    let unknown = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"available_commands_update","availableCommands":[]}}}"#;
+    assert_eq!(
+        parse_acp_message(unknown).unwrap(),
+        ParsedAcpMessage::Ignore
+    );
+    assert!(parse_acp_message("not json").is_none());
+    assert!(parse_acp_message("").is_none());
+}
+
+#[test]
+fn session_config_options_carry_model() {
+    let mut req = test_turn_request();
+    req.model = Some("anthropic/claude-sonnet-4".into());
+    assert_eq!(
+        session_config_options(&req),
+        vec![json!({ "id": "model", "value": "anthropic/claude-sonnet-4" })]
+    );
+    req.model = None;
+    let empty: Vec<Value> = vec![];
+    assert_eq!(session_config_options(&req), empty);
+}
+
+#[test]
+fn request_id_string_round_trip() {
+    let value = json!(42);
+    let id = request_id_string(&value);
+    assert_eq!(id, "42");
+    assert_eq!(request_id_from_string(&id), value);
+    assert_eq!(
+        request_id_from_string("not-a-number"),
+        Value::String("not-a-number".into())
+    );
+}
+
+fn test_turn_request() -> TurnRequest {
+    TurnRequest {
+        prompt: "ping".to_string(),
+        prompt_layers: None,
+        project_root: PathBuf::from("/tmp"),
+        model: None,
+        reasoning_effort: None,
+        execution_phase: None,
+        sandbox_mode: None,
+        approval_policy: None,
+        allowed_tools: None,
+        context: vec![],
+        timeout_secs: None,
+        env_vars: std::collections::HashMap::new(),
+        capability_token: None,
+    }
+}

--- a/crates/harness-core/src/config/agents.rs
+++ b/crates/harness-core/src/config/agents.rs
@@ -103,6 +103,8 @@ pub struct AgentsConfig {
     pub codex: CodexAgentConfig,
     pub anthropic_api: AnthropicApiConfig,
     #[serde(default)]
+    pub opencode: OpenCodeAgentConfig,
+    #[serde(default)]
     pub review: AgentReviewConfig,
     #[serde(default)]
     pub approval_policy: ApprovalPolicy,
@@ -157,6 +159,7 @@ impl Default for AgentsConfig {
             claude: ClaudeAgentConfig::default(),
             codex: CodexAgentConfig::default(),
             anthropic_api: AnthropicApiConfig::default(),
+            opencode: OpenCodeAgentConfig::default(),
             review: AgentReviewConfig::default(),
             approval_policy: ApprovalPolicy::default(),
             sandbox_mode: SandboxMode::default(),
@@ -746,6 +749,23 @@ pub struct AnthropicApiConfig {
     pub default_model: String,
     #[serde(default = "default_anthropic_api_max_tokens")]
     pub max_tokens: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenCodeAgentConfig {
+    pub cli_path: PathBuf,
+    /// Empty string means "use opencode's own configured default model".
+    #[serde(default)]
+    pub default_model: String,
+}
+
+impl Default for OpenCodeAgentConfig {
+    fn default() -> Self {
+        Self {
+            cli_path: PathBuf::from("opencode"),
+            default_model: String::new(),
+        }
+    }
 }
 
 fn default_anthropic_api_max_tokens() -> u32 {

--- a/crates/harness-server/src/handlers/usage_monitor_active.rs
+++ b/crates/harness-server/src/handlers/usage_monitor_active.rs
@@ -88,6 +88,7 @@ pub(super) fn runtime_kind(kind: RuntimeKind) -> &'static str {
         RuntimeKind::CodexJsonrpc => "codex_jsonrpc",
         RuntimeKind::ClaudeCode => "claude_code",
         RuntimeKind::AnthropicApi => "anthropic_api",
+        RuntimeKind::OpenCode => "opencode",
         RuntimeKind::RemoteHost => "remote_host",
     }
 }

--- a/crates/harness-server/src/http/background/runtime_profiles.rs
+++ b/crates/harness-server/src/http/background/runtime_profiles.rs
@@ -7,6 +7,7 @@ fn runtime_kind_from_config(value: &str) -> Option<RuntimeKind> {
         "claude_code" => Some(RuntimeKind::ClaudeCode),
         "anthropic_api" => Some(RuntimeKind::AnthropicApi),
         "remote_host" => Some(RuntimeKind::RemoteHost),
+        "opencode" => Some(RuntimeKind::OpenCode),
         _ => None,
     }
 }
@@ -32,6 +33,13 @@ fn runtime_profile_from_kind(
             profile.model = Some(config.agents.anthropic_api.default_model.clone());
             profile
         }
+        RuntimeKind::OpenCode => {
+            let mut profile = RuntimeProfile::new("opencode-default", kind);
+            if !config.agents.opencode.default_model.is_empty() {
+                profile.model = Some(config.agents.opencode.default_model.clone());
+            }
+            profile
+        }
         RuntimeKind::RemoteHost => RuntimeProfile::new("remote-host-default", kind),
     }
 }
@@ -44,6 +52,7 @@ pub(super) fn runtime_profile_from_agent(
         "codex" => Some(runtime_profile_from_kind(config, RuntimeKind::CodexJsonrpc)),
         "claude" => Some(runtime_profile_from_kind(config, RuntimeKind::ClaudeCode)),
         "anthropic-api" => Some(runtime_profile_from_kind(config, RuntimeKind::AnthropicApi)),
+        "opencode" => Some(runtime_profile_from_kind(config, RuntimeKind::OpenCode)),
         _ => None,
     }
 }

--- a/crates/harness-server/src/workflow_runtime_worker/runtime_profile.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/runtime_profile.rs
@@ -11,6 +11,7 @@ pub(super) fn agent_name_for_runtime_kind(kind: RuntimeKind) -> anyhow::Result<&
         RuntimeKind::CodexExec | RuntimeKind::CodexJsonrpc => Ok("codex"),
         RuntimeKind::ClaudeCode => Ok("claude"),
         RuntimeKind::AnthropicApi => Ok("anthropic-api"),
+        RuntimeKind::OpenCode => Ok("opencode"),
         RuntimeKind::RemoteHost => {
             anyhow::bail!("remote_host runtime jobs must be claimed by an external runtime host")
         }
@@ -146,6 +147,16 @@ fn resolve_model(
             _ => agents.claude.default_model.clone(),
         }),
         RuntimeKind::AnthropicApi => Ok(agents.anthropic_api.default_model.clone()),
+        RuntimeKind::OpenCode => {
+            let model = agents.opencode.default_model.clone();
+            if model.is_empty() {
+                // OpenCode resolves its own default model when none is
+                // configured; record the agent name as the audit placeholder.
+                Ok("opencode".to_string())
+            } else {
+                Ok(model)
+            }
+        }
         RuntimeKind::RemoteHost => {
             anyhow::bail!("remote_host runtime jobs are not resolved by this server")
         }
@@ -168,8 +179,9 @@ fn resolve_reasoning_effort(
             .clone()
             .or_else(|| execution_phase.map(|phase| phase.effort_level().to_string())),
         // The Anthropic API runtime has no reasoning-effort contract, so no
-        // effort value is recorded for it.
-        RuntimeKind::AnthropicApi | RuntimeKind::RemoteHost => None,
+        // effort value is recorded for it. OpenCode's ACP v1 has no
+        // reasoning-effort option either.
+        RuntimeKind::AnthropicApi | RuntimeKind::OpenCode | RuntimeKind::RemoteHost => None,
     }
 }
 
@@ -206,9 +218,10 @@ fn resolve_approval_policy(
             RuntimeKind::CodexExec | RuntimeKind::CodexJsonrpc => {
                 ResolvedApprovalPolicy::UnobservedAgentDefault
             }
-            RuntimeKind::ClaudeCode | RuntimeKind::AnthropicApi | RuntimeKind::RemoteHost => {
-                ResolvedApprovalPolicy::NotApplicable
-            }
+            RuntimeKind::ClaudeCode
+            | RuntimeKind::AnthropicApi
+            | RuntimeKind::OpenCode
+            | RuntimeKind::RemoteHost => ResolvedApprovalPolicy::NotApplicable,
         }),
     }
 }

--- a/crates/harness-workflow/src/runtime/model.rs
+++ b/crates/harness-workflow/src/runtime/model.rs
@@ -461,6 +461,7 @@ pub enum RuntimeKind {
     ClaudeCode,
     AnthropicApi,
     RemoteHost,
+    OpenCode,
 }
 
 impl RuntimeKind {
@@ -471,6 +472,7 @@ impl RuntimeKind {
             Self::ClaudeCode => "claude_code",
             Self::AnthropicApi => "anthropic_api",
             Self::RemoteHost => "remote_host",
+            Self::OpenCode => "opencode",
         }
     }
 }

--- a/docs/opencode-acp-reference.md
+++ b/docs/opencode-acp-reference.md
@@ -63,10 +63,16 @@ Exit code from the process; stdout is a JSONL stream of these events.
 | `usage_update` | `TokenUsage` (input=used, total=size, cost) |
 | `available_commands_update` | ignored |
 
+Note: `usage_update.used`/`size` are the session's current context usage and
+limit, not per-turn consumption — recorded as `input_tokens`/`total_tokens`
+for observability only, not for billing-level accuracy.
+
 Permissions arrive as a `session/request_permission` **JSON-RPC request**
 (the client must respond with its id). Harness surfaces it as
-`AgentEvent::ApprovalRequest` (id = request id as string, command = prompt)
-and responds `{"outcome":"approved"}` / `{"outcome":"rejected","reason":...}`.
+`AgentEvent::ApprovalRequest` (id = request id as string, command = the
+request's `prompt` field — best-effort, the exact field was not exercised in
+the probe environment) and responds `{"outcome":"approved"}` /
+`{"outcome":"rejected","reason":...}`.
 
 Cancellation: `session/cancel` notification; the agent then answers the
 pending `session/prompt` with `stopReason: "cancelled"`.

--- a/docs/opencode-acp-reference.md
+++ b/docs/opencode-acp-reference.md
@@ -1,0 +1,96 @@
+# OpenCode ACP Reference
+
+> Verified against `opencode 1.18.14` (2026-08-06) unless noted.
+
+OpenCode integration reference for the `opencode` runtime kind. Two surfaces
+are wired:
+
+- **Exec backend** (`OpenCodeAgent`): `opencode run --format json` — used by
+  `harness exec --agent opencode` and the legacy `CodeAgent` path.
+- **ACP adapter** (`OpenCodeAcpAdapter`): `opencode acp` — JSON-RPC over stdio
+  implementing the stable Agent Client Protocol v1; used by the workflow
+  runtime for streaming turns with approval and cancellation.
+
+## Configuration
+
+```toml
+[agents.opencode]
+cli_path = "opencode"          # or an absolute path
+default_model = ""             # empty = opencode's own configured default
+```
+
+`default_model` accepts any `provider/model` identifier opencode knows
+(e.g. `anthropic/claude-sonnet-4`, `openai/gpt-5.4`).
+
+Dispatch via `runtime_kind: "opencode"` in workflow runtime dispatch policy,
+or `agent: "opencode"` in prompt execution policies.
+
+## `opencode run --format json` event schema
+
+| type | part | mapping |
+|---|---|---|
+| `step_start` | — | ignored |
+| `text` | `text` | `StreamItem::MessageDelta` / response output |
+| `tool_use` | `state.input.command`, `state.output` | `Item::ShellCommand` |
+| `step_finish` | `reason`, `tokens{input,output,total}`, `cost` | `TokenUsage`; `reason != "stop"` is an error |
+
+Exit code from the process; stdout is a JSONL stream of these events.
+
+## `opencode acp` handshake (ACP v1)
+
+1. Client -> `initialize` with **`protocolVersion: 1`** (number) and
+   `clientInfo`. Omitting `protocolVersion` returns `-32602 Invalid params`.
+2. Client -> `notifications/initialized`.
+3. Client -> `session/new` with **`cwd`** and **`mcpServers: []`** (array).
+   Omitting `mcpServers` returns `-32602`. Response `sessionId` +
+   `configOptions`. Pin the model with
+   `configOptions: [{"id":"model","value":"provider/model"}]`.
+4. Client -> `session/prompt` (`sessionId` + `prompt` text blocks).
+   Agent streams `session/update` notifications; the turn ends when the
+   original `session/prompt` request receives its response
+   (`stopReason`: `end_turn`, `cancelled`, `refusal`, `max_tokens`,
+   `max_turn_requests`).
+
+## Event mapping (session/update -> AgentEvent)
+
+| sessionUpdate | AgentEvent |
+|---|---|
+| `agent_message_chunk` | `MessageDelta` |
+| `agent_thought_chunk` | ignored |
+| `tool_call` | `ToolCall` (name=title, input=toolCallId) |
+| `tool_call_update` (`in_progress`) | `ItemStarted` |
+| `tool_call_update` (`completed`/`error`) | `ItemCompleted` |
+| `usage_update` | `TokenUsage` (input=used, total=size, cost) |
+| `available_commands_update` | ignored |
+
+Permissions arrive as a `session/request_permission` **JSON-RPC request**
+(the client must respond with its id). Harness surfaces it as
+`AgentEvent::ApprovalRequest` (id = request id as string, command = prompt)
+and responds `{"outcome":"approved"}` / `{"outcome":"rejected","reason":...}`.
+
+Cancellation: `session/cancel` notification; the agent then answers the
+pending `session/prompt` with `stopReason: "cancelled"`.
+
+## Capabilities and limitations
+
+- `steer` is unsupported (ACP v1 has no steer method) — the adapter returns
+  `Unsupported`.
+- `reasoning_effort` is not mapped (no ACP v1 option); opencode model variants
+  can be selected via the model id.
+- Approval policy (`approval_policy` in runtime profiles) is rejected for
+  `opencode`, matching the Claude/Anthropic policy contract.
+- exec backend maps `allowed_tools` to the `OPENCODE_PERMISSION` env var
+  (inlined JSON, e.g. `{"bash":"allow"}`); an empty list maps to
+  `{"*":"deny"}`. No allowlist (`None`) maps to `--auto`.
+
+## Platform notes
+
+- **macOS seatbelt**: the OpenCode binary (Bun runtime) crashes with
+  `SIGTRAP` during startup under the Seatbelt `workspace-write` sandbox,
+  matching Claude Code's behavior. Use
+  `--sandbox-mode danger-full-access` on macOS, or rely on Linux
+  landlock/bubblewrap which work with the default sandbox.
+- OpenCode reads `OPENCODE` / `OPENCODE_PID` environment variables as nested
+  session markers. When Harness itself runs inside an OpenCode session, the
+  child OpenCode inherits them; this is harmless for `opencode run` /
+  `opencode acp` and does not need stripping.

--- a/docs/opencode-acp-runtime-spec.md
+++ b/docs/opencode-acp-runtime-spec.md
@@ -1,0 +1,197 @@
+# OpenCode ACP Runtime Integration Spec
+
+- Status: Proposed
+- Date: 2026-08-06
+- Scope: workflow runtime + agents + config
+- Related: GH-1876
+
+## 1. Problem
+
+Harness supports `CodexExec`, `CodexJsonrpc`, `ClaudeCode`, `AnthropicApi`, and
+`RemoteHost` runtimes. OpenCode (a provider-agnostic coding agent with broad
+model support) is not available, so workflows cannot route turns to OpenCode
+with full streaming, interrupt, steer, and approval semantics.
+
+OpenCode 1.18 ships `opencode acp`, a stable **Agent Client Protocol (ACP)**
+server speaking JSON-RPC over stdio — the same transport shape as `codex
+app-server`, which Harness already integrates. This spec adds an OpenCode
+runtime through an ACP adapter plus an exec-mode backend for CLI use.
+
+## 2. Goals
+
+- New `RuntimeKind::OpenCode` (`"opencode"`) routable in workflow runtime and
+  project configs.
+- `OpenCodeAcpAdapter` implementing `AgentAdapter` (start_turn / interrupt /
+  respond_approval) over ACP v1, with parity to `CodexAdapter` lifecycle
+  (spawn, initialize, stall timeout, reset on failure).
+- `OpenCodeExecAgent` implementing `CodeAgent` over `opencode run --format
+  json` so `harness exec --agent opencode` works without the server.
+- Config section `[agents.opencode]` (cli_path, default_model).
+- Protocol behavior pinned by a reference doc.
+
+Non-goals: RemoteHost-style integration with `opencode serve` (private HTTP
+protocol mismatch), ACP v2 (draft), steer (ACP v1 has no steer method),
+reasoning-effort mapping (no ACP v1 equivalent).
+
+## 3. Verified Protocol Facts
+
+Empirically probed against `opencode 1.18.14` on 2026-08-06:
+
+- `initialize` **requires** `protocolVersion: 1` (number). Response carries
+  `agentCapabilities` (loadSession, mcpCapabilities, promptCapabilities,
+  sessionCapabilities).
+- After initialize, client sends `notifications/initialized`.
+- `session/new` **requires** `cwd` and `mcpServers: []` (array). Returns
+  `sessionId` and `configOptions` (model select etc.). Model can be pinned via
+  `configOptions: [{"id":"model","value":"provider/model"}]`.
+- `session/prompt` (id + sessionId + prompt text blocks) streams
+  `session/update` notifications:
+  - `agent_message_chunk` -> text delta
+  - `agent_thought_chunk` -> thinking (ignore)
+  - `tool_call` (toolCallId/title/kind/status) and `tool_call_update`
+    (in_progress/completed)
+  - `usage_update` (used/size/cost)
+  - `available_commands_update` (ignore)
+- Turn ends with the `session/prompt` **response**: `stopReason` (`end_turn`,
+  `cancelled`, `refusal`, ...) plus `usage` counters.
+- Permissions arrive as a `session/request_permission` JSON-RPC **request**
+  (client must respond with id + result). Observed response
+  `{"outcome":"approved"}` is accepted by the agent.
+- Cancellation is a `session/cancel` notification (documented; not probed).
+
+## 4. Design
+
+### 4.1 RuntimeKind
+
+`crates/harness-workflow/src/runtime/model.rs`:
+
+```rust
+pub enum RuntimeKind {
+    CodexExec,
+    CodexJsonrpc,
+    ClaudeCode,
+    AnthropicApi,
+    RemoteHost,
+    OpenCode, // new; as_str() -> "opencode"
+}
+```
+
+### 4.2 Config
+
+`crates/harness-core/src/config/agents.rs`:
+
+```rust
+pub struct OpenCodeAgentConfig {
+    pub cli_path: PathBuf,       // default "opencode"
+    pub default_model: String,   // default "" (use opencode's own config)
+}
+```
+
+`AgentsConfig` gains `pub opencode: OpenCodeAgentConfig` (required field,
+matching claude/codex/anthropic_api style).
+
+### 4.3 OpenCodeExecAgent (CodeAgent)
+
+`crates/harness-agents/src/opencode.rs`, modeled on `codex.rs`:
+
+- Spawn `opencode run --format json [--model <m>] <prompt>` in the project dir
+  through `spawn_contract::prepare_agent_spawn` + `spawn_supervisor`.
+- Parse nd-JSON event lines; reuse `parse_codex_token_usage`-style mapping for
+  usage events; collect message deltas into the final output.
+- `--auto` only when `uses_dangerously_skip_permissions()` (mirrors codex).
+- Registered as `"opencode"` backend so the ACP adapter can attach.
+
+### 4.4 OpenCodeAcpAdapter (AgentAdapter)
+
+`crates/harness-agents/src/opencode_adapter.rs`, modeled on `codex_adapter.rs`
+(no protocol.rs split — parse functions live in the same file):
+
+- State: child, stdin, stdout lines, next_id, session_id, active_request_id.
+- Spawn: `opencode acp --cwd <workspace>` via
+  `spawn_contract::prepare_agent_spawn` (forward_stdin: true), same sandbox and
+  supervisor wiring as `CodexAdapter::ensure_child`.
+- Handshake: `initialize` (protocolVersion 1, clientInfo harness/<version>) ->
+  wait for matching response -> `notifications/initialized` -> `session/new`
+  (cwd, `mcpServers: []`, configOptions model when set) -> capture sessionId.
+- `start_turn`: effective request (model default), ensure child, send
+  `session/prompt`, stream events:
+  - `agent_message_chunk` -> `AgentEvent::MessageDelta`
+  - `tool_call` -> `AgentEvent::ToolCall { name: title, input: {toolCallId,
+    kind} }`; `tool_call_update` status transitions map to
+    `ItemStarted`/`ItemCompleted` on in_progress/completed
+  - `usage_update` -> `AgentEvent::TokenUsage` (input = used, total = size)
+  - `session/request_permission` (a request, not notification) -> send
+    `AgentEvent::ApprovalRequest { id: <request id as string>, command: title
+    or prompt }`, remember pending response id; do NOT answer until
+    `respond_approval`
+  - matching `session/prompt` response -> `AgentEvent::TurnCompleted { output:
+    accumulated text }`
+  - unknown updates ignored; stall timeout applies per read like codex.
+- `interrupt`: send `session/cancel` notification for the session.
+- `steer`: return `Unsupported` (ACP v1 has no steer).
+- `respond_approval`: reply to the remembered request id with
+  `{"outcome":"approved"}` / `{"outcome":"rejected","reason":...}`.
+- `name()` -> "opencode".
+
+Approval id collision risk: ids are JSON-RPC numeric request ids; harness
+`ApprovalRequest.id` is a String. Use `request_id_string()` (numeric to string)
+and parse back — same approach as `CodexAdapter::respond_approval`.
+
+### 4.5 Closed-set match sites (must all update)
+
+| Site | Change |
+|---|---|
+| `runtime/model.rs:458` enum + `as_str` | add variant |
+| `harness-server/src/workflow_runtime_worker/runtime_profile.rs:9` `agent_name_for_runtime_kind` | `=> Ok("opencode")` |
+| same file `resolve_model` (:140) | `agents.opencode.default_model` |
+| same file `resolve_reasoning_effort` (:161) | `None` (no ACP equivalent) |
+| same file approval resolution (:190) | explicit policy rejected, like AnthropicApi/RemoteHost |
+| `harness-server/src/http/background/runtime_profiles.rs` `runtime_kind_from_config` (:3) | `"opencode" => Some(RuntimeKind::OpenCode)` |
+| same file `runtime_profile_from_kind` (:14) | `opencode-default` profile with model |
+| same file `runtime_profile_from_agent` (:39) | `"opencode" => ...` |
+| `harness-server/src/handlers/usage_monitor_active.rs:90` | `RuntimeKind::OpenCode => "opencode"` |
+| `harness-agents/src/builder.rs` `registry_from_config` | register `opencode` backend + adapter factory (ExecuteTurns) |
+| `harness-core/src/config/agents.rs` | `AgentsConfig` + `OpenCodeAgentConfig` |
+
+`runtime_kinds_share_agent` needs no special case (`left == right` covers it).
+
+### 4.6 Reference doc
+
+`docs/opencode-acp-reference.md`: protocol handshake, event schema table, known
+behavior of `opencode acp` 1.18.14, and divergence notes from the probe.
+
+## 5. Affected Files
+
+- `crates/harness-workflow/src/runtime/model.rs`
+- `crates/harness-core/src/config/agents.rs`
+- `crates/harness-agents/src/opencode.rs` (new)
+- `crates/harness-agents/src/opencode_adapter.rs` (new)
+- `crates/harness-agents/src/opencode_adapter_tests.rs` (new)
+- `crates/harness-agents/src/lib.rs` (module exports)
+- `crates/harness-agents/src/builder.rs`
+- `crates/harness-server/src/workflow_runtime_worker/runtime_profile.rs`
+- `crates/harness-server/src/http/background/runtime_profiles.rs`
+- `crates/harness-server/src/handlers/usage_monitor_active.rs`
+- `docs/opencode-acp-reference.md` (new)
+- `harness.toml.example` (document `[agents.opencode]`)
+
+## 6. Verification
+
+- `cargo check -p harness-agents --all-targets`
+- `cargo test -p harness-agents` (adapter parser + builder registry tests)
+- `cargo test -p harness-workflow runtime::model` (enum round-trip)
+- `cargo check --workspace --all-targets`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- Manual: `harness exec --agent opencode "..."` and a workflow runtime
+  submission pinned to `runtime_kind: "opencode"` against `opencode acp`.
+
+## 7. Risks / Open Questions
+
+- `session/request_permission` params schema varies by implementation; probe
+  showed no permission request in a permissive environment. Command text for
+  `ApprovalRequest` may be a best-effort title. (low)
+- `opencode acp` cold boot includes provider/model list fetch; first `session/prompt` may be slow. Stall timeout is on lines, so safe. (low)
+- `opencode run` exec backend output format must be pinned in the reference doc
+  during implementation (probe pending). (medium, implementation-time)
+- If `opencode` binary is missing, spawn failure must classify like codex
+  (`classify_missing_workspace_spawn_failure`). (low)


### PR DESCRIPTION
Closes GH-1876

## Summary

Adds OpenCode as a first-class workflow runtime and exec backend, following the same JSON-RPC-over-stdio integration pattern as `codex app-server`.

- `RuntimeKind::OpenCode` (`"opencode"`) wired through all closed-set match sites
- `OpenCodeAcpAdapter`: ACP v1 (Agent Client Protocol) — initialize / session/new / session/prompt, streaming `agent_message_chunk` / `tool_call` / `usage_update` events, `session/request_permission` approvals, `session/cancel` interrupt, stall-timeout and child-reset parity with CodexAdapter
- `OpenCodeExecAgent`: `opencode run --format json` backend for `harness exec --agent opencode`
- `[agents.opencode]` config (cli_path, default_model)
- `docs/opencode-acp-reference.md` with empirically verified protocol behavior (opencode 1.18.14)

## Verified

- Unit tests: ACP message parsing, exec event parsing, permission env mapping (15 new tests)
- Live round trips: `harness exec --agent opencode` and ACP adapter start_turn against opencode 1.18.14
- `cargo fmt` / workspace check / `cargo clippy -- -D warnings` clean
- PostgreSQL-dependent workflow tests deferred (need HARNESS_DATABASE_URL)

## Notes

- macOS seatbelt: OpenCode (Bun binary) crashes with SIGTRAP under workspace-write, same as Claude Code — documented, use danger-full-access
- steer unsupported (ACP v1 has no steer); reasoning-effort not mapped
- Full spec: docs/opencode-acp-runtime-spec.md