### PR TITLE
feat(eval): govern baseline records

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,7 @@
 /AGENTS.md @majiayu000
 /CLAUDE.md @majiayu000
 /checks/ @majiayu000
+/evals/baselines/ @majiayu000
+/evals/benchmarks/ @majiayu000
 /scripts/ @majiayu000
 /tests/ @majiayu000

--- a/crates/harness-cli/src/commands/eval.rs
+++ b/crates/harness-cli/src/commands/eval.rs
@@ -3,13 +3,16 @@ use clap::{Args, Subcommand};
 use harness_workflow::runtime::eval::model::EvalGrade;
 use harness_workflow::runtime::{
     diff_eval_run_reports, eval_report_dry_run, eval_report_from_evidence,
-    parse_benchmark_manifest_str, EvalAttestationDecision, EvalAttestationTrust,
+    migrate_eval_baseline_report, parse_benchmark_manifest_str, parse_eval_baseline_record_str,
+    record_eval_baseline, validate_eval_baseline, EvalAttestationDecision, EvalAttestationTrust,
+    EvalBaselineCreatorObservation, EvalBaselineProvenance, EvalBaselineRecord,
     EvalBenchmarkManifest, EvalCaseEvidence, EvalCaseInfrastructureStatus, EvalCaseTransition,
     EvalCaseTransitionKind, EvalReportCaseStatus, EvalRunReport, EvalRunReportDiff,
 };
 use serde::Deserialize;
 use std::collections::BTreeMap;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 const PASS_DROP_EPSILON: f64 = 1e-9;
@@ -20,6 +23,11 @@ pub enum EvalCommand {
     Run(EvalRunArgs),
     /// Compare two saved eval run reports
     Diff(EvalDiffArgs),
+    /// Create, migrate, or verify governed eval baseline records
+    Baseline {
+        #[command(subcommand)]
+        cmd: EvalBaselineCommand,
+    },
 }
 
 #[derive(Args)]
@@ -67,10 +75,64 @@ pub struct EvalDiffArgs {
     pub output: Option<PathBuf>,
 }
 
+#[derive(Subcommand)]
+pub enum EvalBaselineCommand {
+    /// Create a new governed baseline record from an eval report
+    Record(EvalBaselineWriteArgs),
+    /// Explicitly migrate a legacy eval report into a governed baseline record
+    Migrate(EvalBaselineWriteArgs),
+    /// Verify a governed baseline record and print its digest summary
+    Verify(EvalBaselineVerifyArgs),
+}
+
+#[derive(Args)]
+pub struct EvalBaselineWriteArgs {
+    /// Eval run report JSON to bind into the baseline
+    #[arg(long)]
+    pub report: PathBuf,
+    /// New baseline record path. Existing files are never overwritten.
+    #[arg(long)]
+    pub output: PathBuf,
+    /// Digest of the benchmark suite or manifest, in sha256:<64-hex> form
+    #[arg(long)]
+    pub suite_digest: String,
+    /// Stable agent stack identifier used to produce the baseline
+    #[arg(long)]
+    pub stack_id: String,
+    /// Source commit observed when the baseline was created
+    #[arg(long)]
+    pub source_commit: String,
+    /// Evidence identifiers supporting the baseline, repeatable
+    #[arg(long = "evidence-id", required = true)]
+    pub evidence_ids: Vec<String>,
+    /// Human or service identity that observed baseline creation
+    #[arg(long)]
+    pub observer: String,
+    /// RFC3339 timestamp for the creator observation
+    #[arg(long)]
+    pub observed_at: String,
+    /// Creator observation note
+    #[arg(long)]
+    pub observation: String,
+    /// Print the created record JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct EvalBaselineVerifyArgs {
+    /// Governed baseline record JSON
+    pub baseline: PathBuf,
+    /// Print JSON instead of the compact text summary
+    #[arg(long)]
+    pub json: bool,
+}
+
 pub async fn run(cmd: EvalCommand) -> anyhow::Result<()> {
     match cmd {
         EvalCommand::Run(args) => run_eval_report(args).await,
         EvalCommand::Diff(args) => diff_eval_reports(args),
+        EvalCommand::Baseline { cmd } => run_eval_baseline_command(cmd),
     }
 }
 
