### PR TITLE
feat(workflow): unblock dependency-gated issue workflows

### DIFF
--- a/crates/harness-server/src/handlers/operator_monitor.rs
+++ b/crates/harness-server/src/handlers/operator_monitor.rs
@@ -5,6 +5,7 @@
 //! questions across workflow runtime state, legacy task rows, failures, and
 //! worktrees.
 
+mod actions;
 mod activity;
 mod driverless_progress;
 mod response;
@@ -16,6 +17,7 @@ use crate::runtime_projection::{
     RuntimeStoppedStateProjection, RuntimeWorkflowProjection,
 };
 use crate::task_runner::{RecentFailureTask, SchedulerAuthorityState, TaskSummary};
+use actions::{operator_actions, workflow_action_kind};
 use activity::{runtime_workflow_counts, source_activity, RuntimeWorkflowCounts, SourceActivity};
 use chrono::{DateTime, Utc};
 use harness_workflow::runtime::{WorkflowInstance, WorkflowRuntimeStore, WorkflowTerminalState};
@@ -46,7 +48,12 @@ const MAX_OPERATOR_ACTIONS: usize = 40;
 const MAX_FAILURE_GROUPS: usize = 20;
 const MAX_RECENT_FAILURES: i64 = 100;
 const STALLED_AFTER_MINS: u64 = 30;
-const OPERATOR_ACTION_STATES: &[&str] = &["ready_to_merge", "awaiting_feedback", "blocked"];
+const OPERATOR_ACTION_STATES: &[&str] = &[
+    "ready_to_merge",
+    "awaiting_feedback",
+    "blocked",
+    "awaiting_dependencies",
+];
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct OperatorMonitorPayload {
@@ -472,116 +479,6 @@ fn filter_workflow_backed_tasks(
         .into_iter()
         .filter(|task| !workflow_task_ids.contains(task.id.as_str()))
         .collect()
-}
-
-fn operator_actions(
-    workflows: &[WorkflowInstance],
-    generated_at: DateTime<Utc>,
-    stopped_eligibility: &HashMap<String, RuntimeStoppedActionEligibility>,
-) -> Vec<OperatorAction> {
-    let mut actions = Vec::new();
-    for workflow in workflows {
-        let Some(kind) = workflow_action_kind(workflow) else {
-            continue;
-        };
-        let projection = RuntimeWorkflowProjection::from_workflow_with_stopped_eligibility(
-            workflow,
-            stopped_eligibility
-                .get(&workflow.id)
-                .copied()
-                .unwrap_or_default(),
-        );
-        let next_action = workflow_next_action(kind, &projection.stopped_state);
-        let task_id = projection
-            .legacy_dedupe_task_handle
-            .as_ref()
-            .map(|task_id| task_id.0.clone())
-            .or_else(|| {
-                projection
-                    .submission_handle
-                    .as_ref()
-                    .map(|task_id| task_id.as_str().to_string())
-            });
-        let repo = string_field(&workflow.data, "repo");
-        let issue = u64_field(&workflow.data, "issue_number");
-        let pr = u64_field(&workflow.data, "pr_number");
-        let pr_url = string_field(&workflow.data, "pr_url");
-        let issue_url = repo
-            .as_ref()
-            .zip(issue)
-            .map(|(repo, issue)| format!("https://github.com/{repo}/issues/{issue}"));
-        actions.push(OperatorAction {
-            kind,
-            repo,
-            issue,
-            pr,
-            evidence_url: task_id
-                .as_ref()
-                .map(|id| format!("/api/workflows/runtime/submissions/{id}")),
-            task_id,
-            workflow_id: workflow.id.clone(),
-            state: workflow.state.clone(),
-            age_secs: generated_at
-                .signed_duration_since(workflow.updated_at)
-                .num_seconds()
-                .max(0) as u64,
-            url: pr_url.or(issue_url),
-            next_action,
-            source: workflow_source(workflow),
-            stopped_state: projection.stopped_state,
-        });
-    }
-    actions.sort_by(|a, b| {
-        action_priority(a.kind)
-            .cmp(&action_priority(b.kind))
-            .then_with(|| b.age_secs.cmp(&a.age_secs))
-    });
-    actions.truncate(MAX_OPERATOR_ACTIONS);
-    actions
-}
-
-fn workflow_action_kind(workflow: &WorkflowInstance) -> Option<&'static str> {
-    if workflow.terminal_state() == Some(WorkflowTerminalState::Failed) {
-        return Some("failed");
-    }
-    if harness_workflow::runtime::declarative_workflow_definition_for_instance(workflow).is_some() {
-        return harness_workflow::runtime::workflow_state_definition_for_instance(
-            workflow,
-            &workflow.state,
-        )
-        .is_some_and(|state| {
-            state.progress_mode
-                == Some(harness_workflow::runtime::WorkflowProgressMode::OperatorGate)
-        })
-        .then_some("blocked");
-    }
-    match workflow.state.as_str() {
-        "ready_to_merge" => Some("ready_to_merge"),
-        "awaiting_feedback" => Some("awaiting_feedback"),
-        "blocked" => Some("blocked"),
-        _ => None,
-    }
-}
-
-fn workflow_next_action(kind: &str, stopped_state: &RuntimeStoppedStateProjection) -> &'static str {
-    match kind {
-        "ready_to_merge" => "Review and merge",
-        "awaiting_feedback" => "Inspect review feedback",
-        "blocked" => "Resolve blocker",
-        "failed" if stopped_state.can_retry => "Retry failed workflow",
-        "failed" => "Inspect failed workflow",
-        _ => "Inspect workflow",
-    }
-}
-
-fn action_priority(kind: &str) -> u8 {
-    match kind {
-        "ready_to_merge" => 0,
-        "blocked" => 1,
-        "failed" => 2,
-        "awaiting_feedback" => 3,
-        _ => 3,
-    }
 }
 
 fn grouped_failures(

--- a/crates/harness-server/src/handlers/operator_monitor/actions.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/actions.rs
@@ -1,0 +1,130 @@
+use super::{string_field, u64_field, workflow_source, OperatorAction};
+use crate::runtime_projection::{
+    RuntimeStoppedActionEligibility, RuntimeStoppedStateProjection, RuntimeWorkflowProjection,
+};
+use chrono::{DateTime, Utc};
+use harness_workflow::runtime::{
+    WorkflowInstance, WorkflowTerminalState, GITHUB_ISSUE_PR_DEFINITION_ID,
+};
+use std::collections::HashMap;
+
+pub(super) fn operator_actions(
+    workflows: &[WorkflowInstance],
+    generated_at: DateTime<Utc>,
+    stopped_eligibility: &HashMap<String, RuntimeStoppedActionEligibility>,
+) -> Vec<OperatorAction> {
+    let mut actions = Vec::new();
+    for workflow in workflows {
+        let eligibility = stopped_eligibility
+            .get(&workflow.id)
+            .copied()
+            .unwrap_or_default();
+        let kind = if workflow.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID
+            && workflow.state == "awaiting_dependencies"
+        {
+            eligibility.can_unblock.then_some("blocked")
+        } else {
+            workflow_action_kind(workflow)
+        };
+        let Some(kind) = kind else { continue };
+        let projection = RuntimeWorkflowProjection::from_workflow_with_stopped_eligibility(
+            workflow,
+            eligibility,
+        );
+        let next_action = workflow_next_action(kind, &projection.stopped_state);
+        let task_id = projection
+            .legacy_dedupe_task_handle
+            .as_ref()
+            .map(|task_id| task_id.0.clone())
+            .or_else(|| {
+                projection
+                    .submission_handle
+                    .as_ref()
+                    .map(|task_id| task_id.as_str().to_string())
+            });
+        let repo = string_field(&workflow.data, "repo");
+        let issue = u64_field(&workflow.data, "issue_number");
+        let pr = u64_field(&workflow.data, "pr_number");
+        let pr_url = string_field(&workflow.data, "pr_url");
+        let issue_url = repo
+            .as_ref()
+            .zip(issue)
+            .map(|(repo, issue)| format!("https://github.com/{repo}/issues/{issue}"));
+        actions.push(OperatorAction {
+            kind,
+            repo,
+            issue,
+            pr,
+            evidence_url: task_id
+                .as_ref()
+                .map(|id| format!("/api/workflows/runtime/submissions/{id}")),
+            task_id,
+            workflow_id: workflow.id.clone(),
+            state: workflow.state.clone(),
+            age_secs: generated_at
+                .signed_duration_since(workflow.updated_at)
+                .num_seconds()
+                .max(0) as u64,
+            url: pr_url.or(issue_url),
+            next_action,
+            source: workflow_source(workflow),
+            stopped_state: projection.stopped_state,
+        });
+    }
+    actions.sort_by(|a, b| {
+        action_priority(a.kind)
+            .cmp(&action_priority(b.kind))
+            .then_with(|| b.age_secs.cmp(&a.age_secs))
+    });
+    actions.truncate(super::MAX_OPERATOR_ACTIONS);
+    actions
+}
+
+pub(super) fn workflow_action_kind(workflow: &WorkflowInstance) -> Option<&'static str> {
+    if workflow.terminal_state() == Some(WorkflowTerminalState::Failed) {
+        return Some("failed");
+    }
+    if workflow.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID
+        && workflow.state == "awaiting_dependencies"
+    {
+        return Some("blocked");
+    }
+    if harness_workflow::runtime::declarative_workflow_definition_for_instance(workflow).is_some() {
+        return harness_workflow::runtime::workflow_state_definition_for_instance(
+            workflow,
+            &workflow.state,
+        )
+        .is_some_and(|state| {
+            state.progress_mode
+                == Some(harness_workflow::runtime::WorkflowProgressMode::OperatorGate)
+        })
+        .then_some("blocked");
+    }
+    match workflow.state.as_str() {
+        "ready_to_merge" => Some("ready_to_merge"),
+        "awaiting_feedback" => Some("awaiting_feedback"),
+        "blocked" => Some("blocked"),
+        _ => None,
+    }
+}
+
+fn workflow_next_action(kind: &str, stopped_state: &RuntimeStoppedStateProjection) -> &'static str {
+    match kind {
+        "ready_to_merge" => "Review and merge",
+        "awaiting_feedback" => "Inspect review feedback",
+        "blocked" => "Resolve blocker",
+        "failed" if stopped_state.can_retry => "Retry failed workflow",
+        "failed" => "Inspect failed workflow",
+        _ => "Inspect workflow",
+    }
+}
+
+fn action_priority(kind: &str) -> u8 {
+    match kind {
+        "ready_to_merge" => 0,
+        "blocked" => 1,
+        "failed" => 2,
+        "awaiting_feedback" => 3,
+        _ => 3,
+    }
+}

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -105,6 +105,28 @@ fn workflow_sample_truncation_preserves_operator_action_and_failed_states() {
 }
 
 #[test]
