### PR TITLE
[ASC-022] Enforce eval network policy reports

### DIFF
--- a/crates/harness-sandbox/src/lib.rs
+++ b/crates/harness-sandbox/src/lib.rs
@@ -13,7 +13,11 @@ use linux::linux_network_only_bwrap_args;
 #[cfg(any(target_os = "linux", test))]
 use linux::{linux_bwrap_args, linux_landlock_args};
 mod network_policy;
-pub use network_policy::NetworkPolicy;
+pub use network_policy::{
+    EvalNetworkAccess, EvalNetworkPolicy, EvalNetworkPolicyReport, NetworkConnectionMetadata,
+    NetworkDecision, NetworkDirection, NetworkPolicy, NetworkPolicyGrant, NetworkPolicyReportError,
+    NetworkProtocol, EVAL_NETWORK_POLICY_CAPABILITY,
+};
 mod resource_limits;
 pub use resource_limits::{
     classify_resource_termination, validate_resource_limit_backend,

--- a/crates/harness-sandbox/src/network_policy.rs
+++ b/crates/harness-sandbox/src/network_policy.rs
@@ -2,6 +2,11 @@
 use harness_core::config::agents::SandboxMode;
 #[cfg(any(target_os = "linux", test))]
 use harness_core::error::SandboxError;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use thiserror::Error;
+
+pub const EVAL_NETWORK_POLICY_CAPABILITY: &str = "eval_network_policy";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum NetworkPolicy {
@@ -52,4 +57,245 @@ impl NetworkPolicy {
             (Self::InheritSandboxMode, _) => vec!["(allow network-outbound)".to_string()],
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvalNetworkPolicy {
+    pub inbound: EvalNetworkAccess,
+    pub outbound: EvalNetworkAccess,
+    #[serde(default)]
+    pub network_allowlist: Vec<String>,
+}
+
+impl EvalNetworkPolicy {
+    pub fn for_allowlist(allowlist: &[String]) -> Result<Self, NetworkPolicyReportError> {
+        let network_allowlist = normalize_dns_allowlist(allowlist)?;
+        let outbound = if network_allowlist.is_empty() {
+            EvalNetworkAccess::Deny
+        } else {
+            EvalNetworkAccess::Allowlist
+        };
+        Ok(Self {
+            inbound: EvalNetworkAccess::Deny,
+            outbound,
+            network_allowlist,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalNetworkAccess {
+    Deny,
+    Allowlist,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvalNetworkPolicyReport {
+    pub enforced: bool,
+    pub policy: EvalNetworkPolicy,
+    #[serde(default)]
+    pub grants: Vec<NetworkPolicyGrant>,
+    #[serde(default)]
+    pub connections: Vec<NetworkConnectionMetadata>,
+    pub payloads_recorded: bool,
+    pub reason: String,
+}
+
+impl EvalNetworkPolicyReport {
+    pub fn validate_against(
+        &self,
+        expected: &EvalNetworkPolicy,
+    ) -> Result<(), NetworkPolicyReportError> {
+        if !self.enforced {
+            return Err(NetworkPolicyReportError::EnforcementMissing);
+        }
+        if self.payloads_recorded {
+            return Err(NetworkPolicyReportError::PayloadRecordingForbidden);
+        }
+        if self.reason.trim().is_empty() {
+            return Err(NetworkPolicyReportError::MissingReason);
+        }
+        if self.policy != *expected {
+            return Err(NetworkPolicyReportError::PolicyMismatch);
+        }
+        validate_grants(&self.grants, expected)?;
+        for connection in &self.connections {
+            validate_connection(connection, expected)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkPolicyGrant {
+    pub direction: NetworkDirection,
+    pub host: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<NetworkProtocol>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkConnectionMetadata {
+    pub direction: NetworkDirection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<NetworkProtocol>,
+    pub decision: NetworkDecision,
+    pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bytes_sent: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bytes_received: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkDirection {
+    Inbound,
+    Outbound,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkProtocol {
+    Tcp,
+    Udp,
+    Dns,
+    Http,
+    Https,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkDecision {
+    Allowed,
+    Denied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NetworkPolicyReportError {
+    #[error("eval network policy report enforcement must be true")]
+    EnforcementMissing,
+    #[error("eval network policy report must not record payloads")]
+    PayloadRecordingForbidden,
+    #[error("eval network policy report reason must not be empty")]
+    MissingReason,
+    #[error("eval network policy report policy does not match the required policy")]
+    PolicyMismatch,
+    #[error("eval network policy report grants do not match the required allowlist")]
+    GrantMismatch,
+    #[error("invalid eval network allowlist hostname `{host}`")]
+    InvalidAllowlistHost { host: String },
+    #[error("eval network connection metadata reason must not be empty")]
+    MissingConnectionReason,
+    #[error("eval network policy report allowed a connection outside the required policy")]
+    UnexpectedAllowedConnection,
+}
+
+fn validate_grants(
+    grants: &[NetworkPolicyGrant],
+    expected: &EvalNetworkPolicy,
+) -> Result<(), NetworkPolicyReportError> {
+    let expected_hosts = expected
+        .network_allowlist
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut actual_hosts = BTreeSet::new();
+    for grant in grants {
+        if grant.direction != NetworkDirection::Outbound {
+            return Err(NetworkPolicyReportError::GrantMismatch);
+        }
+        actual_hosts.insert(normalize_dns_name(&grant.host)?);
+    }
+    if actual_hosts == expected_hosts {
+        Ok(())
+    } else {
+        Err(NetworkPolicyReportError::GrantMismatch)
+    }
+}
+
+fn validate_connection(
+    connection: &NetworkConnectionMetadata,
+    expected: &EvalNetworkPolicy,
+) -> Result<(), NetworkPolicyReportError> {
+    if connection.reason.trim().is_empty() {
+        return Err(NetworkPolicyReportError::MissingConnectionReason);
+    }
+    if connection.decision == NetworkDecision::Denied {
+        return Ok(());
+    }
+    match connection.direction {
+        NetworkDirection::Inbound if expected.inbound == EvalNetworkAccess::Deny => {
+            Err(NetworkPolicyReportError::UnexpectedAllowedConnection)
+        }
+        NetworkDirection::Outbound => {
+            let Some(host) = connection.host.as_deref() else {
+                return Err(NetworkPolicyReportError::UnexpectedAllowedConnection);
+            };
+            let normalized = normalize_dns_name(host)?;
+            if expected.outbound == EvalNetworkAccess::Allowlist
+                && expected.network_allowlist.contains(&normalized)
+            {
+                Ok(())
+            } else {
+                Err(NetworkPolicyReportError::UnexpectedAllowedConnection)
+            }
+        }
+        NetworkDirection::Inbound => Ok(()),
+    }
+}
+
+fn normalize_dns_allowlist(allowlist: &[String]) -> Result<Vec<String>, NetworkPolicyReportError> {
+    let mut seen = BTreeSet::new();
+    let mut normalized = Vec::new();
+    for host in allowlist {
+        let host = normalize_dns_name(host)?;
+        if seen.insert(host.clone()) {
+            normalized.push(host);
+        }
+    }
+    Ok(normalized)
+}
+
+fn normalize_dns_name(value: &str) -> Result<String, NetworkPolicyReportError> {
+    let candidate = value.trim().trim_end_matches('.').to_ascii_lowercase();
+    if candidate.is_empty()
+        || candidate.len() > 253
+        || candidate.contains(['/', ':', '@', '*', '?', '#'])
+        || candidate.parse::<std::net::IpAddr>().is_ok()
+        || candidate == "localhost"
+        || candidate.ends_with(".localhost")
+    {
+        return Err(NetworkPolicyReportError::InvalidAllowlistHost {
+            host: value.to_string(),
+        });
+    }
+    let labels = candidate.split('.').collect::<Vec<_>>();
+    if labels.len() < 2
+        || labels.iter().any(|label| {
+            label.is_empty()
+                || label.len() > 63
+                || label.starts_with('-')
+                || label.ends_with('-')
+                || !label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+    {
+        return Err(NetworkPolicyReportError::InvalidAllowlistHost {
+            host: value.to_string(),
+        });
+    }
+    Ok(candidate)
 }

--- a/crates/harness-sandbox/src/network_policy_tests.rs
+++ b/crates/harness-sandbox/src/network_policy_tests.rs
@@ -103,3 +103,128 @@ fn linux_network_only_bwrap_isolates_the_process_tree() {
     assert!(args.contains(&OsString::from("--unshare-pid")));
     assert!(args.contains(&OsString::from("--die-with-parent")));
 }
+
+#[test]
+fn eval_network_policy_defaults_to_deny_inbound_and_outbound() {
+    let policy = EvalNetworkPolicy::for_allowlist(&[]).unwrap();
+
+    assert_eq!(policy.inbound, EvalNetworkAccess::Deny);
+    assert_eq!(policy.outbound, EvalNetworkAccess::Deny);
+    assert!(policy.network_allowlist.is_empty());
+
+    let report = EvalNetworkPolicyReport {
+        enforced: true,
+        policy: policy.clone(),
+        grants: Vec::new(),
+        connections: vec![NetworkConnectionMetadata {
+            direction: NetworkDirection::Outbound,
+            host: Some("denied.invalid".to_string()),
+            port: Some(443),
+            protocol: Some(NetworkProtocol::Tcp),
+            decision: NetworkDecision::Denied,
+            reason: "empty eval allowlist denies outbound connections".to_string(),
+            bytes_sent: None,
+            bytes_received: None,
+        }],
+        payloads_recorded: false,
+        reason: "container network policy denied all eval networking".to_string(),
+    };
+
+    report.validate_against(&policy).unwrap();
+}
+
+#[test]
+fn eval_network_policy_allows_trusted_dns_allowlist_grants_without_payloads() {
+    let policy = EvalNetworkPolicy::for_allowlist(&[
+        " GitHub.COM. ".to_string(),
+        "api.github.com".to_string(),
+    ])
+    .unwrap();
+
+    assert_eq!(
+        policy.network_allowlist,
+        vec!["github.com".to_string(), "api.github.com".to_string()]
+    );
+    assert_eq!(policy.inbound, EvalNetworkAccess::Deny);
+    assert_eq!(policy.outbound, EvalNetworkAccess::Allowlist);
+
+    let report = EvalNetworkPolicyReport {
+        enforced: true,
+        policy: policy.clone(),
+        grants: vec![
+            NetworkPolicyGrant {
+                direction: NetworkDirection::Outbound,
+                host: "github.com".to_string(),
+                port: Some(443),
+                protocol: Some(NetworkProtocol::Https),
+            },
+            NetworkPolicyGrant {
+                direction: NetworkDirection::Outbound,
+                host: "api.github.com".to_string(),
+                port: Some(443),
+                protocol: Some(NetworkProtocol::Https),
+            },
+        ],
+        connections: vec![NetworkConnectionMetadata {
+            direction: NetworkDirection::Outbound,
+            host: Some("github.com".to_string()),
+            port: Some(443),
+            protocol: Some(NetworkProtocol::Https),
+            decision: NetworkDecision::Allowed,
+            reason: "host matched trusted eval network allowlist".to_string(),
+            bytes_sent: Some(128),
+            bytes_received: Some(256),
+        }],
+        payloads_recorded: false,
+        reason: "recorded grants and connection metadata only".to_string(),
+    };
+
+    report.validate_against(&policy).unwrap();
+}
+
+#[test]
+fn eval_network_policy_rejects_ambiguous_dns_allowlist_entries() {
+    for host in [
+        "https://github.com",
+        "*.github.com",
+        "127.0.0.1",
+        "localhost",
+        "github.com:443",
+        "github.com/path",
+    ] {
+        let error = EvalNetworkPolicy::for_allowlist(&[host.to_string()])
+            .expect_err("ambiguous eval allowlist host should fail closed");
+
+        assert!(matches!(
+            error,
+            NetworkPolicyReportError::InvalidAllowlistHost { .. }
+        ));
+    }
+}
+
+#[test]
+fn eval_network_policy_report_rejects_unsupported_allowed_connections() {
+    let policy = EvalNetworkPolicy::for_allowlist(&[]).unwrap();
+    let report = EvalNetworkPolicyReport {
+        enforced: true,
+        policy: policy.clone(),
+        grants: Vec::new(),
+        connections: vec![NetworkConnectionMetadata {
+            direction: NetworkDirection::Outbound,
+            host: Some("github.com".to_string()),
+            port: Some(443),
+            protocol: Some(NetworkProtocol::Https),
+            decision: NetworkDecision::Allowed,
+            reason: "backend reported an outbound connection despite deny-all policy".to_string(),
+            bytes_sent: None,
+            bytes_received: None,
+        }],
+        payloads_recorded: false,
+        reason: "backend reported enforcement".to_string(),
+    };
+
+    assert_eq!(
+        report.validate_against(&policy),
+        Err(NetworkPolicyReportError::UnexpectedAllowedConnection)
+    );
+}

--- a/crates/harness-server/src/handlers/runtime_hosts.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts.rs
@@ -6,7 +6,8 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use harness_sandbox::{
-    CappedResourceLimits, ResourceLimitReport, ResourceLimits, EVAL_RESOURCE_LIMITS_CAPABILITY,
+    CappedResourceLimits, EvalNetworkPolicy, EvalNetworkPolicyReport, ResourceLimitReport,
+    ResourceLimits, EVAL_NETWORK_POLICY_CAPABILITY, EVAL_RESOURCE_LIMITS_CAPABILITY,
 };
 use harness_workflow::runtime::{
     prepare_runtime_transcript, ActivityArtifact, ActivityErrorKind, ActivityResult, RuntimeJob,
@@ -256,7 +257,9 @@ pub async fn claim_runtime_job_for_runtime_host(
         );
     }
     let host_supports_eval_resource_limits =
-        runtime_host_supports_eval_resource_limits(&state, &host_id);
+        runtime_host_supports_capability(&state, &host_id, EVAL_RESOURCE_LIMITS_CAPABILITY);
+    let host_supports_eval_network_policy =
+        runtime_host_supports_capability(&state, &host_id, EVAL_NETWORK_POLICY_CAPABILITY);
     let store = match workflow_runtime_store(&state) {
         Ok(store) => store,
         Err(response) => return response,
@@ -358,12 +361,13 @@ pub async fn claim_runtime_job_for_runtime_host(
     let resource_limits = match eval_resource_limit_enforcement_for_job(&job) {
         Ok(Some(resource_limits)) => {
             if !host_supports_eval_resource_limits {
-                let (status, response) = defer_runtime_host_resource_limit_claim(
+                let (status, response) = defer_runtime_host_capability_claim(
                     store.as_ref(),
                     &host_id,
                     lease_expires_at,
                     &job,
                     "runtime host lacks eval_resource_limits capability",
+                    EVAL_RESOURCE_LIMITS_CAPABILITY,
                 )
                 .await;
                 return (status, Json(response));
@@ -404,6 +408,60 @@ pub async fn claim_runtime_job_for_runtime_host(
                 host_id = %host_id,
                 %error,
                 "runtime host claim succeeded but eval resource-limit event recording failed"
+            );
+        }
+    }
+
+    let network_policy = match eval_network_policy_enforcement_for_job(&job) {
+        Ok(Some(network_policy)) => {
+            if !host_supports_eval_network_policy {
+                let (status, response) = defer_runtime_host_capability_claim(
+                    store.as_ref(),
+                    &host_id,
+                    lease_expires_at,
+                    &job,
+                    "runtime host lacks eval_network_policy capability",
+                    EVAL_NETWORK_POLICY_CAPABILITY,
+                )
+                .await;
+                return (status, Json(response));
+            }
+            Some(network_policy)
+        }
+        Ok(None) => None,
+        Err(error) => {
+            let result = eval_network_policy_preflight_failure(&job, &error, None);
+            return complete_runtime_host_preflight_failure(
+                &state,
+                store.as_ref(),
+                &host_id,
+                lease_expires_at,
+                &job,
+                result,
+            )
+            .await;
+        }
+    };
+
+    if let Some(network_policy) = &network_policy {
+        set_eval_network_policy_enforcement(&mut job, network_policy);
+        if let Err(error) = store
+            .record_runtime_event(
+                &job.id,
+                "EvalNetworkPolicyApplied",
+                json!({
+                    "host_id": host_id.as_str(),
+                    "network_policy": network_policy,
+                    "reason": "runtime host claim",
+                }),
+            )
+            .await
+        {
+            tracing::warn!(
+                runtime_job_id = %job.id,
+                host_id = %host_id,
+                %error,
+                "runtime host claim succeeded but eval network-policy event recording failed"
             );
         }
     }
@@ -494,15 +552,19 @@ pub async fn claim_runtime_job_for_runtime_host(
     if let Some(resource_limits) = resource_limits {
         response["resource_limits"] = json!(resource_limits);
     }
+    if let Some(network_policy) = network_policy {
+        response["network_policy"] = json!(network_policy);
+    }
     (StatusCode::OK, Json(response))
 }
 
-async fn defer_runtime_host_resource_limit_claim(
+async fn defer_runtime_host_capability_claim(
     store: &WorkflowRuntimeStore,
     host_id: &str,
     lease_expires_at: DateTime<Utc>,
     job: &RuntimeJob,
     reason: &str,
+    required_capability: &str,
 ) -> (StatusCode, serde_json::Value) {
     let not_before =
         Utc::now() + chrono::TimeDelta::seconds(RESOURCE_LIMIT_CAPABILITY_RETRY_DELAY_SECS);
@@ -520,7 +582,7 @@ async fn defer_runtime_host_resource_limit_claim(
                         "not_before": not_before,
                         "reason": reason,
                         "claim_api": "runtime_host",
-                        "required_capability": EVAL_RESOURCE_LIMITS_CAPABILITY,
+                        "required_capability": required_capability,
                     }),
                 )
                 .await
@@ -529,7 +591,7 @@ async fn defer_runtime_host_resource_limit_claim(
                     runtime_job_id = %job.id,
                     host_id = %host_id,
                     %error,
-                    "runtime host resource-limit claim defer succeeded but event recording failed"
+                    "runtime host capability claim defer succeeded but event recording failed"
                 );
             }
             (
@@ -541,7 +603,7 @@ async fn defer_runtime_host_resource_limit_claim(
                     "runtime_job": deferred,
                     "not_before": not_before,
                     "reason": reason,
-                    "required_capability": EVAL_RESOURCE_LIMITS_CAPABILITY,
+                    "required_capability": required_capability,
                 }),
             )
         }
@@ -549,7 +611,7 @@ async fn defer_runtime_host_resource_limit_claim(
             tracing::warn!(
                 runtime_job_id = %job.id,
                 host_id = %host_id,
-                "runtime host resource-limit claim defer ignored because the host no longer owns the lease"
+                "runtime host capability claim defer ignored because the host no longer owns the lease"
             );
             (StatusCode::OK, json!({ "claimed": false }))
         }
@@ -558,7 +620,7 @@ async fn defer_runtime_host_resource_limit_claim(
                 runtime_job_id = %job.id,
                 host_id = %host_id,
                 %error,
-                "runtime host failed to defer resource-limit-incompatible runtime job"
+                "runtime host failed to defer capability-incompatible runtime job"
             );
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -703,6 +765,9 @@ pub async fn complete_runtime_job_for_runtime_host(
     };
     let result =
         crate::workflow_runtime_worker::strip_caller_transcript_unavailable_signal(req.result);
+    if let Err((status, response)) = validate_eval_network_policy_report(&job, &result) {
+        return (status, Json(response));
+    }
     if let Err((status, response)) = validate_eval_resource_limit_report(&job, &result) {
         return (status, Json(response));
     }
@@ -803,11 +868,15 @@ pub async fn complete_runtime_job_for_runtime_host(
     )
 }
 
-fn runtime_host_supports_eval_resource_limits(state: &Arc<AppState>, host_id: &str) -> bool {
+fn runtime_host_supports_capability(
+    state: &Arc<AppState>,
+    host_id: &str,
+    required_capability: &str,
+) -> bool {
     state.runtime_hosts.hosts.get(host_id).is_some_and(|host| {
         host.capabilities
             .iter()
-            .any(|capability| capability == EVAL_RESOURCE_LIMITS_CAPABILITY)
+            .any(|capability| capability == required_capability)
     })
 }
 
@@ -848,6 +917,41 @@ fn eval_metadata(input: &Value) -> Option<&Value> {
         .pointer("/command/eval")
         .or_else(|| input.get("eval"))
         .filter(|value| value.is_object())
+}
+
+fn eval_network_policy_enforcement_for_job(
+    job: &RuntimeJob,
+) -> Result<Option<EvalNetworkPolicy>, String> {
+    let Some(eval) = eval_metadata(&job.input) else {
+        return Ok(None);
+    };
+    let network_allowlist = job
+        .input
+        .pointer("/isolation/network_allowlist")
+        .or_else(|| eval.pointer("/isolation/network_allowlist"))
+        .map(|value| {
+            serde_json::from_value::<Vec<String>>(value.clone())
+                .map_err(|error| format!("invalid eval network_allowlist: {error}"))
+        })
+        .transpose()?
+        .unwrap_or_default();
+    EvalNetworkPolicy::for_allowlist(&network_allowlist)
+        .map(Some)
+        .map_err(|error| format!("invalid eval network policy: {error}"))
+}
+
+fn set_eval_network_policy_enforcement(job: &mut RuntimeJob, network_policy: &EvalNetworkPolicy) {
+    let value = json!(network_policy);
+    if let Some(eval) = job
+        .input
+        .pointer_mut("/command/eval")
+        .and_then(Value::as_object_mut)
+    {
+        eval.insert("network_policy".to_string(), value.clone());
+    }
+    if let Some(eval) = job.input.get_mut("eval").and_then(Value::as_object_mut) {
+        eval.insert("network_policy".to_string(), value);
+    }
 }
 
 fn set_eval_resource_limit_enforcement(
@@ -891,6 +995,30 @@ fn eval_resource_limit_preflight_failure(
     ))
 }
 
+fn eval_network_policy_preflight_failure(
+    job: &RuntimeJob,
+    error: &str,
+    network_policy: Option<EvalNetworkPolicy>,
+) -> ActivityResult {
+    let mut artifact = json!({
+        "enforced": false,
+        "reason": error,
+    });
+    if let Some(network_policy) = network_policy {
+        artifact["network_policy"] = json!(network_policy);
+    }
+    ActivityResult::failed(
+        runtime_job_activity(job),
+        "Evaluation network policy could not be enforced.",
+        error,
+    )
+    .with_error_kind(ActivityErrorKind::Configuration)
+    .with_artifact(ActivityArtifact::new(
+        "network_policy_enforcement",
+        artifact,
+    ))
+}
+
 fn runtime_job_activity(job: &RuntimeJob) -> String {
     job.input
         .get("activity")
@@ -902,6 +1030,48 @@ fn runtime_job_activity(job: &RuntimeJob) -> String {
         })
         .unwrap_or("remote_host")
         .to_string()
+}
+
+fn validate_eval_network_policy_report(
+    job: &RuntimeJob,
+    result: &ActivityResult,
+) -> Result<(), (StatusCode, serde_json::Value)> {
+    let Some(expected_policy) = eval_network_policy_enforcement_for_job(job).map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            json!({ "error": format!("invalid eval network policy: {error}") }),
+        )
+    })?
+    else {
+        return Ok(());
+    };
+
+    let Some(report_value) = result
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.artifact_type == "network_policy_report")
+        .map(|artifact| artifact.artifact.clone())
+    else {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            json!({
+                "error": "eval runtime job completion requires network_policy_report artifact"
+            }),
+        ));
+    };
+    let report: EvalNetworkPolicyReport =
+        serde_json::from_value(report_value).map_err(|error| {
+            (
+                StatusCode::BAD_REQUEST,
+                json!({ "error": format!("invalid network_policy_report artifact: {error}") }),
+            )
+        })?;
+    report.validate_against(&expected_policy).map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            json!({ "error": format!("network_policy_report is not valid: {error}") }),
+        )
+    })
 }
 
 fn validate_eval_resource_limit_report(
@@ -1045,6 +1215,162 @@ mod tests {
         assert_eq!(limits.effective.wall_time_secs, Some(45));
         assert_eq!(limits.effective.cpu_time_secs, Some(45));
         assert_eq!(limits.effective.output_bytes, Some(64 * 1024 * 1024));
+    }
+
+    #[test]
+    fn eval_network_policy_defaults_to_deny_all_when_missing() {
+        let job = RuntimeJob::pending(
+            "cmd-1",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({
+                "activity": "implement_issue",
+                "command": {
+                    "eval": {
+                        "eval_run_id": "run-1",
+                        "case_id": "case-1",
+                        "timeout_secs": 45
+                    }
+                }
+            }),
+        );
+
+        let policy = eval_network_policy_enforcement_for_job(&job)
+            .expect("policy should parse")
+            .expect("eval job should require network policy");
+
+        assert_eq!(policy.inbound, harness_sandbox::EvalNetworkAccess::Deny);
+        assert_eq!(policy.outbound, harness_sandbox::EvalNetworkAccess::Deny);
+        assert!(policy.network_allowlist.is_empty());
+    }
+
+    #[test]
+    fn eval_network_policy_report_is_required_for_eval_completion() {
+        let job = RuntimeJob::pending(
+            "cmd-1",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({
+                "activity": "implement_issue",
+                "command": {
+                    "eval": {
+                        "eval_run_id": "run-1",
+                        "case_id": "case-1",
+                        "timeout_secs": 45
+                    }
+                }
+            }),
+        );
+        let result = ActivityResult::succeeded("implement_issue", "done");
+
+        let err = validate_eval_network_policy_report(&job, &result)
+            .expect_err("missing network report should fail closed");
+
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            err.1["error"],
+            "eval runtime job completion requires network_policy_report artifact"
+        );
+    }
+
+    #[test]
+    fn eval_network_policy_report_accepts_matching_allowlist_metadata() {
+        let job = RuntimeJob::pending(
+            "cmd-1",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({
+                "activity": "implement_issue",
+                "isolation": {
+                    "network_allowlist": ["api.github.com"]
+                },
+                "command": {
+                    "eval": {
+                        "eval_run_id": "run-1",
+                        "case_id": "case-1",
+                        "timeout_secs": 45
+                    }
+                }
+            }),
+        );
+        let result = ActivityResult::succeeded("implement_issue", "done").with_artifact(
+            ActivityArtifact::new(
+                "network_policy_report",
+                json!({
+                    "enforced": true,
+                    "policy": {
+                        "inbound": "deny",
+                        "outbound": "allowlist",
+                        "network_allowlist": ["api.github.com"],
+                    },
+                    "grants": [{
+                        "direction": "outbound",
+                        "host": "api.github.com",
+                        "port": 443,
+                        "protocol": "https",
+                    }],
+                    "connections": [{
+                        "direction": "outbound",
+                        "host": "api.github.com",
+                        "port": 443,
+                        "protocol": "https",
+                        "decision": "allowed",
+                        "reason": "host matched trusted eval allowlist",
+                        "bytes_sent": 512,
+                        "bytes_received": 1024,
+                    }],
+                    "payloads_recorded": false,
+                    "reason": "runtime host enforced eval network policy",
+                }),
+            ),
+        );
+
+        validate_eval_network_policy_report(&job, &result)
+            .expect("matching network policy report should be accepted");
+    }
+
+    #[test]
+    fn eval_network_policy_report_rejects_payload_recording() {
+        let job = RuntimeJob::pending(
+            "cmd-1",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({
+                "activity": "implement_issue",
+                "command": {
+                    "eval": {
+                        "eval_run_id": "run-1",
+                        "case_id": "case-1",
+                        "timeout_secs": 45
+                    }
+                }
+            }),
+        );
+        let result = ActivityResult::succeeded("implement_issue", "done").with_artifact(
+            ActivityArtifact::new(
+                "network_policy_report",
+                json!({
+                    "enforced": true,
+                    "policy": {
+                        "inbound": "deny",
+                        "outbound": "deny",
+                        "network_allowlist": [],
+                    },
+                    "grants": [],
+                    "connections": [],
+                    "payloads_recorded": true,
+                    "reason": "runtime host recorded network details",
+                }),
+            ),
+        );
+
+        let err = validate_eval_network_policy_report(&job, &result)
+            .expect_err("payload recording must fail closed");
+
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(err.1["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("must not record payloads")));
     }
 
     #[test]

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_api_tests.rs
@@ -209,7 +209,12 @@ async fn runtime_job_claim_endpoint_includes_eval_credential_environment_policy(
         return Ok(());
     };
     let app = runtime_hosts_workflow_app(state);
-    register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits"]).await?;
+    register_host_with_capabilities(
+        &app,
+        "host-a",
+        vec!["eval_resource_limits", "eval_network_policy"],
+    )
+    .await?;
 
     let job = enqueue_runtime_host_test_job(
         &store,
@@ -271,6 +276,14 @@ async fn runtime_job_claim_endpoint_includes_eval_credential_environment_policy(
             .as_object()
             .map(serde_json::Map::len),
         Some(0)
+    );
+    assert_eq!(
+        json["network_policy"],
+        json!({
+            "inbound": "deny",
+            "outbound": "deny",
+            "network_allowlist": [],
+        })
     );
     let events = store
         .events_for("runtime-host-test-command-eval-credential-policy")
@@ -551,6 +564,134 @@ async fn runtime_job_claim_endpoint_defers_eval_job_without_resource_limit_capab
         events[1].event["required_capability"],
         "eval_resource_limits"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_claim_endpoint_defers_eval_job_without_network_policy_capability(
+) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state);
+    register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits"]).await?;
+
+    let job = enqueue_runtime_host_test_job(
+        &store,
+        "eval-missing-network-policy-capability",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({
+            "activity": "implement_issue",
+            "isolation": {
+                "network_allowlist": ["api.github.com"]
+            },
+            "command": {
+                "activity": "implement_issue",
+                "eval": {
+                    "eval_run_id": "run-1",
+                    "case_id": "case-1",
+                    "timeout_secs": 45
+                }
+            }
+        }),
+    )
+    .await?;
+    let before_claim = Utc::now();
+
+    let json = post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+
+    assert_eq!(json["claimed"], false);
+    assert_eq!(json["deferred"], true);
+    assert_eq!(json["runtime_job_id"], job.id);
+    assert_eq!(json["required_capability"], "eval_network_policy");
+    let deferred = store
+        .get_runtime_job(&job.id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("eval job should still exist"))?;
+    assert_eq!(deferred.status, RuntimeJobStatus::Pending);
+    assert!(deferred.lease.is_none());
+    assert!(deferred
+        .not_before
+        .is_some_and(|not_before| not_before > before_claim));
+    let events = store.runtime_events_for(&job.id).await?;
+    assert_eq!(events[0].event_type, "RuntimeJobClaimed");
+    assert_eq!(events[1].event_type, "RuntimeJobClaimDeferred");
+    assert_eq!(
+        events[1].event["required_capability"],
+        "eval_network_policy"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_claim_endpoint_includes_eval_network_policy() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state);
+    register_host_with_capabilities(
+        &app,
+        "host-a",
+        vec!["eval_resource_limits", "eval_network_policy"],
+    )
+    .await?;
+
+    let job = enqueue_runtime_host_test_job(
+        &store,
+        "eval-network-policy",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({
+            "activity": "implement_issue",
+            "isolation": {
+                "network_allowlist": ["api.github.com"]
+            },
+            "command": {
+                "activity": "implement_issue",
+                "eval": {
+                    "eval_run_id": "run-1",
+                    "case_id": "case-1",
+                    "timeout_secs": 45
+                }
+            }
+        }),
+    )
+    .await?;
+
+    let json = post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+
+    assert_eq!(json["claimed"], true);
+    assert_eq!(json["runtime_job_id"], job.id);
+    assert_eq!(
+        json["network_policy"],
+        json!({
+            "inbound": "deny",
+            "outbound": "allowlist",
+            "network_allowlist": ["api.github.com"],
+        })
+    );
+    assert_eq!(
+        json["runtime_job"]["input"]["command"]["eval"]["network_policy"],
+        json["network_policy"]
+    );
+    let events = store.runtime_events_for(&job.id).await?;
+    assert!(events.iter().any(|event| {
+        event.event_type == "EvalNetworkPolicyApplied"
+            && event.event["network_policy"] == json["network_policy"]
+    }));
     Ok(())
 }
 

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -687,12 +687,31 @@ fn eval_required_isolation_resolution(
             command.id
         );
     }
+    let network_allowlist = isolation
+        .get("network_allowlist")
+        .map(|value| {
+            serde_json::from_value::<Vec<String>>(value.clone()).with_context(|| {
+                format!(
+                    "eval command {} has invalid eval.isolation.network_allowlist: {value}",
+                    command.id
+                )
+            })
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let network_policy = harness_sandbox::EvalNetworkPolicy::for_allowlist(&network_allowlist)
+        .with_context(|| {
+            format!(
+                "eval command {} has invalid eval.isolation.network_allowlist",
+                command.id
+            )
+        })?;
 
     Ok(Some(IsolationTierResolution {
         tier,
         reason: "eval command required container isolation tier from policy".to_string(),
         trust_class: IsolationTrustClass::NonCollaborator,
-        network_allowlist: Vec::new(),
+        network_allowlist: network_policy.network_allowlist,
     }))
 }
 
@@ -912,6 +931,40 @@ mod tests {
         assert_eq!(resolution.tier, IsolationTier::Container);
         assert_eq!(resolution.trust_class, IsolationTrustClass::NonCollaborator);
         assert!(resolution.reason.contains("eval command required"));
+        Ok(())
+    }
+
+    #[test]
+    fn eval_isolation_command_policy_normalizes_network_allowlist() -> anyhow::Result<()> {
+        let command = command_record(WorkflowCommand::new(
+            WorkflowCommandType::EnqueueActivity,
+            "eval-implement",
+            json!({
+                "activity": "implement_issue",
+                "eval": {
+                    "timeout_secs": 1800,
+                    "isolation": {
+                        "tier": "container",
+                        "runtime_kind": "remote_host",
+                        "runtime_profile": "eval-isolated-runtime-host",
+                        "sandbox": "workspace-write",
+                        "backend": "container_runtime_host",
+                        "image": "harness-eval-runner:local",
+                        "lifecycle": "ephemeral",
+                        "cleanup_required": true,
+                        "network_allowlist": [" GitHub.COM. ", "api.github.com"]
+                    }
+                }
+            }),
+        ));
+
+        let resolution =
+            isolation_resolution_for_command(None, &command, &IsolationConfig::default())?;
+
+        assert_eq!(
+            resolution.network_allowlist,
+            vec!["github.com".to_string(), "api.github.com".to_string()]
+        );
         Ok(())
     }
 

--- a/crates/harness-workflow/src/runtime/eval/manifest.rs
+++ b/crates/harness-workflow/src/runtime/eval/manifest.rs
@@ -51,6 +51,8 @@ pub struct EvalIsolationProfile {
     #[serde(default = "default_eval_isolation_image")]
     pub image: String,
     #[serde(default)]
+    pub network_allowlist: Vec<String>,
+    #[serde(default)]
     pub lifecycle: EvalIsolationLifecycle,
     #[serde(default = "default_cleanup_required")]
     pub cleanup_required: bool,
@@ -65,6 +67,7 @@ impl Default for EvalIsolationProfile {
             sandbox: default_eval_isolation_sandbox(),
             backend: default_eval_isolation_backend(),
             image: default_eval_isolation_image(),
+            network_allowlist: Vec::new(),
             lifecycle: EvalIsolationLifecycle::default(),
             cleanup_required: true,
         }
@@ -490,6 +493,10 @@ fn normalize_isolation_profile(
     profile.sandbox = non_empty(profile.sandbox, "eval isolation sandbox")?;
     profile.backend = non_empty(profile.backend, "eval isolation backend")?;
     profile.image = non_empty(profile.image, "eval isolation image")?;
+    profile.network_allowlist =
+        harness_sandbox::EvalNetworkPolicy::for_allowlist(&profile.network_allowlist)
+            .map_err(|error| ManifestError::new(format!("{context} network_allowlist: {error}")))?
+            .network_allowlist;
 
     match profile.tier {
         IsolationTier::Host => {
@@ -685,7 +692,52 @@ resource_limits = { memory_bytes = 0 }
         assert_eq!(case.isolation.lifecycle, EvalIsolationLifecycle::Ephemeral);
         assert_eq!(case.isolation.backend, "container_runtime_host");
         assert_eq!(case.isolation.image, "harness-eval-runner:local");
+        assert!(case.isolation.network_allowlist.is_empty());
         assert!(case.isolation.cleanup_required);
+    }
+
+    #[test]
+    fn eval_manifest_normalizes_trusted_network_allowlist() {
+        let input = r#"
+suite = "harness-core"
+
+[isolation]
+network_allowlist = [" GitHub.COM. ", "api.github.com"]
+
+[[cases]]
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = ["cargo test"]
+"#;
+
+        let manifest = parse_benchmark_manifest_str(input).expect("allowlisted case should parse");
+
+        assert_eq!(
+            manifest.cases[0].isolation.network_allowlist,
+            vec!["github.com".to_string(), "api.github.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn eval_manifest_rejects_ambiguous_network_allowlist_entries() {
+        let input = r#"
+suite = "harness-core"
+
+[isolation]
+network_allowlist = ["*.github.com"]
+
+[[cases]]
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = ["cargo test"]
+"#;
+
+        let err = parse_benchmark_manifest_str(input)
+            .expect_err("ambiguous eval network allowlist should fail");
+
+        assert!(err.to_string().contains("network_allowlist"));
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/eval/run.rs
+++ b/crates/harness-workflow/src/runtime/eval/run.rs
@@ -303,7 +303,7 @@ fn eval_case_isolation_config(case: &EvalBenchmarkCase) -> IsolationConfig {
             trust: IsolationTrustClass::NonCollaborator,
             tier: case.isolation.tier,
         }],
-        network_allowlist: Vec::new(),
+        network_allowlist: case.isolation.network_allowlist.clone(),
     }
 }
 
@@ -640,6 +640,7 @@ fn eval_isolation_metadata(isolation: &EvalIsolationProfile) -> Value {
         "sandbox": isolation.sandbox,
         "backend": isolation.backend,
         "image": isolation.image,
+        "network_allowlist": isolation.network_allowlist,
         "lifecycle": isolation.lifecycle,
         "cleanup_required": isolation.cleanup_required,
     })
@@ -718,6 +719,10 @@ mod tests {
             initial.data["eval"]["isolation"]["runtime_profile"],
             "eval-isolated-runtime-host"
         );
+        assert_eq!(
+            initial.data["eval"]["isolation"]["network_allowlist"],
+            json!([])
+        );
         assert_eq!(initial.data["eval"]["isolation"]["lifecycle"], "ephemeral");
         assert_eq!(initial.data["eval"]["isolation"]["cleanup_required"], true);
 
@@ -749,6 +754,7 @@ mod tests {
         assert_eq!(command["pull_request_mode"], EVAL_PR_DRAFT_MODE);
         assert_eq!(command["eval"]["isolation"]["tier"], "container");
         assert_eq!(command["eval"]["isolation"]["runtime_kind"], "remote_host");
+        assert_eq!(command["eval"]["isolation"]["network_allowlist"], json!([]));
         assert_eq!(
             command["validation_commands"][0],
             "cargo test -p harness-workflow eval_run"
@@ -762,6 +768,34 @@ mod tests {
         assert!(prompt.contains("open only a draft pull request"));
         assert!(prompt.contains("harness-eval/ branch prefix"));
         assert!(prompt.contains("Use the small implementation slice."));
+    }
+
+    #[test]
+    fn eval_run_isolation_config_preserves_trusted_network_allowlist() {
+        let mut case = EvalBenchmarkCase {
+            case_id: "owner/repo#42".to_string(),
+            repo: "owner/repo".to_string(),
+            issue: 42,
+            base_commit: "abcdef1".to_string(),
+            verify_commands: vec!["cargo test -p harness-workflow eval_run".to_string()],
+            paths: Vec::new(),
+            risk: None,
+            evidence: Vec::new(),
+            resolution_prs: Vec::new(),
+            resolution_commits: Vec::new(),
+            commit_resolution: None,
+            verdict: None,
+            timeout_secs: 120,
+            resource_limits: harness_sandbox::ResourceLimits::evaluation_defaults(120)
+                .cap_by(harness_sandbox::ResourceLimits::operator_default_maxima())
+                .expect("default resource limits should be valid"),
+            isolation: EvalIsolationProfile::default(),
+        };
+        case.isolation.network_allowlist = vec!["api.github.com".to_string()];
+
+        let config = eval_case_isolation_config(&case);
+
+        assert_eq!(config.network_allowlist, vec!["api.github.com".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
Summary
- Add an eval network policy/report model that defaults inbound and outbound access to deny and only accepts exact trusted DNS allowlists.
- Require remote runtime hosts to advertise eval_network_policy capability before claiming eval jobs, inject the expected policy into claims, and validate completion network_policy_report artifacts without payload capture.
- Preserve and normalize eval isolation network_allowlist values through manifests, dispatch, run metadata, and runtime-host claim responses.

Validation
- cargo fmt --all
- cargo fmt --all -- --check
- cargo check -p harness-sandbox -p harness-server --all-targets
- cargo check --workspace --all-targets
- cargo test -p harness-sandbox network_policy
- cargo test -p harness-server eval_network_policy
- cargo test -p harness-server runtime_job_claim_endpoint
- cargo test -p harness-server runtime_job_completion_endpoint
- cargo test -p harness-workflow eval_manifest
- cargo test -p harness-workflow eval_run
- cargo test -p harness-workflow eval_isolation_command_policy
- cargo test -p harness-agents codex_adapter::tests::app_server_protocol_failures_reset_and_reap_child --lib
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check
- git push -u origin harness/runtime-wf-github-issue-pr-ebe0c7a5 (pre-push clippy + database-independent workspace lib tests passed; HARNESS_DATABASE_URL not set so DB-backed suites were deferred by hook)

Scope guard
- origin/main: 8 files changed, 996 lines added, max 30 files and 1500 lines.

Closes #1751