@@ -78,6 +140,7 @@ async fn run_eval_report(args: EvalRunArgs) -> anyhow::Result<()> {
     if args.dry_run && args.evidence.is_some() {
         anyhow::bail!("use either --dry-run or --evidence, not both");
     }
+    ensure_report_output_not_baseline_path(args.output.as_deref())?;
 
     let manifest = read_eval_manifest(&args.manifest)?;
     let run_id = args
@@ -98,7 +161,7 @@ async fn run_eval_report(args: EvalRunArgs) -> anyhow::Result<()> {
 }
 
 fn diff_eval_reports(args: EvalDiffArgs) -> anyhow::Result<()> {
-    let baseline = read_run_report(&args.baseline)?;
+    let baseline = read_baseline_report(&args.baseline)?;
     let candidate = read_run_report(&args.candidate)?;
     if baseline.suite != candidate.suite {
         anyhow::bail!(
@@ -121,6 +184,43 @@ fn diff_eval_reports(args: EvalDiffArgs) -> anyhow::Result<()> {
         return Ok(());
     }
     anyhow::bail!("eval regression gate failed:\n{}", regressions.join("\n"))
+}
+
+fn run_eval_baseline_command(cmd: EvalBaselineCommand) -> anyhow::Result<()> {
+    match cmd {
+        EvalBaselineCommand::Record(args) => record_eval_baseline_command(args),
+        EvalBaselineCommand::Migrate(args) => migrate_eval_baseline_command(args),
+        EvalBaselineCommand::Verify(args) => verify_eval_baseline_command(args),
+    }
+}
+
+fn record_eval_baseline_command(args: EvalBaselineWriteArgs) -> anyhow::Result<()> {
+    let report = read_run_report(&args.report)?;
+    let provenance = baseline_provenance(&args);
+    let baseline = record_eval_baseline(None, report, provenance)
+        .map_err(|error| anyhow::anyhow!("invalid eval baseline record: {error}"))?;
+    write_new_json_output(&baseline, &args.output)?;
+    emit_baseline_record(&baseline, args.json);
+    Ok(())
+}
+
+fn migrate_eval_baseline_command(args: EvalBaselineWriteArgs) -> anyhow::Result<()> {
+    let report = read_run_report(&args.report)?;
+    let provenance = baseline_provenance(&args);
+    let baseline = migrate_eval_baseline_report(report, provenance)
+        .map_err(|error| anyhow::anyhow!("invalid eval baseline migration: {error}"))?;
+    write_new_json_output(&baseline, &args.output)?;
+    emit_baseline_record(&baseline, args.json);
+    Ok(())
+}
+
+fn verify_eval_baseline_command(args: EvalBaselineVerifyArgs) -> anyhow::Result<()> {
+    let baseline = read_eval_baseline_record(&args.baseline)?;
+    validate_eval_baseline(&baseline).map_err(|error| {
+        anyhow::anyhow!("invalid eval baseline {}: {error}", args.baseline.display())
+    })?;
+    emit_baseline_record(&baseline, args.json);
+    Ok(())
 }
 
 fn read_eval_manifest(path: &Path) -> anyhow::Result<EvalBenchmarkManifest> {
@@ -146,6 +246,34 @@ fn read_run_report(path: &Path) -> anyhow::Result<EvalRunReport> {
         .with_context(|| format!("failed to read eval report at {}", path.display()))?;
     serde_json::from_str(&content)
         .map_err(|error| anyhow::anyhow!("invalid eval report {}: {error}", path.display()))
+}
+
+fn read_baseline_report(path: &Path) -> anyhow::Result<EvalRunReport> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read eval baseline at {}", path.display()))?;
+    let value: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse eval baseline at {}", path.display()))?;
+    if is_baseline_record_value(&value) {
+        let baseline = parse_eval_baseline_record_str(&content).map_err(|error| {
+            anyhow::anyhow!("invalid eval baseline {}: {error}", path.display())
+        })?;
+        return Ok(baseline.report);
+    }
+    serde_json::from_value(value)
+        .map_err(|error| anyhow::anyhow!("invalid eval report {}: {error}", path.display()))
+}
+
+fn read_eval_baseline_record(path: &Path) -> anyhow::Result<EvalBaselineRecord> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read eval baseline at {}", path.display()))?;
+    parse_eval_baseline_record_str(&content)
+        .map_err(|error| anyhow::anyhow!("invalid eval baseline {}: {error}", path.display()))
+}
+
+fn is_baseline_record_value(value: &serde_json::Value) -> bool {
+    value.get("schema_version").is_some()
+        || value.get("record_digest").is_some()
+        || value.get("provenance").is_some()
 }
 
 fn emit_report(report: &EvalRunReport, json: bool, output: Option<&Path>) -> anyhow::Result<()> {
@@ -181,6 +309,75 @@ fn write_json_output<T: serde::Serialize>(value: &T, output: Option<&Path>) -> a
         fs::write(output, serde_json::to_string_pretty(value)?)?;
     }
     Ok(())
+}
+
+fn write_new_json_output<T: serde::Serialize>(value: &T, output: &Path) -> anyhow::Result<()> {
+    if let Some(parent) = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create output directory {}", parent.display()))?;
+    }
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(output)
+        .with_context(|| format!("failed to create baseline output {}", output.display()))?;
+    file.write_all(serde_json::to_string_pretty(value)?.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn ensure_report_output_not_baseline_path(output: Option<&Path>) -> anyhow::Result<()> {
+    let Some(output) = output else {
+        return Ok(());
+    };
+    if path_contains_evals_baselines(output) {
+        anyhow::bail!(
+            "candidate eval reports must not be written under evals/baselines; use `harness eval baseline record` or `harness eval baseline migrate`"
+        );
+    }
+    Ok(())
+}
+
+fn path_contains_evals_baselines(path: &Path) -> bool {
+    let components = path
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    components
+        .windows(2)
+        .any(|window| window == ["evals", "baselines"])
+}
+
+fn baseline_provenance(args: &EvalBaselineWriteArgs) -> EvalBaselineProvenance {
+    EvalBaselineProvenance {
+        suite_digest: args.suite_digest.clone(),
+        stack_id: args.stack_id.clone(),
+        source_commit: args.source_commit.clone(),
+        evidence_ids: args.evidence_ids.clone(),
+        creator_observation: EvalBaselineCreatorObservation {
+            observer: args.observer.clone(),
+            observed_at: args.observed_at.clone(),
+            note: args.observation.clone(),
+        },
+    }
+}
+
+fn emit_baseline_record(record: &EvalBaselineRecord, json: bool) {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(record)
+                .expect("EvalBaselineRecord serialization is infallible")
+        );
+    } else {
+        println!(
+            "Eval baseline {} ({}) report_digest={} record_digest={}",
+            record.report.run_id, record.report.suite, record.report_digest, record.record_digest
+        );
+    }
 }
 
 fn default_run_id(suite: &str) -> String {
@@ -638,6 +835,52 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
                 assert!(args.json);
             }
             _ => panic!("expected eval diff command"),
