### PR TITLE
feat(workflow): gate dispatch on per-profile daily spend caps (GH-1770)

### DIFF
--- a/crates/harness-core/src/config/workflow/budget.rs
+++ b/crates/harness-core/src/config/workflow/budget.rs
@@ -21,6 +21,11 @@ pub struct RuntimeBudgetPolicy {
     /// unlimited; only this flag does.
     #[serde(default)]
     pub unlimited: bool,
+    /// Per-runtime-profile spend cap in USD over the current UTC day.
+    /// `None` = no daily cap; daily caps roll out last per the GH-1770
+    /// spec, so unlike the workflow ceiling there is no built-in default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daily_profile_cap_usd: Option<f64>,
 }
 
 impl Default for RuntimeBudgetPolicy {
@@ -29,6 +34,7 @@ impl Default for RuntimeBudgetPolicy {
             default_workflow_budget_usd: default_workflow_budget_usd(),
             enforcement: RuntimeBudgetEnforcement::default(),
             unlimited: false,
+            daily_profile_cap_usd: None,
         }
     }
 }
@@ -43,6 +49,13 @@ impl RuntimeBudgetPolicy {
             anyhow::bail!(
                 "runtime_budget_policy.default_workflow_budget_usd must be a positive finite number"
             );
+        }
+        if let Some(cap) = self.daily_profile_cap_usd {
+            if !cap.is_finite() || cap <= 0.0 {
+                anyhow::bail!(
+                    "runtime_budget_policy.daily_profile_cap_usd must be a positive finite number when set"
+                );
+            }
         }
         Ok(())
     }
@@ -103,6 +116,33 @@ mod tests {
             serde_yaml::to_string(&RuntimeBudgetEnforcement::Enforce).unwrap(),
             "enforce\n"
         );
+    }
+
+    #[test]
+    fn daily_cap_defaults_off_and_is_not_serialized() {
+        let policy = RuntimeBudgetPolicy::default();
+        assert_eq!(policy.daily_profile_cap_usd, None);
+        let rendered = serde_yaml::to_string(&policy).expect("serialize");
+        assert!(
+            !rendered.contains("daily_profile_cap_usd"),
+            "absent cap must not appear in rendered config: {rendered}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_non_positive_daily_cap() {
+        for cap in [0.0, -5.0, f64::NAN, f64::INFINITY] {
+            let policy = RuntimeBudgetPolicy {
+                daily_profile_cap_usd: Some(cap),
+                ..RuntimeBudgetPolicy::default()
+            };
+            assert!(policy.validate().is_err(), "cap {cap} must be rejected");
+        }
+        let policy = RuntimeBudgetPolicy {
+            daily_profile_cap_usd: Some(200.0),
+            ..RuntimeBudgetPolicy::default()
+        };
+        policy.validate().expect("positive cap validates");
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/dispatch_barrier.rs
+++ b/crates/harness-workflow/src/runtime/dispatch_barrier.rs
@@ -59,6 +59,7 @@ pub enum DispatchBarrierReasonCode {
     WorkflowConfigInvalid,
     IsolationTierUnavailable,
     WorkflowBudgetExhausted,
+    ProfileDailyCapReached,
 }
 
 impl DispatchBarrierReasonCode {
@@ -68,6 +69,7 @@ impl DispatchBarrierReasonCode {
             Self::WorkflowConfigInvalid => "workflow_config_invalid",
             Self::IsolationTierUnavailable => "isolation_tier_unavailable",
             Self::WorkflowBudgetExhausted => "workflow_budget_exhausted",
+            Self::ProfileDailyCapReached => "profile_daily_cap_reached",
         }
     }
 }

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -320,7 +320,7 @@ impl<'a> RuntimeCommandDispatcher<'a> {
             );
         }
         if let Some(outcome) = self
