### PR TITLE
feat(workflow): dead-letter lease-expired activity completions

### DIFF
--- a/crates/harness-workflow/src/runtime/store/activity_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/activity_completion.rs
@@ -1,4 +1,5 @@
 use super::*;
+use uuid::Uuid;
 
 impl WorkflowRuntimeStore {
     pub async fn complete_runtime_job_if_owned(
@@ -375,5 +376,50 @@ fn command_status_for_activity(status: ActivityStatus) -> WorkflowCommandStatus 
         ActivityStatus::Failed => WorkflowCommandStatus::Failed,
         ActivityStatus::Blocked => WorkflowCommandStatus::Blocked,
         ActivityStatus::Cancelled => WorkflowCommandStatus::Cancelled,
+    }
+}
+
+impl WorkflowRuntimeStore {
+    /// Durably record a completed activity result that the worker can no
+    /// longer commit because its job lease expired or was reclaimed
+    /// (GH-1878). The payload — result plus optional transcript — lands in
+    /// `runtime_job_completions_dlq` instead of being dropped, so no finished
+    /// agent work vanishes silently; reconciliation can decide later whether
+    /// the result is still applicable or the job must re-run.
+    pub async fn record_lease_expired_completion(
+        &self,
+        runtime_job_id: &str,
+        owner: &str,
+        lease_expires_at: DateTime<Utc>,
+        result: &ActivityResult,
+        transcript: Option<&crate::runtime::transcript::PendingRuntimeTranscript>,
+    ) -> anyhow::Result<()> {
+        let transcript_json = transcript
+            .map(|pending| serde_json::to_value(&pending.record))
+            .transpose()?;
+        sqlx::query(
+            "INSERT INTO runtime_job_completions_dlq
+                (id, runtime_job_id, owner, lease_expires_at, result, transcript)
+             VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(runtime_job_id)
+        .bind(owner)
+        .bind(lease_expires_at)
+        .bind(serde_json::to_value(result)?)
+        .bind(transcript_json)
+        .execute(&self.pool)
+        .await?;
+        self.record_runtime_event(
+            runtime_job_id,
+            "LeaseExpiredCompletionRecorded",
+            serde_json::json!({
+                "owner": owner,
+                "lease_expires_at": lease_expires_at,
+                "applied": false,
+            }),
+        )
+        .await?;
+        Ok(())
     }
 }

--- a/crates/harness-workflow/src/runtime/store/activity_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/activity_completion.rs
@@ -1,5 +1,4 @@
 use super::*;
-use uuid::Uuid;
 
 impl WorkflowRuntimeStore {
     pub async fn complete_runtime_job_if_owned(
@@ -397,19 +396,27 @@ impl WorkflowRuntimeStore {
         let transcript_json = transcript
             .map(|pending| serde_json::to_value(&pending.record))
             .transpose()?;
-        sqlx::query(
+        // The DLQ holds at most one record per job (id = runtime_job_id):
+        // a later re-expiry of the same job keeps the first record, which
+        // represents the same turn's final result, and reconciliation sees
+        // exactly one pending decision per job.
+        let inserted = sqlx::query(
             "INSERT INTO runtime_job_completions_dlq
                 (id, runtime_job_id, owner, lease_expires_at, result, transcript)
-             VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb)",
+             VALUES ($1, $1, $2, $3, $4::jsonb, $5::jsonb)
+             ON CONFLICT (id) DO NOTHING",
         )
-        .bind(Uuid::new_v4().to_string())
         .bind(runtime_job_id)
         .bind(owner)
         .bind(lease_expires_at)
         .bind(serde_json::to_value(result)?)
         .bind(transcript_json)
         .execute(&self.pool)
-        .await?;
+        .await?
+        .rows_affected();
+        if inserted == 0 {
+            return Ok(());
+        }
         self.record_runtime_event(
             runtime_job_id,
             "LeaseExpiredCompletionRecorded",

--- a/crates/harness-workflow/src/runtime/store_migrations.rs
+++ b/crates/harness-workflow/src/runtime/store_migrations.rs
@@ -625,4 +625,22 @@ pub(super) static WORKFLOW_RUNTIME_MIGRATIONS: &[Migration] = &[
               CREATE INDEX IF NOT EXISTS idx_runtime_usage_events_agent_run
               ON runtime_usage_events (agent_run_id)",
     },
+    Migration {
+        version: 26,
+        description: "dead-letter completed activity results rejected by lease ownership",
+        sql: "CREATE TABLE IF NOT EXISTS runtime_job_completions_dlq (
+                id TEXT PRIMARY KEY,
+                runtime_job_id TEXT NOT NULL,
+                owner TEXT NOT NULL,
+                lease_expires_at TIMESTAMPTZ NOT NULL,
+                result JSONB NOT NULL,
+                transcript JSONB,
+                recorded_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                applied BOOLEAN NOT NULL DEFAULT FALSE
+              );
+              CREATE INDEX IF NOT EXISTS idx_runtime_job_completions_dlq_job
+              ON runtime_job_completions_dlq (runtime_job_id);
+              CREATE INDEX IF NOT EXISTS idx_runtime_job_completions_dlq_unapplied
+              ON runtime_job_completions_dlq (applied, recorded_at)",
+    },
 ];

--- a/crates/harness-workflow/src/runtime/tests/runtime_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_store.rs
@@ -815,3 +815,85 @@ async fn dedupe_uses_runtime_job_timestamps_not_uuid_order() -> anyhow::Result<(
     }
     Ok(())
 }
+
+#[tokio::test]
+async fn lease_expired_completion_is_recorded_to_dead_letter() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let job = enqueue_test_runtime_job(
+        &store,
+        "command-dlq",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "check" }),
+    )
+    .await?;
+
+    let first_claim = store
+        .claim_next_runtime_job("worker-a", Utc::now() + Duration::minutes(5))
+        .await?
+        .expect("runtime job should be claimable");
+    let first_lease_expires_at = first_claim
+        .lease
+        .as_ref()
+        .expect("lease should exist")
+        .expires_at;
+
+    let result = ActivityResult::succeeded("check", "Completed work from a stale lease.");
+    store
+        .record_lease_expired_completion(
+            &first_claim.id,
+            "worker-a",
+            first_lease_expires_at,
+            &result,
+            None,
+        )
+        .await?;
+
+    let (dlq_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM runtime_job_completions_dlq WHERE runtime_job_id = $1",
+    )
+    .bind(&first_claim.id)
+    .fetch_one(store.pool())
+    .await?;
+    assert_eq!(
+        dlq_count, 1,
+        "lease-expired completion must be durable in the DLQ"
+    );
+
+    let (result_payload, applied): (serde_json::Value, bool) = sqlx::query_as(
+        "SELECT result, applied FROM runtime_job_completions_dlq WHERE runtime_job_id = $1",
+    )
+    .bind(&first_claim.id)
+    .fetch_one(store.pool())
+    .await?;
+    assert_eq!(
+        result_payload["summary"],
+        "Completed work from a stale lease."
+    );
+    assert!(!applied, "DLQ record must start unapplied");
+
+    let (event_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM runtime_events
+         WHERE runtime_job_id = $1 AND event_type = 'LeaseExpiredCompletionRecorded'",
+    )
+    .bind(&first_claim.id)
+    .fetch_one(store.pool())
+    .await?;
+    assert_eq!(
+        event_count, 1,
+        "DLQ recording must be surfaced as a runtime event"
+    );
+
+    let job_now = store.get_runtime_job(&job.id).await?.expect("job exists");
+    assert_eq!(
+        job_now.status,
+        RuntimeJobStatus::Running,
+        "job must remain reclaimable"
+    );
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/tests/runtime_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/runtime_store.rs
@@ -895,5 +895,95 @@ async fn lease_expired_completion_is_recorded_to_dead_letter() -> anyhow::Result
         RuntimeJobStatus::Running,
         "job must remain reclaimable"
     );