+        }
+
+        let cli = Cli::try_parse_from([
+            "harness",
+            "eval",
+            "baseline",
+            "record",
+            "--report",
+            "report.json",
+            "--output",
+            "evals/baselines/harness-core/latest.json",
+            "--suite-digest",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--stack-id",
+            "agent-stack-v1",
+            "--source-commit",
+            "1111111111111111111111111111111111111111",
+            "--evidence-id",
+            "issue:1744",
+            "--evidence-id",
+            "run:baseline-1",
+            "--observer",
+            "maintainer@example.com",
+            "--observed-at",
+            "2026-08-12T20:00:00Z",
+            "--observation",
+            "approved baseline",
+            "--json",
+        ])
+        .unwrap_or_else(|error| panic!("eval baseline record command should parse: {error}"));
+        match cli.command {
+            Command::Eval {
+                cmd:
+                    EvalCommand::Baseline {
+                        cmd: EvalBaselineCommand::Record(args),
+                    },
+            } => {
+                assert_eq!(args.report, PathBuf::from("report.json"));
+                assert_eq!(
+                    args.output,
+                    PathBuf::from("evals/baselines/harness-core/latest.json")
+                );
+                assert_eq!(args.evidence_ids, vec!["issue:1744", "run:baseline-1"]);
+                assert!(args.json);
+            }
+            _ => panic!("expected eval baseline record command"),
         }
     }
 
@@ -1125,6 +1368,107 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
         assert!(output.exists());
     }
 
