### PR TITLE
docs: consolidate project agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ There is no type literally named `AgentRuntime` in the codebase. The phrase is u
 
 ## PR Workflow
 
-- Before merging, every PR must receive a fresh-context review from an agent process that did not author the changes. The reviewer must return `APPROVE` or `REQUEST_CHANGES` with concrete findings; missing or unparseable output is not approval.
+- Before merging, every PR must receive a fresh-context review from an agent process that did not author the changes. The reviewer must put `APPROVED` on the last non-empty line when no blockers remain, or list each blocking finding on its own line prefixed with `ISSUE:`; missing or unparseable output is not approval.
 - External review bots are optional advisors. Address valid feedback when it arrives, but bot silence, quota exhaustion, or service failure does not block a merge.
 - Address valid reviewer findings before merge. Record the reason for rejecting false positives in the handoff; posting that reason to the PR requires operator approval.
 - Merging requires explicit operator approval, a passing `CI Result` check, and squash merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Validation workflow:
 
 ## Architecture
 
-Harness is an agent orchestration layer. It constructs prompts and manages lifecycle — agents (Codex CLI) decide how to execute.
+Harness is an agent orchestration layer. It constructs prompts and manages lifecycle; the selected coding agent decides how to execute.
 
 - ZERO `Command::new("gh")` or `Command::new("git")` calls inside harness crates — all GitHub/git interaction must be in agent prompts only
 - When testing Harness product behavior for "fix issue X" or "handle PR Y", delegate to harness server (`POST /api/workflows/runtime/submissions`). For direct repository maintenance in this checkout, implement and verify the requested code change directly unless the user explicitly asks to exercise the Harness server flow.
@@ -44,7 +44,7 @@ These names overlap in everyday speech but mean different things in code. Use th
 |---|---|---|
 | **workflow runtime** | Orchestration layer that decides what should happen next; event-sourced state machine with a command outbox. | `crates/harness-workflow/src/runtime/` |
 | **agent runtime** (a.k.a. `CodeAgent` / `AgentAdapter`) | Agent abstraction; receives an `AgentRequest` and returns a stream or response. | `crates/harness-core/src/agent.rs`, `crates/harness-agents/src/` |
-| **`RuntimeKind`** | Label the workflow layer attaches to an agent type (`CodexExec` / `CodexJsonrpc` / `ClaudeCode` / `AnthropicApi` / `RemoteHost`). | `crates/harness-workflow/src/runtime/model.rs` |
+| **`RuntimeKind`** | Label the workflow layer attaches to an agent implementation. Treat the enum definition as the source of truth; do not duplicate its variants in documentation. | `crates/harness-workflow/src/runtime/model.rs` |
 | **task** | Legacy execution unit; submissions are being migrated to flow through the workflow runtime instead. | `crates/harness-server/src/task_runner/` |
 | **runtime host** | Process instance that executes runtime jobs; can register remotely via `/api/runtime-hosts`. | `crates/harness-server/src/runtime_hosts.rs` |
 
@@ -58,9 +58,12 @@ There is no type literally named `AgentRuntime` in the codebase. The phrase is u
 
 ## PR Workflow
 
-- After creating a PR, wait for the Codex review bot before merging
-- If the review bot leaves comments, address valid feedback before merge
-- If no comments or only false positives, proceed with merge
+- Before merging, every PR must receive a fresh-context review from an agent process that did not author the changes. The reviewer must return `APPROVE` or `REQUEST_CHANGES` with concrete findings; missing or unparseable output is not approval.
+- External review bots are optional advisors. Address valid feedback when it arrives, but bot silence, quota exhaustion, or service failure does not block a merge.
+- Address valid reviewer findings before merge. Record the reason for rejecting false positives in the handoff; posting that reason to the PR requires operator approval.
+- Merging requires explicit operator approval, a passing `CI Result` check, and squash merge.
+- Do not change `Cargo.toml` versions in feature or fix PRs; version bumps happen during releases.
+- Keep implementation PRs within the scope guard in `WORKFLOW.md` (currently 30 changed files and 1,500 added lines). If the work cannot fit, split it or obtain operator approval for the larger scope.
 - Resolving a review thread does not require separate user approval once its feedback has been verified as addressed.
 - Posting a new comment or reply remains an externally visible action and requires explicit user approval.
 
