### PR TITLE
Refactor retrieval foundation for shadow comparison

### DIFF
--- a/crates/harness-context/src/providers.rs
+++ b/crates/harness-context/src/providers.rs
@@ -2,7 +2,10 @@ use crate::{
     ComposeRequest, ContextItem, ContextProvider, Degraded, ItemClass, ItemId, Priority,
     ProviderError, ProviderId,
 };
-use harness_core::retrieval::{score_lexical_relevance, RetrievalField};
+use harness_core::retrieval::{
+    score_retrieval_candidate, KnowledgeRetriever, LexicalKnowledgeRetriever, RetrievalCandidate,
+    RetrievalField, RetrievalQuery, RetrievalSurface,
+};
 use harness_core::types::{DraftStatus, ExecPlanStatus, ProjectId};
 use harness_rules::engine::Rule;
 use harness_skills::store::Skill;
@@ -65,20 +68,16 @@ impl ContextProvider for SkillsProvider {
 
     fn propose(&self, req: &ComposeRequest) -> Result<Vec<ContextItem>, ProviderError> {
         let prompt = req.task_profile.prompt.as_deref().unwrap_or_default();
-        let mut skills = self
-            .skills
-            .iter()
-            .filter_map(|skill| {
-                if skill.trigger_patterns.is_empty() {
-                    Some((skill.clone(), 0.15))
-                } else if skill_trigger_relevance(prompt, skill) > 0.0 {
-                    let relevance = skill_context_relevance(prompt, skill);
-                    Some((skill.clone(), relevance))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+        let retriever = LexicalKnowledgeRetriever;
+        let mut skills = Vec::new();
+        for skill in &self.skills {
+            if skill.trigger_patterns.is_empty() {
+                skills.push((skill.clone(), 0.15));
+            } else if skill_trigger_relevance(&retriever, prompt, skill)? > 0.0 {
+                let relevance = skill_context_relevance(&retriever, prompt, skill)?;
+                skills.push((skill.clone(), relevance));
+            }
+        }
         skills.sort_by(|(left, left_score), (right, right_score)| {
             right_score
                 .total_cmp(left_score)
@@ -109,7 +108,11 @@ impl ContextProvider for SkillsProvider {
     }
 }
 
-fn skill_context_relevance(prompt: &str, skill: &Skill) -> f64 {
+fn skill_context_relevance(
+    retriever: &dyn KnowledgeRetriever,
+    prompt: &str,
+    skill: &Skill,
+) -> Result<f64, ProviderError> {
     let mut fields = Vec::with_capacity(skill.trigger_patterns.len() + 3);
     for pattern in &skill.trigger_patterns {
         fields.push(RetrievalField::new(pattern, 2.0));
@@ -117,16 +120,32 @@ fn skill_context_relevance(prompt: &str, skill: &Skill) -> f64 {
     fields.push(RetrievalField::new(&skill.name, 0.8));
     fields.push(RetrievalField::new(&skill.description, 1.2));
     fields.push(RetrievalField::new(&skill.content, 0.25));
-    score_lexical_relevance(prompt, &fields).score
+    score_skill_candidate(retriever, prompt, skill, fields)
 }
 
-fn skill_trigger_relevance(prompt: &str, skill: &Skill) -> f64 {
+fn skill_trigger_relevance(
+    retriever: &dyn KnowledgeRetriever,
+    prompt: &str,
+    skill: &Skill,
+) -> Result<f64, ProviderError> {
     let fields = skill
         .trigger_patterns
         .iter()
         .map(|pattern| RetrievalField::new(pattern, 2.0))
         .collect::<Vec<_>>();
-    score_lexical_relevance(prompt, &fields).score
+    score_skill_candidate(retriever, prompt, skill, fields)
+}
+
+fn score_skill_candidate(
+    retriever: &dyn KnowledgeRetriever,
+    prompt: &str,
+    skill: &Skill,
+    fields: Vec<RetrievalField<'_>>,
+) -> Result<f64, ProviderError> {
+    let query = RetrievalQuery::new(RetrievalSurface::Skill, prompt, 1);
+    let candidate = RetrievalCandidate::new(&skill.name, fields);
+    score_retrieval_candidate(retriever, &query, candidate)
+        .map_err(|error| ProviderError::new("skills", error.to_string()))
 }
 
 pub struct ContractProvider;

--- a/crates/harness-core/src/retrieval.rs
+++ b/crates/harness-core/src/retrieval.rs
@@ -1,4 +1,230 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum RetrievalSurface {
+    Skill,
+    RepoMemory,
+}
+
+impl RetrievalSurface {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Skill => "skill",
+            Self::RepoMemory => "repo_memory",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RetrievalQuery<'a> {
+    pub surface: RetrievalSurface,
+    pub text: &'a str,
+    pub activity_class: Option<&'a str>,
+    pub repo: Option<&'a str>,
+    pub limit: usize,
+}
+
+impl<'a> RetrievalQuery<'a> {
+    pub const fn new(surface: RetrievalSurface, text: &'a str, limit: usize) -> Self {
+        Self {
+            surface,
+            text,
+            activity_class: None,
+            repo: None,
+            limit,
+        }
+    }
+
+    pub const fn with_activity_class(mut self, activity_class: &'a str) -> Self {
+        self.activity_class = Some(activity_class);
+        self
+    }
+
+    pub const fn with_repo(mut self, repo: &'a str) -> Self {
+        self.repo = Some(repo);
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RetrievalCandidate<'a> {
+    pub id: &'a str,
+    pub fields: Vec<RetrievalField<'a>>,
+    pub native_repo: bool,
+}
+
+impl<'a> RetrievalCandidate<'a> {
+    pub fn new(id: &'a str, fields: Vec<RetrievalField<'a>>) -> Self {
+        Self {
+            id,
+            fields,
+            native_repo: true,
+        }
+    }
+
+    pub const fn with_native_repo(mut self, native_repo: bool) -> Self {
+        self.native_repo = native_repo;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoredCandidate {
+    pub id: String,
+    pub score: f64,
+    pub native_repo: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetrievalError {
+    message: String,
+}
+
+impl RetrievalError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RetrievalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for RetrievalError {}
+
+pub trait KnowledgeRetriever: Send + Sync {
+    fn name(&self) -> &'static str;
+
+    fn rank(
+        &self,
+        query: &RetrievalQuery<'_>,
+        candidates: &[RetrievalCandidate<'_>],
+    ) -> Result<Vec<ScoredCandidate>, RetrievalError>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LexicalKnowledgeRetriever;
+
+impl KnowledgeRetriever for LexicalKnowledgeRetriever {
+    fn name(&self) -> &'static str {
+        "lexical"
+    }
+
+    fn rank(
+        &self,
+        query: &RetrievalQuery<'_>,
+        candidates: &[RetrievalCandidate<'_>],
+    ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
+        if query.limit == 0 || candidates.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut scored = candidates
+            .iter()
+            .map(|candidate| ScoredCandidate {
+                id: candidate.id.to_string(),
+                score: score_lexical_relevance(query.text, &candidate.fields).score,
+                native_repo: candidate.native_repo,
+            })
+            .collect::<Vec<_>>();
+        scored.sort_by(|left, right| {
+            right
+                .score
+                .total_cmp(&left.score)
+                .then_with(|| right.native_repo.cmp(&left.native_repo))
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        scored.truncate(query.limit);
+        Ok(scored)
+    }
+}
+
+pub fn score_retrieval_candidate(
+    retriever: &dyn KnowledgeRetriever,
+    query: &RetrievalQuery<'_>,
+    candidate: RetrievalCandidate<'_>,
+) -> Result<f64, RetrievalError> {
+    let candidate_id = candidate.id.to_string();
+    Ok(retriever
+        .rank(query, std::slice::from_ref(&candidate))?
+        .into_iter()
+        .find(|scored| scored.id == candidate_id)
+        .map(|scored| scored.score)
+        .unwrap_or(0.0))
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetrievalExecution {
+    pub selected: Vec<ScoredCandidate>,
+    pub comparison: Option<RetrievalComparison>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetrievalComparison {
+    pub surface: RetrievalSurface,
+    pub primary_implementation: &'static str,
+    pub shadow_implementation: &'static str,
+    pub primary_ranked: Vec<ScoredCandidate>,
+    pub shadow_ranked: Vec<ScoredCandidate>,
+    pub overlap_count: usize,
+    pub rank_divergence: f64,
+    pub shadow_error: Option<String>,
+}
+
+pub struct RetrievalExecutor<'a> {
+    primary: &'a dyn KnowledgeRetriever,
+    shadow: Option<&'a dyn KnowledgeRetriever>,
+}
+
+impl<'a> RetrievalExecutor<'a> {
+    pub fn new(primary: &'a dyn KnowledgeRetriever) -> Self {
+        Self {
+            primary,
+            shadow: None,
+        }
+    }
+
+    pub fn with_shadow(mut self, shadow: &'a dyn KnowledgeRetriever) -> Self {
+        self.shadow = Some(shadow);
+        self
+    }
+
+    pub fn retrieve(
+        &self,
+        query: &RetrievalQuery<'_>,
+        candidates: &[RetrievalCandidate<'_>],
+    ) -> Result<RetrievalExecution, RetrievalError> {
+        let selected = self.primary.rank(query, candidates)?;
+        let Some(shadow) = self.shadow else {
+            return Ok(RetrievalExecution {
+                selected,
+                comparison: None,
+            });
+        };
+        let (shadow_ranked, shadow_error) = match shadow.rank(query, candidates) {
+            Ok(ranked) => (ranked, None),
+            Err(error) => (Vec::new(), Some(error.to_string())),
+        };
+        let comparison = RetrievalComparison {
+            surface: query.surface,
+            primary_implementation: self.primary.name(),
+            shadow_implementation: shadow.name(),
+            overlap_count: overlap_count(&selected, &shadow_ranked),
+            rank_divergence: rank_divergence(&selected, &shadow_ranked),
+            primary_ranked: selected.clone(),
+            shadow_ranked,
+            shadow_error,
+        };
+        Ok(RetrievalExecution {
+            selected,
+            comparison: Some(comparison),
+        })
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct RetrievalField<'a> {
@@ -194,6 +420,45 @@ fn is_stopword(term: &str) -> bool {
     )
 }
 
+fn overlap_count(primary: &[ScoredCandidate], shadow: &[ScoredCandidate]) -> usize {
+    let primary_ids = primary
+        .iter()
+        .map(|candidate| candidate.id.as_str())
+        .collect::<BTreeSet<_>>();
+    shadow
+        .iter()
+        .filter(|candidate| primary_ids.contains(candidate.id.as_str()))
+        .count()
+}
+
+fn rank_divergence(primary: &[ScoredCandidate], shadow: &[ScoredCandidate]) -> f64 {
+    if primary.is_empty() && shadow.is_empty() {
+        return 0.0;
+    }
+    let max_rank = primary.len().max(shadow.len()).max(1);
+    let mut ids = primary
+        .iter()
+        .map(|candidate| candidate.id.as_str())
+        .collect::<BTreeSet<_>>();
+    ids.extend(shadow.iter().map(|candidate| candidate.id.as_str()));
+    let rank_delta_sum = ids
+        .iter()
+        .map(|id| {
+            let primary_rank = primary
+                .iter()
+                .position(|candidate| candidate.id.as_str() == *id)
+                .unwrap_or(max_rank);
+            let shadow_rank = shadow
+                .iter()
+                .position(|candidate| candidate.id.as_str() == *id)
+                .unwrap_or(max_rank);
+            primary_rank.abs_diff(shadow_rank)
+        })
+        .sum::<usize>();
+    let denominator = (ids.len() * max_rank).max(1) as f64;
+    (rank_delta_sum as f64 / denominator).min(1.0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -232,5 +497,141 @@ mod tests {
             score.score
         );
         assert_eq!(score.matched_terms, 1);
+    }
+
+    #[test]
+    fn lexical_retriever_ranks_candidates_by_weighted_score() {
+        let retriever = LexicalKnowledgeRetriever;
+        let query = RetrievalQuery::new(RetrievalSurface::Skill, "review code changes", 10);
+        let ranked = retriever
+            .rank(
+                &query,
+                &[
+                    RetrievalCandidate::new(
+                        "skill:build-fix",
+                        vec![RetrievalField::new("build error", 2.0)],
+                    ),
+                    RetrievalCandidate::new(
+                        "skill:review",
+                        vec![RetrievalField::new("code review", 2.0)],
+                    ),
+                ],
+            )
+            .expect("lexical ranking succeeds");
+
+        assert_eq!(ranked[0].id, "skill:review");
+        assert!(ranked[0].score > ranked[1].score);
+    }
+
+    #[test]
+    fn lexical_retriever_prefers_native_repo_on_score_ties() {
+        let retriever = LexicalKnowledgeRetriever;
+        let query = RetrievalQuery::new(RetrievalSurface::RepoMemory, "postgres timeout", 10);
+        let ranked = retriever
+            .rank(
+                &query,
+                &[
+                    RetrievalCandidate::new(
+                        "foreign",
+                        vec![RetrievalField::new("postgres timeout", 1.0)],
+                    )
+                    .with_native_repo(false),
+                    RetrievalCandidate::new(
+                        "native",
+                        vec![RetrievalField::new("postgres timeout", 1.0)],
+                    ),
+                ],
+            )
+            .expect("lexical ranking succeeds");
+
+        assert_eq!(ranked[0].id, "native");
+    }
+
+    #[test]
+    fn retrieval_executor_keeps_primary_selection_with_shadow_comparison() {
+        struct ReverseRetriever;
+        impl KnowledgeRetriever for ReverseRetriever {
+            fn name(&self) -> &'static str {
+                "reverse"
+            }
+
+            fn rank(
+                &self,
+                _query: &RetrievalQuery<'_>,
+                candidates: &[RetrievalCandidate<'_>],
+            ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
+                Ok(candidates
+                    .iter()
+                    .rev()
+                    .map(|candidate| ScoredCandidate {
+                        id: candidate.id.to_string(),
+                        score: 1.0,
+                        native_repo: candidate.native_repo,
+                    })
+                    .collect())
+            }
+        }
+
+        let primary = LexicalKnowledgeRetriever;
+        let shadow = ReverseRetriever;
+        let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 2);
+        let result = RetrievalExecutor::new(&primary)
+            .with_shadow(&shadow)
+            .retrieve(
+                &query,
+                &[
+                    RetrievalCandidate::new("a", vec![RetrievalField::new("code review", 1.0)]),
+                    RetrievalCandidate::new("b", vec![RetrievalField::new("build error", 1.0)]),
+                ],
+            )
+            .expect("primary retrieval succeeds");
+
+        assert_eq!(result.selected[0].id, "a");
+        let comparison = result.comparison.expect("comparison is recorded");
+        assert_eq!(comparison.primary_implementation, "lexical");
+        assert_eq!(comparison.shadow_implementation, "reverse");
+        assert_eq!(comparison.overlap_count, 2);
+        assert!(comparison.rank_divergence > 0.0);
+        assert!(comparison.shadow_error.is_none());
+    }
+
+    #[test]
+    fn retrieval_executor_isolates_shadow_failure() {
+        struct FailingRetriever;
+        impl KnowledgeRetriever for FailingRetriever {
+            fn name(&self) -> &'static str {
+                "failing"
+            }
+
+            fn rank(
+                &self,
+                _query: &RetrievalQuery<'_>,
+                _candidates: &[RetrievalCandidate<'_>],
+            ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
+                Err(RetrievalError::new("embedding backend unavailable"))
+            }
+        }
+
+        let primary = LexicalKnowledgeRetriever;
+        let shadow = FailingRetriever;
+        let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 1);
+        let result = RetrievalExecutor::new(&primary)
+            .with_shadow(&shadow)
+            .retrieve(
+                &query,
+                &[RetrievalCandidate::new(
+                    "skill:review",
+                    vec![RetrievalField::new("code review", 1.0)],
+                )],
+            )
+            .expect("primary retrieval succeeds");
+
+        assert_eq!(result.selected.len(), 1);
+        let comparison = result.comparison.expect("comparison is recorded");
+        assert_eq!(
+            comparison.shadow_error.as_deref(),
+            Some("embedding backend unavailable")
+        );
+        assert!(comparison.shadow_ranked.is_empty());
     }
 }

--- a/crates/harness-core/src/retrieval.rs
+++ b/crates/harness-core/src/retrieval.rs
@@ -148,11 +148,10 @@ pub fn score_retrieval_candidate(
     query: &RetrievalQuery<'_>,
     candidate: RetrievalCandidate<'_>,
 ) -> Result<f64, RetrievalError> {
-    let candidate_id = candidate.id.to_string();
     Ok(retriever
         .rank(query, std::slice::from_ref(&candidate))?
         .into_iter()
-        .find(|scored| scored.id == candidate_id)
+        .find(|scored| scored.id == candidate.id)
         .map(|scored| scored.score)
         .unwrap_or(0.0))
 }

--- a/crates/harness-core/src/retrieval.rs
+++ b/crates/harness-core/src/retrieval.rs
@@ -198,7 +198,8 @@ impl<'a> RetrievalExecutor<'a> {
         query: &RetrievalQuery<'_>,
         candidates: &[RetrievalCandidate<'_>],
     ) -> Result<RetrievalExecution, RetrievalError> {
-        let selected = self.primary.rank(query, candidates)?;
+        let mut selected = self.primary.rank(query, candidates)?;
+        selected.truncate(query.limit);
         let Some(shadow) = self.shadow else {
             return Ok(RetrievalExecution {
                 selected,
@@ -206,7 +207,10 @@ impl<'a> RetrievalExecutor<'a> {
             });
         };
         let (shadow_ranked, shadow_error) = match shadow.rank(query, candidates) {
-            Ok(ranked) => (ranked, None),
+            Ok(mut ranked) => {
+                ranked.truncate(query.limit);
+                (ranked, None)
+            }
             Err(error) => (Vec::new(), Some(error.to_string())),
         };
         let comparison = RetrievalComparison {
@@ -441,27 +445,70 @@ fn rank_divergence(primary: &[ScoredCandidate], shadow: &[ScoredCandidate]) -> f
         .map(|candidate| candidate.id.as_str())
         .collect::<BTreeSet<_>>();
     ids.extend(shadow.iter().map(|candidate| candidate.id.as_str()));
-    let rank_delta_sum = ids
+    let primary_ranks = ids
         .iter()
         .map(|id| {
-            let primary_rank = primary
+            primary
                 .iter()
                 .position(|candidate| candidate.id.as_str() == *id)
-                .unwrap_or(max_rank);
-            let shadow_rank = shadow
-                .iter()
-                .position(|candidate| candidate.id.as_str() == *id)
-                .unwrap_or(max_rank);
-            primary_rank.abs_diff(shadow_rank)
+                .unwrap_or(max_rank)
         })
+        .collect::<Vec<_>>();
+    let shadow_ranks = ids
+        .iter()
+        .map(|id| {
+            shadow
+                .iter()
+                .position(|candidate| candidate.id.as_str() == *id)
+                .unwrap_or(max_rank)
+        })
+        .collect::<Vec<_>>();
+    let rank_delta_sum = primary_ranks
+        .iter()
+        .zip(&shadow_ranks)
+        .map(|(primary_rank, shadow_rank)| primary_rank.abs_diff(*shadow_rank))
         .sum::<usize>();
-    let denominator = (ids.len() * max_rank).max(1) as f64;
+    let mut sorted_primary_ranks = primary_ranks;
+    let mut sorted_shadow_ranks = shadow_ranks;
+    sorted_primary_ranks.sort_unstable();
+    sorted_shadow_ranks.sort_unstable();
+    // Opposite ordering is the maximum attainable footrule distance for these ranks.
+    let maximum_rank_delta = sorted_primary_ranks
+        .iter()
+        .zip(sorted_shadow_ranks.iter().rev())
+        .map(|(primary_rank, shadow_rank)| primary_rank.abs_diff(*shadow_rank))
+        .sum::<usize>();
+    let denominator = maximum_rank_delta.max(1) as f64;
     (rank_delta_sum as f64 / denominator).min(1.0)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct ReverseRetriever;
+
+    impl KnowledgeRetriever for ReverseRetriever {
+        fn name(&self) -> &'static str {
+            "reverse"
+        }
+
+        fn rank(
+            &self,
+            _query: &RetrievalQuery<'_>,
+            candidates: &[RetrievalCandidate<'_>],
+        ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
+            Ok(candidates
+                .iter()
+                .rev()
+                .map(|candidate| ScoredCandidate {
+                    id: candidate.id.to_string(),
+                    score: 1.0,
+                    native_repo: candidate.native_repo,
+                })
+                .collect())
+        }
+    }
 
     #[test]
     fn lexical_relevance_matches_terms_regardless_of_order() {
@@ -549,32 +596,35 @@ mod tests {
 
     #[test]
     fn retrieval_executor_keeps_primary_selection_with_shadow_comparison() {
-        struct ReverseRetriever;
-        impl KnowledgeRetriever for ReverseRetriever {
-            fn name(&self) -> &'static str {
-                "reverse"
-            }
-
-            fn rank(
-                &self,
-                _query: &RetrievalQuery<'_>,
-                candidates: &[RetrievalCandidate<'_>],
-            ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
-                Ok(candidates
-                    .iter()
-                    .rev()
-                    .map(|candidate| ScoredCandidate {
-                        id: candidate.id.to_string(),
-                        score: 1.0,
-                        native_repo: candidate.native_repo,
-                    })
-                    .collect())
-            }
-        }
-
         let primary = LexicalKnowledgeRetriever;
         let shadow = ReverseRetriever;
-        let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 2);
+        let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 3);
+        let result = RetrievalExecutor::new(&primary)
+            .with_shadow(&shadow)
+            .retrieve(
+                &query,
+                &[
+                    RetrievalCandidate::new("a", vec![RetrievalField::new("code review", 1.0)]),
+                    RetrievalCandidate::new("b", vec![RetrievalField::new("build error", 1.0)]),
+                    RetrievalCandidate::new("c", vec![RetrievalField::new("deploy", 1.0)]),
+                ],
+            )
+            .expect("primary retrieval succeeds");
+
+        assert_eq!(result.selected[0].id, "a");
+        let comparison = result.comparison.expect("comparison is recorded");
+        assert_eq!(comparison.primary_implementation, "lexical");
+        assert_eq!(comparison.shadow_implementation, "reverse");
+        assert_eq!(comparison.overlap_count, 3);
+        assert_eq!(comparison.rank_divergence, 1.0);
+        assert!(comparison.shadow_error.is_none());
+    }
+
+    #[test]
+    fn retrieval_executor_clamps_primary_and_shadow_results_to_query_limit() {
+        let primary = ReverseRetriever;
+        let shadow = ReverseRetriever;
+        let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 1);
         let result = RetrievalExecutor::new(&primary)
             .with_shadow(&shadow)
             .retrieve(
@@ -584,15 +634,21 @@ mod tests {
                     RetrievalCandidate::new("b", vec![RetrievalField::new("build error", 1.0)]),
                 ],
             )
-            .expect("primary retrieval succeeds");
+            .expect("retrieval succeeds");
 
-        assert_eq!(result.selected[0].id, "a");
+        assert_eq!(
+            result
+                .selected
+                .iter()
+                .map(|candidate| candidate.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["b"]
+        );
         let comparison = result.comparison.expect("comparison is recorded");
-        assert_eq!(comparison.primary_implementation, "lexical");
-        assert_eq!(comparison.shadow_implementation, "reverse");
-        assert_eq!(comparison.overlap_count, 2);
-        assert!(comparison.rank_divergence > 0.0);
-        assert!(comparison.shadow_error.is_none());
+        assert_eq!(comparison.primary_ranked, result.selected);
+        assert_eq!(comparison.shadow_ranked.len(), 1);
+        assert_eq!(comparison.shadow_ranked[0].id, "b");
+        assert_eq!(comparison.overlap_count, 1);
     }
 
     #[test]

--- a/crates/harness-core/src/retrieval.rs
+++ b/crates/harness-core/src/retrieval.rs
@@ -461,50 +461,40 @@ fn overlap_count(primary: &[ScoredCandidate], shadow: &[ScoredCandidate]) -> usi
 }
 
 fn rank_divergence(primary: &[ScoredCandidate], shadow: &[ScoredCandidate]) -> f64 {
-    if primary.is_empty() && shadow.is_empty() {
-        return 0.0;
-    }
-    let max_rank = primary.len().max(shadow.len()).max(1);
     let mut ids = primary
         .iter()
         .map(|candidate| candidate.id.as_str())
         .collect::<BTreeSet<_>>();
     ids.extend(shadow.iter().map(|candidate| candidate.id.as_str()));
-    let primary_ranks = ids
-        .iter()
-        .map(|id| {
-            primary
-                .iter()
-                .position(|candidate| candidate.id.as_str() == *id)
-                .unwrap_or(max_rank)
+    if ids.len() < 2 {
+        return 0.0;
+    }
+    let max_rank = primary.len().max(shadow.len()).max(1);
+    let rank = |items: &[ScoredCandidate], id: &str| {
+        items
+            .iter()
+            .position(|candidate| candidate.id == id)
+            .unwrap_or(max_rank)
+    };
+    let ids = ids.into_iter().collect::<Vec<_>>();
+    let divergence = (0..ids.len())
+        .flat_map(|left| (left + 1..ids.len()).map(move |right| (left, right)))
+        .map(|(left, right)| {
+            let primary_order = rank(primary, ids[left]).cmp(&rank(primary, ids[right]));
+            let shadow_order = rank(shadow, ids[left]).cmp(&rank(shadow, ids[right]));
+            if primary_order == shadow_order {
+                0.0
+            } else if primary_order == std::cmp::Ordering::Equal
+                || shadow_order == std::cmp::Ordering::Equal
+            {
+                0.5
+            } else {
+                1.0
+            }
         })
-        .collect::<Vec<_>>();
-    let shadow_ranks = ids
-        .iter()
-        .map(|id| {
-            shadow
-                .iter()
-                .position(|candidate| candidate.id.as_str() == *id)
-                .unwrap_or(max_rank)
-        })
-        .collect::<Vec<_>>();
-    let rank_delta_sum = primary_ranks
-        .iter()
-        .zip(&shadow_ranks)
-        .map(|(primary_rank, shadow_rank)| primary_rank.abs_diff(*shadow_rank))
-        .sum::<usize>();
-    let mut sorted_primary_ranks = primary_ranks;
-    let mut sorted_shadow_ranks = shadow_ranks;
-    sorted_primary_ranks.sort_unstable();
-    sorted_shadow_ranks.sort_unstable();
-    // Opposite ordering is the maximum attainable footrule distance for these ranks.
-    let maximum_rank_delta = sorted_primary_ranks
-        .iter()
-        .zip(sorted_shadow_ranks.iter().rev())
-        .map(|(primary_rank, shadow_rank)| primary_rank.abs_diff(*shadow_rank))
-        .sum::<usize>();
-    let denominator = maximum_rank_delta.max(1) as f64;
-    (rank_delta_sum as f64 / denominator).min(1.0)
+        .sum::<f64>();
+    let pair_count = ids.len() * (ids.len() - 1) / 2;
+    divergence / pair_count as f64
 }
 
 #[cfg(test)]

--- a/crates/harness-core/src/retrieval.rs
+++ b/crates/harness-core/src/retrieval.rs
@@ -100,6 +100,9 @@ impl std::error::Error for RetrievalError {}
 pub trait KnowledgeRetriever: Send + Sync {
     fn name(&self) -> &'static str;
 
+    /// Returns candidates in descending rank order. Implementations must remove
+    /// duplicate IDs before applying `query.limit` so lower-ranked unique
+    /// candidates are not discarded at the cutoff.
     fn rank(
         &self,
         query: &RetrievalQuery<'_>,
@@ -138,8 +141,7 @@ impl KnowledgeRetriever for LexicalKnowledgeRetriever {
                 .then_with(|| right.native_repo.cmp(&left.native_repo))
                 .then_with(|| left.id.cmp(&right.id))
         });
-        scored.truncate(query.limit);
-        Ok(scored)
+        Ok(canonicalize_ranked(scored, query.limit))
     }
 }
 
@@ -169,8 +171,8 @@ pub struct RetrievalComparison {
     pub shadow_implementation: &'static str,
     pub primary_ranked: Vec<ScoredCandidate>,
     pub shadow_ranked: Vec<ScoredCandidate>,
-    pub overlap_count: usize,
-    pub rank_divergence: f64,
+    pub overlap_count: Option<usize>,
+    pub rank_divergence: Option<f64>,
     pub shadow_error: Option<String>,
 }
 
@@ -197,8 +199,7 @@ impl<'a> RetrievalExecutor<'a> {
         query: &RetrievalQuery<'_>,
         candidates: &[RetrievalCandidate<'_>],
     ) -> Result<RetrievalExecution, RetrievalError> {
-        let mut selected = self.primary.rank(query, candidates)?;
-        selected.truncate(query.limit);
+        let selected = canonicalize_ranked(self.primary.rank(query, candidates)?, query.limit);
         let Some(shadow) = self.shadow else {
             return Ok(RetrievalExecution {
                 selected,
@@ -206,18 +207,23 @@ impl<'a> RetrievalExecutor<'a> {
             });
         };
         let (shadow_ranked, shadow_error) = match shadow.rank(query, candidates) {
-            Ok(mut ranked) => {
-                ranked.truncate(query.limit);
-                (ranked, None)
-            }
+            Ok(ranked) => (canonicalize_ranked(ranked, query.limit), None),
             Err(error) => (Vec::new(), Some(error.to_string())),
+        };
+        let (overlap_count, rank_divergence) = if shadow_error.is_none() {
+            (
+                Some(overlap_count(&selected, &shadow_ranked)),
+                Some(rank_divergence(&selected, &shadow_ranked)),
+            )
+        } else {
+            (None, None)
         };
         let comparison = RetrievalComparison {
             surface: query.surface,
             primary_implementation: self.primary.name(),
             shadow_implementation: shadow.name(),
-            overlap_count: overlap_count(&selected, &shadow_ranked),
-            rank_divergence: rank_divergence(&selected, &shadow_ranked),
+            overlap_count,
+            rank_divergence,
             primary_ranked: selected.clone(),
             shadow_ranked,
             shadow_error,
@@ -227,6 +233,26 @@ impl<'a> RetrievalExecutor<'a> {
             comparison: Some(comparison),
         })
     }
+}
+
+fn canonicalize_ranked(ranked: Vec<ScoredCandidate>, limit: usize) -> Vec<ScoredCandidate> {
+    if limit == 0 {
+        return Vec::new();
+    }
+    let mut canonical = Vec::with_capacity(limit.min(ranked.len()));
+    for candidate in ranked {
+        if canonical
+            .iter()
+            .any(|existing: &ScoredCandidate| existing.id == candidate.id)
+        {
+            continue;
+        }
+        canonical.push(candidate);
+        if canonical.len() == limit {
+            break;
+        }
+    }
+    canonical
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -482,211 +508,5 @@ fn rank_divergence(primary: &[ScoredCandidate], shadow: &[ScoredCandidate]) -> f
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    struct ReverseRetriever;
-
-    impl KnowledgeRetriever for ReverseRetriever {
-        fn name(&self) -> &'static str {
-            "reverse"
-        }
-
-        fn rank(
-            &self,
-            _query: &RetrievalQuery<'_>,
-            candidates: &[RetrievalCandidate<'_>],
-        ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
-            Ok(candidates
-                .iter()
-                .rev()
-                .map(|candidate| ScoredCandidate {
-                    id: candidate.id.to_string(),
-                    score: 1.0,
-                    native_repo: candidate.native_repo,
-                })
-                .collect())
-        }
-    }
-
-    #[test]
-    fn lexical_relevance_matches_terms_regardless_of_order() {
-        let score = score_lexical_relevance(
-            "please review the code changes",
-            &[RetrievalField::new("code review", 2.0)],
-        );
-
-        assert!(score.score > 0.7, "score was {}", score.score);
-        assert_eq!(score.matched_terms, 2);
-    }
-
-    #[test]
-    fn lexical_relevance_returns_zero_without_content_overlap() {
-        let score = score_lexical_relevance(
-            "fix a postgres migration",
-            &[RetrievalField::new("frontend visual polish", 1.0)],
-        );
-
-        assert_eq!(score, LexicalRelevanceScore::none(3));
-    }
-
-    #[test]
-    fn lexical_relevance_does_not_phrase_match_inside_tokens() {
-        let score = score_lexical_relevance(
-            "cargo build failed",
-            &[RetrievalField::new("go build", 2.0)],
-        );
-
-        assert!(
-            score.score < 0.7,
-            "score should not receive a phrase bonus from 'cargo', was {}",
-            score.score
-        );
-        assert_eq!(score.matched_terms, 1);
-    }
-
-    #[test]
-    fn lexical_retriever_ranks_candidates_by_weighted_score() {
-        let retriever = LexicalKnowledgeRetriever;
-        let query = RetrievalQuery::new(RetrievalSurface::Skill, "review code changes", 10);
-        let ranked = retriever
-            .rank(
-                &query,
-                &[
-                    RetrievalCandidate::new(
-                        "skill:build-fix",
-                        vec![RetrievalField::new("build error", 2.0)],
-                    ),
-                    RetrievalCandidate::new(
-                        "skill:review",
-                        vec![RetrievalField::new("code review", 2.0)],
-                    ),
-                ],
-            )
-            .expect("lexical ranking succeeds");
-
-        assert_eq!(ranked[0].id, "skill:review");
-        assert!(ranked[0].score > ranked[1].score);
-    }
-
-    #[test]
-    fn lexical_retriever_prefers_native_repo_on_score_ties() {
-        let retriever = LexicalKnowledgeRetriever;
-        let query = RetrievalQuery::new(RetrievalSurface::RepoMemory, "postgres timeout", 10);
-        let ranked = retriever
-            .rank(
-                &query,
-                &[
-                    RetrievalCandidate::new(
-                        "foreign",
-                        vec![RetrievalField::new("postgres timeout", 1.0)],
-                    )
-                    .with_native_repo(false),
-                    RetrievalCandidate::new(
-                        "native",
-                        vec![RetrievalField::new("postgres timeout", 1.0)],
-                    ),
-                ],
-            )
-            .expect("lexical ranking succeeds");
-
-        assert_eq!(ranked[0].id, "native");
-    }
-
-    #[test]
-    fn retrieval_executor_keeps_primary_selection_with_shadow_comparison() {
-        let primary = LexicalKnowledgeRetriever;
-        let shadow = ReverseRetriever;
-        let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 3);
-        let result = RetrievalExecutor::new(&primary)
-            .with_shadow(&shadow)
-            .retrieve(
-                &query,
-                &[
-                    RetrievalCandidate::new("a", vec![RetrievalField::new("code review", 1.0)]),
-                    RetrievalCandidate::new("b", vec![RetrievalField::new("build error", 1.0)]),
-                    RetrievalCandidate::new("c", vec![RetrievalField::new("deploy", 1.0)]),
-                ],
-            )
-            .expect("primary retrieval succeeds");
-
-        assert_eq!(result.selected[0].id, "a");
-        let comparison = result.comparison.expect("comparison is recorded");
-        assert_eq!(comparison.primary_implementation, "lexical");
-        assert_eq!(comparison.shadow_implementation, "reverse");
-        assert_eq!(comparison.overlap_count, 3);
-        assert_eq!(comparison.rank_divergence, 1.0);
-        assert!(comparison.shadow_error.is_none());
-    }
-
-    #[test]
-    fn retrieval_executor_clamps_primary_and_shadow_results_to_query_limit() {
-        let primary = ReverseRetriever;
-        let shadow = ReverseRetriever;
-        let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 1);
-        let result = RetrievalExecutor::new(&primary)
-            .with_shadow(&shadow)
-            .retrieve(
-                &query,
-                &[
-                    RetrievalCandidate::new("a", vec![RetrievalField::new("code review", 1.0)]),
-                    RetrievalCandidate::new("b", vec![RetrievalField::new("build error", 1.0)]),
-                ],
-            )
-            .expect("retrieval succeeds");
-
-        assert_eq!(
-            result
-                .selected
-                .iter()
-                .map(|candidate| candidate.id.as_str())
-                .collect::<Vec<_>>(),
-            vec!["b"]
-        );
-        let comparison = result.comparison.expect("comparison is recorded");
-        assert_eq!(comparison.primary_ranked, result.selected);
-        assert_eq!(comparison.shadow_ranked.len(), 1);
-        assert_eq!(comparison.shadow_ranked[0].id, "b");
-        assert_eq!(comparison.overlap_count, 1);
-    }
-
-    #[test]
-    fn retrieval_executor_isolates_shadow_failure() {
-        struct FailingRetriever;
-        impl KnowledgeRetriever for FailingRetriever {
-            fn name(&self) -> &'static str {
-                "failing"
-            }
-
-            fn rank(
-                &self,
-                _query: &RetrievalQuery<'_>,
-                _candidates: &[RetrievalCandidate<'_>],
-            ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
-                Err(RetrievalError::new("embedding backend unavailable"))
-            }
-        }
-
-        let primary = LexicalKnowledgeRetriever;
-        let shadow = FailingRetriever;
-        let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 1);
-        let result = RetrievalExecutor::new(&primary)
-            .with_shadow(&shadow)
-            .retrieve(
-                &query,
-                &[RetrievalCandidate::new(
-                    "skill:review",
-                    vec![RetrievalField::new("code review", 1.0)],
-                )],
-            )
-            .expect("primary retrieval succeeds");
-
-        assert_eq!(result.selected.len(), 1);
-        let comparison = result.comparison.expect("comparison is recorded");
-        assert_eq!(
-            comparison.shadow_error.as_deref(),
-            Some("embedding backend unavailable")
-        );
-        assert!(comparison.shadow_ranked.is_empty());
-    }
-}
+#[path = "retrieval_tests.rs"]
+mod tests;

--- a/crates/harness-core/src/retrieval_tests.rs
+++ b/crates/harness-core/src/retrieval_tests.rs
@@ -1,0 +1,328 @@
+use super::*;
+
+struct ReverseRetriever;
+
+impl KnowledgeRetriever for ReverseRetriever {
+    fn name(&self) -> &'static str {
+        "reverse"
+    }
+
+    fn rank(
+        &self,
+        _query: &RetrievalQuery<'_>,
+        candidates: &[RetrievalCandidate<'_>],
+    ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
+        Ok(candidates
+            .iter()
+            .rev()
+            .map(|candidate| ScoredCandidate {
+                id: candidate.id.to_string(),
+                score: 1.0,
+                native_repo: candidate.native_repo,
+            })
+            .collect())
+    }
+}
+
+struct DuplicateRetriever;
+
+impl KnowledgeRetriever for DuplicateRetriever {
+    fn name(&self) -> &'static str {
+        "duplicate"
+    }
+
+    fn rank(
+        &self,
+        _query: &RetrievalQuery<'_>,
+        _candidates: &[RetrievalCandidate<'_>],
+    ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
+        Ok(["a", "a", "b"]
+            .into_iter()
+            .map(|id| ScoredCandidate {
+                id: id.to_string(),
+                score: 1.0,
+                native_repo: true,
+            })
+            .collect())
+    }
+}
+
+struct EmptyRetriever;
+
+impl KnowledgeRetriever for EmptyRetriever {
+    fn name(&self) -> &'static str {
+        "empty"
+    }
+
+    fn rank(
+        &self,
+        _query: &RetrievalQuery<'_>,
+        _candidates: &[RetrievalCandidate<'_>],
+    ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
+        Ok(Vec::new())
+    }
+}
+
+struct FailingRetriever;
+
+impl KnowledgeRetriever for FailingRetriever {
+    fn name(&self) -> &'static str {
+        "failing"
+    }
+
+    fn rank(
+        &self,
+        _query: &RetrievalQuery<'_>,
+        _candidates: &[RetrievalCandidate<'_>],
+    ) -> Result<Vec<ScoredCandidate>, RetrievalError> {
+        Err(RetrievalError::new("embedding backend unavailable"))
+    }
+}
+
+#[test]
+fn lexical_relevance_matches_terms_regardless_of_order() {
+    let score = score_lexical_relevance(
+        "please review the code changes",
+        &[RetrievalField::new("code review", 2.0)],
+    );
+
+    assert!(score.score > 0.7, "score was {}", score.score);
+    assert_eq!(score.matched_terms, 2);
+}
+
+#[test]
+fn lexical_relevance_returns_zero_without_content_overlap() {
+    let score = score_lexical_relevance(
+        "fix a postgres migration",
+        &[RetrievalField::new("frontend visual polish", 1.0)],
+    );
+
+    assert_eq!(score, LexicalRelevanceScore::none(3));
+}
+
+#[test]
+fn lexical_relevance_does_not_phrase_match_inside_tokens() {
+    let score = score_lexical_relevance(
+        "cargo build failed",
+        &[RetrievalField::new("go build", 2.0)],
+    );
+
+    assert!(
+        score.score < 0.7,
+        "score should not receive a phrase bonus from 'cargo', was {}",
+        score.score
+    );
+    assert_eq!(score.matched_terms, 1);
+}
+
+#[test]
+fn lexical_retriever_ranks_candidates_by_weighted_score() {
+    let retriever = LexicalKnowledgeRetriever;
+    let query = RetrievalQuery::new(RetrievalSurface::Skill, "review code changes", 10);
+    let ranked = retriever
+        .rank(
+            &query,
+            &[
+                RetrievalCandidate::new(
+                    "skill:build-fix",
+                    vec![RetrievalField::new("build error", 2.0)],
+                ),
+                RetrievalCandidate::new(
+                    "skill:review",
+                    vec![RetrievalField::new("code review", 2.0)],
+                ),
+            ],
+        )
+        .expect("lexical ranking succeeds");
+
+    assert_eq!(ranked[0].id, "skill:review");
+    assert!(ranked[0].score > ranked[1].score);
+}
+
+#[test]
+fn lexical_retriever_prefers_native_repo_on_score_ties() {
+    let retriever = LexicalKnowledgeRetriever;
+    let query = RetrievalQuery::new(RetrievalSurface::RepoMemory, "postgres timeout", 10);
+    let ranked = retriever
+        .rank(
+            &query,
+            &[
+                RetrievalCandidate::new(
+                    "foreign",
+                    vec![RetrievalField::new("postgres timeout", 1.0)],
+                )
+                .with_native_repo(false),
+                RetrievalCandidate::new(
+                    "native",
+                    vec![RetrievalField::new("postgres timeout", 1.0)],
+                ),
+            ],
+        )
+        .expect("lexical ranking succeeds");
+
+    assert_eq!(ranked[0].id, "native");
+}
+
+#[test]
+fn lexical_retriever_deduplicates_before_query_limit() {
+    let retriever = LexicalKnowledgeRetriever;
+    let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 2);
+    let candidates = [
+        RetrievalCandidate::new("a", vec![RetrievalField::new("code review", 1.0)]),
+        RetrievalCandidate::new("a", vec![RetrievalField::new("code review", 1.0)]),
+        RetrievalCandidate::new("b", vec![RetrievalField::new("build error", 1.0)]),
+    ];
+
+    let ranked = retriever
+        .rank(&query, &candidates)
+        .expect("lexical ranking succeeds");
+    assert_eq!(
+        ranked
+            .iter()
+            .map(|candidate| candidate.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "b"]
+    );
+
+    let result = RetrievalExecutor::new(&retriever)
+        .with_shadow(&retriever)
+        .retrieve(&query, &candidates)
+        .expect("retrieval succeeds");
+    assert_eq!(result.selected, ranked);
+    let comparison = result.comparison.expect("comparison is recorded");
+    assert_eq!(comparison.shadow_ranked, ranked);
+    assert_eq!(comparison.overlap_count, Some(2));
+    assert_eq!(comparison.rank_divergence, Some(0.0));
+}
+
+#[test]
+fn retrieval_executor_keeps_primary_selection_with_shadow_comparison() {
+    let primary = LexicalKnowledgeRetriever;
+    let shadow = ReverseRetriever;
+    let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 3);
+    let result = RetrievalExecutor::new(&primary)
+        .with_shadow(&shadow)
+        .retrieve(
+            &query,
+            &[
+                RetrievalCandidate::new("a", vec![RetrievalField::new("code review", 1.0)]),
+                RetrievalCandidate::new("b", vec![RetrievalField::new("build error", 1.0)]),
+                RetrievalCandidate::new("c", vec![RetrievalField::new("deploy", 1.0)]),
+            ],
+        )
+        .expect("primary retrieval succeeds");
+
+    assert_eq!(result.selected[0].id, "a");
+    let comparison = result.comparison.expect("comparison is recorded");
+    assert_eq!(comparison.primary_implementation, "lexical");
+    assert_eq!(comparison.shadow_implementation, "reverse");
+    assert_eq!(comparison.overlap_count, Some(3));
+    assert_eq!(comparison.rank_divergence, Some(1.0));
+    assert!(comparison.shadow_error.is_none());
+}
+
+#[test]
+fn retrieval_executor_clamps_primary_and_shadow_results_to_query_limit() {
+    let primary = ReverseRetriever;
+    let shadow = ReverseRetriever;
+    let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 1);
+    let result = RetrievalExecutor::new(&primary)
+        .with_shadow(&shadow)
+        .retrieve(
+            &query,
+            &[
+                RetrievalCandidate::new("a", vec![RetrievalField::new("code review", 1.0)]),
+                RetrievalCandidate::new("b", vec![RetrievalField::new("build error", 1.0)]),
+            ],
+        )
+        .expect("retrieval succeeds");
+
+    assert_eq!(
+        result
+            .selected
+            .iter()
+            .map(|candidate| candidate.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["b"]
+    );
+    let comparison = result.comparison.expect("comparison is recorded");
+    assert_eq!(comparison.primary_ranked, result.selected);
+    assert_eq!(comparison.shadow_ranked.len(), 1);
+    assert_eq!(comparison.shadow_ranked[0].id, "b");
+    assert_eq!(comparison.overlap_count, Some(1));
+}
+
+#[test]
+fn retrieval_executor_deduplicates_rankings_before_applying_query_limit() {
+    let retriever = DuplicateRetriever;
+    let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 2);
+    let candidates = [
+        RetrievalCandidate::new("a", vec![RetrievalField::new("code review", 1.0)]),
+        RetrievalCandidate::new("b", vec![RetrievalField::new("build error", 1.0)]),
+    ];
+    let result = RetrievalExecutor::new(&retriever)
+        .with_shadow(&retriever)
+        .retrieve(&query, &candidates)
+        .expect("retrieval succeeds");
+
+    assert_eq!(
+        result
+            .selected
+            .iter()
+            .map(|candidate| candidate.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "b"]
+    );
+    let comparison = result.comparison.expect("comparison is recorded");
+    assert_eq!(comparison.shadow_ranked, result.selected);
+    assert_eq!(comparison.overlap_count, Some(2));
+    assert_eq!(comparison.rank_divergence, Some(0.0));
+
+    let zero_limit = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 0);
+    let zero_result = RetrievalExecutor::new(&retriever)
+        .retrieve(&zero_limit, &candidates)
+        .expect("zero-limit retrieval succeeds");
+    assert!(zero_result.selected.is_empty());
+}
+
+#[test]
+fn retrieval_executor_isolates_shadow_failure() {
+    let primary = LexicalKnowledgeRetriever;
+    let shadow = FailingRetriever;
+    let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 1);
+    let result = RetrievalExecutor::new(&primary)
+        .with_shadow(&shadow)
+        .retrieve(
+            &query,
+            &[RetrievalCandidate::new(
+                "skill:review",
+                vec![RetrievalField::new("code review", 1.0)],
+            )],
+        )
+        .expect("primary retrieval succeeds");
+
+    assert_eq!(result.selected.len(), 1);
+    let comparison = result.comparison.expect("comparison is recorded");
+    assert_eq!(
+        comparison.shadow_error.as_deref(),
+        Some("embedding backend unavailable")
+    );
+    assert!(comparison.shadow_ranked.is_empty());
+    assert_eq!(comparison.overlap_count, None);
+    assert_eq!(comparison.rank_divergence, None);
+}
+
+#[test]
+fn retrieval_executor_omits_metrics_for_shadow_failure_with_empty_primary() {
+    let query = RetrievalQuery::new(RetrievalSurface::Skill, "code review", 1);
+    let result = RetrievalExecutor::new(&EmptyRetriever)
+        .with_shadow(&FailingRetriever)
+        .retrieve(&query, &[])
+        .expect("primary retrieval succeeds");
+    let comparison = result.comparison.expect("comparison is recorded");
+
+    assert!(result.selected.is_empty());
+    assert!(comparison.shadow_error.is_some());
+    assert_eq!(comparison.overlap_count, None);
+    assert_eq!(comparison.rank_divergence, None);
+}

--- a/crates/harness-core/src/retrieval_tests.rs
+++ b/crates/harness-core/src/retrieval_tests.rs
@@ -222,6 +222,32 @@ fn retrieval_executor_keeps_primary_selection_with_shadow_comparison() {
 }
 
 #[test]
+fn rank_divergence_uses_kendall_pair_inversions() {
+    let ranked = |ids: &[&str]| {
+        ids.iter()
+            .map(|id| ScoredCandidate {
+                id: (*id).to_owned(),
+                score: 1.0,
+                native_repo: true,
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        rank_divergence(&ranked(&["a", "b", "c"]), &ranked(&["b", "a", "c"])),
+        1.0 / 3.0
+    );
+    assert_eq!(rank_divergence(&ranked(&[]), &ranked(&["a", "b"])), 0.5);
+    assert_eq!(
+        rank_divergence(&ranked(&["a", "b"]), &ranked(&["b", "c"])),
+        2.0 / 3.0
+    );
+    assert_eq!(
+        rank_divergence(&ranked(&["a", "b"]), &ranked(&["c", "d"])),
+        5.0 / 6.0
+    );
+}
+
+#[test]
 fn retrieval_executor_clamps_primary_and_shadow_results_to_query_limit() {
     let primary = ReverseRetriever;
     let shadow = ReverseRetriever;

--- a/crates/harness-skills/src/store.rs
+++ b/crates/harness-skills/src/store.rs
@@ -1,6 +1,9 @@
 use chrono::{DateTime, Utc};
 use harness_core::{
-    retrieval::{score_lexical_relevance, LexicalRelevanceScore, RetrievalField},
+    retrieval::{
+        score_retrieval_candidate, KnowledgeRetriever, LexicalKnowledgeRetriever,
+        RetrievalCandidate, RetrievalField, RetrievalQuery, RetrievalSurface,
+    },
     types::SkillId,
     types::SkillLocation,
 };
@@ -276,6 +279,7 @@ impl SkillStore {
     }
 
     pub fn match_prompt(&self, prompt: &str) -> Vec<&Skill> {
+        let retriever = LexicalKnowledgeRetriever;
         let mut matches = self
             .skills
             .iter()
@@ -283,11 +287,10 @@ impl SkillStore {
                 if skill.trigger_patterns.is_empty() || !allows_auto_injection(skill, prompt) {
                     return None;
                 }
-                if skill_trigger_relevance(prompt, skill).score <= 0.0 {
+                if skill_trigger_relevance(&retriever, prompt, skill) <= 0.0 {
                     return None;
                 }
-                let relevance = skill_prompt_relevance(prompt, skill);
-                Some((skill, relevance.score))
+                Some((skill, skill_prompt_relevance(&retriever, prompt, skill)))
             })
             .collect::<Vec<_>>();
         matches.sort_by(|(left, left_score), (right, right_score)| {
@@ -688,7 +691,7 @@ fn allows_auto_injection(skill: &Skill, prompt: &str) -> bool {
     }
 }
 
-fn skill_prompt_relevance(prompt: &str, skill: &Skill) -> LexicalRelevanceScore {
+fn skill_prompt_relevance(retriever: &dyn KnowledgeRetriever, prompt: &str, skill: &Skill) -> f64 {
     let mut fields = Vec::with_capacity(skill.trigger_patterns.len() + 3);
     for pattern in &skill.trigger_patterns {
         fields.push(RetrievalField::new(pattern, 2.0));
@@ -696,16 +699,27 @@ fn skill_prompt_relevance(prompt: &str, skill: &Skill) -> LexicalRelevanceScore 
     fields.push(RetrievalField::new(&skill.name, 0.8));
     fields.push(RetrievalField::new(&skill.description, 1.2));
     fields.push(RetrievalField::new(&skill.content, 0.25));
-    score_lexical_relevance(prompt, &fields)
+    score_skill_candidate(retriever, prompt, skill, fields)
 }
 
-fn skill_trigger_relevance(prompt: &str, skill: &Skill) -> LexicalRelevanceScore {
+fn skill_trigger_relevance(retriever: &dyn KnowledgeRetriever, prompt: &str, skill: &Skill) -> f64 {
     let fields = skill
         .trigger_patterns
         .iter()
         .map(|pattern| RetrievalField::new(pattern, 2.0))
         .collect::<Vec<_>>();
-    score_lexical_relevance(prompt, &fields)
+    score_skill_candidate(retriever, prompt, skill, fields)
+}
+
+fn score_skill_candidate(
+    retriever: &dyn KnowledgeRetriever,
+    prompt: &str,
+    skill: &Skill,
+    fields: Vec<RetrievalField<'_>>,
+) -> f64 {
+    let query = RetrievalQuery::new(RetrievalSurface::Skill, prompt, 1);
+    let candidate = RetrievalCandidate::new(&skill.name, fields);
+    score_retrieval_candidate(retriever, &query, candidate).unwrap_or(0.0)
 }
 
 fn in_canary_bucket(skill_id: &SkillId, prompt: &str, ratio: f64) -> bool {

--- a/crates/harness-workflow/src/runtime/memory_retrieval.rs
+++ b/crates/harness-workflow/src/runtime/memory_retrieval.rs
@@ -100,7 +100,7 @@ fn select_repo_memory_records(
 }
 
 fn rank_repo_memory_candidates(
-    candidates: &mut [RepoMemoryRecord],
+    candidates: &mut Vec<RepoMemoryRecord>,
     activity_class: &str,
     task_text: Option<&str>,
 ) {
@@ -110,9 +110,8 @@ fn rank_repo_memory_candidates(
         RetrievalQuery::new(RetrievalSurface::RepoMemory, &query_text, candidates.len())
             .with_activity_class(activity_class);
     let retriever = LexicalKnowledgeRetriever;
-    let mut ranked = candidates
-        .iter()
-        .cloned()
+    let mut ranked = std::mem::take(candidates)
+        .into_iter()
         .map(|record| RankedRepoMemoryCandidate {
             activity_mismatch: record.activity_class != activity_class,
             relevance: repo_memory_relevance(&retriever, &record, &retrieval_query),
@@ -127,9 +126,7 @@ fn rank_repo_memory_candidates(
             .then_with(|| right.record.created_at.cmp(&left.record.created_at))
             .then_with(|| left.record.id.cmp(&right.record.id))
     });
-    for (target, ranked) in candidates.iter_mut().zip(ranked) {
-        *target = ranked.record;
-    }
+    *candidates = ranked.into_iter().map(|ranked| ranked.record).collect();
 }
 
 #[derive(Debug, Clone)]

--- a/crates/harness-workflow/src/runtime/memory_retrieval.rs
+++ b/crates/harness-workflow/src/runtime/memory_retrieval.rs
@@ -2,7 +2,10 @@ use super::repo_memory::{
     record_from_row, RepoMemoryKind, RepoMemoryOutcome, RepoMemoryRecord, RepoMemoryRecordRow,
 };
 use super::store::WorkflowRuntimeStore;
-use harness_core::retrieval::{score_lexical_relevance, RetrievalField};
+use harness_core::retrieval::{
+    score_retrieval_candidate, KnowledgeRetriever, LexicalKnowledgeRetriever, RetrievalCandidate,
+    RetrievalField, RetrievalQuery, RetrievalSurface,
+};
 use serde_json::Value;
 
 pub const DEFAULT_REPO_MEMORY_RETRIEVAL_LIMIT: usize = 5;
@@ -102,13 +105,17 @@ fn rank_repo_memory_candidates(
     task_text: Option<&str>,
 ) {
     let activity_class = activity_class.trim();
-    let query = repo_memory_relevance_query(activity_class, task_text);
+    let query_text = repo_memory_relevance_query(activity_class, task_text);
+    let retrieval_query =
+        RetrievalQuery::new(RetrievalSurface::RepoMemory, &query_text, candidates.len())
+            .with_activity_class(activity_class);
+    let retriever = LexicalKnowledgeRetriever;
     let mut ranked = candidates
         .iter()
         .cloned()
         .map(|record| RankedRepoMemoryCandidate {
             activity_mismatch: record.activity_class != activity_class,
-            relevance: repo_memory_relevance(&record, &query),
+            relevance: repo_memory_relevance(&retriever, &record, &retrieval_query),
             record,
         })
         .collect::<Vec<_>>();
@@ -139,20 +146,29 @@ fn repo_memory_relevance_query(activity_class: &str, task_text: Option<&str>) ->
     }
 }
 
-fn repo_memory_relevance(record: &RepoMemoryRecord, query: &str) -> f64 {
+fn repo_memory_relevance(
+    retriever: &dyn KnowledgeRetriever,
+    record: &RepoMemoryRecord,
+    query: &RetrievalQuery<'_>,
+) -> f64 {
     let payload = compact_payload(&record.payload_json);
     let evidence = record.evidence_ref.as_deref().unwrap_or_default();
-    score_lexical_relevance(
+    let id = record.id.to_string();
+    score_retrieval_candidate(
+        retriever,
         query,
-        &[
-            RetrievalField::new(&record.activity_class, 1.5),
-            RetrievalField::new(record.kind.db_value(), 0.7),
-            RetrievalField::new(record.outcome.db_value(), 0.3),
-            RetrievalField::new(&payload, 1.0),
-            RetrievalField::new(evidence, 0.2),
-        ],
+        RetrievalCandidate::new(
+            &id,
+            vec![
+                RetrievalField::new(&record.activity_class, 1.5),
+                RetrievalField::new(record.kind.db_value(), 0.7),
+                RetrievalField::new(record.outcome.db_value(), 0.3),
+                RetrievalField::new(&payload, 1.0),
+                RetrievalField::new(evidence, 0.2),
+            ],
+        ),
     )
-    .score
+    .unwrap_or(0.0)
 }
 
 fn select_with_budget<'a>(


### PR DESCRIPTION
## Summary
- Add a shared KnowledgeRetriever interface, lexical primary retriever, and RetrievalExecutor that records primary/shadow ranked lists, overlap, divergence, and shadow failures.
- Route skill-store matching, Context Composer skill proposals, and repo-memory relevance scoring through the lexical retriever without changing default gating or tie-break behavior.
- Add retrieval executor tests for primary-only injection semantics and shadow failure isolation.

## Scope
This is the first GH1769 landing slice. It does not close the full issue; embeddings, Composer enforce mode, and cross-repo memory sharing remain follow-up stages.

## Validation
- cargo test -p harness-core retrieval
- cargo test -p harness-skills match_prompt
- cargo test -p harness-context skills_provider
- env XDG_CONFIG_HOME=/tmp/harness-no-config cargo test --manifest-path <workspace>/Cargo.toml -p harness-workflow memory_retrieval
- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- pre-commit hook: staged fmt + clippy passed
- pre-push hook: clippy + DB-independent workspace lib tests passed; DB-backed suites deferred because HARNESS_DATABASE_URL is unset

Refs #1769