### PR TITLE
feat(workflow): deprioritize profiles inside their daily throttle band (GH-1770)

### DIFF
--- a/crates/harness-core/src/config/workflow/budget.rs
+++ b/crates/harness-core/src/config/workflow/budget.rs
@@ -26,6 +26,15 @@ pub struct RuntimeBudgetPolicy {
     /// spec, so unlike the workflow ceiling there is no built-in default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daily_profile_cap_usd: Option<f64>,
+    /// Fraction of `daily_profile_cap_usd` at which a profile enters the
+    /// throttle band. Inside the band the profile still runs, but its commands
+    /// yield the dispatch slot to profiles that are under their own threshold.
+    /// Ignored when no daily cap is configured.
+    #[serde(
+        default = "default_daily_throttle_ratio",
+        skip_serializing_if = "is_default_daily_throttle_ratio"
+    )]
+    pub daily_throttle_ratio: f64,
 }
 
 impl Default for RuntimeBudgetPolicy {
@@ -35,6 +44,7 @@ impl Default for RuntimeBudgetPolicy {
             enforcement: RuntimeBudgetEnforcement::default(),
             unlimited: false,
             daily_profile_cap_usd: None,
+            daily_throttle_ratio: default_daily_throttle_ratio(),
         }
     }
 }
@@ -56,8 +66,23 @@ impl RuntimeBudgetPolicy {
                     "runtime_budget_policy.daily_profile_cap_usd must be a positive finite number when set"
                 );
             }
+            if !self.daily_throttle_ratio.is_finite()
+                || self.daily_throttle_ratio <= 0.0
+                || self.daily_throttle_ratio > 1.0
+            {
+                anyhow::bail!(
+                    "runtime_budget_policy.daily_throttle_ratio must be within (0, 1] when a daily cap is set"
+                );
+            }
         }
         Ok(())
+    }
+
+    /// USD spend at which a profile enters the throttle band, or `None` when
+    /// no daily cap is configured.
+    pub fn daily_throttle_threshold_usd(&self) -> Option<f64> {
+        self.daily_profile_cap_usd
+            .map(|cap| cap * self.daily_throttle_ratio)
     }
 }
 
@@ -82,6 +107,16 @@ impl RuntimeBudgetEnforcement {
 
 fn default_workflow_budget_usd() -> f64 {
     15.0
+}
+
+fn default_daily_throttle_ratio() -> f64 {
+    0.8
+}
+
+/// The built-in ratio is not rendered back into config, so an unchanged policy
+/// serializes exactly as it did before the throttle band existed.
+fn is_default_daily_throttle_ratio(ratio: &f64) -> bool {
+    *ratio == default_daily_throttle_ratio()
 }
 
 #[cfg(test)]
@@ -127,6 +162,10 @@ mod tests {
             !rendered.contains("daily_profile_cap_usd"),
             "absent cap must not appear in rendered config: {rendered}"
         );
+        assert!(
+            !rendered.contains("daily_throttle_ratio"),
+            "the built-in throttle ratio must not appear in rendered config: {rendered}"
+        );
     }
 
     #[test]
@@ -143,6 +182,39 @@ mod tests {
             ..RuntimeBudgetPolicy::default()
         };
         policy.validate().expect("positive cap validates");