@@ -87,10 +90,10 @@ There is no type literally named `AgentRuntime` in the codebase. The phrase is u
 - Prefer standard library over new dependencies
 - Run `cargo audit` before adding security-sensitive crates
 
-## VibeGuard Overrides (Harness-specific, from GC Learn 2026-03-19)
+## VibeGuard Overrides
 
 - RS-03 exempt: `fn main()` scope, `Mutex::lock().unwrap()`, `RwLock::{read,write}().unwrap()`
 - RS-13: only flag functions returning `()` or `Result<()>` — typed returns are transformers, not action functions
-- U-16 exempt: `**/prompts.rs` → 1200-line limit, `**/dispatch.rs` → 1000-line limit
+- U-16 exempt: `crates/harness-core/src/prompts/parsing.rs` → 1100-line limit; `crates/harness-cli/src/commands.rs` → 1700-line limit. Remove an exemption after the file is split below the default limit.
 - L1 exempt: new files matching `src/**/{mod,lib,main}.rs` (standard Rust module files)
 - gh/git guard: AGENTS.md rule is semantic (agent prompts only); bash guard should not double-block `cargo test` subprocesses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ There is no type literally named `AgentRuntime` in the codebase. The phrase is u
 
 ## PR Workflow
 
-- Before merging, every PR must receive a fresh-context review from an agent process that did not author the changes. The reviewer must put `APPROVED` on the last non-empty line when no blockers remain, or list each blocking finding on its own line prefixed with `ISSUE:`; missing or unparseable output is not approval.
+- Before merging, every PR must receive a fresh-context review from an agent process that did not author the changes. Review output must be machine-parseable: direct reviews must put `APPROVED` on the last non-empty line when no blockers remain or prefix each blocking finding with `ISSUE:`; packaged review workflows may instead use their declared verdict field, such as `Assessment: APPROVE` or `Consensus: APPROVE`. Missing or unparseable output is not approval.
 - External review bots are optional advisors. Address valid feedback when it arrives, but bot silence, quota exhaustion, or service failure does not block a merge.
 - Address valid reviewer findings before merge. Record the reason for rejecting false positives in the handoff; posting that reason to the PR requires operator approval.
 - Merging requires explicit operator approval, a passing `CI Result` check, and squash merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,6 @@ Read and follow `AGENTS.md`; it is the canonical source for shared project rules
 
 ## Server Operation
 
-- Nested Claude session markers can make spawned agents fail. When product behavior must be exercised from Claude Code, start the server with `scripts/start-harness-codex-safe.sh` or an equivalent launcher that removes the keys listed in `crates/harness-agents/src/spawn_contract.rs`.
+- Nested Claude session markers and Codex wrapper variables can make spawned agents fail. When product behavior must be exercised from Claude Code, start the server with `scripts/start-harness-codex-safe.sh` or an equivalent launcher that removes both every nested Claude marker listed in `crates/harness-agents/src/spawn_contract.rs` (`CLAUDECODE`, `CLAUDE_CODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_SESSION_ID`, `CLAUDE_SESSION_ID`) and every Codex wrapper variable matched by the safe script (`CODEX*` and `Codex*`) before launching `harness serve`.
 - Prefer a standalone terminal for long-running manual dogfood sessions when an operator needs an independently owned process.
 - Before starting a server, check whether the target port is already in use. Stop only Harness processes you started unless the user explicitly asks otherwise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,82 +1,6 @@
-# Harness — Project Rules
+# Harness — Claude Code Rules
 
