### PR TITLE
feat(eval): fail diff on configured regressions

### DIFF
--- a/crates/harness-cli/src/commands/eval.rs
+++ b/crates/harness-cli/src/commands/eval.rs
@@ -11,6 +11,8 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+const PASS_DROP_EPSILON: f64 = 1e-9;
+
 #[derive(Subcommand)]
 pub enum EvalCommand {
     /// Emit an eval report from a manifest and collected case evidence
@@ -329,13 +331,13 @@ fn eval_diff_regressions(
         if !max_pass_drop.is_finite() || !(0.0..=1.0).contains(&max_pass_drop) {
             anyhow::bail!("--max-pass-drop must be between 0.0 and 1.0");
         }
-        if diff.delta.pass_at_1_delta < -max_pass_drop {
+        if pass_drop_exceeds(diff.delta.pass_at_1_delta, max_pass_drop) {
             regressions.push(format!(
                 "pass@1 drop {:+.4} exceeded max drop {:.4}",
                 diff.delta.pass_at_1_delta, max_pass_drop
             ));
         }
-        if diff.delta.pass_to_k_delta < -max_pass_drop {
+        if pass_drop_exceeds(diff.delta.pass_to_k_delta, max_pass_drop) {
             regressions.push(format!(
                 "pass^{} drop {:+.4} exceeded max drop {:.4}",
                 diff.k, diff.delta.pass_to_k_delta, max_pass_drop
@@ -347,6 +349,10 @@ fn eval_diff_regressions(
         regressions.extend(new_f_cap_gate_regressions(baseline, candidate));
     }
     Ok(regressions)
+}
+
+fn pass_drop_exceeds(delta: f64, max_pass_drop: f64) -> bool {
+    -delta > max_pass_drop + PASS_DROP_EPSILON
 }
 
 fn new_f_cap_gate_regressions(baseline: &EvalRunReport, candidate: &EvalRunReport) -> Vec<String> {
@@ -361,7 +367,7 @@ fn new_f_cap_gate_regressions(baseline: &EvalRunReport, candidate: &EvalRunRepor
         .iter()
         .filter_map(|candidate_case| {
             let baseline_case = baseline_by_case.get(candidate_case.case_id.as_str())?;
-            if !baseline_case.passed || candidate_case.passed {
+            if !baseline_case.passed {
                 return None;
             }
             let gates = candidate_case
@@ -403,7 +409,8 @@ mod tests {
         Confidence, EvalGrade, HardGateName, UsageSnapshot,
     };
     use harness_workflow::runtime::{
-        EvalEvidenceStatus, EvalQualityGateEvidence, EvalReportFailedGate, EvalSubmissionEvidence,
+        EvalEvidenceStatus, EvalQualityGateEvidence, EvalReportCase, EvalReportFailedGate,
+        EvalReportMetrics, EvalSubmissionEvidence,
     };
 
     fn sample_eval_manifest() -> EvalBenchmarkManifest {
@@ -771,7 +778,29 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
     }
 
     #[test]
-    fn eval_report_diff_fails_on_new_f_cap_gate_when_enabled() {
+    fn eval_report_diff_allows_pass_drop_at_threshold() {
+        let tempdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("tempdir should be creatable: {error}"));
+        let baseline_path = tempdir.path().join("baseline.json");
+        let candidate_path = tempdir.path().join("candidate.json");
+        let baseline = report_with_pass_count("baseline", 10, 8);
+        let candidate = report_with_pass_count("candidate", 10, 7);
+        write_report(&baseline_path, &baseline);
+        write_report(&candidate_path, &candidate);
+
+        diff_eval_reports(EvalDiffArgs {
+            baseline: baseline_path,
+            candidate: candidate_path,
+            max_pass_drop: Some(0.1),
+            fail_on_new_f_gate: false,
+            json: false,
+            output: None,
+        })
+        .unwrap_or_else(|error| panic!("exact threshold drop should pass: {error}"));
+    }
+
+    #[test]
+    fn eval_report_diff_fails_on_new_f_cap_gate_even_when_candidate_passed() {
         let tempdir = tempfile::tempdir()
             .unwrap_or_else(|error| panic!("tempdir should be creatable: {error}"));
         let baseline_path = tempdir.path().join("baseline.json");
@@ -794,7 +823,7 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
             3,
             vec![case_evidence(
                 "case-pass",
-                EvalEvidenceStatus::Failed,
+                EvalEvidenceStatus::Passed,
                 vec![usage_snapshot(80, 30)],
                 Vec::new(),
             )],
@@ -884,6 +913,55 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
             cost_usd_micros: Some(cost_usd_micros),
             token_confidence: Confidence::Observed,
             cost_confidence: Confidence::Estimated,
+        }
+    }
+
+    fn report_with_pass_count(run_id: &str, total_cases: u64, passed_cases: u64) -> EvalRunReport {
+        let pass_at_1 = passed_cases as f64 / total_cases as f64;
+        let cases = (0..total_cases)
+            .map(|index| {
+                let passed = index < passed_cases;
+                EvalReportCase {
+                    case_id: format!("case-{index:02}"),
+                    repo: "majiayu000/harness".to_string(),
+                    issue: 1400 + index,
+                    base_commit: "b308b380".to_string(),
+                    verify_commands: vec!["cargo test".to_string()],
+                    status: if passed {
+                        EvalReportCaseStatus::Passed
+                    } else {
+                        EvalReportCaseStatus::Failed
+                    },
+                    passed,
+                    final_grade: None,
+                    failed_hard_gates: Vec::new(),
+                    workflow_id: Some(format!("workflow-{index:02}")),
+                    total_tokens: 0,
+                    cost_usd_micros: 0,
+                    missing_evidence: Vec::new(),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        EvalRunReport {
+            run_id: run_id.to_string(),
+            suite: "harness-core".to_string(),
+            k: 1,
+            metrics: EvalReportMetrics {
+                total_cases,
+                scored_cases: total_cases,
+                passed_cases,
+                failed_cases: total_cases - passed_cases,
+                pending_cases: 0,
+                infra_failed_cases: 0,
+                pass_at_1,
+                pass_to_k: pass_at_1,
+                total_tokens: 0,
+                avg_tokens_per_scored_case: Some(0.0),
+                total_cost_usd_micros: 0,
+                avg_cost_usd_micros_per_scored_case: Some(0.0),
+            },
+            cases,
         }
     }
 

--- a/crates/harness-cli/src/commands/eval.rs
+++ b/crates/harness-cli/src/commands/eval.rs
@@ -1,11 +1,13 @@
 use anyhow::Context;
 use clap::{Args, Subcommand};
+use harness_workflow::runtime::eval::model::EvalGrade;
 use harness_workflow::runtime::{
     diff_eval_run_reports, eval_report_dry_run, eval_report_from_evidence,
     parse_benchmark_manifest_str, EvalBenchmarkManifest, EvalCaseEvidence, EvalCaseTransitionKind,
     EvalReportCaseStatus, EvalRunReport, EvalRunReportDiff,
 };
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -48,6 +50,12 @@ pub struct EvalDiffArgs {
     pub baseline: PathBuf,
     /// Candidate eval run report JSON
     pub candidate: PathBuf,
+    /// Fail when pass@1 or pass^k drops by more than this amount
+    #[arg(long)]
+    pub max_pass_drop: Option<f64>,
+    /// Fail when a previously passing case newly fails an F-cap hard gate
+    #[arg(long)]
+    pub fail_on_new_f_gate: bool,
     /// Print JSON instead of the compact text diff
     #[arg(long)]
     pub json: bool,
@@ -104,7 +112,12 @@ fn diff_eval_reports(args: EvalDiffArgs) -> anyhow::Result<()> {
         );
     }
     let diff = diff_eval_run_reports(&baseline, &candidate);
-    emit_diff(&diff, args.json, args.output.as_deref())
+    let regressions = eval_diff_regressions(&baseline, &candidate, &diff, &args)?;
+    emit_diff(&diff, args.json, args.output.as_deref())?;
+    if regressions.is_empty() {
+        return Ok(());
+    }
+    anyhow::bail!("eval regression gate failed:\n{}", regressions.join("\n"))
 }
 
 fn read_eval_manifest(path: &Path) -> anyhow::Result<EvalBenchmarkManifest> {
@@ -225,6 +238,20 @@ pub(crate) fn render_run_report(report: &EvalRunReport) -> String {
                 case.missing_evidence.join(", ")
             ));
         }
+        if let Some(final_grade) = case.final_grade {
+            output.push_str(&format!("  final_grade: {}\n", grade_label(final_grade)));
+        }
+        if !case.failed_hard_gates.is_empty() {
+            let gates = case
+                .failed_hard_gates
+                .iter()
+                .map(|gate| {
+                    let cap = gate.grade_cap.map(grade_label).unwrap_or("none");
+                    format!("{:?}(cap={cap})", gate.name)
+                })
+                .collect::<Vec<_>>();
+            output.push_str(&format!("  failed_hard_gates: {}\n", gates.join(", ")));
+        }
     }
     output
 }
@@ -281,6 +308,85 @@ fn transition_kind_label(kind: EvalCaseTransitionKind) -> &'static str {
     }
 }
 
+fn grade_label(grade: EvalGrade) -> &'static str {
+    match grade {
+        EvalGrade::F => "F",
+        EvalGrade::D => "D",
+        EvalGrade::C => "C",
+        EvalGrade::B => "B",
+        EvalGrade::A => "A",
+    }
+}
+
+fn eval_diff_regressions(
+    baseline: &EvalRunReport,
+    candidate: &EvalRunReport,
+    diff: &EvalRunReportDiff,
+    args: &EvalDiffArgs,
+) -> anyhow::Result<Vec<String>> {
+    let mut regressions = Vec::new();
+    if let Some(max_pass_drop) = args.max_pass_drop {
+        if !max_pass_drop.is_finite() || !(0.0..=1.0).contains(&max_pass_drop) {
+            anyhow::bail!("--max-pass-drop must be between 0.0 and 1.0");
+        }
+        if diff.delta.pass_at_1_delta < -max_pass_drop {
+            regressions.push(format!(
+                "pass@1 drop {:+.4} exceeded max drop {:.4}",
+                diff.delta.pass_at_1_delta, max_pass_drop
+            ));
+        }
+        if diff.delta.pass_to_k_delta < -max_pass_drop {
+            regressions.push(format!(
+                "pass^{} drop {:+.4} exceeded max drop {:.4}",
+                diff.k, diff.delta.pass_to_k_delta, max_pass_drop
+            ));
+        }
+    }
+
+    if args.fail_on_new_f_gate {
+        regressions.extend(new_f_cap_gate_regressions(baseline, candidate));
+    }
+    Ok(regressions)
+}
+
+fn new_f_cap_gate_regressions(baseline: &EvalRunReport, candidate: &EvalRunReport) -> Vec<String> {
+    let baseline_by_case = baseline
+        .cases
+        .iter()
+        .map(|case| (case.case_id.as_str(), case))
+        .collect::<BTreeMap<_, _>>();
+
+    candidate
+        .cases
+        .iter()
+        .filter_map(|candidate_case| {
+            let baseline_case = baseline_by_case.get(candidate_case.case_id.as_str())?;
+            if !baseline_case.passed || candidate_case.passed {
+                return None;
+            }
+            let gates = candidate_case
+                .failed_hard_gates
+                .iter()
+                .filter(|gate| gate.grade_cap == Some(EvalGrade::F))
+                .filter(|gate| {
+                    !baseline_case.failed_hard_gates.iter().any(|baseline_gate| {
+                        baseline_gate.name == gate.name
+                            && baseline_gate.grade_cap == Some(EvalGrade::F)
+                    })
+                })
+                .map(|gate| format!("{:?}", gate.name))
+                .collect::<Vec<_>>();
+            (!gates.is_empty()).then(|| {
+                format!(
+                    "{} newly failed F-cap hard gate(s): {}",
+                    candidate_case.case_id,
+                    gates.join(", ")
+                )
+            })
+        })
+        .collect()
+}
+
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum EvidenceInput {
@@ -293,9 +399,11 @@ mod tests {
     use super::super::{Cli, Command};
     use super::*;
     use clap::Parser;
-    use harness_workflow::runtime::eval::model::{Confidence, UsageSnapshot};
+    use harness_workflow::runtime::eval::model::{
+        Confidence, EvalGrade, HardGateName, UsageSnapshot,
+    };
     use harness_workflow::runtime::{
-        EvalEvidenceStatus, EvalQualityGateEvidence, EvalSubmissionEvidence,
+        EvalEvidenceStatus, EvalQualityGateEvidence, EvalReportFailedGate, EvalSubmissionEvidence,
     };
 
     fn sample_eval_manifest() -> EvalBenchmarkManifest {
@@ -363,6 +471,9 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
             "diff",
             "baseline.json",
             "candidate.json",
+            "--max-pass-drop",
+            "0.1",
+            "--fail-on-new-f-gate",
             "--json",
         ])
         .unwrap_or_else(|error| panic!("eval diff command should parse: {error}"));
@@ -372,6 +483,8 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
             } => {
                 assert_eq!(args.baseline, PathBuf::from("baseline.json"));
                 assert_eq!(args.candidate, PathBuf::from("candidate.json"));
+                assert_eq!(args.max_pass_drop, Some(0.1));
+                assert!(args.fail_on_new_f_gate);
                 assert!(args.json);
             }
             _ => panic!("expected eval diff command"),
@@ -529,6 +642,8 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
         let error = match diff_eval_reports(EvalDiffArgs {
             baseline: baseline_path.clone(),
             candidate: candidate_path.clone(),
+            max_pass_drop: None,
+            fail_on_new_f_gate: false,
             json: false,
             output: None,
         }) {
@@ -549,6 +664,8 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
         let error = match diff_eval_reports(EvalDiffArgs {
             baseline: baseline_path,
             candidate: candidate_path,
+            max_pass_drop: None,
+            fail_on_new_f_gate: false,
             json: false,
             output: None,
         }) {
@@ -557,6 +674,154 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
         };
 
         assert!(error.to_string().contains("different k values"));
+    }
+
+    #[test]
+    fn eval_report_diff_preserves_exit_zero_without_gate_flags() {
+        let tempdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("tempdir should be creatable: {error}"));
+        let baseline_path = tempdir.path().join("baseline.json");
+        let candidate_path = tempdir.path().join("candidate.json");
+        let baseline = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "baseline",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Passed,
+                vec![usage_snapshot(100, 40)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("baseline report should build: {error}"));
+        let candidate = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "candidate",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Failed,
+                vec![usage_snapshot(80, 30)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("candidate report should build: {error}"));
+        write_report(&baseline_path, &baseline);
+        write_report(&candidate_path, &candidate);
+
+        diff_eval_reports(EvalDiffArgs {
+            baseline: baseline_path,
+            candidate: candidate_path,
+            max_pass_drop: None,
+            fail_on_new_f_gate: false,
+            json: false,
+            output: None,
+        })
+        .unwrap_or_else(|error| panic!("ungated diff should stay exit-zero: {error}"));
+    }
+
+    #[test]
+    fn eval_report_diff_fails_when_pass_drop_exceeds_threshold() {
+        let tempdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("tempdir should be creatable: {error}"));
+        let baseline_path = tempdir.path().join("baseline.json");
+        let candidate_path = tempdir.path().join("candidate.json");
+        let baseline = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "baseline",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Passed,
+                vec![usage_snapshot(100, 40)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("baseline report should build: {error}"));
+        let candidate = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "candidate",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Failed,
+                vec![usage_snapshot(80, 30)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("candidate report should build: {error}"));
+        write_report(&baseline_path, &baseline);
+        write_report(&candidate_path, &candidate);
+
+        let error = match diff_eval_reports(EvalDiffArgs {
+            baseline: baseline_path,
+            candidate: candidate_path,
+            max_pass_drop: Some(0.1),
+            fail_on_new_f_gate: false,
+            json: false,
+            output: None,
+        }) {
+            Ok(_) => panic!("threshold breach should fail"),
+            Err(error) => error,
+        };
+
+        let message = error.to_string();
+        assert!(message.contains("pass@1 drop"));
+        assert!(message.contains("pass^3 drop"));
+    }
+
+    #[test]
+    fn eval_report_diff_fails_on_new_f_cap_gate_when_enabled() {
+        let tempdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("tempdir should be creatable: {error}"));
+        let baseline_path = tempdir.path().join("baseline.json");
+        let candidate_path = tempdir.path().join("candidate.json");
+        let baseline = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "baseline",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Passed,
+                vec![usage_snapshot(100, 40)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("baseline report should build: {error}"));
+        let mut candidate = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "candidate",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Failed,
+                vec![usage_snapshot(80, 30)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("candidate report should build: {error}"));
+        candidate.cases[0].failed_hard_gates = vec![EvalReportFailedGate {
+            name: HardGateName::TargetCorrectness,
+            grade_cap: Some(EvalGrade::F),
+        }];
+        write_report(&baseline_path, &baseline);
+        write_report(&candidate_path, &candidate);
+
+        let error = match diff_eval_reports(EvalDiffArgs {
+            baseline: baseline_path,
+            candidate: candidate_path,
+            max_pass_drop: None,
+            fail_on_new_f_gate: true,
+            json: false,
+            output: None,
+        }) {
+            Ok(_) => panic!("new F-cap gate should fail"),
+            Err(error) => error,
+        };
+
+        let message = error.to_string();
+        assert!(message.contains("case-pass"));
+        assert!(message.contains("TargetCorrectness"));
     }
 
     #[test]
@@ -600,6 +865,7 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
                 validation_passed: true,
                 validation_commands: vec!["cargo test".to_string()],
             }),
+            quality: None,
             missing_evidence,
         }
     }