+    }
+
+    #[test]
+    fn validate_rejects_out_of_range_throttle_ratio() {
+        for ratio in [0.0, -0.5, 1.5, f64::NAN, f64::INFINITY] {
+            let policy = RuntimeBudgetPolicy {
+                daily_profile_cap_usd: Some(200.0),
+                daily_throttle_ratio: ratio,
+                ..RuntimeBudgetPolicy::default()
+            };
+            assert!(policy.validate().is_err(), "ratio {ratio} must be rejected");
+        }
+        // Without a daily cap the ratio is inert and must not fail validation.
+        let policy = RuntimeBudgetPolicy {
+            daily_profile_cap_usd: None,
+            daily_throttle_ratio: 5.0,
+            ..RuntimeBudgetPolicy::default()
+        };
+        policy.validate().expect("ratio is ignored without a cap");
+    }
+
+    #[test]
+    fn throttle_threshold_defaults_to_eighty_percent_of_the_cap() {
+        let policy = RuntimeBudgetPolicy {
+            daily_profile_cap_usd: Some(200.0),
+            ..RuntimeBudgetPolicy::default()
+        };
+        assert_eq!(policy.daily_throttle_ratio, 0.8);
+        assert_eq!(policy.daily_throttle_threshold_usd(), Some(160.0));
+        assert_eq!(
+            RuntimeBudgetPolicy::default().daily_throttle_threshold_usd(),
+            None
+        );
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/dispatch_barrier.rs
+++ b/crates/harness-workflow/src/runtime/dispatch_barrier.rs
@@ -60,6 +60,7 @@ pub enum DispatchBarrierReasonCode {
     IsolationTierUnavailable,
     WorkflowBudgetExhausted,
     ProfileDailyCapReached,
+    ProfileDailyThrottled,
 }
 
 impl DispatchBarrierReasonCode {
@@ -70,6 +71,7 @@ impl DispatchBarrierReasonCode {
             Self::IsolationTierUnavailable => "isolation_tier_unavailable",
             Self::WorkflowBudgetExhausted => "workflow_budget_exhausted",
             Self::ProfileDailyCapReached => "profile_daily_cap_reached",
+            Self::ProfileDailyThrottled => "profile_daily_throttled",
         }
     }
 }

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -1,3 +1,4 @@
+use super::dispatcher_throttle::{daily_throttle_breach, ThrottleBandRequest};
 use super::model::{RuntimeJob, RuntimeProfile, WorkflowCommandRecord, WorkflowInstance};
 use super::store::{
     cost_usd_from_micros, cost_usd_to_micros, ClaimedCommandTerminalOutcome,
@@ -467,6 +468,29 @@ impl<'a> RuntimeCommandDispatcher<'a> {
                             "profile_spent_usd_today": profile_spent_usd,
                             "daily_profile_cap_usd": cap_usd,
                         }),
+                    )
+                    .await;
+            }
+            // Throttle band (GH-1770 §4.1): deprioritize, do not block.
+            if let Some(breach) = daily_throttle_breach(ThrottleBandRequest {
+                store: self.store,
+                profile_selector: &self.profile_selector,
+                budget_policy: &self.budget_policy,
+                runtime_profile_name,
+                profile_spent_usd_micros: profile_spent_micros,
+                cap_usd,
+                utc_day_start,
+                peek_limit: self.batch_limit,
+            })
+            .await?
+            {
+                return self
+                    .budget_breach_outcome(
+                        instance,
+                        command,
+                        DispatchBarrierReasonCode::ProfileDailyThrottled,
+                        breach.reason,
+                        breach.evidence,
                     )
                     .await;
             }