-## Language
-
-Use the user's language for conversation. Keep repository artifacts in English, including:
-- Code comments and documentation
-- Commit messages and PR titles/descriptions
-- Prompt templates in `prompts.rs`
-- Issue titles and descriptions
-- CLI help text and error messages
-
-## Build
-
-- Use the smallest validation command that covers the changed surface during implementation.
-- Run relevant tests before committing behavior-changing code.
-- Before pushing a PR, ALWAYS run `cargo clippy --workspace --all-targets -- -D warnings` to catch CI-equivalent warnings and lints (dead code, unused imports, missing match arms, clippy findings)
-- When adding a new enum variant, grep ALL match sites for that enum and update them — CI uses exhaustive match checks
-- Run `cargo fmt --all` before every commit — CI enforces `cargo fmt --all -- --check`
-- Dead code in `#[cfg(test)]` modules still triggers `-D warnings` in CI; delete unused test helpers instead of suppressing with `#[allow(dead_code)]`
-- Pre-commit hook (`.githooks/pre-commit`) runs fmt + staged-scope clippy as a fast commit gate. After cloning, activate with: `git config core.hooksPath .githooks`
-- Pre-push hook (`.githooks/pre-push`) always runs full workspace clippy. In DB-less mode it runs database-independent workspace and `harness-workflow` lib tests under an isolated config root. With `HARNESS_DATABASE_URL`, it runs the full `harness-workflow` and `harness-server` lib suites.
-- PostgreSQL-dependent `harness-workflow` and `harness-server` tests require an isolated disposable database through `HARNESS_DATABASE_URL`; without it, pre-push defers those explicit PostgreSQL suites to CI or a configured local database.
-
-## Local Cargo Concurrency
-
-- Cargo cannot safely be configured to ignore its build-directory lock. If commands wait on a Cargo build lock, that is usually protecting a shared `target/` directory.
-- Different projects can run Cargo concurrently as long as they do not share `CARGO_TARGET_DIR` or a global `build.target-dir`.
-- Do NOT set a global shared Cargo target directory when the goal is cross-project concurrency; it makes unrelated projects contend for the same lock.
-- For concurrent Cargo commands in the same repository, isolate build outputs by command:
-  - `CARGO_TARGET_DIR=target/cargo-check cargo check --workspace --all-targets -j 6`
-  - `CARGO_TARGET_DIR=target/cargo-test cargo test --workspace --all-targets -j 6`
-  - `CARGO_TARGET_DIR=target/cargo-clippy cargo clippy --workspace --all-targets -j 6 -- -D warnings`
-- On an M2 Max with 96GB RAM, keep total Cargo `-j` across concurrent jobs around 10-14 for predictable interactive performance; use lower values if other heavy builds are already running.
-- If the user wants non-blocking local commands, prefer explicit shell helpers such as `cargo_fast` or `cargobg` in `~/.zshrc` rather than overriding `cargo` globally:
-
-```bash
-cargo_fast() {
-  case "$1" in
-    check)
-      CARGO_TARGET_DIR=target/cargo-check command cargo "$@"
-      ;;
-    test)
-      CARGO_TARGET_DIR=target/cargo-test command cargo "$@"
-      ;;
-    clippy)
-      CARGO_TARGET_DIR=target/cargo-clippy command cargo "$@"
-      ;;
-    *)
-      command cargo "$@"
-      ;;
-  esac
-}
-
-cargobg() {
-  cargo_fast "$@" &
-}
-```
-
-## Architecture
-
-Harness is an agent orchestration layer. It constructs prompts and manages lifecycle — agents (Claude Code CLI) decide how to execute.
-
-- ZERO `Command::new("gh")` or `Command::new("git")` calls inside harness crates — all GitHub/git interaction must be in agent prompts only
-- When testing Harness product behavior for "fix issue X" or "handle PR Y", delegate to harness server (`POST /api/workflows/runtime/submissions`). For direct repository maintenance in this checkout, implement and verify the requested code change directly unless the user explicitly asks to exercise the Harness server flow.
-
-## Worktree Usage
-
-- NEVER use `isolation: "worktree"` for tasks that depend on unpushed local commits — worktrees check out from remote, missing local changes
-- Before using worktree isolation, check `git log origin/main..HEAD` — if there are unpushed commits that affect the files being modified, work directly on main instead
-- Worktrees are only safe for truly independent tasks on code that hasn't been locally modified
-
-## PR Workflow
-
-- Merge once the `CI Result` status check passes — external review bots are unavailable (Codex quota exhausted, Gemini deprecated), so do not wait for bot reviews
-- If a review bot does leave comments, address valid feedback before merge
-- **Squash-merge only** — enforced via GitHub ruleset (squash is the only allowed merge method; no bypass for anyone)
-- **Required CI** — the `CI Result` status check must pass before merging (enforced via ruleset)
-- **Do NOT modify `Cargo.toml` version in feature/fix PRs** — version bumps happen only at release time (prevents merge conflicts across parallel PRs)
-- CI uses path-based change detection — only affected crate tests run on PRs
+Read and follow `AGENTS.md`; it is the canonical source for shared project rules. This file contains only Claude Code-specific additions. If duplicated guidance is discovered, remove it from this file rather than maintaining two copies.
 
 ## Claude CLI Argument Order (CRITICAL)
 
