### PR TITLE
feat(observe): alert when the runtime pool starves with gated work (GH-1895)

### DIFF
--- a/crates/harness-core/src/alert.rs
+++ b/crates/harness-core/src/alert.rs
@@ -24,6 +24,7 @@ pub enum AlertClass {
     ReconciliationAnomaly,
     ReadyToMergeAging,
     NotifyChannelDrop,
+    RuntimePoolStarved,
 }
 
 impl AlertClass {
@@ -37,6 +38,7 @@ impl AlertClass {
             AlertClass::ReconciliationAnomaly => "reconciliation_anomaly",
             AlertClass::ReadyToMergeAging => "ready_to_merge_aging",
             AlertClass::NotifyChannelDrop => "notify_channel_drop",
+            AlertClass::RuntimePoolStarved => "runtime_pool_starved",
         }
     }
 }

--- a/crates/harness-core/src/config/alerting.rs
+++ b/crates/harness-core/src/config/alerting.rs
@@ -36,6 +36,10 @@ fn default_heartbeat_interval_secs() -> u64 {
     60
 }
 
+fn default_pool_starvation_ticks() -> u32 {
+    20
+}
+
 /// Delivery channel kind. Slack and Feishu are formatters over the same
 /// payload; `webhook` posts the raw JSON contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -160,6 +164,11 @@ pub struct AlertingConfig {
     pub channels: Vec<AlertChannelConfig>,
     #[serde(default)]
     pub heartbeat: AlertingHeartbeatConfig,
+    /// Consecutive empty dispatcher ticks before the pool-starvation probe
+    /// runs (GH-1895). Only fires when gated work exists; a genuinely idle
+    /// pool never alerts.
+    #[serde(default = "default_pool_starvation_ticks")]
+    pub pool_starvation_ticks: u32,
 }
 
 impl Default for AlertingConfig {
@@ -172,6 +181,7 @@ impl Default for AlertingConfig {
             shutdown_flush_secs: default_shutdown_flush_secs(),
             channels: Vec::new(),
             heartbeat: AlertingHeartbeatConfig::default(),
+            pool_starvation_ticks: default_pool_starvation_ticks(),
         }
     }
 }
@@ -188,6 +198,9 @@ impl AlertingConfig {
         }
         if self.queue_capacity == 0 {
             anyhow::bail!("alerting.queue_capacity must be >= 1");
+        }
+        if self.pool_starvation_ticks == 0 {
+            anyhow::bail!("alerting.pool_starvation_ticks must be >= 1");
         }
         let mut names = HashSet::new();
         for channel in &self.channels {
@@ -259,6 +272,7 @@ mod tests {
         assert!(config.event_classes.is_empty());
         assert!(config.channels.is_empty());
         assert!(!config.heartbeat.enabled);
+        assert_eq!(config.pool_starvation_ticks, 20);
         config.validate().expect("inert config validates");
     }
 

--- a/crates/harness-server/src/alerting/mod.rs
+++ b/crates/harness-server/src/alerting/mod.rs
@@ -293,6 +293,7 @@ mod tests {
             shutdown_flush_secs: 5,
             channels,
             heartbeat: Default::default(),
+            pool_starvation_ticks: 20,
         }
     }
 

--- a/crates/harness-server/src/alerting/producers.rs
+++ b/crates/harness-server/src/alerting/producers.rs
@@ -106,6 +106,58 @@ pub fn ready_to_merge_aging(
     })
 }
 
