### PR TITLE
docs(GH1733): deny mutable openat2 and BPF execution

### DIFF
--- a/specs/GH1733/product.md
+++ b/specs/GH1733/product.md
@@ -440,7 +440,7 @@ attempt vocabularies are normative in `runtime-product.md`.
       After verified initial exec, syscall-entry fixtures prove `fork`, `vfork`,
       `clone`, `clone3`, `execve`, `execveat`, executable `mmap`/`mprotect`,
       executable `shmat`, x86_64 `uselib`, `ptrace`, `process_vm_writev`, `userfaultfd`,
-      `io_uring_setup`, `pidfd_getfd`, `recvmsg`/`recvmmsg`, `prctl`,
+      `io_uring_setup`, `pidfd_getfd`, `recvmsg`/`recvmmsg`, `prctl`, `openat2`,
       non-query `personality`, and write-capable/truncating open-family requests are
       stopped before kernel execution, yield the exact closed
       transitive-denial class, execute no second-image/child/mapping/mutation
@@ -451,11 +451,12 @@ attempt vocabularies are normative in `runtime-product.md`.
       `READ_IMPLIES_EXEC` attempts are denied. The exact
       `personality(0xffff_ffff)` query is resumed, returns through the ordinary
       entry/exit trace transition, and does not produce denial evidence; every
-      other argument is denied. Exact and extended `openat2`
-      payloads are decoded, while short, unreadable, unknown-tail, and
-      unknown/conflicting-flag payloads return no-envelope execution
-      verification failure. Missing/untagged/unreadable syscall stops return no
-      envelope and cleanup the target.
+      other argument is denied. Every `openat2` entry is denied without reading
+      attacker-owned `open_how` memory, so an external same-UID writer cannot
+      change approved flags after validation. Native `bpf`, `init_module`, and
+      `finit_module` entries are denied as kernel-code loading regardless of
+      command or current capabilities. Missing/untagged/unreadable syscall stops
+      return no envelope and cleanup the target.
       A static aux-vector fixture proves each direct-exec attempt records
       `linux_fd_cloexec_execveat_empty_path_fd_10`, observes exact
       `AT_EXECFN = "/dev/fd/10"`, cannot reopen fd 10 after exec, and does not

--- a/specs/GH1733/runtime-observation.md
+++ b/specs/GH1733/runtime-observation.md
@@ -686,19 +686,19 @@ ABI gate does the owner reject closed `RuntimeTransitiveExecutionClass`:
   `io_uring_setup`, `pidfd_getfd`, `recvmsg`, `recvmmsg`, `prctl`, every
   `personality` argument other than the side-effect-free exact
   `0xffff_ffff` query,
-  `creat`, or `open`/`openat`/`open_by_handle_at`/`openat2` whose flags request
-  `O_WRONLY`, `O_RDWR`, or `O_TRUNC`;
-- `KernelModuleLoading`: native `init_module` or `finit_module`, regardless of
-  current capabilities; and
+  `creat`, every `openat2`, or `open`/`openat`/`open_by_handle_at` whose flags
+  request `O_WRONLY`, `O_RDWR`, or `O_TRUNC`;
+- `KernelCodeLoading`: native `bpf`, `init_module`, or `finit_module`,
+  regardless of command or current capabilities; and
 - `ProcessSignalling`: `kill`, `tkill`, `tgkill`, `rt_sigqueueinfo`,
   `rt_tgsigqueueinfo`, or `pidfd_send_signal`, for every target, signal, PID,
   TID, pidfd, zero, negative, process-group, and broadcast form.
 
-The fixed-size `open_how` prefix used by `openat2` is copied from the stopped
-single-threaded target with one bounded `process_vm_readv`; an unreadable
-pointer, a size smaller than the flags field, nonzero unknown tail bytes, or
-unknown/conflicting flag bits is `ExecutionVerificationUnavailable`. It is
-never resumed as a read-only open. Descriptor isolation proves that the target
+Every `openat2` entry is denied without reading `open_how`. A cooperating
+same-UID process therefore cannot mutate attacker-owned argument memory between
+classification and kernel consumption. Denying native `bpf` in full prevents
+program loading and later attachment from bypassing the initial-image-only
+contract. Descriptor isolation proves that the target
 inherits no writable memory fd or Unix socket. Denying every later
 write-capable open blocks `/proc/self/mem`, `/proc/thread-self/mem`, numeric
 proc aliases, and mount aliases without parsing an attacker-controlled