+
+    // A later re-expiry of the same job must not duplicate the DLQ record.
+    store
+        .record_lease_expired_completion(
+            &first_claim.id,
+            "worker-a",
+            first_lease_expires_at,
+            &result,
+            None,
+        )
+        .await?;
+    let (dlq_count_after,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM runtime_job_completions_dlq WHERE runtime_job_id = $1",
+    )
+    .bind(&first_claim.id)
+    .fetch_one(store.pool())
+    .await?;
+    assert_eq!(dlq_count_after, 1, "DLQ must keep one record per job");
+    Ok(())
+}
+
+#[tokio::test]
+async fn lease_expired_completion_persists_transcript_payload() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let workflow =
+        crate::runtime::tests::issue_instance("implementing").with_id("dlq-transcript-workflow");
+    store
+        .force_upsert_lifecycle_state_for_test(&workflow)
+        .await?;
+    let command = WorkflowCommand::enqueue_activity("implement_issue", "command-dlq-transcript");
+    let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+    store
+        .enqueue_runtime_job(
+            &command_id,
+            RuntimeKind::CodexExec,
+            "codex-default",
+            json!({
+                "workflow_id": workflow.id,
+                "activity": "implement_issue",
+                "command": {"activity": "implement_issue"},
+            }),
+        )
+        .await?;
+    let lease_expires_at = Utc::now() + Duration::minutes(5);
+    let claimed = store
+        .claim_next_runtime_job("worker-a", lease_expires_at)
+        .await?
+        .expect("runtime job should be claimable");
+
+    let result = ActivityResult::succeeded("implement_issue", "opened pull request").with_artifact(
+        ActivityArtifact::new(
+            crate::runtime::transcript::RUNTIME_TRANSCRIPT_SOURCE_ARTIFACT,
+            json!({
+                "content": "{\"messages\":[]}",
+                "content_format": "harness.turn.v1+json",
+                "turn_id": "dlq-turn-1",
+            }),
+        ),
+    );
+    let (result, pending) =
+        crate::runtime::transcript::prepare_runtime_transcript(&claimed, result)?;
+
+    store
+        .record_lease_expired_completion(
+            &claimed.id,
+            "worker-a",
+            lease_expires_at,
+            &result,
+            pending.as_ref(),
+        )
+        .await?;
+
+    let (transcript_json,): (Option<serde_json::Value>,) = sqlx::query_as(
+        "SELECT transcript FROM runtime_job_completions_dlq WHERE runtime_job_id = $1",
+    )
+    .bind(&claimed.id)
+    .fetch_one(store.pool())
+    .await?;
+    let transcript = transcript_json.expect("transcript must be persisted in the DLQ");
+    assert_eq!(transcript["schema"], "harness.runtime.transcript.v1");
+    assert_eq!(
+        transcript["reference"]["producer_runtime_job_id"],
+        claimed.id
+    );
+    assert_eq!(transcript["workflow_id"], "dlq-transcript-workflow");
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -168,10 +168,31 @@ impl<'a> RuntimeWorker<'a> {
             )
             .await?
         else {
+            // The lease was lost mid-turn. The completed work must not
+            // vanish: persist it to the dead-letter table so reconciliation
+            // can decide whether it still applies (GH-1878).
+            if let Err(dlq_error) = self
+                .store
+                .record_lease_expired_completion(
+                    &job.id,
+                    &self.owner,
+                    lease_expires_at,
+                    &result,
+                    transcript.as_ref(),
+                )
+                .await
+            {
+                tracing::error!(
+                    runtime_job_id = %job.id,
+                    owner = %self.owner,
+                    error = %dlq_error,
+                    "failed to record lease-expired completion to dead-letter"
+                );
+            }
             tracing::warn!(
                 runtime_job_id = %job.id,
                 owner = %self.owner,
-                "runtime job completion ignored because the worker no longer owns the lease"
+                "runtime job completion rejected because the worker no longer owns the lease; recorded to dead-letter"
             );
             return Ok(None);
         };


### PR DESCRIPTION
Closes GH-1878

## Summary

When a worker's job lease expired mid-turn, `commit_runtime_activity_completion_with_transcript_if_owned` returned `None` and the worker dropped the completed result — a full successful turn with artifacts could vanish with no durable record, no retry signal, and no operator visibility.

- New `runtime_job_completions_dlq` table (store migration v26): `runtime_job_id`, `owner`, `lease_expires_at`, `result` (JSONB), `transcript` (JSONB), `recorded_at`, `applied`
- `record_lease_expired_completion` store method persists the rejected payload and emits a `LeaseExpiredCompletionRecorded` runtime event (operator-visible)
- Local worker now records to the DLQ instead of silently dropping; the job stays running and reclaimable, so dispatch behavior is unchanged
- Remote-host path already surfaced lease rejection as 409 to the caller — untouched

## Verified

- New DB test: DLQ row durable + unapplied, runtime event emitted, job remains reclaimable
- Full harness-workflow DB suite: 649 pass (local Postgres)
- `cargo fmt` / workspace check / `cargo clippy -- -D warnings` clean

## Notes

Reconciliation that decides apply-vs-rerun is deliberately out of scope — it needs the ownership-epoch work of GH-1877 to be safe.