-            .budget_gate_outcome(instance.as_ref(), &command)
+            .budget_gate_outcome(instance.as_ref(), &command, &runtime_profile.name)
             .await?
         {
             return Ok(outcome);
@@ -407,13 +407,14 @@ impl<'a> RuntimeCommandDispatcher<'a> {
         &self,
         instance: Option<&WorkflowInstance>,
         command: &WorkflowCommandRecord,
+        runtime_profile_name: &str,
     ) -> anyhow::Result<Option<CommandDispatchOutcome>> {
         if self.budget_policy.unlimited {
             return Ok(None);
         }
-        let budget_usd = self.budget_policy.default_workflow_budget_usd;
         // Compare in integer micro-dollars: spend is stored in micros, and a
         // float comparison could flip the gate at the boundary.
+        let budget_usd = self.budget_policy.default_workflow_budget_usd;
         let budget_usd_micros = cost_usd_to_micros(budget_usd)?;
         let spent_usd_micros = self
             .store
@@ -421,40 +422,92 @@ impl<'a> RuntimeCommandDispatcher<'a> {
             .await?
             .map(|usage| usage.cost_usd_micros)
             .unwrap_or(0);
-        if spent_usd_micros < budget_usd_micros {
-            return Ok(None);
+        if spent_usd_micros >= budget_usd_micros {
+            let spent_usd = cost_usd_from_micros(spent_usd_micros);
+            return self
+                .budget_breach_outcome(
+                    instance,
+                    command,
+                    DispatchBarrierReasonCode::WorkflowBudgetExhausted,
+                    format!(
+                        "workflow {} spent {spent_usd:.2} USD, reaching its {budget_usd:.2} USD budget",
+                        command.workflow_id
+                    ),
+                    json!({
+                        "spent_usd": spent_usd,
+                        "budget_usd": budget_usd,
+                    }),
+                )
+                .await;
         }
-        let spent_usd = cost_usd_from_micros(spent_usd_micros);
+        if let Some(cap_usd) = self.budget_policy.daily_profile_cap_usd {
+            let cap_usd_micros = cost_usd_to_micros(cap_usd)?;
+            let utc_day_start = Utc::now()
+                .date_naive()
+                .and_hms_opt(0, 0, 0)
+                .map(|day_start| day_start.and_utc())
+                .context("failed to compute UTC day start for the daily profile cap")?;
+            let profile_spent_micros = self
+                .store
+                .runtime_usage_cost_for_profile_since(runtime_profile_name, utc_day_start)
+                .await?;
+            if profile_spent_micros >= cap_usd_micros {
+                let profile_spent_usd = cost_usd_from_micros(profile_spent_micros);
+                return self
+                    .budget_breach_outcome(
+                        instance,
+                        command,
+                        DispatchBarrierReasonCode::ProfileDailyCapReached,
+                        format!(
+                            "runtime profile {runtime_profile_name} spent {profile_spent_usd:.2} USD \
+                             today, reaching its {cap_usd:.2} USD daily cap",
+                        ),
+                        json!({
+                            "runtime_profile": runtime_profile_name,
+                            "profile_spent_usd_today": profile_spent_usd,
+                            "daily_profile_cap_usd": cap_usd,
+                        }),
+                    )
+                    .await;
+            }
+        }
+        Ok(None)
+    }
+
+    /// Shared shadow/enforce disposition for a breached budget ceiling.
+    /// Shadow records a `BudgetShadowDecision` runtime event and dispatches;
+    /// enforce defers the command with the given barrier reason.
+    async fn budget_breach_outcome(
+        &self,
+        instance: Option<&WorkflowInstance>,
+        command: &WorkflowCommandRecord,
+        reason_code: DispatchBarrierReasonCode,
+        reason: String,
+        mut evidence: Value,
+    ) -> anyhow::Result<Option<CommandDispatchOutcome>> {
         match self.budget_policy.enforcement {
             RuntimeBudgetEnforcement::Shadow => {
+                if let Some(evidence) = evidence.as_object_mut() {
+                    evidence.insert("command_id".to_string(), json!(command.id));
+                    evidence.insert("decision".to_string(), json!("would_defer"));
+                    evidence.insert(
+                        "barrier_reason_code".to_string(),
+                        json!(reason_code.as_str()),
+                    );
+                }
                 self.store
                     .append_event(
                         &command.workflow_id,
                         "BudgetShadowDecision",
                         "workflow_runtime_command_dispatcher",
-                        json!({
-                            "command_id": command.id,
-                            "decision": "would_defer",
-                            "barrier_reason_code":
-                                DispatchBarrierReasonCode::WorkflowBudgetExhausted.as_str(),
-                            "spent_usd": spent_usd,
-                            "budget_usd": budget_usd,
-                        }),
+                        evidence,
                     )
                     .await?;
                 Ok(None)
             }
             RuntimeBudgetEnforcement::Enforce => {
-                let reason = format!(
-                    "workflow {} spent {spent_usd:.2} USD, reaching its {budget_usd:.2} USD budget",
-                    command.workflow_id
-                );
                 let project_id = command_project_id(instance, command)?;
-                let barrier = DispatchBarrierInput::new(
-                    DispatchBarrierReasonCode::WorkflowBudgetExhausted,
-                    reason,
-                    project_id,
-                );
+                let barrier = DispatchBarrierInput::new(reason_code, reason, project_id);
                 dispatch_deferral_outcome(
                     command,
                     self.store

--- a/crates/harness-workflow/src/runtime/store/runtime_usage.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_usage.rs
@@ -296,6 +296,25 @@ impl WorkflowRuntimeStore {
         }))
     }
 
+    /// Total adapter-reported spend (micro-dollars) for one runtime profile
+    /// since `since` — the daily-profile-cap input for the GH-1770 gate.
+    pub async fn runtime_usage_cost_for_profile_since(
+        &self,
+        runtime_profile: &str,
+        since: DateTime<Utc>,
+    ) -> anyhow::Result<u64> {
+        let (cost_usd_micros,): (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(cost_usd_micros), 0)::BIGINT
+             FROM runtime_usage_events
+             WHERE runtime_profile = $1 AND reported_at >= $2",
+        )
+        .bind(runtime_profile)
+        .bind(since)
+        .fetch_one(&self.pool)
+        .await?;
+        i64_to_u64(cost_usd_micros, "cost_usd_micros")
+    }
+
     /// Single durable query path for "what did agent X do in workflow/run Y?"
     ///
     /// This returns the workflow outcome from `workflow_instances` plus the

--- a/crates/harness-workflow/src/runtime/tests/command_dispatcher_budget.rs
+++ b/crates/harness-workflow/src/runtime/tests/command_dispatcher_budget.rs
@@ -24,11 +24,31 @@ fn budget_usage_upsert(workflow_id: &str, cost_usd_micros: u64) -> RuntimeUsageU
     }
 }
 
+fn profile_usage_upsert(
+    workflow_id: &str,
+    runtime_profile: &str,
+    cost_usd_micros: u64,
+) -> RuntimeUsageUpsert {
+    RuntimeUsageUpsert {
+        runtime_profile: runtime_profile.to_string(),
+        ..budget_usage_upsert(workflow_id, cost_usd_micros)
+    }
+}
+
+fn daily_cap_policy(cap_usd: f64, enforcement: RuntimeBudgetEnforcement) -> RuntimeBudgetPolicy {
+    RuntimeBudgetPolicy {
+        enforcement,
+        daily_profile_cap_usd: Some(cap_usd),
+        ..RuntimeBudgetPolicy::default()
+    }
+}
+
 fn enforce_budget_policy(budget_usd: f64) -> RuntimeBudgetPolicy {
     RuntimeBudgetPolicy {
         default_workflow_budget_usd: budget_usd,
         enforcement: RuntimeBudgetEnforcement::Enforce,
         unlimited: false,
+        daily_profile_cap_usd: None,
     }
 }
 
@@ -202,6 +222,136 @@ async fn budget_gate_unlimited_skips_check() -> anyhow::Result<()> {
     );
     assert!(store
         .events_for(&instance.id)
+        .await?
+        .iter()
+        .all(|event| event.event_type != "BudgetShadowDecision"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn daily_profile_cap_shadow_records_event_and_dispatches() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let (instance, _) = issue_with_pending_command(&store, 505).await?;
+    // The cap aggregates today's spend across workflows for the profile the
+    // dispatcher selects ("codex-high" here), not just this workflow.
+    store
+        .upsert_runtime_usage(&profile_usage_upsert(
+            "other-workflow",
+            "codex-high",
+            cost_usd_to_micros(9.0)?,
+        ))
+        .await?;
+    store
+        .upsert_runtime_usage(&profile_usage_upsert(
+            &instance.id,
+            "codex-high",
+            cost_usd_to_micros(2.0)?,
+        ))
+        .await?;
+
+    let dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-high", RuntimeKind::CodexJsonrpc),
+    )
+    .with_budget_policy(daily_cap_policy(10.0, RuntimeBudgetEnforcement::Shadow));
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    assert!(
+        matches!(outcome, CommandDispatchOutcome::Enqueued { .. }),
+        "shadow mode must dispatch despite the breached daily cap: {outcome:?}"
+    );
+    let events = store.events_for(&instance.id).await?;
+    let shadow = events
+        .iter()
+        .find(|event| event.event_type == "BudgetShadowDecision")
+        .expect("shadow mode records a BudgetShadowDecision event");
+    assert_eq!(shadow.event["decision"], "would_defer");
+    assert_eq!(
+        shadow.event["barrier_reason_code"],
+        "profile_daily_cap_reached"
+    );
+    assert_eq!(shadow.event["runtime_profile"], "codex-high");
+    assert_eq!(shadow.event["daily_profile_cap_usd"], 10.0);
+    assert_eq!(shadow.event["profile_spent_usd_today"], 11.0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn daily_profile_cap_enforce_defers_and_ignores_other_profiles() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let (_instance, command_id) = issue_with_pending_command(&store, 506).await?;
+    store
+        .upsert_runtime_usage(&profile_usage_upsert(
+            "other-workflow",
+            "codex-high",
+            cost_usd_to_micros(10.0)?,
+        ))
+        .await?;
+    // Spend on a different profile must not count toward this cap.
+    store
+        .upsert_runtime_usage(&profile_usage_upsert(
+            "unrelated-workflow",
+            "codex-low",
+            cost_usd_to_micros(100.0)?,
+        ))
+        .await?;
+
+    let dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-high", RuntimeKind::CodexJsonrpc),
+    )
+    .with_budget_policy(daily_cap_policy(10.0, RuntimeBudgetEnforcement::Enforce));
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    let barrier = match outcome {
+        CommandDispatchOutcome::Deferred {
+            command_id: id,
+            barrier,
+        } => {
+            assert_eq!(id, command_id);
+            barrier
+        }
+        other => panic!("enforce mode must defer past the daily cap: {other:?}"),
+    };
+    assert_eq!(
+        barrier.reason_code,
+        DispatchBarrierReasonCode::ProfileDailyCapReached
+    );
+    assert!(barrier.reason.contains("codex-high"), "{}", barrier.reason);
+
+    // Under the cap on a fresh profile, the same policy dispatches.
+    let (under_instance, _) = issue_with_pending_command(&store, 507).await?;
+    let under_dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-fresh", RuntimeKind::CodexJsonrpc),
+    )
+    .with_budget_policy(daily_cap_policy(10.0, RuntimeBudgetEnforcement::Enforce));
+    let under_outcome = under_dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+    assert!(
+        matches!(under_outcome, CommandDispatchOutcome::Enqueued { .. }),
+        "fresh profile under the cap must dispatch: {under_outcome:?}"
+    );
+    assert!(store
+        .events_for(&under_instance.id)
         .await?
         .iter()
         .all(|event| event.event_type != "BudgetShadowDecision"));


### PR DESCRIPTION
## Summary

Second enforcement increment from `specs/GH1770/tech.md` §4.1 (after the per-workflow ceiling in #1893): the **daily profile cap**.

- **Config**: `runtime_budget_policy.daily_profile_cap_usd` — `None` by default (daily caps are the last rollout phase per the spec, so they are opt-in, unlike the built-in 15 USD workflow ceiling). Validated positive/finite when set; an absent value is skipped during serialization so the frozen model-facing prompt fixture is byte-identical.
- **Store**: `runtime_usage_cost_for_profile_since(profile, since)` aggregates adapter-reported `cost_usd_micros` for one runtime profile from UTC day start — same reuse-runtime-usage approach as v1, no ledger tables.
- **Gate**: after the workflow ceiling passes, the dispatcher compares the selected profile's UTC-day spend against the cap in integer micro-dollars. Breaches route through a shared shadow/enforce path: shadow records a `BudgetShadowDecision` event with `barrier_reason_code=profile_daily_cap_reached` and dispatches; enforce defers with the new `profile_daily_cap_reached` dispatch barrier through the existing defer/backoff machinery.

Remaining GH-1770 phases: turn-stream watchdog, reducer hard ceiling, throttle band, shadow→enforce default flip.

## Test plan

- [x] `cargo test -p harness-core --lib budget` — 14 passed (default-off, not-serialized, validation)
- [x] `cargo test -p harness-workflow --lib budget` — 13 passed (2 new Postgres-gated gate tests; skip without `HARNESS_DATABASE_URL`, run in CI)
- [x] `cargo test -p harness-server --lib prompt_packet` — 53 passed (frozen fixture unchanged)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`