+fn workflow_sample_truncation_preserves_github_dependency_waits() {
+    let base = Utc::now();
+    let mut workflows = (0..500)
+        .map(|index| {
+            let mut workflow = workflow("checking", json!({})).with_id(format!("checking-{index}"));
+            workflow.updated_at = base + chrono::Duration::seconds(index);
+            workflow
+        })
+        .collect::<Vec<_>>();
+    let mut dependency_wait =
+        workflow("awaiting_dependencies", json!({})).with_id("older-dependency-wait".to_string());
+    dependency_wait.updated_at = base - chrono::Duration::hours(1);
+    workflows.push(dependency_wait);
+
+    truncate_workflow_sample(&mut workflows, 500);
+
+    assert!(workflows
+        .iter()
+        .any(|workflow| workflow.id == "older-dependency-wait"));
+}
+
+#[test]
 fn workflow_sample_truncation_preserves_failed_reserve_before_operator_actions() {
     let base = Utc::now();
     let mut workflows = (0..500)
@@ -516,6 +538,47 @@ fn operator_monitor_stuck_workflows_expose_structured_stop_metadata() {
     assert_eq!(row["last_stop"]["runtime_job_id"], "job-blocked");
     assert_eq!(row["can_unblock"], true);
     assert_eq!(row["can_retry"], false);
+}
+
+#[test]
+fn operator_actions_include_only_eligible_github_dependency_waits() {
+    let eligible = workflow(
+        "awaiting_dependencies",
+        json!({"repo": "owner/repo", "issue_number": 1885}),
+    )
+    .with_id("eligible-dependency-wait".to_string());
+    let ineligible = workflow(
+        "awaiting_dependencies",
+        json!({"repo": "owner/repo", "issue_number": 1886}),
+    )
+    .with_id("ineligible-dependency-wait".to_string());
+    let unrelated = WorkflowInstance::new(
+        QUALITY_GATE_DEFINITION_ID,
+        1,
+        "awaiting_dependencies",
+        WorkflowSubject::new("issue", "issue:1887"),
+    )
+    .with_id("unrelated-external-wait".to_string());
+    let mut eligibility = std::collections::HashMap::new();
+    for workflow_id in ["eligible-dependency-wait", "unrelated-external-wait"] {
+        eligibility.insert(
+            workflow_id.to_string(),
+            RuntimeStoppedActionEligibility {
+                can_unblock: true,
+                can_retry: false,
+            },
+        );
+    }
+
+    let actions = operator_actions(&[eligible, ineligible, unrelated], Utc::now(), &eligibility);
+
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].workflow_id, "eligible-dependency-wait");
+    assert_eq!(actions[0].kind, "blocked");
+    assert_eq!(actions[0].state, "awaiting_dependencies");
+    assert_eq!(actions[0].next_action, "Resolve blocker");
+    assert!(actions[0].stopped_state.can_unblock);
+    assert!(!actions[0].stopped_state.can_retry);
 }
 
 #[test]

--- a/crates/harness-server/src/runtime_projection/stopped_actions.rs
+++ b/crates/harness-server/src/runtime_projection/stopped_actions.rs
@@ -134,6 +134,14 @@ fn stopped_action_plan(workflow: &WorkflowInstance) -> Option<StoppedActionPlan>
             legacy_fallback: true,
         });
     }
+    if workflow.state == "awaiting_dependencies" {
+        return Some(StoppedActionPlan {
+            action: StoppedRecoveryAction::Unblock,
+            target: RecoveryDispatchTarget { activity: "" },
+            runtime_job_id: None,
+            legacy_fallback: true,
+        });
+    }
     let action = match workflow.state.as_str() {
         "blocked" => StoppedRecoveryAction::Unblock,
         "failed" => StoppedRecoveryAction::Retry,

--- a/crates/harness-server/src/runtime_projection/stopped_actions.rs
+++ b/crates/harness-server/src/runtime_projection/stopped_actions.rs
@@ -146,6 +146,23 @@ fn stopped_action_plan(workflow: &WorkflowInstance) -> Option<StoppedActionPlan>
             legacy_fallback: true,
         });
     }
+    if workflow.state == "failed"
+        && workflow
+            .data
+            .get("dependency_failure_status")
+            .and_then(Value::as_str)
+            == Some("dependency_cycle")
+    {
+        if candidate_fanout_from_value(&workflow.data).is_err() {
+            return None;
+        }
+        return Some(StoppedActionPlan {
+            action: StoppedRecoveryAction::Retry,
+            target: RecoveryDispatchTarget { activity: "" },
+            runtime_job_id: None,
+            legacy_fallback: true,
+        });
+    }
     let action = match workflow.state.as_str() {
         "blocked" => StoppedRecoveryAction::Unblock,
         "failed" => StoppedRecoveryAction::Retry,
@@ -359,6 +376,25 @@ mod tests {
             },
         }));
         assert!(stopped_action_plan(&malformed).is_none());
+
+        let cycle = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "failed",
+            WorkflowSubject::new("issue", "issue:1886"),
+        )
+        .with_server_data(json!({
+            "dependency_failure_status": "dependency_cycle",
+        }));
+        assert!(stopped_action_plan(&cycle).is_some());
+        let malformed_cycle = cycle.with_server_data(json!({
+            "dependency_failure_status": "dependency_cycle",
+            "candidate_fanout": {
+                "candidate_group_id": "dependency-projection:candidate-group:issue-1886",
+                "candidate_count": "two",
+            },
+        }));
+        assert!(stopped_action_plan(&malformed_cycle).is_none());
     }
 
     #[test]

