### PR TITLE
fix(runtime): keep agent diagnostics non-terminal

### DIFF
--- a/crates/harness-agents/src/claude_stream.rs
+++ b/crates/harness-agents/src/claude_stream.rs
@@ -108,6 +108,9 @@ fn apply_claude_stream_event(
         AgentEvent::Warning { message } => {
             emitted_items.push(StreamItem::Warning { message });
         }
+        AgentEvent::Diagnostic { message, .. } => {
+            emitted_items.push(StreamItem::Warning { message });
+        }
         AgentEvent::Error { message } => {
             emitted_items.push(StreamItem::Error { message });
         }
@@ -125,6 +128,10 @@ fn apply_claude_stream_event(
                     content: parsed.output.clone(),
                 },
             });
+            parsed.completed = true;
+        }
+        AgentEvent::TurnCancelled { message } => {
+            emitted_items.push(StreamItem::TurnCancelled { message });
             parsed.completed = true;
         }
         AgentEvent::ToolCall { name, input } => {
@@ -167,6 +174,7 @@ fn stream_item_label(item: &StreamItem) -> &'static str {
         StreamItem::ItemCompleted { .. } => "item_completed",
         StreamItem::TokenUsage { .. } => "token_usage",
         StreamItem::Warning { .. } => "warning",
+        StreamItem::TurnCancelled { .. } => "turn_cancelled",
         StreamItem::Error { .. } => "error",
         StreamItem::ApprovalRequest { .. } => "approval_request",
         StreamItem::Done => "done",

--- a/crates/harness-agents/src/codex_adapter.rs
+++ b/crates/harness-agents/src/codex_adapter.rs
@@ -1,6 +1,8 @@
 use crate::streaming::capture_agent_stderr_diagnostics;
 use async_trait::async_trait;
-use harness_core::agent::{AgentAdapter, AgentEvent, ApprovalDecision, TurnRequest};
+use harness_core::agent::{
+    AgentAdapter, AgentDiagnosticSeverity, AgentEvent, ApprovalDecision, TurnRequest,
+};
 use harness_core::config::agents::{CodexAgentConfig, CodexCloudConfig, SandboxMode};
 use harness_sandbox::SandboxSpec;
 use serde_json::{json, Value};
@@ -142,6 +144,16 @@ pub enum ParsedCodexMessage {
     Response { id: Value, result: Value },
     Ignore,
 }
+
+fn log_codex_diagnostic(severity: AgentDiagnosticSeverity, message: &str) {
+    match severity {
+        AgentDiagnosticSeverity::Warning => tracing::warn!(agent = "codex", "{message}"),
+        AgentDiagnosticSeverity::Error => {
+            tracing::error!(agent = "codex", "non-terminal Codex diagnostic: {message}")
+        }
+    }
+}
+
 impl CodexAdapter {
     pub fn new(cli_path: PathBuf) -> Self {
         let config = CodexAgentConfig {
@@ -399,6 +411,12 @@ impl CodexAdapter {
                     Some(ParsedCodexMessage::Event(AgentEvent::Warning { message })) => {
                         tracing::warn!(agent = "codex", "{message}");
                     }
+                    Some(ParsedCodexMessage::Event(AgentEvent::Diagnostic {
+                        severity,
+                        message,
+                    })) => {
+                        log_codex_diagnostic(severity, &message);
+                    }
                     Some(ParsedCodexMessage::Event(AgentEvent::Error { message })) => {
                         return Err(harness_core::error::HarnessError::AgentExecution(message));
                     }
@@ -447,6 +465,12 @@ impl CodexAdapter {
                     }
                     Some(ParsedCodexMessage::Event(AgentEvent::Warning { message })) => {
                         tracing::warn!(agent = "codex", "{message}");
+                    }
+                    Some(ParsedCodexMessage::Event(AgentEvent::Diagnostic {
+                        severity,
+                        message,
+                    })) => {
+                        log_codex_diagnostic(severity, &message);
                     }
                     Some(ParsedCodexMessage::Event(AgentEvent::Error { message })) => {
                         return Err(harness_core::error::HarnessError::AgentExecution(message));
@@ -584,7 +608,9 @@ impl AgentAdapter for CodexAdapter {
                     ParsedCodexMessage::Event(event) => {
                         let is_terminal = matches!(
                             event,
-                            AgentEvent::TurnCompleted { .. } | AgentEvent::Error { .. }
+                            AgentEvent::TurnCompleted { .. }
+                                | AgentEvent::TurnCancelled { .. }
+                                | AgentEvent::Error { .. }
                         );
                         if is_terminal {
                             self.clear_active_turn_id().await;

--- a/crates/harness-agents/src/codex_adapter/protocol.rs
+++ b/crates/harness-agents/src/codex_adapter/protocol.rs
@@ -1,5 +1,5 @@
 use crate::codex::{parse_codex_error_item_message, parse_codex_item, parse_codex_token_usage};
-use harness_core::agent::{AgentEvent, ApprovalDecision, TurnRequest};
+use harness_core::agent::{AgentDiagnosticSeverity, AgentEvent, ApprovalDecision, TurnRequest};
 use harness_core::config::agents::SandboxMode;
 use serde_json::{json, Value};
 use std::path::Path;
@@ -171,7 +171,10 @@ fn parse_app_server_agent_event(
             .get("item")
             .map(|item| {
                 if let Some(message) = parse_codex_error_item_message(item) {
-                    ParsedCodexMessage::Event(AgentEvent::Error { message })
+                    ParsedCodexMessage::Event(AgentEvent::Diagnostic {
+                        severity: AgentDiagnosticSeverity::Error,
+                        message,
+                    })
                 } else {
                     parse_codex_item(item)
                         .map(|item| {
@@ -187,34 +190,15 @@ fn parse_app_server_agent_event(
             .and_then(parse_codex_token_usage)
             .map(|usage| ParsedCodexMessage::Event(AgentEvent::TokenUsage { usage }))
             .unwrap_or(ParsedCodexMessage::Ignore),
-        "warning" => ParsedCodexMessage::Event(AgentEvent::Warning {
-            message: params
-                .get("message")
-                .and_then(Value::as_str)
-                .unwrap_or("unknown warning")
-                .to_string(),
+        "warning" => ParsedCodexMessage::Event(AgentEvent::Diagnostic {
+            severity: AgentDiagnosticSeverity::Warning,
+            message: app_server_message(params, "unknown warning"),
         }),
-        "error" => ParsedCodexMessage::Event(AgentEvent::Error {
-            message: params
-                .get("error")
-                .and_then(|error| error.get("message"))
-                .and_then(Value::as_str)
-                .or_else(|| params.get("message").and_then(Value::as_str))
-                .unwrap_or("unknown error")
-                .to_string(),
+        "error" => ParsedCodexMessage::Event(AgentEvent::Diagnostic {
+            severity: AgentDiagnosticSeverity::Error,
+            message: app_server_message(params, "unknown error"),
         }),
-        "turn/completed" => ParsedCodexMessage::Event(AgentEvent::TurnCompleted {
-            output: params
-                .get("turn")
-                .and_then(|turn| turn.get("items"))
-                .and_then(Value::as_array)
-                .and_then(|items| items.iter().rev().find_map(parse_codex_item))
-                .and_then(|item| match item {
-                    harness_core::types::Item::AgentReasoning { content } => Some(content),
-                    _ => None,
-                })
-                .unwrap_or_default(),
-        }),
+        "turn/completed" => parse_turn_completed(params),
         "item/commandExecution/requestApproval"
         | "item/fileChange/requestApproval"
         | "item/permissions/requestApproval" => {
@@ -230,6 +214,53 @@ fn parse_app_server_agent_event(
         }
         _ => ParsedCodexMessage::Ignore,
     }
+}
+
+fn parse_turn_completed(params: &Value) -> ParsedCodexMessage {
+    let turn = params.get("turn").unwrap_or(&Value::Null);
+    match turn.get("status").and_then(Value::as_str) {
+        Some("completed") => ParsedCodexMessage::Event(AgentEvent::TurnCompleted {
+            output: turn
+                .get("items")
+                .and_then(Value::as_array)
+                .and_then(|items| items.iter().rev().find_map(parse_codex_item))
+                .and_then(|item| match item {
+                    harness_core::types::Item::AgentReasoning { content } => Some(content),
+                    _ => None,
+                })
+                .unwrap_or_default(),
+        }),
+        Some("interrupted") => ParsedCodexMessage::Event(AgentEvent::TurnCancelled {
+            message: app_server_message(params, "codex turn interrupted"),
+        }),
+        Some("failed") => ParsedCodexMessage::Event(AgentEvent::Error {
+            message: app_server_message(params, "codex turn failed"),
+        }),
+        Some(status) => ParsedCodexMessage::Event(AgentEvent::Error {
+            message: format!("codex turn completed with unsupported status `{status}`"),
+        }),
+        None => ParsedCodexMessage::Event(AgentEvent::Error {
+            message: "codex turn/completed omitted required turn.status".to_string(),
+        }),
+    }
+}
+
+fn app_server_message(params: &Value, fallback: &str) -> String {
+    params
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)
+        .or_else(|| {
+            params
+                .get("turn")
+                .and_then(|turn| turn.get("error"))
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+        })
+        .or_else(|| params.get("message").and_then(Value::as_str))
+        .or_else(|| params.get("reason").and_then(Value::as_str))
+        .unwrap_or(fallback)
+        .to_string()
 }
 
 pub fn parse_codex_message(line: &str) -> Option<ParsedCodexMessage> {

--- a/crates/harness-agents/src/codex_adapter_tests.rs
+++ b/crates/harness-agents/src/codex_adapter_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use harness_core::types::Item;
+use harness_core::{agent::AgentDiagnosticSeverity, types::Item};
 use std::collections::HashMap;
 
 fn test_turn_request(project_root: PathBuf) -> TurnRequest {
@@ -117,7 +117,8 @@ fn parse_item_completed_error_notification() {
     let message = parse_codex_message(line).unwrap();
     assert_eq!(
         message,
-        ParsedCodexMessage::Event(AgentEvent::Error {
+        ParsedCodexMessage::Event(AgentEvent::Diagnostic {
+            severity: AgentDiagnosticSeverity::Error,
             message: "bad config".into()
         })
     );
@@ -129,7 +130,8 @@ fn parse_warning_notification() {
     let message = parse_codex_message(line).unwrap();
     assert_eq!(
         message,
-        ParsedCodexMessage::Event(AgentEvent::Warning {
+        ParsedCodexMessage::Event(AgentEvent::Diagnostic {
+            severity: AgentDiagnosticSeverity::Warning,
             message: "be careful".into()
         })
     );
@@ -141,8 +143,45 @@ fn parse_error_notification() {
     let message = parse_codex_message(line).unwrap();
     assert_eq!(
         message,
-        ParsedCodexMessage::Event(AgentEvent::Error {
+        ParsedCodexMessage::Event(AgentEvent::Diagnostic {
+            severity: AgentDiagnosticSeverity::Error,
             message: "boom".into()
+        })
+    );
+}
+
+#[test]
+fn parse_failed_turn_completed_notification_as_terminal_error() {
+    let line = r#"{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","status":"failed","items":[],"error":{"message":"model failed"}}}}"#;
+    let message = parse_codex_message(line).unwrap();
+    assert_eq!(
+        message,
+        ParsedCodexMessage::Event(AgentEvent::Error {
+            message: "model failed".into()
+        })
+    );
+}
+
+#[test]
+fn parse_interrupted_turn_completed_notification_as_cancellation() {
+    let line = r#"{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","status":"interrupted","items":[],"error":null}}}"#;
+    let message = parse_codex_message(line).unwrap();
+    assert_eq!(
+        message,
+        ParsedCodexMessage::Event(AgentEvent::TurnCancelled {
+            message: "codex turn interrupted".into()
+        })
+    );
+}
+
+#[test]
+fn parse_turn_completed_without_status_fails_closed() {
+    let line = r#"{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[]}}}"#;
+    let message = parse_codex_message(line).unwrap();
+    assert_eq!(
+        message,
+        ParsedCodexMessage::Event(AgentEvent::Error {
+            message: "codex turn/completed omitted required turn.status".into()
         })
     );
 }
@@ -571,7 +610,7 @@ async fn app_server_protocol_failures_reset_and_reap_child() -> anyhow::Result<(
     let scenarios = [
         ("", "initialize stalled"),
         (
-            r#"printf '%s\n' '{"method":"error","params":{"message":"init failed"}}'"#,
+            r#"printf '%s\n' '{"id":1,"error":{"message":"init failed"}}'"#,
             "init failed",
         ),
         (
@@ -582,7 +621,7 @@ async fn app_server_protocol_failures_reset_and_reap_child() -> anyhow::Result<(
             concat!(
                 r#"printf '%s\n' '{"id":1,"result":{}}'"#,
                 "\n",
-                r#"printf '%s\n' '{"method":"error","params":{"message":"thread failed"}}'"#,
+                r#"printf '%s\n' '{"id":2,"error":{"message":"thread failed"}}'"#,
             ),
             "thread failed",
         ),
@@ -772,6 +811,65 @@ async fn start_turn_fails_when_stdout_eofs_before_terminal_event() {
     assert!(state.stdout_lines.is_none());
     assert!(state.thread_id.is_none());
     assert!(state.active_turn_id.is_none());
+}
+
+#[tokio::test]
+async fn start_turn_continues_after_error_notification_until_completed() -> anyhow::Result<()> {
+    let project_root = tempfile::tempdir()?;
+    let adapter = CodexAdapter::new(PathBuf::from("codex"));
+    let mut child = tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(
+            r#"printf '%s\n' '{"method":"turn/started","params":{"threadId":"thread-1","turn":{"id":"turn-1","status":"inProgress","items":[]}}}'; printf '%s\n' '{"method":"error","params":{"threadId":"thread-1","turnId":"turn-1","willRetry":false,"error":{"message":"Skill descriptions were shortened to fit the skills context budget."}}}'; printf '%s\n' '{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed","items":[]}}}'; read _ || true"#,
+        )
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("stdout should be piped"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("stdin should be piped"))?;
+    {
+        let mut state = adapter.state.lock().await;
+        state.child = Some(crate::ManagedChild::new(child, "codex app-server test"));
+        state.stdin = Some(stdin);
+        state.stdout_lines = Some(BufReader::new(stdout).lines());
+        state.thread_id = Some("thread-1".into());
+        state.child_workspace = Some(project_root.path().to_path_buf());
+    }
+
+    let request = test_turn_request(project_root.path().to_path_buf());
+    adapter.state.lock().await.spawn_policy_fingerprint = Some(
+        crate::spawn_contract::adapter_spawn_policy_fingerprint(&request, adapter.sandbox_mode),
+    );
+    let (tx, mut rx) = mpsc::channel(8);
+
+    adapter.start_turn(request, tx).await?;
+
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::Diagnostic {
+                severity: AgentDiagnosticSeverity::Error,
+                ..
+            }
+        )
+    }));
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::TurnCompleted { .. })),
+        "diagnostic notifications must not hide the explicit turn terminal event: {events:?}"
+    );
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/harness-agents/src/codex_exec_parser.rs
+++ b/crates/harness-agents/src/codex_exec_parser.rs
@@ -300,6 +300,7 @@ pub(crate) async fn stream_codex_exec_output(
                 StreamItem::ItemCompleted { .. } => "item_completed",
                 StreamItem::TokenUsage { .. } => "token_usage",
                 StreamItem::Warning { .. } => "warning",
+                StreamItem::TurnCancelled { .. } => "turn_cancelled",
                 StreamItem::Error { .. } => "error",
                 StreamItem::ApprovalRequest { .. } => "approval_request",
                 StreamItem::Done => "done",

--- a/crates/harness-core/src/agent.rs
+++ b/crates/harness-core/src/agent.rs
@@ -329,6 +329,7 @@ pub enum StreamItem {
     ItemCompleted { item: Item },
     TokenUsage { usage: TokenUsage },
     Warning { message: String },
+    TurnCancelled { message: String },
     Error { message: String },
     ApprovalRequest { id: String, command: String },
     Done,
@@ -355,6 +356,13 @@ pub enum TaskComplexity {
 // === Streaming Agent Adapter (new, coexists with CodeAgent) ===
 
 /// Events emitted by an agent adapter during a turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentDiagnosticSeverity {
+    Warning,
+    Error,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentEvent {
@@ -391,8 +399,15 @@ pub enum AgentEvent {
     Warning {
         message: String,
     },
+    Diagnostic {
+        severity: AgentDiagnosticSeverity,
+        message: String,
+    },
     TurnCompleted {
         output: String,
+    },
+    TurnCancelled {
+        message: String,
     },
     Error {
         message: String,

--- a/crates/harness-server/src/runtime_circuit_breaker.rs
+++ b/crates/harness-server/src/runtime_circuit_breaker.rs
@@ -447,9 +447,7 @@ mod tests {
             FailureClass::ZeroOutputSpawnFailure
         );
         assert_eq!(
-            classify_agent_failure(
-                "codex exited with exit status: 1: stderr=[Reading additional input"
-            ),
+            classify_agent_failure("codex exited: usage limit reached; try again later"),
             FailureClass::QuotaInteractiveWait
         );
         assert_eq!(
@@ -507,7 +505,7 @@ mod tests {
     fn success_clears_closed_counts() {
         let registry = test_registry();
         let now = Utc::now();
-        registry.record_failure("codex", "job-1", FailureClass::Unclassified, now);
+        registry.record_failure("codex", "job-1", FailureClass::QuotaInteractiveWait, now);
 
         registry.record_success("codex", "job-2", now);
 
@@ -520,7 +518,12 @@ mod tests {
         let registry = test_registry();
         let now = Utc::now();
         for _ in 0..3 {
-            registry.record_failure("codex", "failing-job", FailureClass::Unclassified, now);
+            registry.record_failure(
+                "codex",
+                "failing-job",
+                FailureClass::QuotaInteractiveWait,
+                now,
+            );
         }
 
         let later = now + Duration::seconds(11);
@@ -536,7 +539,12 @@ mod tests {
             registry.before_execute(&probe, later, later + Duration::minutes(5)),
             RuntimeJobClaimDecision::Proceed
         );
-        let events = registry.record_failure("codex", &probe.id, FailureClass::Unclassified, later);
+        let events = registry.record_failure(
+            "codex",
+            &probe.id,
+            FailureClass::QuotaInteractiveWait,
+            later,
+        );
 
         assert_eq!(events[0].kind, CircuitBreakerEventKind::Opened);
         assert_eq!(
@@ -645,9 +653,9 @@ mod tests {
     fn interleaved_failure_classes_count_independently() {
         let registry = test_registry();
         let now = Utc::now();
-        registry.record_failure("codex", "job-1", FailureClass::Unclassified, now);
-        registry.record_failure("codex", "job-2", FailureClass::CliMissingFile, now);
-        registry.record_failure("codex", "job-3", FailureClass::Unclassified, now);
+        registry.record_failure("codex", "job-1", FailureClass::QuotaInteractiveWait, now);
+        registry.record_failure("codex", "job-2", FailureClass::ZeroOutputSpawnFailure, now);
+        registry.record_failure("codex", "job-3", FailureClass::QuotaInteractiveWait, now);
 
         assert!(registry.defer_open_profiles(now).is_empty());
         assert_eq!(registry.snapshots(now)[0].state, "closed");
@@ -658,7 +666,7 @@ mod tests {
         let registry = test_registry();
         let now = Utc::now();
         for _ in 0..3 {
-            registry.record_failure("codex", "job-1", FailureClass::Unclassified, now);
+            registry.record_failure("codex", "job-1", FailureClass::QuotaInteractiveWait, now);
         }
 
         let event = registry.reset("codex", now);

--- a/crates/harness-server/src/runtime_circuit_breaker/failure_class.rs
+++ b/crates/harness-server/src/runtime_circuit_breaker/failure_class.rs
@@ -23,7 +23,10 @@ impl FailureClass {
         }
     }
     pub(crate) fn trips_runtime_profile_breaker(self) -> bool {
-        !matches!(self, Self::StructuredOutputInvalid)
+        matches!(
+            self,
+            Self::ZeroOutputSpawnFailure | Self::QuotaInteractiveWait
+        )
     }
 }
 pub(crate) fn classify_agent_failure(error: &str) -> FailureClass {
@@ -34,10 +37,7 @@ pub(crate) fn classify_agent_failure(error: &str) -> FailureClass {
     {
         return FailureClass::ZeroOutputSpawnFailure;
     }
-    if error.contains("Reading additional input")
-        || lower.contains("hit your limit")
-        || lower.contains("hit your usage limit")
-    {
+    if harness_core::error::is_quota_failure_message(error) {
         return FailureClass::QuotaInteractiveWait;
     }
     if error.contains("No such file or directory") {
@@ -59,4 +59,39 @@ pub(crate) fn classify_agent_failure(error: &str) -> FailureClass {
         return FailureClass::SandboxPermission;
     }
     FailureClass::Unclassified
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_circuit_breaker::RuntimeCircuitBreakerRegistry;
+    use chrono::Utc;
+    use harness_core::config::workflow_circuit_breaker::RuntimeCircuitBreakerPolicy;
+
+    #[test]
+    fn twenty_task_failures_do_not_open_runtime_profile_breaker() {
+        let non_runtime_classes = [
+            FailureClass::CliMissingFile,
+            FailureClass::WorktreeCollision,
+            FailureClass::StructuredOutputMissing,
+            FailureClass::StructuredOutputInvalid,
+            FailureClass::SandboxPermission,
+            FailureClass::Unclassified,
+        ];
+
+        for class in non_runtime_classes {
+            let registry =
+                RuntimeCircuitBreakerRegistry::new(RuntimeCircuitBreakerPolicy::default());
+            let now = Utc::now();
+
+            for index in 0..20 {
+                assert!(registry
+                    .record_failure("codex", &format!("task-job-{index}"), class, now)
+                    .is_empty());
+            }
+
+            assert!(registry.defer_open_profiles(now).is_empty());
+            assert!(registry.snapshots(now).is_empty());
+        }
+    }
 }

--- a/crates/harness-server/src/workflow_runtime_worker.rs
+++ b/crates/harness-server/src/workflow_runtime_worker.rs
@@ -697,7 +697,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_job_failure_class_falls_back_to_error_text() -> anyhow::Result<()> {
+    fn runtime_job_failure_class_does_not_treat_stdin_banner_as_quota() -> anyhow::Result<()> {
         let mut job = RuntimeJob::pending(
             "command-1",
             harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
@@ -711,10 +711,7 @@ mod tests {
         );
         job.complete(&result)?;
 
-        assert_eq!(
-            runtime_job_failure_class(&job),
-            FailureClass::QuotaInteractiveWait
-        );
+        assert_eq!(runtime_job_failure_class(&job), FailureClass::Unclassified);
         Ok(())
     }
 

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result.rs
@@ -15,17 +15,6 @@ mod activity_result_parser;
 use super::prompt_packet::workflow_prompt_artifact;
 use activity_result_parser::parse_activity_result_json;
 
-const CODEX_SKILL_BUDGET_WARNING: &str =
-    "Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
-const CODEX_SKILL_BUDGET_WARNING_ADVICE: &str =
-    " Disable unused skills or plugins to leave more room for the rest.";
-const CODEX_SKILL_BUDGET_AGENT_ERROR: &str =
-    "agent execution failed: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
-const CODEX_SKILL_BUDGET_STRUCTURED_AGENT_ERROR: &str =
-    "agent execution failed: codex structured error: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
-const CODEX_SKILL_BUDGET_STRUCTURED_AGENT_ERROR_PREFIX: &str =
-    "agent execution failed: codex structured error: exit ";
-
 pub(super) fn activity_result_from_turn_with_workflow(
     job: &RuntimeJob,
     status: &TurnStatus,
@@ -84,18 +73,6 @@ pub(super) fn activity_result_from_turn_with_workflow(
                     turn_status = ?status,
                     items = items.len(),
                     "runtime turn failed: {error}"
-                );
-            }
-        }
-        ActivityResultEnvelopeOutcome::AcceptedWithTurnWarning => {
-            if let Some(error) = envelope.extraction_error.as_deref() {
-                tracing::warn!(
-                    runtime_job_id = %job.id,
-                    activity = %activity,
-                    agent = %agent_name,
-                    turn_status = ?status,
-                    items = items.len(),
-                    "accepted structured activity result despite non-fatal turn warning: {error}"
                 );
             }
         }
@@ -172,7 +149,6 @@ enum ActivityResultExtractionStrategy {
 #[serde(rename_all = "snake_case")]
 enum ActivityResultEnvelopeOutcome {
     Accepted,
-    AcceptedWithTurnWarning,
     MissingStructuredOutput,
     InvalidStructuredOutput,
     ZeroOutputSpawnFailure,
@@ -210,29 +186,6 @@ impl ActivityResultEnvelope {
             raw_status,
             extracted_activity: Some(result.activity.clone()),
             extraction_error: None,
-            final_result: result,
-        }
-    }
-
-    fn accepted_with_turn_warning(
-        raw_status: TurnStatus,
-        extraction_strategy: ActivityResultExtractionStrategy,
-        result: ActivityResult,
-        warning: String,
-        workflow_definition: Option<&str>,
-    ) -> Self {
-        let (downgraded, result) = enforce_activity_status_contract(workflow_definition, result);
-        let outcome = if downgraded {
-            ActivityResultEnvelopeOutcome::StatusContractDowngraded
-        } else {
-            ActivityResultEnvelopeOutcome::AcceptedWithTurnWarning
-        };
-        Self {
-            extraction_strategy,
-            outcome,
-            raw_status,
-            extracted_activity: Some(result.activity.clone()),
-            extraction_error: Some(warning),
             final_result: result,
         }
     }
@@ -471,37 +424,7 @@ fn activity_result_envelope_from_turn(
             ActivityResultEnvelope::cancelled(*status, activity.to_string(), summary)
         }
         TurnStatus::Failed => {
-            let error = failed_turn_error(items);
-            if let Some(warning) = failed_turn_warning_allows_structured_result(items) {
-                match structured_activity_result(items, activity) {
-                    StructuredActivityResult::Parsed {
-                        result,
-                        extraction_strategy,
-                    } => {
-                        return ActivityResultEnvelope::accepted_with_turn_warning(
-                            *status,
-                            extraction_strategy,
-                            result,
-                            warning,
-                            workflow_definition,
-                        );
-                    }
-                    StructuredActivityResult::Invalid {
-                        error: parse_error,
-                        extracted_activity,
-                        extraction_strategy,
-                    } => {
-                        return ActivityResultEnvelope::invalid_structured_output(
-                            *status,
-                            extraction_strategy,
-                            activity.to_string(),
-                            parse_error,
-                            extracted_activity,
-                        );
-                    }
-                    StructuredActivityResult::Missing => {}
-                }
-            }
+            let error = last_error(items).unwrap_or_else(|| "agent turn failed".to_string());
             ActivityResultEnvelope::failed(*status, activity.to_string(), summary, error)
         }
         TurnStatus::Running => {
@@ -560,57 +483,6 @@ fn turn_error_is_timeout(error: &str) -> bool {
 fn turn_error_is_non_retryable_agent_limit(error: &str) -> bool {
     harness_core::error::is_quota_failure_message(error)
         || harness_core::error::is_billing_failure_message(error)
-}
-
-fn failed_turn_error(items: &[Item]) -> String {
-    items
-        .iter()
-        .filter_map(|item| match item {
-            Item::Error { message, .. } if !failed_turn_error_allows_structured_result(message) => {
-                Some(truncate_summary(message.trim()))
-            }
-            _ => None,
-        })
-        .next_back()
-        .or_else(|| last_error(items))
-        .unwrap_or_else(|| "agent turn failed".to_string())
-}
-
-fn failed_turn_warning_allows_structured_result(items: &[Item]) -> Option<String> {
-    let mut warning = None;
-    for item in items {
-        if let Item::Error { message, .. } = item {
-            if !failed_turn_error_allows_structured_result(message) {
-                return None;
-            }
-            warning = Some(message.clone());
-        }
-    }
-    warning
-}
-
-fn failed_turn_error_allows_structured_result(error: &str) -> bool {
-    let error = error.trim();
-    let error = error
-        .strip_suffix(CODEX_SKILL_BUDGET_WARNING_ADVICE)
-        .unwrap_or(error);
-    error == CODEX_SKILL_BUDGET_WARNING
-        || error == CODEX_SKILL_BUDGET_AGENT_ERROR
-        || error == CODEX_SKILL_BUDGET_STRUCTURED_AGENT_ERROR
-        || codex_structured_skill_budget_error_allows_structured_result(error)
-}
-
-fn codex_structured_skill_budget_error_allows_structured_result(error: &str) -> bool {
-    let Some(rest) = error.strip_prefix(CODEX_SKILL_BUDGET_STRUCTURED_AGENT_ERROR_PREFIX) else {
-        return false;
-    };
-    let Some(status_prefix) = rest.strip_suffix(CODEX_SKILL_BUDGET_WARNING) else {
-        return false;
-    };
-    let Some(status_text) = status_prefix.strip_suffix(": ") else {
-        return false;
-    };
-    !status_text.trim().is_empty() && !status_text.contains(['\n', '\r'])
 }
 
 enum StructuredActivityResult {

--- a/crates/harness-server/src/workflow_runtime_worker/activity_result_limit_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result_limit_tests.rs
@@ -1,13 +1,6 @@
 use super::*;
 use harness_workflow::runtime::{ActivityStatus, RuntimeKind};
 
-const SKILL_BUDGET_AGENT_ERROR: &str = "agent execution failed: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
-const SKILL_BUDGET_AGENT_ERROR_WITH_STDERR: &str = "agent execution failed: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.; stderr=[adapter failed]";
-const SKILL_BUDGET_CODEX_STRUCTURED_AGENT_ERROR: &str = "agent execution failed: codex structured error: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
-const SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR: &str = "agent execution failed: codex structured error: exit exit status: 1: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.";
-const SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR_WITH_STDERR: &str = "agent execution failed: codex structured error: exit exit status: 1: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter.; stderr=[adapter failed]";
-const SKILL_BUDGET_CODEX_STRUCTURED_AGENT_ERROR_WITH_ADVICE: &str = "agent execution failed: codex structured error: Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter. Disable unused skills or plugins to leave more room for the rest.";
-
 #[test]
 fn activity_result_from_turn_marks_quota_failure_non_retryable() {
     let job = RuntimeJob::pending(
@@ -44,7 +37,7 @@ fn activity_result_from_turn_marks_quota_failure_non_retryable() {
 }
 
 #[test]
-fn failed_skill_budget_warning_accepts_structured_activity_result() {
+fn failed_turn_never_accepts_stale_structured_activity_result() {
     let job = RuntimeJob::pending(
         "command-1",
         RuntimeKind::CodexJsonrpc,
@@ -55,7 +48,7 @@ fn failed_skill_budget_warning_accepts_structured_activity_result() {
     );
     let items = vec![
         Item::AgentReasoning {
-            content: r#"The agent completed the PR before the wrapper warning.
+            content: r#"A stale result must not override an explicit terminal failure.
 
 ```harness-activity-result
 {"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
@@ -64,15 +57,7 @@ fn failed_skill_budget_warning_accepts_structured_activity_result() {
         },
         Item::Error {
             code: 1,
-            message: SKILL_BUDGET_AGENT_ERROR.to_string(),
-        },
-        Item::Error {
-            code: 1,
-            message: SKILL_BUDGET_CODEX_STRUCTURED_AGENT_ERROR.to_string(),
-        },
-        Item::Error {
-            code: 1,
-            message: SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR.to_string(),
+            message: "Codex reported turn/failed".to_string(),
         },
     ];
 
@@ -88,124 +73,15 @@ fn failed_skill_budget_warning_accepts_structured_activity_result() {
     );
 
     assert_eq!(result.activity, "implement_issue");
-    assert_eq!(result.status, ActivityStatus::Succeeded);
-    assert_eq!(result.summary, "Implementation completed.");
-    assert!(result.error.is_none());
-    assert!(result
+    assert_eq!(result.status, ActivityStatus::Failed);
+    assert_eq!(result.error.as_deref(), Some("Codex reported turn/failed"));
+    assert!(!result
         .artifacts
         .iter()
         .any(|artifact| artifact.artifact_type == "pull_request"));
     let envelope = envelope_artifact(&result);
-    assert_eq!(envelope["outcome"], "accepted_with_turn_warning");
-    assert_eq!(envelope["raw_status"], "failed");
-    assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
-    assert!(envelope["extraction_error"]
-        .as_str()
-        .is_some_and(|error| error.contains("Skill descriptions were shortened")));
-    assert_eq!(envelope["final_result"]["status"], "succeeded");
-}
-
-#[test]
-fn failed_skill_budget_warning_with_advice_accepts_structured_activity_result() {
-    let job = RuntimeJob::pending(
-        "command-1",
-        RuntimeKind::CodexJsonrpc,
-        "codex-default",
-        json!({
-            "activity": "plan_issue"
-        }),
-    );
-    let items = vec![
-        Item::AgentReasoning {
-            content: r#"```harness-activity-result
-{"activity":"plan_issue","status":"succeeded","summary":"Planning completed.","artifacts":[{"artifact_type":"issue_plan","artifact":{"summary":"Verify the existing PR.","task_class":"bugfix","target_files":[],"validation_plan":["cargo test"],"blockers":[]}}]}
-```"#
-                .to_string(),
-        },
-        Item::Error {
-            code: 1,
-            message: SKILL_BUDGET_CODEX_STRUCTURED_AGENT_ERROR_WITH_ADVICE.to_string(),
-        },
-    ];
-
-    let result = activity_result_from_turn(
-        &job,
-        &TurnStatus::Failed,
-        &items,
-        &ThreadId::from_str("thread-1"),
-        &TurnId::from_str("turn-1"),
-        "codex",
-        Path::new("/project"),
-        "digest-1",
-    );
-
-    assert_eq!(result.activity, "plan_issue");
-    assert_eq!(result.status, ActivityStatus::Succeeded);
-    assert_eq!(result.summary, "Planning completed.");
-    assert!(result.error.is_none());
-    assert!(result
-        .artifacts
-        .iter()
-        .any(|artifact| artifact.artifact_type == "issue_plan"));
-    assert_eq!(
-        envelope_artifact(&result)["outcome"],
-        "accepted_with_turn_warning"
-    );
-}
-
-#[test]
-fn failed_wrapped_skill_budget_warning_accepts_structured_activity_result() {
-    let job = RuntimeJob::pending(
-        "command-1",
-        RuntimeKind::CodexJsonrpc,
-        "codex-default",
-        json!({
-            "activity": "implement_issue"
-        }),
-    );
-    let items = vec![
-        Item::AgentReasoning {
-            content: r#"The agent completed the PR before the structured wrapper warning.
-
-```harness-activity-result
-{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
-```"#
-                .to_string(),
-        },
-        Item::Error {
-            code: 1,
-            message: SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR.to_string(),
-        },
-    ];
-
-    let result = activity_result_from_turn(
-        &job,
-        &TurnStatus::Failed,
-        &items,
-        &ThreadId::from_str("thread-1"),
-        &TurnId::from_str("turn-1"),
-        "codex",
-        Path::new("/project"),
-        "digest-1",
-    );
-
-    assert_eq!(result.activity, "implement_issue");
-    assert_eq!(result.status, ActivityStatus::Succeeded);
-    assert_eq!(result.summary, "Implementation completed.");
-    assert!(result.error.is_none());
-    assert!(result
-        .artifacts
-        .iter()
-        .any(|artifact| artifact.artifact_type == "pull_request"));
-    let envelope = envelope_artifact(&result);
-    assert_eq!(envelope["outcome"], "accepted_with_turn_warning");
-    assert_eq!(envelope["raw_status"], "failed");
-    assert_eq!(envelope["extraction_strategy"], "fenced_activity_result");
-    assert_eq!(
-        envelope["extraction_error"],
-        SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR
-    );
-    assert_eq!(envelope["final_result"]["status"], "succeeded");
+    assert_eq!(envelope["outcome"], "turn_failed");
+    assert_eq!(envelope["extraction_strategy"], "not_attempted");
 }
 
 #[test]
@@ -223,7 +99,7 @@ fn failed_timeout_ignores_stale_structured_activity_result() {
             content: r#"An old result should not override a real timeout.
 
 ```harness-activity-result
-{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
+{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[]}
 ```"#
                 .to_string(),
         },
@@ -244,183 +120,12 @@ fn failed_timeout_ignores_stale_structured_activity_result() {
         "digest-1",
     );
 
-    assert_eq!(result.activity, "implement_issue");
     assert_eq!(result.status, ActivityStatus::Failed);
     assert_eq!(result.error_kind, Some(ActivityErrorKind::Timeout));
     assert_eq!(
         result.error.as_deref(),
         Some("Agent turn timed out after 30s")
     );
-    assert!(!result
-        .artifacts
-        .iter()
-        .any(|artifact| artifact.artifact_type == "pull_request"));
-    let envelope = envelope_artifact(&result);
-    assert_eq!(envelope["outcome"], "turn_failed");
-    assert_eq!(envelope["extraction_strategy"], "not_attempted");
-}
-
-#[test]
-fn failed_real_error_before_skill_budget_warning_ignores_structured_activity_result() {
-    let job = RuntimeJob::pending(
-        "command-1",
-        RuntimeKind::CodexJsonrpc,
-        "codex-default",
-        json!({
-            "activity": "implement_issue"
-        }),
-    );
-    let items = vec![
-        Item::AgentReasoning {
-            content: r#"A stale success must not hide a real failure.
-
-```harness-activity-result
-{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
-```"#
-                .to_string(),
-        },
-        Item::Error {
-            code: 1,
-            message: "Agent turn timed out after 30s".to_string(),
-        },
-        Item::Error {
-            code: 1,
-            message: SKILL_BUDGET_AGENT_ERROR.to_string(),
-        },
-        Item::Error {
-            code: 1,
-            message: SKILL_BUDGET_CODEX_STRUCTURED_AGENT_ERROR.to_string(),
-        },
-        Item::Error {
-            code: 1,
-            message: SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR.to_string(),
-        },
-    ];
-
-    let result = activity_result_from_turn(
-        &job,
-        &TurnStatus::Failed,
-        &items,
-        &ThreadId::from_str("thread-1"),
-        &TurnId::from_str("turn-1"),
-        "codex",
-        Path::new("/project"),
-        "digest-1",
-    );
-
-    assert_eq!(result.activity, "implement_issue");
-    assert_eq!(result.status, ActivityStatus::Failed);
-    assert_eq!(result.error_kind, Some(ActivityErrorKind::Timeout));
-    assert_eq!(
-        result.error.as_deref(),
-        Some("Agent turn timed out after 30s")
-    );
-    assert!(!result
-        .artifacts
-        .iter()
-        .any(|artifact| artifact.artifact_type == "pull_request"));
-    let envelope = envelope_artifact(&result);
-    assert_eq!(envelope["outcome"], "turn_failed");
-    assert_eq!(envelope["extraction_strategy"], "not_attempted");
-}
-
-#[test]
-fn failed_skill_budget_warning_with_stderr_ignores_structured_activity_result() {
-    let job = RuntimeJob::pending(
-        "command-1",
-        RuntimeKind::CodexJsonrpc,
-        "codex-default",
-        json!({
-            "activity": "implement_issue"
-        }),
-    );
-    let items = vec![
-        Item::AgentReasoning {
-            content: r#"A warning with stderr diagnostics is still a failed turn.
-
-```harness-activity-result
-{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
-```"#
-                .to_string(),
-        },
-        Item::Error {
-            code: 1,
-            message: SKILL_BUDGET_AGENT_ERROR_WITH_STDERR.to_string(),
-        },
-    ];
-
-    let result = activity_result_from_turn(
-        &job,
-        &TurnStatus::Failed,
-        &items,
-        &ThreadId::from_str("thread-1"),
-        &TurnId::from_str("turn-1"),
-        "codex",
-        Path::new("/project"),
-        "digest-1",
-    );
-
-    assert_eq!(result.activity, "implement_issue");
-    assert_eq!(result.status, ActivityStatus::Failed);
-    assert_eq!(
-        result.error.as_deref(),
-        Some(SKILL_BUDGET_AGENT_ERROR_WITH_STDERR)
-    );
-    assert!(!result
-        .artifacts
-        .iter()
-        .any(|artifact| artifact.artifact_type == "pull_request"));
-    let envelope = envelope_artifact(&result);
-    assert_eq!(envelope["outcome"], "turn_failed");
-    assert_eq!(envelope["extraction_strategy"], "not_attempted");
-}
-
-#[test]
-fn failed_wrapped_skill_budget_warning_with_stderr_ignores_structured_activity_result() {
-    let job = RuntimeJob::pending(
-        "command-1",
-        RuntimeKind::CodexJsonrpc,
-        "codex-default",
-        json!({
-            "activity": "implement_issue"
-        }),
-    );
-    let items = vec![
-        Item::AgentReasoning {
-            content: r#"A structured wrapper warning with stderr diagnostics is still a failed turn.
-
-```harness-activity-result
-{"activity":"implement_issue","status":"succeeded","summary":"Implementation completed.","artifacts":[{"artifact_type":"pull_request","artifact":{"pr_number":170,"pr_url":"https://github.com/owner/repo/pull/170"}}]}
-```"#
-                .to_string(),
-        },
-        Item::Error {
-            code: 1,
-            message: SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR_WITH_STDERR.to_string(),
-        },
-    ];
-
-    let result = activity_result_from_turn(
-        &job,
-        &TurnStatus::Failed,
-        &items,
-        &ThreadId::from_str("thread-1"),
-        &TurnId::from_str("turn-1"),
-        "codex",
-        Path::new("/project"),
-        "digest-1",
-    );
-
-    assert_eq!(result.activity, "implement_issue");
-    assert_eq!(result.status, ActivityStatus::Failed);
-    assert_eq!(
-        result.error.as_deref(),
-        Some(SKILL_BUDGET_EXIT_STRUCTURED_AGENT_ERROR_WITH_STDERR)
-    );
-    assert!(!result
-        .artifacts
-        .iter()
-        .any(|artifact| artifact.artifact_type == "pull_request"));
     let envelope = envelope_artifact(&result);
     assert_eq!(envelope["outcome"], "turn_failed");
     assert_eq!(envelope["extraction_strategy"], "not_attempted");

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/helpers.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/helpers.rs
@@ -359,6 +359,29 @@ pub(crate) async fn mark_turn_failed(
     tracing::error!("turn failed: {error}");
 }
 
+pub(crate) async fn mark_turn_cancelled(
+    server: &crate::server::HarnessServer,
+    notify_tx: &Option<crate::notify::NotifySender>,
+    notification_tx: &tokio::sync::broadcast::Sender<RpcNotification>,
+    thread_id: &ThreadId,
+    turn_id: &TurnId,
+    reason: String,
+) {
+    if let Err(err) = server.thread_manager.cancel_turn(thread_id, turn_id) {
+        tracing::warn!("failed to mark turn as cancelled: {err}");
+    }
+    emit_runtime_notification(
+        notify_tx,
+        notification_tx,
+        Notification::TurnCompleted {
+            turn_id: turn_id.clone(),
+            status: TurnStatus::Cancelled,
+            token_usage: harness_core::types::TokenUsage::default(),
+        },
+    );
+    tracing::info!("turn cancelled: {reason}");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -373,6 +396,38 @@ mod tests {
         RuntimeKind, WorkflowInstance, WorkflowRuntimeStore, WorkflowSubject,
     };
     use std::str::FromStr;
+
+    #[tokio::test]
+    async fn mark_turn_cancelled_transitions_turn_status() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut config = HarnessConfig::default();
+        config.server.project_root = dir.path().to_path_buf();
+        let server = HarnessServer::new(config, ThreadManager::new(), AgentRegistry::new("codex"));
+        let thread_id = server.thread_manager.start_thread(dir.path().to_path_buf());
+        let turn_id = server.thread_manager.start_turn(
+            &thread_id,
+            "prompt".to_string(),
+            AgentId::from_str("codex"),
+        )?;
+        let (notification_tx, _) = tokio::sync::broadcast::channel(16);
+
+        mark_turn_cancelled(
+            &server,
+            &None,
+            &notification_tx,
+            &thread_id,
+            &turn_id,
+            "codex turn interrupted".to_string(),
+        )
+        .await;
+
+        let turn = server
+            .thread_manager
+            .get_turn(&thread_id, &turn_id)
+            .ok_or_else(|| anyhow::anyhow!("turn should exist"))?;
+        assert_eq!(turn.status, TurnStatus::Cancelled);
+        Ok(())
+    }
 
     #[tokio::test]
     async fn workflow_runtime_worker_token_usage_persists_runtime_usage() -> anyhow::Result<()> {

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
@@ -1,7 +1,10 @@
 use super::helpers::{
-    emit_runtime_notification, mark_turn_failed, process_stream_item, RuntimeUsageContext,
+    emit_runtime_notification, mark_turn_cancelled, mark_turn_failed, process_stream_item,
+    RuntimeUsageContext,
 };
-use harness_core::agent::{AgentEvent, AgentRequest, StreamItem, TurnRequest};
+use harness_core::agent::{
+    AgentDiagnosticSeverity, AgentEvent, AgentRequest, StreamItem, TurnRequest,
+};
 use harness_core::config::agents::{AgentPermissionMode, SandboxMode};
 use harness_core::config::stall_timeout::normalize_stall_timeout_secs;
 use harness_core::error::HarnessError;
@@ -44,7 +47,22 @@ pub(super) fn bridge_agent_event(
         }
         AgentEvent::TokenUsage { usage } => Some(StreamItem::TokenUsage { usage }),
         AgentEvent::Warning { message } => Some(StreamItem::Warning { message }),
+        AgentEvent::Diagnostic { severity, message } => {
+            match severity {
+                AgentDiagnosticSeverity::Warning => {
+                    tracing::warn!(agent_diagnostic = true, "{message}");
+                }
+                AgentDiagnosticSeverity::Error => {
+                    tracing::error!(
+                        agent_diagnostic = true,
+                        "non-terminal agent diagnostic: {message}"
+                    );
+                }
+            }
+            Some(StreamItem::Warning { message })
+        }
         AgentEvent::Error { message } => Some(StreamItem::Error { message }),
+        AgentEvent::TurnCancelled { message } => Some(StreamItem::TurnCancelled { message }),
         AgentEvent::TurnCompleted { output } => {
             if *emitted_agent_completion {
                 output_buf.clear();
@@ -288,6 +306,7 @@ pub(crate) async fn run_turn_lifecycle_with_options(
     let mut stream_closed = false;
     let mut execution_result: Option<harness_core::error::Result<()>> = None;
     let mut stream_error: Option<String> = None;
+    let mut stream_cancelled: Option<String> = None;
     let mut last_activity = Instant::now();
     let execution_deadline = timeout_secs.map(|secs| Instant::now() + Duration::from_secs(secs));
     let execution_timeout = async {
@@ -316,6 +335,9 @@ pub(crate) async fn run_turn_lifecycle_with_options(
                         last_activity = Instant::now();
                         if let StreamItem::Error { message } = &item {
                             stream_error.get_or_insert_with(|| message.clone());
+                        }
+                        if let StreamItem::TurnCancelled { message } = &item {
+                            stream_cancelled.get_or_insert_with(|| message.clone());
                         }
                         let budget_stop = process_stream_item(
                             &server,
@@ -433,6 +455,18 @@ pub(crate) async fn run_turn_lifecycle_with_options(
         ))
     }) {
         Ok(()) => {
+            if let Some(message) = stream_cancelled {
+                mark_turn_cancelled(
+                    &server,
+                    &notify_tx,
+                    &notification_tx,
+                    &thread_id,
+                    &turn_id,
+                    message,
+                )
+                .await;
+                return;
+            }
             if let Some(error_msg) = stream_error {
                 mark_turn_failed(
                     &server,

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle_tests.rs
@@ -7,7 +7,8 @@ use super::turn_lifecycle::{
 use crate::{server::HarnessServer, thread_manager::ThreadManager};
 use harness_agents::registry::{AdapterExecutionStrategy, AgentRegistry};
 use harness_core::agent::{
-    AgentAdapter, AgentEvent, AgentRequest, AgentResponse, CodeAgent, StreamItem, TurnRequest,
+    AgentAdapter, AgentDiagnosticSeverity, AgentEvent, AgentRequest, AgentResponse, CodeAgent,
+    StreamItem, TurnRequest,
 };
 use harness_core::config::HarnessConfig;
 use harness_core::error::HarnessError;
@@ -386,6 +387,8 @@ async fn prefired_lease_lost_still_interrupts_turn() -> anyhow::Result<()> {
 fn bridge_preserves_warning_and_token_usage_events() {
     let mut output_buf = String::new();
     let mut warning_completion = false;
+    let mut diagnostic_completion = false;
+    let mut cancelled_completion = false;
     let mut usage_completion = false;
 
     let warning = bridge_agent_event(
@@ -394,6 +397,21 @@ fn bridge_preserves_warning_and_token_usage_events() {
         },
         &mut output_buf,
         &mut warning_completion,
+    );
+    let diagnostic = bridge_agent_event(
+        AgentEvent::Diagnostic {
+            severity: AgentDiagnosticSeverity::Error,
+            message: "provider diagnostic".into(),
+        },
+        &mut output_buf,
+        &mut diagnostic_completion,
+    );
+    let cancelled = bridge_agent_event(
+        AgentEvent::TurnCancelled {
+            message: "interrupted".into(),
+        },
+        &mut output_buf,
+        &mut cancelled_completion,
     );
     let usage = bridge_agent_event(
         AgentEvent::TokenUsage {
@@ -412,6 +430,18 @@ fn bridge_preserves_warning_and_token_usage_events() {
         warning,
         Some(StreamItem::Warning {
             message: "careful".into()
+        })
+    );
+    assert_eq!(
+        diagnostic,
+        Some(StreamItem::Warning {
+            message: "provider diagnostic".into()
+        })
+    );
+    assert_eq!(
+        cancelled,
+        Some(StreamItem::TurnCancelled {
+            message: "interrupted".into()
         })
     );
     assert_eq!(


### PR DESCRIPTION
## Problem

Codex app-server warning and error notifications were treated as terminal turn failures. A non-fatal diagnostic could therefore stop the active turn, and provider-specific warning text had to be hardcoded later to rescue selected failures. Ordinary task failures could also open the shared runtime-profile circuit breaker and pause unrelated concurrent work.

## Changes

- add typed diagnostic and cancellation events to the agent stream
- parse Codex `turn/completed.status` as the lifecycle source of truth
- keep warning and error notifications non-terminal
- handle interrupted turns as cancellation and fail closed on missing or unknown statuses
- remove provider-message allowlists and stale structured-result failure rescue
- restrict the shared circuit breaker to quota waits and zero-output spawn failures
- add regression coverage for diagnostic continuation, cancellation, failure handling, and 20 concurrent task failures

## Test plan

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --package harness-agents`
- `cargo test -p harness-workflow --lib -- --skip runtime::tests::remote_host_lease`
- database-independent pre-push test suite

## Review

Fresh-context independent review: `APPROVED`.
