### PR TITLE
feat(workflow): enforce runtime budgets by default

### DIFF
--- a/crates/harness-core/src/config/workflow/budget.rs
+++ b/crates/harness-core/src/config/workflow/budget.rs
@@ -6,10 +6,11 @@ use serde::{Deserialize, Serialize};
 /// for the workflow instance. The gate runs in the runtime command dispatcher
 /// before a command is enqueued as a runtime job.
 ///
-/// The default enforcement is [`RuntimeBudgetEnforcement::Shadow`]: the
-/// dispatcher records the would-block decision as a `BudgetShadowDecision`
-/// runtime event but still dispatches. `Enforce` defers the command with the
-/// `workflow_budget_exhausted` dispatch barrier reason.
+/// The default enforcement is [`RuntimeBudgetEnforcement::Enforce`]:
+/// over-budget workflow dispatch is deferred with the
+/// `workflow_budget_exhausted` dispatch barrier reason. Operators can set
+/// `Shadow` explicitly to record would-block decisions as
+/// `BudgetShadowDecision` runtime events while still dispatching.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeBudgetPolicy {
     /// Per-workflow-instance spend ceiling in USD.
@@ -90,9 +91,9 @@ impl RuntimeBudgetPolicy {
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeBudgetEnforcement {
     /// Record the decision, never block.
-    #[default]
     Shadow,
     /// Defer dispatch once the workflow spend reaches the budget.
+    #[default]
     Enforce,
 }
 
@@ -124,20 +125,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_policy_is_shadow_with_builtin_budget() {
+    fn default_policy_enforces_builtin_budget() {
         let policy = RuntimeBudgetPolicy::default();
         assert_eq!(policy.default_workflow_budget_usd, 15.0);
-        assert_eq!(policy.enforcement, RuntimeBudgetEnforcement::Shadow);
+        assert_eq!(policy.enforcement, RuntimeBudgetEnforcement::Enforce);
         assert!(!policy.unlimited);
         policy.validate().expect("default policy is valid");
     }
 
     #[test]
-    fn policy_deserializes_from_partial_front_matter() {
-        let policy: RuntimeBudgetPolicy =
-            serde_yaml::from_str("enforcement: enforce").expect("partial policy parses");
-        assert_eq!(policy.default_workflow_budget_usd, 15.0);
+    fn policy_deserializes_missing_enforcement_as_enforce() {
+        let policy: RuntimeBudgetPolicy = serde_yaml::from_str("default_workflow_budget_usd: 20.0")
+            .expect("partial policy parses");
+        assert_eq!(policy.default_workflow_budget_usd, 20.0);
         assert_eq!(policy.enforcement, RuntimeBudgetEnforcement::Enforce);
+        assert!(!policy.unlimited);
+    }
+
+    #[test]
+    fn policy_deserializes_explicit_shadow_mode() {
+        let policy: RuntimeBudgetPolicy =
+            serde_yaml::from_str("enforcement: shadow").expect("partial policy parses");
+        assert_eq!(policy.default_workflow_budget_usd, 15.0);
+        assert_eq!(policy.enforcement, RuntimeBudgetEnforcement::Shadow);
         assert!(!policy.unlimited);
     }
 

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/fixtures/model_facing_prompt_v1.txt
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/fixtures/model_facing_prompt_v1.txt
@@ -389,7 +389,7 @@ Prompt packet:
       },
       "runtime_budget_policy": {
         "default_workflow_budget_usd": 15.0,
-        "enforcement": "shadow",
+        "enforcement": "enforce",
         "unlimited": false
       },
       "runtime_completion": {

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -132,8 +132,8 @@ pub(super) use transaction_helpers::{enum_str, insert_event_tx, to_jsonb_string}
 pub struct WorkflowRuntimeStore {
     pub(super) pool: PgPool,
     /// Hard workflow budget ceiling policy (GH-1770 spec §4.4), applied when a
-    /// completed activity commits its decision. Defaults to shadow enforcement
-    /// so a store opened without explicit wiring only records decisions.
+    /// completed activity commits its decision. Defaults to enforcement unless
+    /// callers explicitly configure shadow mode.
     pub(super) budget_policy: RuntimeBudgetPolicy,
 }
 const WORKFLOW_RUNTIME_SHARED_POOL_MIGRATIONS_TABLE: &str = "workflow_runtime_schema_migrations";

--- a/crates/harness-workflow/src/runtime/tests/command_dispatcher_budget.rs
+++ b/crates/harness-workflow/src/runtime/tests/command_dispatcher_budget.rs
@@ -83,7 +83,11 @@ async fn budget_gate_shadow_records_event_and_dispatches() -> anyhow::Result<()>
     let dispatcher = RuntimeCommandDispatcher::new(
         &store,
         RuntimeProfile::new("codex-high", RuntimeKind::CodexJsonrpc),
-    );
+    )
+    .with_budget_policy(RuntimeBudgetPolicy {
+        enforcement: RuntimeBudgetEnforcement::Shadow,
+        ..RuntimeBudgetPolicy::default()
+    });
     let outcome = dispatcher
         .dispatch_once()
         .await?
@@ -106,6 +110,62 @@ async fn budget_gate_shadow_records_event_and_dispatches() -> anyhow::Result<()>
     );
     assert_eq!(shadow.event["budget_usd"], 15.0);
     assert_eq!(shadow.event["spent_usd"], 20.0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_gate_default_enforces_budget_barrier() -> anyhow::Result<()> {
+    if resolve_database_url(None).is_err() {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let (instance, command_id) = issue_with_pending_command(&store, 520).await?;
+    store
+        .upsert_runtime_usage(&budget_usage_upsert(&instance.id, cost_usd_to_micros(16.0)?))
+        .await?;
+
+    let dispatcher = RuntimeCommandDispatcher::new(
+        &store,
+        RuntimeProfile::new("codex-high", RuntimeKind::CodexJsonrpc),
+    );
+    let outcome = dispatcher
+        .dispatch_once()
+        .await?
+        .expect("pending command should dispatch");
+
+    let barrier = match outcome {
+        CommandDispatchOutcome::Deferred {
+            command_id: id,
+            barrier,
+        } => {
+            assert_eq!(id, command_id);
+            barrier
+        }
+        other => panic!("default budget policy must enforce over-budget commands: {other:?}"),
+    };
+    assert_eq!(
+        barrier.reason_code,
+        DispatchBarrierReasonCode::WorkflowBudgetExhausted
+    );
+    assert_eq!(
+        store.commands_for(&instance.id).await?[0].status,
+        WorkflowCommandStatus::Deferred
+    );
+    let events = store.events_for(&instance.id).await?;
+    let deferred = events
+        .iter()
+        .find(|event| event.event_type == "WorkflowRuntimeDispatchDeferred")
+        .expect("default enforcement records a dispatch-deferred audit event");
+    assert_eq!(deferred.source, "workflow_runtime_command_dispatcher");
+    assert_eq!(
+        deferred.event["dispatch_barrier"]["reason_code"],
+        "workflow_budget_exhausted"
+    );
+    assert!(events
+        .iter()
+        .all(|event| event.event_type != "BudgetShadowDecision"));
     Ok(())
 }
 

--- a/specs/GH1770/product.md
+++ b/specs/GH1770/product.md
@@ -82,10 +82,10 @@ draining a quota window.
    `provider_confirmed`. An estimate is never presented as confirmed.
    Usage rows for models absent from the pricing table are priced with
    a conservative fallback and flagged.
-8. **B-008:** Budget enforcement ships with a shadow mode: ledgers are
-   computed and reason codes logged, but no dispatch is deferred and no
-   workflow blocked. Enforcement activates per profile via
-   configuration.
+8. **B-008:** Budget enforcement includes an explicit shadow mode:
+   ledgers are computed and reason codes logged, but no dispatch is
+   deferred and no workflow is blocked while shadow is configured. The
+   built-in default after rollout enforces the per-workflow ceiling.
 9. **B-009:** Budget state is observable: workflow status exposes
    budget, accumulated spend, and threshold state; profile status
    exposes daily spend, cap, and ladder position. Existing usage
@@ -153,7 +153,9 @@ draining a quota window.
 
 Phase 1 ships ledgers, pricing, and shadow mode; operators observe
 computed spend and would-have-fired reason codes. Phase 2 activates
-per-workflow enforcement for one low-volume profile, then broadly.
-Phase 3 activates daily caps. Reverting enforcement returns to
-observation-only behavior; ledgers and events remain. No database
-migration is destructive; new columns/tables are additive.
+per-workflow enforcement for one low-volume profile, then broadly, and
+makes enforcement the built-in default after the observation window.
+Phase 3 activates daily caps. Explicitly reverting enforcement to
+`shadow` returns to observation-only behavior; ledgers and events
+remain. No database migration is destructive; new columns/tables are
+additive.

--- a/specs/GH1770/tech.md
+++ b/specs/GH1770/tech.md
@@ -101,7 +101,7 @@ runtime_budget_policy:
   soft_threshold_ratio: 0.8
   daily_profile_cap_usd: 200.0
   daily_throttle_ratio: 0.8
-  enforcement: shadow | enforce         # default shadow
+  enforcement: shadow | enforce         # default enforce after rollout
   unlimited: false                      # explicit opt-out only
 ```
 
@@ -164,8 +164,9 @@ the activity share across candidates, mirroring the existing
    raise recovers (reuses `OperatorGate` machinery; no new lifecycle
    states).
 5. **Shadow mode**: all four points compute and log
-   (`budget_shadow_decision` runtime events) but take no action unless
-   `enforcement: enforce` for the profile.
+   (`budget_shadow_decision` runtime events) but take no action when the
+   global runtime budget policy explicitly configures `enforcement:
+   shadow`.
 
 ### 5. Typed outcomes
 
@@ -194,7 +195,8 @@ the activity share across candidates, mirroring the existing
 2. Wire shadow decisions at all four enforcement points; observe for a
    week; tune `default_workflow_budget_usd` from observed p95 workflow
    spend.
-3. Enable `enforce` for one low-volume profile; then broadly.
+3. Make `enforce` the built-in default while preserving explicit
+   `shadow` for rollback and profile-specific observation.
 4. Enable daily caps last.
 
 Rollback at any phase = revert config to `shadow`; tables and events


### PR DESCRIPTION
## What

Flip the built-in `runtime_budget_policy.enforcement` default from `shadow` to `enforce` now that the GH-1770 budget enforcement increments have landed.

Fixes #1770

## Why

Missing workflow budget configuration should no longer leave Harness in observation-only mode. Explicit `enforcement: shadow` remains available for rollback or profile-specific observation.

## Changes

- Make `RuntimeBudgetEnforcement::Enforce` the serde/default enum variant.
- Add coverage that omitted enforcement parses as `enforce`, while explicit `shadow` still works.
- Keep the dispatcher shadow test explicit and add a regression for the default budget gate enforcing `workflow_budget_exhausted`.
- Update the frozen prompt packet fixture and GH-1770 specs to describe enforce as the post-rollout default.

## Test Plan

- [x] `cargo test -p harness-core config::workflow::budget`
- [x] `cargo test -p harness-server prompt_packet`
- [x] `cargo fmt --all`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `tmp_home=$(mktemp -d); env -u HARNESS_DATABASE_URL HOME="$tmp_home" CARGO_HOME=/Users/apple/.cargo RUSTUP_HOME=/Users/apple/.rustup XDG_CONFIG_HOME="$tmp_home/.config" cargo test -p harness-workflow budget -- --test-threads=1`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] pre-commit hook: fmt + scoped clippy
- [x] pre-push hook: clippy + database-independent workspace lib tests
- [ ] `cargo test --workspace` was attempted but failed in unrelated PostgreSQL-backed server tests because this environment resolved a non-test `harness` database and then exhausted Postgres pools; the command reported 1363 passed / 207 failed before exit.