--- a/crates/harness-server/src/runtime_projection/stopped_actions.rs
+++ b/crates/harness-server/src/runtime_projection/stopped_actions.rs
@@ -1,8 +1,9 @@
 use super::{RuntimeRecoveryTargetProjection, RuntimeStoppedActionEligibility};
 use harness_workflow::runtime::{
-    workflow_declarative_definition, ActivityErrorKind, WorkflowCommand, WorkflowCommandType,
-    WorkflowInstance, WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY,
-    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
+    candidate_fanout_from_value, workflow_declarative_definition, ActivityErrorKind,
+    WorkflowCommand, WorkflowCommandType, WorkflowInstance, WorkflowRuntimeStore,
+    GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY, PR_FEEDBACK_DEFINITION_ID,
+    PR_FEEDBACK_INSPECT_ACTIVITY,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -135,6 +136,9 @@ fn stopped_action_plan(workflow: &WorkflowInstance) -> Option<StoppedActionPlan>
         });
     }
     if workflow.state == "awaiting_dependencies" {
+        if candidate_fanout_from_value(&workflow.data).is_err() {
+            return None;
+        }
         return Some(StoppedActionPlan {
             action: StoppedRecoveryAction::Unblock,
             target: RecoveryDispatchTarget { activity: "" },
@@ -327,6 +331,34 @@ mod tests {
         for payload in [Value::Null, Value::String("implement_issue".to_string())] {
             assert!(!enqueue_payload_matches_target(&payload));
         }
+    }
+
+    #[test]
+    fn dependency_projection_requires_valid_candidate_fanout() {
+        let workflow = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "awaiting_dependencies",
+            WorkflowSubject::new("issue", "issue:1885"),
+        );
+        assert!(stopped_action_plan(&workflow).is_some());
+
+        let valid = workflow.clone().with_server_data(json!({
+            "candidate_fanout": {
+                "candidate_group_id": "dependency-projection:candidate-group:issue-1885",
+                "candidate_count": 2,
+                "trigger_label": "best-of-n",
+            },
+        }));
+        assert!(stopped_action_plan(&valid).is_some());
+
+        let malformed = workflow.with_server_data(json!({
+            "candidate_fanout": {
+                "candidate_group_id": "dependency-projection:candidate-group:issue-1885",
+                "candidate_count": "two",
+            },
+        }));
+        assert!(stopped_action_plan(&malformed).is_none());
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/store/dependency_override_recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/dependency_override_recovery.rs
@@ -1,0 +1,97 @@
+use super::{
+    copy_optional_data_field, optional_string_field, recovery_prompt,
+    RecoveryDispatchCommandSource, RecoveryDispatchPlan, RecoveryDispatchTarget,
+    WorkflowRuntimeRecoveryAction, WorkflowRuntimeRecoveryRequest, RECOVERY_CONTEXT_FIELDS,
+};
+use crate::runtime::reducer::GITHUB_ISSUE_PR_DEFINITION_ID;
+use crate::runtime::{
+    candidate_fanout_from_value, WorkflowCommand, WorkflowCommandType, WorkflowInstance,
+};
+use anyhow::Context;
+use serde_json::{json, Value};
+
+pub(super) fn matches(instance: &WorkflowInstance, action: WorkflowRuntimeRecoveryAction) -> bool {
+    if instance.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID {
+        return false;
+    }
+    match (instance.state.as_str(), action) {
+        ("awaiting_dependencies", WorkflowRuntimeRecoveryAction::Unblock) => true,
+        ("failed", WorkflowRuntimeRecoveryAction::Retry) => dependency_cycle(&instance.data),
+        _ => false,
+    }
+}
+
+pub(super) fn matches_persisted_state(
+    data: &Value,
+    action: WorkflowRuntimeRecoveryAction,
+    previous_state: &str,
+) -> bool {
+    matches!(
+        (previous_state, action),
+        (
+            "awaiting_dependencies",
+            WorkflowRuntimeRecoveryAction::Unblock
+        )
+    ) || (previous_state == "failed"
+        && action == WorkflowRuntimeRecoveryAction::Retry
+        && dependency_cycle(data))
+}
+
+fn dependency_cycle(data: &Value) -> bool {
+    data.get("dependency_failure_status")
+        .and_then(Value::as_str)
+        == Some("dependency_cycle")
+}
+
+pub(super) fn dispatch_plan(
+    instance: &WorkflowInstance,
+    request: &WorkflowRuntimeRecoveryRequest<'_>,
+) -> anyhow::Result<RecoveryDispatchPlan> {
+    let force_execute = instance
+        .data
+        .get("force_execute")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let (state, activity) = if force_execute {
+        ("implementing", "implement_issue")
+    } else {
+        ("planning", "plan_issue")
+    };
+    let remote_fact_hash = optional_string_field(&instance.data, "last_remote_fact_hash");
+    let dispatch_fact_hash = remote_fact_hash.clone();
+    let mut payload = json!({
+        "activity": activity,
+        "additional_prompt": recovery_prompt::dependency_override(&instance.data, request.reason),
+        "dependency_override": {
+            "previous_state": instance.state,
+            "reason": request.reason,
+        },
+        "dispatch_gate": {
+            "reason": "operator_dependency_override",
+            "fact_hash": dispatch_fact_hash,
+        },
+        "remote_fact_hash": remote_fact_hash,
+        "submission_mode": optional_string_field(&instance.data, "submission_mode")
+            .unwrap_or_else(|| "immediate".to_string()),
+    });
+    for field in RECOVERY_CONTEXT_FIELDS {
+        copy_optional_data_field(&mut payload, &instance.data, field);
+    }
+    let candidate_fanout = candidate_fanout_from_value(&instance.data)
+        .context("invalid candidate_fanout recovery metadata")?;
+    let candidate_fanout = force_execute.then_some(candidate_fanout).flatten();
+    Ok(RecoveryDispatchPlan {
+        target: RecoveryDispatchTarget {
+            state: state.to_string(),
+            activity: Some(activity.to_string()),
+        },
+        command_source: RecoveryDispatchCommandSource::Synthetic {
+            command: WorkflowCommand::new(
+                WorkflowCommandType::EnqueueActivity,
+                "operator-dependency-override-preview",
+                payload,
+            ),
+            candidate_fanout,
+        },
+    })
+}

--- a/crates/harness-workflow/src/runtime/store/recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery.rs
@@ -42,13 +42,6 @@ impl WorkflowRuntimeRecoveryAction {
         }
     }
 
-    fn expected_state(self) -> &'static str {
-        match self {
-            Self::Unblock => "blocked",
-            Self::Retry => "failed",
-        }
-    }
-
     fn event_type(self) -> &'static str {
         match self {
             Self::Unblock => "WorkflowRuntimeUnblocked",
@@ -89,6 +82,7 @@ struct RecoveryDispatchPlan { target: RecoveryDispatchTarget, command_source: Re
 #[derive(Debug, Clone, PartialEq)]
 enum RecoveryDispatchCommandSource {
     Replay(WorkflowCommand),
+    Synthetic(WorkflowCommand),
     LegacyFallback,
     DeclarativeProgress(WorkflowCommandType),
 }
@@ -294,7 +288,7 @@ fn recovery_rejection(
         ));
     }
 
-    if instance.state != request.action.expected_state() {
+    if !recovery_action_matches_state(request.action, &instance.state) {
         return Ok(Some(WorkflowRuntimeRecoveryOutcome::WrongState {
             workflow: instance.clone(),
         }));
@@ -315,6 +309,15 @@ fn recovery_rejection(
     }
 
     Ok(None)
+}
+
+fn recovery_action_matches_state(action: WorkflowRuntimeRecoveryAction, state: &str) -> bool {
+    match action {
+        WorkflowRuntimeRecoveryAction::Unblock => {
+            matches!(state, "blocked" | "awaiting_dependencies")
+        }
+        WorkflowRuntimeRecoveryAction::Retry => state == "failed",
+    }
 }
 
 fn custom_declarative_definition(
@@ -361,6 +364,14 @@ async fn recovery_dispatch_plan_tx(
     if let Some(Ok(definition)) = custom_declarative_definition(instance) {
         return declarative_recovery_dispatch_plan(request, &definition);
     }
+    if instance.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID
+        && instance.state == "awaiting_dependencies"
+        && request.action == WorkflowRuntimeRecoveryAction::Unblock
+    {
+        return Ok(Ok(awaiting_dependencies_recovery_dispatch_plan(
+            instance, request,
+        )));
+    }
     validate_stopped_metadata(&instance.data)?;
     let activity = stopped_activity(&instance.data)?;
     let target = match recovery_dispatch_target(&instance.data, activity.as_deref())? {
@@ -389,6 +400,56 @@ async fn recovery_dispatch_plan_tx(
         target: target.clone(),
         command_source,
     }))
+}
+
+fn awaiting_dependencies_recovery_dispatch_plan(
+    instance: &WorkflowInstance,
+    request: &WorkflowRuntimeRecoveryRequest<'_>,
+) -> RecoveryDispatchPlan {
+    let force_execute = instance
+        .data
+        .get("force_execute")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let (state, activity) = if force_execute {
+        ("implementing", "implement_issue")
+    } else {
+        ("planning", "plan_issue")
+    };
+    let remote_fact_hash = optional_string_field(&instance.data, "last_remote_fact_hash");
+    let dispatch_fact_hash = remote_fact_hash.clone();
+    let mut payload = json!({
+        "activity": activity,
+        "additional_prompt": format!(
+            "Operator requested workflow runtime unblock after overriding the dependency gate. Recovery reason: {}",
+            request.reason
+        ),
+        "dependency_override": {
+            "previous_state": instance.state,
+            "reason": request.reason,
+        },
+        "dispatch_gate": {
+            "reason": "operator_dependency_override",
+            "fact_hash": dispatch_fact_hash,
+        },
+        "remote_fact_hash": remote_fact_hash,
+        "submission_mode": optional_string_field(&instance.data, "submission_mode")
+            .unwrap_or_else(|| "immediate".to_string()),
+    });
+    for field in RECOVERY_CONTEXT_FIELDS {
+        copy_optional_data_field(&mut payload, &instance.data, field);
+    }
+    RecoveryDispatchPlan {
+        target: RecoveryDispatchTarget {
+            state: state.to_string(),
+            activity: Some(activity.to_string()),
+        },
+        command_source: RecoveryDispatchCommandSource::Synthetic(WorkflowCommand::new(
+            WorkflowCommandType::EnqueueActivity,
+            "operator-dependency-override-preview",
+            payload,
+        )),
+    }
 }
 
 fn declarative_recovery_dispatch_plan(
@@ -606,7 +667,7 @@ fn persist_operator_recovery_data(
     // A successful recovery ends the stop episode. Stop classification and
     // auto-recovery state must not leak into later terminal history or keep
     // recovered transcript dependency families pinned.
-    instance.apply_data_writes([
+    let mut writes = vec![
         crate::runtime::WorkflowDataWrite::remove(
             "auto_recovery",
             crate::runtime::DataProvenance::Server,
@@ -639,7 +700,27 @@ fn persist_operator_recovery_data(
             }),
             crate::runtime::DataProvenance::Server,
         ),
-    ])
+    ];
+    if previous_state == "awaiting_dependencies" {
+        writes.push(crate::runtime::WorkflowDataWrite::set(
+            "dependencies_blocked",
+            json!(false),
+            crate::runtime::DataProvenance::Server,
+        ));
+        writes.push(crate::runtime::WorkflowDataWrite::set(
+            "dependency_override",
+            json!({
+                "action": action.as_str(),
+                "reason": reason,
+                "actor": actor,
+                "previous_state": previous_state,
+                "state": state,
+                "event_id": event_id,
+            }),
+            crate::runtime::DataProvenance::Server,
+        ));
+    }
+    instance.apply_data_writes(writes)
 }
 
 fn recovery_dispatch_decision(
@@ -683,7 +764,9 @@ fn recovery_dispatch_command(
         instance.id,
         event_id
     );
-    if let RecoveryDispatchCommandSource::Replay(command) = &plan.command_source {
+    if let RecoveryDispatchCommandSource::Replay(command)
+    | RecoveryDispatchCommandSource::Synthetic(command) = &plan.command_source
+    {
         let mut command = command.clone();
         command.dedupe_key = dedupe_key;
         return command;

--- a/crates/harness-workflow/src/runtime/store/recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery.rs
@@ -23,10 +23,12 @@ use crate::runtime::state_registry::{
 use crate::runtime::status::WorkflowCommandStatus;
 use crate::runtime::submission::append_candidate_commands;
 use crate::runtime::validator::ValidationContext;
-use crate::runtime::{candidate_fanout_from_value, CandidateFanoutRequest};
+use crate::runtime::CandidateFanoutRequest;
 use anyhow::{bail, Context};
 use serde_json::{json, Value};
 
+#[path = "dependency_override_recovery.rs"]
+mod dependency_override_recovery;
 #[path = "recovery_prompt.rs"]
 mod recovery_prompt;
 #[path = "recovery_validation.rs"]
@@ -371,11 +373,8 @@ async fn recovery_dispatch_plan_tx(
     if let Some(Ok(definition)) = custom_declarative_definition(instance) {
         return declarative_recovery_dispatch_plan(request, &definition);
     }
-    if instance.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID
-        && instance.state == "awaiting_dependencies"
-        && request.action == WorkflowRuntimeRecoveryAction::Unblock
-    {
-        return Ok(Ok(awaiting_dependencies_recovery_dispatch_plan(
+    if dependency_override_recovery::matches(instance, request.action) {
+        return Ok(Ok(dependency_override_recovery::dispatch_plan(
             instance, request,
         )?));
     }
@@ -407,59 +406,6 @@ async fn recovery_dispatch_plan_tx(
         target: target.clone(),
         command_source,
     }))
-}
-
-fn awaiting_dependencies_recovery_dispatch_plan(
-    instance: &WorkflowInstance,
-    request: &WorkflowRuntimeRecoveryRequest<'_>,
-) -> anyhow::Result<RecoveryDispatchPlan> {
-    let force_execute = instance
-        .data
-        .get("force_execute")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let (state, activity) = if force_execute {
-        ("implementing", "implement_issue")
-    } else {
-        ("planning", "plan_issue")
-    };
-    let remote_fact_hash = optional_string_field(&instance.data, "last_remote_fact_hash");
-    let dispatch_fact_hash = remote_fact_hash.clone();
-    let mut payload = json!({
-        "activity": activity,
-        "additional_prompt": recovery_prompt::dependency_override(&instance.data, request.reason),
-        "dependency_override": {
-            "previous_state": instance.state,
-            "reason": request.reason,
-        },
-        "dispatch_gate": {
-            "reason": "operator_dependency_override",
-            "fact_hash": dispatch_fact_hash,
-        },
-        "remote_fact_hash": remote_fact_hash,
-        "submission_mode": optional_string_field(&instance.data, "submission_mode")
-            .unwrap_or_else(|| "immediate".to_string()),
-    });
-    for field in RECOVERY_CONTEXT_FIELDS {
-        copy_optional_data_field(&mut payload, &instance.data, field);
-    }
-    let candidate_fanout = candidate_fanout_from_value(&instance.data)
-        .context("invalid candidate_fanout recovery metadata")?;
-    let candidate_fanout = force_execute.then_some(candidate_fanout).flatten();
-    Ok(RecoveryDispatchPlan {
-        target: RecoveryDispatchTarget {
-            state: state.to_string(),
-            activity: Some(activity.to_string()),
-        },
-        command_source: RecoveryDispatchCommandSource::Synthetic {
-            command: WorkflowCommand::new(
-                WorkflowCommandType::EnqueueActivity,
-                "operator-dependency-override-preview",
-                payload,
-            ),
-            candidate_fanout,
-        },
-    })
 }
 
 fn declarative_recovery_dispatch_plan(
@@ -711,10 +657,15 @@ fn persist_operator_recovery_data(
             crate::runtime::DataProvenance::Server,
         ),
     ];
-    if previous_state == "awaiting_dependencies" {
+    if dependency_override_recovery::matches_persisted_state(&instance.data, action, previous_state)
+    {
         writes.push(crate::runtime::WorkflowDataWrite::set(
             "dependencies_blocked",
             json!(false),
+            crate::runtime::DataProvenance::Server,
+        ));
+        writes.push(crate::runtime::WorkflowDataWrite::remove(
+            "dependency_failure_status",
             crate::runtime::DataProvenance::Server,
         ));
         writes.push(crate::runtime::WorkflowDataWrite::set(

--- a/crates/harness-workflow/src/runtime/store/recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery.rs
@@ -443,11 +443,9 @@ fn awaiting_dependencies_recovery_dispatch_plan(
     for field in RECOVERY_CONTEXT_FIELDS {
         copy_optional_data_field(&mut payload, &instance.data, field);
     }
-    let candidate_fanout = if force_execute {
-        candidate_fanout_from_value(&instance.data)?
-    } else {
-        None
-    };
+    let candidate_fanout = candidate_fanout_from_value(&instance.data)
+        .context("invalid candidate_fanout recovery metadata")?;
+    let candidate_fanout = force_execute.then_some(candidate_fanout).flatten();
     Ok(RecoveryDispatchPlan {
         target: RecoveryDispatchTarget {
             state: state.to_string(),

--- a/crates/harness-workflow/src/runtime/store/recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery.rs
@@ -27,6 +27,8 @@ use crate::runtime::{candidate_fanout_from_value, CandidateFanoutRequest};
 use anyhow::{bail, Context};
 use serde_json::{json, Value};
 
+#[path = "recovery_prompt.rs"]
+mod recovery_prompt;
 #[path = "recovery_validation.rs"]
 mod recovery_validation;
 
@@ -425,10 +427,7 @@ fn awaiting_dependencies_recovery_dispatch_plan(
     let dispatch_fact_hash = remote_fact_hash.clone();
     let mut payload = json!({
         "activity": activity,
-        "additional_prompt": format!(
-            "Operator requested workflow runtime unblock after overriding the dependency gate. Recovery reason: {}",
-            request.reason
-        ),
+        "additional_prompt": recovery_prompt::dependency_override(&instance.data, request.reason),
         "dependency_override": {
             "previous_state": instance.state,
             "reason": request.reason,

--- a/crates/harness-workflow/src/runtime/store/recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery.rs
@@ -21,7 +21,9 @@ use crate::runtime::state_registry::{
     DeclarativeDefinitionPinError, DeclarativeDefinitionResolution, WorkflowProgressMode,
 };
 use crate::runtime::status::WorkflowCommandStatus;
+use crate::runtime::submission::append_candidate_commands;
 use crate::runtime::validator::ValidationContext;
+use crate::runtime::{candidate_fanout_from_value, CandidateFanoutRequest};
 use anyhow::{bail, Context};
 use serde_json::{json, Value};
 
@@ -82,7 +84,10 @@ struct RecoveryDispatchPlan { target: RecoveryDispatchTarget, command_source: Re
 #[derive(Debug, Clone, PartialEq)]
 enum RecoveryDispatchCommandSource {
     Replay(WorkflowCommand),
-    Synthetic(WorkflowCommand),
+    Synthetic {
+        command: WorkflowCommand,
+        candidate_fanout: Option<CandidateFanoutRequest>,
+    },
     LegacyFallback,
     DeclarativeProgress(WorkflowCommandType),
 }
@@ -370,7 +375,7 @@ async fn recovery_dispatch_plan_tx(
     {
         return Ok(Ok(awaiting_dependencies_recovery_dispatch_plan(
             instance, request,
-        )));
+        )?));
     }
     validate_stopped_metadata(&instance.data)?;
     let activity = stopped_activity(&instance.data)?;
@@ -405,7 +410,7 @@ async fn recovery_dispatch_plan_tx(
 fn awaiting_dependencies_recovery_dispatch_plan(
     instance: &WorkflowInstance,
     request: &WorkflowRuntimeRecoveryRequest<'_>,
-) -> RecoveryDispatchPlan {
+) -> anyhow::Result<RecoveryDispatchPlan> {
     let force_execute = instance
         .data
         .get("force_execute")
@@ -439,17 +444,25 @@ fn awaiting_dependencies_recovery_dispatch_plan(
     for field in RECOVERY_CONTEXT_FIELDS {
         copy_optional_data_field(&mut payload, &instance.data, field);
     }
-    RecoveryDispatchPlan {
+    let candidate_fanout = if force_execute {
+        candidate_fanout_from_value(&instance.data)?
+    } else {
+        None
+    };
+    Ok(RecoveryDispatchPlan {
         target: RecoveryDispatchTarget {
             state: state.to_string(),
             activity: Some(activity.to_string()),
         },
-        command_source: RecoveryDispatchCommandSource::Synthetic(WorkflowCommand::new(
-            WorkflowCommandType::EnqueueActivity,
-            "operator-dependency-override-preview",
-            payload,
-        )),
-    }
+        command_source: RecoveryDispatchCommandSource::Synthetic {
+            command: WorkflowCommand::new(
+                WorkflowCommandType::EnqueueActivity,
+                "operator-dependency-override-preview",
+                payload,
+            ),
+            candidate_fanout,
+        },
+    })
 }
 
 fn declarative_recovery_dispatch_plan(
@@ -732,7 +745,7 @@ fn recovery_dispatch_decision(
     event_id: &str,
     evidence: &[WorkflowEvidence],
 ) -> WorkflowDecision {
-    let mut decision = WorkflowDecision::new(
+    let decision = WorkflowDecision::new(
         &instance.id,
         previous_state,
         format!("operator_runtime_{}", action.as_str()),
@@ -741,10 +754,14 @@ fn recovery_dispatch_decision(
             "operator requested workflow runtime {} after resolving the stopped condition",
             action.as_str()
         ),
-    )
-    .with_command(recovery_dispatch_command(
-        instance, action, reason, plan, event_id,
-    ));
+    );
+    let command = recovery_dispatch_command(instance, action, reason, plan, event_id);
+    let mut decision = match &plan.command_source {
+        RecoveryDispatchCommandSource::Synthetic {
+            candidate_fanout, ..
+        } => append_candidate_commands(decision, command, candidate_fanout.as_ref()),
+        _ => decision.with_command(command),
+    };
     for item in evidence {
         decision = decision.with_evidence(item.clone());
     }
@@ -764,9 +781,12 @@ fn recovery_dispatch_command(
         instance.id,
         event_id
     );
-    if let RecoveryDispatchCommandSource::Replay(command)
-    | RecoveryDispatchCommandSource::Synthetic(command) = &plan.command_source
-    {
+    if let RecoveryDispatchCommandSource::Replay(command) = &plan.command_source {
+        let mut command = command.clone();
+        command.dedupe_key = dedupe_key;
+        return command;
+    }
+    if let RecoveryDispatchCommandSource::Synthetic { command, .. } = &plan.command_source {
         let mut command = command.clone();
         command.dedupe_key = dedupe_key;
         return command;

--- a/crates/harness-workflow/src/runtime/store/recovery_prompt.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery_prompt.rs
@@ -1,0 +1,11 @@
+use serde_json::Value;
+
+pub(super) fn dependency_override(data: &Value, reason: &str) -> String {
+    let recovery = format!(
+        "Operator requested workflow runtime unblock after overriding the dependency gate. Recovery reason: {reason}"
+    );
+    data.get("additional_prompt")
+        .and_then(Value::as_str)
+        .filter(|prompt| !prompt.trim().is_empty())
+        .map_or(recovery.clone(), |prompt| format!("{prompt}\n\n{recovery}"))
+}

--- a/crates/harness-workflow/src/runtime/store/recovery_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery_tests.rs
@@ -4,6 +4,7 @@ use crate::runtime::model::{WorkflowEvidence, WorkflowSubject};
 use harness_core::config::workflow::{
     DeclaredProgressMode, DeclaredState, WorkflowActivityPolicy, WorkflowDefinitionPolicy,
 };
+use serde_json::json;
 use std::collections::BTreeMap;
 
 fn definition() -> crate::runtime::declarative::DeclarativeWorkflowDefinition {
@@ -167,4 +168,95 @@ fn declarative_recovery_builds_exact_progress_driver_and_preserves_evidence() {
         WorkflowCommandType::EnqueueActivity
     );
     assert_eq!(decision.commands[0].activity_name(), Some("run"));
+}
+
+#[test]
+fn dependency_gate_recovery_builds_override_plan_and_evidence() {
+    for (force_execute, expected_state, expected_activity) in [
+        (false, "planning", "plan_issue"),
+        (true, "implementing", "implement_issue"),
+    ] {
+        let mut instance = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "awaiting_dependencies",
+            WorkflowSubject::new("issue", "issue:1885"),
+        )
+        .with_id(format!("dependency-override-{force_execute}"))
+        .with_server_data(json!({
+            "project_id": "/project-a",
+            "repo": "owner/repo",
+            "issue_number": 1885,
+            "task_id": "github-issue:owner/repo:issue:1885",
+            "source": "github",
+            "external_id": "1885",
+            "depends_on": ["github-issue:owner/repo:issue:1884"],
+            "dependencies_blocked": true,
+            "force_execute": force_execute,
+            "last_remote_fact_hash": "sha256:abc",
+        }));
+        let request = WorkflowRuntimeRecoveryRequest {
+            workflow_id: "dependency-override",
+            action: WorkflowRuntimeRecoveryAction::Unblock,
+            reason: "operator approved dependency override",
+            actor: "operator",
+            target_state: None,
+            evidence: &[],
+        };
+
+        assert!(recovery_rejection(&instance, &request)
+            .expect("rejection check should parse")
+            .is_none());
+
+        let plan = awaiting_dependencies_recovery_dispatch_plan(&instance, &request);
+        assert_eq!(plan.target.state, expected_state);
+        assert_eq!(plan.target.activity.as_deref(), Some(expected_activity));
+        let command = recovery_dispatch_command(
+            &instance,
+            WorkflowRuntimeRecoveryAction::Unblock,
+            request.reason,
+            &plan,
+            "event-one",
+        );
+        assert_eq!(command.command_type, WorkflowCommandType::EnqueueActivity);
+        assert_eq!(command.activity_name(), Some(expected_activity));
+        assert_eq!(command.command["issue_number"], 1885);
+        assert_eq!(
+            command.command["dispatch_gate"]["reason"],
+            "operator_dependency_override"
+        );
+        assert_eq!(command.command["dispatch_gate"]["fact_hash"], "sha256:abc");
+        assert!(command.command["additional_prompt"]
+            .as_str()
+            .is_some_and(|prompt| prompt.contains("overriding the dependency gate")));
+
+        persist_operator_recovery_data(
+            &mut instance,
+            WorkflowRuntimeRecoveryAction::Unblock,
+            request.reason,
+            request.actor,
+            "awaiting_dependencies",
+            expected_state,
+            "event-one",
+        )
+        .expect("operator recovery data should persist");
+        assert_eq!(instance.data["dependencies_blocked"], false);
+        assert_eq!(instance.data["dependency_override"]["action"], "unblock");
+        assert_eq!(
+            instance.data["dependency_override"]["previous_state"],
+            "awaiting_dependencies"
+        );
+        assert_eq!(
+            instance.data["dependency_override"]["state"],
+            expected_state
+        );
+        assert_eq!(
+            instance.data["dependency_override"]["event_id"],
+            "event-one"
+        );
+        assert_eq!(
+            instance.data["last_operator_recovery"]["previous_state"],
+            "awaiting_dependencies"
+        );
+    }
 }

--- a/crates/harness-workflow/src/runtime/store/recovery_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery_tests.rs
@@ -209,7 +209,7 @@ fn dependency_gate_recovery_builds_override_plan_and_evidence() {
             .expect("rejection check should parse")
             .is_none());
 
-        let plan = awaiting_dependencies_recovery_dispatch_plan(&instance, &request)
+        let plan = dependency_override_recovery::dispatch_plan(&instance, &request)
             .expect("dependency override plan should build");
         assert_eq!(plan.target.state, expected_state);
         assert_eq!(plan.target.activity.as_deref(), Some(expected_activity));
@@ -267,6 +267,120 @@ fn dependency_gate_recovery_builds_override_plan_and_evidence() {
 }
 
 #[test]
+fn dependency_cycle_retry_builds_override_plan_and_cleans_failure_marker() {
+    for (force_execute, expected_state, expected_activity) in [
+        (false, "planning", "plan_issue"),
+        (true, "implementing", "implement_issue"),
+    ] {
+        let mut instance = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "failed",
+            WorkflowSubject::new("issue", "issue:1885"),
+        )
+        .with_id(format!("dependency-cycle-retry-{force_execute}"))
+        .with_server_data(json!({
+            "project_id": "/project-a",
+            "issue_number": 1885,
+            "dependencies_blocked": true,
+            "dependency_failure_status": "dependency_cycle",
+            "force_execute": force_execute,
+        }));
+        let request = WorkflowRuntimeRecoveryRequest {
+            workflow_id: "dependency-cycle-retry",
+            action: WorkflowRuntimeRecoveryAction::Retry,
+            reason: "operator approved dependency override",
+            actor: "operator",
+            target_state: None,
+            evidence: &[],
+        };
+
+        assert!(recovery_rejection(&instance, &request)
+            .expect("rejection check should parse")
+            .is_none());
+        assert!(dependency_override_recovery::matches(
+            &instance,
+            request.action
+        ));
+        let plan = dependency_override_recovery::dispatch_plan(&instance, &request)
+            .expect("cycle retry plan should build");
+        assert_eq!(plan.target.state, expected_state);
+        assert_eq!(plan.target.activity.as_deref(), Some(expected_activity));
+        let decision = recovery_dispatch_decision(
+            &instance,
+            request.action,
+            request.reason,
+            "failed",
+            &plan,
+            "event-one",
+            &[],
+        );
+        assert_eq!(decision.decision, "operator_runtime_retry");
+        assert!(decision.commands[0]
+            .dedupe_key
+            .starts_with("operator-recovery:retry:"));
+        validator_for_instance(&instance)
+            .expect("validator lookup should succeed")
+            .expect("GitHub issue workflow should have a validator")
+            .validate(
+                &instance,
+                &decision,
+                &ValidationContext::new("workflow_runtime_operator_action", chrono::Utc::now())
+                    .allow_terminal_reopen(),
+            )
+            .expect("cycle retry should be a valid terminal reopen");
+
+        persist_operator_recovery_data(
+            &mut instance,
+            request.action,
+            request.reason,
+            request.actor,
+            "failed",
+            expected_state,
+            "event-one",
+        )
+        .expect("operator recovery data should persist");
+        assert_eq!(instance.data["dependencies_blocked"], false);
+        assert_eq!(instance.data["dependency_override"]["action"], "retry");
+        assert_eq!(
+            instance.data["dependency_override"]["previous_state"],
+            "failed"
+        );
+        assert_eq!(instance.data["last_operator_recovery"]["action"], "retry");
+        assert_eq!(
+            instance.data["last_operator_recovery"]["previous_state"],
+            "failed"
+        );
+        assert!(instance.data.get("dependency_failure_status").is_none());
+    }
+
+    let malformed = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "failed",
+        WorkflowSubject::new("issue", "issue:1886"),
+    )
+    .with_server_data(json!({
+        "dependency_failure_status": "dependency_cycle",
+        "candidate_fanout": {
+            "candidate_group_id": "dependency-cycle-malformed",
+            "candidate_count": "two",
+        },
+    }));
+    let request = WorkflowRuntimeRecoveryRequest {
+        workflow_id: "dependency-cycle-malformed",
+        action: WorkflowRuntimeRecoveryAction::Retry,
+        reason: "operator approved dependency override",
+        actor: "operator",
+        target_state: None,
+        evidence: &[],
+    };
+    let error = dependency_override_recovery::dispatch_plan(&malformed, &request)
+        .expect_err("malformed cycle fan-out must fail before recovery mutation");
+    assert!(error.to_string().contains("candidate_fanout"));
+}
+
+#[test]
 fn dependency_gate_recovery_preserves_candidate_fanout_for_force_execute() -> anyhow::Result<()> {
     let mut instance = WorkflowInstance::new(
         GITHUB_ISSUE_PR_DEFINITION_ID,
@@ -302,7 +416,7 @@ fn dependency_gate_recovery_preserves_candidate_fanout_for_force_execute() -> an
         evidence: &[],
     };
 
-    let plan = awaiting_dependencies_recovery_dispatch_plan(&instance, &request)
+    let plan = dependency_override_recovery::dispatch_plan(&instance, &request)
         .expect("dependency override plan should build");
     let decision = recovery_dispatch_decision(
         &instance,
@@ -386,7 +500,7 @@ fn dependency_gate_recovery_validates_candidate_fanout_before_planning() {
         evidence: &[],
     };
 
-    let error = awaiting_dependencies_recovery_dispatch_plan(&instance, &request)
+    let error = dependency_override_recovery::dispatch_plan(&instance, &request)
         .expect_err("malformed candidate fan-out must fail before planning");
 
     assert!(error.to_string().contains("candidate_fanout"));
@@ -420,7 +534,7 @@ fn dependency_gate_recovery_validates_but_defers_fanout_until_after_planning() {
         evidence: &[],
     };
 
-    let plan = awaiting_dependencies_recovery_dispatch_plan(&instance, &request)
+    let plan = dependency_override_recovery::dispatch_plan(&instance, &request)
         .expect("valid fan-out metadata should allow recovery planning");
     let decision = recovery_dispatch_decision(
         &instance,

--- a/crates/harness-workflow/src/runtime/store/recovery_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery_tests.rs
@@ -357,3 +357,132 @@ fn dependency_gate_recovery_preserves_candidate_fanout_for_force_execute() -> an
     assert_eq!(instance.data["dependencies_blocked"], false);
     Ok(())
 }
+
+#[test]
+fn dependency_gate_recovery_validates_candidate_fanout_before_planning() {
+    let instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "awaiting_dependencies",
+        WorkflowSubject::new("issue", "issue:1885"),
+    )
+    .with_id("dependency-override-invalid-fanout")
+    .with_server_data(json!({
+        "project_id": "/project-a",
+        "issue_number": 1885,
+        "dependencies_blocked": true,
+        "force_execute": false,
+        "candidate_fanout": {
+            "candidate_group_id": "dependency-override-invalid-fanout:candidate-group:issue-1885",
+            "candidate_count": "two",
+        },
+    }));
+    let request = WorkflowRuntimeRecoveryRequest {
+        workflow_id: "dependency-override-invalid-fanout",
+        action: WorkflowRuntimeRecoveryAction::Unblock,
+        reason: "operator approved dependency override",
+        actor: "operator",
+        target_state: None,
+        evidence: &[],
+    };
+
+    let error = awaiting_dependencies_recovery_dispatch_plan(&instance, &request)
+        .expect_err("malformed candidate fan-out must fail before planning");
+
+    assert!(error.to_string().contains("candidate_fanout"));
+}
+
+#[test]
+fn dependency_gate_recovery_validates_but_defers_fanout_until_after_planning() {
+    let mut instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "awaiting_dependencies",
+        WorkflowSubject::new("issue", "issue:1885"),
+    )
+    .with_id("dependency-override-deferred-fanout")
+    .with_server_data(json!({
+        "project_id": "/project-a",
+        "issue_number": 1885,
+        "force_execute": false,
+        "candidate_fanout": {
+            "candidate_group_id": "dependency-override-deferred-fanout:candidate-group:issue-1885",
+            "candidate_count": 2,
+            "trigger_label": "best-of-n",
+        },
+    }));
+    let request = WorkflowRuntimeRecoveryRequest {
+        workflow_id: "dependency-override-deferred-fanout",
+        action: WorkflowRuntimeRecoveryAction::Unblock,
+        reason: "operator approved dependency override",
+        actor: "operator",
+        target_state: None,
+        evidence: &[],
+    };
+
+    let plan = awaiting_dependencies_recovery_dispatch_plan(&instance, &request)
+        .expect("valid fan-out metadata should allow recovery planning");
+    let decision = recovery_dispatch_decision(
+        &instance,
+        request.action,
+        request.reason,
+        "awaiting_dependencies",
+        &plan,
+        "event-one",
+        &[],
+    );
+
+    assert_eq!(decision.next_state, "planning");
+    assert_eq!(decision.commands.len(), 1);
+    assert_eq!(decision.commands[0].activity_name(), Some("plan_issue"));
+    assert!(decision.commands[0].command.get("candidate").is_none());
+    instance.state = "planning".to_string();
+    persist_operator_recovery_data(
+        &mut instance,
+        request.action,
+        request.reason,
+        request.actor,
+        "awaiting_dependencies",
+        "planning",
+        "event-one",
+    )
+    .expect("recovery metadata should persist");
+    assert!(instance.data.get("candidate_fanout").is_some());
+
+    let result =
+        crate::runtime::model::ActivityResult::succeeded("plan_issue", "Issue plan ready.")
+            .with_artifact(crate::runtime::model::ActivityArtifact::new(
+                "issue_plan",
+                json!({
+                    "summary": "Implement the dependency-gated issue.",
+                    "task_class": "runtime_or_data",
+                    "target_files": ["crates/harness-workflow/src/runtime/store/recovery.rs"],
+                    "validation_plan": ["cargo test -p harness-workflow dependency_gate_recovery"],
+                    "blockers": [],
+                }),
+            ));
+    let event = crate::runtime::model::WorkflowEvent::new(
+        &instance.id,
+        1,
+        crate::runtime::RUNTIME_JOB_COMPLETED_EVENT,
+        "runtime-one",
+    )
+    .with_payload(json!({
+        "command_id": "plan-command",
+        "command": decision.commands[0],
+        "runtime_job_id": "runtime-one",
+        "activity_result": result,
+    }));
+    let implementation = crate::runtime::reduce_runtime_job_completed(&instance, &event)
+        .expect("plan completion event should parse")
+        .expect("plan completion should start implementation");
+    assert_eq!(implementation.commands.len(), 2);
+    for (candidate_index, command) in (1..=2).zip(&implementation.commands) {
+        assert_eq!(command.activity_name(), Some("implement_issue"));
+        assert_eq!(command.command["submission_mode"], "deferred");
+        assert_eq!(
+            command.command["candidate"]["candidate_index"],
+            candidate_index
+        );
+    }
+}

--- a/crates/harness-workflow/src/runtime/store/recovery_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery_tests.rs
@@ -208,7 +208,8 @@ fn dependency_gate_recovery_builds_override_plan_and_evidence() {
             .expect("rejection check should parse")
             .is_none());
 
-        let plan = awaiting_dependencies_recovery_dispatch_plan(&instance, &request);
+        let plan = awaiting_dependencies_recovery_dispatch_plan(&instance, &request)
+            .expect("dependency override plan should build");
         assert_eq!(plan.target.state, expected_state);
         assert_eq!(plan.target.activity.as_deref(), Some(expected_activity));
         let command = recovery_dispatch_command(
@@ -259,4 +260,96 @@ fn dependency_gate_recovery_builds_override_plan_and_evidence() {
             "awaiting_dependencies"
         );
     }
+}
+
+#[test]
+fn dependency_gate_recovery_preserves_candidate_fanout_for_force_execute() -> anyhow::Result<()> {
+    let mut instance = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "awaiting_dependencies",
+        WorkflowSubject::new("issue", "issue:1885"),
+    )
+    .with_id("dependency-override-fanout")
+    .with_server_data(json!({
+        "project_id": "/project-a",
+        "repo": "owner/repo",
+        "issue_number": 1885,
+        "task_id": "github-issue:owner/repo:issue:1885",
+        "source": "github",
+        "external_id": "1885",
+        "depends_on": ["github-issue:owner/repo:issue:1884"],
+        "dependencies_blocked": true,
+        "force_execute": true,
+        "candidate_fanout": {
+            "candidate_group_id": "dependency-override-fanout:candidate-group:issue-1885",
+            "candidate_count": 2,
+            "trigger_label": "best-of-n",
+            "max_turns_per_candidate": 4,
+        },
+        "last_remote_fact_hash": "sha256:abc",
+    }));
+    let request = WorkflowRuntimeRecoveryRequest {
+        workflow_id: "dependency-override-fanout",
+        action: WorkflowRuntimeRecoveryAction::Unblock,
+        reason: "operator approved dependency override",
+        actor: "operator",
+        target_state: None,
+        evidence: &[],
+    };
+
+    let plan = awaiting_dependencies_recovery_dispatch_plan(&instance, &request)
+        .expect("dependency override plan should build");
+    let decision = recovery_dispatch_decision(
+        &instance,
+        WorkflowRuntimeRecoveryAction::Unblock,
+        request.reason,
+        "awaiting_dependencies",
+        &plan,
+        "event-one",
+        &[],
+    );
+
+    assert_eq!(decision.next_state, "implementing");
+    assert_eq!(decision.commands.len(), 2);
+    for (candidate_index, command) in (1..=2).zip(&decision.commands) {
+        assert_eq!(command.activity_name(), Some("implement_issue"));
+        assert_eq!(command.command["submission_mode"], "deferred");
+        assert_eq!(
+            command.command["candidate"]["candidate_index"],
+            candidate_index
+        );
+        assert_eq!(command.command["candidate"]["candidate_count"], 2);
+        assert_eq!(
+            command.command["candidate"]["budget"]["max_turns_per_candidate"],
+            4
+        );
+        assert_eq!(
+            command.dedupe_key,
+            format!(
+                "operator-recovery:unblock:dependency-override-fanout:event-one:candidate:c{candidate_index}"
+            )
+        );
+    }
+
+    validator_for_instance(&instance)?
+        .expect("GitHub issue workflow should have a validator")
+        .validate(
+            &instance,
+            &decision,
+            &ValidationContext::new("workflow_runtime_operator_action", chrono::Utc::now()),
+        )?;
+
+    persist_operator_recovery_data(
+        &mut instance,
+        WorkflowRuntimeRecoveryAction::Unblock,
+        request.reason,
+        request.actor,
+        "awaiting_dependencies",
+        "implementing",
+        "event-one",
+    )
+    .expect("operator recovery data should persist");
+    assert_eq!(instance.data["dependencies_blocked"], false);
+    Ok(())
 }

--- a/crates/harness-workflow/src/runtime/store/recovery_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery_tests.rs
@@ -193,6 +193,7 @@ fn dependency_gate_recovery_builds_override_plan_and_evidence() {
             "depends_on": ["github-issue:owner/repo:issue:1884"],
             "dependencies_blocked": true,
             "force_execute": force_execute,
+            "additional_prompt": "Preserve the operator's issue-specific instruction.",
             "last_remote_fact_hash": "sha256:abc",
         }));
         let request = WorkflowRuntimeRecoveryRequest {
@@ -230,6 +231,9 @@ fn dependency_gate_recovery_builds_override_plan_and_evidence() {
         assert!(command.command["additional_prompt"]
             .as_str()
             .is_some_and(|prompt| prompt.contains("overriding the dependency gate")));
+        assert!(command.command["additional_prompt"]
+            .as_str()
+            .is_some_and(|prompt| prompt.contains("issue-specific instruction")));
 
         persist_operator_recovery_data(
             &mut instance,

--- a/crates/harness-workflow/src/runtime/tests/command_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/command_store.rs
@@ -225,16 +225,18 @@ async fn dependency_recovery_rejects_invalid_candidate_fanout_without_mutation(
 
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
-    for (issue_number, force_execute) in [(1885, false), (1886, true)] {
-        let original = project_issue_instance(
-            "/project-a",
-            issue_number,
-            "awaiting_dependencies",
-        )
-        .with_server_data(json!({
+    use super::WorkflowRuntimeRecoveryAction::{Retry, Unblock};
+    for (issue_number, state, action, force_execute) in [
+        (1885, "awaiting_dependencies", Unblock, false),
+        (1886, "awaiting_dependencies", Unblock, true),
+        (1887, "failed", Retry, false),
+        (1888, "failed", Retry, true),
+    ] {
+        let original = project_issue_instance("/project-a", issue_number, state).with_server_data(json!({
             "project_id": "/project-a",
             "issue_number": issue_number,
             "dependencies_blocked": true,
+            "dependency_failure_status": (state == "failed").then_some("dependency_cycle"),
             "force_execute": force_execute,
             "candidate_fanout": {
                 "candidate_group_id": "invalid-candidate-fanout",
@@ -283,7 +285,7 @@ async fn dependency_recovery_rejects_invalid_candidate_fanout_without_mutation(
         let error = recover(
             &store,
             &original.id,
-            super::WorkflowRuntimeRecoveryAction::Unblock,
+            action,
         )
         .await
         .expect_err("malformed candidate fan-out must reject recovery");
@@ -299,6 +301,73 @@ async fn dependency_recovery_rejects_invalid_candidate_fanout_without_mutation(
         assert_eq!(store.runtime_jobs_for_commands(&command_ids).await?, jobs_before);
         assert!(store.events_for(&original.id).await?.is_empty());
         assert!(store.decisions_for(&original.id).await?.is_empty());
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn dependency_cycle_retry_persists_override_and_routes_by_force_execute(
+) -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    for (issue_number, force_execute, expected_state, expected_activity, command_count) in [
+        (1890, false, "planning", "plan_issue", 1),
+        (1891, true, "implementing", "implement_issue", 2),
+    ] {
+        let original = project_issue_instance("/project-a", issue_number, "failed")
+            .with_server_data(json!({
+                "project_id": "/project-a",
+                "issue_number": issue_number,
+                "dependencies_blocked": true,
+                "dependency_failure_status": "dependency_cycle",
+                "force_execute": force_execute,
+                "candidate_fanout": {
+                    "candidate_group_id": format!("dependency-cycle-{issue_number}"),
+                    "candidate_count": 2,
+                    "trigger_label": "best-of-n",
+                },
+            }));
+        store
+            .force_upsert_lifecycle_state_for_test(&original)
+            .await?;
+
+        let workflow = recovered_workflow(
+            recover(
+                &store,
+                &original.id,
+                super::WorkflowRuntimeRecoveryAction::Retry,
+            )
+            .await?,
+            "dependency cycle retry",
+        )?;
+
+        assert_eq!(workflow.state, expected_state);
+        assert_eq!(workflow.data["dependencies_blocked"], false);
+        assert_eq!(workflow.data["dependency_override"]["action"], "retry");
+        assert_eq!(
+            workflow.data["dependency_override"]["previous_state"],
+            "failed"
+        );
+        assert!(workflow.data.get("dependency_failure_status").is_none());
+        let commands = store.commands_for(&original.id).await?;
+        assert_eq!(commands.len(), command_count);
+        assert!(commands.iter().all(|command| {
+            command.status == WorkflowCommandStatus::Pending
+                && command.command.activity_name() == Some(expected_activity)
+        }));
+        assert_operator_recovery_audit(
+            &store,
+            &original.id,
+            "WorkflowRuntimeRetried",
+            "retry",
+            "failed",
+            expected_state,
+        )
+        .await?;
     }
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/tests/command_store.rs
+++ b/crates/harness-workflow/src/runtime/tests/command_store.rs
@@ -216,6 +216,93 @@ async fn runtime_recovery_skips_superseded_active_commands() -> anyhow::Result<(
     Ok(())
 }
 
+#[tokio::test]
+async fn dependency_recovery_rejects_invalid_candidate_fanout_without_mutation(
+) -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    for (issue_number, force_execute) in [(1885, false), (1886, true)] {
+        let original = project_issue_instance(
+            "/project-a",
+            issue_number,
+            "awaiting_dependencies",
+        )
+        .with_server_data(json!({
+            "project_id": "/project-a",
+            "issue_number": issue_number,
+            "dependencies_blocked": true,
+            "force_execute": force_execute,
+            "candidate_fanout": {
+                "candidate_group_id": "invalid-candidate-fanout",
+                "candidate_count": "two",
+            },
+        }));
+        store
+            .force_upsert_lifecycle_state_for_test(&original)
+            .await?;
+        let pending_id = store
+            .enqueue_command(
+                &original.id,
+                None,
+                &WorkflowCommand::enqueue_activity(
+                    "plan_issue",
+                    format!("preexisting-pending-{issue_number}"),
+                ),
+            )
+            .await?;
+        let dispatching_id = store
+            .enqueue_command(
+                &original.id,
+                None,
+                &WorkflowCommand::enqueue_activity(
+                    "plan_issue",
+                    format!("preexisting-dispatching-{issue_number}"),
+                ),
+            )
+            .await?;
+        store
+            .mark_command_status(&dispatching_id, WorkflowCommandStatus::Dispatching)
+            .await?;
+        let (dispatched_id, _) = enqueue_original_runtime_job(
+            &store,
+            &original.id,
+            &WorkflowCommand::enqueue_activity(
+                "plan_issue",
+                format!("preexisting-dispatched-{issue_number}"),
+            ),
+        )
+        .await?;
+        let command_ids = vec![pending_id, dispatching_id, dispatched_id];
+        let commands_before = store.commands_for(&original.id).await?;
+        let jobs_before = store.runtime_jobs_for_commands(&command_ids).await?;
+
+        let error = recover(
+            &store,
+            &original.id,
+            super::WorkflowRuntimeRecoveryAction::Unblock,
+        )
+        .await
+        .expect_err("malformed candidate fan-out must reject recovery");
+
+        assert!(error.to_string().contains("candidate_fanout"));
+        let stored = store
+            .get_instance(&original.id)
+            .await?
+            .expect("workflow should still exist");
+        assert_eq!(stored.state, original.state);
+        assert_eq!(stored.data, original.data);
+        assert_eq!(store.commands_for(&original.id).await?, commands_before);
+        assert_eq!(store.runtime_jobs_for_commands(&command_ids).await?, jobs_before);
+        assert!(store.events_for(&original.id).await?.is_empty());
+        assert!(store.decisions_for(&original.id).await?.is_empty());
+    }
+    Ok(())
+}
+
 #[rustfmt::skip]
 #[tokio::test]
 async fn runtime_recovery_unblocks_legacy_blocked_without_stop_metadata() -> anyhow::Result<()> {


### PR DESCRIPTION
## What

Adds an explicit operator recovery path for GitHub issue workflows parked in `awaiting_dependencies`.

- Allows the existing runtime unblock API to promote dependency-gated issue workflows.
- Records dependency override evidence and clears `dependencies_blocked` on successful recovery.
- Re-dispatches to `plan_issue` by default, or directly to `implement_issue` when `force_execute` is set.
- Surfaces `can_unblock` for `awaiting_dependencies` issue workflows in runtime projection eligibility.

Fixes #1885

## Why

Dependency cycles and manually approved dependency overrides need an auditable promotion path instead of leaving workflows parked indefinitely. This reuses the existing operator recovery API and audit event model instead of introducing a silent auto-skip policy.

## Test Plan

- [x] `cargo test -p harness-workflow dependency_gate_recovery_builds_override_plan_and_evidence`
- [x] `cargo check -p harness-workflow --all-targets`
- [x] `cargo check -p harness-server --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `git push -u origin HEAD` (pre-push hook: clippy + database-independent workspace lib tests passed; PostgreSQL suites deferred because `HARNESS_DATABASE_URL` is unset)
