### PR TITLE
feat(workflow): block over-budget workflows at activity completion (GH-1770)

### DIFF
--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -48,6 +48,10 @@ pub(crate) async fn build_registry(
                 project_root.display()
             )
         })?;
+    // Cloned before `storage` is moved out: the runtime store enforces the
+    // same policy at activity completion that the dispatcher enforces
+    // pre-dispatch (GH-1770).
+    let runtime_budget_policy = workflow_config.runtime_budget_policy.clone();
     let workflow_ns = workflow_config.storage.schema_namespace;
     let mut startup_results = Vec::new();
     let plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>> = Arc::new(DashMap::new());
@@ -269,7 +273,8 @@ pub(crate) async fn build_registry(
                     &context,
                     &setup_pool,
                 )
-                .await?;
+                .await?
+                .with_budget_policy(runtime_budget_policy.clone());
                 let historical_definitions = store.list_persisted_declarative_definitions().await?;
                 harness_workflow::runtime::register_historical_declarative_workflow_definitions(
                     historical_definitions,

--- a/crates/harness-workflow/src/runtime/reason_class.rs
+++ b/crates/harness-workflow/src/runtime/reason_class.rs
@@ -54,6 +54,10 @@ pub const STOP_REASON_RUNTIME_TRANSCRIPT_LOST: &str = "runtime_transcript_lost";
 pub const STOP_REASON_MAINTAINER_INPUT_REQUIRED: &str = "maintainer_input_required";
 /// Stop reason code for structurally invalid agent output (terminal).
 pub const STOP_REASON_INVALID_AGENT_OUTPUT: &str = "invalid_agent_output";
+/// Stop reason code for a workflow that reached its USD budget ceiling
+/// (terminal, GH-1770). Distinct from turn-budget exhaustion: only an
+/// operator unblock or a raised budget resumes the workflow.
+pub const STOP_REASON_BUDGET_EXHAUSTED: &str = "budget_exhausted";
 
 /// The initial transient stop-reason code set. Expanding this table is a
 /// spec/config change, never a runtime inference.
@@ -128,6 +132,7 @@ mod tests {
         for code in [
             STOP_REASON_MAINTAINER_INPUT_REQUIRED,
             STOP_REASON_INVALID_AGENT_OUTPUT,
+            STOP_REASON_BUDGET_EXHAUSTED,
             "some_future_code",
         ] {
             assert_eq!(classify_stop(Some(code), None), StopReasonClass::Terminal);

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -26,7 +26,9 @@ use self::declarative_completion::{
     definition_pin_blocked_decision, reduce_declarative_completion,
 };
 pub(crate) use self::prompt_completion_evidence::first_valid_prompt_validation_report;
-pub(crate) use self::support::invalid_agent_output_blocked_decision;
+pub(crate) use self::support::{
+    budget_exhausted_blocked_decision, invalid_agent_output_blocked_decision,
+};
 use super::model::{ActivityResult, WorkflowDecision, WorkflowEvent, WorkflowInstance};
 use super::state_registry::{resolve_declarative_definition, DeclarativeDefinitionResolution};
 use serde_json::Value;

--- a/crates/harness-workflow/src/runtime/reducer/support.rs
+++ b/crates/harness-workflow/src/runtime/reducer/support.rs
@@ -2,7 +2,9 @@ use crate::runtime::model::{
     ActivityErrorKind, ActivityResult, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
     WorkflowEvent, WorkflowEvidence, WorkflowInstance,
 };
-use crate::runtime::reason_class::{classify_stop, STOP_REASON_INVALID_AGENT_OUTPUT};
+use crate::runtime::reason_class::{
+    classify_stop, STOP_REASON_BUDGET_EXHAUSTED, STOP_REASON_INVALID_AGENT_OUTPUT,
+};
 use serde_json::{json, Value};
 
 pub(crate) fn invalid_agent_output_blocked_decision(
@@ -32,6 +34,45 @@ pub(crate) fn invalid_agent_output_blocked_decision(
             "reason": reason,
             "activity": result.activity,
             "runtime_job_id": event_field_string(event, "runtime_job_id"),
+        }),
+    ))
+    .with_evidence(runtime_completion_evidence(event, result))
+    .high_confidence()
+}
+
+/// Hard workflow budget ceiling (GH-1770 spec §4.4): the completed activity
+/// pushed the instance past its USD budget, so the workflow stops instead of
+/// scheduling more work. Recovery is the existing operator path — unblock
+/// after raising the budget — so no new lifecycle state is introduced.
+pub(crate) fn budget_exhausted_blocked_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+    reason: &str,
+    evidence: Value,
+) -> WorkflowDecision {
+    WorkflowDecision::new(
+        &instance.id,
+        &instance.state,
+        "block_budget_exhausted",
+        "blocked",
+        reason,
+    )
+    .with_command(runtime_blocked_command(
+        reason,
+        Some(STOP_REASON_BUDGET_EXHAUSTED),
+        format!("runtime-completion:{}:budget-exhausted:block", event.id),
+        event,
+        result,
+    ))
+    .with_command(WorkflowCommand::new(
+        WorkflowCommandType::RequestOperatorAttention,
+        format!("runtime-completion:{}:budget-exhausted:operator", event.id),
+        json!({
+            "reason": reason,
+            "activity": result.activity,
+            "runtime_job_id": event_field_string(event, "runtime_job_id"),
+            "budget": evidence,
         }),
     ))
     .with_evidence(runtime_completion_evidence(event, result))

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -12,6 +12,7 @@ use super::store_migrations::WORKFLOW_RUNTIME_MIGRATIONS;
 use super::transcript::PendingRuntimeTranscript;
 use anyhow::Context;
 use chrono::{DateTime, Utc};
+use harness_core::config::workflow::{RuntimeBudgetEnforcement, RuntimeBudgetPolicy};
 use harness_core::db::PgStoreContext;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
@@ -62,6 +63,8 @@ mod prompt_payloads;
 mod recovery;
 #[path = "store/runtime_completion.rs"]
 mod runtime_completion;
+#[path = "store/runtime_completion_budget.rs"]
+mod runtime_completion_budget;
 #[path = "store/runtime_job_leases.rs"]
 pub mod runtime_job_leases;
 #[path = "store/runtime_job_queries.rs"]
@@ -119,6 +122,10 @@ use transaction_helpers::{
 pub(super) use transaction_helpers::{enum_str, insert_event_tx, to_jsonb_string};
 pub struct WorkflowRuntimeStore {
     pub(super) pool: PgPool,
+    /// Hard workflow budget ceiling policy (GH-1770 spec §4.4), applied when a
+    /// completed activity commits its decision. Defaults to shadow enforcement
+    /// so a store opened without explicit wiring only records decisions.
+    pub(super) budget_policy: RuntimeBudgetPolicy,
 }
 pub struct WorkflowInstancePage {
     pub instances: Vec<WorkflowInstance>,
@@ -310,7 +317,10 @@ impl WorkflowRuntimeStore {
         let pool = context
             .open_migrated_pool(WORKFLOW_RUNTIME_MIGRATIONS)
             .await?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            budget_policy: RuntimeBudgetPolicy::default(),
+        })
     }
     pub async fn open_with_database_url_and_schema(
         configured_database_url: Option<&str>,
@@ -320,7 +330,10 @@ impl WorkflowRuntimeStore {
         let pool = context
             .open_migrated_pool(WORKFLOW_RUNTIME_MIGRATIONS)
             .await?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            budget_policy: RuntimeBudgetPolicy::default(),
+        })
     }
     pub async fn open_with_context(
         context: &PgStoreContext,
@@ -329,7 +342,16 @@ impl WorkflowRuntimeStore {
         let pool = context
             .open_migrated_pool_with_setup_pool(setup_pool, WORKFLOW_RUNTIME_MIGRATIONS)
             .await?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            budget_policy: RuntimeBudgetPolicy::default(),
+        })
+    }
+    /// Wire the runtime budget policy that governs the hard workflow ceiling
+    /// applied when an activity completion commits its decision (GH-1770).
+    pub fn with_budget_policy(mut self, budget_policy: RuntimeBudgetPolicy) -> Self {
+        self.budget_policy = budget_policy;
+        self
     }
     pub fn pool(&self) -> &PgPool {
         &self.pool

--- a/crates/harness-workflow/src/runtime/store/activity_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/activity_completion.rs
@@ -352,6 +352,7 @@ impl WorkflowRuntimeStore {
             &command.workflow_id,
             owner,
             &event,
+            &self.budget_policy,
         )
         .await?;
 

--- a/crates/harness-workflow/src/runtime/store/runtime_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion.rs
@@ -1,7 +1,8 @@
+use super::runtime_completion_budget::budget_ceiling_blocked_decision;
 use super::{
     apply_inline_command_side_effect, command_store, commit_decision_instance_tx,
     insert_decision_record_once_tx, insert_event_tx, select_instance_for_update_tx,
-    WorkflowRuntimeStore,
+    RuntimeBudgetPolicy, WorkflowRuntimeStore,
 };
 use crate::runtime::model::{
     ActivityResult, ActivityStatus, WorkflowCommand, WorkflowDecision, WorkflowDecisionRecord,
@@ -58,9 +59,14 @@ impl WorkflowRuntimeStore {
             payload,
         )
         .await?;
-        let decision =
-            apply_runtime_completion_decision_for_instance_tx(&mut tx, instance, source, &event)
-                .await?;
+        let decision = apply_runtime_completion_decision_for_instance_tx(
+            &mut tx,
+            instance,
+            source,
+            &event,
+            &self.budget_policy,
+        )
+        .await?;
         tx.commit().await?;
         if let Some(decision) = decision.as_ref() {
             self.record_terminal_repo_memory_for_completion(&event, decision)
@@ -102,11 +108,13 @@ pub(super) async fn apply_runtime_completion_decision_tx(
     workflow_id: &str,
     source: &str,
     event: &WorkflowEvent,
+    budget_policy: &RuntimeBudgetPolicy,
 ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
     let Some(instance) = select_instance_for_update_tx(tx, workflow_id).await? else {
         return Ok(None);
     };
-    apply_runtime_completion_decision_for_instance_tx(tx, instance, source, event).await
+    apply_runtime_completion_decision_for_instance_tx(tx, instance, source, event, budget_policy)
+        .await
 }
 
 async fn apply_runtime_completion_decision_for_instance_tx(
@@ -114,11 +122,29 @@ async fn apply_runtime_completion_decision_for_instance_tx(
     instance: WorkflowInstance,
     source: &str,
     event: &WorkflowEvent,
+    budget_policy: &RuntimeBudgetPolicy,
 ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
     let driverless_decision = driverless_structured_completion_decision(&instance, source, event)?;
     let Some(decision) = reduce_runtime_job_completed(&instance, event)? else {
         return Ok(None);
     };
+    // Hard workflow budget ceiling (GH-1770 §4.4). Checked before the policy
+    // fallbacks below: those already stop the workflow, so a budget block on
+    // top of them would only mask the real reason.
+    if let Some(budget_decision) =
+        budget_ceiling_blocked_decision(tx, budget_policy, &instance, source, event, &decision)
+            .await?
+    {
+        return persist_runtime_completion_decision_tx(
+            tx,
+            instance,
+            source,
+            event,
+            budget_decision,
+        )
+        .await
+        .map(Some);
+    }
     // Preserve the requested liveness rejection only when the reducer found no
     // authoritative domain outcome and would apply its generic invalid-output policy.
     // The separate blocked policy decision remains the committed outcome, so the

--- a/crates/harness-workflow/src/runtime/store/runtime_completion_budget.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion_budget.rs
@@ -1,0 +1,103 @@
+//! Hard workflow budget ceiling at activity completion (GH-1770 spec §4.4).
+//!
+//! The pre-dispatch gate in `runtime/dispatcher.rs` defers commands once a
+//! workflow has reached its USD budget, but deferral alone leaves the instance
+//! looping on backoff with nobody told. This module closes that loop: when the
+//! activity completion that crossed the ceiling commits its decision, the
+//! workflow stops in `blocked` and requests operator attention instead of
+//! scheduling more work.
+//!
+//! Enforcement follows the same shadow/enforce split as the dispatch gate:
+//! `shadow` records a `BudgetShadowDecision` runtime event and keeps the
+//! reducer's decision, `enforce` replaces it.
+
+use super::runtime_usage::{
+    cost_usd_from_micros, cost_usd_to_micros, runtime_usage_cost_for_workflow_tx,
+};
+use super::{insert_event_tx, RuntimeBudgetEnforcement, RuntimeBudgetPolicy};
+use crate::runtime::model::{ActivityResult, WorkflowDecision, WorkflowEvent, WorkflowInstance};
+use crate::runtime::reducer::budget_exhausted_blocked_decision;
+use crate::runtime::terminal_state::workflow_terminal_state_for_version;
+use serde_json::json;
+
+/// Returns the replacement decision when the completed activity pushed the
+/// workflow past its budget ceiling and enforcement is active; `None` when the
+/// reducer's own decision stands.
+pub(super) async fn budget_ceiling_blocked_decision(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    budget_policy: &RuntimeBudgetPolicy,
+    instance: &WorkflowInstance,
+    source: &str,
+    event: &WorkflowEvent,
+    decision: &WorkflowDecision,
+) -> anyhow::Result<Option<WorkflowDecision>> {
+    if budget_policy.unlimited || !decision_schedules_more_work(instance, decision) {
+        return Ok(None);
+    }
+    // Compare in integer micro-dollars, matching the dispatch gate: spend is
+    // stored in micros and a float comparison could flip at the boundary.
+    let budget_usd = budget_policy.default_workflow_budget_usd;
+    let budget_usd_micros = cost_usd_to_micros(budget_usd)?;
+    let spent_usd_micros = runtime_usage_cost_for_workflow_tx(tx, &instance.id).await?;
+    if spent_usd_micros < budget_usd_micros {
+        return Ok(None);
+    }
+
+    let spent_usd = cost_usd_from_micros(spent_usd_micros);
+    let reason = format!(
+        "workflow {} spent {spent_usd:.2} USD, reaching its {budget_usd:.2} USD budget; \
+         raise the budget and unblock the workflow to continue",
+        instance.id
+    );
+    let evidence = json!({
+        "spent_usd": spent_usd,
+        "budget_usd": budget_usd,
+        "enforcement": budget_policy.enforcement.as_str(),
+    });
+
+    match budget_policy.enforcement {
+        RuntimeBudgetEnforcement::Shadow => {
+            let mut shadow_evidence = evidence;
+            if let Some(shadow_evidence) = shadow_evidence.as_object_mut() {
+                shadow_evidence.insert("decision".to_string(), json!("would_block"));
+                shadow_evidence.insert("event_id".to_string(), json!(event.id));
+                shadow_evidence.insert("reducer_decision".to_string(), json!(decision.decision));
+                shadow_evidence
+                    .insert("reducer_next_state".to_string(), json!(decision.next_state));
+            }
+            insert_event_tx(
+                tx,
+                &instance.id,
+                "BudgetShadowDecision",
+                source,
+                shadow_evidence,
+            )
+            .await?;
+            Ok(None)
+        }
+        RuntimeBudgetEnforcement::Enforce => {
+            let result: ActivityResult =
+                serde_json::from_value(event.event.get("activity_result").cloned().ok_or_else(
+                    || anyhow::anyhow!("RuntimeJobCompleted event missing activity_result"),
+                )?)?;
+            Ok(Some(budget_exhausted_blocked_decision(
+                instance, event, &result, &reason, evidence,
+            )))
+        }
+    }
+}
+
+/// The ceiling only preempts decisions that would keep the workflow running.
+/// A decision that already lands in a terminal state or in `blocked` needs no
+/// budget intervention — the workflow is stopping either way.
+fn decision_schedules_more_work(instance: &WorkflowInstance, decision: &WorkflowDecision) -> bool {
+    if decision.next_state == "blocked" {
+        return false;
+    }
+    workflow_terminal_state_for_version(
+        &instance.definition_id,
+        instance.definition_version,
+        &decision.next_state,
+    )
+    .is_none()
+}

--- a/crates/harness-workflow/src/runtime/store/runtime_usage.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_usage.rs
@@ -317,6 +317,9 @@ impl WorkflowRuntimeStore {
 
     /// Single durable query path for "what did agent X do in workflow/run Y?"
     ///
+    /// (see [`runtime_usage_cost_for_workflow_tx`] for the transaction-scoped
+    /// spend read used by the completion-time budget ceiling)
+    ///
     /// This returns the workflow outcome from `workflow_instances` plus the
     /// per-turn usage rows for one persisted runtime agent plus policy-hook
     /// events linked by the persisted runtime usage `agent_run_id`.
@@ -391,6 +394,24 @@ impl WorkflowRuntimeStore {
             })
             .collect()
     }
+}
+
+/// Adapter-reported spend (micro-dollars) for one workflow, read inside the
+/// activity-completion transaction so the hard budget ceiling (GH-1770 spec
+/// §4.4) sees the spend of the activity it is committing.
+pub(super) async fn runtime_usage_cost_for_workflow_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workflow_id: &str,
+) -> anyhow::Result<u64> {
+    let (cost_usd_micros,): (i64,) = sqlx::query_as(
+        "SELECT COALESCE(SUM(cost_usd_micros), 0)::BIGINT
+         FROM runtime_usage_events
+         WHERE workflow_id = $1",
+    )
+    .bind(workflow_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    i64_to_u64(cost_usd_micros, "cost_usd_micros")
 }
 
 async fn policy_events_for_usage_records(

--- a/crates/harness-workflow/src/runtime/tests.rs
+++ b/crates/harness-workflow/src/runtime/tests.rs
@@ -54,6 +54,7 @@ include!("tests/durable_store.rs");
 include!("tests/prompt_continuation_store.rs");
 include!("tests/command_dispatcher.rs");
 include!("tests/command_dispatcher_budget.rs");
+include!("tests/completion_budget_ceiling.rs");
 include!("tests/command_store.rs");
 include!("tests/deferred_dispatch.rs");
 include!("tests/deferred_dispatch_review.rs");

--- a/crates/harness-workflow/src/runtime/tests/completion_budget_ceiling.rs
+++ b/crates/harness-workflow/src/runtime/tests/completion_budget_ceiling.rs
@@ -1,0 +1,278 @@
+// Hard workflow budget ceiling at activity completion (GH-1770 spec §4.4).
+// The reducer's decision stands unless the completed activity pushed the
+// instance past its USD budget under `enforce`.
+
+fn ceiling_store_policy(
+    budget_usd: f64,
+    enforcement: RuntimeBudgetEnforcement,
+) -> RuntimeBudgetPolicy {
+    RuntimeBudgetPolicy {
+        default_workflow_budget_usd: budget_usd,
+        enforcement,
+        unlimited: false,
+        daily_profile_cap_usd: None,
+    }
+}
+
+fn ceiling_usage_upsert(workflow_id: &str, cost_usd_micros: u64) -> RuntimeUsageUpsert {
+    RuntimeUsageUpsert {
+        runtime_job_id: format!("ceiling-job-{workflow_id}"),
+        command_id: format!("ceiling-command-{workflow_id}"),
+        workflow_id: workflow_id.to_string(),
+        turn_id: Some(format!("ceiling-turn-{workflow_id}")),
+        agent_run_id: None,
+        runtime_kind: RuntimeKind::CodexExec,
+        runtime_profile: "codex-default".to_string(),
+        agent: "codex".to_string(),
+        model: "gpt-5".to_string(),
+        project: "/project-a".to_string(),
+        task_id: None,
+        candidate_group_id: None,
+        candidate_id: None,
+        candidate_index: None,
+        candidate_count: None,
+        metrics: RuntimeUsageMetrics::default(),
+        cost_usd_micros,
+        reported_at: Utc::now(),
+    }
+}
+
+/// A completion that the reducer turns into the progressing `bind_pr` decision
+/// (`implementing` -> `pr_open`) — the case the ceiling must be able to stop.
+fn progressing_completion_payload() -> anyhow::Result<serde_json::Value> {
+    let result = ActivityResult::succeeded("implement_issue", "Implementation completed.")
+        .with_artifact(ActivityArtifact::new(
+            "pull_request",
+            json!({
+                "pr_number": 77,
+                "pr_url": "https://github.com/owner/repo/pull/77"
+            }),
+        ))
+        .with_artifact(verified_pr_binding(77));
+    Ok(json!({
+        "command_id": "ceiling-command",
+        "runtime_job_id": "ceiling-job",
+        "activity_result": result,
+    }))
+}
+
+async fn ceiling_instance(
+    store: &WorkflowRuntimeStore,
+    id: &str,
+    spent_usd: f64,
+) -> anyhow::Result<WorkflowInstance> {
+    let instance = issue_instance("implementing").with_id(id);
+    store
+        .force_upsert_lifecycle_state_for_test(&instance)
+        .await?;
+    store
+        .upsert_runtime_usage(&ceiling_usage_upsert(
+            &instance.id,
+            cost_usd_to_micros(spent_usd)?,
+        ))
+        .await?;
+    Ok(instance)
+}
+
+#[tokio::test]
+async fn budget_ceiling_enforce_blocks_progressing_completion() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db"))
+        .await?
+        .with_budget_policy(ceiling_store_policy(15.0, RuntimeBudgetEnforcement::Enforce));
+    let instance = ceiling_instance(&store, "budget-ceiling-enforce", 20.0).await?;
+
+    let record = store
+        .commit_parent_runtime_completion(
+            &instance.id,
+            "runtime-1",
+            progressing_completion_payload()?,
+        )
+        .await?
+        .expect("an over-budget completion still produces a decision");
+
+    assert!(record.accepted, "{:?}", record.rejection_reason);
+    assert_eq!(record.decision.decision, "block_budget_exhausted");
+    assert_eq!(record.decision.next_state, "blocked");
+    assert!(record
+        .decision
+        .commands
+        .iter()
+        .any(|command| command.command_type == WorkflowCommandType::MarkBlocked));
+    let operator = record
+        .decision
+        .commands
+        .iter()
+        .find(|command| command.command_type == WorkflowCommandType::RequestOperatorAttention)
+        .expect("the ceiling requests operator attention");
+    assert_eq!(operator.command["budget"]["spent_usd"], 20.0);
+    assert_eq!(operator.command["budget"]["budget_usd"], 15.0);
+    assert_eq!(operator.command["budget"]["enforcement"], "enforce");
+
+    let blocked = record
+        .decision
+        .commands
+        .iter()
+        .find(|command| command.command_type == WorkflowCommandType::MarkBlocked)
+        .expect("the ceiling marks the workflow blocked");
+    assert_eq!(blocked.command["stop_reason_code"], "budget_exhausted");
+    assert_eq!(blocked.command["reason_class"], "terminal");
+
+    let after = store
+        .get_instance(&instance.id)
+        .await?
+        .expect("workflow instance should remain visible");
+    assert_eq!(after.state, "blocked");
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_ceiling_shadow_records_event_and_keeps_decision() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db"))
+        .await?
+        .with_budget_policy(ceiling_store_policy(15.0, RuntimeBudgetEnforcement::Shadow));
+    let instance = ceiling_instance(&store, "budget-ceiling-shadow", 20.0).await?;
+
+    let record = store
+        .commit_parent_runtime_completion(
+            &instance.id,
+            "runtime-1",
+            progressing_completion_payload()?,
+        )
+        .await?
+        .expect("shadow mode still commits the reducer decision");
+
+    assert!(record.accepted, "{:?}", record.rejection_reason);
+    assert_eq!(record.decision.decision, "bind_pr");
+    assert_eq!(record.decision.next_state, "pr_open");
+
+    let events = store.events_for(&instance.id).await?;
+    let shadow = events
+        .iter()
+        .find(|event| event.event_type == "BudgetShadowDecision")
+        .expect("shadow mode records a BudgetShadowDecision event");
+    assert_eq!(shadow.event["decision"], "would_block");
+    assert_eq!(shadow.event["spent_usd"], 20.0);
+    assert_eq!(shadow.event["budget_usd"], 15.0);
+    assert_eq!(shadow.event["reducer_decision"], "bind_pr");
+    assert_eq!(shadow.event["reducer_next_state"], "pr_open");
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_ceiling_leaves_under_budget_completion_untouched() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db"))
+        .await?
+        .with_budget_policy(ceiling_store_policy(15.0, RuntimeBudgetEnforcement::Enforce));
+    let instance = ceiling_instance(&store, "budget-ceiling-under", 5.0).await?;
+
+    let record = store
+        .commit_parent_runtime_completion(
+            &instance.id,
+            "runtime-1",
+            progressing_completion_payload()?,
+        )
+        .await?
+        .expect("an under-budget completion produces the reducer decision");
+
+    assert_eq!(record.decision.decision, "bind_pr");
+    assert_eq!(record.decision.next_state, "pr_open");
+    assert!(
+        store
+            .events_for(&instance.id)
+            .await?
+            .iter()
+            .all(|event| event.event_type != "BudgetShadowDecision"),
+        "an under-budget completion records no budget decision"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_ceiling_does_not_preempt_terminal_completion() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db"))
+        .await?
+        .with_budget_policy(ceiling_store_policy(15.0, RuntimeBudgetEnforcement::Enforce));
+    let instance = ceiling_instance(&store, "budget-ceiling-terminal", 20.0).await?;
+
+    // A workflow that is finishing anyway must not be rewritten into `blocked`:
+    // blocking it would hide the real outcome and strand a done workflow.
+    let result = ActivityResult::succeeded(
+        "implement_issue",
+        "The issue was already closed before implementation completed.",
+    )
+    .with_signal(ActivitySignal::new(
+        "IssueClosed",
+        json!({
+            "issue_number": 123,
+            "state": "closed",
+            "issue_url": "https://github.com/owner/repo/issues/123"
+        }),
+    ));
+
+    let record = store
+        .commit_parent_runtime_completion(
+            &instance.id,
+            "runtime-1",
+            json!({
+                "command_id": "ceiling-terminal-command",
+                "runtime_job_id": "ceiling-terminal-job",
+                "activity_result": result,
+            }),
+        )
+        .await?
+        .expect("closed issue evidence should produce a domain decision");
+
+    assert_eq!(record.decision.decision, "finish_closed_issue");
+    assert_eq!(record.decision.next_state, "done");
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_ceiling_unlimited_policy_never_blocks() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db"))
+        .await?
+        .with_budget_policy(RuntimeBudgetPolicy {
+            unlimited: true,
+            enforcement: RuntimeBudgetEnforcement::Enforce,
+            ..RuntimeBudgetPolicy::default()
+        });
+    let instance = ceiling_instance(&store, "budget-ceiling-unlimited", 500.0).await?;
+
+    let record = store
+        .commit_parent_runtime_completion(
+            &instance.id,
+            "runtime-1",
+            progressing_completion_payload()?,
+        )
+        .await?
+        .expect("unlimited policy commits the reducer decision");
+
+    assert_eq!(record.decision.decision, "bind_pr");
+    assert_eq!(record.decision.next_state, "pr_open");
+    Ok(())
+}


### PR DESCRIPTION
Third enforcement increment from `specs/GH1770/tech.md` §4.4, after the per-workflow pre-dispatch gate (#1893) and the daily profile cap (#1903).

## Why

The dispatch gate only *defers* commands. In `enforce` mode a workflow that reached its USD ceiling therefore looped on dispatch backoff indefinitely with no operator signal — the spec's hard ceiling is what escalates it.

## What

- `WorkflowRuntimeStore` now carries the `RuntimeBudgetPolicy` (wired from `WORKFLOW.md` in the registry builder, default `shadow`) and applies it inside the activity-completion transaction, so the check sees the spend of the activity it is committing.
- New `runtime_usage_cost_for_workflow_tx` reads workflow spend in that transaction; comparison stays in integer micro-dollars, matching the dispatch gate.
- An over-ceiling completion whose decision would keep the workflow running is replaced by a `block_budget_exhausted` decision: `MarkBlocked` with the new terminal `budget_exhausted` stop reason + `RequestOperatorAttention` carrying spent/budget evidence. Recovery reuses the existing operator unblock path; no new lifecycle state.
- Decisions already landing in `blocked` or a terminal state are left alone — blocking a finishing workflow would mask the real outcome.
- `shadow` records a `BudgetShadowDecision` event naming the reducer decision it would have replaced, and changes nothing.

## Validation

- `cargo test -p harness-workflow --lib` (Postgres): 664 passed, including 5 new `budget_ceiling_*` tests — enforce blocks a progressing completion, shadow records and keeps it, under-budget and `unlimited` pass through, terminal completion never preempted.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo test -p harness-server --lib`: 1475 passed, 1 failure (`http::builders::intake::tests::runtime_issue_concurrency_startup_projects_override_registry`) that reproduces unchanged on `main` in this environment.

Remaining for GH-1770: turn-stream watchdog (§4.3), throttle band, and the shadow→enforce default flip.