### PR TITLE
fix(workflow): count awaiting_dependencies as gated in the starvation probe (GH-1885 follow-up)

### DIFF
--- a/crates/harness-workflow/src/runtime/store/command_facade.rs
+++ b/crates/harness-workflow/src/runtime/store/command_facade.rs
@@ -21,7 +21,9 @@ impl DispatchPoolSnapshot {
 
 impl WorkflowRuntimeStore {
     /// Count commands by dispatch status plus workflows parked in gated
-    /// states (`blocked`, `awaiting_feedback`).
+    /// states (`blocked`, `awaiting_feedback`, `awaiting_dependencies` —
+    /// the last one is how the 08-01 mutual-dependency starvation presented
+    /// while nothing was dispatching, GH-1885).
     pub async fn dispatch_pool_snapshot(&self) -> anyhow::Result<DispatchPoolSnapshot> {
         let (pending, deferred, dispatched): (i64, i64, i64) = sqlx::query_as(
             "SELECT COUNT(*) FILTER (WHERE status = 'pending'),
@@ -33,7 +35,7 @@ impl WorkflowRuntimeStore {
         .await?;
         let (gated_workflows,): (i64,) = sqlx::query_as(
             "SELECT COUNT(*) FROM workflow_instances
-             WHERE state IN ('blocked', 'awaiting_feedback')",
+             WHERE state IN ('blocked', 'awaiting_feedback', 'awaiting_dependencies')",
         )
         .fetch_one(&self.pool)
         .await?;


### PR DESCRIPTION
## Summary

One-line follow-up recorded on #1885: the 08-01 starvation presented as mutually-waiting `awaiting_dependencies` workflows with nothing dispatching. The GH-1895 `dispatch_pool_snapshot()` gated-workflows set now includes `awaiting_dependencies` alongside `blocked` and `awaiting_feedback`, so that scenario raises the `runtime_pool_starved` alert instead of reading as an idle pool.

## Test plan

- [x] `cargo check -p harness-workflow` (SQL literal + doc comment change only; snapshot query behavior is Postgres-gated and covered by CI)
- [x] `cargo fmt --all`