### PR TITLE
fix(server): fail-closed cross-review protocol (GH-1767 D1)

### DIFF
--- a/crates/harness-core/src/agent.rs
+++ b/crates/harness-core/src/agent.rs
@@ -15,6 +15,13 @@ pub const AGENT_OUTPUT_SCHEMA_PATH_ENV: &str = "HARNESS_AGENT_OUTPUT_SCHEMA_PATH
 #[async_trait]
 pub trait CodeAgent: Send + Sync {
     fn name(&self) -> &str;
+    /// Stable identity used to detect "primary == challenger" misconfigurations
+    /// in cross-review. Defaults to the registry key (`name`); implementations
+    /// that wrap multiple backends should include the backend/model so two
+    /// registry entries backed by the same model compare equal.
+    fn id(&self) -> String {
+        self.name().to_string()
+    }
     fn capabilities(&self) -> Vec<Capability>;
     async fn execute(&self, req: AgentRequest) -> crate::error::Result<AgentResponse>;
     async fn execute_stream(

--- a/crates/harness-core/src/prompts/cross_review.rs
+++ b/crates/harness-core/src/prompts/cross_review.rs
@@ -25,7 +25,9 @@ pub fn challenger_prompt(safe_primary: &str, outstanding: &str) -> String {
          CONFIRMED: <issue>  — the issue is a real problem\n\
          FALSE-POSITIVE: <issue>  — the issue is wrong or not applicable\n\
          Also list any issues the primary review missed as:\n\
-         MISSED: <new issue>{outstanding}"
+         MISSED: <new issue>\n\
+         Protocol: your reply MUST contain at least one CONFIRMED:, FALSE-POSITIVE:, or MISSED: line. \
+         A reply with none is a protocol failure and fails the review.{outstanding}"
     )
 }
 
@@ -48,7 +50,8 @@ mod tests {
         assert!(prompt.contains("CONFIRMED:"));
         assert!(prompt.contains("FALSE-POSITIVE:"));
         assert!(prompt.contains("MISSED:"));
-        assert!(prompt.ends_with("MISSED: <new issue>"));
+        assert!(prompt.contains("protocol failure"));
+        assert!(prompt.ends_with("fails the review."));
     }
 
     #[test]

--- a/crates/harness-observe/src/quality.rs
+++ b/crates/harness-observe/src/quality.rs
@@ -8,7 +8,8 @@ pub struct QualityReport {
     pub dimensions: QualityDimensions,
     pub recommended_gc_interval: std::time::Duration,
     /// Semantic verdict from challenger-agent cross-review.
-    /// "APPROVED" | "NOT_CONVERGED" | None (cross-review not run)
+    /// "APPROVED" | "APPROVED_DEGRADED" | "NOT_CONVERGED" | "PROTOCOL_FAILURE"
+    /// | None (cross-review not run)
     pub semantic_verdict: Option<String>,
 }
 

--- a/crates/harness-server/src/handlers/cross_review.rs
+++ b/crates/harness-server/src/handlers/cross_review.rs
@@ -405,8 +405,9 @@ fn has_any_tag_prefix(output: &str) -> bool {
 }
 
 fn bounded_excerpt(reply: &str) -> String {
-    let mut excerpt: String = reply.chars().take(PROTOCOL_FAILURE_EXCERPT_MAX).collect();
-    if reply.chars().count() > PROTOCOL_FAILURE_EXCERPT_MAX {
+    let mut chars = reply.chars();
+    let mut excerpt: String = chars.by_ref().take(PROTOCOL_FAILURE_EXCERPT_MAX).collect();
+    if chars.next().is_some() {
         excerpt.push('…');
     }
     excerpt

--- a/crates/harness-server/src/handlers/cross_review.rs
+++ b/crates/harness-server/src/handlers/cross_review.rs
@@ -36,15 +36,65 @@ impl CrossReviewCompressionContext {
     }
 }
 
+/// Whether the challenger round ran under a distinct model or the review
+/// degraded to a single model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CrossReviewMode {
+    CrossModel,
+    SingleModelDegraded,
+}
+
+/// Fail-closed verdict. Serializes as the legacy uppercase strings for RPC
+/// compatibility; `ApprovedDegraded` and `ProtocolFailure` are new wires.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CrossReviewVerdict {
+    /// Cross-model review, tags parsed, no consensus issues.
+    Approved,
+    /// Single-model degraded review with no issues — never reported as
+    /// `Approved` so callers can tell the review lacked a challenger.
+    ApprovedDegraded,
+    NotConverged,
+    /// Challenger reply followed none of the protocol tags; the round is
+    /// unparseable and must not read as approval.
+    ProtocolFailure,
+}
+
+impl CrossReviewVerdict {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CrossReviewVerdict::Approved => "APPROVED",
+            CrossReviewVerdict::ApprovedDegraded => "APPROVED_DEGRADED",
+            CrossReviewVerdict::NotConverged => "NOT_CONVERGED",
+            CrossReviewVerdict::ProtocolFailure => "PROTOCOL_FAILURE",
+        }
+    }
+}
+
+/// A challenger round whose reply carried no protocol tag at all.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProtocolFailure {
+    pub round: u32,
+    /// Bounded excerpt of the offending reply.
+    pub excerpt: String,
+}
+
+/// Maximum chars of a protocol-failure reply kept in `ProtocolFailure`.
+const PROTOCOL_FAILURE_EXCERPT_MAX: usize = 280;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CrossReviewResult {
+    pub mode: CrossReviewMode,
+    pub primary_agent_id: String,
+    pub challenger_agent_id: Option<String>,
     pub primary_review: String,
     pub challenger_review: String,
     pub consensus_issues: Vec<String>,
     pub contested_issues: Vec<String>,
     pub rounds: u32,
-    /// "APPROVED" if no consensus issues; "NOT_CONVERGED" if issues remain.
-    pub final_verdict: String,
+    pub final_verdict: CrossReviewVerdict,
+    pub protocol_failure: Option<ProtocolFailure>,
 }
 
 pub async fn cross_review(
@@ -61,7 +111,7 @@ pub async fn cross_review(
         None => return RpcResponse::error(id, INTERNAL_ERROR, "no agent registered"),
     };
 
-    let challenger = state.core.server.agent_registry.get("codex");
+    let challenger = distinct_challenger(&primary, state.core.server.agent_registry.get("codex"));
     let rounds = max_rounds.unwrap_or(DEFAULT_MAX_ROUNDS);
 
     let result =
@@ -134,20 +184,30 @@ pub(crate) async fn run_cross_review_with_context(
 
     let challenger = match challenger {
         None => {
-            // Graceful degradation: treat all ISSUE lines as consensus.
+            // Degraded single-model review: treat all ISSUE lines as
+            // consensus, and never report a clean review as fully approved.
             let consensus_issues = harness_core::prompts::extract_review_issues(&primary_review);
-            let verdict = verdict_for(&consensus_issues);
+            let verdict = if consensus_issues.is_empty() {
+                CrossReviewVerdict::ApprovedDegraded
+            } else {
+                CrossReviewVerdict::NotConverged
+            };
             return Ok(CrossReviewResult {
+                mode: CrossReviewMode::SingleModelDegraded,
+                primary_agent_id: primary.id(),
+                challenger_agent_id: None,
                 primary_review,
                 challenger_review: String::new(),
                 consensus_issues,
                 contested_issues: Vec::new(),
                 rounds: 1,
                 final_verdict: verdict,
+                protocol_failure: None,
             });
         }
         Some(c) => c,
     };
+    let challenger_agent_id = challenger.id();
 
     let mut challenger_review = String::new();
     let mut rounds_done = 1u32;
@@ -225,16 +285,44 @@ pub(crate) async fn run_cross_review_with_context(
             .into_iter()
             .chain(extract_tagged(&challenger_review, "MISSED"))
             .collect();
+        let contested = extract_tagged(&challenger_review, "FALSE-POSITIVE");
+
+        // Fail closed (GH-1767): a challenger reply with no protocol tag at
+        // all is unparseable, not an approval. A reply carrying only
+        // FALSE-POSITIVE tags remains a valid approving round.
+        if consensus_issues.is_empty()
+            && contested.is_empty()
+            && !has_any_tag_prefix(&challenger_review)
+        {
+            return Ok(CrossReviewResult {
+                mode: CrossReviewMode::CrossModel,
+                primary_agent_id: primary.id(),
+                challenger_agent_id: Some(challenger_agent_id.clone()),
+                primary_review,
+                challenger_review: challenger_review.clone(),
+                consensus_issues: Vec::new(),
+                contested_issues: Vec::new(),
+                rounds: rounds_done,
+                final_verdict: CrossReviewVerdict::ProtocolFailure,
+                protocol_failure: Some(ProtocolFailure {
+                    round: rounds_done,
+                    excerpt: bounded_excerpt(&challenger_review),
+                }),
+            });
+        }
 
         if consensus_issues.is_empty() {
-            let contested = extract_tagged(&challenger_review, "FALSE-POSITIVE");
             return Ok(CrossReviewResult {
+                mode: CrossReviewMode::CrossModel,
+                primary_agent_id: primary.id(),
+                challenger_agent_id: Some(challenger_agent_id.clone()),
                 primary_review,
                 challenger_review,
                 consensus_issues: Vec::new(),
                 contested_issues: contested,
                 rounds: rounds_done,
-                final_verdict: "APPROVED".to_string(),
+                final_verdict: CrossReviewVerdict::Approved,
+                protocol_failure: None,
             });
         }
     }
@@ -245,22 +333,83 @@ pub(crate) async fn run_cross_review_with_context(
         .collect();
     let contested_issues = extract_tagged(&challenger_review, "FALSE-POSITIVE");
 
+    // `rounds_done == 1` means the loop never ran (max_rounds <= 1): no
+    // challenger reply exists to judge, so this is neither an approval nor a
+    // protocol failure — fall through to NOT_CONVERGED.
+    if rounds_done > 1 && consensus_issues.is_empty() && contested_issues.is_empty() {
+        if !has_any_tag_prefix(&challenger_review) {
+            return Ok(CrossReviewResult {
+                mode: CrossReviewMode::CrossModel,
+                primary_agent_id: primary.id(),
+                challenger_agent_id: Some(challenger_agent_id),
+                primary_review,
+                challenger_review: challenger_review.clone(),
+                consensus_issues: Vec::new(),
+                contested_issues: Vec::new(),
+                rounds: rounds_done,
+                final_verdict: CrossReviewVerdict::ProtocolFailure,
+                protocol_failure: Some(ProtocolFailure {
+                    round: rounds_done,
+                    excerpt: bounded_excerpt(&challenger_review),
+                }),
+            });
+        }
+        // Tags were present but all bodies were empty: parseable reply with
+        // no findings — an approving round, not a failure.
+        return Ok(CrossReviewResult {
+            mode: CrossReviewMode::CrossModel,
+            primary_agent_id: primary.id(),
+            challenger_agent_id: Some(challenger_agent_id),
+            primary_review,
+            challenger_review,
+            consensus_issues: Vec::new(),
+            contested_issues: Vec::new(),
+            rounds: rounds_done,
+            final_verdict: CrossReviewVerdict::Approved,
+            protocol_failure: None,
+        });
+    }
+
     Ok(CrossReviewResult {
+        mode: CrossReviewMode::CrossModel,
+        primary_agent_id: primary.id(),
+        challenger_agent_id: Some(challenger_agent_id),
         primary_review,
         challenger_review,
         consensus_issues,
         contested_issues,
         rounds: rounds_done,
-        final_verdict: "NOT_CONVERGED".to_string(),
+        final_verdict: CrossReviewVerdict::NotConverged,
+        protocol_failure: None,
     })
 }
 
-fn verdict_for(issues: &[String]) -> String {
-    if issues.is_empty() {
-        "APPROVED".to_string()
-    } else {
-        "NOT_CONVERGED".to_string()
+/// Identity guard (GH-1767): a challenger resolving to the same agent
+/// identity as the primary is no challenger at all — degrade instead of
+/// "reviewing" with a single model twice.
+fn distinct_challenger(
+    primary: &Arc<dyn CodeAgent>,
+    challenger: Option<Arc<dyn CodeAgent>>,
+) -> Option<Arc<dyn CodeAgent>> {
+    challenger.filter(|candidate| candidate.id() != primary.id())
+}
+
+/// True when any line carries one of the three protocol tag prefixes, even
+/// with an empty body (which `extract_tagged` filters out).
+fn has_any_tag_prefix(output: &str) -> bool {
+    output.lines().map(str::trim).any(|line| {
+        line.starts_with("CONFIRMED:")
+            || line.starts_with("MISSED:")
+            || line.starts_with("FALSE-POSITIVE:")
+    })
+}
+
+fn bounded_excerpt(reply: &str) -> String {
+    let mut excerpt: String = reply.chars().take(PROTOCOL_FAILURE_EXCERPT_MAX).collect();
+    if reply.chars().count() > PROTOCOL_FAILURE_EXCERPT_MAX {
+        excerpt.push('…');
     }
+    excerpt
 }
 
 fn extract_tagged(output: &str, tag: &str) -> Vec<String> {
@@ -480,7 +629,11 @@ mod tests {
 
         assert_eq!(result.consensus_issues, vec!["Missing error handling"]);
         assert_eq!(result.contested_issues, vec!["Unbounded loop"]);
-        assert_eq!(result.final_verdict, "NOT_CONVERGED");
+        assert_eq!(result.final_verdict, CrossReviewVerdict::NotConverged);
+        assert_eq!(result.mode, CrossReviewMode::CrossModel);
+        assert_eq!(result.primary_agent_id, "primary");
+        assert_eq!(result.challenger_agent_id.as_deref(), Some("challenger"));
+        assert!(result.protocol_failure.is_none());
         assert!(result.rounds >= 1);
     }
 
@@ -504,7 +657,9 @@ mod tests {
             result.consensus_issues,
             vec!["Missing error handling", "Unbounded loop"]
         );
-        assert_eq!(result.final_verdict, "NOT_CONVERGED");
+        assert_eq!(result.final_verdict, CrossReviewVerdict::NotConverged);
+        assert_eq!(result.mode, CrossReviewMode::SingleModelDegraded);
+        assert_eq!(result.challenger_agent_id, None);
     }
 
     #[tokio::test]
@@ -521,7 +676,9 @@ mod tests {
         .await
         .expect("lgtm path should succeed");
 
-        assert_eq!(result.final_verdict, "APPROVED");
+        // A clean single-model review degrades; it is never full approval.
+        assert_eq!(result.final_verdict, CrossReviewVerdict::ApprovedDegraded);
+        assert_eq!(result.mode, CrossReviewMode::SingleModelDegraded);
         assert!(result.consensus_issues.is_empty());
     }
 
@@ -683,6 +840,127 @@ mod tests {
         assert_eq!(
             result.primary_review,
             "ISSUE: Missing error handling\nISSUE: Unbounded loop"
+        );
+    }
+    struct TaglessChallenger;
+
+    #[async_trait::async_trait]
+    impl CodeAgent for TaglessChallenger {
+        fn name(&self) -> &str {
+            "tagless-challenger"
+        }
+        fn capabilities(&self) -> Vec<Capability> {
+            vec![]
+        }
+        async fn execute(&self, _req: AgentRequest) -> HarnessResult<AgentResponse> {
+            Ok(AgentResponse {
+                output: "The primary review looks mostly fine to me.".to_string(),
+                stderr: String::new(),
+                items: vec![],
+                token_usage: TokenUsage::default(),
+                model: "mock".to_string(),
+                exit_code: Some(0),
+            })
+        }
+        async fn execute_stream(
+            &self,
+            _req: AgentRequest,
+            _tx: Sender<StreamItem>,
+        ) -> HarnessResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn tagless_challenger_reply_is_protocol_failure_not_approval() {
+        let proj = proj_dir();
+        let result = run_cross_review(
+            Arc::new(PrimaryMock),
+            Some(Arc::new(TaglessChallenger)),
+            proj.path().to_path_buf(),
+            "fn foo() {}".to_string(),
+            3,
+            None,
+        )
+        .await
+        .expect("protocol failure is a verdict, not an error");
+
+        assert_eq!(result.final_verdict, CrossReviewVerdict::ProtocolFailure);
+        assert_eq!(result.mode, CrossReviewMode::CrossModel);
+        let failure = result.protocol_failure.expect("failure detail recorded");
+        assert_eq!(failure.round, 2);
+        assert!(failure.excerpt.contains("looks mostly fine"));
+        assert!(result.consensus_issues.is_empty());
+    }
+
+    #[tokio::test]
+    async fn false_positive_only_reply_is_a_valid_approving_round() {
+        let proj = proj_dir();
+        let result = run_cross_review(
+            Arc::new(PrimaryMock),
+            Some(Arc::new(CapturingChallenger {
+                prompts: Arc::new(Mutex::new(Vec::new())),
+            })),
+            proj.path().to_path_buf(),
+            "fn foo() {}".to_string(),
+            3,
+            None,
+        )
+        .await
+        .expect("false-positive-only round should succeed");
+
+        assert_eq!(result.final_verdict, CrossReviewVerdict::Approved);
+        assert_eq!(result.contested_issues, vec!["Missing error handling"]);
+        assert!(result.protocol_failure.is_none());
+    }
+
+    #[tokio::test]
+    async fn single_round_with_challenger_is_not_a_protocol_failure() {
+        let proj = proj_dir();
+        let result = run_cross_review(
+            Arc::new(PrimaryMock),
+            Some(Arc::new(ChallengerMock)),
+            proj.path().to_path_buf(),
+            "fn foo() {}".to_string(),
+            1,
+            None,
+        )
+        .await
+        .expect("single-round review should succeed");
+
+        assert_eq!(result.rounds, 1);
+        assert_eq!(result.final_verdict, CrossReviewVerdict::NotConverged);
+        assert!(result.protocol_failure.is_none());
+    }
+
+    #[test]
+    fn identity_guard_drops_same_identity_challenger() {
+        let primary: Arc<dyn CodeAgent> = Arc::new(PrimaryMock);
+        let same: Arc<dyn CodeAgent> = Arc::new(PrimaryMock);
+        let distinct: Arc<dyn CodeAgent> = Arc::new(ChallengerMock);
+
+        assert!(distinct_challenger(&primary, Some(same)).is_none());
+        assert!(distinct_challenger(&primary, Some(distinct)).is_some());
+        assert!(distinct_challenger(&primary, None).is_none());
+    }
+
+    #[test]
+    fn verdict_serializes_as_legacy_uppercase_strings() {
+        assert_eq!(
+            serde_json::to_value(CrossReviewVerdict::Approved).unwrap(),
+            "APPROVED"
+        );
+        assert_eq!(
+            serde_json::to_value(CrossReviewVerdict::ApprovedDegraded).unwrap(),
+            "APPROVED_DEGRADED"
+        );
+        assert_eq!(
+            serde_json::to_value(CrossReviewVerdict::NotConverged).unwrap(),
+            "NOT_CONVERGED"
+        );
+        assert_eq!(
+            serde_json::to_value(CrossReviewVerdict::ProtocolFailure).unwrap(),
+            "PROTOCOL_FAILURE"
         );
     }
 }

--- a/crates/harness-server/src/quality_trigger.rs
+++ b/crates/harness-server/src/quality_trigger.rs
@@ -259,8 +259,16 @@ impl QualityTrigger {
                             .await
                             {
                                 Ok(Ok(result)) => {
-                                    report.semantic_verdict = Some(result.final_verdict.clone());
-                                    if result.final_verdict == "NOT_CONVERGED" {
+                                    report.semantic_verdict =
+                                        Some(result.final_verdict.as_str().to_string());
+                                    // Fail closed (GH-1767): both an unconverged
+                                    // review and an unparseable challenger reply
+                                    // downgrade the grade.
+                                    if matches!(
+                                        result.final_verdict,
+                                        crate::handlers::cross_review::CrossReviewVerdict::NotConverged
+                                            | crate::handlers::cross_review::CrossReviewVerdict::ProtocolFailure
+                                    ) {
                                         let original = report.grade;
                                         report.grade = Self::downgrade(report.grade);
                                         tracing::info!(


### PR DESCRIPTION
Part of #1767 — implements **D1 only**; the D2 escalation ladder (or D3 vestige deletion) remains for a follow-up.

## Problem

Three fail-open defects in cross-review (analysis: `docs/references/review-integrity.md`):

1. A challenger reply with no `CONFIRMED:`/`MISSED:`/`FALSE-POSITIVE:` tag lines yielded an empty consensus set → `APPROVED`. Unparseable output read as approval.
2. A missing challenger silently degraded to a single-model result whose clean verdict was `APPROVED`, indistinguishable from a real cross-model pass.
3. `default_agent()` vs `get("codex")` could resolve to the same agent — the "challenger" was the primary reviewing itself.

## Changes

- `CrossReviewVerdict` enum — `Approved` / `ApprovedDegraded` / `NotConverged` / `ProtocolFailure` — serializing as the legacy uppercase strings (RPC-compatible, additive new wires).
- `CrossReviewResult` gains `mode` (`CrossModel` | `SingleModelDegraded`), `primary_agent_id`, `challenger_agent_id`, and `protocol_failure` (round + excerpt bounded to 280 chars).
- Tagless challenger reply → `ProtocolFailure` verdict (fail closed). A reply with only `FALSE-POSITIVE:` tags remains a valid approving round; a never-executed challenger round (`max_rounds <= 1`) is neither approval nor protocol failure.
- No-challenger path reports `ApprovedDegraded` for clean reviews — never `Approved`.
- Identity guard: a challenger whose `id()` equals the primary's is dropped to the degraded path; `CodeAgent` gains an additive `id()` defaulting to the registry key.
- `quality_trigger` downgrades the grade on `ProtocolFailure` as well as `NotConverged` (fail closed).
- Challenger prompt now states the tag contract explicitly.

## Validation

- `cargo test -p harness-server --lib cross_review` — 15 passed (3 new: protocol failure, false-positive-only approval, single-round edge, identity guard, verdict wires)
- `cargo test -p harness-server --lib quality_trigger` — 19 passed
- `cargo clippy -p harness-server -p harness-core --all-targets -- -D warnings` — clean