### PR TITLE
fix(workflow): cancel agent and release workspace when job lease is lost

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -48,20 +48,22 @@ use structured_output::{
 };
 pub(super) struct ServerRuntimeJobExecutor<'a> {
     pub(super) state: &'a Arc<AppState>,
-    /// Fired when the owning runtime job lease is lost mid-turn so the turn
-    /// loop interrupts the agent and the workspace cleanup can run (GH-1877).
-    lease_lost: Arc<tokio::sync::Notify>,
+    /// Stateful lease-lost signal: `watch` keeps the latest value, so a
+    /// cancellation that fires before the turn loop starts polling is not
+    /// lost (GH-1877).
+    lease_lost: Arc<tokio::sync::watch::Sender<bool>>,
 }
 impl<'a> ServerRuntimeJobExecutor<'a> {
     pub(super) fn new(state: &'a Arc<AppState>) -> Self {
+        let (lease_lost, _) = tokio::sync::watch::channel(false);
         Self {
             state,
-            lease_lost: Arc::new(tokio::sync::Notify::new()),
+            lease_lost: Arc::new(lease_lost),
         }
     }
 
     pub(super) fn cancel_lease_lost(&self) {
-        self.lease_lost.notify_waiters();
+        let _ = self.lease_lost.send(true);
     }
 
     pub(super) async fn execute_inner(&self, job: RuntimeJob) -> anyhow::Result<ActivityResult> {
@@ -235,7 +237,7 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                         },
                         timeout_secs: Some(resolved_settings.timeout_secs),
                         stall_timeout_secs: Some(resolved_settings.stall_timeout_secs),
-                        lease_lost: Some(Arc::clone(&self.lease_lost)),
+                        lease_lost: Some(self.lease_lost.subscribe()),
                         env_vars,
                         allowed_tools: correction_only.then(Vec::new),
                         force_code_agent: force_code_agent || correction_only,

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -48,10 +48,20 @@ use structured_output::{
 };
 pub(super) struct ServerRuntimeJobExecutor<'a> {
     pub(super) state: &'a Arc<AppState>,
+    /// Fired when the owning runtime job lease is lost mid-turn so the turn
+    /// loop interrupts the agent and the workspace cleanup can run (GH-1877).
+    lease_lost: Arc<tokio::sync::Notify>,
 }
 impl<'a> ServerRuntimeJobExecutor<'a> {
     pub(super) fn new(state: &'a Arc<AppState>) -> Self {
-        Self { state }
+        Self {
+            state,
+            lease_lost: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+
+    pub(super) fn cancel_lease_lost(&self) {
+        self.lease_lost.notify_waiters();
     }
 
     pub(super) async fn execute_inner(&self, job: RuntimeJob) -> anyhow::Result<ActivityResult> {
@@ -225,6 +235,7 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                         },
                         timeout_secs: Some(resolved_settings.timeout_secs),
                         stall_timeout_secs: Some(resolved_settings.stall_timeout_secs),
+                        lease_lost: Some(Arc::clone(&self.lease_lost)),
                         env_vars,
                         allowed_tools: correction_only.then(Vec::new),
                         force_code_agent: force_code_agent || correction_only,

--- a/crates/harness-server/src/workflow_runtime_worker/executor_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor_contract.rs
@@ -39,6 +39,13 @@ impl RuntimeJobExecutor for ServerRuntimeJobExecutor<'_> {
             Err(error) => execution_error_result(activity, error),
         }
     }
+
+    async fn cancel_execution(&self, _job: &RuntimeJob) {
+        // The turn loop watches this notification and interrupts the agent,
+        // which terminates the child process and lets the workspace cleanup
+        // run before execute returns (GH-1877).
+        self.cancel_lease_lost();
+    }
 }
 
 fn execution_error_result(activity: String, error: anyhow::Error) -> ActivityResult {

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
@@ -72,6 +72,10 @@ pub(crate) struct TurnLifecycleOptions {
     pub allowed_tools: Option<Vec<String>>,
     pub env_vars: HashMap<String, String>,
     pub runtime_usage: Option<RuntimeUsageContext>,
+    /// Fired when the owning runtime job lease is lost mid-turn: the turn
+    /// interrupts the agent so the child process terminates and the
+    /// workspace cleanup can run (GH-1877).
+    pub lease_lost: Option<Arc<tokio::sync::Notify>>,
 }
 
 pub(crate) async fn run_turn_lifecycle_with_options(
@@ -326,6 +330,31 @@ pub(crate) async fn run_turn_lifecycle_with_options(
                     "Agent stream stalled: no output for {}s",
                     stall_timeout.as_secs()
                 ))));
