### PR TITLE
feat(workflow): interrupt in-flight turns at the workflow budget ceiling (GH-1770)

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker/runtime_usage.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/runtime_usage.rs
@@ -14,6 +14,7 @@ pub(super) fn runtime_usage_context(
     source_project_root: &Path,
 ) -> Option<RuntimeUsageContext> {
     let store = state.core.workflow_runtime_store.as_ref()?.clone();
+    let budget_policy = store.budget_policy().clone();
     let workflow_id = workflow
         .map(|workflow| workflow.id.clone())
         .or_else(|| optional_string(&job.input, "workflow_id"))
@@ -43,6 +44,7 @@ pub(super) fn runtime_usage_context(
         candidate_id: candidate.and_then(|value| optional_string(value, "candidate_id")),
         candidate_index: candidate.and_then(|value| optional_u32_value(value, "candidate_index")),
         candidate_count: candidate.and_then(|value| optional_u32_value(value, "candidate_count")),
+        budget_policy,
     })
 }
 

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/helpers.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/helpers.rs
@@ -1,12 +1,24 @@
 use harness_core::agent::StreamItem;
+use harness_core::config::workflow::{RuntimeBudgetEnforcement, RuntimeBudgetPolicy};
 use harness_core::run_id::RunId;
 use harness_core::types::{ThreadId, TokenUsage, TurnId, TurnStatus};
 use harness_protocol::{notifications::Notification, notifications::RpcNotification};
 use harness_workflow::runtime::{
-    cost_usd_to_micros, RuntimeKind, RuntimeUsageMetrics, RuntimeUsageUpsert,
+    cost_usd_from_micros, cost_usd_to_micros, RuntimeKind, RuntimeUsageMetrics, RuntimeUsageUpsert,
     RuntimeUsageUpsertOutcome, WorkflowRuntimeStore,
 };
+use serde_json::json;
 use std::sync::Arc;