--- a/specs/GH1733/runtime-product.md
+++ b/specs/GH1733/runtime-product.md
@@ -349,7 +349,7 @@ with `product.md`, `runtime-observation.md`, `runtime-supervision.md`,
    equal the recorded digest. Resume occurs only under the B-007 syscall-stop
    guard: every later process-creation or image-execution syscall, every
    request for a new executable mapping, and every closed existing-image
-   mutation or native kernel-module-loading syscall is stopped before kernel
+   mutation or native kernel-code-loading syscall is stopped before kernel
    execution and fails closed. Thus
    an allowed static target cannot use PATH, cwd, `dlopen`, `/proc/self/mem`,
    asynchronous I/O submission, or a child process to execute
@@ -459,8 +459,9 @@ with `product.md`, `runtime-observation.md`, `runtime-supervision.md`,
    `PTRACE_SYSCALL` and classifies every syscall-entry stop before execution.
    x86_64 x32 dispatch is rejected before native decoding. Denied classes are
    process creation; image execution; executable mapping, including
-   x86_64 `uselib`; executable-image mutation; native kernel module loading
-   through `init_module` or `finit_module`; and process signalling.
+   x86_64 `uselib`; executable-image mutation, including every `openat2`;
+   native kernel-code loading through `bpf`, `init_module`, or `finit_module`;
+   and process signalling.
    `mmap`/native `mmap2`, `mprotect`, `pkey_mprotect`, or `shmat`
    requesting executable access are executable mapping. The frozen native
    x86_64 table additionally classifies `uselib` as executable mapping;
@@ -597,7 +598,7 @@ no-envelope producer errors defined in B-006 and never enter this list.
 | `version_probe` | `handle_execution_unavailable` | Mandatory ptrace containment passed, but the candidate's fully frozen fd-10 `execveat(AT_EMPTY_PATH)` returned exact `ENOSYS`, `EPERM`, or `EINVAL`; every created target helper was reaped and no target instruction ran. |
 | `version_probe` | `supervision_setup_failed` | An initial/retry registered target failed working-directory entry or pre-exec ptrace stop/options setup; the closed stage is exactly `working_directory_enter` or `trace_setup`, the target was reaped, and handle exec was never attempted. |
 | `version_probe` | `spawn_failed` | Direct exec of an inspected candidate failed terminally before start; no selected/executed claim is emitted. |
-| `version_probe` | `transitive_execution_denied` | After the verified initial static image began under syscall-stop supervision, it attempted closed class `process_creation`, `image_execution`, `executable_mapping`, `executable_image_mutation`, `kernel_module_loading`, or `process_signalling`; the denied syscall never executed, stopped-target cleanup began, cleanup outcome is independent, and no version fact was emitted. |
+| `version_probe` | `transitive_execution_denied` | After the verified initial static image began under syscall-stop supervision, it attempted closed class `process_creation`, `image_execution`, `executable_mapping`, `executable_image_mutation`, `kernel_code_loading`, or `process_signalling`; the denied syscall never executed, stopped-target cleanup began, cleanup outcome is independent, and no version fact was emitted. |
 | `version_probe` | `bare_eacces_exhausted` | Every inspected Unix bare-name exec attempt returned exact `EACCES`; no executable was selected or started. |
 | `version_probe` | `timeout` | The probe deadline expired; cleanup outcome is represented independently. |
 | `version_probe` | `output_limit_exceeded` | Combined stdout/stderr exceeded the inclusive hard byte limit; cleanup outcome is represented independently. |

--- a/specs/GH1733/runtime-supervision.md
+++ b/specs/GH1733/runtime-supervision.md
@@ -130,8 +130,8 @@ before native-table decoding. Denied classes are:
   `pkey_mprotect`, or `shmat` requesting executable access, plus x86_64
   `uselib`;
 - `executable_image_mutation`: the closed writable-image and descriptor