+/// Runtime pool starvation (GH-1895): nothing dispatchable for N consecutive
+/// dispatcher ticks while gated work sits in the pool. A genuinely idle pool
+/// (no commands, no gated workflows) never raises.
+pub fn runtime_pool_starved(
+    empty_ticks: u32,
+    snapshot: &harness_workflow::runtime::store::DispatchPoolSnapshot,
+) -> AlertPayload {
+    AlertPayload::new(
+        AlertClass::RuntimePoolStarved,
+        AlertSeverity::Error,
+        format!(
+            "runtime pool starved: 0 dispatched commands across {empty_ticks} dispatcher ticks \
+             while work is gated (deferred_commands={}, gated_workflows={}, pending_commands={})",
+            snapshot.deferred_commands, snapshot.gated_workflows, snapshot.pending_commands
+        ),
+        AlertPayload::dedup_key_for(AlertClass::RuntimePoolStarved, "runtime"),
+    )
+    .with_subject(AlertSubject {
+        entity: Some("runtime_command_dispatcher".to_string()),
+        ..AlertSubject::default()
+    })
+}
+
+/// Counts consecutive dispatcher ticks that dispatched nothing and decides
+/// when the starvation probe should run. Pure bookkeeping so the contract is
+/// unit-testable without a store.
+pub struct PoolStarvationTracker {
+    threshold: u32,
+    empty_ticks: u32,
+}
+
+impl PoolStarvationTracker {
+    pub fn new(threshold: u32) -> Self {
+        Self {
+            threshold: threshold.max(1),
+            empty_ticks: 0,
+        }
+    }
+
+    /// Record a tick. Returns the consecutive empty-tick count when the
+    /// starvation probe should run (once per threshold window), `None`
+    /// otherwise. Any dispatched command resets the window.
+    pub fn observe_tick(&mut self, dispatched_any: bool) -> Option<u32> {
+        if dispatched_any {
+            self.empty_ticks = 0;
+            return None;
+        }
+        self.empty_ticks = self.empty_ticks.saturating_add(1);
+        (self.empty_ticks % self.threshold == 0).then_some(self.empty_ticks)
+    }
+}
+
 fn notify_channel_drop(delta: u64, total: u64) -> AlertPayload {
     AlertPayload::new(
         AlertClass::NotifyChannelDrop,
@@ -170,6 +222,48 @@ mod tests {
             aging.dedup_key,
             "ready_to_merge_aging:https://github.com/o/r/pull/1"
         );
+    }
+
+    #[test]
+    fn starvation_tracker_fires_once_per_threshold_window_and_resets_on_dispatch() {
+        let mut tracker = PoolStarvationTracker::new(3);
+        assert_eq!(tracker.observe_tick(false), None);
+        assert_eq!(tracker.observe_tick(false), None);
+        assert_eq!(tracker.observe_tick(false), Some(3));
+        assert_eq!(tracker.observe_tick(false), None);
+        assert_eq!(tracker.observe_tick(false), None);
+        assert_eq!(tracker.observe_tick(false), Some(6));
+        assert_eq!(tracker.observe_tick(true), None);
+        assert_eq!(tracker.observe_tick(false), None);
+        assert_eq!(tracker.observe_tick(false), None);
+        assert_eq!(tracker.observe_tick(false), Some(3));
+    }
+
+    #[test]
+    fn starvation_tracker_clamps_zero_threshold() {
+        let mut tracker = PoolStarvationTracker::new(0);
+        assert_eq!(tracker.observe_tick(false), Some(1));
+    }
+
+    #[test]
+    fn runtime_pool_starved_payload_carries_gated_evidence() {
+        let snapshot = harness_workflow::runtime::store::DispatchPoolSnapshot {
+            pending_commands: 1,
+            deferred_commands: 4,
+            dispatched_commands: 0,
+            gated_workflows: 41,
+        };
+        assert!(snapshot.has_gated_work());
+        let payload = runtime_pool_starved(20, &snapshot);
+        assert_eq!(payload.event_class, AlertClass::RuntimePoolStarved);
+        assert_eq!(payload.severity, AlertSeverity::Error);
+        assert_eq!(payload.dedup_key, "runtime_pool_starved:runtime");
+        assert!(payload.message.contains("20 dispatcher ticks"));
+        assert!(payload.message.contains("deferred_commands=4"));
+        assert!(payload.message.contains("gated_workflows=41"));
+
+        let idle = harness_workflow::runtime::store::DispatchPoolSnapshot::default();
+        assert!(!idle.has_gated_work());
     }
 
     #[test]

--- a/crates/harness-server/src/http/background/auto_recovery_recovery_tests.rs
+++ b/crates/harness-server/src/http/background/auto_recovery_recovery_tests.rs
@@ -120,6 +120,7 @@ async fn auto_recovery_state_attempt_bound_survives_restart_and_exhaustion_is_id
             backoff_base_ms: 1,
         }],
         heartbeat: Default::default(),
