### PR TITLE
Improve lexical retrieval ranking

### DIFF
--- a/crates/harness-context/src/providers.rs
+++ b/crates/harness-context/src/providers.rs
@@ -69,8 +69,10 @@ impl ContextProvider for SkillsProvider {
             .skills
             .iter()
             .filter_map(|skill| {
-                let relevance = skill_context_relevance(prompt, skill);
-                if skill.trigger_patterns.is_empty() || relevance > 0.0 {
+                if skill.trigger_patterns.is_empty() {
+                    Some((skill.clone(), 0.15))
+                } else if skill_trigger_relevance(prompt, skill) > 0.0 {
+                    let relevance = skill_context_relevance(prompt, skill);
                     Some((skill.clone(), relevance))
                 } else {
                     None
@@ -108,9 +110,6 @@ impl ContextProvider for SkillsProvider {
 }
 
 fn skill_context_relevance(prompt: &str, skill: &Skill) -> f64 {
-    if skill.trigger_patterns.is_empty() {
-        return 0.15;
-    }
     let mut fields = Vec::with_capacity(skill.trigger_patterns.len() + 3);
     for pattern in &skill.trigger_patterns {
         fields.push(RetrievalField::new(pattern, 2.0));
@@ -118,6 +117,15 @@ fn skill_context_relevance(prompt: &str, skill: &Skill) -> f64 {
     fields.push(RetrievalField::new(&skill.name, 0.8));
     fields.push(RetrievalField::new(&skill.description, 1.2));
     fields.push(RetrievalField::new(&skill.content, 0.25));
+    score_lexical_relevance(prompt, &fields).score
+}
+
+fn skill_trigger_relevance(prompt: &str, skill: &Skill) -> f64 {
+    let fields = skill
+        .trigger_patterns
+        .iter()
+        .map(|pattern| RetrievalField::new(pattern, 2.0))
+        .collect::<Vec<_>>();
     score_lexical_relevance(prompt, &fields).score
 }
 

--- a/crates/harness-context/src/providers.rs
+++ b/crates/harness-context/src/providers.rs
@@ -2,6 +2,7 @@ use crate::{
     ComposeRequest, ContextItem, ContextProvider, Degraded, ItemClass, ItemId, Priority,
     ProviderError, ProviderId,
 };
+use harness_core::retrieval::{score_lexical_relevance, RetrievalField};
 use harness_core::types::{DraftStatus, ExecPlanStatus, ProjectId};
 use harness_rules::engine::Rule;
 use harness_skills::store::Skill;
@@ -63,28 +64,28 @@ impl ContextProvider for SkillsProvider {
     }
 
     fn propose(&self, req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
-        let prompt = req
-            .task_profile
-            .prompt
-            .as_deref()
-            .unwrap_or_default()
-            .to_lowercase();
+        let prompt = req.task_profile.prompt.as_deref().unwrap_or_default();
         let mut skills = self
             .skills
             .iter()
-            .filter(|skill| {
-                skill.trigger_patterns.is_empty()
-                    || skill
-                        .trigger_patterns
-                        .iter()
-                        .any(|pattern| prompt.contains(&pattern.to_lowercase()))
+            .filter_map(|skill| {
+                let relevance = skill_context_relevance(prompt, skill);
+                if skill.trigger_patterns.is_empty() || relevance > 0.0 {
+                    Some((skill.clone(), relevance))
+                } else {
+                    None
+                }
             })
-            .cloned()
             .collect::<Vec<_>>();
-        skills.sort_by(|left, right| left.name.cmp(&right.name));
+        skills.sort_by(|(left, left_score), (right, right_score)| {
+            right_score
+                .total_cmp(left_score)
+                .then_with(|| right.quality_score.total_cmp(&left.quality_score))
+                .then_with(|| left.name.cmp(&right.name))
+        });
         Ok(skills
             .into_iter()
-            .map(|skill| ContextItem {
+            .map(|(skill, relevance)| ContextItem {
                 id: ItemId::new(format!("skill:{}", skill.name)),
                 class: ItemClass::Skill,
                 content: skill.content,
@@ -93,7 +94,7 @@ impl ContextProvider for SkillsProvider {
                 relevance: if skill.trigger_patterns.is_empty() {
                     0.4
                 } else {
-                    0.75
+                    (0.35 + relevance * 0.6).min(0.95) as f32
                 },
                 degrade: vec![
                     Degraded::Summary(skill.description.clone()),
@@ -104,6 +105,20 @@ impl ContextProvider for SkillsProvider {
             })
             .collect())
     }
+}
+
+fn skill_context_relevance(prompt: &str, skill: &Skill) -> f64 {
+    if skill.trigger_patterns.is_empty() {
+        return 0.15;
+    }
+    let mut fields = Vec::with_capacity(skill.trigger_patterns.len() + 3);
+    for pattern in &skill.trigger_patterns {
+        fields.push(RetrievalField::new(pattern, 2.0));
+    }
+    fields.push(RetrievalField::new(&skill.name, 0.8));
+    fields.push(RetrievalField::new(&skill.description, 1.2));
+    fields.push(RetrievalField::new(&skill.content, 0.25));
+    score_lexical_relevance(prompt, &fields).score
 }
 
 pub struct ContractProvider;

--- a/crates/harness-context/src/tests.rs
+++ b/crates/harness-context/src/tests.rs
@@ -1,6 +1,8 @@
-use crate::providers::{ExecPlanProvider, StaticProvider};
+use crate::providers::{ExecPlanProvider, SkillsProvider, StaticProvider};
 use crate::*;
 use harness_core::types::{ProjectId, ThreadId};
+use harness_core::types::{SkillId, SkillLocation};
+use harness_skills::store::{Skill, SkillGovernanceStatus};
 
 fn req() -> ComposeRequest {
     ComposeRequest {
@@ -26,6 +28,30 @@ fn item(id: &str, class: ItemClass, content_len: usize, priority: Priority) -> C
         ],
         dedupe_key: None,
         instruction_bearing: false,
+    }
+}
+
+fn skill(name: &str, description: &str, trigger_patterns: &[&str]) -> Skill {
+    Skill {
+        id: SkillId::new(),
+        name: name.to_string(),
+        description: description.to_string(),
+        content: format!("# {name}\n{description}"),
+        trigger_patterns: trigger_patterns
+            .iter()
+            .map(|pattern| (*pattern).to_string())
+            .collect(),
+        version: "1.0.0".to_string(),
+        author: "test".to_string(),
+        location: SkillLocation::System,
+        content_hash: format!("hash-{name}"),
+        usage_count: 0,
+        last_used: None,
+        quality_score: 0.5,
+        scored_samples: 0,
+        governance_status: SkillGovernanceStatus::Active,
+        canary_ratio: 1.0,
+        last_scored: None,
     }
 }
 
@@ -261,6 +287,33 @@ fn manifest_serialization_omits_item_content() {
 
     assert!(manifest_json.contains("rule:secret"));
     assert!(!manifest_json.contains(secret_content));
+}
+
+#[test]
+fn skills_provider_matches_reversed_prompt_terms() {
+    let provider = SkillsProvider::new(vec![skill("review", "review code", &["code review"])]);
+    let mut request = req();
+    request.task_profile.prompt = Some("please review code changes before merging".to_string());
+
+    let items = provider.propose(&request).expect("provider succeeds");
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].id.as_str(), "skill:review");
+    assert!(items[0].relevance > 0.7);
+}
+
+#[test]
+fn skills_provider_ranks_by_lexical_relevance() {
+    let provider = SkillsProvider::new(vec![
+        skill("build-fix", "fix builds", &["build error"]),
+        skill("review", "review code", &["code review"]),
+    ]);
+    let mut request = req();
+    request.task_profile.prompt = Some("review code changes before merging".to_string());
+
+    let items = provider.propose(&request).expect("provider succeeds");
+
+    assert_eq!(items[0].id.as_str(), "skill:review");
 }
 
 #[test]

--- a/crates/harness-context/src/tests.rs
+++ b/crates/harness-context/src/tests.rs
@@ -317,6 +317,18 @@ fn skills_provider_ranks_by_lexical_relevance() {
 }
 
 #[test]
+fn skills_provider_requires_trigger_overlap_before_auxiliary_fields() {
+    let provider =
+        SkillsProvider::new(vec![skill("review", "implement feature", &["code review"])]);
+    let mut request = req();
+    request.task_profile.prompt = Some("implement feature support".to_string());
+
+    let items = provider.propose(&request).expect("provider succeeds");
+
+    assert!(items.is_empty());
+}
+
+#[test]
 fn providers_include_active_exec_plans_for_matching_project() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut plan = harness_exec::plan::ExecPlan::from_spec("# Ship context composer", dir.path())

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod interceptor;
 pub mod lang_detect;
 pub mod prompts;
 pub mod proof_of_work;
+pub mod retrieval;
 pub mod review;
 pub mod run_id;
 pub mod run_registry;

--- a/crates/harness-core/src/retrieval.rs
+++ b/crates/harness-core/src/retrieval.rs
@@ -58,7 +58,7 @@ pub fn score_lexical_relevance(
         let field_term_count = normalized_field.split_whitespace().count();
         if (1..=8).contains(&field_term_count)
             && !normalized_field.is_empty()
-            && normalized_query.contains(&normalized_field)
+            && contains_token_phrase(&normalized_query, &normalized_field)
         {
             phrase_bonus = phrase_bonus.max(0.20 * weight.min(2.0));
         }
@@ -136,6 +136,16 @@ fn normalize_phrase(text: &str) -> String {
     tokenize(text).join(" ")
 }
 
+fn contains_token_phrase(normalized_text: &str, normalized_phrase: &str) -> bool {
+    let text_terms = normalized_text.split_whitespace().collect::<Vec<_>>();
+    let phrase_terms = normalized_phrase.split_whitespace().collect::<Vec<_>>();
+    !phrase_terms.is_empty()
+        && phrase_terms.len() <= text_terms.len()
+        && text_terms
+            .windows(phrase_terms.len())
+            .any(|window| window == phrase_terms.as_slice())
+}
+
 fn is_stopword(term: &str) -> bool {
     matches!(
         term,
@@ -207,5 +217,20 @@ mod tests {
         );
 
         assert_eq!(score, LexicalRelevanceScore::none(3));
+    }
+
+    #[test]
+    fn lexical_relevance_does_not_phrase_match_inside_tokens() {
+        let score = score_lexical_relevance(
+            "cargo build failed",
+            &[RetrievalField::new("go build", 2.0)],
+        );
+
+        assert!(
+            score.score < 0.7,
+            "score should not receive a phrase bonus from 'cargo', was {}",
+            score.score
+        );
+        assert_eq!(score.matched_terms, 1);
     }
 }

--- a/crates/harness-core/src/retrieval.rs
+++ b/crates/harness-core/src/retrieval.rs
@@ -1,0 +1,211 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, Copy)]
+pub struct RetrievalField<'a> {
+    pub text: &'a str,
+    pub weight: f64,
+}
+
+impl<'a> RetrievalField<'a> {
+    pub fn new(text: &'a str, weight: f64) -> Self {
+        Self { text, weight }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LexicalRelevanceScore {
+    pub score: f64,
+    pub matched_terms: usize,
+    pub query_terms: usize,
+}
+
+impl LexicalRelevanceScore {
+    pub const fn none(query_terms: usize) -> Self {
+        Self {
+            score: 0.0,
+            matched_terms: 0,
+            query_terms,
+        }
+    }
+}
+
+pub fn score_lexical_relevance(
+    query: &str,
+    fields: &[RetrievalField<'_>],
+) -> LexicalRelevanceScore {
+    let query_terms = retrieval_terms(query);
+    if query_terms.is_empty() || fields.is_empty() {
+        return LexicalRelevanceScore::none(query_terms.len());
+    }
+
+    let mut document_counts: BTreeMap<String, f64> = BTreeMap::new();
+    let mut document_weight = 0.0f64;
+    let normalized_query = normalize_phrase(query);
+    let mut phrase_bonus = 0.0f64;
+
+    for field in fields {
+        let weight = field.weight.max(0.0);
+        if weight == 0.0 || field.text.trim().is_empty() {
+            continue;
+        }
+        let field_terms = retrieval_terms(field.text);
+        document_weight += weight * field_terms.len() as f64;
+        for term in field_terms {
+            *document_counts.entry(term).or_insert(0.0) += weight;
+        }
+
+        let normalized_field = normalize_phrase(field.text);
+        let field_term_count = normalized_field.split_whitespace().count();
+        if (1..=8).contains(&field_term_count)
+            && !normalized_field.is_empty()
+            && normalized_query.contains(&normalized_field)
+        {
+            phrase_bonus = phrase_bonus.max(0.20 * weight.min(2.0));
+        }
+    }
+
+    if document_counts.is_empty() {
+        return LexicalRelevanceScore::none(query_terms.len());
+    }
+
+    let mut matched = BTreeSet::new();
+    let mut weighted_hits = 0.0f64;
+    for term in &query_terms {
+        if let Some(weight) = document_counts.get(term) {
+            matched.insert(term.clone());
+            weighted_hits += *weight;
+        }
+    }
+    if matched.is_empty() {
+        return LexicalRelevanceScore::none(query_terms.len());
+    }
+
+    let denominator = query_terms.len().min(document_counts.len()).max(1) as f64;
+    let coverage = matched.len() as f64 / denominator;
+    let density = (weighted_hits / document_weight.max(1.0)).min(1.0);
+    let score = (coverage * 0.78 + density * 0.22 + phrase_bonus).min(1.0);
+
+    LexicalRelevanceScore {
+        score,
+        matched_terms: matched.len(),
+        query_terms: query_terms.len(),
+    }
+}
+
+fn retrieval_terms(text: &str) -> BTreeSet<String> {
+    tokenize(text)
+        .into_iter()
+        .filter(|term| !is_stopword(term))
+        .collect()
+}
+
+fn tokenize(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        if ch.is_alphanumeric() {
+            current.extend(ch.to_lowercase());
+        } else if !current.is_empty() {
+            push_normalized_token(&mut tokens, &current);
+            current.clear();
+        }
+    }
+    if !current.is_empty() {
+        push_normalized_token(&mut tokens, &current);
+    }
+    tokens
+}
+
+fn push_normalized_token(tokens: &mut Vec<String>, token: &str) {
+    if token.len() <= 1 {
+        return;
+    }
+    tokens.push(normalize_token(token));
+}
+
+fn normalize_token(token: &str) -> String {
+    for suffix in ["ing", "ed", "es", "s"] {
+        if token.len() > suffix.len() + 3 && token.ends_with(suffix) {
+            return token[..token.len() - suffix.len()].to_string();
+        }
+    }
+    token.to_string()
+}
+
+fn normalize_phrase(text: &str) -> String {
+    tokenize(text).join(" ")
+}
+
+fn is_stopword(term: &str) -> bool {
+    matches!(
+        term,
+        "about"
+            | "after"
+            | "again"
+            | "against"
+            | "also"
+            | "and"
+            | "any"
+            | "are"
+            | "because"
+            | "before"
+            | "but"
+            | "can"
+            | "could"
+            | "did"
+            | "does"
+            | "for"
+            | "from"
+            | "had"
+            | "has"
+            | "have"
+            | "how"
+            | "into"
+            | "its"
+            | "make"
+            | "must"
+            | "not"
+            | "our"
+            | "out"
+            | "over"
+            | "please"
+            | "should"
+            | "that"
+            | "the"
+            | "their"
+            | "then"
+            | "there"
+            | "this"
+            | "through"
+            | "with"
+            | "would"
+            | "you"
+            | "your"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lexical_relevance_matches_terms_regardless_of_order() {
+        let score = score_lexical_relevance(
+            "please review the code changes",
+            &[RetrievalField::new("code review", 2.0)],
+        );
+
+        assert!(score.score > 0.7, "score was {}", score.score);
+        assert_eq!(score.matched_terms, 2);
+    }
+
+    #[test]
+    fn lexical_relevance_returns_zero_without_content_overlap() {
+        let score = score_lexical_relevance(
+            "fix a postgres migration",
+            &[RetrievalField::new("frontend visual polish", 1.0)],
+        );
+
+        assert_eq!(score, LexicalRelevanceScore::none(3));
+    }
+}

--- a/crates/harness-server/src/workflow_runtime_worker/executor.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor.rs
@@ -150,6 +150,7 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                 self.state.core.workflow_runtime_store.as_deref(),
                 workflow.as_ref(),
                 &job,
+                prompt_task_request.prompt_text(),
             )
             .await;
             let prompt_packet = build_runtime_prompt_packet(

--- a/crates/harness-server/src/workflow_runtime_worker/repo_memory_prompt.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/repo_memory_prompt.rs
@@ -18,6 +18,7 @@ pub(super) async fn repo_memory_for_prompt_packet(
     store: Option<&WorkflowRuntimeStore>,
     workflow: Option<&WorkflowInstance>,
     job: &RuntimeJob,
+    prompt_task_text: Option<&str>,
 ) -> RepoMemoryPromptContext {
     if !memory_enabled {
         return RepoMemoryPromptContext::default();
@@ -26,7 +27,7 @@ pub(super) async fn repo_memory_for_prompt_packet(
         return RepoMemoryPromptContext::default();
     };
     let activity = activity_name(job);
-    let task_text = repo_memory_task_text(workflow, job);
+    let task_text = repo_memory_task_text(workflow, job, prompt_task_text);
     let Some(store) = store else {
         return RepoMemoryPromptContext {
             records: Vec::new(),
@@ -114,8 +115,18 @@ fn repo_for_memory_prompt(workflow: Option<&WorkflowInstance>, job: &RuntimeJob)
         .map(str::to_string)
 }
 
-fn repo_memory_task_text(workflow: Option<&WorkflowInstance>, job: &RuntimeJob) -> Option<String> {
+fn repo_memory_task_text(
+    workflow: Option<&WorkflowInstance>,
+    job: &RuntimeJob,
+    prompt_task_text: Option<&str>,
+) -> Option<String> {
     let mut parts = Vec::new();
+    if let Some(prompt_task_text) = prompt_task_text
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+    {
+        parts.push(prompt_task_text.to_string());
+    }
     if let Some(workflow) = workflow {
         if let Ok(subject) = serde_json::to_string(&workflow.subject) {
             parts.push(subject);
@@ -153,7 +164,8 @@ mod tests {
 
     #[tokio::test]
     async fn memory_flag_degraded_disabled_flag_skips_prompt_memory_lookup() {
-        let context = repo_memory_for_prompt_packet(false, None, None, &repo_runtime_job()).await;
+        let context =
+            repo_memory_for_prompt_packet(false, None, None, &repo_runtime_job(), None).await;
 
         assert!(context.records.is_empty());
         assert!(context.degradation.is_none());
@@ -162,7 +174,7 @@ mod tests {
     #[tokio::test]
     async fn memory_flag_degraded_enabled_store_unavailable_records_degradation() {
         let job = repo_runtime_job();
-        let context = repo_memory_for_prompt_packet(true, None, None, &job).await;
+        let context = repo_memory_for_prompt_packet(true, None, None, &job, None).await;
 
         assert!(context.records.is_empty());
         let Some(degradation) = context.degradation else {
@@ -176,5 +188,15 @@ mod tests {
         assert_eq!(degradation.artifact["repo"], "owner/repo");
         assert_eq!(degradation.artifact["activity"], "implement_issue");
         assert_eq!(degradation.artifact["memory_enabled"], true);
+    }
+
+    #[test]
+    fn repo_memory_task_text_includes_resolved_prompt_text() {
+        let job = repo_runtime_job();
+        let text = repo_memory_task_text(None, &job, Some("fix rust toolchain cache failures"))
+            .expect("task text exists");
+
+        assert!(text.contains("fix rust toolchain cache failures"));
+        assert!(text.contains("implement_issue"));
     }
 }

--- a/crates/harness-server/src/workflow_runtime_worker/repo_memory_prompt.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/repo_memory_prompt.rs
@@ -26,6 +26,7 @@ pub(super) async fn repo_memory_for_prompt_packet(
         return RepoMemoryPromptContext::default();
     };
     let activity = activity_name(job);
+    let task_text = repo_memory_task_text(workflow, job);
     let Some(store) = store else {
         return RepoMemoryPromptContext {
             records: Vec::new(),
@@ -39,7 +40,12 @@ pub(super) async fn repo_memory_for_prompt_packet(
         };
     };
     match store
-        .retrieve_repo_memory_records(&repo, &activity, RepoMemoryRetrievalOptions::default())
+        .retrieve_repo_memory_records_for_task(
+            &repo,
+            &activity,
+            task_text.as_deref(),
+            RepoMemoryRetrievalOptions::default(),
+        )
         .await
     {
         Ok(records) => RepoMemoryPromptContext {
@@ -106,6 +112,26 @@ fn repo_for_memory_prompt(workflow: Option<&WorkflowInstance>, job: &RuntimeJob)
         .map(str::trim)
         .filter(|repo| !repo.is_empty())
         .map(str::to_string)
+}
+
+fn repo_memory_task_text(workflow: Option<&WorkflowInstance>, job: &RuntimeJob) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(workflow) = workflow {
+        if let Ok(subject) = serde_json::to_string(&workflow.subject) {
+            parts.push(subject);
+        }
+        if let Ok(data) = serde_json::to_string(&workflow.data) {
+            parts.push(data);
+        }
+    }
+    if let Ok(input) = serde_json::to_string(&job.input) {
+        parts.push(input);
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n"))
+    }
 }
 
 #[cfg(test)]

--- a/crates/harness-skills/src/store.rs
+++ b/crates/harness-skills/src/store.rs
@@ -283,8 +283,11 @@ impl SkillStore {
                 if skill.trigger_patterns.is_empty() || !allows_auto_injection(skill, prompt) {
                     return None;
                 }
+                if skill_trigger_relevance(prompt, skill).score <= 0.0 {
+                    return None;
+                }
                 let relevance = skill_prompt_relevance(prompt, skill);
-                (relevance.score > 0.0).then_some((skill, relevance.score))
+                Some((skill, relevance.score))
             })
             .collect::<Vec<_>>();
         matches.sort_by(|(left, left_score), (right, right_score)| {
@@ -693,6 +696,15 @@ fn skill_prompt_relevance(prompt: &str, skill: &Skill) -> LexicalRelevanceScore 
     fields.push(RetrievalField::new(&skill.name, 0.8));
     fields.push(RetrievalField::new(&skill.description, 1.2));
     fields.push(RetrievalField::new(&skill.content, 0.25));
+    score_lexical_relevance(prompt, &fields)
+}
+
+fn skill_trigger_relevance(prompt: &str, skill: &Skill) -> LexicalRelevanceScore {
+    let fields = skill
+        .trigger_patterns
+        .iter()
+        .map(|pattern| RetrievalField::new(pattern, 2.0))
+        .collect::<Vec<_>>();
     score_lexical_relevance(prompt, &fields)
 }
 

--- a/crates/harness-skills/src/store.rs
+++ b/crates/harness-skills/src/store.rs
@@ -1,5 +1,9 @@
 use chrono::{DateTime, Utc};
-use harness_core::{types::SkillId, types::SkillLocation};
+use harness_core::{
+    retrieval::{score_lexical_relevance, LexicalRelevanceScore, RetrievalField},
+    types::SkillId,
+    types::SkillLocation,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -272,18 +276,24 @@ impl SkillStore {
     }
 
     pub fn match_prompt(&self, prompt: &str) -> Vec<&Skill> {
-        let prompt_lower = prompt.to_lowercase();
-        self.skills
+        let mut matches = self
+            .skills
             .iter()
-            .filter(|skill| {
-                !skill.trigger_patterns.is_empty()
-                    && skill
-                        .trigger_patterns
-                        .iter()
-                        .any(|p| prompt_lower.contains(&p.to_lowercase()))
-                    && allows_auto_injection(skill, prompt)
+            .filter_map(|skill| {
+                if skill.trigger_patterns.is_empty() || !allows_auto_injection(skill, prompt) {
+                    return None;
+                }
+                let relevance = skill_prompt_relevance(prompt, skill);
+                (relevance.score > 0.0).then_some((skill, relevance.score))
             })
-            .collect()
+            .collect::<Vec<_>>();
+        matches.sort_by(|(left, left_score), (right, right_score)| {
+            right_score
+                .total_cmp(left_score)
+                .then_with(|| right.quality_score.total_cmp(&left.quality_score))
+                .then_with(|| left.name.cmp(&right.name))
+        });
+        matches.into_iter().map(|(skill, _score)| skill).collect()
     }
 
     /// Apply an outcome summary to a skill and update governance state.
@@ -673,6 +683,17 @@ fn allows_auto_injection(skill: &Skill, prompt: &str) -> bool {
         }
         SkillGovernanceStatus::Retired => false,
     }
+}
+
+fn skill_prompt_relevance(prompt: &str, skill: &Skill) -> LexicalRelevanceScore {
+    let mut fields = Vec::with_capacity(skill.trigger_patterns.len() + 3);
+    for pattern in &skill.trigger_patterns {
+        fields.push(RetrievalField::new(pattern, 2.0));
+    }
+    fields.push(RetrievalField::new(&skill.name, 0.8));
+    fields.push(RetrievalField::new(&skill.description, 1.2));
+    fields.push(RetrievalField::new(&skill.content, 0.25));
+    score_lexical_relevance(prompt, &fields)
 }
 
 fn in_canary_bucket(skill_id: &SkillId, prompt: &str, ratio: f64) -> bool {

--- a/crates/harness-skills/src/store/tests.rs
+++ b/crates/harness-skills/src/store/tests.rs
@@ -331,6 +331,22 @@ fn match_prompt_ranks_more_relevant_skill_first() {
 }
 
 #[test]
+fn match_prompt_requires_trigger_overlap_before_auxiliary_fields() {
+    let mut store = SkillStore::new();
+    store.skills.push(make_skill_with_patterns(
+        "review",
+        SkillLocation::System,
+        "implement feature",
+        &["code review"],
+        "system",
+    ));
+
+    let matches = store.match_prompt("implement feature support");
+
+    assert!(matches.is_empty());
+}
+
+#[test]
 fn match_prompt_skips_skills_without_patterns() {
     let mut store = SkillStore::new();
     store

--- a/crates/harness-skills/src/store/tests.rs
+++ b/crates/harness-skills/src/store/tests.rs
@@ -295,6 +295,42 @@ fn match_prompt_is_case_insensitive() {
 }
 
 #[test]
+fn match_prompt_uses_lexical_relevance_when_phrase_order_differs() {
+    let mut store = SkillStore::new();
+    store.skills.push(make_skill_with_patterns(
+        "review",
+        SkillLocation::System,
+        "review code",
+        &["code review"],
+        "system",
+    ));
+    let matches = store.match_prompt("please review code changes in this PR");
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].name, "review");
+}
+
+#[test]
+fn match_prompt_ranks_more_relevant_skill_first() {
+    let mut store = SkillStore::new();
+    store.skills.push(make_skill_with_patterns(
+        "build-fix",
+        SkillLocation::System,
+        "fix builds",
+        &["build error"],
+        "system",
+    ));
+    store.skills.push(make_skill_with_patterns(
+        "review",
+        SkillLocation::System,
+        "review code",
+        &["code review"],
+        "system",
+    ));
+    let matches = store.match_prompt("review code changes before merging");
+    assert_eq!(matches[0].name, "review");
+}
+
+#[test]
 fn match_prompt_skips_skills_without_patterns() {
     let mut store = SkillStore::new();
     store

--- a/crates/harness-workflow/src/runtime/memory_retrieval.rs
+++ b/crates/harness-workflow/src/runtime/memory_retrieval.rs
@@ -103,18 +103,33 @@ fn rank_repo_memory_candidates(
 ) {
     let activity_class = activity_class.trim();
     let query = repo_memory_relevance_query(activity_class, task_text);
-    candidates.sort_by(|left, right| {
-        let left_activity_mismatch = left.activity_class != activity_class;
-        let right_activity_mismatch = right.activity_class != activity_class;
-        let left_relevance = repo_memory_relevance(left, &query);
-        let right_relevance = repo_memory_relevance(right, &query);
-        left_activity_mismatch
-            .cmp(&right_activity_mismatch)
-            .then_with(|| right_relevance.total_cmp(&left_relevance))
-            .then_with(|| right.use_count.cmp(&left.use_count))
-            .then_with(|| right.created_at.cmp(&left.created_at))
-            .then_with(|| left.id.cmp(&right.id))
+    let mut ranked = candidates
+        .iter()
+        .cloned()
+        .map(|record| RankedRepoMemoryCandidate {
+            activity_mismatch: record.activity_class != activity_class,
+            relevance: repo_memory_relevance(&record, &query),
+            record,
+        })
+        .collect::<Vec<_>>();
+    ranked.sort_by(|left, right| {
+        left.activity_mismatch
+            .cmp(&right.activity_mismatch)
+            .then_with(|| right.relevance.total_cmp(&left.relevance))
+            .then_with(|| right.record.use_count.cmp(&left.record.use_count))
+            .then_with(|| right.record.created_at.cmp(&left.record.created_at))
+            .then_with(|| left.record.id.cmp(&right.record.id))
     });
+    for (target, ranked) in candidates.iter_mut().zip(ranked) {
+        *target = ranked.record;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RankedRepoMemoryCandidate {
+    record: RepoMemoryRecord,
+    activity_mismatch: bool,
+    relevance: f64,
 }
 
 fn repo_memory_relevance_query(activity_class: &str, task_text: Option<&str>) -> String {

--- a/crates/harness-workflow/src/runtime/memory_retrieval.rs
+++ b/crates/harness-workflow/src/runtime/memory_retrieval.rs
@@ -2,6 +2,7 @@ use super::repo_memory::{
     record_from_row, RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord, RepoMemoryRecordRow,
 };
 use super::store::WorkflowRuntimeStore;
+use harness_core::retrieval::{score_lexical_relevance, RetrievalField};
 use serde_json::Value;
 
 pub const DEFAULT_REPO_MEMORY_RETRIEVAL_LIMIT: usize = 5;
@@ -36,6 +37,17 @@ impl WorkflowRuntimeStore {
         activity_class: &str,
         options: RepoMemoryRetrievalOptions,
     ) -> anyhow::Result<Vec<RetrievedRepoMemoryRecord>> {
+        self.retrieve_repo_memory_records_for_task(repo, activity_class, None, options)
+            .await
+    }
+
+    pub async fn retrieve_repo_memory_records_for_task(
+        &self,
+        repo: &str,
+        activity_class: &str,
+        task_text: Option<&str>,
+        options: RepoMemoryRetrievalOptions,
+    ) -> anyhow::Result<Vec<RetrievedRepoMemoryRecord>> {
         if repo.trim().is_empty() || options.limit == 0 || options.token_budget == 0 {
             return Ok(Vec::new());
         }
@@ -63,6 +75,7 @@ impl WorkflowRuntimeStore {
         Ok(select_repo_memory_records(
             candidates,
             activity_class,
+            task_text,
             options,
         ))
     }
@@ -71,27 +84,60 @@ impl WorkflowRuntimeStore {
 fn select_repo_memory_records(
     mut candidates: Vec<RepoMemoryRecord>,
     activity_class: &str,
+    task_text: Option<&str>,
     options: RepoMemoryRetrievalOptions,
 ) -> Vec<RetrievedRepoMemoryRecord> {
     if options.limit == 0 || options.token_budget == 0 {
         return Vec::new();
     }
-    rank_repo_memory_candidates(&mut candidates, activity_class);
+    rank_repo_memory_candidates(&mut candidates, activity_class, task_text);
     let mut selected = select_with_budget(candidates.iter(), options.limit, options.token_budget);
     ensure_failure_lesson_mix(&mut selected, &candidates, options);
     selected
 }
 
-fn rank_repo_memory_candidates(candidates: &mut [RepoMemoryRecord], activity_class: &str) {
+fn rank_repo_memory_candidates(
+    candidates: &mut [RepoMemoryRecord],
+    activity_class: &str,
+    task_text: Option<&str>,
+) {
     let activity_class = activity_class.trim();
+    let query = repo_memory_relevance_query(activity_class, task_text);
     candidates.sort_by(|left, right| {
         let left_activity_mismatch = left.activity_class != activity_class;
         let right_activity_mismatch = right.activity_class != activity_class;
+        let left_relevance = repo_memory_relevance(left, &query);
+        let right_relevance = repo_memory_relevance(right, &query);
         left_activity_mismatch
             .cmp(&right_activity_mismatch)
+            .then_with(|| right_relevance.total_cmp(&left_relevance))
+            .then_with(|| right.use_count.cmp(&left.use_count))
             .then_with(|| right.created_at.cmp(&left.created_at))
             .then_with(|| left.id.cmp(&right.id))
     });
+}
+
+fn repo_memory_relevance_query(activity_class: &str, task_text: Option<&str>) -> String {
+    match task_text.map(str::trim).filter(|text| !text.is_empty()) {
+        Some(task_text) => format!("{activity_class}\n{task_text}"),
+        None => activity_class.to_string(),
+    }
+}
+
+fn repo_memory_relevance(record: &RepoMemoryRecord, query: &str) -> f64 {
+    let payload = compact_payload(&record.payload_json);
+    let evidence = record.evidence_ref.as_deref().unwrap_or_default();
+    score_lexical_relevance(
+        query,
+        &[
+            RetrievalField::new(&record.activity_class, 1.5),
+            RetrievalField::new(record.kind.db_value(), 0.7),
+            RetrievalField::new(record.outcome.db_value(), 0.3),
+            RetrievalField::new(&payload, 1.0),
+            RetrievalField::new(evidence, 0.2),
+        ],
+    )
+    .score
 }
 
 fn select_with_budget<'a>(
@@ -269,6 +315,7 @@ mod tests {
         let selected = select_repo_memory_records(
             vec![same_old.clone(), other_new.clone(), same_new.clone()],
             "implement_issue",
+            None,
             RepoMemoryRetrievalOptions {
                 limit: 5,
                 token_budget: 10_000,
@@ -277,6 +324,39 @@ mod tests {
 
         let ids: Vec<Uuid> = selected.iter().map(|entry| entry.record.id).collect();
         assert_eq!(ids, vec![same_new.id, same_old.id, other_new.id]);
+    }
+
+    #[test]
+    fn memory_retrieval_ranks_task_relevant_payload_before_newer_record() {
+        let relevant_old = memory_record(
+            1,
+            "implement_issue",
+            RepoMemoryOutcome::Done,
+            RepoMemoryKind::EnvironmentNote,
+            90,
+            json!({"lesson": "Rust toolchain cache failures require cargo clean before retry"}),
+        );
+        let unrelated_new = memory_record(
+            2,
+            "implement_issue",
+            RepoMemoryOutcome::Done,
+            RepoMemoryKind::EnvironmentNote,
+            1,
+            json!({"lesson": "Frontend color spacing changed in the dashboard"}),
+        );
+
+        let selected = select_repo_memory_records(
+            vec![unrelated_new.clone(), relevant_old.clone()],
+            "implement_issue",
+            Some("fix a rust toolchain cache failure"),
+            RepoMemoryRetrievalOptions {
+                limit: 2,
+                token_budget: 10_000,
+            },
+        );
+
+        let ids: Vec<Uuid> = selected.iter().map(|entry| entry.record.id).collect();
+        assert_eq!(ids, vec![relevant_old.id, unrelated_new.id]);
     }
 
     #[test]
@@ -306,6 +386,7 @@ mod tests {
         let selected = select_repo_memory_records(
             records,
             "implement_issue",
+            None,
             RepoMemoryRetrievalOptions {
                 limit: 5,
                 token_budget: 10_000,
@@ -350,6 +431,7 @@ mod tests {
         let selected = select_repo_memory_records(
             vec![first.clone(), oversized.clone(), third.clone()],
             "implement_issue",
+            None,
             RepoMemoryRetrievalOptions {
                 limit: 5,
                 token_budget,
@@ -376,6 +458,7 @@ mod tests {
         let selected = select_repo_memory_records(
             vec![record],
             "implement_issue",
+            None,
             RepoMemoryRetrievalOptions {
                 limit: 5,
                 token_budget: 1,


### PR DESCRIPTION
## Summary
- Add a shared deterministic lexical relevance scorer in harness-core.
- Use scored lexical relevance for skill prompt matching and Context Composer skill proposals instead of substring-only selection.
- Rerank repo-memory candidates by task-text relevance within the existing activity, budget, and failure-lesson mix constraints.

## Validation
- cargo test -p harness-core retrieval
- cargo test -p harness-skills match_prompt
- cargo test -p harness-context skills_provider
- cargo test -p harness-workflow memory_retrieval
- cargo check -p harness-server --all-targets
- cargo test -p harness-server repo_memory_prompt
- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings

Refs #1769