-  acquisition operations in the product contract;
-- `kernel_module_loading`: native `init_module` and `finit_module`; and
+  acquisition operations in the product contract, including every `openat2`;
+- `kernel_code_loading`: native `bpf`, `init_module`, and `finit_module`; and
 - `process_signalling`: every closed signal syscall and target form.
 
 The frozen x86_64 syscall table includes `uselib`; aarch64 does not invent an

--- a/specs/GH1733/tasks.md
+++ b/specs/GH1733/tasks.md
@@ -66,8 +66,9 @@ implementation PR or force-push.
       separate deadline. Success requires exact target reap, complete bounded
       streams, a passing post-reap checkpoint, and an empty registry.
       The post-exec guard denies process creation, image execution, executable
-      mapping (including x86_64 `uselib`), image mutation, and signalling
-      plus native `init_module`/`finit_module` before execution. Retained-handle
+      mapping (including x86_64 `uselib`), image mutation including every
+      `openat2`, signalling, and native `bpf`/`init_module`/`finit_module`
+      kernel-code loading before execution. Retained-handle
       hashes use bounded offset-zero `pread`, never a shared sequential offset.
       The claim is registry-empty plus no executed
       process-creation syscall, never descendant-tree-empty.
@@ -98,7 +99,7 @@ implementation PR or force-push.
       membership stages, or descendant-tree claims. It must also cover
       owner-mask restore failure, child-disposition reset, and exact empty child
       mask before readiness/exec; offset-zero `pread`
-      hashing across transferred handles; native `init_module`/`finit_module` denial;
+      hashing across transferred handles; native `bpf`/`init_module`/`finit_module` denial;
       an unrelated same-session process repeatedly changing process groups
       without entering the registry, being observed/signalled, or changing
       success evidence;
@@ -185,8 +186,9 @@ of silently expanding scope.
       ptrace exec-stop/first-instruction ordering and hash/image validation under
       kernel write denial; W+X/executable-stack rejection; post-exec
       syscall-stop denial of process/image/executable-mapping (including
-      x86_64 `uselib`) and existing-executable-mutation transitions,
-      native `init_module`/`finit_module` kernel-module loading,
+      x86_64 `uselib`) and existing-executable-mutation transitions including
+      unconditional `openat2` denial, native `bpf`/`init_module`/`finit_module`
+      kernel-code loading,
       target-initiated process signalling, and pre-native x32 rejection;
       legal signal-delivery reinjection and illegal-state rejection;
       retained-handle pre-exec; exact registered-pidfd-only signalling and reap
@@ -205,7 +207,7 @@ of silently expanding scope.
 | B-004 | Frozen Unix/Windows command-form and digest vectors; `O_PATH` retained cwd with no `O_NOFOLLOW`; search-only cwd and pathname replacement; raw Unix bytes and Windows UTF-16 units; exact `EACCES` fallback, one 150 ms `ETXTBSY` retry, candidate 65, no shell, and fd-10 execution context; later pre-target outcomes preserve prior reaped attempts while the registry is empty |
 | B-005, B-010 | Closed environment policy, setup-secret exclusion, exact PATH and Claude-directory digest vectors, Unix/Windows key rules, direct/env shebang rejection before target/interpreter creation, and proof that only sanitized PATH reaches an admitted static target |
 | B-006 | Nonblocking retained executable handle, offset-zero `pread` hashing, size and strong-identity checkpoints, hard-link authorization, kill-isolated observation helpers, atomic pidfd registration before `GO`, exact observation errors, static ELF/exec-stop verification, path-race rejection, and no in-process blocking worker |
