### PR TITLE
fix(server): classify and retry git worktree add failures (GH-1886)

### DIFF
--- a/crates/harness-server/src/workspace.rs
+++ b/crates/harness-server/src/workspace.rs
@@ -45,6 +45,8 @@ mod workspace_create;
 pub(crate) mod workspace_helpers;
 #[path = "workspace_reconcile.rs"]
 mod workspace_reconcile;
+#[path = "workspace_worktree_add.rs"]
+mod workspace_worktree_add;
 
 pub(crate) use workspace_helpers::run_hook;
 use workspace_helpers::*;

--- a/crates/harness-server/src/workspace_create.rs
+++ b/crates/harness-server/src/workspace_create.rs
@@ -546,84 +546,20 @@ impl WorkspaceManager {
             _decision = WorkspaceAcquireDecision::RecreatedStale;
         }
 
-        // Create git worktree based on remote/base_branch (latest upstream).
-        // Falls back to local base_branch only when strict remote-head
-        // admission is disabled.
-        let output = match git_command()
-            .args([
-                "-C",
-                &source_repo.to_string_lossy(),
-                "worktree",
-                "add",
-                "-B",
-                &branch,
-                &workspace_path.to_string_lossy(),
-                &remote_ref,
-            ])
-            .output()
-            .await
+        // Create git worktree based on remote/base_branch (latest upstream),
+        // with class-targeted recovery for stale admin entries and lock
+        // contention (GH-1886). Falls back to local base_branch only when
+        // strict remote-head admission is disabled.
+        if let Err(error) = workspace_worktree_add::worktree_add_with_recovery(
+            source_repo,
+            &branch,
+            &workspace_path,
+            &remote_ref,
+        )
+        .await
         {
-            Ok(output) => output,
-            Err(e) => {
-                if let Err(cleanup_err) = self
-                    .cleanup_created_workspace_then_release(
-                        task_id,
-                        source_repo,
-                        &workspace_path,
-                        None,
-                    )
-                    .await
-                {
-                    tracing::warn!(
-                        "failed to cleanup partial worktree after worktree-add spawn failure: {cleanup_err}"
-                    );
-                }
-                return Err(WorkspaceLifecycleError::CreateFailed {
-                    message: format!("git worktree add failed for task {}: {e}", task_id.0),
-                });
-            }
-        };
-
-        if !output.status.success() {
-            if options.require_remote_head {
-                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-                if let Err(cleanup_err) = self
-                    .cleanup_created_workspace_then_release(
-                        task_id,
-                        source_repo,
-                        &workspace_path,
-                        None,
-                    )
-                    .await
-                {
-                    tracing::warn!(
-                        "failed to cleanup partial worktree after worktree-add failure: {cleanup_err}"
-                    );
-                }
-                return Err(WorkspaceLifecycleError::CreateFailed {
-                    message: format!(
-                        "git worktree add from {remote_ref} failed for task {}: {}",
-                        task_id.0, stderr
-                    ),
-                });
-            }
-            // Fallback: try local base_branch (useful for repos without remotes, e.g. tests).
-            let fallback = match git_command()
-                .args([
-                    "-C",
-                    &source_repo.to_string_lossy(),
-                    "worktree",
-                    "add",
-                    "-B",
-                    &branch,
-                    &workspace_path.to_string_lossy(),
-                    base_branch,
-                ])
-                .output()
-                .await
-            {
-                Ok(output) => output,
-                Err(e) => {
+            match error {
+                workspace_worktree_add::WorktreeAddError::Spawn(e) => {
                     if let Err(cleanup_err) = self
                         .cleanup_created_workspace_then_release(
                             task_id,
@@ -634,36 +570,74 @@ impl WorkspaceManager {
                         .await
                     {
                         tracing::warn!(
-                            "failed to cleanup partial worktree after fallback worktree-add spawn failure: {cleanup_err}"
+                            "failed to cleanup partial worktree after worktree-add spawn failure: {cleanup_err}"
                         );
                     }
                     return Err(WorkspaceLifecycleError::CreateFailed {
-                        message: format!(
-                            "git worktree add fallback failed for task {}: {e}",
-                            task_id.0
-                        ),
+                        message: format!("git worktree add failed for task {}: {e}", task_id.0),
                     });
                 }
-            };
-
-            if !fallback.status.success() {
-                let stderr = String::from_utf8_lossy(&fallback.stderr).trim().to_string();
-                if let Err(cleanup_err) = self
-                    .cleanup_created_workspace_then_release(
-                        task_id,
+                workspace_worktree_add::WorktreeAddError::Failed(failure) => {
+                    if options.require_remote_head {
+                        if let Err(cleanup_err) = self
+                            .cleanup_created_workspace_then_release(
+                                task_id,
+                                source_repo,
+                                &workspace_path,
+                                None,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                "failed to cleanup partial worktree after worktree-add failure: {cleanup_err}"
+                            );
+                        }
+                        return Err(WorkspaceLifecycleError::CreateFailed {
+                            message: format!(
+                                "git worktree add from {remote_ref} failed for task {}: {}",
+                                task_id.0,
+                                failure.evidence()
+                            ),
+                        });
+                    }
+                    // Fallback: try local base_branch (useful for repos without remotes, e.g. tests).
+                    if let Err(fallback_error) = workspace_worktree_add::worktree_add_with_recovery(
                         source_repo,
+                        &branch,
                         &workspace_path,
-                        None,
+                        base_branch,
                     )
                     .await
-                {
-                    tracing::warn!(
-                        "failed to cleanup partial worktree after fallback worktree-add failure: {cleanup_err}"
-                    );
+                    {
+                        if let Err(cleanup_err) = self
+                            .cleanup_created_workspace_then_release(
+                                task_id,
+                                source_repo,
+                                &workspace_path,
+                                None,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                "failed to cleanup partial worktree after fallback worktree-add failure: {cleanup_err}"
+                            );
+                        }
+                        let message = match fallback_error {
+                            workspace_worktree_add::WorktreeAddError::Spawn(e) => format!(
+                                "git worktree add fallback failed for task {}: {e}",
+                                task_id.0
+                            ),
+                            workspace_worktree_add::WorktreeAddError::Failed(failure) => {
+                                format!(
+                                    "git worktree add failed for task {}: {}",
+                                    task_id.0,
+                                    failure.evidence()
+                                )
+                            }
+                        };
+                        return Err(WorkspaceLifecycleError::CreateFailed { message });
+                    }
                 }
-                return Err(WorkspaceLifecycleError::CreateFailed {
-                    message: format!("git worktree add failed for task {}: {}", task_id.0, stderr),
-                });
             }
         }
 

--- a/crates/harness-server/src/workspace_worktree_add.rs
+++ b/crates/harness-server/src/workspace_worktree_add.rs
@@ -1,0 +1,264 @@
+use super::*;
+
+/// Failure classes for `git worktree add` (GH-1886). Each class carries a
+/// stable string recorded in job-facing error messages so ops reviews can
+/// aggregate failures by cause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorktreeAddFailureClass {
+    /// A worktree admin entry (branch or path) is registered but its
+    /// directory is gone — `git worktree prune` clears it.
+    StaleWorktreeEntry,
+    /// Another git process holds a lock in the admin area — transient.
+    LockContention,
+    /// The target path exists on disk and is not a registered worktree.
+    PathCollision,
+    /// The start ref does not resolve (fetch failed or ref deleted upstream).
+    MissingRef,
+    Unknown,
+}
+
+impl WorktreeAddFailureClass {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::StaleWorktreeEntry => "stale_worktree_entry",
+            Self::LockContention => "lock_contention",
+            Self::PathCollision => "path_collision",
+            Self::MissingRef => "missing_ref",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+pub(crate) fn classify_worktree_add_stderr(stderr: &str) -> WorktreeAddFailureClass {
+    let lower = stderr.to_lowercase();
+    if lower.contains("missing but already registered")
+        || lower.contains("missing but locked")
+        || lower.contains("is already used by worktree")
+        || lower.contains("is already checked out at")
+    {
+        WorktreeAddFailureClass::StaleWorktreeEntry
+    } else if lower.contains("could not lock")
+        || lower.contains("another git process")
+        || (lower.contains("unable to create") && lower.contains(".lock"))
+    {
+        WorktreeAddFailureClass::LockContention
+    } else if lower.contains("already exists") {
+        WorktreeAddFailureClass::PathCollision
+    } else if lower.contains("invalid reference")
+        || lower.contains("not a valid ref")
+        || lower.contains("unknown revision")
+    {
+        WorktreeAddFailureClass::MissingRef
+    } else {
+        WorktreeAddFailureClass::Unknown
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct WorktreeAddFailure {
+    pub(crate) class: WorktreeAddFailureClass,
+    pub(crate) attempts: u32,
+    pub(crate) stderr: String,
+}
+
+impl WorktreeAddFailure {
+    /// Render the queryable evidence suffix embedded in job-facing errors.
+    pub(crate) fn evidence(&self) -> String {
+        format!(
+            "worktree_add_failure_class={} attempts={}: {}",
+            self.class.as_str(),
+            self.attempts,
+            self.stderr
+        )
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum WorktreeAddError {
+    Spawn(std::io::Error),
+    Failed(WorktreeAddFailure),
+}
+
+const WORKTREE_ADD_MAX_ATTEMPTS: u32 = 2;
+const WORKTREE_ADD_LOCK_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Run `git worktree add -B <branch> <path> <start_ref>` with class-targeted
+/// recovery (GH-1886): stale admin entries get one `git worktree prune` +
+/// retry, lock contention gets one backoff + retry, other classes fail
+/// immediately with the classified evidence.
+pub(crate) async fn worktree_add_with_recovery(
+    source_repo: &Path,
+    branch: &str,
+    workspace_path: &Path,
+    start_ref: &str,
+) -> Result<(), WorktreeAddError> {
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        let output = git_command()
+            .args([
+                "-C",
+                &source_repo.to_string_lossy(),
+                "worktree",
+                "add",
+                "-B",
+                branch,
+                &workspace_path.to_string_lossy(),
+                start_ref,
+            ])
+            .output()
+            .await
+            .map_err(WorktreeAddError::Spawn)?;
+        if output.status.success() {
+            return Ok(());
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let class = classify_worktree_add_stderr(&stderr);
+        if attempts >= WORKTREE_ADD_MAX_ATTEMPTS {
+            return Err(WorktreeAddError::Failed(WorktreeAddFailure {
+                class,
+                attempts,
+                stderr,
+            }));
+        }
+        match class {
+            WorktreeAddFailureClass::StaleWorktreeEntry => {
+                tracing::warn!(
+                    failure_class = class.as_str(),
+                    branch,
+                    "git worktree add hit a stale admin entry; pruning and retrying"
+                );
+                let prune = git_command()
+                    .args(["-C", &source_repo.to_string_lossy(), "worktree", "prune"])
+                    .output()
+                    .await
+                    .map_err(WorktreeAddError::Spawn)?;
+                if !prune.status.success() {
+                    return Err(WorktreeAddError::Failed(WorktreeAddFailure {
+                        class,
+                        attempts,
+                        stderr: format!(
+                            "{stderr}; git worktree prune also failed: {}",
+                            String::from_utf8_lossy(&prune.stderr).trim()
+                        ),
+                    }));
+                }
+            }
+            WorktreeAddFailureClass::LockContention => {
+                tracing::warn!(
+                    failure_class = class.as_str(),
+                    branch,
+                    "git worktree add hit lock contention; backing off and retrying"
+                );
+                tokio::time::sleep(WORKTREE_ADD_LOCK_RETRY_DELAY).await;
+            }
+            WorktreeAddFailureClass::PathCollision
+            | WorktreeAddFailureClass::MissingRef
+            | WorktreeAddFailureClass::Unknown => {
+                return Err(WorktreeAddError::Failed(WorktreeAddFailure {
+                    class,
+                    attempts,
+                    stderr,
+                }));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace::test_support::{init_git_repo, run_git};
+    use tempfile::TempDir;
+
+    #[test]
+    fn classifies_stale_entry_variants() {
+        for stderr in [
+            "fatal: 'harness/runtime-wf-github-issue-pr-81eb5207' is already used by worktree at '/tmp/wt'",
+            "fatal: '/tmp/wt' is a missing but already registered worktree;\nuse 'add -f' to override, or 'prune' or 'remove' to clear",
+            "fatal: 'main' is already checked out at '/tmp/other'",
+        ] {
+            assert_eq!(
+                classify_worktree_add_stderr(stderr),
+                WorktreeAddFailureClass::StaleWorktreeEntry,
+                "stderr: {stderr}"
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_lock_path_and_ref_failures() {
+        assert_eq!(
+            classify_worktree_add_stderr(
+                "fatal: Unable to create '/repo/.git/worktrees/x/index.lock': File exists.\n\nAnother git process seems to be running"
+            ),
+            WorktreeAddFailureClass::LockContention
+        );
+        assert_eq!(
+            classify_worktree_add_stderr("fatal: '/tmp/wt' already exists"),
+            WorktreeAddFailureClass::PathCollision
+        );
+        assert_eq!(
+            classify_worktree_add_stderr("fatal: invalid reference: origin/main"),
+            WorktreeAddFailureClass::MissingRef
+        );
+        assert_eq!(
+            classify_worktree_add_stderr("fatal: something novel"),
+            WorktreeAddFailureClass::Unknown
+        );
+    }
+
+    #[tokio::test]
+    async fn recovers_from_stale_worktree_entry_by_pruning() {
+        let repo_dir = TempDir::new().expect("repo dir");
+        init_git_repo(repo_dir.path());
+        let repo = repo_dir.path().to_string_lossy().to_string();
+
+        let stale_path = repo_dir.path().join("stale-wt");
+        run_git(&[
+            "-C",
+            &repo,
+            "worktree",
+            "add",
+            "-B",
+            "harness/stale-task",
+            &stale_path.to_string_lossy(),
+            "HEAD",
+        ]);
+        // Delete the worktree directory without deregistering it: the branch
+        // stays "used by" a worktree whose directory is gone.
+        std::fs::remove_dir_all(&stale_path).expect("remove stale worktree dir");
+
+        let new_path = repo_dir.path().join("fresh-wt");
+        worktree_add_with_recovery(repo_dir.path(), "harness/stale-task", &new_path, "HEAD")
+            .await
+            .expect("prune + retry should recover the stale entry");
+        assert!(new_path.join(".git").exists());
+    }
+
+    #[tokio::test]
+    async fn missing_ref_fails_without_retry_and_carries_evidence() {
+        let repo_dir = TempDir::new().expect("repo dir");
+        init_git_repo(repo_dir.path());
+        let new_path = repo_dir.path().join("wt");
+
+        let err = worktree_add_with_recovery(
+            repo_dir.path(),
+            "harness/task",
+            &new_path,
+            "origin/does-not-exist",
+        )
+        .await
+        .expect_err("missing ref must fail");
+        match err {
+            WorktreeAddError::Failed(failure) => {
+                assert_eq!(failure.class, WorktreeAddFailureClass::MissingRef);
+                assert_eq!(failure.attempts, 1);
+                assert!(failure
+                    .evidence()
+                    .starts_with("worktree_add_failure_class=missing_ref attempts=1:"));
+            }
+            other => panic!("expected classified failure, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1886 (split from the #1883 F1 outage finding: 4 of 8 daily job failures on 08-03 were opaque `git worktree add` fatals).

- **New `workspace_worktree_add` module**: classifies `git worktree add` stderr into `stale_worktree_entry` (branch/path registered but directory gone — the 08-03 outage class), `lock_contention`, `path_collision`, `missing_ref`, `unknown`.
- **Class-targeted recovery** before failing the job: stale admin entries run `git worktree prune` + one retry; lock contention backs off 250ms + one retry; path collision / missing ref / unknown fail immediately (retrying cannot help).
- **Queryable evidence**: failed adds embed `worktree_add_failure_class=<class> attempts=<n>` in the job-facing `CreateFailed` message, so the failure class lands in the job record and is aggregatable in ops reviews.
- Both the remote-ref path and the local-branch fallback in `create_workspace_with_options` go through the same recovery wrapper; cleanup-on-failure behavior is unchanged.

## Test plan

- [x] `cargo test -p harness-server --lib worktree_add` — 4 new tests: classifier coverage for all classes (including the exact 08-03 outage stderr), prune-recovery integration test on a real repo with a stale registered worktree, missing-ref fails without retry and carries evidence
- [x] `cargo test -p harness-server --lib workspace` — 92 passed (no regression in create/reconcile/pool suites)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`