+        pool_starvation_ticks: 20,
     };
     let alerts = crate::alerting::spawn_alerting(&alerting_config, None, events, transport.clone());
 

--- a/crates/harness-server/src/http/background/runtime_command_dispatch.rs
+++ b/crates/harness-server/src/http/background/runtime_command_dispatch.rs
@@ -484,6 +484,44 @@ fn expand_home_path(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
+/// Pool starvation probe (GH-1895): after N consecutive empty dispatcher
+/// ticks, decide between "no work exists" (idle, log only) and "work exists
+/// but is gated" (starvation: warn and raise `runtime_pool_starved` through
+/// the GH-1582 alerting channel).
+async fn probe_pool_starvation(state: &Arc<AppState>, empty_ticks: u32) {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return;
+    };
+    let snapshot = match store.dispatch_pool_snapshot().await {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            tracing::warn!("pool starvation probe could not read the dispatch pool: {error}");
+            return;
+        }
+    };
+    if !snapshot.has_gated_work() {
+        tracing::debug!(
+            empty_ticks,
+            "runtime pool has no dispatchable and no gated work (idle)"
+        );
+        return;
+    }
+    tracing::warn!(
+        empty_ticks,
+        deferred_commands = snapshot.deferred_commands,
+        gated_workflows = snapshot.gated_workflows,
+        pending_commands = snapshot.pending_commands,
+        "runtime pool starved: work exists but nothing has dispatched"
+    );
+    state
+        .observability
+        .alerts
+        .raise(crate::alerting::producers::runtime_pool_starved(
+            empty_ticks,
+            &snapshot,
+        ));
+}
+
 pub(in crate::http) fn spawn_runtime_command_dispatcher(state: &Arc<AppState>) {
     if state.core.workflow_runtime_store.is_none() {
         tracing::debug!("workflow runtime command dispatcher disabled: store unavailable");
@@ -491,6 +529,9 @@ pub(in crate::http) fn spawn_runtime_command_dispatcher(state: &Arc<AppState>) {
     }
 
     let weak_state = Arc::downgrade(state);
+    let mut starvation = crate::alerting::producers::PoolStarvationTracker::new(
+        state.core.server.config.alerting.pool_starvation_ticks,
+    );
     tokio::spawn(async move {
         loop {
             let state = match weak_state.upgrade() {
@@ -549,15 +590,20 @@ pub(in crate::http) fn spawn_runtime_command_dispatcher(state: &Arc<AppState>) {
             )
             .await
             {
-                Ok(tick) if tick.touched_anything() => {
-                    tracing::info!(
-                        enqueued = tick.enqueued,
-                        already_dispatched = tick.already_dispatched,
-                        skipped = tick.skipped,
-                        "workflow runtime command dispatcher tick complete"
-                    );
+                Ok(tick) => {
+                    if tick.touched_anything() {
+                        tracing::info!(
+                            enqueued = tick.enqueued,
+                            already_dispatched = tick.already_dispatched,
+                            skipped = tick.skipped,
+                            "workflow runtime command dispatcher tick complete"
+                        );
+                    }
+                    let dispatched_any = tick.enqueued > 0 || tick.already_dispatched > 0;
+                    if let Some(empty_ticks) = starvation.observe_tick(dispatched_any) {
+                        probe_pool_starvation(&state, empty_ticks).await;
+                    }
                 }
-                Ok(_) => {}
                 Err(e) => {
                     tracing::warn!("workflow runtime command dispatcher tick failed: {e}");
                 }

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -83,6 +83,7 @@ mod transaction_helpers;
 #[path = "store/transition_validation.rs"]
 mod transition_validation;
 pub use child_instance_start::{WorkflowChildStart, WorkflowChildStartOutcome};
+pub use command_facade::DispatchPoolSnapshot;
 pub use coverage_recovery::{
     WorkflowCoverageRecoveryExpected, WorkflowCoverageRecoveryOutcome,
     WorkflowCoverageRecoveryTransition,

--- a/crates/harness-workflow/src/runtime/store/command_facade.rs
+++ b/crates/harness-workflow/src/runtime/store/command_facade.rs
@@ -1,6 +1,50 @@
 use super::*;
 
+/// Point-in-time dispatch pool state used by the starvation probe (GH-1895):
+/// distinguishes "no work exists" from "work exists but is gated".
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DispatchPoolSnapshot {
+    pub pending_commands: u64,
+    pub deferred_commands: u64,
+    pub dispatched_commands: u64,
+    pub gated_workflows: u64,
+}
+
+impl DispatchPoolSnapshot {
+    /// True when undispatchable work is sitting in the pool: deferred
+    /// commands behind a dispatch barrier, or workflows parked in a gated
+    /// state. This is the starvation case; an all-zero snapshot is idle.
+    pub fn has_gated_work(&self) -> bool {
+        self.deferred_commands > 0 || self.gated_workflows > 0
+    }
+}
+
 impl WorkflowRuntimeStore {
+    /// Count commands by dispatch status plus workflows parked in gated
+    /// states (`blocked`, `awaiting_feedback`).
+    pub async fn dispatch_pool_snapshot(&self) -> anyhow::Result<DispatchPoolSnapshot> {
+        let (pending, deferred, dispatched): (i64, i64, i64) = sqlx::query_as(
+            "SELECT COUNT(*) FILTER (WHERE status = 'pending'),
+                    COUNT(*) FILTER (WHERE status = 'deferred'),
+                    COUNT(*) FILTER (WHERE status = 'dispatched')
+             FROM workflow_commands",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        let (gated_workflows,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM workflow_instances
+             WHERE state IN ('blocked', 'awaiting_feedback')",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(DispatchPoolSnapshot {
+            pending_commands: pending.max(0) as u64,
+            deferred_commands: deferred.max(0) as u64,
+            dispatched_commands: dispatched.max(0) as u64,
+            gated_workflows: gated_workflows.max(0) as u64,
+        })
+    }
+
     pub async fn enqueue_command(
         &self,
         workflow_id: &str,


### PR DESCRIPTION
## Summary

Fixes #1895 (from #1883 F2: from 08-01 the self-runtime pool had nothing dispatchable — runtime jobs/day 1549 → 6 → 7 → 21 — and nothing told the operator).

- **New `runtime_pool_starved` alert class** delivered through the existing GH-1582 alerting channel (explicit `event_classes` opt-in, standard dedup cooldown). No new delivery path.
- **`PoolStarvationTracker`** (pure, unit-tested) counts consecutive dispatcher ticks that dispatched nothing; every `alerting.pool_starvation_ticks` (default 20, validated ≥1) empty ticks the probe runs. Any dispatched command resets the window.
- **The probe distinguishes no-work from gated-work** (the issue's key requirement) via a new `dispatch_pool_snapshot()` store query: commands counted by status plus workflows parked in `blocked`/`awaiting_feedback`. A genuinely idle pool never alerts; gated work raises an error-severity alert with evidence (`deferred_commands`, `gated_workflows`, `pending_commands`, empty-tick count) and always emits a structured warn log, even when alerting is disabled.

## Test plan

- [x] `cargo test -p harness-server --lib producers::` — 5 passed (tracker window/reset semantics, zero-threshold clamp, payload evidence)
- [x] `cargo test -p harness-core --lib alerting` — 11 passed (default + validation for the new knob)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Postgres-dependent alerting delivery tests defer to CI per repo policy (no local `HARNESS_DATABASE_URL`)