@@ -87,20 +11,6 @@ Harness is an agent orchestration layer. It constructs prompts and manages lifec
 
 ## Server Operation
 
-- NEVER start `harness serve` from within a Claude Code session — the `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` env vars cause spawned agents to SIGTRAP
-- Always start the server from a standalone terminal: `./target/release/harness serve --transport http --port 9800 --project-root <path>`
-- If already running inside Claude Code, only stop/kill the server — let the user start it manually
-
-## Dependencies
-
-- NEVER downgrade dependency versions unless explicitly requested
-- Prefer standard library over new dependencies
-- Run `cargo audit` before adding security-sensitive crates
-
-## VibeGuard Overrides (Harness-specific, from GC Learn 2026-03-19)
-
-- RS-03 exempt: `fn main()` scope, `Mutex::lock().unwrap()`, `RwLock::{read,write}().unwrap()`
-- RS-13: only flag functions returning `()` or `Result<()>` — typed returns are transformers, not action functions
-- U-16 exempt: `**/prompts/parsing.rs` → 1100-line limit, `**/harness-cli/src/commands.rs` → 1700-line limit (oversized files pending split), `**/task_runner/spawn.rs` → 850-line limit and `**/task_executor/triage_pipeline.rs` → 1400-line limit (both pending GH-1434 deletion). Stale exemptions removed 2026-07-25 after splits landed: dispatch.rs, services/execution.rs (537 actual), task_runner/store.rs (82), workflow runtime store.rs (290), workflow_runtime_pr_feedback.rs (607), webhook.rs (335)
-- L1 exempt: new files matching `src/**/{mod,lib,main}.rs` (standard Rust module files)
-- gh/git guard: CLAUDE.md rule is semantic (agent prompts only); bash guard should not double-block `cargo test` subprocesses
+- Nested Claude session markers can make spawned agents fail. When product behavior must be exercised from Claude Code, start the server with `scripts/start-harness-codex-safe.sh` or an equivalent launcher that removes the keys listed in `crates/harness-agents/src/spawn_contract.rs`.
+- Prefer a standalone terminal for long-running manual dogfood sessions when an operator needs an independently owned process.
+- Before starting a server, check whether the target port is already in use. Stop only Harness processes you started unless the user explicitly asks otherwise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,5 +12,3 @@ Read and follow `AGENTS.md`; it is the canonical source for shared project rules
 ## Server Operation
 
 - Nested Claude session markers and Codex wrapper variables can make spawned agents fail. When product behavior must be exercised from Claude Code, start the server with `scripts/start-harness-codex-safe.sh` or an equivalent launcher that removes both every nested Claude marker listed in `crates/harness-agents/src/spawn_contract.rs` (`CLAUDECODE`, `CLAUDE_CODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_SESSION_ID`, `CLAUDE_SESSION_ID`) and every Codex wrapper variable matched by the safe script (`CODEX*` and `Codex*`) before launching `harness serve`.
-- Prefer a standalone terminal for long-running manual dogfood sessions when an operator needs an independently owned process.
-- Before starting a server, check whether the target port is already in use. Stop only Harness processes you started unless the user explicitly asks otherwise.


### PR DESCRIPTION
## Summary

- make AGENTS.md the canonical source for shared project rules
- keep CLAUDE.md limited to Claude Code-specific additions
- clarify runtime terminology, review gates, VibeGuard exemptions, and safe server startup guidance

## Validation

- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- repository pre-commit and pre-push hooks