### PR TITLE
fix(server): unify background-loop tick reporting semantics (GH-1880)

### DIFF
--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -221,6 +221,8 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
         .workspace_mgr
         .as_deref()
         .map(|manager| manager.live_count());
+    let loop_snapshots = state.background_loops.snapshot(BACKGROUND_LOOP_STALE_SECS);
+    let config_parse_failure = state.background_loops.config_failure_snapshot();
 
     Ok(OperatorMonitorPayload {
         generated_at: generated_at.to_rfc3339(),
@@ -229,7 +231,7 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
             status: health_status,
             degraded_subsystems: {
                 let mut subsystems = degraded_subsystems;
-                for loop_snapshot in state.background_loops.snapshot(BACKGROUND_LOOP_STALE_SECS) {
+                for loop_snapshot in &loop_snapshots {
                     if loop_snapshot.stale {
                         subsystems.push(match loop_snapshot.name {
                             "orphan_schema_reaper" => "orphan_schema_reaper_stale",
@@ -245,7 +247,7 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
                         });
                     }
                 }
-                if state.background_loops.config_failure_snapshot().is_some() {
+                if config_parse_failure.is_some() {
                     subsystems.push("workflow_config_parse_failure");
                 }
                 subsystems
@@ -264,8 +266,8 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
                 .unwrap_or(0),
             runtime_hosts_online: runtime_hosts.iter().filter(|host| host.online).count() as u64,
             runtime_hosts_total: runtime_hosts.len() as u64,
-            background_loops: state.background_loops.snapshot(BACKGROUND_LOOP_STALE_SECS),
-            config_parse_failure: state.background_loops.config_failure_snapshot(),
+            background_loops: loop_snapshots,
+            config_parse_failure,
         },
         activity: OperatorActivity {
             runtime_workflows,

--- a/crates/harness-server/src/http/background.rs
+++ b/crates/harness-server/src/http/background.rs
@@ -53,13 +53,15 @@ pub(super) use runtime_workers::spawn_runtime_job_workers;
 /// WORKFLOW.md surfaces once, at error level, with the affected loop names —
 /// retention, watchdog, and the reaper can no longer fail silently while the
 /// dispatcher keeps running.
+///
+/// Config load success is not a completed tick: each loop reports its own
+/// tick outcome via `LoopHandle` at the point where the tick's work is done.
 pub(crate) async fn load_workflow_config_for_loop(
     state: &Arc<crate::http::AppState>,
     handle: &LoopHandle,
 ) -> anyhow::Result<harness_core::config::workflow::WorkflowConfig> {
     match harness_core::config::workflow::load_workflow_config(&state.core.project_root) {
         Ok(config) => {
-            handle.tick_ok();
             // Config recovered: clear the aggregated failure so operators see
             // the loop return to a healthy state.
             state.background_loops.clear_config_failure();

--- a/crates/harness-server/src/http/background/loop_health.rs
+++ b/crates/harness-server/src/http/background/loop_health.rs
@@ -105,10 +105,6 @@ impl BackgroundLoopHealth {
     /// Record a workflow-config parse failure affecting `name`. Aggregated so
     /// every consumer reports into one operator-visible signal.
     pub(crate) fn record_config_failure(&self, name: &'static str, error: &str) {
-        self.record_config_failure_inner(name, error);
-    }
-
-    fn record_config_failure_inner(&self, name: &'static str, error: &str) {
         let now = Utc::now();
         let mut guard = self
             .config_failure

--- a/crates/harness-server/src/http/orphan_reaper.rs
+++ b/crates/harness-server/src/http/orphan_reaper.rs
@@ -66,6 +66,7 @@ pub(super) fn spawn_orphan_schema_reaper(state: &Arc<AppState>) {
                 tracing::debug!(
                     "orphan schema reaper disabled by config; re-checking next interval"
                 );
+                handle.tick_ok();
             } else if let Some(store) = state.core.workflow_runtime_store.as_ref() {
                 let workspace_roots =
                     workspace_roots_for_reaper(state.concurrency.workspace_mgr.as_deref());
@@ -111,6 +112,7 @@ pub(super) fn spawn_orphan_schema_reaper(state: &Arc<AppState>) {
                         }
                     }
                     Err(error) => {
+                        handle.tick_failed(&error.to_string());
                         tracing::warn!("orphan schema reaper tick failed: {error}");
                     }
                 }

--- a/crates/harness-server/src/http/runtime_retention.rs
+++ b/crates/harness-server/src/http/runtime_retention.rs
@@ -61,14 +61,18 @@ pub(super) fn spawn_runtime_retention(state: &Arc<AppState>) {
                             )
                             .await
                         {
-                            Ok(candidates) if candidates > 0 => tracing::info!(
-                                dry_run_passes_remaining = *dry_run_remaining,
-                                candidate_root_families = candidates,
-                                retention_days = workflow_cfg.storage.runtime_retention_days,
-                                "runtime retention dry-run: next passes will prune this many terminal workflow families"
-                            ),
-                            Ok(_) => {}
+                            Ok(candidates) if candidates > 0 => {
+                                handle.tick_ok();
+                                tracing::info!(
+                                    dry_run_passes_remaining = *dry_run_remaining,
+                                    candidate_root_families = candidates,
+                                    retention_days = workflow_cfg.storage.runtime_retention_days,
+                                    "runtime retention dry-run: next passes will prune this many terminal workflow families"
+                                )
+                            }
+                            Ok(_) => handle.tick_ok(),
                             Err(error) => {
+                                handle.tick_failed(&error.to_string());
                                 tracing::warn!("runtime retention dry-run count failed: {error}")
                             }
                         }
@@ -80,17 +84,20 @@ pub(super) fn spawn_runtime_retention(state: &Arc<AppState>) {
                             )
                             .await
                         {
-                            Ok(summary) if !summary.is_empty() => tracing::info!(
-                                workflow_instances = summary.workflow_instances_deleted,
-                                workflow_events = summary.workflow_events_deleted,
-                                workflow_decisions = summary.workflow_decisions_deleted,
-                                workflow_commands = summary.workflow_commands_deleted,
-                                runtime_jobs = summary.runtime_jobs_deleted,
-                                runtime_events = summary.runtime_events_deleted,
-                                workflow_artifacts = summary.workflow_artifacts_deleted,
-                                "runtime retention pruned terminal workflow history"
-                            ),
-                            Ok(_) => {}
+                            Ok(summary) if !summary.is_empty() => {
+                                handle.tick_ok();
+                                tracing::info!(
+                                    workflow_instances = summary.workflow_instances_deleted,
+                                    workflow_events = summary.workflow_events_deleted,
+                                    workflow_decisions = summary.workflow_decisions_deleted,
+                                    workflow_commands = summary.workflow_commands_deleted,
+                                    runtime_jobs = summary.runtime_jobs_deleted,
+                                    runtime_events = summary.runtime_events_deleted,
+                                    workflow_artifacts = summary.workflow_artifacts_deleted,
+                                    "runtime retention pruned terminal workflow history"
+                                )
+                            }
+                            Ok(_) => handle.tick_ok(),
                             Err(error) => {
                                 handle.tick_failed(&error.to_string());
                                 tracing::warn!("runtime retention tick failed: {error}")
@@ -100,6 +107,7 @@ pub(super) fn spawn_runtime_retention(state: &Arc<AppState>) {
                 }
             } else {
                 tracing::debug!("runtime retention disabled by config; re-checking next interval");
+                handle.tick_ok();
             }
 
             drop(state);

--- a/crates/harness-server/src/http/task_retention.rs
+++ b/crates/harness-server/src/http/task_retention.rs
@@ -54,14 +54,20 @@ pub(super) fn spawn_task_retention(state: &Arc<AppState>) {
                         )
                         .await
                     {
-                        Ok(candidates) if candidates > 0 => tracing::info!(
-                            dry_run_passes_remaining = *dry_run_remaining,
-                            candidate_tasks = candidates,
-                            retention_days = workflow_cfg.storage.task_retention_days,
-                            "task retention dry-run: next passes will prune this many terminal tasks"
-                        ),
-                        Ok(_) => {}
-                        Err(error) => tracing::warn!("task retention dry-run count failed: {error}"),
+                        Ok(candidates) if candidates > 0 => {
+                            handle.tick_ok();
+                            tracing::info!(
+                                    dry_run_passes_remaining = *dry_run_remaining,
+                                    candidate_tasks = candidates,
+                                    retention_days = workflow_cfg.storage.task_retention_days,
+                                    "task retention dry-run: next passes will prune this many terminal tasks"
+                                )
+                        }
+                        Ok(_) => handle.tick_ok(),
+                        Err(error) => {
+                            handle.tick_failed(&error.to_string());
+                            tracing::warn!("task retention dry-run count failed: {error}")
+                        }
                     }
                 } else {
                     match state
@@ -73,14 +79,17 @@ pub(super) fn spawn_task_retention(state: &Arc<AppState>) {
                         )
                         .await
                     {
-                        Ok(summary) if !summary.pruned_task_ids.is_empty() => tracing::info!(
-                            tasks = summary.tasks_deleted,
-                            artifacts = summary.artifacts_deleted,
-                            prompts = summary.prompts_deleted,
-                            checkpoints = summary.checkpoints_deleted,
-                            "task retention pruned terminal task history"
-                        ),
-                        Ok(_) => {}
+                        Ok(summary) if !summary.pruned_task_ids.is_empty() => {
+                            handle.tick_ok();
+                            tracing::info!(
+                                tasks = summary.tasks_deleted,
+                                artifacts = summary.artifacts_deleted,
+                                prompts = summary.prompts_deleted,
+                                checkpoints = summary.checkpoints_deleted,
+                                "task retention pruned terminal task history"
+                            )
+                        }
+                        Ok(_) => handle.tick_ok(),
                         Err(error) => {
                             handle.tick_failed(&error.to_string());
                             tracing::warn!("task retention tick failed: {error}")
@@ -89,6 +98,7 @@ pub(super) fn spawn_task_retention(state: &Arc<AppState>) {
                 }
             } else {
                 tracing::debug!("task retention disabled by config; re-checking next interval");
+                handle.tick_ok();
             }
 
             drop(state);

--- a/crates/harness-server/src/http/workflow_watchdog.rs
+++ b/crates/harness-server/src/http/workflow_watchdog.rs
@@ -82,7 +82,9 @@ pub(super) fn spawn_workflow_watchdog(state: &Arc<AppState>) {
                             }
                         }
                         Err(error) => {
-                            tick_error = Some(error.to_string());
+                            if tick_error.is_none() {
+                                tick_error = Some(error.to_string());
+                            }
                             tracing::warn!("workflow watchdog tick failed: {error}")
                         }
                     }
@@ -107,7 +109,9 @@ pub(super) fn spawn_workflow_watchdog(state: &Arc<AppState>) {
                             }
                         }
                         Err(error) => {
-                            tick_error = Some(error.to_string());
+                            if tick_error.is_none() {
+                                tick_error = Some(error.to_string());
+                            }
                             tracing::error!(
                                 "workflow watchdog driverless-progress scan failed: {error}"
                             );
@@ -180,7 +184,9 @@ pub(super) fn spawn_workflow_watchdog(state: &Arc<AppState>) {
                                 }
                             }
                             Err(error) => {
-                                tick_error = Some(error.to_string());
+                                if tick_error.is_none() {
+                                    tick_error = Some(error.to_string());
+                                }
                                 tracing::warn!("workflow alert scan failed: {error}")
                             }
                         }

--- a/crates/harness-server/src/http/workflow_watchdog.rs
+++ b/crates/harness-server/src/http/workflow_watchdog.rs
@@ -44,6 +44,7 @@ pub(super) fn spawn_workflow_watchdog(state: &Arc<AppState>) {
                 workflow_cfg.storage.workflow_watchdog_interval_secs.max(1),
             );
             if workflow_cfg.storage.workflow_watchdog_enabled {
+                let mut tick_error: Option<String> = None;
                 if let Some(store) = state.core.workflow_runtime_store.as_ref() {
                     let cutoff = Utc::now()
                         - chrono::Duration::minutes(
@@ -80,7 +81,10 @@ pub(super) fn spawn_workflow_watchdog(state: &Arc<AppState>) {
                                 );
                             }
                         }
-                        Err(error) => tracing::warn!("workflow watchdog tick failed: {error}"),
+                        Err(error) => {
+                            tick_error = Some(error.to_string());
+                            tracing::warn!("workflow watchdog tick failed: {error}")
+                        }
                     }
 
                     match store
@@ -103,6 +107,7 @@ pub(super) fn spawn_workflow_watchdog(state: &Arc<AppState>) {
                             }
                         }
                         Err(error) => {
+                            tick_error = Some(error.to_string());
                             tracing::error!(
                                 "workflow watchdog driverless-progress scan failed: {error}"
                             );
@@ -175,13 +180,19 @@ pub(super) fn spawn_workflow_watchdog(state: &Arc<AppState>) {
                                 }
                             }
                             Err(error) => {
+                                tick_error = Some(error.to_string());
                                 tracing::warn!("workflow alert scan failed: {error}")
                             }
                         }
                     }
                 }
+                match tick_error {
+                    Some(error) => handle.tick_failed(&error),
+                    None => handle.tick_ok(),
+                }
             } else {
                 tracing::debug!("workflow watchdog disabled by config; re-checking next interval");
+                handle.tick_ok();
             }
 
             drop(state);


### PR DESCRIPTION
Review fixes for the GH-1880 background-loop health reporting landed in #1890.

**Problems found in review:**
1. load_workflow_config_for_loop recorded tick_ok on config load success — config load is not a completed tick. The reaper counted 2 ticks per iteration while retention counted config loads, so tick_count was incomparable across loops.
2. Config-disabled loops (watchdog/retention/reaper) never reported any tick → permanently stale in operator health, falsely degrading /health 15 minutes after a config that disables them.
3. Loop-body errors were invisible: reaper reap failure, retention/task prune failures were only traced, never surfaced in the registry.
4. operator_monitor called snapshot() and config_failure_snapshot() twice per request.

**Changes:**
- load_workflow_config_for_loop: config success only clears the aggregated config failure; tick reporting is each loop's responsibility
- Each loop reports tick_ok at its work-done point (disabled-by-config counts as a healthy no-op tick)
- Reaper/retention/task-retention/watchdog report tick_failed on loop-body errors
- Watchdog aggregates the first scan error into one tick result
- operator_monitor takes single snapshots

**Verified:** cargo fmt --check, cargo clippy -p harness-server --all-targets -- -D warnings, cargo test -p harness-server --lib operator_monitor (35/35), loop_health tests (3/3).