--- a/crates/harness-workflow/src/runtime/dispatcher_throttle.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher_throttle.rs
@@ -1,0 +1,152 @@
+//! Daily-cap throttle band for the pre-dispatch budget gate (GH-1770 §4.1).
+//!
+//! Between `daily_profile_cap_usd * daily_throttle_ratio` and the cap itself a
+//! runtime profile is not blocked — it is deprioritized: its commands yield the
+//! dispatch slot while work from a profile under its own threshold is
+//! claimable. When no such alternative exists the throttled command dispatches,
+//! so a single busy profile still makes progress instead of starving.
+
+use super::dispatcher::RuntimeProfileSelector;
+use super::model::WorkflowCommandRecord;
+use super::store::{cost_usd_from_micros, cost_usd_to_micros, WorkflowRuntimeStore};
+use chrono::{DateTime, Utc};
+use harness_core::config::workflow::RuntimeBudgetPolicy;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+/// A throttle-band breach: the profile is inside its daily band and another
+/// profile under its own threshold has claimable work.
+pub(super) struct ThrottleBreach {
+    pub(super) reason: String,
+    pub(super) evidence: Value,
+}
+
+/// Throttle-band decision for one claimed command. `None` means dispatch may
+/// proceed — either the profile is under its threshold or nothing better is
+/// claimable, in which case a lone busy profile is slowed, never starved.
+pub(super) struct ThrottleBandRequest<'a> {
+    pub(super) store: &'a WorkflowRuntimeStore,
+    pub(super) profile_selector: &'a RuntimeProfileSelector,
+    pub(super) budget_policy: &'a RuntimeBudgetPolicy,
+    pub(super) runtime_profile_name: &'a str,
+    pub(super) profile_spent_usd_micros: u64,
+    pub(super) cap_usd: f64,
+    pub(super) utc_day_start: DateTime<Utc>,
+    pub(super) peek_limit: i64,
+}
+
+pub(super) async fn daily_throttle_breach(
+    request: ThrottleBandRequest<'_>,
+) -> anyhow::Result<Option<ThrottleBreach>> {
+    let ThrottleBandRequest {
+        store,
+        profile_selector,
+        budget_policy,
+        runtime_profile_name,
+        profile_spent_usd_micros,
+        cap_usd,
+        utc_day_start,
+        peek_limit,
+    } = request;
+    let Some(threshold_usd) = budget_policy.daily_throttle_threshold_usd() else {
+        return Ok(None);
+    };
+    let threshold_usd_micros = cost_usd_to_micros(threshold_usd)?;
+    if profile_spent_usd_micros < threshold_usd_micros {
+        return Ok(None);
+    }
+    let Some(alternative) = under_threshold_alternative_profile(
+        store,
+        profile_selector,
+        runtime_profile_name,
+        threshold_usd_micros,
+        utc_day_start,
+        peek_limit,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let profile_spent_usd = cost_usd_from_micros(profile_spent_usd_micros);
+    Ok(Some(ThrottleBreach {
+        reason: format!(
+            "runtime profile {runtime_profile_name} spent {profile_spent_usd:.2} USD today, \
+             inside the throttle band of its {cap_usd:.2} USD daily cap; runtime profile \
+             {alternative} is under its threshold and goes first"
+        ),
+        evidence: json!({
+            "runtime_profile": runtime_profile_name,
+            "profile_spent_usd_today": profile_spent_usd,
+            "daily_profile_cap_usd": cap_usd,
+            "daily_throttle_threshold_usd": threshold_usd,
+            "yielded_to_runtime_profile": alternative,
+        }),
+    }))
+}
+
+/// The runtime profile of some other claimable command that is under its daily
+/// throttle threshold, if any. `None` means nothing better is waiting and the
+/// throttled command may dispatch.
+async fn under_threshold_alternative_profile(
+    store: &WorkflowRuntimeStore,
+    profile_selector: &RuntimeProfileSelector,
+    throttled_profile: &str,
+    threshold_usd_micros: u64,
+    utc_day_start: DateTime<Utc>,
+    peek_limit: i64,
+) -> anyhow::Result<Option<String>> {
+    let claimable = store.peek_claimable_commands(peek_limit).await?;
+    let mut definition_ids: HashMap<String, Option<String>> = HashMap::new();
+    let mut profile_spend: HashMap<String, u64> = HashMap::new();
+
+    for command in &claimable {
+        let profile =
+            candidate_profile_name(store, profile_selector, command, &mut definition_ids).await?;
+        if profile == throttled_profile {
+            continue;
+        }
+        let spent_usd_micros = match profile_spend.get(&profile) {
+            Some(spent) => *spent,
+            None => {
+                let spent = store
+                    .runtime_usage_cost_for_profile_since(&profile, utc_day_start)
+                    .await?;
+                profile_spend.insert(profile.clone(), spent);
+                spent
+            }
+        };
+        if spent_usd_micros < threshold_usd_micros {
+            return Ok(Some(profile));
+        }
+    }
+    Ok(None)
+}
+
+/// Resolve the runtime profile a claimable command would dispatch under,
+/// memoizing the workflow lookup so a batch of commands from one workflow costs
+/// a single instance read.
+async fn candidate_profile_name(
+    store: &WorkflowRuntimeStore,
+    profile_selector: &RuntimeProfileSelector,
+    command: &WorkflowCommandRecord,
+    definition_ids: &mut HashMap<String, Option<String>>,
+) -> anyhow::Result<String> {
+    let definition_id = match definition_ids.get(&command.workflow_id) {
+        Some(definition_id) => definition_id.clone(),
+        None => {
+            let definition_id = store
+                .get_instance(&command.workflow_id)
+                .await?
+                .map(|instance| instance.definition_id);
+            definition_ids.insert(command.workflow_id.clone(), definition_id.clone());
+            definition_id
+        }
+    };
+    Ok(profile_selector
+        .select(
+            definition_id.as_deref(),
+            Some(command.command.runtime_activity_key()),
+        )
+        .name
+        .clone())
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -18,6 +18,7 @@ mod declarative_interpreter;
 mod declarative_pinning;
 mod dispatch_barrier;
 pub mod dispatcher;
+mod dispatcher_throttle;
 pub mod errors;
 pub mod eval;
 mod job_claim;

--- a/crates/harness-workflow/src/runtime/store/command_facade.rs
+++ b/crates/harness-workflow/src/runtime/store/command_facade.rs
@@ -214,27 +214,21 @@ impl WorkflowRuntimeStore {
             .collect()
     }
 
-    pub async fn claim_pending_commands(
-        &self,
-        owner: &str,
-        expires_at: DateTime<Utc>,
-        limit: i64,
-    ) -> anyhow::Result<Vec<WorkflowCommandRecord>> {
-        let limit = limit.clamp(1, 500);
-        let mut tx = self.pool.begin().await?;
-        let rows: Vec<WorkflowCommandRecordRow> = sqlx::query_as(
-            "WITH candidates AS (
-                 SELECT command.id
-                 FROM workflow_commands AS command
-                 JOIN workflow_instances AS workflow ON workflow.id = command.workflow_id
-             WHERE command.status = $3
+    /// The single definition of "claimable now" (B-001): a pending command, a
+    /// dispatching command whose lease expired, or a deferred command whose
+    /// backoff elapsed with an intact barrier. `claim_pending_commands` and
+    /// `peek_claimable_commands` must not drift apart, so both render this
+    /// fragment with their own bind indices.
+    fn claimable_command_predicate(pending: u8, dispatching: u8, deferred: u8) -> String {
+        format!(
+            "command.status = ${pending}
                     OR (
-                        command.status = $4
+                        command.status = ${dispatching}
                         AND COALESCE(command.dispatch_lease_expires_at, '-infinity'::timestamptz)
                             <= CURRENT_TIMESTAMP
                     )
                     OR (
-                        command.status = $5
+                        command.status = ${deferred}
                         AND command.dispatch_not_before <= CURRENT_TIMESTAMP
                         AND command.dispatch_owner IS NULL
                         AND command.dispatch_lease_expires_at IS NULL
@@ -253,7 +247,56 @@ impl WorkflowRuntimeStore {
                             = command.dispatch_claim_generation
                         AND (command.dispatch_barrier->>'next_dispatch_at')::TIMESTAMPTZ
                             = command.dispatch_not_before
-                    )
+                    )"
+        )
+    }
+
+    /// Claimable commands without claiming them — the throttle band needs to
+    /// know whether other work could run instead (GH-1770 §4.1).
+    pub async fn peek_claimable_commands(
+        &self,
+        limit: i64,
+    ) -> anyhow::Result<Vec<WorkflowCommandRecord>> {
+        let limit = limit.clamp(1, 500);
+        let rows: Vec<WorkflowCommandRecordRow> = sqlx::query_as(&format!(
+            "SELECT command.id, command.workflow_id, command.decision_id, command.status,
+                    command.dispatch_owner, command.dispatch_lease_expires_at,
+                    command.dispatch_not_before, command.dispatch_attempt_count,
+                    command.dispatch_claim_generation, command.dispatch_barrier::text,
+                    command.data::text, command.created_at, command.updated_at,
+                    command.attempt_generation, command.superseded_by_command_id
+             FROM workflow_commands AS command
+             JOIN workflow_instances AS workflow ON workflow.id = command.workflow_id
+             WHERE {}
+             ORDER BY command.created_at ASC
+             LIMIT $4",
+            Self::claimable_command_predicate(1, 2, 3)
+        ))
+        .bind(WorkflowCommandStatus::Pending.as_str())
+        .bind(WorkflowCommandStatus::Dispatching.as_str())
+        .bind(WorkflowCommandStatus::Deferred.as_str())
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(workflow_command_record_from_row)
+            .collect()
+    }
+
+    pub async fn claim_pending_commands(
+        &self,
+        owner: &str,
+        expires_at: DateTime<Utc>,
+        limit: i64,
+    ) -> anyhow::Result<Vec<WorkflowCommandRecord>> {
+        let limit = limit.clamp(1, 500);
+        let mut tx = self.pool.begin().await?;
+        let rows: Vec<WorkflowCommandRecordRow> = sqlx::query_as(&format!(
+            "WITH candidates AS (
+                 SELECT command.id
+                 FROM workflow_commands AS command
+                 JOIN workflow_instances AS workflow ON workflow.id = command.workflow_id
+                 WHERE {}
                  ORDER BY command.created_at ASC
                  LIMIT $6
                  FOR UPDATE OF command SKIP LOCKED
@@ -272,7 +315,8 @@ impl WorkflowRuntimeStore {
                        command.dispatch_claim_generation, command.dispatch_barrier::text,
                        command.data::text, command.created_at, command.updated_at,
                        command.attempt_generation, command.superseded_by_command_id",
-        )
+            Self::claimable_command_predicate(3, 4, 5)
+        ))
         .bind(owner)
         .bind(expires_at)
         .bind(WorkflowCommandStatus::Pending.as_str())

--- a/crates/harness-workflow/src/runtime/tests/command_dispatcher_budget.rs
+++ b/crates/harness-workflow/src/runtime/tests/command_dispatcher_budget.rs
@@ -49,6 +49,7 @@ fn enforce_budget_policy(budget_usd: f64) -> RuntimeBudgetPolicy {
         enforcement: RuntimeBudgetEnforcement::Enforce,
         unlimited: false,
         daily_profile_cap_usd: None,
+        daily_throttle_ratio: 0.8,
     }
 }
 
@@ -352,6 +353,205 @@ async fn daily_profile_cap_enforce_defers_and_ignores_other_profiles() -> anyhow
     );
     assert!(store
         .events_for(&under_instance.id)
+        .await?
+        .iter()
+        .all(|event| event.event_type != "BudgetShadowDecision"));
+    Ok(())
+}
+
+// Throttle band (GH-1770 §4.1): inside the band a profile yields the dispatch
+// slot to a profile under its own threshold, but is never starved when it is
+// the only claimable work.
+
+fn throttle_policy(cap_usd: f64, enforcement: RuntimeBudgetEnforcement) -> RuntimeBudgetPolicy {
+    RuntimeBudgetPolicy {
+        enforcement,
+        daily_profile_cap_usd: Some(cap_usd),
+        daily_throttle_ratio: 0.8,
+        ..RuntimeBudgetPolicy::default()
+    }
+}
+
+/// Selector where `replan_issue` keeps the (throttled) default profile and
+/// `implement_issue` resolves to a second, cheaper profile.
+fn throttle_profile_selector() -> RuntimeProfileSelector {
+    RuntimeProfileSelector::new(RuntimeProfile::new("codex-high", RuntimeKind::CodexJsonrpc))
+        .with_activity_profile(
+            "implement_issue",
+            RuntimeProfile::new("codex-low", RuntimeKind::CodexJsonrpc),
+        )
+}
+
+async fn issue_with_pending_activity(
+    store: &WorkflowRuntimeStore,
+    issue_number: u64,
+    activity: &str,
+) -> anyhow::Result<(WorkflowInstance, String)> {
+    let instance = project_issue_instance("/project-a", issue_number, "replanning");
+    store.force_upsert_lifecycle_state_for_test(&instance).await?;
+    let command = WorkflowCommand::enqueue_activity(
+        activity,
+        format!("issue-{issue_number}-{activity}-throttle"),
+    );
+    let command_id = store.enqueue_command(&instance.id, None, &command).await?;
+    Ok((instance, command_id))
+}
+
+#[tokio::test]
+async fn throttle_band_yields_to_a_profile_under_its_threshold() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    // Claimed first (oldest): the throttled profile's command.
+    let (throttled_instance, throttled_command_id) =
+        issue_with_pending_activity(&store, 511, "replan_issue").await?;
+    issue_with_pending_activity(&store, 512, "implement_issue").await?;
+    // 8.50 of a 10.00 cap: inside the band (threshold 8.00), under the cap.
+    store
+        .upsert_runtime_usage(&profile_usage_upsert(
+            &throttled_instance.id,
+            "codex-high",
+            cost_usd_to_micros(8.5)?,
+        ))
+        .await?;
+
+    let dispatcher =
+        RuntimeCommandDispatcher::with_profile_selector(&store, throttle_profile_selector())
+            .with_budget_policy(throttle_policy(10.0, RuntimeBudgetEnforcement::Enforce));
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    let barrier = match outcome {
+        CommandDispatchOutcome::Deferred {
+            command_id: id,
+            barrier,
+        } => {
+            assert_eq!(id, throttled_command_id);
+            barrier
+        }
+        other => panic!("throttled profile must yield the slot: {other:?}"),
+    };
+    assert_eq!(
+        barrier.reason_code,
+        DispatchBarrierReasonCode::ProfileDailyThrottled
+    );
+    assert!(barrier.reason.contains("codex-low"), "{}", barrier.reason);
+    Ok(())
+}
+
+#[tokio::test]
+async fn throttle_band_dispatches_when_it_is_the_only_claimable_work() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let (instance, _) = issue_with_pending_activity(&store, 513, "replan_issue").await?;
+    // A second command on the same throttled profile is not an alternative:
+    // yielding to it would leave both deferred forever.
+    issue_with_pending_activity(&store, 514, "replan_issue").await?;
+    store
+        .upsert_runtime_usage(&profile_usage_upsert(
+            &instance.id,
+            "codex-high",
+            cost_usd_to_micros(8.5)?,
+        ))
+        .await?;
+
+    let dispatcher =
+        RuntimeCommandDispatcher::with_profile_selector(&store, throttle_profile_selector())
+            .with_budget_policy(throttle_policy(10.0, RuntimeBudgetEnforcement::Enforce));
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    assert!(
+        matches!(outcome, CommandDispatchOutcome::Enqueued { .. }),
+        "a throttled profile with no better alternative must still run: {outcome:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn throttle_band_shadow_records_the_decision_and_dispatches() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let (instance, _) = issue_with_pending_activity(&store, 515, "replan_issue").await?;
+    issue_with_pending_activity(&store, 516, "implement_issue").await?;
+    store
+        .upsert_runtime_usage(&profile_usage_upsert(
+            &instance.id,
+            "codex-high",
+            cost_usd_to_micros(8.5)?,
+        ))
+        .await?;
+
+    let dispatcher =
+        RuntimeCommandDispatcher::with_profile_selector(&store, throttle_profile_selector())
+            .with_budget_policy(throttle_policy(10.0, RuntimeBudgetEnforcement::Shadow));
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    assert!(
+        matches!(outcome, CommandDispatchOutcome::Enqueued { .. }),
+        "shadow mode must dispatch inside the throttle band: {outcome:?}"
+    );
+    let events = store.events_for(&instance.id).await?;
+    let shadow = events
+        .iter()
+        .find(|event| event.event_type == "BudgetShadowDecision")
+        .expect("shadow mode records a BudgetShadowDecision event");
+    assert_eq!(shadow.event["barrier_reason_code"], "profile_daily_throttled");
+    assert_eq!(shadow.event["daily_throttle_threshold_usd"], 8.0);
+    assert_eq!(shadow.event["yielded_to_runtime_profile"], "codex-low");
+    Ok(())
+}
+
+#[tokio::test]
+async fn throttle_band_is_inert_below_the_threshold() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let (instance, _) = issue_with_pending_activity(&store, 517, "replan_issue").await?;
+    issue_with_pending_activity(&store, 518, "implement_issue").await?;
+    store
+        .upsert_runtime_usage(&profile_usage_upsert(
+            &instance.id,
+            "codex-high",
+            cost_usd_to_micros(7.99)?,
+        ))
+        .await?;
+
+    let dispatcher =
+        RuntimeCommandDispatcher::with_profile_selector(&store, throttle_profile_selector())
+            .with_budget_policy(throttle_policy(10.0, RuntimeBudgetEnforcement::Enforce));
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    assert!(
+        matches!(outcome, CommandDispatchOutcome::Enqueued { .. }),
+        "below the threshold the band must not engage: {outcome:?}"
+    );
+    assert!(store
+        .events_for(&instance.id)
         .await?
         .iter()
         .all(|event| event.event_type != "BudgetShadowDecision"));

--- a/crates/harness-workflow/src/runtime/tests/completion_budget_ceiling.rs
+++ b/crates/harness-workflow/src/runtime/tests/completion_budget_ceiling.rs
@@ -11,6 +11,7 @@ fn ceiling_store_policy(
         enforcement,
         unlimited: false,
         daily_profile_cap_usd: None,
+        daily_throttle_ratio: 0.8,
     }
 }
 


