### PR TITLE
feat(workflow): gate dispatch on per-workflow budget with shadow default (GH-1770)

### DIFF
--- a/crates/harness-core/src/config/workflow.rs
+++ b/crates/harness-core/src/config/workflow.rs
@@ -3,12 +3,14 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+mod budget;
 mod candidates;
 mod defaults;
 mod intake_binding;
 mod reserved_keys;
 mod runtime_completion;
 mod storage;
+pub use budget::{RuntimeBudgetEnforcement, RuntimeBudgetPolicy};
 pub use candidates::WorkflowCandidatesPolicy;
 use defaults::*;
 pub use intake_binding::{IntakeFilterPolicy, WorkflowDefinitionIntakePolicy};
@@ -366,6 +368,8 @@ pub struct WorkflowConfig {
     #[serde(default)]
     pub runtime_retry_policy: RuntimeRetryPolicy,
     #[serde(default)]
+    pub runtime_budget_policy: RuntimeBudgetPolicy,
+    #[serde(default)]
     pub memory: WorkflowMemoryPolicy,
     #[serde(default)]
     pub candidates: WorkflowCandidatesPolicy,
@@ -708,6 +712,7 @@ pub(super) fn load_workflow_document_with_base(
         definition.validate_identifiers()?;
     }
     config.runtime_dispatch.apply_default_activity_profiles();
+    config.runtime_budget_policy.validate()?;
     let defer_floor = config.runtime_dispatch.defer_backoff_secs;
     let defer_ceiling = config.runtime_dispatch.defer_backoff_max_secs;
     let chrono_seconds = |seconds: u64| {

--- a/crates/harness-core/src/config/workflow/budget.rs
+++ b/crates/harness-core/src/config/workflow/budget.rs
@@ -1,0 +1,131 @@
+use serde::{Deserialize, Serialize};
+
+/// Pre-dispatch workflow budget gate policy (GH-1770).
+///
+/// Spend is aggregated from adapter-reported `runtime_usage.cost_usd_micros`
+/// for the workflow instance. The gate runs in the runtime command dispatcher
+/// before a command is enqueued as a runtime job.
+///
+/// The default enforcement is [`RuntimeBudgetEnforcement::Shadow`]: the
+/// dispatcher records the would-block decision as a `BudgetShadowDecision`
+/// runtime event but still dispatches. `Enforce` defers the command with the
+/// `workflow_budget_exhausted` dispatch barrier reason.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeBudgetPolicy {
+    /// Per-workflow-instance spend ceiling in USD.
+    #[serde(default = "default_workflow_budget_usd")]
+    pub default_workflow_budget_usd: f64,
+    #[serde(default)]
+    pub enforcement: RuntimeBudgetEnforcement,
+    /// Explicit opt-out: no gate at all. An absent policy no longer means
+    /// unlimited; only this flag does.
+    #[serde(default)]
+    pub unlimited: bool,
+}
+
+impl Default for RuntimeBudgetPolicy {
+    fn default() -> Self {
+        Self {
+            default_workflow_budget_usd: default_workflow_budget_usd(),
+            enforcement: RuntimeBudgetEnforcement::default(),
+            unlimited: false,
+        }
+    }
+}
+
+impl RuntimeBudgetPolicy {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.unlimited {
+            return Ok(());
+        }
+        if !self.default_workflow_budget_usd.is_finite() || self.default_workflow_budget_usd <= 0.0
+        {
+            anyhow::bail!(
+                "runtime_budget_policy.default_workflow_budget_usd must be a positive finite number"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeBudgetEnforcement {
+    /// Record the decision, never block.
+    #[default]
+    Shadow,
+    /// Defer dispatch once the workflow spend reaches the budget.
+    Enforce,
+}
+
+impl RuntimeBudgetEnforcement {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Shadow => "shadow",
+            Self::Enforce => "enforce",
+        }
+    }
+}
+
+fn default_workflow_budget_usd() -> f64 {
+    15.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_policy_is_shadow_with_builtin_budget() {
+        let policy = RuntimeBudgetPolicy::default();
+        assert_eq!(policy.default_workflow_budget_usd, 15.0);
+        assert_eq!(policy.enforcement, RuntimeBudgetEnforcement::Shadow);
+        assert!(!policy.unlimited);
+        policy.validate().expect("default policy is valid");
+    }
+
+    #[test]
+    fn policy_deserializes_from_partial_front_matter() {
+        let policy: RuntimeBudgetPolicy =
+            serde_yaml::from_str("enforcement: enforce").expect("partial policy parses");
+        assert_eq!(policy.default_workflow_budget_usd, 15.0);
+        assert_eq!(policy.enforcement, RuntimeBudgetEnforcement::Enforce);
+        assert!(!policy.unlimited);
+    }
+
+    #[test]
+    fn enforcement_serializes_as_snake_case() {
+        assert_eq!(
+            serde_yaml::to_string(&RuntimeBudgetEnforcement::Shadow).unwrap(),
+            "shadow\n"
+        );
+        assert_eq!(
+            serde_yaml::to_string(&RuntimeBudgetEnforcement::Enforce).unwrap(),
+            "enforce\n"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_non_positive_budget() {
+        for budget in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let policy = RuntimeBudgetPolicy {
+                default_workflow_budget_usd: budget,
+                ..RuntimeBudgetPolicy::default()
+            };
+            assert!(
+                policy.validate().is_err(),
+                "budget {budget} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn unlimited_skips_budget_validation() {
+        let policy = RuntimeBudgetPolicy {
+            default_workflow_budget_usd: 0.0,
+            unlimited: true,
+            ..RuntimeBudgetPolicy::default()
+        };
+        policy.validate().expect("unlimited policy ignores budget");
+    }
+}

--- a/crates/harness-server/src/http/background/runtime_command_dispatch.rs
+++ b/crates/harness-server/src/http/background/runtime_command_dispatch.rs
@@ -157,17 +157,14 @@ async fn dispatch_runtime_command_with_project_policy(
     let repo = command_repo_hint(store, &command).await?;
     let activity = command.command.runtime_activity_key().to_string();
     let dispatch_gate_fact_hash = command_dispatch_gate_fact_hash(&command);
+    let workflow_cfg =
+        load_runtime_workflow_config(&project_root, "workflow runtime command dispatcher")?;
     let outcome = RuntimeCommandDispatcher::with_profile_selector(store, profile_selector)
         .with_isolation_config(isolation_config)
         .with_isolation_availability(state.isolation_availability.clone())
         .with_dispatcher_id(dispatch_owner)
-        .with_defer_backoff(dispatch_backoff(
-            &load_runtime_workflow_config(
-                &project_root,
-                "workflow runtime command dispatcher backoff",
-            )?
-            .runtime_dispatch,
-        )?)
+        .with_defer_backoff(dispatch_backoff(&workflow_cfg.runtime_dispatch)?)
+        .with_budget_policy(workflow_cfg.runtime_budget_policy)
         .dispatch_command(command)
         .await?;
     record_runtime_agent_dispatch_counter(

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/fixtures/model_facing_prompt_v1.txt
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/fixtures/model_facing_prompt_v1.txt
@@ -387,6 +387,11 @@ Prompt packet:
         "max_files_changed": 30,
         "max_lines_added": 1500
       },
+      "runtime_budget_policy": {
+        "default_workflow_budget_usd": 15.0,
+        "enforcement": "shadow",
+        "unlimited": false
+      },
       "runtime_completion": {
         "quality_gate_validation_timeout_secs": 900
       },

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -712,8 +712,9 @@ fn model_facing_prompt_matches_frozen_v1_fixture_while_durable_packet_remains_v2
     // workflow, no memory, and a non-empty prompt template. The frozen fixture
     // was re-rendered when the ActivityResult contract gained its strict
     // output-schema form (json_schema, required arrays, nullable error
-    // fields); the fixed input bytes still match the current default
-    // configuration.
+    // fields), and again when WorkflowConfig gained the runtime_budget_policy
+    // section (GH-1770); the fixed input bytes still match the current
+    // default configuration.
     let mut job = RuntimeJob::pending(
         "command-fixture-1",
         RuntimeKind::CodexJsonrpc,

--- a/crates/harness-workflow/src/runtime/dispatch_barrier.rs
+++ b/crates/harness-workflow/src/runtime/dispatch_barrier.rs
@@ -58,6 +58,7 @@ pub enum DispatchBarrierReasonCode {
     RuntimePolicyDisabled,
     WorkflowConfigInvalid,
     IsolationTierUnavailable,
+    WorkflowBudgetExhausted,
 }
 
 impl DispatchBarrierReasonCode {
@@ -66,6 +67,7 @@ impl DispatchBarrierReasonCode {
             Self::RuntimePolicyDisabled => "runtime_policy_disabled",
             Self::WorkflowConfigInvalid => "workflow_config_invalid",
             Self::IsolationTierUnavailable => "isolation_tier_unavailable",
+            Self::WorkflowBudgetExhausted => "workflow_budget_exhausted",
         }
     }
 }
@@ -213,6 +215,7 @@ impl DispatchBarrier {
             }
             DispatchBarrierReasonCode::RuntimePolicyDisabled
             | DispatchBarrierReasonCode::WorkflowConfigInvalid
+            | DispatchBarrierReasonCode::WorkflowBudgetExhausted
                 if self.required_tier.is_some() || self.trust_class.is_some() =>
             {
                 anyhow::bail!("non-isolation barrier must not include isolation evidence")
@@ -444,6 +447,35 @@ mod tests {
             Utc::now(),
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn budget_barrier_rejects_isolation_evidence() {
+        let result = DispatchBarrier::new(
+            DispatchBarrierReasonCode::WorkflowBudgetExhausted,
+            "spent 15.00 of 15.00 USD",
+            "/project",
+            "command",
+            "workflow",
+            Some("container".to_string()),
+            None,
+            "owner",
+            1,
+            1,
+            Utc::now(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn budget_barrier_reason_code_serializes_as_workflow_budget_exhausted() {
+        assert_eq!(
+            DispatchBarrierReasonCode::WorkflowBudgetExhausted.as_str(),
+            "workflow_budget_exhausted"
+        );
+        let json = serde_json::to_string(&DispatchBarrierReasonCode::WorkflowBudgetExhausted)
+            .expect("reason code serializes");
+        assert_eq!(json, "\"workflow_budget_exhausted\"");
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -1,5 +1,8 @@
-use super::model::{RuntimeJob, RuntimeProfile, WorkflowCommandRecord};
-use super::store::{ClaimedCommandTerminalOutcome, RuntimeJobEnqueueOutcome, WorkflowRuntimeStore};
+use super::model::{RuntimeJob, RuntimeProfile, WorkflowCommandRecord, WorkflowInstance};
+use super::store::{
+    cost_usd_from_micros, ClaimedCommandTerminalOutcome, RuntimeJobEnqueueOutcome,
+    WorkflowRuntimeStore,
+};
 use super::tier_resolution::{
     resolve_isolation_tier, IsolationTaskMetadata, IsolationTierResolution,
 };
@@ -12,6 +15,7 @@ use chrono::{DateTime, Duration, Utc};
 use harness_core::config::isolation::{
     IsolationAvailability, IsolationConfig, IsolationTrustClass,
 };
+use harness_core::config::workflow::{RuntimeBudgetEnforcement, RuntimeBudgetPolicy};
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use uuid::Uuid;
@@ -121,6 +125,7 @@ pub struct RuntimeCommandDispatcher<'a> {
     dispatcher_id: String,
     lease_duration: Duration,
     defer_backoff: DispatchBackoffPolicy,
+    budget_policy: RuntimeBudgetPolicy,
 }
 
 impl<'a> RuntimeCommandDispatcher<'a> {
@@ -141,6 +146,7 @@ impl<'a> RuntimeCommandDispatcher<'a> {
             dispatcher_id: format!("dispatcher:{}", Uuid::new_v4()),
             lease_duration: Duration::seconds(30),
             defer_backoff: DispatchBackoffPolicy::default(),
+            budget_policy: RuntimeBudgetPolicy::default(),
         }
     }
 
@@ -174,6 +180,11 @@ impl<'a> RuntimeCommandDispatcher<'a> {
 
     pub fn with_defer_backoff(mut self, defer_backoff: DispatchBackoffPolicy) -> Self {
         self.defer_backoff = defer_backoff;
+        self
+    }
+
+    pub fn with_budget_policy(mut self, budget_policy: RuntimeBudgetPolicy) -> Self {
+        self.budget_policy = budget_policy;
         self
     }
 
@@ -308,6 +319,12 @@ impl<'a> RuntimeCommandDispatcher<'a> {
                     .await?,
             );
         }
+        if let Some(outcome) = self
+            .budget_gate_outcome(instance.as_ref(), &command)
+            .await?
+        {
+            return Ok(outcome);
+        }
         let not_before = retry_not_before_for_command(&command)?;
         match self
             .store
@@ -378,6 +395,78 @@ impl<'a> RuntimeCommandDispatcher<'a> {
                 Some(command.command.runtime_activity_key()),
             )
             .clone())
+    }
+
+    /// Pre-dispatch budget gate (GH-1770). Returns `Some(outcome)` when the
+    /// command was deferred; `None` when dispatch may proceed.
+    ///
+    /// Shadow enforcement records the would-block decision as a
+    /// `BudgetShadowDecision` runtime event and lets the command through;
+    /// enforce defers it with the `workflow_budget_exhausted` barrier.
+    async fn budget_gate_outcome(
+        &self,
+        instance: Option<&WorkflowInstance>,
+        command: &WorkflowCommandRecord,
+    ) -> anyhow::Result<Option<CommandDispatchOutcome>> {
+        if self.budget_policy.unlimited {
+            return Ok(None);
+        }
+        let budget_usd = self.budget_policy.default_workflow_budget_usd;
+        let spent_usd = self
+            .store
+            .runtime_usage_for_workflow(&command.workflow_id)
+            .await?
+            .map(|usage| cost_usd_from_micros(usage.cost_usd_micros))
+            .unwrap_or(0.0);
+        if spent_usd < budget_usd {
+            return Ok(None);
+        }
+        match self.budget_policy.enforcement {
+            RuntimeBudgetEnforcement::Shadow => {
+                self.store
+                    .append_event(
+                        &command.workflow_id,
+                        "BudgetShadowDecision",
+                        "workflow_runtime_command_dispatcher",
+                        json!({
+                            "command_id": command.id,
+                            "decision": "would_defer",
+                            "barrier_reason_code":
+                                DispatchBarrierReasonCode::WorkflowBudgetExhausted.as_str(),
+                            "spent_usd": spent_usd,
+                            "budget_usd": budget_usd,
+                        }),
+                    )
+                    .await?;
+                Ok(None)
+            }
+            RuntimeBudgetEnforcement::Enforce => {
+                let reason = format!(
+                    "workflow {} spent {spent_usd:.2} USD, reaching its {budget_usd:.2} USD budget",
+                    command.workflow_id
+                );
+                let project_id = command_project_id(instance, command)?;
+                let barrier = DispatchBarrierInput::new(
+                    DispatchBarrierReasonCode::WorkflowBudgetExhausted,
+                    reason,
+                    project_id,
+                );
+                dispatch_deferral_outcome(
+                    command,
+                    self.store
+                        .defer_claimed_command_if_owned(
+                            &command.id,
+                            &self.dispatcher_id,
+                            command.dispatch_claim_generation,
+                            barrier,
+                            Utc::now(),
+                            self.defer_backoff,
+                        )
+                        .await?,
+                )
+                .map(Some)
+            }
+        }
     }
 }
 

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -1,7 +1,7 @@
 use super::model::{RuntimeJob, RuntimeProfile, WorkflowCommandRecord, WorkflowInstance};
 use super::store::{
-    cost_usd_from_micros, ClaimedCommandTerminalOutcome, RuntimeJobEnqueueOutcome,
-    WorkflowRuntimeStore,
+    cost_usd_from_micros, cost_usd_to_micros, ClaimedCommandTerminalOutcome,
+    RuntimeJobEnqueueOutcome, WorkflowRuntimeStore,
 };
 use super::tier_resolution::{
     resolve_isolation_tier, IsolationTaskMetadata, IsolationTierResolution,
@@ -412,15 +412,19 @@ impl<'a> RuntimeCommandDispatcher<'a> {
             return Ok(None);
         }
         let budget_usd = self.budget_policy.default_workflow_budget_usd;
-        let spent_usd = self
+        // Compare in integer micro-dollars: spend is stored in micros, and a
+        // float comparison could flip the gate at the boundary.
+        let budget_usd_micros = cost_usd_to_micros(budget_usd)?;
+        let spent_usd_micros = self
             .store
             .runtime_usage_for_workflow(&command.workflow_id)
             .await?
-            .map(|usage| cost_usd_from_micros(usage.cost_usd_micros))
-            .unwrap_or(0.0);
-        if spent_usd < budget_usd {
+            .map(|usage| usage.cost_usd_micros)
+            .unwrap_or(0);
+        if spent_usd_micros < budget_usd_micros {
             return Ok(None);
         }
+        let spent_usd = cost_usd_from_micros(spent_usd_micros);
         match self.budget_policy.enforcement {
             RuntimeBudgetEnforcement::Shadow => {
                 self.store

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -53,6 +53,7 @@ include!("tests/worker_limits.rs");
 include!("tests/durable_store.rs");
 include!("tests/prompt_continuation_store.rs");
 include!("tests/command_dispatcher.rs");
+include!("tests/command_dispatcher_budget.rs");
 include!("tests/command_store.rs");
 include!("tests/deferred_dispatch.rs");
 include!("tests/deferred_dispatch_review.rs");

--- a/crates/harness-workflow/src/runtime/tests/command_dispatcher_budget.rs
+++ b/crates/harness-workflow/src/runtime/tests/command_dispatcher_budget.rs
@@ -1,0 +1,209 @@
+use crate::runtime::{cost_usd_to_micros, RuntimeUsageMetrics, RuntimeUsageUpsert};
+use harness_core::config::workflow::{RuntimeBudgetEnforcement, RuntimeBudgetPolicy};
+
+fn budget_usage_upsert(workflow_id: &str, cost_usd_micros: u64) -> RuntimeUsageUpsert {
+    RuntimeUsageUpsert {
+        runtime_job_id: format!("runtime-job-{workflow_id}"),
+        command_id: format!("command-{workflow_id}"),
+        workflow_id: workflow_id.to_string(),
+        turn_id: Some(format!("turn-{workflow_id}")),
+        agent_run_id: None,
+        runtime_kind: RuntimeKind::CodexExec,
+        runtime_profile: "codex-default".to_string(),
+        agent: "codex".to_string(),
+        model: "gpt-5".to_string(),
+        project: "/project-a".to_string(),
+        task_id: None,
+        candidate_group_id: None,
+        candidate_id: None,
+        candidate_index: None,
+        candidate_count: None,
+        metrics: RuntimeUsageMetrics::default(),
+        cost_usd_micros,
+        reported_at: Utc::now(),
+    }
+}
+
+fn enforce_budget_policy(budget_usd: f64) -> RuntimeBudgetPolicy {
+    RuntimeBudgetPolicy {
+        default_workflow_budget_usd: budget_usd,
+        enforcement: RuntimeBudgetEnforcement::Enforce,
+        unlimited: false,
+    }
+}
+
+async fn issue_with_pending_command(
+    store: &WorkflowRuntimeStore,
+    issue_number: u64,
+) -> anyhow::Result<(WorkflowInstance, String)> {
+    let instance = project_issue_instance("/project-a", issue_number, "replanning");
+    store.force_upsert_lifecycle_state_for_test(&instance).await?;
+    let command = WorkflowCommand::enqueue_activity(
+        "replan_issue",
+        format!("issue-{issue_number}-replan-budget"),
+    );
+    let command_id = store.enqueue_command(&instance.id, None, &command).await?;
+    Ok((instance, command_id))
+}
+
+#[tokio::test]
+async fn budget_gate_shadow_records_event_and_dispatches() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let (instance, _) = issue_with_pending_command(&store, 501).await?;
+    store
+        .upsert_runtime_usage(&budget_usage_upsert(&instance.id, cost_usd_to_micros(20.0)?))
+        .await?;
+
+    let dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-high", RuntimeKind::CodexJsonrpc),
+    );
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    assert!(
+        matches!(outcome, CommandDispatchOutcome::Enqueued { .. }),
+        "shadow mode must dispatch despite the exhausted budget: {outcome:?}"
+    );
+    let events = store.events_for(&instance.id).await?;
+    let shadow = events
+        .iter()
+        .find(|event| event.event_type == "BudgetShadowDecision")
+        .expect("shadow mode records a BudgetShadowDecision event");
+    assert_eq!(shadow.source, "workflow_runtime_command_dispatcher");
+    assert_eq!(shadow.event["decision"], "would_defer");
+    assert_eq!(
+        shadow.event["barrier_reason_code"],
+        "workflow_budget_exhausted"
+    );
+    assert_eq!(shadow.event["budget_usd"], 15.0);
+    assert_eq!(shadow.event["spent_usd"], 20.0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_gate_enforce_defers_with_budget_barrier() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let (instance, command_id) = issue_with_pending_command(&store, 502).await?;
+    store
+        .upsert_runtime_usage(&budget_usage_upsert(&instance.id, cost_usd_to_micros(16.0)?))
+        .await?;
+
+    let dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-high", RuntimeKind::CodexJsonrpc),
+    )
+    .with_budget_policy(enforce_budget_policy(15.0));
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    let barrier = match outcome {
+        CommandDispatchOutcome::Deferred { command_id: id, barrier } => {
+            assert_eq!(id, command_id);
+            barrier
+        }
+        other => panic!("enforce mode must defer an over-budget command: {other:?}"),
+    };
+    assert_eq!(
+        barrier.reason_code,
+        DispatchBarrierReasonCode::WorkflowBudgetExhausted
+    );
+    assert!(barrier.reason.contains("16.00"), "{}", barrier.reason);
+    assert_eq!(
+        store.commands_for(&instance.id).await?[0].status,
+        WorkflowCommandStatus::Deferred
+    );
+    assert!(store
+        .events_for(&instance.id)
+        .await?
+        .iter()
+        .all(|event| event.event_type != "BudgetShadowDecision"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_gate_enforce_dispatches_under_budget() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let (instance, _) = issue_with_pending_command(&store, 503).await?;
+    store
+        .upsert_runtime_usage(&budget_usage_upsert(&instance.id, cost_usd_to_micros(1.0)?))
+        .await?;
+
+    let dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-high", RuntimeKind::CodexJsonrpc),
+    )
+    .with_budget_policy(enforce_budget_policy(15.0));
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    assert!(
+        matches!(outcome, CommandDispatchOutcome::Enqueued { .. }),
+        "under-budget command must dispatch: {outcome:?}"
+    );
+    assert!(store
+        .events_for(&instance.id)
+        .await?
+        .iter()
+        .all(|event| event.event_type != "BudgetShadowDecision"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_gate_unlimited_skips_check() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let (instance, _) = issue_with_pending_command(&store, 504).await?;
+    store
+        .upsert_runtime_usage(&budget_usage_upsert(&instance.id, cost_usd_to_micros(500.0)?))
+        .await?;
+
+    let dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-high", RuntimeKind::CodexJsonrpc),
+    )
+    .with_budget_policy(RuntimeBudgetPolicy {
+        unlimited: true,
+        ..RuntimeBudgetPolicy::default()
+    });
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    assert!(
+        matches!(outcome, CommandDispatchOutcome::Enqueued { .. }),
+        "unlimited policy must dispatch regardless of spend: {outcome:?}"
+    );
+    assert!(store
+        .events_for(&instance.id)
+        .await?
+        .iter()
+        .all(|event| event.event_type != "BudgetShadowDecision"));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements the pre-dispatch budget gate from `specs/GH1770/tech.md` §4.1 (v1 scope: workflow-level ceiling only; daily profile caps, the turn-stream watchdog, and the reducer hard ceiling remain for follow-ups).

- **Config**: new `runtime_budget_policy` WORKFLOW.md section — `default_workflow_budget_usd` (default 15.0), `enforcement: shadow | enforce` (default **shadow**), `unlimited` (explicit opt-out). An absent policy no longer means unlimited; only `unlimited: true` does. Non-positive/non-finite budgets are rejected at config load unless `unlimited` is set.
- **Gate**: `RuntimeCommandDispatcher` aggregates adapter-reported spend via the existing `runtime_usage_for_workflow` (`cost_usd_micros`, from #1852) before enqueueing a runtime job.
  - **shadow** (default): records a `BudgetShadowDecision` runtime event (`would_defer`, spent/budget evidence) and dispatches anyway.
  - **enforce**: defers the command with the new `workflow_budget_exhausted` dispatch-barrier reason through the existing defer/backoff machinery — raising the budget or setting `unlimited` lets a later tick dispatch it.
- **Server wiring**: the background dispatcher passes the project-scoped policy from the same WORKFLOW.md load used for defer backoff.
- Frozen model-facing prompt fixture re-rendered for the new default config section (5 added lines, verified byte-exact by the frozen test).

## Test plan

- [x] `cargo test -p harness-core --lib` — 805 passed (5 new budget policy tests)
- [x] `cargo test -p harness-workflow --lib` (PostgreSQL) — 657 passed (4 new gate tests: shadow event + dispatch, enforce defer + barrier reason + command Deferred, under-budget dispatch, unlimited skip)
- [x] `cargo test -p harness-server --lib runtime_command_dispatch` + frozen fixture test — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — applied

Closes nothing yet — this is phase 1-2 of the #1770 rollout order (shadow-first); `enforce` rollout and the remaining enforcement points track under #1770.