-| B-007 | Eight-owner deadlines; pre-fork signal masking and child disposition reset; bounded pre-ready inherited-fd transient plus post-ready 28 + 12 retained capacity; two pidfds per owner; capability-child validating/consuming `waitid(P_PIDFD)`, bootstrap exact-PID fallback, then exact-pidfd-only signal/reap; initial/retry `working_directory_enter` and `trace_setup`; process/image/mapping/mutation/kernel-module-loading/signalling denial including x86_64 `uselib` and native `init_module`/`finit_module`; target reap + complete output + post-reap checkpoint + empty registry success barrier; unrelated same-session `setpgid` churn is never registered/observed/signalled and cannot affect success; no anchor/PGID/membership/descendant-tree claim; non-Linux pre-observation failure |
+| B-007 | Eight-owner deadlines; pre-fork signal masking and child disposition reset; bounded pre-ready inherited-fd transient plus post-ready 28 + 12 retained capacity; two pidfds per owner; capability-child validating/consuming `waitid(P_PIDFD)`, bootstrap exact-PID fallback, then exact-pidfd-only signal/reap; initial/retry `working_directory_enter` and `trace_setup`; process/image/mapping/mutation/kernel-code-loading/signalling denial including x86_64 `uselib`, every `openat2`, and native `bpf`/`init_module`/`finit_module`; target reap + complete output + post-reap checkpoint + empty registry success barrier; unrelated same-session `setpgid` churn is never registered/observed/signalled and cannot affect success; no anchor/PGID/membership/descendant-tree claim; non-Linux pre-observation failure |
 | B-008 | Closed failure vocabulary and canonical ordering; observation errors remain no-envelope; termination/reap/drain cleanup failures retain exact ownership; removed `lingering_process_group`, anchor, and membership values are rejected |
 | B-009 | Exact Codex/Claude whole-stream grammars and stream selection; capture error precedence; after complete capture signal/nonzero exclusivity; zero-exit-only UTF-8/blank/grammar classification; exact HT/LF/CR/SP blank predicate and success-only output digests |
 | B-012 | `mcp_description_preserves_absent_empty_space_tab_and_newline_distinctions`; `mcp_output_schema_absence_and_presence_are_distinct`; `mcp_annotations_preserve_absent_empty_hints_title_vendor_values_and_ordered_arrays`; `mcp_annotation_hints_do_not_infer_capabilities`; exact-limit and limit-plus-one tool-name/description/annotations fixtures |
@@ -230,8 +232,9 @@ Cross-cutting mandatory runtime tests additionally prove:
 - cwd opens with `O_PATH | O_DIRECTORY | O_CLOEXEC` and no `O_NOFOLLOW`,
   including a search/execute-only directory and pathname replacement;
 - x86_64 x32 dispatch fails before native classification, x86_64 `uselib` is
-  denied as executable mapping, aarch64 has no fabricated `uselib` entry, and
-  native `init_module`/`finit_module` is denied on both supported architectures;
+  denied as executable mapping, aarch64 has no fabricated `uselib` entry,
+  every `openat2` is denied without reading `open_how`, and native
+  `bpf`/`init_module`/`finit_module` is denied on both supported architectures;
 - output overflow/read failure precedes exit classification; fatal delivered
   signals are reinjected and yield only `terminated_by_signal`, caught/ignored
   signals continue, direct `SIGKILL` is semantic only from `AwaitEntry` or

--- a/specs/GH1733/tech.md
+++ b/specs/GH1733/tech.md
@@ -691,7 +691,8 @@ stopped-image identity/hash validation under kernel write denial,
 offset-zero bounded `pread` hashing that ignores shared open-description offsets,
 W+X/executable-stack rejection, post-exec syscall-stop denial of process
 creation, image execution, executable mappings, and existing executable-image
-mutation plus native `init_module`/`finit_module` kernel-module loading,
+mutation including every `openat2`, plus native `bpf`/`init_module`/`finit_module`
+kernel-code loading,
 post-capability registered-pidfd-only signalling and reap ordering, legal
 signal-delivery reinjection and illegal-state rejection,
 argument/environment pointers, NUL validation, error


### PR DESCRIPTION
## Summary

- resolve the two remaining P1 review findings from #1862
- deny every `openat2` syscall before reading attacker-owned `open_how` memory
- classify native `bpf`, `init_module`, and `finit_module` as closed kernel-code-loading denials
- update the complete six-file GH-1733 specification packet and verification matrix consistently

## Why

The previous contract validated `open_how` once and then resumed the syscall, leaving a same-UID process-memory mutation race. It also allowed `bpf`, which can load and run repository-controlled kernel programs. Both violate the initial-image-only execution claim.

## Verification

- `git diff --check`
- all six specification files remain at or below 800 lines
- `cargo fmt --all -- --check`
- pre-push workspace clippy passed
- pre-push database-independent workspace tests passed
- SpecRail checker is absent on current `main`; no checker success is claimed

Refs #1733