+
+/// Mid-turn budget stop (GH-1770 spec §4.3): the streamed usage that was just
+/// persisted put the workflow at or over its USD ceiling, so the in-flight
+/// turn must be interrupted rather than allowed to keep spending.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TurnBudgetStop {
+    pub(crate) workflow_id: String,
+    pub(crate) spent_usd: f64,
+    pub(crate) budget_usd: f64,
+}
 
 #[derive(Clone)]
 pub(crate) struct RuntimeUsageContext {
@@ -25,6 +37,9 @@ pub(crate) struct RuntimeUsageContext {
     pub(crate) candidate_id: Option<String>,
     pub(crate) candidate_index: Option<u32>,
     pub(crate) candidate_count: Option<u32>,
+    /// Budget policy for the mid-turn watchdog; the same policy the dispatch
+    /// gate and the completion ceiling apply.
+    pub(crate) budget_policy: RuntimeBudgetPolicy,
 }
 
 impl std::fmt::Debug for RuntimeUsageContext {
@@ -108,6 +123,55 @@ impl RuntimeUsageContext {
         }
         Ok(())
     }
+
+    /// Mid-turn ceiling check (GH-1770 §4.3), run right after the streamed
+    /// usage was persisted so the aggregate already includes it.
+    ///
+    /// `enforce` returns the stop for the caller to act on; `shadow` records a
+    /// `BudgetShadowDecision` runtime event and returns `None`.
+    async fn budget_stop(&self) -> anyhow::Result<Option<TurnBudgetStop>> {
+        if self.budget_policy.unlimited {
+            return Ok(None);
+        }
+        // Integer micro-dollars, matching the dispatch gate and the completion
+        // ceiling: a float comparison could flip at the boundary.
+        let budget_usd = self.budget_policy.default_workflow_budget_usd;
+        let budget_usd_micros = cost_usd_to_micros(budget_usd)?;
+        let spent_usd_micros = self
+            .store
+            .runtime_usage_for_workflow(&self.workflow_id)
+            .await?
+            .map(|usage| usage.cost_usd_micros)
+            .unwrap_or(0);
+        if spent_usd_micros < budget_usd_micros {
+            return Ok(None);
+        }
+        let spent_usd = cost_usd_from_micros(spent_usd_micros);
+        match self.budget_policy.enforcement {
+            RuntimeBudgetEnforcement::Shadow => {
+                self.store
+                    .append_event(
+                        &self.workflow_id,
+                        "BudgetShadowDecision",
+                        "workflow_runtime_turn_watchdog",
+                        json!({
+                            "decision": "would_interrupt",
+                            "spent_usd": spent_usd,
+                            "budget_usd": budget_usd,
+                            "runtime_job_id": self.runtime_job_id,
+                            "command_id": self.command_id,
+                        }),
+                    )
+                    .await?;
+                Ok(None)
+            }
+            RuntimeBudgetEnforcement::Enforce => Ok(Some(TurnBudgetStop {
+                workflow_id: self.workflow_id.clone(),
+                spent_usd,
+                budget_usd,
+            })),
+        }
+    }
 }
 
 pub(crate) fn emit_runtime_notification(
@@ -119,6 +183,9 @@ pub(crate) fn emit_runtime_notification(
     let _ = notification_tx.send(RpcNotification::new(notification));
 }
 
+/// Returns a [`TurnBudgetStop`] when the streamed usage just persisted put the
+/// workflow at or over its budget under `enforce`; the caller interrupts the
+/// in-flight turn (GH-1770 §4.3).
 pub(crate) async fn process_stream_item(
     server: &crate::server::HarnessServer,
     notify_tx: &Option<crate::notify::NotifySender>,
@@ -127,7 +194,8 @@ pub(crate) async fn process_stream_item(
     thread_id: &ThreadId,
     turn_id: &TurnId,
     stream_item: StreamItem,
-) {
+) -> Option<TurnBudgetStop> {
+    let mut budget_stop = None;
     match stream_item {
         StreamItem::ItemStarted { item } => {
             if let Err(err) = server
@@ -185,6 +253,18 @@ pub(crate) async fn process_stream_item(
                         workflow_id = %context.workflow_id,
                         "failed to persist workflow runtime token usage: {error}"
                     );
+                }
+                // Evaluated after the persist above so the aggregate includes
+                // the usage that may have crossed the ceiling. A failed check
+                // must not silently disable the watchdog: it is logged at
+                // error level and the completion ceiling remains the backstop.
+                match context.budget_stop().await {
+                    Ok(stop) => budget_stop = stop,
+                    Err(error) => tracing::error!(
+                        runtime_job_id = %context.runtime_job_id,
+                        workflow_id = %context.workflow_id,
+                        "failed to evaluate the mid-turn workflow budget ceiling: {error}"
+                    ),
                 }
             }
         }
@@ -252,6 +332,7 @@ pub(crate) async fn process_stream_item(
         }
         _ => {}
     }
+    budget_stop
 }
 
 pub(crate) async fn mark_turn_failed(
@@ -287,7 +368,9 @@ mod tests {
         db::resolve_database_url,
         types::{AgentId, TokenUsage},
     };
-    use harness_workflow::runtime::{RuntimeKind, WorkflowRuntimeStore};
+    use harness_workflow::runtime::{
+        RuntimeKind, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
+    };
     use std::str::FromStr;
 
     #[tokio::test]
@@ -324,6 +407,7 @@ mod tests {
             candidate_id: Some("candidate-1".to_string()),
             candidate_index: Some(1),
             candidate_count: Some(2),
+            budget_policy: RuntimeBudgetPolicy::default(),
         };
 
         process_stream_item(
@@ -367,6 +451,237 @@ mod tests {
         assert_eq!(records[0].cost_usd_micros, 125_000);
         assert_eq!(records[0].candidate_id.as_deref(), Some("candidate-1"));
         assert_eq!(turn.token_usage.total_tokens, 20);
+        Ok(())
+    }
+
+    struct WatchdogFixture {
+        _dir: tempfile::TempDir,
+        store: Arc<WorkflowRuntimeStore>,
+        server: HarnessServer,
+        thread_id: ThreadId,
+        turn_id: TurnId,
+        notification_tx: tokio::sync::broadcast::Sender<RpcNotification>,
+    }
+
+    /// The watchdog's shadow event is a workflow event, so its instance row
+    /// must exist for the foreign key.
+    async fn watchdog_fixture(workflow_id: &str) -> anyhow::Result<WatchdogFixture> {
+        let dir = tempfile::tempdir()?;
+        let store = Arc::new(WorkflowRuntimeStore::open(&dir.path().join("runtime")).await?);
+        store
+            .upsert_instance(
+                &WorkflowInstance::new(
+                    "github_issue_pr",
+                    1,
+                    "discovered",
+                    WorkflowSubject::new("issue", "issue:1770"),
+                )
+                .with_id(workflow_id),
+            )
+            .await?;
+        let mut config = HarnessConfig::default();
+        config.server.project_root = dir.path().to_path_buf();
+        let server = HarnessServer::new(config, ThreadManager::new(), AgentRegistry::new("codex"));
+        let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+        let turn_id = server.thread_manager.start_turn(
+            &thread_id,
+            "prompt".to_string(),
+            AgentId::from_str("codex"),
+        )?;
+        let (notification_tx, _) = tokio::sync::broadcast::channel(16);
+        Ok(WatchdogFixture {
+            _dir: dir,
+            store,
+            server,
+            thread_id,
+            turn_id,
+            notification_tx,
+        })
+    }
+
+    fn watchdog_context(
+        store: Arc<WorkflowRuntimeStore>,
+        workflow_id: &str,
+        budget_policy: RuntimeBudgetPolicy,
+    ) -> RuntimeUsageContext {
+        RuntimeUsageContext {
+            store,
+            runtime_job_id: format!("runtime-job-{workflow_id}"),
+            command_id: format!("command-{workflow_id}"),
+            workflow_id: workflow_id.to_string(),
+            agent_run_id: None,
+            runtime_kind: RuntimeKind::CodexExec,
+            runtime_profile: "codex-default".to_string(),
+            agent: "codex".to_string(),
+            model: "gpt-5".to_string(),
+            project: "/project-a".to_string(),
+            task_id: None,
+            candidate_group_id: None,
+            candidate_id: None,
+            candidate_index: None,
+            candidate_count: None,
+            budget_policy,
+        }
+    }
+
+    fn watchdog_usage(cost_usd: f64) -> StreamItem {
+        StreamItem::TokenUsage {
+            usage: TokenUsage {
+                input_tokens: 10,
+                output_tokens: 5,
+                total_tokens: 15,
+                cost_usd,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn budget_watchdog_enforce_stops_turn_at_the_ceiling() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+
+        let fixture = watchdog_fixture("watchdog-enforce").await?;
+        let context = watchdog_context(
+            fixture.store.clone(),
+            "watchdog-enforce",
+            RuntimeBudgetPolicy {
+                default_workflow_budget_usd: 0.10,
+                enforcement: RuntimeBudgetEnforcement::Enforce,
+                ..RuntimeBudgetPolicy::default()
+            },
+        );
+
+        let stop = process_stream_item(
+            &fixture.server,
+            &None,
+            &fixture.notification_tx,
+            Some(&context),
+            &fixture.thread_id,
+            &fixture.turn_id,
+            watchdog_usage(0.125),
+        )
+        .await
+        .expect("crossing the ceiling mid-turn must stop the turn");
+
+        assert_eq!(stop.workflow_id, "watchdog-enforce");
+        assert_eq!(stop.spent_usd, 0.125);
+        assert_eq!(stop.budget_usd, 0.10);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn budget_watchdog_shadow_records_event_without_stopping() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+
+        let fixture = watchdog_fixture("watchdog-shadow").await?;
+        let context = watchdog_context(
+            fixture.store.clone(),
+            "watchdog-shadow",
+            RuntimeBudgetPolicy {
+                default_workflow_budget_usd: 0.10,
+                enforcement: RuntimeBudgetEnforcement::Shadow,
+                ..RuntimeBudgetPolicy::default()
+            },
+        );
+
+        let stop = process_stream_item(
+            &fixture.server,
+            &None,
+            &fixture.notification_tx,
+            Some(&context),
+            &fixture.thread_id,
+            &fixture.turn_id,
+            watchdog_usage(0.125),
+        )
+        .await;
+
+        assert!(stop.is_none(), "shadow mode must not stop the turn");
+        let events = fixture.store.events_for("watchdog-shadow").await?;
+        let shadow = events
+            .iter()
+            .find(|event| event.event_type == "BudgetShadowDecision")
+            .expect("shadow mode records a BudgetShadowDecision event");
+        assert_eq!(shadow.source, "workflow_runtime_turn_watchdog");
+        assert_eq!(shadow.event["decision"], "would_interrupt");
+        assert_eq!(shadow.event["spent_usd"], 0.125);
+        assert_eq!(shadow.event["budget_usd"], 0.10);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn budget_watchdog_leaves_under_budget_turns_running() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+
+        let fixture = watchdog_fixture("watchdog-under").await?;
+        let context = watchdog_context(
+            fixture.store.clone(),
+            "watchdog-under",
+            RuntimeBudgetPolicy {
+                default_workflow_budget_usd: 15.0,
+                enforcement: RuntimeBudgetEnforcement::Enforce,
+                ..RuntimeBudgetPolicy::default()
+            },
+        );
+
+        let stop = process_stream_item(
+            &fixture.server,
+            &None,
+            &fixture.notification_tx,
+            Some(&context),
+            &fixture.thread_id,
+            &fixture.turn_id,
+            watchdog_usage(0.125),
+        )
+        .await;
+
+        assert!(stop.is_none(), "an under-budget turn keeps running");
+        assert!(
+            fixture
+                .store
+                .events_for("watchdog-under")
+                .await?
+                .iter()
+                .all(|event| event.event_type != "BudgetShadowDecision"),
+            "an under-budget turn records no budget decision"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn budget_watchdog_unlimited_policy_never_stops() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+
+        let fixture = watchdog_fixture("watchdog-unlimited").await?;
+        let context = watchdog_context(
+            fixture.store.clone(),
+            "watchdog-unlimited",
+            RuntimeBudgetPolicy {
+                default_workflow_budget_usd: 0.01,
+                enforcement: RuntimeBudgetEnforcement::Enforce,
+                unlimited: true,
+                ..RuntimeBudgetPolicy::default()
+            },
+        );
+
+        let stop = process_stream_item(
+            &fixture.server,
+            &None,
+            &fixture.notification_tx,
+            Some(&context),
+            &fixture.thread_id,
+            &fixture.turn_id,
+            watchdog_usage(5.0),
+        )
+        .await;
+
+        assert!(stop.is_none(), "unlimited opt-out disables the watchdog");
         Ok(())
     }
 }

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/mod.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/mod.rs
@@ -12,3 +12,6 @@ mod stall_tests;
 
 #[cfg(test)]
 mod terminal_error_tests;
+
+#[cfg(test)]
+mod turn_lifecycle_tests;

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::time::{Duration, Instant};
 
-fn bridge_agent_event(
+pub(super) fn bridge_agent_event(
     event: AgentEvent,
     output_buf: &mut String,
     emitted_agent_completion: &mut bool,
@@ -300,7 +300,7 @@ pub(crate) async fn run_turn_lifecycle_with_options(
                         if let StreamItem::Error { message } = &item {
                             stream_error.get_or_insert_with(|| message.clone());
                         }
-                        process_stream_item(
+                        let budget_stop = process_stream_item(
                             &server,
                             &notify_tx,
                             &notification_tx,
@@ -309,6 +309,33 @@ pub(crate) async fn run_turn_lifecycle_with_options(
                             &turn_id,
                             item,
                         ).await;
+                        // GH-1770 §4.3: an activity that already blew the
+                        // workflow ceiling is precisely the case dispatch-time
+                        // gating cannot catch, so the in-flight turn stops.
+                        if let Some(stop) = budget_stop {
+                            tracing::warn!(
+                                thread_id = %thread_id,
+                                turn_id = %turn_id,
+                                workflow_id = %stop.workflow_id,
+                                spent_usd = stop.spent_usd,
+                                budget_usd = stop.budget_usd,
+                                "workflow budget ceiling reached mid-turn; interrupting agent"
+                            );
+                            if let Some(adapter) = adapter_opt.as_ref() {
+                                if let Err(error) = adapter.interrupt().await {
+                                    tracing::warn!(
+                                        thread_id = %thread_id,
+                                        turn_id = %turn_id,
+                                        "failed to interrupt agent after the budget ceiling: {error}"
+                                    );
+                                }
+                            }
+                            execution_result = Some(Err(HarnessError::AgentExecution(format!(
+                                "Workflow {} spent {:.2} USD, reaching its {:.2} USD budget; turn interrupted.",
+                                stop.workflow_id, stop.spent_usd, stop.budget_usd
+                            ))));
+                            break 'outer;
+                        }
                     }
                     None => {
                         stream_closed = true;
@@ -465,429 +492,5 @@ pub(crate) async fn run_turn_lifecycle_with_options(
             )
             .await;
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{bridge_agent_event, run_turn_lifecycle_with_options, TurnLifecycleOptions};
-    use crate::{server::HarnessServer, thread_manager::ThreadManager};
-    use harness_agents::registry::{AdapterExecutionStrategy, AgentRegistry};
-    use harness_core::agent::{
-        AgentAdapter, AgentEvent, AgentRequest, AgentResponse, CodeAgent, StreamItem, TurnRequest,
-    };
-    use harness_core::config::HarnessConfig;
-    use harness_core::error::HarnessError;
-    use harness_core::types::{AgentId, Capability, Item, TokenUsage, TurnId, TurnStatus};
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    };
-    use tokio::sync::mpsc;
-
-    struct CountingAgent {
-        calls: Arc<AtomicUsize>,
-    }
-
-    #[async_trait::async_trait]
-    impl CodeAgent for CountingAgent {
-        fn name(&self) -> &str {
-            "codex"
-        }
-
-        fn capabilities(&self) -> Vec<Capability> {
-            vec![Capability::Read]
-        }
-
-        async fn execute(&self, _req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
-            Ok(AgentResponse {
-                output: "ok".to_string(),
-                stderr: String::new(),
-                items: Vec::new(),
-                token_usage: TokenUsage::default(),
-                model: "codex".to_string(),
-                exit_code: Some(0),
-            })
-        }
-
-        async fn execute_stream(
-            &self,
-            _req: AgentRequest,
-            tx: mpsc::Sender<StreamItem>,
-        ) -> harness_core::error::Result<()> {
-            self.calls.fetch_add(1, Ordering::AcqRel);
-            tx.send(StreamItem::ItemCompleted {
-                item: Item::AgentReasoning {
-                    content: "agent stream done".to_string(),
-                },
-            })
-            .await
-            .map_err(|error| HarnessError::AgentExecution(format!("stream closed: {error}")))?;
-            tx.send(StreamItem::Done)
-                .await
-                .map_err(|error| HarnessError::AgentExecution(format!("stream closed: {error}")))?;
-            Ok(())
-        }
-    }
-
-    struct CountingAdapter {
-        calls: Arc<AtomicUsize>,
-    }
-
-    #[async_trait::async_trait]
-    impl AgentAdapter for CountingAdapter {
-        fn name(&self) -> &str {
-            "codex"
-        }
-
-        async fn start_turn(
-            &self,
-            _req: TurnRequest,
-            tx: mpsc::Sender<AgentEvent>,
-        ) -> harness_core::error::Result<()> {
-            self.calls.fetch_add(1, Ordering::AcqRel);
-            tx.send(AgentEvent::TurnCompleted {
-                output: "adapter done".to_string(),
-            })
-            .await
-            .map_err(|error| HarnessError::AgentExecution(format!("adapter closed: {error}")))?;
-            Ok(())
-        }
-
-        async fn interrupt(&self) -> harness_core::error::Result<()> {
-            Ok(())
-        }
-    }
-
-    struct InterruptTrackingAdapter {
-        interrupt_calls: Arc<AtomicUsize>,
-        /// start_turn blocks until interrupt fires, so the lease-lost branch
-        /// of the turn loop deterministically wins the select race.
-        release: Arc<tokio::sync::Notify>,
-    }
-
-    #[async_trait::async_trait]
-    impl AgentAdapter for InterruptTrackingAdapter {
-        fn name(&self) -> &str {
-            "codex"
-        }
-
-        async fn start_turn(
-            &self,
-            _req: TurnRequest,
-            tx: mpsc::Sender<AgentEvent>,
-        ) -> harness_core::error::Result<()> {
-            self.release.notified().await;
-            tx.send(AgentEvent::TurnCompleted {
-                output: "adapter done after interrupt".to_string(),
-            })
-            .await
-            .map_err(|error| HarnessError::AgentExecution(format!("adapter closed: {error}")))?;
-            Ok(())
-        }
-
-        async fn interrupt(&self) -> harness_core::error::Result<()> {
-            self.interrupt_calls.fetch_add(1, Ordering::AcqRel);
-            self.release.notify_waiters();
-            Ok(())
-        }
-    }
-
-    fn server_with_codex_counts(
-        root: &std::path::Path,
-        agent_calls: Arc<AtomicUsize>,
-        adapter_calls: Arc<AtomicUsize>,
-    ) -> anyhow::Result<Arc<HarnessServer>> {
-        let mut config = HarnessConfig::default();
-        config.server.project_root = root.to_path_buf();
-        config.agents.default_agent = "codex".to_string();
-
-        let mut registry = AgentRegistry::new("codex");
-        registry.register("codex", Arc::new(CountingAgent { calls: agent_calls }));
-        let adapter_calls_for_factory = adapter_calls.clone();
-        registry
-            .register_adapter_factory_with_strategy(
-                "codex",
-                move || {
-                    Arc::new(CountingAdapter {
-                        calls: adapter_calls_for_factory.clone(),
-                    })
-                },
-                AdapterExecutionStrategy::ExecuteTurns,
-            )
-            .map_err(|error| anyhow::anyhow!("{error}"))?;
-
-        Ok(Arc::new(HarnessServer::new(
-            config,
-            ThreadManager::new(),
-            registry,
-        )))
-    }
-
-    fn start_test_turn(server: &HarnessServer, root: &std::path::Path) -> anyhow::Result<TurnId> {
-        let thread_id = server.thread_manager.start_thread(root.to_path_buf());
-        server
-            .thread_manager
-            .start_turn(&thread_id, "prompt".to_string(), AgentId::from_str("codex"))
-            .map_err(|error| anyhow::anyhow!("{error}"))
-    }
-
-    async fn run_test_turn(
-        server: Arc<HarnessServer>,
-        root: &std::path::Path,
-        turn_id: TurnId,
-        options: TurnLifecycleOptions,
-    ) -> anyhow::Result<()> {
-        let thread_id = server
-            .thread_manager
-            .find_thread_for_turn(&turn_id)
-            .ok_or_else(|| anyhow::anyhow!("turn should belong to a thread"))?;
-        let (notification_tx, _) = tokio::sync::broadcast::channel(16);
-        run_turn_lifecycle_with_options(
-            server,
-            None,
-            notification_tx,
-            thread_id,
-            turn_id,
-            "prompt".to_string(),
-            "codex".to_string(),
-            options,
-        )
-        .await;
-        anyhow::ensure!(root.exists(), "test root should still exist");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn lifecycle_uses_registered_turn_adapter_by_default() -> anyhow::Result<()> {
-        let root = tempfile::tempdir()?;
-        let agent_calls = Arc::new(AtomicUsize::new(0));
-        let adapter_calls = Arc::new(AtomicUsize::new(0));
-        let server =
-            server_with_codex_counts(root.path(), agent_calls.clone(), adapter_calls.clone())?;
-        let turn_id = start_test_turn(&server, root.path())?;
-
-        run_test_turn(
-            server.clone(),
-            root.path(),
-            turn_id.clone(),
-            TurnLifecycleOptions::default(),
-        )
-        .await?;
-
-        assert_eq!(agent_calls.load(Ordering::Acquire), 0);
-        assert_eq!(adapter_calls.load(Ordering::Acquire), 1);
-        let thread_id = server
-            .thread_manager
-            .find_thread_for_turn(&turn_id)
-            .ok_or_else(|| anyhow::anyhow!("turn should belong to a thread"))?;
-        let turn = server
-            .thread_manager
-            .get_turn(&thread_id, &turn_id)
-            .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
-        assert_eq!(turn.status, TurnStatus::Completed);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn lifecycle_force_code_agent_bypasses_turn_adapter() -> anyhow::Result<()> {
-        let root = tempfile::tempdir()?;
-        let agent_calls = Arc::new(AtomicUsize::new(0));
-        let adapter_calls = Arc::new(AtomicUsize::new(0));
-        let server =
-            server_with_codex_counts(root.path(), agent_calls.clone(), adapter_calls.clone())?;
-        let turn_id = start_test_turn(&server, root.path())?;
-
-        run_test_turn(
-            server.clone(),
-            root.path(),
-            turn_id.clone(),
-            TurnLifecycleOptions {
-                force_code_agent: true,
-                ..TurnLifecycleOptions::default()
-            },
-        )
-        .await?;
-
-        assert_eq!(agent_calls.load(Ordering::Acquire), 1);
-        assert_eq!(adapter_calls.load(Ordering::Acquire), 0);
-        let thread_id = server
-            .thread_manager
-            .find_thread_for_turn(&turn_id)
-            .ok_or_else(|| anyhow::anyhow!("turn should belong to a thread"))?;
-        let turn = server
-            .thread_manager
-            .get_turn(&thread_id, &turn_id)
-            .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
-        assert_eq!(turn.status, TurnStatus::Completed);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn prefired_lease_lost_still_interrupts_turn() -> anyhow::Result<()> {
-        let root = tempfile::tempdir()?;
-        let agent_calls = Arc::new(AtomicUsize::new(0));
-        let interrupt_calls = Arc::new(AtomicUsize::new(0));
-        let mut config = HarnessConfig::default();
-        config.server.project_root = root.path().to_path_buf();
-        config.agents.default_agent = "codex".to_string();
-        let mut registry = AgentRegistry::new("codex");
-        registry.register("codex", Arc::new(CountingAgent { calls: agent_calls }));
-        let interrupt_calls_for_factory = interrupt_calls.clone();
-        let release_for_factory = Arc::new(tokio::sync::Notify::new());
-        registry
-            .register_adapter_factory_with_strategy(
-                "codex",
-                move || {
-                    Arc::new(InterruptTrackingAdapter {
-                        interrupt_calls: interrupt_calls_for_factory.clone(),
-                        release: release_for_factory.clone(),
-                    })
-                },
-                AdapterExecutionStrategy::ExecuteTurns,
-            )
-            .map_err(|error| anyhow::anyhow!("{error}"))?;
-        let server = Arc::new(HarnessServer::new(config, ThreadManager::new(), registry));
-        let turn_id = start_test_turn(&server, root.path())?;
-
-        // Fire the lease-lost signal BEFORE the turn loop starts polling: the
-        // watch channel must not lose it (GH-1877).
-        let (lease_lost, receiver) = tokio::sync::watch::channel(false);
-        let _ = lease_lost.send(true);
-        run_test_turn(
-            server.clone(),
-            root.path(),
-            turn_id.clone(),
-            TurnLifecycleOptions {
-                lease_lost: Some(receiver),
-                ..TurnLifecycleOptions::default()
-            },
-        )
-        .await?;
-
-        assert_eq!(
-            interrupt_calls.load(Ordering::Acquire),
-            1,
-            "pre-fired lease-lost must interrupt the agent"
-        );
-        let thread_id = server
-            .thread_manager
-            .find_thread_for_turn(&turn_id)
-            .ok_or_else(|| anyhow::anyhow!("turn should belong to a thread"))?;
-        let turn = server
-            .thread_manager
-            .get_turn(&thread_id, &turn_id)
-            .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
-        assert_eq!(turn.status, TurnStatus::Failed);
-        Ok(())
-    }
-
-    #[test]
-    fn bridge_preserves_warning_and_token_usage_events() {
-        let mut output_buf = String::new();
-        let mut warning_completion = false;
-        let mut usage_completion = false;
-
-        let warning = bridge_agent_event(
-            AgentEvent::Warning {
-                message: "careful".into(),
-            },
-            &mut output_buf,
-            &mut warning_completion,
-        );
-        let usage = bridge_agent_event(
-            AgentEvent::TokenUsage {
-                usage: TokenUsage {
-                    input_tokens: 1,
-                    output_tokens: 2,
-                    total_tokens: 3,
-                    cost_usd: 0.0,
-                },
-            },
-            &mut output_buf,
-            &mut usage_completion,
-        );
-
-        assert_eq!(
-            warning,
-            Some(StreamItem::Warning {
-                message: "careful".into()
-            })
-        );
-        assert_eq!(
-            usage,
-            Some(StreamItem::TokenUsage {
-                usage: TokenUsage {
-                    input_tokens: 1,
-                    output_tokens: 2,
-                    total_tokens: 3,
-                    cost_usd: 0.0,
-                }
-            })
-        );
-    }
-
-    #[test]
-    fn bridge_uses_buffered_output_when_turn_completed_payload_is_empty() {
-        let mut output_buf = String::new();
-        let mut emitted_agent_completion = false;
-        let _ = bridge_agent_event(
-            AgentEvent::MessageDelta {
-                text: "hello".into(),
-            },
-            &mut output_buf,
-            &mut emitted_agent_completion,
-        );
-        let completed = bridge_agent_event(
-            AgentEvent::TurnCompleted {
-                output: String::new(),
-            },
-            &mut output_buf,
-            &mut emitted_agent_completion,
-        );
-
-        assert_eq!(
-            completed,
-            Some(StreamItem::ItemCompleted {
-                item: Item::AgentReasoning {
-                    content: "hello".into()
-                }
-            })
-        );
-        assert!(output_buf.is_empty());
-    }
-
-    #[test]
-    fn bridge_suppresses_duplicate_turn_completed_after_agent_message_completion() {
-        let mut output_buf = String::new();
-        let mut emitted_agent_completion = false;
-        let item_completed = bridge_agent_event(
-            AgentEvent::ItemCompletedPayload {
-                item: Item::AgentReasoning {
-                    content: "done".into(),
-                },
-            },
-            &mut output_buf,
-            &mut emitted_agent_completion,
-        );
-        let turn_completed = bridge_agent_event(
-            AgentEvent::TurnCompleted {
-                output: "done".into(),
-            },
-            &mut output_buf,
-            &mut emitted_agent_completion,
-        );
-
-        assert_eq!(
-            item_completed,
-            Some(StreamItem::ItemCompleted {
-                item: Item::AgentReasoning {
-                    content: "done".into()
-                }
-            })
-        );
-        assert!(emitted_agent_completion);
-        assert_eq!(turn_completed, None);
-        assert!(output_buf.is_empty());
     }
 }

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle_tests.rs
@@ -1,0 +1,423 @@
+//! Tests for the runtime turn lifecycle, split out of `turn_lifecycle.rs`
+//! to keep that file under the repository file-size ceiling.
+
+use super::turn_lifecycle::{
+    bridge_agent_event, run_turn_lifecycle_with_options, TurnLifecycleOptions,
+};
+use crate::{server::HarnessServer, thread_manager::ThreadManager};
+use harness_agents::registry::{AdapterExecutionStrategy, AgentRegistry};
+use harness_core::agent::{
+    AgentAdapter, AgentEvent, AgentRequest, AgentResponse, CodeAgent, StreamItem, TurnRequest,
+};
+use harness_core::config::HarnessConfig;
+use harness_core::error::HarnessError;
+use harness_core::types::{AgentId, Capability, Item, TokenUsage, TurnId, TurnStatus};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use tokio::sync::mpsc;
+
+struct CountingAgent {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl CodeAgent for CountingAgent {
+    fn name(&self) -> &str {
+        "codex"
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        vec![Capability::Read]
+    }
+
+    async fn execute(&self, _req: AgentRequest) -> harness_core::error::Result<AgentResponse> {
+        Ok(AgentResponse {
+            output: "ok".to_string(),
+            stderr: String::new(),
+            items: Vec::new(),
+            token_usage: TokenUsage::default(),
+            model: "codex".to_string(),
+            exit_code: Some(0),
+        })
+    }
+
+    async fn execute_stream(
+        &self,
+        _req: AgentRequest,
+        tx: mpsc::Sender<StreamItem>,
+    ) -> harness_core::error::Result<()> {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        tx.send(StreamItem::ItemCompleted {
+            item: Item::AgentReasoning {
+                content: "agent stream done".to_string(),
+            },
+        })
+        .await
+        .map_err(|error| HarnessError::AgentExecution(format!("stream closed: {error}")))?;
+        tx.send(StreamItem::Done)
+            .await
+            .map_err(|error| HarnessError::AgentExecution(format!("stream closed: {error}")))?;
+        Ok(())
+    }
+}
+
+struct CountingAdapter {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl AgentAdapter for CountingAdapter {
+    fn name(&self) -> &str {
+        "codex"
+    }
+
+    async fn start_turn(
+        &self,
+        _req: TurnRequest,
+        tx: mpsc::Sender<AgentEvent>,
+    ) -> harness_core::error::Result<()> {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        tx.send(AgentEvent::TurnCompleted {
+            output: "adapter done".to_string(),
+        })
+        .await
+        .map_err(|error| HarnessError::AgentExecution(format!("adapter closed: {error}")))?;
+        Ok(())
+    }
+
+    async fn interrupt(&self) -> harness_core::error::Result<()> {
+        Ok(())
+    }
+}
+
+struct InterruptTrackingAdapter {
+    interrupt_calls: Arc<AtomicUsize>,
+    /// start_turn blocks until interrupt fires, so the lease-lost branch
+    /// of the turn loop deterministically wins the select race.
+    release: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait::async_trait]
+impl AgentAdapter for InterruptTrackingAdapter {
+    fn name(&self) -> &str {
+        "codex"
+    }
+
+    async fn start_turn(
+        &self,
+        _req: TurnRequest,
+        tx: mpsc::Sender<AgentEvent>,
+    ) -> harness_core::error::Result<()> {
+        self.release.notified().await;
+        tx.send(AgentEvent::TurnCompleted {
+            output: "adapter done after interrupt".to_string(),
+        })
+        .await
+        .map_err(|error| HarnessError::AgentExecution(format!("adapter closed: {error}")))?;
+        Ok(())
+    }
+
+    async fn interrupt(&self) -> harness_core::error::Result<()> {
+        self.interrupt_calls.fetch_add(1, Ordering::AcqRel);
+        self.release.notify_waiters();
+        Ok(())
+    }
+}
+
+fn server_with_codex_counts(
+    root: &std::path::Path,
+    agent_calls: Arc<AtomicUsize>,
+    adapter_calls: Arc<AtomicUsize>,
+) -> anyhow::Result<Arc<HarnessServer>> {
+    let mut config = HarnessConfig::default();
+    config.server.project_root = root.to_path_buf();
+    config.agents.default_agent = "codex".to_string();
+
+    let mut registry = AgentRegistry::new("codex");
+    registry.register("codex", Arc::new(CountingAgent { calls: agent_calls }));
+    let adapter_calls_for_factory = adapter_calls.clone();
+    registry
+        .register_adapter_factory_with_strategy(
+            "codex",
+            move || {
+                Arc::new(CountingAdapter {
+                    calls: adapter_calls_for_factory.clone(),
+                })
+            },
+            AdapterExecutionStrategy::ExecuteTurns,
+        )
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    Ok(Arc::new(HarnessServer::new(
+        config,
+        ThreadManager::new(),
+        registry,
+    )))
+}
+
+fn start_test_turn(server: &HarnessServer, root: &std::path::Path) -> anyhow::Result<TurnId> {
+    let thread_id = server.thread_manager.start_thread(root.to_path_buf());
+    server
+        .thread_manager
+        .start_turn(&thread_id, "prompt".to_string(), AgentId::from_str("codex"))
+        .map_err(|error| anyhow::anyhow!("{error}"))
+}
+
+async fn run_test_turn(
+    server: Arc<HarnessServer>,
+    root: &std::path::Path,
+    turn_id: TurnId,
+    options: TurnLifecycleOptions,
+) -> anyhow::Result<()> {
+    let thread_id = server
+        .thread_manager
+        .find_thread_for_turn(&turn_id)
+        .ok_or_else(|| anyhow::anyhow!("turn should belong to a thread"))?;
+    let (notification_tx, _) = tokio::sync::broadcast::channel(16);
+    run_turn_lifecycle_with_options(
+        server,
+        None,
+        notification_tx,
+        thread_id,
+        turn_id,
+        "prompt".to_string(),
+        "codex".to_string(),
+        options,
+    )
+    .await;
+    anyhow::ensure!(root.exists(), "test root should still exist");
+    Ok(())
+}
+
+#[tokio::test]
+async fn lifecycle_uses_registered_turn_adapter_by_default() -> anyhow::Result<()> {
+    let root = tempfile::tempdir()?;
+    let agent_calls = Arc::new(AtomicUsize::new(0));
+    let adapter_calls = Arc::new(AtomicUsize::new(0));
+    let server = server_with_codex_counts(root.path(), agent_calls.clone(), adapter_calls.clone())?;
+    let turn_id = start_test_turn(&server, root.path())?;
+
+    run_test_turn(
+        server.clone(),
+        root.path(),
+        turn_id.clone(),
+        TurnLifecycleOptions::default(),
+    )
+    .await?;
+
+    assert_eq!(agent_calls.load(Ordering::Acquire), 0);
+    assert_eq!(adapter_calls.load(Ordering::Acquire), 1);
+    let thread_id = server
+        .thread_manager
+        .find_thread_for_turn(&turn_id)
+        .ok_or_else(|| anyhow::anyhow!("turn should belong to a thread"))?;
+    let turn = server
+        .thread_manager
+        .get_turn(&thread_id, &turn_id)
+        .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
+    assert_eq!(turn.status, TurnStatus::Completed);
+    Ok(())
+}
+
+#[tokio::test]
+async fn lifecycle_force_code_agent_bypasses_turn_adapter() -> anyhow::Result<()> {
+    let root = tempfile::tempdir()?;
+    let agent_calls = Arc::new(AtomicUsize::new(0));
+    let adapter_calls = Arc::new(AtomicUsize::new(0));
+    let server = server_with_codex_counts(root.path(), agent_calls.clone(), adapter_calls.clone())?;
+    let turn_id = start_test_turn(&server, root.path())?;
+
+    run_test_turn(
+        server.clone(),
+        root.path(),
+        turn_id.clone(),
+        TurnLifecycleOptions {
+            force_code_agent: true,
+            ..TurnLifecycleOptions::default()
+        },
+    )
+    .await?;
+
+    assert_eq!(agent_calls.load(Ordering::Acquire), 1);
+    assert_eq!(adapter_calls.load(Ordering::Acquire), 0);
+    let thread_id = server
+        .thread_manager
+        .find_thread_for_turn(&turn_id)
+        .ok_or_else(|| anyhow::anyhow!("turn should belong to a thread"))?;
+    let turn = server
+        .thread_manager
+        .get_turn(&thread_id, &turn_id)
+        .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
+    assert_eq!(turn.status, TurnStatus::Completed);
+    Ok(())
+}
+
+#[tokio::test]
+async fn prefired_lease_lost_still_interrupts_turn() -> anyhow::Result<()> {
+    let root = tempfile::tempdir()?;
+    let agent_calls = Arc::new(AtomicUsize::new(0));
+    let interrupt_calls = Arc::new(AtomicUsize::new(0));
+    let mut config = HarnessConfig::default();
+    config.server.project_root = root.path().to_path_buf();
+    config.agents.default_agent = "codex".to_string();
+    let mut registry = AgentRegistry::new("codex");
+    registry.register("codex", Arc::new(CountingAgent { calls: agent_calls }));
+    let interrupt_calls_for_factory = interrupt_calls.clone();
+    let release_for_factory = Arc::new(tokio::sync::Notify::new());
+    registry
+        .register_adapter_factory_with_strategy(
+            "codex",
+            move || {
+                Arc::new(InterruptTrackingAdapter {
+                    interrupt_calls: interrupt_calls_for_factory.clone(),
+                    release: release_for_factory.clone(),
+                })
+            },
+            AdapterExecutionStrategy::ExecuteTurns,
+        )
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let server = Arc::new(HarnessServer::new(config, ThreadManager::new(), registry));
+    let turn_id = start_test_turn(&server, root.path())?;
+
+    // Fire the lease-lost signal BEFORE the turn loop starts polling: the
+    // watch channel must not lose it (GH-1877).
+    let (lease_lost, receiver) = tokio::sync::watch::channel(false);
+    let _ = lease_lost.send(true);
+    run_test_turn(
+        server.clone(),
+        root.path(),
+        turn_id.clone(),
+        TurnLifecycleOptions {
+            lease_lost: Some(receiver),
+            ..TurnLifecycleOptions::default()
+        },
+    )
+    .await?;
+
+    assert_eq!(
+        interrupt_calls.load(Ordering::Acquire),
+        1,
+        "pre-fired lease-lost must interrupt the agent"
+    );
+    let thread_id = server
+        .thread_manager
+        .find_thread_for_turn(&turn_id)
+        .ok_or_else(|| anyhow::anyhow!("turn should belong to a thread"))?;
+    let turn = server
+        .thread_manager
+        .get_turn(&thread_id, &turn_id)
+        .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
+    assert_eq!(turn.status, TurnStatus::Failed);
+    Ok(())
+}
+
+#[test]
+fn bridge_preserves_warning_and_token_usage_events() {
+    let mut output_buf = String::new();
+    let mut warning_completion = false;
+    let mut usage_completion = false;
+
+    let warning = bridge_agent_event(
+        AgentEvent::Warning {
+            message: "careful".into(),
+        },
+        &mut output_buf,
+        &mut warning_completion,
+    );
+    let usage = bridge_agent_event(
+        AgentEvent::TokenUsage {
+            usage: TokenUsage {
+                input_tokens: 1,
+                output_tokens: 2,
+                total_tokens: 3,
+                cost_usd: 0.0,
+            },
+        },
+        &mut output_buf,
+        &mut usage_completion,
+    );
+
+    assert_eq!(
+        warning,
+        Some(StreamItem::Warning {
+            message: "careful".into()
+        })
+    );
+    assert_eq!(
+        usage,
+        Some(StreamItem::TokenUsage {
+            usage: TokenUsage {
+                input_tokens: 1,
+                output_tokens: 2,
+                total_tokens: 3,
+                cost_usd: 0.0,
+            }
+        })
+    );
+}
+
+#[test]
+fn bridge_uses_buffered_output_when_turn_completed_payload_is_empty() {
+    let mut output_buf = String::new();
+    let mut emitted_agent_completion = false;
+    let _ = bridge_agent_event(
+        AgentEvent::MessageDelta {
+            text: "hello".into(),
+        },
+        &mut output_buf,
+        &mut emitted_agent_completion,
+    );
+    let completed = bridge_agent_event(
+        AgentEvent::TurnCompleted {
+            output: String::new(),
+        },
+        &mut output_buf,
+        &mut emitted_agent_completion,
+    );
+
+    assert_eq!(
+        completed,
+        Some(StreamItem::ItemCompleted {
+            item: Item::AgentReasoning {
+                content: "hello".into()
+            }
+        })
+    );
+    assert!(output_buf.is_empty());
+}
+
+#[test]
+fn bridge_suppresses_duplicate_turn_completed_after_agent_message_completion() {
+    let mut output_buf = String::new();
+    let mut emitted_agent_completion = false;
+    let item_completed = bridge_agent_event(
+        AgentEvent::ItemCompletedPayload {
+            item: Item::AgentReasoning {
+                content: "done".into(),
+            },
+        },
+        &mut output_buf,
+        &mut emitted_agent_completion,
+    );
+    let turn_completed = bridge_agent_event(
+        AgentEvent::TurnCompleted {
+            output: "done".into(),
+        },
+        &mut output_buf,
+        &mut emitted_agent_completion,
+    );
+
+    assert_eq!(
+        item_completed,
+        Some(StreamItem::ItemCompleted {
+            item: Item::AgentReasoning {
+                content: "done".into()
+            }
+        })
+    );
+    assert!(emitted_agent_completion);
+    assert_eq!(turn_completed, None);
+    assert!(output_buf.is_empty());
+}

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -353,6 +353,12 @@ impl WorkflowRuntimeStore {
         self.budget_policy = budget_policy;
         self
     }
+    /// The wired budget policy, so mid-turn enforcement (the GH-1770 §4.3
+    /// turn-stream watchdog) applies the same ceiling as the dispatch gate and
+    /// the completion ceiling instead of re-reading config.
+    pub fn budget_policy(&self) -> &RuntimeBudgetPolicy {
+        &self.budget_policy
+    }
     pub fn pool(&self) -> &PgPool {
         &self.pool
     }


### PR DESCRIPTION
Fourth enforcement increment from `specs/GH1770/tech.md` §4.3, after the pre-dispatch gate (#1893), the daily profile cap (#1903), and the completion ceiling (#1904).

## Why

Dispatch-time gating cannot catch an activity that blows its budget *inside* a turn, and the completion ceiling only reacts once that turn already finished spending. The spec calls this out explicitly as a deliberate departure from the "gate new dispatch only" posture.

## What

- `RuntimeUsageContext` carries the store's `RuntimeBudgetPolicy`. Right after each streamed `TokenUsage` is persisted, the watchdog re-reads workflow spend — so the aggregate already includes the usage that may have crossed the ceiling. Comparison stays in integer micro-dollars, matching the other two enforcement points.
- `enforce` returns a `TurnBudgetStop` from `process_stream_item`; the turn loop interrupts the agent through the same `adapter.interrupt()` path the lease-lost branch uses, then ends the turn with a budget message.
- `shadow` records a `BudgetShadowDecision` event (`source: workflow_runtime_turn_watchdog`, `decision: would_interrupt`) and lets the turn run.
- A failed ceiling read logs at error level instead of silently disabling the watchdog; the completion ceiling stays the backstop.

## Refactor included

`turn_lifecycle.rs` was 893 lines — already over the repository's 800-line ceiling, so any addition was blocked. Its inline test module moved to `turn_lifecycle_tests.rs`, matching the sibling `stall_tests.rs` / `terminal_error_tests.rs` convention in the same directory. No test bodies changed; `bridge_agent_event` became `pub(super)` for the moved tests.

## Validation

- `cargo test -p harness-server --lib` (Postgres): 1479 passed, including 4 new `budget_watchdog_*` tests. The single failure (`http::builders::intake::tests::runtime_issue_concurrency_startup_projects_override_registry`) reproduces unchanged on `main` in this environment.
- `cargo test -p harness-workflow --lib`: 664 passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.

Remaining for GH-1770: throttle band (`profile_daily_throttled`) and the shadow→enforce default flip after a shadow observation window.