+    #[test]
+    fn eval_run_output_rejects_baseline_directory() {
+        let error = ensure_report_output_not_baseline_path(Some(Path::new(
+            "evals/baselines/harness-core/latest.json",
+        )))
+        .expect_err("candidate output must not target committed baselines");
+
+        assert!(error.to_string().contains("candidate eval reports"));
+    }
+
+    #[test]
+    fn eval_baseline_record_creates_record_without_overwrite() {
+        let tempdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("tempdir should be creatable: {error}"));
+        let report_path = tempdir.path().join("report.json");
+        let output_path = tempdir.path().join("baseline.json");
+        let report = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "baseline",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Passed,
+                vec![usage_snapshot(100, 40)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("baseline report should build: {error}"));
+        write_report(&report_path, &report);
+
+        record_eval_baseline_command(baseline_write_args(
+            report_path.clone(),
+            output_path.clone(),
+        ))
+        .unwrap_or_else(|error| panic!("baseline record should write: {error}"));
+        let baseline = read_eval_baseline_record(&output_path)
+            .unwrap_or_else(|error| panic!("baseline record should read: {error}"));
+
+        assert_eq!(baseline.report.run_id, "baseline");
+        assert_eq!(baseline.provenance.stack_id, "agent-stack-v1");
+
+        let error = record_eval_baseline_command(baseline_write_args(report_path, output_path))
+            .expect_err("record command must not overwrite an existing baseline");
+        assert!(error
+            .to_string()
+            .contains("failed to create baseline output"));
+    }
+
+    #[test]
+    fn eval_diff_reads_validated_baseline_record() {
+        let tempdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("tempdir should be creatable: {error}"));
+        let baseline_path = tempdir.path().join("baseline.json");
+        let candidate_path = tempdir.path().join("candidate.json");
+        let baseline_report = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "baseline",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Passed,
+                vec![usage_snapshot(100, 40)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("baseline report should build: {error}"));
+        let baseline = record_eval_baseline(None, baseline_report, baseline_provenance_fixture())
+            .unwrap_or_else(|error| panic!("baseline record should build: {error}"));
+        fs::write(
+            &baseline_path,
+            serde_json::to_string_pretty(&baseline)
+                .unwrap_or_else(|error| panic!("baseline should serialize: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("baseline should write: {error}"));
+        let candidate = eval_report_from_evidence(
+            &sample_eval_manifest(),
+            "candidate",
+            3,
+            vec![case_evidence(
+                "case-pass",
+                EvalEvidenceStatus::Failed,
+                vec![usage_snapshot(80, 30)],
+                Vec::new(),
+            )],
+        )
+        .unwrap_or_else(|error| panic!("candidate report should build: {error}"));
+        write_report(&candidate_path, &candidate);
+
+        let error = diff_eval_reports(EvalDiffArgs {
+            baseline: baseline_path,
+            candidate: candidate_path,
+            max_pass_drop: Some(0.1),
+            fail_on_new_f_gate: false,
+            json: false,
+            output: None,
+        })
+        .expect_err("validated baseline diff should apply regression gates");
+
+        assert!(error.to_string().contains("pass@1 drop"));
+    }
+
     fn case_evidence(
         case_id: &str,
         status: EvalEvidenceStatus,
@@ -1184,6 +1528,35 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
             cost_usd_micros: Some(cost_usd_micros),
             token_confidence: Confidence::Observed,
             cost_confidence: Confidence::Estimated,
+        }
+    }
+
+    fn baseline_write_args(report: PathBuf, output: PathBuf) -> EvalBaselineWriteArgs {
+        EvalBaselineWriteArgs {
+            report,
+            output,
+            suite_digest: format!("sha256:{}", "a".repeat(64)),
+            stack_id: "agent-stack-v1".to_string(),
+            source_commit: "1".repeat(40),
+            evidence_ids: vec!["issue:1744".to_string(), "run:baseline-1".to_string()],
+            observer: "maintainer@example.com".to_string(),
+            observed_at: "2026-08-12T20:00:00Z".to_string(),
+            observation: "approved baseline".to_string(),
+            json: false,
+        }
+    }
+
+    fn baseline_provenance_fixture() -> EvalBaselineProvenance {
+        EvalBaselineProvenance {
+            suite_digest: format!("sha256:{}", "a".repeat(64)),
+            stack_id: "agent-stack-v1".to_string(),
+            source_commit: "1".repeat(40),
+            evidence_ids: vec!["issue:1744".to_string(), "run:baseline-1".to_string()],
+            creator_observation: EvalBaselineCreatorObservation {
+                observer: "maintainer@example.com".to_string(),
+                observed_at: "2026-08-12T20:00:00Z".to_string(),
+                note: "approved baseline".to_string(),
+            },
         }
     }
 

--- a/crates/harness-workflow/src/runtime/eval/baseline.rs
+++ b/crates/harness-workflow/src/runtime/eval/baseline.rs
@@ -1,0 +1,562 @@
+use super::report::{diff_eval_run_reports, EvalRunReport, EvalRunReportDiff};
+use chrono::DateTime;
+use harness_core::stack::Sha256Digest;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use thiserror::Error;
+
+pub const EVAL_BASELINE_RECORD_SCHEMA_VERSION: &str = "eval-baseline/v0.1";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalBaselineCreatorObservation {
+    pub observer: String,
+    pub observed_at: String,
+    pub note: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalBaselineProvenance {
+    pub suite_digest: String,
+    pub stack_id: String,
+    pub source_commit: String,
+    pub evidence_ids: Vec<String>,
+    pub creator_observation: EvalBaselineCreatorObservation,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvalBaselineRecord {
+    pub schema_version: String,
+    pub provenance: EvalBaselineProvenance,
+    pub report: EvalRunReport,
+    pub report_digest: String,
+    pub record_digest: String,
+}
+
+#[derive(Debug, Error)]
+pub enum EvalBaselineError {
+    #[error("baseline record already exists; compare against it or use explicit migration")]
+    BaselineAlreadyExists,
+    #[error("invalid eval baseline JSON: {source}")]
+    InvalidJson {
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("unsupported eval baseline schema version `{actual}`; expected `{expected}`")]
+    UnsupportedSchemaVersion {
+        expected: &'static str,
+        actual: String,
+    },
+    #[error("invalid eval baseline provenance `{field}`: {reason}")]
+    InvalidProvenance {
+        field: &'static str,
+        reason: &'static str,
+    },
+    #[error("invalid eval baseline report `{field}`: {reason}")]
+    InvalidReport {
+        field: &'static str,
+        reason: &'static str,
+    },
+    #[error("eval baseline {field} mismatch: expected `{expected}`, got `{actual}`")]
+    DigestMismatch {
+        field: &'static str,
+        expected: String,
+        actual: String,
+    },
+    #[error("cannot compare baseline suite `{baseline}` to candidate suite `{candidate}`")]
+    SuiteMismatch { baseline: String, candidate: String },
+    #[error("cannot compare baseline k `{baseline}` to candidate k `{candidate}`")]
+    KMismatch { baseline: u32, candidate: u32 },
+    #[error("failed to serialize baseline digest payload: {source}")]
+    Serialize {
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+pub fn record_eval_baseline(
+    existing: Option<&EvalBaselineRecord>,
+    report: EvalRunReport,
+    provenance: EvalBaselineProvenance,
+) -> Result<EvalBaselineRecord, EvalBaselineError> {
+    if existing.is_some() {
+        return Err(EvalBaselineError::BaselineAlreadyExists);
+    }
+    build_eval_baseline_record(report, provenance)
+}
+
+pub fn migrate_eval_baseline_report(
+    report: EvalRunReport,
+    provenance: EvalBaselineProvenance,
+) -> Result<EvalBaselineRecord, EvalBaselineError> {
+    build_eval_baseline_record(report, provenance)
+}
+
+pub fn parse_eval_baseline_record_str(
+    input: &str,
+) -> Result<EvalBaselineRecord, EvalBaselineError> {
+    let record: EvalBaselineRecord =
+        serde_json::from_str(input).map_err(|source| EvalBaselineError::InvalidJson { source })?;
+    validate_eval_baseline(&record)?;
+    Ok(record)
+}
+
+pub fn validate_eval_baseline(record: &EvalBaselineRecord) -> Result<(), EvalBaselineError> {
+    if record.schema_version != EVAL_BASELINE_RECORD_SCHEMA_VERSION {
+        return Err(EvalBaselineError::UnsupportedSchemaVersion {
+            expected: EVAL_BASELINE_RECORD_SCHEMA_VERSION,
+            actual: record.schema_version.clone(),
+        });
+    }
+    validate_provenance(&record.provenance)?;
+    validate_report(&record.report)?;
+    let expected_report_digest = eval_baseline_report_digest(&record.report)?;
+    if record.report_digest != expected_report_digest {
+        return Err(EvalBaselineError::DigestMismatch {
+            field: "report_digest",
+            expected: expected_report_digest,
+            actual: record.report_digest.clone(),
+        });
+    }
+    validate_prefixed_sha256(&record.record_digest, "record_digest")?;
+    let expected_record_digest = eval_baseline_record_digest(
+        &record.schema_version,
+        &record.provenance,
+        &record.report,
+        &record.report_digest,
+    )?;
+    if record.record_digest != expected_record_digest {
+        return Err(EvalBaselineError::DigestMismatch {
+            field: "record_digest",
+            expected: expected_record_digest,
+            actual: record.record_digest.clone(),
+        });
+    }
+    Ok(())
+}
+
+pub fn compare_eval_baseline(
+    baseline: &EvalBaselineRecord,
+    candidate: &EvalRunReport,
+) -> Result<EvalRunReportDiff, EvalBaselineError> {
+    validate_eval_baseline(baseline)?;
+    if baseline.report.suite != candidate.suite {
+        return Err(EvalBaselineError::SuiteMismatch {
+            baseline: baseline.report.suite.clone(),
+            candidate: candidate.suite.clone(),
+        });
+    }
+    if baseline.report.k != candidate.k {
+        return Err(EvalBaselineError::KMismatch {
+            baseline: baseline.report.k,
+            candidate: candidate.k,
+        });
+    }
+    Ok(diff_eval_run_reports(&baseline.report, candidate))
+}
+
+pub fn eval_baseline_report_digest(report: &EvalRunReport) -> Result<String, EvalBaselineError> {
+    sha256_json(report)
+}
+
+fn build_eval_baseline_record(
+    report: EvalRunReport,
+    provenance: EvalBaselineProvenance,
+) -> Result<EvalBaselineRecord, EvalBaselineError> {
+    validate_provenance(&provenance)?;
+    validate_report(&report)?;
+    let report_digest = eval_baseline_report_digest(&report)?;
+    let record_digest = eval_baseline_record_digest(
+        EVAL_BASELINE_RECORD_SCHEMA_VERSION,
+        &provenance,
+        &report,
+        &report_digest,
+    )?;
+    let record = EvalBaselineRecord {
+        schema_version: EVAL_BASELINE_RECORD_SCHEMA_VERSION.to_string(),
+        provenance,
+        report,
+        report_digest,
+        record_digest,
+    };
+    validate_eval_baseline(&record)?;
+    Ok(record)
+}
+
+#[derive(Serialize)]
+struct EvalBaselineRecordDigestPayload<'a> {
+    schema_version: &'a str,
+    provenance: &'a EvalBaselineProvenance,
+    report: &'a EvalRunReport,
+    report_digest: &'a str,
+}
+
+fn eval_baseline_record_digest(
+    schema_version: &str,
+    provenance: &EvalBaselineProvenance,
+    report: &EvalRunReport,
+    report_digest: &str,
+) -> Result<String, EvalBaselineError> {
+    sha256_json(&EvalBaselineRecordDigestPayload {
+        schema_version,
+        provenance,
+        report,
+        report_digest,
+    })
+}
+
+fn sha256_json(value: &impl Serialize) -> Result<String, EvalBaselineError> {
+    let encoded =
+        serde_json::to_vec(value).map_err(|source| EvalBaselineError::Serialize { source })?;
+    Ok(format!("sha256:{:x}", Sha256::digest(encoded)))
+}
+
+fn validate_provenance(provenance: &EvalBaselineProvenance) -> Result<(), EvalBaselineError> {
+    validate_prefixed_sha256(&provenance.suite_digest, "suite_digest")?;
+    validate_non_empty_line(&provenance.stack_id, "stack_id")?;
+    if !is_valid_source_commit(&provenance.source_commit) {
+        return Err(EvalBaselineError::InvalidProvenance {
+            field: "source_commit",
+            reason: "must be a 40- or 64-character hexadecimal commit",
+        });
+    }
+    if provenance.evidence_ids.is_empty() {
+        return Err(EvalBaselineError::InvalidProvenance {
+            field: "evidence_ids",
+            reason: "must contain at least one evidence id",
+        });
+    }
+    let mut seen = BTreeSet::new();
+    for evidence_id in &provenance.evidence_ids {
+        validate_non_empty_line(evidence_id, "evidence_ids")?;
+        if !seen.insert(evidence_id.as_str()) {
+            return Err(EvalBaselineError::InvalidProvenance {
+                field: "evidence_ids",
+                reason: "must not contain duplicates",
+            });
+        }
+    }
+    validate_non_empty_line(
+        &provenance.creator_observation.observer,
+        "creator_observation",
+    )?;
+    validate_non_empty_line(&provenance.creator_observation.note, "creator_observation")?;
+    if DateTime::parse_from_rfc3339(&provenance.creator_observation.observed_at).is_err() {
+        return Err(EvalBaselineError::InvalidProvenance {
+            field: "creator_observation",
+            reason: "observed_at must be RFC3339",
+        });
+    }
+    Ok(())
+}
+
+fn validate_report(report: &EvalRunReport) -> Result<(), EvalBaselineError> {
+    validate_non_empty_report_field(&report.run_id, "run_id")?;
+    validate_non_empty_report_field(&report.suite, "suite")?;
+    if report.k == 0 {
+        return Err(EvalBaselineError::InvalidReport {
+            field: "k",
+            reason: "must be greater than zero",
+        });
+    }
+    if report.cases.is_empty() {
+        return Err(EvalBaselineError::InvalidReport {
+            field: "cases",
+            reason: "must contain at least one case",
+        });
+    }
+    if report.metrics.total_cases != report.cases.len() as u64 {
+        return Err(EvalBaselineError::InvalidReport {
+            field: "metrics.total_cases",
+            reason: "must match cases length",
+        });
+    }
+    for case in &report.cases {
+        validate_non_empty_report_field(&case.case_id, "case_id")?;
+        validate_non_empty_report_field(&case.repo, "repo")?;
+        validate_non_empty_report_field(&case.base_commit, "base_commit")?;
+        validate_non_empty_report_field(&case.source_commit, "source_commit")?;
+        if case.verify_commands.is_empty()
+            || case
+                .verify_commands
+                .iter()
+                .any(|command| command.trim().is_empty() || contains_newline(command))
+        {
+            return Err(EvalBaselineError::InvalidReport {
+                field: "verify_commands",
+                reason: "must contain single-line commands",
+            });
+        }
+        if case.passed != matches!(case.status, super::report::EvalReportCaseStatus::Passed) {
+            return Err(EvalBaselineError::InvalidReport {
+                field: "passed",
+                reason: "must match case status",
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_prefixed_sha256(value: &str, field: &'static str) -> Result<(), EvalBaselineError> {
+    let Some(digest) = value.strip_prefix("sha256:") else {
+        return Err(EvalBaselineError::InvalidProvenance {
+            field,
+            reason: "must use sha256:<64-hex> format",
+        });
+    };
+    Sha256Digest::parse(digest).map_err(|_| EvalBaselineError::InvalidProvenance {
+        field,
+        reason: "must use sha256:<64-hex> format",
+    })?;
+    Ok(())
+}
+
+fn validate_non_empty_line(value: &str, field: &'static str) -> Result<(), EvalBaselineError> {
+    if value.trim().is_empty() || contains_newline(value) {
+        return Err(EvalBaselineError::InvalidProvenance {
+            field,
+            reason: "must be a non-empty single-line value",
+        });
+    }
+    Ok(())
+}
+
+fn validate_non_empty_report_field(
+    value: &str,
+    field: &'static str,
+) -> Result<(), EvalBaselineError> {
+    if value.trim().is_empty() {
+        return Err(EvalBaselineError::InvalidReport {
+            field,
+            reason: "must be non-empty",
+        });
+    }
+    Ok(())
+}
+
+fn contains_newline(value: &str) -> bool {
+    value.contains('\n') || value.contains('\r')
+}
+
+fn is_valid_source_commit(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::report::{
+        EvalCaseInfrastructureStatus, EvalReportCase, EvalReportCaseStatus, EvalReportMetrics,
+    };
+    use super::*;
+
+    #[test]
+    fn record_eval_baseline_binds_provenance_and_compares() {
+        let baseline = record_eval_baseline(
+            None,
+            report("baseline", EvalReportCaseStatus::Passed),
+            provenance(),
+        )
+        .expect("baseline should record");
+
+        assert_eq!(baseline.provenance.stack_id, "agent-stack-v1");
+        assert_eq!(
+            baseline.provenance.evidence_ids,
+            vec!["issue:1744", "run:baseline-1"]
+        );
+        validate_eval_baseline(&baseline).expect("recorded baseline should validate");
+
+        let candidate = report("candidate", EvalReportCaseStatus::Failed);
+        let diff = compare_eval_baseline(&baseline, &candidate).expect("baseline should compare");
+
+        assert_eq!(diff.baseline_run_id, "baseline");
+        assert_eq!(diff.candidate_run_id, "candidate");
+        assert_eq!(diff.regression_ids, vec!["case-1"]);
+    }
+
+    #[test]
+    fn validate_eval_baseline_rejects_report_tampering() {
+        let mut baseline = record_eval_baseline(
+            None,
+            report("baseline", EvalReportCaseStatus::Passed),
+            provenance(),
+        )
+        .expect("baseline should record");
+        baseline.report.cases[0].status = EvalReportCaseStatus::Failed;
+        baseline.report.cases[0].passed = false;
+
+        let error =
+            validate_eval_baseline(&baseline).expect_err("tampered report must be rejected");
+
+        assert!(matches!(
+            error,
+            EvalBaselineError::DigestMismatch {
+                field: "report_digest",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_eval_baseline_rejects_provenance_tampering() {
+        let mut baseline = record_eval_baseline(
+            None,
+            report("baseline", EvalReportCaseStatus::Passed),
+            provenance(),
+        )
+        .expect("baseline should record");
+        baseline.provenance.stack_id = "agent-stack-v2".to_string();
+
+        let error =
+            validate_eval_baseline(&baseline).expect_err("tampered provenance must be rejected");
+
+        assert!(matches!(
+            error,
+            EvalBaselineError::DigestMismatch {
+                field: "record_digest",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn record_eval_baseline_rejects_candidate_overwrite() {
+        let baseline = record_eval_baseline(
+            None,
+            report("baseline", EvalReportCaseStatus::Passed),
+            provenance(),
+        )
+        .expect("baseline should record");
+
+        let error = record_eval_baseline(
+            Some(&baseline),
+            report("candidate", EvalReportCaseStatus::Failed),
+            provenance(),
+        )
+        .expect_err("candidate record must not overwrite existing baseline");
+
+        assert!(matches!(error, EvalBaselineError::BaselineAlreadyExists));
+    }
+
+    #[test]
+    fn eval_baseline_requires_complete_provenance() {
+        let mut provenance = provenance();
+        provenance.evidence_ids.clear();
+
+        let error = record_eval_baseline(
+            None,
+            report("baseline", EvalReportCaseStatus::Passed),
+            provenance,
+        )
+        .expect_err("missing evidence ids must be rejected");
+
+        assert!(matches!(
+            error,
+            EvalBaselineError::InvalidProvenance {
+                field: "evidence_ids",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn migrate_eval_baseline_report_requires_explicit_operation() {
+        let migrated = migrate_eval_baseline_report(
+            report("legacy-baseline", EvalReportCaseStatus::Passed),
+            provenance(),
+        )
+        .expect("legacy report should migrate through explicit operation");
+
+        assert_eq!(migrated.schema_version, EVAL_BASELINE_RECORD_SCHEMA_VERSION);
+        validate_eval_baseline(&migrated).expect("migrated baseline should validate");
+    }
+
+    #[test]
+    fn parse_eval_baseline_record_str_rejects_incomplete_record() {
+        let baseline = record_eval_baseline(
+            None,
+            report("baseline", EvalReportCaseStatus::Passed),
+            provenance(),
+        )
+        .expect("baseline should record");
+        let mut json =
+            serde_json::to_value(&baseline).expect("baseline record should serialize to JSON");
+        json.as_object_mut()
+            .expect("record JSON should be an object")
+            .remove("provenance");
+        let input = serde_json::to_string(&json).expect("incomplete JSON should serialize");
+
+        let error =
+            parse_eval_baseline_record_str(&input).expect_err("incomplete record must fail");
+
+        assert!(matches!(error, EvalBaselineError::InvalidJson { .. }));
+    }
+
+    fn provenance() -> EvalBaselineProvenance {
+        EvalBaselineProvenance {
+            suite_digest: format!("sha256:{}", "a".repeat(64)),
+            stack_id: "agent-stack-v1".to_string(),
+            source_commit: "1".repeat(40),
+            evidence_ids: vec!["issue:1744".to_string(), "run:baseline-1".to_string()],
+            creator_observation: EvalBaselineCreatorObservation {
+                observer: "maintainer@example.com".to_string(),
+                observed_at: "2026-08-12T20:00:00Z".to_string(),
+                note: "baseline approved from collected eval evidence".to_string(),
+            },
+        }
+    }
+
+    fn report(run_id: &str, status: EvalReportCaseStatus) -> EvalRunReport {
+        let case = EvalReportCase {
+            case_id: "case-1".to_string(),
+            repo: "majiayu000/harness".to_string(),
+            issue: 1744,
+            base_commit: "0".repeat(40),
+            source_commit: "1".repeat(40),
+            verify_commands: vec!["cargo test -p harness-workflow eval_baseline".to_string()],
+            status,
+            passed: status == EvalReportCaseStatus::Passed,
+            attestation_trust: super::super::attestation::EvalAttestationTrust::Verified,
+            attestation_decision: Some(
+                super::super::attestation::EvalAttestationDecision::Approved,
+            ),
+            explicit_evidence: true,
+            final_grade: None,
+            failed_hard_gates: Vec::new(),
+            workflow_id: Some("workflow-1".to_string()),
+            terminal_state: Some("done".to_string()),
+            infrastructure_status: EvalCaseInfrastructureStatus::Healthy,
+            total_tokens: 100,
+            cost_usd_micros: 50,
+            missing_evidence: Vec::new(),
+        };
+        EvalRunReport {
+            run_id: run_id.to_string(),
+            suite: "harness-core".to_string(),
+            k: 3,
+            metrics: EvalReportMetrics {
+                total_cases: 1,
+                scored_cases: 1,
+                passed_cases: u64::from(status == EvalReportCaseStatus::Passed),
+                failed_cases: u64::from(status == EvalReportCaseStatus::Failed),
+                skipped_cases: 0,
+                pending_cases: 0,
+                infra_failed_cases: 0,
+                pass_at_1: if status == EvalReportCaseStatus::Passed {
+                    1.0
+                } else {
+                    0.0
+                },
+                pass_to_k: if status == EvalReportCaseStatus::Passed {
+                    1.0
+                } else {
+                    0.0
+                },
+                total_tokens: 100,
+                avg_tokens_per_scored_case: Some(100.0),
+                total_cost_usd_micros: 50,
+                avg_cost_usd_micros_per_scored_case: Some(50.0),
+            },
+            cases: vec![case],
+        }
+    }
+}

--- a/crates/harness-workflow/src/runtime/eval/mod.rs
+++ b/crates/harness-workflow/src/runtime/eval/mod.rs
@@ -5,6 +5,7 @@
 //! deterministic scoring primitives, and standard-path eval dispatch helpers.
 
 pub mod attestation;
+pub mod baseline;
 mod data;
 pub mod evidence;
 pub mod historical_replay;
@@ -24,6 +25,12 @@ pub use attestation::{
     EvalAttestationTrust, EvalAttestationVerificationError, EvalRunAttestation,
     EvalRunAttestationClaims, EvalRunAttestationExpected, KeylessOidcProvider,
     KeylessOidcVerification, VerifiedEvalRunAttestation, EVAL_RUN_ATTESTATION_SCHEMA_VERSION,
+};
+pub use baseline::{
+    compare_eval_baseline, eval_baseline_report_digest, migrate_eval_baseline_report,
+    parse_eval_baseline_record_str, record_eval_baseline, validate_eval_baseline,
+    EvalBaselineCreatorObservation, EvalBaselineError, EvalBaselineProvenance, EvalBaselineRecord,
+    EVAL_BASELINE_RECORD_SCHEMA_VERSION,
 };
 pub use evidence::{
     collect_eval_case_evidence, collect_eval_case_evidence_from_records, EvalCaseEvidence,

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -91,13 +91,15 @@ pub use dispatcher::{CommandDispatchOutcome, RuntimeCommandDispatcher, RuntimePr
 pub use errors::RuntimeJobNotFoundError;
 pub use eval::{
     classify_eval_run_attestation, collect_eval_case_evidence,
-    collect_eval_case_evidence_from_records, diff_eval_run_reports, dispatch_eval_case_workflow,
-    enqueue_eval_case_workflow, eval_isolated_runtime_profile, eval_report_dry_run,
-    eval_report_from_evidence, eval_run_attestation_payload_digest,
-    historical_replay_command_digest, parse_benchmark_manifest_str,
-    parse_historical_replay_cohort_str, score_pr_repair_eval, validate_historical_replay_cohort,
+    collect_eval_case_evidence_from_records, compare_eval_baseline, diff_eval_run_reports,
+    dispatch_eval_case_workflow, enqueue_eval_case_workflow, eval_isolated_runtime_profile,
+    eval_report_dry_run, eval_report_from_evidence, eval_run_attestation_payload_digest,
+    historical_replay_command_digest, migrate_eval_baseline_report, parse_benchmark_manifest_str,
+    parse_eval_baseline_record_str, parse_historical_replay_cohort_str, record_eval_baseline,
+    score_pr_repair_eval, validate_eval_baseline, validate_historical_replay_cohort,
     verify_eval_run_attestation, EvalAttestationDecision, EvalAttestationSummary,
-    EvalAttestationTrust, EvalAttestationVerificationError, EvalBenchmarkCase,
+    EvalAttestationTrust, EvalAttestationVerificationError, EvalBaselineCreatorObservation,
+    EvalBaselineError, EvalBaselineProvenance, EvalBaselineRecord, EvalBenchmarkCase,
     EvalBenchmarkManifest, EvalCaseDispatchOutcome, EvalCaseEnqueueOutcome, EvalCaseEvidence,
     EvalCaseInfrastructureStatus, EvalCaseRisk, EvalCaseTransition, EvalCaseTransitionCounts,
     EvalCaseTransitionKind, EvalCaseVerdict, EvalCaseWorkflowInput, EvalCaseWorkflowPlan,
@@ -111,8 +113,9 @@ pub use eval::{
     HistoricalReplayPullRequestSnapshot, HistoricalReplayVerification, KeylessOidcProvider,
     KeylessOidcVerification, ManifestError, ScoringError, VerifiedEvalRunAttestation,
     DEFAULT_CASE_TIMEOUT_SECS, DEFAULT_EVAL_ISOLATION_BACKEND, DEFAULT_EVAL_ISOLATION_IMAGE,
-    DEFAULT_EVAL_ISOLATION_RUNTIME_PROFILE, DEFAULT_EVAL_ISOLATION_SANDBOX, EVAL_BRANCH_PREFIX,
-    EVAL_PR_DRAFT_MODE, EVAL_RUN_ATTESTATION_SCHEMA_VERSION, HISTORICAL_REPLAY_COHORT_SCHEMA,
+    DEFAULT_EVAL_ISOLATION_RUNTIME_PROFILE, DEFAULT_EVAL_ISOLATION_SANDBOX,
+    EVAL_BASELINE_RECORD_SCHEMA_VERSION, EVAL_BRANCH_PREFIX, EVAL_PR_DRAFT_MODE,
+    EVAL_RUN_ATTESTATION_SCHEMA_VERSION, HISTORICAL_REPLAY_COHORT_SCHEMA,
 };
 pub use lease_state::{runtime_job_running_lease_state_at, RuntimeJobRunningLeaseState};
 pub use memory_retrieval::{

--- a/evals/baselines/README.md
+++ b/evals/baselines/README.md
@@ -1,0 +1,25 @@
+# Runtime Eval Baselines
+
+Committed eval baselines are governed records, not mutable run reports. Create
+them with `harness eval baseline record` or explicitly migrate a legacy report
+with `harness eval baseline migrate`.
+
+Each baseline record binds:
+
+- `suite_digest`
+- `stack_id`
+- `source_commit`
+- `evidence_ids`
+- `creator_observation`
+- the baseline report digest
+- the full record digest
+
+Candidate eval reports must be written outside `evals/baselines/` and compared
+against a baseline record with `harness eval diff`. The CLI rejects candidate
+report output under this directory so a candidate run cannot overwrite a
+committed baseline by using `--output`.
+
+Branch protection for `main` must require a fresh CODEOWNERS review before
+changes to this directory can merge. The repository CODEOWNERS file assigns
+`/evals/baselines/` to the maintainer owner; baseline updates are therefore
+human-reviewed governance changes, not ordinary candidate eval artifacts.

--- a/evals/benchmarks/README.md
+++ b/evals/benchmarks/README.md
@@ -45,3 +45,8 @@ Historical replay cases can also record structured replay metadata:
 - `commit_resolution` is `resolved` or `pending`.
 - `verdict` is `replayable` or `pending`; pending commit pairs must not be
   marked replayable, dispatched, or counted from collected evidence.
+
+Committed baselines live under `evals/baselines/` as governed baseline records.
+Do not copy candidate run reports into that directory. Use
+`harness eval baseline record` for new baselines and
+`harness eval baseline migrate` for explicit legacy-report migrations.


### PR DESCRIPTION
## Summary
- Add governed eval baseline records that bind provenance, report digest, and full record digest before compare.
- Add `harness eval baseline record|migrate|verify`, allow `harness eval diff` to read validated baseline records, and block candidate run output under `evals/baselines/`.
- Document CODEOWNERS and branch protection expectations for committed eval baselines.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p harness-workflow --all-targets`
- `cargo test -p harness-workflow eval_baseline`
- `cargo check -p harness-cli --all-targets`
- `cargo test -p harness-cli baseline`
- `cargo test -p harness-cli eval_report_cli_parses_run_and_diff_commands`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Pre-push hook: clippy and database-independent workspace lib tests passed; PostgreSQL-backed suites deferred because `HARNESS_DATABASE_URL` is unset.

Scope guard: 7 files changed, 988 added lines against `origin/main` (limits: 30 files, 1500 added lines).

Closes #1744