@@ -619,5 +885,14 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
             token_confidence: Confidence::Observed,
             cost_confidence: Confidence::Estimated,
         }
+    }
+
+    fn write_report(path: &Path, report: &EvalRunReport) {
+        fs::write(
+            path,
+            serde_json::to_string_pretty(report)
+                .unwrap_or_else(|error| panic!("report should serialize: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("report should write: {error}"));
     }
 }

--- a/crates/harness-workflow/src/runtime/eval/evidence.rs
+++ b/crates/harness-workflow/src/runtime/eval/evidence.rs
@@ -1,5 +1,6 @@
 use super::model::{
-    Confidence, RuntimeErrorKind, RuntimeJobSnapshot, RuntimeSnapshot, UsageSnapshot,
+    Confidence, QualitySnapshot, RuntimeErrorKind, RuntimeJobSnapshot, RuntimeSnapshot,
+    UsageSnapshot,
 };
 use crate::runtime::{
     ActivityErrorKind, ActivityResult, RuntimeEvent, RuntimeJob, RuntimeJobStatus,
@@ -27,6 +28,8 @@ pub struct EvalCaseEvidence {
     pub usage: Vec<UsageSnapshot>,
     pub submission: Option<EvalSubmissionEvidence>,
     pub quality_gate: Option<EvalQualityGateEvidence>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quality: Option<QualitySnapshot>,
     pub missing_evidence: Vec<String>,
 }
 
@@ -146,6 +149,7 @@ pub fn collect_eval_case_evidence_from_records(
         usage,
         submission,
         quality_gate,
+        quality: None,
         missing_evidence,
     }
 }

--- a/crates/harness-workflow/src/runtime/eval/mod.rs
+++ b/crates/harness-workflow/src/runtime/eval/mod.rs
@@ -27,7 +27,8 @@ pub use manifest::{
 pub use report::{
     diff_eval_run_reports, eval_report_dry_run, eval_report_from_evidence, EvalCaseTransition,
     EvalCaseTransitionKind, EvalReportCase, EvalReportCaseStatus, EvalReportError,
-    EvalReportMetricDelta, EvalReportMetrics, EvalRunReport, EvalRunReportDiff,
+    EvalReportFailedGate, EvalReportMetricDelta, EvalReportMetrics, EvalRunReport,
+    EvalRunReportDiff,
 };
 pub use run::{
     cleanup_cancelled_eval_run, dispatch_eval_case_workflow, enqueue_eval_case_workflow,

--- a/crates/harness-workflow/src/runtime/eval/report.rs
+++ b/crates/harness-workflow/src/runtime/eval/report.rs
@@ -1,5 +1,6 @@
 use super::evidence::{EvalCaseEvidence, EvalEvidenceStatus};
 use super::manifest::EvalBenchmarkManifest;
+use super::model::{EvalGrade, GateStatus, HardGateName, QualitySnapshot};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::{error::Error, fmt};
@@ -38,10 +39,20 @@ pub struct EvalReportCase {
     pub verify_commands: Vec<String>,
     pub status: EvalReportCaseStatus,
     pub passed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_grade: Option<EvalGrade>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_hard_gates: Vec<EvalReportFailedGate>,
     pub workflow_id: Option<String>,
     pub total_tokens: u64,
     pub cost_usd_micros: u64,
     pub missing_evidence: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalReportFailedGate {
+    pub name: HardGateName,
+    pub grade_cap: Option<EvalGrade>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -129,6 +140,8 @@ pub fn eval_report_dry_run(
             verify_commands: case.verify_commands.clone(),
             status: EvalReportCaseStatus::Pending,
             passed: false,
+            final_grade: None,
+            failed_hard_gates: Vec::new(),
             workflow_id: None,
             total_tokens: 0,
             cost_usd_micros: 0,
@@ -179,6 +192,8 @@ pub fn eval_report_from_evidence(
                 verify_commands: case.verify_commands.clone(),
                 status: EvalReportCaseStatus::Failed,
                 passed: false,
+                final_grade: None,
+                failed_hard_gates: Vec::new(),
                 workflow_id: None,
                 total_tokens: 0,
                 cost_usd_micros: 0,
@@ -245,6 +260,7 @@ fn report_case_from_evidence(
     let (total_tokens, cost_usd_micros) = evidence_usage_totals(&evidence);
     let passed = evidence.status == EvalEvidenceStatus::Passed;
     let status = evidence_case_status(&evidence, passed);
+    let (final_grade, failed_hard_gates) = quality_summary(evidence.quality.as_ref());
     EvalReportCase {
         case_id: case.case_id.clone(),
         repo: case.repo.clone(),
@@ -253,11 +269,31 @@ fn report_case_from_evidence(
         verify_commands: case.verify_commands.clone(),
         status,
         passed,
+        final_grade,
+        failed_hard_gates,
         workflow_id: evidence.workflow_id,
         total_tokens,
         cost_usd_micros,
         missing_evidence: evidence.missing_evidence,
     }
+}
+
+fn quality_summary(
+    quality: Option<&QualitySnapshot>,
+) -> (Option<EvalGrade>, Vec<EvalReportFailedGate>) {
+    let Some(quality) = quality else {
+        return (None, Vec::new());
+    };
+    let failed_hard_gates = quality
+        .hard_gates
+        .iter()
+        .filter(|gate| gate.status == GateStatus::Fail)
+        .map(|gate| EvalReportFailedGate {
+            name: gate.name,
+            grade_cap: gate.grade_cap,
+        })
+        .collect();
+    (Some(quality.final_grade), failed_hard_gates)
 }
 
 fn evidence_case_status(evidence: &EvalCaseEvidence, passed: bool) -> EvalReportCaseStatus {

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -96,9 +96,9 @@ pub use eval::{
     EvalBenchmarkCase, EvalBenchmarkManifest, EvalCaseDispatchOutcome, EvalCaseEnqueueOutcome,
     EvalCaseEvidence, EvalCaseTransition, EvalCaseTransitionKind, EvalCaseWorkflowInput,
     EvalCaseWorkflowPlan, EvalEvidenceStatus, EvalQualityGateEvidence, EvalReportCase,
-    EvalReportCaseStatus, EvalReportError, EvalReportMetricDelta, EvalReportMetrics, EvalRunReport,
-    EvalRunReportDiff, EvalSubmissionEvidence, ManifestError, ScoringError,
-    DEFAULT_CASE_TIMEOUT_SECS, EVAL_BRANCH_PREFIX, EVAL_PR_DRAFT_MODE,
+    EvalReportCaseStatus, EvalReportError, EvalReportFailedGate, EvalReportMetricDelta,
+    EvalReportMetrics, EvalRunReport, EvalRunReportDiff, EvalSubmissionEvidence, ManifestError,
+    ScoringError, DEFAULT_CASE_TIMEOUT_SECS, EVAL_BRANCH_PREFIX, EVAL_PR_DRAFT_MODE,
 };
 pub use lease_state::{runtime_job_running_lease_state_at, RuntimeJobRunningLeaseState};
 pub use memory_retrieval::{


### PR DESCRIPTION
## Summary

- add optional eval quality summaries to case evidence and run reports so saved reports can carry final grades and failed hard gates without breaking older JSON inputs
- extend `harness eval diff` with `--max-pass-drop` and `--fail-on-new-f-gate`, returning nonzero when configured pass-rate or F-cap hard-gate regressions are detected
- address review feedback so F-cap regressions are caught even when candidate evidence is otherwise complete, and exact-threshold pass drops do not fail due to floating-point noise
- render report grade/gate details and cover the gated/ungated diff behavior with CLI tests

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p harness-cli eval_report`
- `cargo test -p harness-workflow eval_report`
- `cargo check -p harness-cli --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Scope guard

- base: `origin/main`
- files changed: 5 / 30
- lines added: 402 / 1500

Refs #1768