### PR DESCRIPTION
Final enforcement increment from `specs/GH1770/tech.md` §4.1, after the pre-dispatch gate (#1893), the daily profile cap (#1903), the completion ceiling (#1904), and the turn-stream watchdog (#1905).

## What

Between `daily_profile_cap_usd * daily_throttle_ratio` and the cap itself, a profile is not blocked — it is **deprioritized**.

- `runtime_budget_policy.daily_throttle_ratio` (default `0.8`), validated in `(0, 1]` only when a daily cap is set. Like the cap before it, the built-in value is not rendered back into config, so the frozen model-facing prompt fixture is unchanged.
- New `peek_claimable_commands` store query. "Claimable now" became a single SQL fragment rendered by *both* the claim and the peek query, so the two definitions cannot drift apart.
- New `profile_daily_throttled` dispatch barrier reason. Inside the band the dispatcher defers the claimed command **only when another claimable command resolves to a profile under its own threshold**; with no such alternative the throttled command dispatches.
- Shadow enforcement reuses the shared breach path and records the would-defer decision.

## Starvation is the interesting case

Yielding to *any* other claimable work would deadlock: two commands on the same throttled profile would each see "other work exists" and defer forever. The alternative must be under *its own* threshold, so a lone busy profile is slowed, never starved — that case has its own test.

Peeked commands memoize instance lookups and per-profile daily spend, so a batch costs one query per distinct workflow and profile, and the peek only runs while a profile is actually in the band.

## Validation

- `cargo test -p harness-workflow --lib` (Postgres): 668 passed, including 4 new `throttle_band_*` tests.
- `cargo test -p harness-core --lib`: 809 passed (throttle ratio validation + serialization).
- `cargo test -p harness-server --lib`: 1475 passed, 1 failure (`http::builders::intake::tests::runtime_issue_concurrency_startup_projects_override_registry`) that reproduces unchanged on `main` in this environment.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.

This lands every code item in the GH-1770 spec. What remains before the issue closes is operational, not code: run a shadow observation window, tune `default_workflow_budget_usd` from observed p95 workflow spend, then flip the default to `enforce`.