+                break 'outer;
+            }
+            _ = async {
+                    match options.lease_lost.as_ref() {
+                        Some(notify) => notify.notified().await,
+                        None => std::future::pending().await,
+                    }
+                }, if execution_result.is_none() && !stream_closed => {
+                tracing::warn!(
+                    thread_id = %thread_id,
+                    turn_id = %turn_id,
+                    "runtime job lease lost mid-turn; interrupting agent"
+                );
+                if let Some(adapter) = adapter_opt.as_ref() {
+                    if let Err(error) = adapter.interrupt().await {
+                        tracing::warn!(
+                            thread_id = %thread_id,
+                            turn_id = %turn_id,
+                            "failed to interrupt agent after lease loss: {error}"
+                        );
+                    }
+                }
+                execution_result = Some(Err(HarnessError::AgentExecution(
+                    "Runtime job lease was lost before the agent completed; turn interrupted.".to_string(),
+                )));
                 break 'outer;
             }
             _ = &mut execution_timeout, if execution_result.is_none() => {

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
@@ -72,10 +72,10 @@ pub(crate) struct TurnLifecycleOptions {
     pub allowed_tools: Option<Vec<String>>,
     pub env_vars: HashMap<String, String>,
     pub runtime_usage: Option<RuntimeUsageContext>,
-    /// Fired when the owning runtime job lease is lost mid-turn: the turn
-    /// interrupts the agent so the child process terminates and the
-    /// workspace cleanup can run (GH-1877).
-    pub lease_lost: Option<Arc<tokio::sync::Notify>>,
+    /// Stateful lease-lost signal (watch channel): when the owning runtime
+    /// job lease is lost mid-turn, the turn interrupts the agent so the
+    /// child process terminates and the workspace cleanup can run (GH-1877).
+    pub lease_lost: Option<tokio::sync::watch::Receiver<bool>>,
 }
 
 pub(crate) async fn run_turn_lifecycle_with_options(
@@ -334,7 +334,17 @@ pub(crate) async fn run_turn_lifecycle_with_options(
             }
             _ = async {
                     match options.lease_lost.as_ref() {
-                        Some(notify) => notify.notified().await,
+                        Some(receiver) => {
+                            let mut receiver = receiver.clone();
+                            loop {
+                                if receiver.changed().await.is_err() {
+                                    return;
+                                }
+                                if *receiver.borrow() {
+                                    return;
+                                }
+                            }
+                        }
                         None => std::future::pending().await,
                     }
                 }, if execution_result.is_none() && !stream_closed => {
@@ -549,6 +559,40 @@ mod tests {
         }
     }
 
+    struct InterruptTrackingAdapter {
+        interrupt_calls: Arc<AtomicUsize>,
+        /// start_turn blocks until interrupt fires, so the lease-lost branch
+        /// of the turn loop deterministically wins the select race.
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl AgentAdapter for InterruptTrackingAdapter {
+        fn name(&self) -> &str {
+            "codex"
+        }
+
+        async fn start_turn(
+            &self,
+            _req: TurnRequest,
+            tx: mpsc::Sender<AgentEvent>,
+        ) -> harness_core::error::Result<()> {
+            self.release.notified().await;
+            tx.send(AgentEvent::TurnCompleted {
+                output: "adapter done after interrupt".to_string(),
+            })
+            .await
+            .map_err(|error| HarnessError::AgentExecution(format!("adapter closed: {error}")))?;
+            Ok(())
+        }
+
+        async fn interrupt(&self) -> harness_core::error::Result<()> {
+            self.interrupt_calls.fetch_add(1, Ordering::AcqRel);
+            self.release.notify_waiters();
+            Ok(())
+        }
+    }
+
     fn server_with_codex_counts(
         root: &std::path::Path,
         agent_calls: Arc<AtomicUsize>,
@@ -676,6 +720,65 @@ mod tests {
             .get_turn(&thread_id, &turn_id)
             .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
         assert_eq!(turn.status, TurnStatus::Completed);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prefired_lease_lost_still_interrupts_turn() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let agent_calls = Arc::new(AtomicUsize::new(0));
+        let interrupt_calls = Arc::new(AtomicUsize::new(0));
+        let mut config = HarnessConfig::default();
+        config.server.project_root = root.path().to_path_buf();
+        config.agents.default_agent = "codex".to_string();
+        let mut registry = AgentRegistry::new("codex");
+        registry.register("codex", Arc::new(CountingAgent { calls: agent_calls }));
+        let interrupt_calls_for_factory = interrupt_calls.clone();
+        let release_for_factory = Arc::new(tokio::sync::Notify::new());
+        registry
+            .register_adapter_factory_with_strategy(
+                "codex",
+                move || {
+                    Arc::new(InterruptTrackingAdapter {
+                        interrupt_calls: interrupt_calls_for_factory.clone(),
+                        release: release_for_factory.clone(),
+                    })
+                },
+                AdapterExecutionStrategy::ExecuteTurns,
+            )
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+        let server = Arc::new(HarnessServer::new(config, ThreadManager::new(), registry));
+        let turn_id = start_test_turn(&server, root.path())?;
+
+        // Fire the lease-lost signal BEFORE the turn loop starts polling: the
+        // watch channel must not lose it (GH-1877).
+        let (lease_lost, receiver) = tokio::sync::watch::channel(false);
+        let _ = lease_lost.send(true);
+        run_test_turn(
+            server.clone(),
+            root.path(),
+            turn_id.clone(),
+            TurnLifecycleOptions {
+                lease_lost: Some(receiver),
+                ..TurnLifecycleOptions::default()
+            },
+        )
+        .await?;
+
+        assert_eq!(
+            interrupt_calls.load(Ordering::Acquire),
+            1,
+            "pre-fired lease-lost must interrupt the agent"
+        );
+        let thread_id = server
+            .thread_manager
+            .find_thread_for_turn(&turn_id)
+            .ok_or_else(|| anyhow::anyhow!("turn should belong to a thread"))?;
+        let turn = server
+            .thread_manager
+            .get_turn(&thread_id, &turn_id)
+            .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
+        assert_eq!(turn.status, TurnStatus::Failed);
         Ok(())
     }
 

--- a/crates/harness-workflow/src/runtime/model.rs
+++ b/crates/harness-workflow/src/runtime/model.rs
@@ -86,6 +86,10 @@ pub struct WorkflowInstance {
     pub data: Value,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data_provenance: Option<super::data_provenance::WorkflowDataProvenance>,
+    /// Informational mutation counter, NOT a concurrency guard. All writes go
+    /// through `SELECT ... FOR UPDATE` with an explicit `expected_state`; do
+    /// not use this field for optimistic locking — a writer that does will
+    /// silently lose updates (GH-1877 Cluster B).
     pub version: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lease: Option<WorkflowLease>,

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -20,6 +20,12 @@ pub trait RuntimeJobExecutor: Send + Sync {
     }
 
     async fn execute(&self, job: RuntimeJob) -> ActivityResult;
+
+    /// Cancel the in-flight execution of `job`: the executor interrupts the
+    /// agent process and releases its workspace so a reclaimer never runs
+    /// against a dirty tree (GH-1877). The `execute` future then resolves to
+    /// a cancelled/failed result shortly after.
+    async fn cancel_execution(&self, _job: &RuntimeJob) {}
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -272,12 +278,26 @@ impl<'a> RuntimeWorker<'a> {
                         )
                         .await?
                     else {
-                        return Ok(RuntimeJobExecution {
-                            result: ActivityResult::failed(
+                        // Lease lost mid-turn: cancel the in-flight agent and
+                        // wait for the executor's cleanup (agent termination +
+                        // workspace release) so a reclaimer never sees a
+                        // dirty tree. Bounded by a grace period; if cleanup
+                        // does not finish, the future is dropped and the
+                        // workspace reaper is the backstop (GH-1877).
+                        executor.cancel_execution(job).await;
+                        let cleanup_grace = std::time::Duration::from_secs(30);
+                        let result = match tokio::time::timeout(cleanup_grace, &mut execution)
+                            .await
+                        {
+                            Ok(result) => result,
+                            Err(_) => ActivityResult::failed(
                                 activity,
                                 "Runtime job lease was lost before the agent completed.",
-                                "Another runtime worker reclaimed the job after this worker's lease expired.",
+                                "Another runtime worker reclaimed the job after this worker's lease expired; agent cleanup exceeded the grace period.",
                             ),
+                        };
+                        return Ok(RuntimeJobExecution {
+                            result,
                             lease_expires_at,
                         });
                     };

--- a/crates/harness-workflow/src/runtime/worker/tests.rs
+++ b/crates/harness-workflow/src/runtime/worker/tests.rs
@@ -287,3 +287,85 @@ fn prompt_task_instance() -> WorkflowInstance {
         WorkflowSubject::new("p", "1"),
     )
 }
+
+struct LeaseLostExecutor {
+    cancel_calls: Arc<AtomicUsize>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl RuntimeJobExecutor for LeaseLostExecutor {
+    async fn execute(&self, _job: RuntimeJob) -> ActivityResult {
+        self.release.notified().await;
+        ActivityResult::cancelled("check", "cancelled after lease lost")
+    }
+
+    async fn cancel_execution(&self, _job: &RuntimeJob) {
+        self.cancel_calls.fetch_add(1, Ordering::SeqCst);
+        self.release.notify_waiters();
+    }
+}
+
+#[tokio::test]
+async fn lease_lost_cancels_execution_and_waits_for_cleanup() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let job = enqueue_test_runtime_job(
+        &store,
+        "lease-lost-cancel",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({ "activity": "check" }),
+    )
+    .await?;
+
+    let cancel_calls = Arc::new(AtomicUsize::new(0));
+    let release = Arc::new(tokio::sync::Notify::new());
+    let executor = LeaseLostExecutor {
+        cancel_calls: Arc::clone(&cancel_calls),
+        release: Arc::clone(&release),
+    };
+    // Short lease so the renewal loop hits the tampered lease quickly; the
+    // tamper task steals ownership while execute is still blocked.
+    let worker =
+        RuntimeWorker::new(&store, "lease-lost-worker").with_lease_ttl(Duration::seconds(4));
+    let pool = store.pool().clone();
+    let tamper_job_id = job.id.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+        sqlx::query(
+            r#"UPDATE runtime_jobs
+               SET data = jsonb_set(data, '{lease,owner}', '"other-worker"')
+               WHERE id = $1"#,
+        )
+        .bind(&tamper_job_id)
+        .execute(&pool)
+        .await
+        .expect("lease tamper should apply");
+    });
+
+    let completed = worker.run_once(&executor).await?;
+
+    assert_eq!(
+        cancel_calls.load(Ordering::SeqCst),
+        1,
+        "executor cancel must be invoked"
+    );
+    assert!(completed.is_none(), "lease-lost completion must not commit");
+
+    let (dlq_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM runtime_job_completions_dlq WHERE runtime_job_id = $1",
+    )
+    .bind(&job.id)
+    .fetch_one(store.pool())
+    .await?;
+    assert_eq!(
+        dlq_count, 1,
+        "lease-lost result must land in the dead-letter"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Closes GH-1877

## Summary

When a worker's job lease expired mid-turn, `execute_with_lease_renewal` **dropped the execution future**: the agent process kept running, `finish_runtime_workspace` never ran (workspace leaked), and a second worker claiming the job re-ran against a dirty tree. The workspace lease could not prevent this — workflow workers share one server process, so `owner_session` is identical for both workers.

**Fix:**
- `RuntimeJobExecutor::cancel_execution` (default no-op): on lease loss the worker signals the executor via a per-executor `Notify` (race-free: executor instances are per-worker-tick)
- The turn loop watches the signal, `adapter.interrupt()` terminates the agent child, execute returns a cancelled result, and the normal workspace finalization releases the workspace **before** a reclaimer can touch it
- The worker waits up to 30s for that cleanup instead of dropping the future
- GH-1878's DLQ remains the backstop for the result payload; the workspace reaper backs up cleanup

**Cluster B (same issue):** `WorkflowInstance.version` is documented as informational — a mutation counter, not a CAS token. Every write goes through `SELECT FOR UPDATE` + `expected_state`; the doc comment prevents future optimistic writes.

## Verified

- New lease-tamper worker test: tamper steals the lease mid-execution → cancel invoked once, execution awaited (not dropped), result lands in DLQ
- harness-workflow DB suite: 651 pass (local Postgres)
- `cargo fmt` / workspace check / `cargo clippy -- -D warnings` clean

## Notes

Live multi-worker contention against a real adapter is not covered by CI; the lease-tamper test exercises the exact code path deterministically.