### PR TITLE
fix(runtime): preserve local review outcome signals

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -87,7 +87,7 @@ pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> Ac
                     harness_workflow::runtime::LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
                     harness_workflow::runtime::LOCAL_REVIEW_BLOCKED_SIGNAL,
                 ])
-                .requires("at_least_one_local_review_outcome_signal")
+                .requires("exactly_one_local_review_outcome_signal")
         }
         (GITHUB_ISSUE_PR_DEFINITION_ID, "sweep_pr_feedback")
         | (GITHUB_ISSUE_PR_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY) => {

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
@@ -436,6 +436,63 @@ fn activity_result_from_turn_preserves_declared_local_review_outcomes() {
 }
 
 #[test]
+fn activity_result_from_turn_preserves_local_review_changes_requested_with_unresolved_threads() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": LOCAL_REVIEW_ACTIVITY
+        }),
+    );
+    let items = vec![Item::AgentReasoning {
+        content: r#"Local review report.
+
+```harness-activity-result
+{"activity":"run_local_review","status":"succeeded","summary":"Local review found two unresolved review threads on PR #1914 and requested changes.","artifacts":[{"artifact_type":"local_review_findings","artifact":{"unresolved_review_threads":[{"path":"AGENTS.md","line":61,"body":"Use the review verdicts accepted by the parser."},{"path":"CLAUDE.md","line":14,"body":"Require Codex-variable stripping in equivalent launchers."}],"blockers":["two unresolved review threads"]}}],"signals":[{"signal_type":"LocalReviewChangesRequested","signal":{"pr_number":1914,"pr_url":"https://github.com/majiayu000/harness/pull/1914"}}],"validation":[],"error":null,"error_kind":null}
+```"#
+            .to_string(),
+    }];
+
+    let result = activity_result_from_turn_with_workflow(
+        &job,
+        &TurnStatus::Completed,
+        &items,
+        &ThreadId::from_str("thread-1"),
+        &TurnId::from_str("turn-1"),
+        "codex",
+        Path::new("/project"),
+        "digest-1",
+        Some(GITHUB_ISSUE_PR_DEFINITION_ID),
+    );
+
+    assert_eq!(result.activity, LOCAL_REVIEW_ACTIVITY);
+    assert_eq!(result.status, ActivityStatus::Succeeded);
+    assert!(result
+        .signals
+        .iter()
+        .any(|signal| signal.signal_type == LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL));
+    assert!(!result
+        .signals
+        .iter()
+        .any(|signal| signal.signal_type == "ActivityStatusContractDowngraded"));
+    let findings = artifact_by_type(&result, "local_review_findings");
+    assert_eq!(
+        findings.artifact["unresolved_review_threads"]
+            .as_array()
+            .map(Vec::len),
+        Some(2)
+    );
+    assert_eq!(
+        findings.artifact["blockers"],
+        json!(["two unresolved review threads"])
+    );
+    let envelope = envelope_artifact(&result);
+    assert_eq!(envelope["outcome"], "accepted");
+    assert_eq!(envelope["final_result"]["status"], "succeeded");
+}
+
+#[test]
 fn activity_result_from_turn_downgrades_succeeded_with_structured_blockers() {
     let job = RuntimeJob::pending(
         "command-1",

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
@@ -1,5 +1,9 @@
 use super::*;
-use harness_workflow::runtime::{ActivityStatus, RuntimeKind, PROMPT_TASK_DEFINITION_ID};
+use harness_workflow::runtime::{
+    ActivityStatus, RuntimeKind, GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY,
+    LOCAL_REVIEW_BLOCKED_SIGNAL, LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL, LOCAL_REVIEW_PASSED_SIGNAL,
+    PROMPT_TASK_DEFINITION_ID,
+};
 
 #[test]
 fn activity_result_from_turn_fails_when_no_fenced_block_present() {
@@ -367,6 +371,68 @@ fn activity_result_from_turn_preserves_prompt_nonzero_validation_report() {
     let envelope = envelope_artifact(&result);
     assert_eq!(envelope["outcome"], "accepted");
     assert_eq!(envelope["final_result"]["status"], "succeeded");
+}
+
+#[test]
+fn activity_result_from_turn_preserves_declared_local_review_outcomes() {
+    for (signal_type, summary) in [
+        (LOCAL_REVIEW_PASSED_SIGNAL, "Local review passed."),
+        (
+            LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+            "Local review requested fixes.",
+        ),
+        (
+            LOCAL_REVIEW_BLOCKED_SIGNAL,
+            "Local review could not complete.",
+        ),
+    ] {
+        let job = RuntimeJob::pending(
+            "command-1",
+            RuntimeKind::CodexJsonrpc,
+            "codex-default",
+            json!({
+                "activity": LOCAL_REVIEW_ACTIVITY
+            }),
+        );
+        let content = format!(
+            r#"Local review report.
+
+```harness-activity-result
+{{"activity":"{LOCAL_REVIEW_ACTIVITY}","status":"succeeded","summary":"{summary}","signals":[{{"signal_type":"{signal_type}","signal":{{"pr_number":77,"pr_url":"https://github.com/owner/repo/pull/77"}}}}]}}
+```"#
+        );
+        let items = vec![Item::AgentReasoning { content }];
+
+        let result = activity_result_from_turn_with_workflow(
+            &job,
+            &TurnStatus::Completed,
+            &items,
+            &ThreadId::from_str("thread-1"),
+            &TurnId::from_str("turn-1"),
+            "codex",
+            Path::new("/project"),
+            "digest-1",
+            Some(GITHUB_ISSUE_PR_DEFINITION_ID),
+        );
+
+        assert_eq!(result.activity, LOCAL_REVIEW_ACTIVITY);
+        assert_eq!(
+            result.status,
+            ActivityStatus::Succeeded,
+            "{signal_type} should remain available to the reducer"
+        );
+        assert!(result
+            .signals
+            .iter()
+            .any(|signal| signal.signal_type == signal_type));
+        assert!(!result
+            .signals
+            .iter()
+            .any(|signal| signal.signal_type == "ActivityStatusContractDowngraded"));
+        let envelope = envelope_artifact(&result);
+        assert_eq!(envelope["outcome"], "accepted");
+        assert_eq!(envelope["final_result"]["status"], "succeeded");
+    }
 }
 
 #[test]

--- a/crates/harness-server/src/workflow_runtime_worker/activity_status_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_status_contract.rs
@@ -1,6 +1,8 @@
 use harness_workflow::runtime::reducer::prompt_validation_report_has_nonzero_exit;
 use harness_workflow::runtime::{
-    ActivityArtifact, ActivityResult, ActivitySignal, ActivityStatus, PROMPT_TASK_DEFINITION_ID,
+    ActivityArtifact, ActivityResult, ActivitySignal, ActivityStatus,
+    GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY, LOCAL_REVIEW_BLOCKED_SIGNAL,
+    LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL, PROMPT_TASK_DEFINITION_ID,
     PROMPT_TASK_IMPLEMENT_ACTIVITY,
 };
 use serde_json::{json, Value};
@@ -113,6 +115,10 @@ fn activity_status_contract_blockers(
     let mut blockers = Vec::new();
 
     for signal in &result.signals {
+        if is_declared_local_review_outcome_signal(workflow_definition, result, &signal.signal_type)
+        {
+            continue;
+        }
         if BLOCKING_SIGNAL_TYPES.contains(&signal.signal_type.as_str()) {
             push_unique(&mut blockers, format!("signal:{}", signal.signal_type));
         }
@@ -138,6 +144,19 @@ fn activity_status_contract_blockers(
     }
 
     blockers
+}
+
+fn is_declared_local_review_outcome_signal(
+    workflow_definition: Option<&str>,
+    result: &ActivityResult,
+    signal_type: &str,
+) -> bool {
+    workflow_definition == Some(GITHUB_ISSUE_PR_DEFINITION_ID)
+        && result.activity == LOCAL_REVIEW_ACTIVITY
+        && matches!(
+            signal_type,
+            LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL | LOCAL_REVIEW_BLOCKED_SIGNAL
+        )
 }
 
 fn collect_structured_blockers(value: &Value, blockers: &mut Vec<String>) {
@@ -268,6 +287,7 @@ fn push_unique(blockers: &mut Vec<String>, blocker: impl Into<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harness_workflow::runtime::LOCAL_REVIEW_PASSED_SIGNAL;
 
     fn prompt_result_with_report(exit_code: Value) -> ActivityResult {
         ActivityResult::succeeded(
@@ -297,6 +317,58 @@ mod tests {
                 status_contract_blockers_from_result(&result),
                 vec![format!("signal:{signal_type}")]
             );
+        }
+    }
+
+    #[test]
+    fn declared_local_review_outcome_signals_are_preserved_for_github_issue_pr() {
+        for signal_type in [
+            LOCAL_REVIEW_PASSED_SIGNAL,
+            LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+            LOCAL_REVIEW_BLOCKED_SIGNAL,
+        ] {
+            let claimed = ActivityResult::succeeded(LOCAL_REVIEW_ACTIVITY, "Review completed.")
+                .with_signal(ActivitySignal::new(signal_type, json!({})));
+
+            let (changed, result) =
+                enforce_activity_status_contract(Some(GITHUB_ISSUE_PR_DEFINITION_ID), claimed);
+
+            assert!(
+                !changed,
+                "signal {signal_type} should stay reducer-routable"
+            );
+            assert_eq!(result.status, ActivityStatus::Succeeded);
+            assert!(status_contract_blockers_from_result(&result).is_empty());
+        }
+    }
+
+    #[test]
+    fn local_review_blocker_like_signals_still_downgrade_outside_declared_context() {
+        for (workflow_definition, activity) in [
+            (Some(GITHUB_ISSUE_PR_DEFINITION_ID), "inspect_pr_feedback"),
+            (Some("custom_workflow"), LOCAL_REVIEW_ACTIVITY),
+            (None, LOCAL_REVIEW_ACTIVITY),
+        ] {
+            for signal_type in [
+                LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+                LOCAL_REVIEW_BLOCKED_SIGNAL,
+            ] {
+                let claimed = ActivityResult::succeeded(activity, "Review completed.")
+                    .with_signal(ActivitySignal::new(signal_type, json!({})));
+
+                let (changed, result) =
+                    enforce_activity_status_contract(workflow_definition, claimed);
+
+                assert!(
+                    changed,
+                    "signal {signal_type} must downgrade for workflow={workflow_definition:?} activity={activity}"
+                );
+                assert_eq!(result.status, ActivityStatus::SucceededWithBlockers);
+                assert_eq!(
+                    status_contract_blockers_from_result(&result),
+                    vec![format!("signal:{signal_type}")]
+                );
+            }
         }
     }
 

--- a/crates/harness-server/src/workflow_runtime_worker/activity_status_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_status_contract.rs
@@ -21,6 +21,7 @@ use serde_json::{json, Value};
 const BLOCKING_SIGNAL_TYPES: &[&str] = &[
     "ChangesRequested",
     "ChecksFailed",
+    "LocalReviewPassed",
     "LocalReviewChangesRequested",
     "LocalReviewBlocked",
     "QualityBlocked",
@@ -166,29 +167,24 @@ fn declared_local_review_outcome(
         return None;
     }
 
-    let changes_requested = result
-        .signals
-        .iter()
-        .any(|signal| signal.signal_type == LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL);
-    let blocked = result
-        .signals
-        .iter()
-        .any(|signal| signal.signal_type == LOCAL_REVIEW_BLOCKED_SIGNAL);
-    let passed = result
-        .signals
-        .iter()
-        .any(|signal| signal.signal_type == LOCAL_REVIEW_PASSED_SIGNAL);
-    if u8::from(changes_requested) + u8::from(blocked) + u8::from(passed) != 1 {
+    let mut declared_count = 0;
+    let mut declared_outcome = None;
+    for signal in &result.signals {
+        let outcome = match signal.signal_type.as_str() {
+            LOCAL_REVIEW_PASSED_SIGNAL => LocalReviewOutcome::Passed,
+            LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL => LocalReviewOutcome::ChangesRequested,
+            LOCAL_REVIEW_BLOCKED_SIGNAL => LocalReviewOutcome::Blocked,
+            _ => continue,
+        };
+        declared_count += 1;
+        declared_outcome = Some(outcome);
+    }
+
+    if declared_count != 1 {
         return None;
     }
 
-    if changes_requested {
-        Some(LocalReviewOutcome::ChangesRequested)
-    } else if blocked {
-        Some(LocalReviewOutcome::Blocked)
-    } else {
-        Some(LocalReviewOutcome::Passed)
-    }
+    declared_outcome
 }
 
 fn is_local_review_outcome_signal(signal_type: &str) -> bool {
@@ -487,6 +483,32 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_declared_local_review_outcomes_downgrade() {
+        for signal_type in [
+            LOCAL_REVIEW_PASSED_SIGNAL,
+            LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+            LOCAL_REVIEW_BLOCKED_SIGNAL,
+        ] {
+            let claimed = ActivityResult::succeeded(LOCAL_REVIEW_ACTIVITY, "Review completed.")
+                .with_signal(ActivitySignal::new(signal_type, json!({})))
+                .with_signal(ActivitySignal::new(signal_type, json!({})));
+
+            let (changed, result) =
+                enforce_activity_status_contract(Some(GITHUB_ISSUE_PR_DEFINITION_ID), claimed);
+
+            assert!(
+                changed,
+                "duplicate {signal_type} declarations must fail closed"
+            );
+            assert_eq!(result.status, ActivityStatus::SucceededWithBlockers);
+            assert_eq!(
+                status_contract_blockers_from_result(&result),
+                vec![format!("signal:{signal_type}")]
+            );
+        }
+    }
+
+    #[test]
     fn local_review_blocker_evidence_still_downgrades_without_declared_outcome() {
         let claimed = ActivityResult::succeeded(
             LOCAL_REVIEW_ACTIVITY,
@@ -520,6 +542,7 @@ mod tests {
             (None, LOCAL_REVIEW_ACTIVITY),
         ] {
             for signal_type in [
+                LOCAL_REVIEW_PASSED_SIGNAL,
                 LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
                 LOCAL_REVIEW_BLOCKED_SIGNAL,
             ] {

--- a/crates/harness-server/src/workflow_runtime_worker/activity_status_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_status_contract.rs
@@ -1,8 +1,8 @@
 use harness_workflow::runtime::reducer::prompt_validation_report_has_nonzero_exit;
 use harness_workflow::runtime::{
-    ActivityArtifact, ActivityResult, ActivitySignal, ActivityStatus,
+    ActivityArtifact, ActivityResult, ActivitySignal, ActivityStatus, LocalReviewOutcome,
     GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY, LOCAL_REVIEW_BLOCKED_SIGNAL,
-    LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL, PROMPT_TASK_DEFINITION_ID,
+    LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL, LOCAL_REVIEW_PASSED_SIGNAL, PROMPT_TASK_DEFINITION_ID,
     PROMPT_TASK_IMPLEMENT_ACTIVITY,
 };
 use serde_json::{json, Value};
@@ -113,9 +113,15 @@ fn activity_status_contract_blockers(
     result: &ActivityResult,
 ) -> Vec<String> {
     let mut blockers = Vec::new();
+    let local_review_outcome = declared_local_review_outcome(workflow_definition, result);
+    let local_review_outcome_accepts_blockers = matches!(
+        local_review_outcome,
+        Some(LocalReviewOutcome::ChangesRequested | LocalReviewOutcome::Blocked)
+    );
 
     for signal in &result.signals {
-        if is_declared_local_review_outcome_signal(workflow_definition, result, &signal.signal_type)
+        if local_review_outcome.is_some()
+            && is_local_review_outcome_signal(signal.signal_type.as_str())
         {
             continue;
         }
@@ -124,12 +130,16 @@ fn activity_status_contract_blockers(
         }
     }
 
-    for artifact in &result.artifacts {
-        collect_structured_blockers(&artifact.artifact, &mut blockers);
+    if !local_review_outcome_accepts_blockers {
+        for artifact in &result.artifacts {
+            collect_structured_blockers(&artifact.artifact, &mut blockers);
+        }
     }
 
     let mut summary_blockers = Vec::new();
-    collect_textual_blockers(&result.summary, &mut summary_blockers);
+    if !local_review_outcome_accepts_blockers {
+        collect_textual_blockers(&result.summary, &mut summary_blockers);
+    }
     if workflow_definition == Some(PROMPT_TASK_DEFINITION_ID)
         && result.activity == PROMPT_TASK_IMPLEMENT_ACTIVITY
         && prompt_validation_report_has_nonzero_exit(result)
@@ -146,17 +156,48 @@ fn activity_status_contract_blockers(
     blockers
 }
 
-fn is_declared_local_review_outcome_signal(
+fn declared_local_review_outcome(
     workflow_definition: Option<&str>,
     result: &ActivityResult,
-    signal_type: &str,
-) -> bool {
-    workflow_definition == Some(GITHUB_ISSUE_PR_DEFINITION_ID)
-        && result.activity == LOCAL_REVIEW_ACTIVITY
-        && matches!(
-            signal_type,
-            LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL | LOCAL_REVIEW_BLOCKED_SIGNAL
-        )
+) -> Option<LocalReviewOutcome> {
+    if workflow_definition != Some(GITHUB_ISSUE_PR_DEFINITION_ID)
+        || result.activity != LOCAL_REVIEW_ACTIVITY
+    {
+        return None;
+    }
+
+    let changes_requested = result
+        .signals
+        .iter()
+        .any(|signal| signal.signal_type == LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL);
+    let blocked = result
+        .signals
+        .iter()
+        .any(|signal| signal.signal_type == LOCAL_REVIEW_BLOCKED_SIGNAL);
+    let passed = result
+        .signals
+        .iter()
+        .any(|signal| signal.signal_type == LOCAL_REVIEW_PASSED_SIGNAL);
+    if u8::from(changes_requested) + u8::from(blocked) + u8::from(passed) != 1 {
+        return None;
+    }
+
+    if changes_requested {
+        Some(LocalReviewOutcome::ChangesRequested)
+    } else if blocked {
+        Some(LocalReviewOutcome::Blocked)
+    } else {
+        Some(LocalReviewOutcome::Passed)
+    }
+}
+
+fn is_local_review_outcome_signal(signal_type: &str) -> bool {
+    matches!(
+        signal_type,
+        LOCAL_REVIEW_PASSED_SIGNAL
+            | LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL
+            | LOCAL_REVIEW_BLOCKED_SIGNAL
+    )
 }
 
 fn collect_structured_blockers(value: &Value, blockers: &mut Vec<String>) {
@@ -340,6 +381,135 @@ mod tests {
             assert_eq!(result.status, ActivityStatus::Succeeded);
             assert!(status_contract_blockers_from_result(&result).is_empty());
         }
+    }
+
+    #[test]
+    fn declared_local_review_blocker_outcomes_preserve_matching_blocker_evidence() {
+        for signal_type in [
+            LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+            LOCAL_REVIEW_BLOCKED_SIGNAL,
+        ] {
+            let claimed = ActivityResult::succeeded(
+                LOCAL_REVIEW_ACTIVITY,
+                "Local review found two unresolved review threads and requested changes.",
+            )
+            .with_signal(ActivitySignal::new(
+                signal_type,
+                json!({ "pr_number": 1914 }),
+            ))
+            .with_artifact(ActivityArtifact::new(
+                "local_review_findings",
+                json!({
+                    "unresolved_review_threads": [
+                        {"path": "AGENTS.md", "line": 61},
+                        {"path": "CLAUDE.md", "line": 14}
+                    ],
+                    "blockers": [
+                        "two unresolved review threads"
+                    ]
+                }),
+            ));
+
+            let (changed, result) =
+                enforce_activity_status_contract(Some(GITHUB_ISSUE_PR_DEFINITION_ID), claimed);
+
+            assert!(
+                !changed,
+                "declared {signal_type} should reach the github_issue_pr reducer"
+            );
+            assert_eq!(result.status, ActivityStatus::Succeeded);
+            assert!(status_contract_blockers_from_result(&result).is_empty());
+        }
+    }
+
+    #[test]
+    fn local_review_passed_with_blocker_evidence_still_downgrades() {
+        let claimed = ActivityResult::succeeded(
+            LOCAL_REVIEW_ACTIVITY,
+            "Local review passed, but two unresolved review threads remain.",
+        )
+        .with_signal(ActivitySignal::new(
+            LOCAL_REVIEW_PASSED_SIGNAL,
+            json!({ "pr_number": 1914 }),
+        ))
+        .with_artifact(ActivityArtifact::new(
+            "local_review_findings",
+            json!({
+                "unresolved_review_threads": [
+                    {"path": "AGENTS.md", "line": 61},
+                    {"path": "CLAUDE.md", "line": 14}
+                ]
+            }),
+        ));
+
+        let (changed, result) =
+            enforce_activity_status_contract(Some(GITHUB_ISSUE_PR_DEFINITION_ID), claimed);
+
+        assert!(changed);
+        assert_eq!(result.status, ActivityStatus::SucceededWithBlockers);
+        let blockers = status_contract_blockers_from_result(&result);
+        assert!(blockers.contains(&"field:unresolved_review_threads".to_string()));
+        assert!(blockers.contains(&"text:unresolved_review_threads".to_string()));
+    }
+
+    #[test]
+    fn conflicting_declared_local_review_outcomes_still_downgrade() {
+        let claimed = ActivityResult::succeeded(
+            LOCAL_REVIEW_ACTIVITY,
+            "Local review requested changes and could not complete.",
+        )
+        .with_signal(ActivitySignal::new(
+            LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+            json!({ "pr_number": 1914 }),
+        ))
+        .with_signal(ActivitySignal::new(
+            LOCAL_REVIEW_BLOCKED_SIGNAL,
+            json!({ "pr_number": 1914 }),
+        ))
+        .with_artifact(ActivityArtifact::new(
+            "local_review_findings",
+            json!({
+                "unresolved_review_threads": [
+                    {"path": "AGENTS.md", "line": 61}
+                ]
+            }),
+        ));
+
+        let (changed, result) =
+            enforce_activity_status_contract(Some(GITHUB_ISSUE_PR_DEFINITION_ID), claimed);
+
+        assert!(changed);
+        assert_eq!(result.status, ActivityStatus::SucceededWithBlockers);
+        let blockers = status_contract_blockers_from_result(&result);
+        assert!(blockers.contains(&format!("signal:{LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL}")));
+        assert!(blockers.contains(&format!("signal:{LOCAL_REVIEW_BLOCKED_SIGNAL}")));
+        assert!(blockers.contains(&"field:unresolved_review_threads".to_string()));
+    }
+
+    #[test]
+    fn local_review_blocker_evidence_still_downgrades_without_declared_outcome() {
+        let claimed = ActivityResult::succeeded(
+            LOCAL_REVIEW_ACTIVITY,
+            "Local review found two unresolved review threads.",
+        )
+        .with_artifact(ActivityArtifact::new(
+            "local_review_findings",
+            json!({
+                "unresolved_review_threads": [
+                    {"path": "AGENTS.md", "line": 61},
+                    {"path": "CLAUDE.md", "line": 14}
+                ]
+            }),
+        ));
+
+        let (changed, result) =
+            enforce_activity_status_contract(Some(GITHUB_ISSUE_PR_DEFINITION_ID), claimed);
+
+        assert!(changed);
+        assert_eq!(result.status, ActivityStatus::SucceededWithBlockers);
+        let blockers = status_contract_blockers_from_result(&result);
+        assert!(blockers.contains(&"field:unresolved_review_threads".to_string()));
+        assert!(blockers.contains(&"text:unresolved_review_threads".to_string()));
     }
 
     #[test]

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -5,8 +5,9 @@ use harness_workflow::runtime::{
     RepoMemoryRecord, RetrievedRepoMemoryRecord, RuntimeKind, TransitionAllowlist, TransitionRule,
     WorkflowDefinitionRegistry, WorkflowProgressMode, WorkflowRuntimeRecoveryAction,
     WorkflowRuntimeStore, WorkflowStateDefinition, WorkflowSubject, ISSUE_PLAN_ACTIVITY,
-    ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL, PR_REPAIR_SNAPSHOT_ARTIFACT,
-    SERVER_PR_SNAPSHOT_ARTIFACT,
+    ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL, LOCAL_REVIEW_ACTIVITY,
+    LOCAL_REVIEW_BLOCKED_SIGNAL, LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL, LOCAL_REVIEW_PASSED_SIGNAL,
+    PR_REPAIR_SNAPSHOT_ARTIFACT, SERVER_PR_SNAPSHOT_ARTIFACT,
 };
 
 fn resolved_settings_for_tests(profile: &RuntimeProfile) -> ResolvedRuntimeSettings {
@@ -168,6 +169,40 @@ fn activity_result_schema_reminds_pr_feedback_to_recheck_pr_state() {
             ["validation_commands"]
             .as_str()
             .is_some_and(|value| value.contains("successful status"))
+    );
+}
+
+#[test]
+fn activity_result_schema_requires_exactly_one_local_review_outcome() {
+    let job = RuntimeJob::pending(
+        "command-1",
+        RuntimeKind::CodexJsonrpc,
+        "codex-default",
+        json!({
+            "activity": LOCAL_REVIEW_ACTIVITY
+        }),
+    );
+    let workflow = WorkflowInstance::new(
+        "github_issue_pr",
+        1,
+        "local_review_gate",
+        WorkflowSubject::new("issue", "issue:123"),
+    )
+    .with_id("issue-123");
+
+    let schema = activity_result_schema(&job, Some(&workflow));
+
+    assert_eq!(
+        schema["activity_contract"]["success_requires"],
+        "exactly_one_local_review_outcome_signal"
+    );
+    assert_eq!(
+        schema["activity_contract"]["accepted_signals"],
+        json!([
+            LOCAL_REVIEW_PASSED_SIGNAL,
+            LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+            LOCAL_REVIEW_BLOCKED_SIGNAL,
+        ])
     );
 }
 

--- a/crates/harness-workflow/src/runtime/reducer/builtin_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/builtin_completion.rs
@@ -228,7 +228,7 @@ fn reduce_success(
         && instance.state == "local_review_gate"
         && result.activity == LOCAL_REVIEW_ACTIVITY
     {
-        let reason = "run_local_review succeeded without a LocalReviewPassed, LocalReviewChangesRequested, or LocalReviewBlocked signal";
+        let reason = "run_local_review succeeded without exactly one LocalReviewPassed, LocalReviewChangesRequested, or LocalReviewBlocked signal";
         return Some(invalid_agent_output_blocked_decision(
             instance, event, result, reason,
         ));

--- a/crates/harness-workflow/src/runtime/reducer/builtin_pr_feedback.rs
+++ b/crates/harness-workflow/src/runtime/reducer/builtin_pr_feedback.rs
@@ -238,16 +238,24 @@ fn pr_feedback_outcome_from_signals(result: &ActivityResult) -> Option<PrFeedbac
 }
 
 fn local_review_outcome_from_signals(result: &ActivityResult) -> Option<LocalReviewOutcome> {
-    if has_signal(result, LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL) {
-        return Some(LocalReviewOutcome::ChangesRequested);
+    let mut declared_count = 0;
+    let mut declared_outcome = None;
+    for signal in &result.signals {
+        let outcome = match signal.signal_type.as_str() {
+            LOCAL_REVIEW_PASSED_SIGNAL => LocalReviewOutcome::Passed,
+            LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL => LocalReviewOutcome::ChangesRequested,
+            LOCAL_REVIEW_BLOCKED_SIGNAL => LocalReviewOutcome::Blocked,
+            _ => continue,
+        };
+        declared_count += 1;
+        declared_outcome = Some(outcome);
     }
-    if has_signal(result, LOCAL_REVIEW_BLOCKED_SIGNAL) {
-        return Some(LocalReviewOutcome::Blocked);
+
+    if declared_count == 1 {
+        declared_outcome
+    } else {
+        None
     }
-    if has_signal(result, LOCAL_REVIEW_PASSED_SIGNAL) {
-        return Some(LocalReviewOutcome::Passed);
-    }
-    None
 }
 
 fn github_issue_pr_feedback_activity_matches(

--- a/crates/harness-workflow/src/runtime/tests/local_review.rs
+++ b/crates/harness-workflow/src/runtime/tests/local_review.rs
@@ -407,6 +407,52 @@ fn local_review_blocked_result_routes_to_blocked() {
 }
 
 #[test]
+fn duplicate_identical_local_review_outcome_blocks_invalid_output() {
+    let instance = issue_instance("local_review_gate");
+    let result = ActivityResult::succeeded(LOCAL_REVIEW_ACTIVITY, "Local review passed.")
+        .with_signal(ActivitySignal::new(
+            super::super::LOCAL_REVIEW_PASSED_SIGNAL,
+            json!({ "pr_number": 77 }),
+        ))
+        .with_signal(ActivitySignal::new(
+            super::super::LOCAL_REVIEW_PASSED_SIGNAL,
+            json!({ "pr_number": 77 }),
+        ));
+    let event = runtime_completion_event(&instance, LOCAL_REVIEW_ACTIVITY, result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("duplicate local review outcomes should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("without exactly one"));
+}
+
+#[test]
+fn mixed_local_review_outcomes_block_invalid_output() {
+    let instance = issue_instance("local_review_gate");
+    let result = ActivityResult::succeeded(LOCAL_REVIEW_ACTIVITY, "Local review was ambiguous.")
+        .with_signal(ActivitySignal::new(
+            super::super::LOCAL_REVIEW_PASSED_SIGNAL,
+            json!({ "pr_number": 77 }),
+        ))
+        .with_signal(ActivitySignal::new(
+            super::super::LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+            json!({ "pr_number": 77 }),
+        ));
+    let event = runtime_completion_event(&instance, LOCAL_REVIEW_ACTIVITY, result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("mixed local review outcomes should block");
+
+    assert_eq!(decision.decision, "block_invalid_agent_output");
+    assert_eq!(decision.next_state, "blocked");
+    assert!(decision.reason.contains("without exactly one"));
+}
+
+#[test]
 fn local_review_success_without_outcome_signal_blocks_invalid_output() {
     let instance = issue_instance("local_review_gate");
     let result = ActivityResult::succeeded(

--- a/crates/harness-workflow/src/runtime/tests/local_review.rs
+++ b/crates/harness-workflow/src/runtime/tests/local_review.rs
@@ -299,6 +299,71 @@ fn local_review_changes_requested_result_routes_to_feedback_repair() {
 }
 
 #[test]
+fn local_review_changes_requested_with_unresolved_review_threads_routes_to_feedback_repair() {
+    let instance = issue_instance("local_review_gate").with_server_data(json!({
+        "pr_number": 1914,
+        "pr_url": "https://github.com/majiayu000/harness/pull/1914",
+    }));
+    let summary =
+        "Local review found two unresolved review threads on PR #1914 and requested changes.";
+    let result = ActivityResult::succeeded(LOCAL_REVIEW_ACTIVITY, summary)
+        .with_signal(ActivitySignal::new(
+            super::super::LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+            json!({
+                "pr_number": 1914,
+                "pr_url": "https://github.com/majiayu000/harness/pull/1914",
+            }),
+        ))
+        .with_artifact(ActivityArtifact::new(
+            "local_review_findings",
+            json!({
+                "unresolved_review_threads": [
+                    {
+                        "path": "AGENTS.md",
+                        "line": 61,
+                        "body": "Use the review verdicts accepted by the parser."
+                    },
+                    {
+                        "path": "CLAUDE.md",
+                        "line": 14,
+                        "body": "Require Codex-variable stripping in equivalent launchers."
+                    }
+                ],
+                "blockers": [
+                    "two unresolved review threads"
+                ]
+            }),
+        ));
+    let event = runtime_completion_event(&instance, LOCAL_REVIEW_ACTIVITY, result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("local review changes should request repair");
+
+    assert_eq!(decision.decision, "address_local_review_feedback");
+    assert_eq!(decision.next_state, "addressing_feedback");
+    assert_eq!(decision.reason, summary);
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].activity_name(),
+        Some("address_pr_feedback")
+    );
+    assert_eq!(
+        decision.commands[0].dedupe_key,
+        format!("local-review:{}:1914:address:command-1", instance.id)
+    );
+    assert_eq!(decision.commands[0].command["source"], "local_review");
+    assert_eq!(decision.commands[0].command["review_summary"], summary);
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("local review changes-requested decision should validate");
+}
+
+#[test]
 fn local_review_blocked_result_routes_to_blocked() {
     let instance = issue_instance("local_review_gate").with_server_data(json!({
         "pr_number": 77,

--- a/crates/harness-workflow/src/runtime/tests/local_review.rs
+++ b/crates/harness-workflow/src/runtime/tests/local_review.rs
@@ -224,6 +224,124 @@ fn local_review_changes_requested_uses_completed_command_dedupe_key() {
 }
 
 #[test]
+fn local_review_passed_result_routes_to_awaiting_feedback() {
+    let instance = issue_instance("local_review_gate").with_server_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+    }));
+    let result = ActivityResult::succeeded(LOCAL_REVIEW_ACTIVITY, "Local review passed.")
+        .with_signal(ActivitySignal::new(
+            super::super::LOCAL_REVIEW_PASSED_SIGNAL,
+            json!({ "pr_number": 77 }),
+        ));
+    let event = runtime_completion_event(&instance, LOCAL_REVIEW_ACTIVITY, result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("local review pass should wait for remote feedback");
+
+    assert_eq!(decision.decision, "local_review_passed");
+    assert_eq!(decision.next_state, "awaiting_feedback");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(decision.commands[0].command_type, WorkflowCommandType::Wait);
+    assert_eq!(
+        decision.commands[0].dedupe_key,
+        "local-review:job-1:77:passed"
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("local review passed decision should validate");
+}
+
+#[test]
+fn local_review_changes_requested_result_routes_to_feedback_repair() {
+    let instance = issue_instance("local_review_gate").with_server_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+    }));
+    let result = ActivityResult::succeeded(LOCAL_REVIEW_ACTIVITY, "Local review requested fixes.")
+        .with_signal(ActivitySignal::new(
+            super::super::LOCAL_REVIEW_CHANGES_REQUESTED_SIGNAL,
+            json!({
+                "pr_number": 77,
+                "pr_url": "https://github.com/owner/repo/pull/77",
+            }),
+        ));
+    let event = runtime_completion_event(&instance, LOCAL_REVIEW_ACTIVITY, result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("local review changes should request repair");
+
+    assert_eq!(decision.decision, "address_local_review_feedback");
+    assert_eq!(decision.next_state, "addressing_feedback");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].activity_name(),
+        Some("address_pr_feedback")
+    );
+    assert_eq!(
+        decision.commands[0].dedupe_key,
+        format!("local-review:{}:77:address:command-1", instance.id)
+    );
+    assert_eq!(decision.commands[0].command["source"], "local_review");
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("local review changes-requested decision should validate");
+}
+
+#[test]
+fn local_review_blocked_result_routes_to_blocked() {
+    let instance = issue_instance("local_review_gate").with_server_data(json!({
+        "pr_number": 77,
+        "pr_url": "https://github.com/owner/repo/pull/77",
+    }));
+    let result = ActivityResult::succeeded(
+        LOCAL_REVIEW_ACTIVITY,
+        "Local review could not inspect the PR context.",
+    )
+    .with_signal(ActivitySignal::new(
+        super::super::LOCAL_REVIEW_BLOCKED_SIGNAL,
+        json!({
+            "pr_number": 77,
+            "pr_url": "https://github.com/owner/repo/pull/77",
+        }),
+    ));
+    let event = runtime_completion_event(&instance, LOCAL_REVIEW_ACTIVITY, result);
+
+    let decision = reduce_runtime_job_completed(&instance, &event)
+        .expect("event should parse")
+        .expect("local review blocked should block workflow");
+
+    assert_eq!(decision.decision, "local_review_blocked");
+    assert_eq!(decision.next_state, "blocked");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(
+        decision.commands[0].command_type,
+        WorkflowCommandType::MarkBlocked
+    );
+    assert_eq!(
+        decision.commands[0].dedupe_key,
+        "local-review:job-1:77:blocked"
+    );
+    DecisionValidator::github_issue_pr()
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("runtime-1", Utc::now()),
+        )
+        .expect("local review blocked decision should validate");
+}
+
+#[test]
 fn local_review_success_without_outcome_signal_blocks_invalid_output() {
     let instance = issue_instance("local_review_gate");
     let result = ActivityResult::succeeded(


### PR DESCRIPTION
## Summary
- Preserve declared `run_local_review` outcome signals for the `github_issue_pr` workflow so the reducer can route pass, changes-requested, and blocked outcomes.
- Keep the generic succeeded-with-blockers guard strict for undeclared local-review blocker-like signals.
- Add worker parsing and reducer regression coverage for local-review outcomes.

## Validation
- `cargo test -p harness-server activity_status_contract`
- `cargo test -p harness-server activity_result_from_turn_preserves_declared_local_review_outcomes`
- `cargo test -p harness-workflow local_review`
- `cargo fmt --all -- --check`
- `cargo check -p harness-server --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

Closes #1915