### PR TITLE
feat(eval): require approval for suite drift

### DIFF
--- a/crates/harness-cli/src/commands/eval.rs
+++ b/crates/harness-cli/src/commands/eval.rs
@@ -1,11 +1,13 @@
 use anyhow::Context;
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use harness_workflow::runtime::eval::model::EvalGrade;
 use harness_workflow::runtime::{
-    diff_eval_run_reports, eval_report_dry_run, eval_report_from_evidence,
+    assess_eval_suite_drift, diff_eval_run_reports, eval_report_dry_run, eval_report_from_evidence,
     parse_benchmark_manifest_str, EvalAttestationDecision, EvalAttestationTrust,
     EvalBenchmarkManifest, EvalCaseEvidence, EvalCaseInfrastructureStatus, EvalCaseTransition,
     EvalCaseTransitionKind, EvalReportCaseStatus, EvalRunReport, EvalRunReportDiff,
+    EvalSuiteDriftAssessment, EvalSuiteDriftDecision, EvalSuiteDriftPolicy,
+    EvalSuiteMigrationRecord,
 };
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -20,6 +22,8 @@ pub enum EvalCommand {
     Run(EvalRunArgs),
     /// Compare two saved eval run reports
     Diff(EvalDiffArgs),
+    /// Compare two benchmark manifests and require migration approval for drift
+    SuiteDrift(EvalSuiteDriftArgs),
 }
 
 #[derive(Args)]
@@ -67,10 +71,46 @@ pub struct EvalDiffArgs {
     pub output: Option<PathBuf>,
 }
 
+#[derive(Args)]
+pub struct EvalSuiteDriftArgs {
+    /// Baseline benchmark manifest path
+    pub baseline: PathBuf,
+    /// Candidate benchmark manifest path
+    pub candidate: PathBuf,
+    /// Versioned suite migration approval record JSON
+    #[arg(long)]
+    pub migration: Option<PathBuf>,
+    /// Policy to apply when drift has no valid approved migration record
+    #[arg(long, value_enum, default_value = "block")]
+    pub policy: EvalSuiteDriftPolicyArg,
+    /// Print JSON instead of the compact text assessment
+    #[arg(long)]
+    pub json: bool,
+    /// Also write the JSON assessment to this path
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum EvalSuiteDriftPolicyArg {
+    Block,
+    NeedsHuman,
+}
+
+impl From<EvalSuiteDriftPolicyArg> for EvalSuiteDriftPolicy {
+    fn from(value: EvalSuiteDriftPolicyArg) -> Self {
+        match value {
+            EvalSuiteDriftPolicyArg::Block => Self::Block,
+            EvalSuiteDriftPolicyArg::NeedsHuman => Self::NeedsHuman,
+        }
+    }
+}
+
 pub async fn run(cmd: EvalCommand) -> anyhow::Result<()> {
     match cmd {
         EvalCommand::Run(args) => run_eval_report(args).await,
         EvalCommand::Diff(args) => diff_eval_reports(args),
+        EvalCommand::SuiteDrift(args) => diff_eval_suite_drift(args),
     }
 }
 
@@ -123,11 +163,50 @@ fn diff_eval_reports(args: EvalDiffArgs) -> anyhow::Result<()> {
     anyhow::bail!("eval regression gate failed:\n{}", regressions.join("\n"))
 }
 
+fn diff_eval_suite_drift(args: EvalSuiteDriftArgs) -> anyhow::Result<()> {
+    let baseline = read_eval_manifest(&args.baseline)?;
+    let candidate = read_eval_manifest(&args.candidate)?;
+    let migration = args
+        .migration
+        .as_ref()
+        .map(|path| read_suite_migration_record(path))
+        .transpose()?;
+    let assessment = assess_eval_suite_drift(
+        &baseline,
+        &candidate,
+        migration.as_ref(),
+        EvalSuiteDriftPolicy::from(args.policy),
+    );
+    emit_suite_drift_assessment(&assessment, args.json, args.output.as_deref())?;
+    match assessment.decision {
+        EvalSuiteDriftDecision::NoDrift | EvalSuiteDriftDecision::Approved => Ok(()),
+        EvalSuiteDriftDecision::Block | EvalSuiteDriftDecision::NeedsHuman => anyhow::bail!(
+            "eval suite drift requires approval:\n{}",
+            assessment.blockers.join("\n")
+        ),
+    }
+}
+
 fn read_eval_manifest(path: &Path) -> anyhow::Result<EvalBenchmarkManifest> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("failed to read eval manifest at {}", path.display()))?;
     parse_benchmark_manifest_str(&content)
         .map_err(|error| anyhow::anyhow!("invalid eval manifest {}: {error}", path.display()))
+}
+
+fn read_suite_migration_record(path: &Path) -> anyhow::Result<EvalSuiteMigrationRecord> {
+    let content = fs::read_to_string(path).with_context(|| {
+        format!(
+            "failed to read eval suite migration record at {}",
+            path.display()
+        )
+    })?;
+    serde_json::from_str(&content).map_err(|error| {
+        anyhow::anyhow!(
+            "invalid eval suite migration record {}: {error}",
+            path.display()
+        )
+    })
 }
 
 fn read_evidence(path: &Path) -> anyhow::Result<Vec<EvalCaseEvidence>> {
@@ -164,6 +243,20 @@ fn emit_diff(diff: &EvalRunReportDiff, json: bool, output: Option<&Path>) -> any
         println!("{}", serde_json::to_string_pretty(diff)?);
     } else {
         print!("{}", render_diff_report(diff));
+    }
+    Ok(())
+}
+
+fn emit_suite_drift_assessment(
+    assessment: &EvalSuiteDriftAssessment,
+    json: bool,
+    output: Option<&Path>,
+) -> anyhow::Result<()> {
+    write_json_output(assessment, output)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(assessment)?);
+    } else {
+        print!("{}", render_suite_drift_assessment(assessment));
     }
     Ok(())
 }
@@ -327,6 +420,87 @@ pub(crate) fn render_diff_report(diff: &EvalRunReportDiff) -> String {
     output
 }
 
+pub(crate) fn render_suite_drift_assessment(assessment: &EvalSuiteDriftAssessment) -> String {
+    let drift = &assessment.drift;
+    let mut output = String::new();
+    output.push_str("Eval suite drift assessment\n");
+    output.push_str(&format!(
+        "decision={} policy={}\n",
+        suite_drift_decision_label(assessment.decision),
+        suite_drift_policy_label(assessment.policy)
+    ));
+    output.push_str(&format!(
+        "suite_digest: baseline={} candidate={}\n",
+        assessment.baseline_suite_digest, assessment.candidate_suite_digest
+    ));
+    output.push_str(&format!("drift_digest: {}\n", assessment.drift_digest));
+    if let Some(migration_id) = assessment.approved_migration_id.as_deref() {
+        output.push_str(&format!("approved_migration_id: {migration_id}\n"));
+    }
+    if !assessment.blockers.is_empty() {
+        output.push_str("blockers:\n");
+        for blocker in &assessment.blockers {
+            output.push_str(&format!("- {blocker}\n"));
+        }
+    }
+    if let Some(suite_name) = &drift.suite_name {
+        output.push_str(&format!(
+            "suite_name: {} -> {}\n",
+            suite_name.baseline, suite_name.candidate
+        ));
+    }
+    output.push_str(&format!(
+        "changed_cases: count={}\n",
+        drift.changed_cases.len()
+    ));
+    for change in &drift.changed_cases {
+        output.push_str(&format!(
+            "- {} {:?} direction={}\n",
+            change.case_id,
+            change.kind,
+            suite_change_direction_label(change.direction)
+        ));
+    }
+    output.push_str(&format!(
+        "changed_commands: count={}\n",
+        drift.changed_commands.len()
+    ));
+    for change in &drift.changed_commands {
+        output.push_str(&format!(
+            "- {} direction={} baseline={} candidate={}\n",
+            change.case_id,
+            suite_change_direction_label(change.direction),
+            change.baseline.join(" && "),
+            change.candidate.join(" && ")
+        ));
+    }
+    output.push_str(&format!(
+        "changed_expectations: count={}\n",
+        drift.changed_expectations.len()
+    ));
+    for change in &drift.changed_expectations {
+        output.push_str(&format!(
+            "- {} direction={}\n",
+            change.case_id,
+            suite_change_direction_label(change.direction)
+        ));
+    }
+    output.push_str(&format!(
+        "changed_thresholds: count={}\n",
+        drift.changed_thresholds.len()
+    ));
+    for change in &drift.changed_thresholds {
+        output.push_str(&format!(
+            "- {} direction={} timeout_secs={}->{}\n",
+            change.case_id,
+            suite_change_direction_label(change.direction),
+            change.baseline.timeout_secs,
+            change.candidate.timeout_secs
+        ));
+    }
+    output
+}
+
 fn format_optional_float(value: Option<f64>) -> String {
     value
         .map(|value| format!("{value:.2}"))
@@ -460,6 +634,32 @@ fn grade_label(grade: EvalGrade) -> &'static str {
         EvalGrade::C => "C",
         EvalGrade::B => "B",
         EvalGrade::A => "A",
+    }
+}
+
+fn suite_drift_decision_label(decision: EvalSuiteDriftDecision) -> &'static str {
+    match decision {
+        EvalSuiteDriftDecision::NoDrift => "no_drift",
+        EvalSuiteDriftDecision::Approved => "approved",
+        EvalSuiteDriftDecision::Block => "block",
+        EvalSuiteDriftDecision::NeedsHuman => "needs_human",
+    }
+}
+
+fn suite_drift_policy_label(policy: EvalSuiteDriftPolicy) -> &'static str {
+    match policy {
+        EvalSuiteDriftPolicy::Block => "block",
+        EvalSuiteDriftPolicy::NeedsHuman => "needs_human",
+    }
+}
+
+fn suite_change_direction_label(
+    direction: harness_workflow::runtime::EvalSuiteChangeDirection,
+) -> &'static str {
+    match direction {
+        harness_workflow::runtime::EvalSuiteChangeDirection::Changed => "changed",
+        harness_workflow::runtime::EvalSuiteChangeDirection::Strengthened => "strengthened",
+        harness_workflow::runtime::EvalSuiteChangeDirection::Weakened => "weakened",
     }
 }
 
@@ -638,6 +838,32 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
                 assert!(args.json);
             }
             _ => panic!("expected eval diff command"),
+        }
+
+        let cli = Cli::try_parse_from([
+            "harness",
+            "eval",
+            "suite-drift",
+            "baseline.toml",
+            "candidate.toml",
+            "--migration",
+            "migration.json",
+            "--policy",
+            "needs-human",
+            "--json",
+        ])
+        .unwrap_or_else(|error| panic!("eval suite-drift command should parse: {error}"));
+        match cli.command {
+            Command::Eval {
+                cmd: EvalCommand::SuiteDrift(args),
+            } => {
+                assert_eq!(args.baseline, PathBuf::from("baseline.toml"));
+                assert_eq!(args.candidate, PathBuf::from("candidate.toml"));
+                assert_eq!(args.migration, Some(PathBuf::from("migration.json")));
+                assert!(matches!(args.policy, EvalSuiteDriftPolicyArg::NeedsHuman));
+                assert!(args.json);
+            }
+            _ => panic!("expected eval suite-drift command"),
         }
     }
 
@@ -1109,6 +1335,62 @@ verify_commands = ["cargo test -p harness-cli eval_report"]
         let message = error.to_string();
         assert!(message.contains("case-pass"));
         assert!(message.contains("TargetCorrectness"));
+    }
+
+    #[test]
+    fn eval_suite_drift_cli_fails_closed_and_writes_assessment() {
+        let tempdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("tempdir should be creatable: {error}"));
+        let baseline_path = tempdir.path().join("baseline.toml");
+        let candidate_path = tempdir.path().join("candidate.toml");
+        let output_path = tempdir.path().join("suite-drift.json");
+        fs::write(
+            &baseline_path,
+            r#"
+suite = "harness-core"
+
+[[cases]]
+case_id = "case-pass"
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = ["cargo test", "cargo clippy"]
+"#,
+        )
+        .unwrap_or_else(|error| panic!("baseline manifest should write: {error}"));
+        fs::write(
+            &candidate_path,
+            r#"
+suite = "harness-core"
+
+[[cases]]
+case_id = "case-pass"
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = ["cargo test"]
+"#,
+        )
+        .unwrap_or_else(|error| panic!("candidate manifest should write: {error}"));
+
+        let error = diff_eval_suite_drift(EvalSuiteDriftArgs {
+            baseline: baseline_path,
+            candidate: candidate_path,
+            migration: None,
+            policy: EvalSuiteDriftPolicyArg::NeedsHuman,
+            json: false,
+            output: Some(output_path.clone()),
+        })
+        .expect_err("unapproved suite drift must fail closed");
+
+        assert!(error.to_string().contains("requires approval"));
+        let assessment: EvalSuiteDriftAssessment = serde_json::from_str(
+            &fs::read_to_string(output_path)
+                .unwrap_or_else(|error| panic!("assessment should be readable: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("assessment should parse: {error}"));
+        assert_eq!(assessment.decision, EvalSuiteDriftDecision::NeedsHuman);
+        assert_eq!(assessment.drift.changed_commands.len(), 1);
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/eval/mod.rs
+++ b/crates/harness-workflow/src/runtime/eval/mod.rs
@@ -16,6 +16,7 @@ pub mod run;
 #[path = "run_concurrency_tests.rs"]
 mod run_concurrency_tests;
 pub mod scoring;
+pub mod suite_drift;
 mod transition_outcome;
 
 pub use attestation::{
@@ -58,3 +59,12 @@ pub use run::{
     EVAL_BRANCH_PREFIX, EVAL_PR_DRAFT_MODE,
 };
 pub use scoring::{score_pr_repair_eval, ScoringError};
+pub use suite_drift::{
+    assess_eval_suite_drift, eval_suite_digest, eval_suite_drift_digest, EvalSuiteCaseChange,
+    EvalSuiteCaseChangeKind, EvalSuiteCaseDefinition, EvalSuiteCaseExpectations,
+    EvalSuiteCaseThresholds, EvalSuiteChangeDirection, EvalSuiteCommandsChange,
+    EvalSuiteDriftAssessment, EvalSuiteDriftDecision, EvalSuiteDriftPolicy, EvalSuiteDriftSummary,
+    EvalSuiteExpectationsChange, EvalSuiteMigrationApproverKind, EvalSuiteMigrationRecord,
+    EvalSuiteStringChange, EvalSuiteThresholdsChange, EVAL_SUITE_DIGEST_SCHEMA_VERSION,
+    EVAL_SUITE_MIGRATION_RECORD_SCHEMA_VERSION,
+};

--- a/crates/harness-workflow/src/runtime/eval/suite_drift.rs
+++ b/crates/harness-workflow/src/runtime/eval/suite_drift.rs
@@ -1,0 +1,801 @@
+use super::manifest::{
+    EvalBenchmarkCase, EvalBenchmarkManifest, EvalCaseRisk, EvalCaseVerdict, EvalCommitResolution,
+    EvalIsolationProfile,
+};
+use harness_sandbox::{CappedResourceLimits, ResourceLimits};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub const EVAL_SUITE_DIGEST_SCHEMA_VERSION: &str = "eval-suite/v0.1";
+pub const EVAL_SUITE_MIGRATION_RECORD_SCHEMA_VERSION: &str = "eval-suite-migration/v0.1";
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalSuiteDriftPolicy {
+    #[default]
+    Block,
+    NeedsHuman,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalSuiteDriftDecision {
+    NoDrift,
+    Approved,
+    Block,
+    NeedsHuman,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalSuiteChangeDirection {
+    Changed,
+    Strengthened,
+    Weakened,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSuiteDriftAssessment {
+    pub baseline_suite_digest: String,
+    pub candidate_suite_digest: String,
+    pub drift_digest: String,
+    pub policy: EvalSuiteDriftPolicy,
+    pub decision: EvalSuiteDriftDecision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_migration_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blockers: Vec<String>,
+    pub drift: EvalSuiteDriftSummary,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSuiteDriftSummary {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suite_name: Option<EvalSuiteStringChange>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_cases: Vec<EvalSuiteCaseChange>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_commands: Vec<EvalSuiteCommandsChange>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_expectations: Vec<EvalSuiteExpectationsChange>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_thresholds: Vec<EvalSuiteThresholdsChange>,
+}
+
+impl EvalSuiteDriftSummary {
+    pub fn is_empty(&self) -> bool {
+        self.suite_name.is_none()
+            && self.changed_cases.is_empty()
+            && self.changed_commands.is_empty()
+            && self.changed_expectations.is_empty()
+            && self.changed_thresholds.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSuiteStringChange {
+    pub baseline: String,
+    pub candidate: String,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalSuiteCaseChangeKind {
+    Added,
+    Removed,
+    MetadataChanged,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSuiteCaseChange {
+    pub case_id: String,
+    pub kind: EvalSuiteCaseChangeKind,
+    pub direction: EvalSuiteChangeDirection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub baseline: Option<EvalSuiteCaseDefinition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate: Option<EvalSuiteCaseDefinition>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSuiteCaseDefinition {
+    pub case_id: String,
+    pub repo: String,
+    pub issue: u64,
+    pub base_commit: String,
+    pub paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk: Option<EvalCaseRisk>,
+    pub evidence: Vec<String>,
+    pub isolation: EvalIsolationProfile,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSuiteCommandsChange {
+    pub case_id: String,
+    pub direction: EvalSuiteChangeDirection,
+    pub baseline: Vec<String>,
+    pub candidate: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSuiteExpectationsChange {
+    pub case_id: String,
+    pub direction: EvalSuiteChangeDirection,
+    pub baseline: EvalSuiteCaseExpectations,
+    pub candidate: EvalSuiteCaseExpectations,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSuiteCaseExpectations {
+    pub resolution_prs: Vec<u64>,
+    pub resolution_commits: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_resolution: Option<EvalCommitResolution>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verdict: Option<EvalCaseVerdict>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSuiteThresholdsChange {
+    pub case_id: String,
+    pub direction: EvalSuiteChangeDirection,
+    pub baseline: EvalSuiteCaseThresholds,
+    pub candidate: EvalSuiteCaseThresholds,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvalSuiteCaseThresholds {
+    pub timeout_secs: u64,
+    pub resource_limits: CappedResourceLimits,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvalSuiteMigrationRecord {
+    pub schema_version: String,
+    pub migration_id: String,
+    pub baseline_suite: String,
+    pub candidate_suite: String,
+    pub baseline_suite_digest: String,
+    pub candidate_suite_digest: String,
+    pub drift_digest: String,
+    pub approver_kind: EvalSuiteMigrationApproverKind,
+    pub approved_by: String,
+    pub approval_url: String,
+    pub approved_at: String,
+    pub rationale: String,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalSuiteMigrationApproverKind {
+    Human,
+    Agent,
+    Automation,
+}
+
+pub fn assess_eval_suite_drift(
+    baseline: &EvalBenchmarkManifest,
+    candidate: &EvalBenchmarkManifest,
+    migration: Option<&EvalSuiteMigrationRecord>,
+    policy: EvalSuiteDriftPolicy,
+) -> EvalSuiteDriftAssessment {
+    let baseline_suite_digest = eval_suite_digest(baseline);
+    let candidate_suite_digest = eval_suite_digest(candidate);
+    let drift = diff_eval_suites(baseline, candidate);
+    let drift_digest = eval_suite_drift_digest(&drift);
+    let mut blockers = Vec::new();
+    let approved_migration_id = if drift.is_empty() {
+        None
+    } else if let Some(record) = migration {
+        blockers = validate_migration_record(
+            record,
+            baseline,
+            candidate,
+            &baseline_suite_digest,
+            &candidate_suite_digest,
+            &drift_digest,
+        );
+        blockers
+            .is_empty()
+            .then(|| record.migration_id.trim().to_string())
+    } else {
+        blockers
+            .push("suite drift requires a versioned human-approved migration record".to_string());
+        None
+    };
+
+    let decision = if drift.is_empty() {
+        EvalSuiteDriftDecision::NoDrift
+    } else if approved_migration_id.is_some() {
+        EvalSuiteDriftDecision::Approved
+    } else {
+        match policy {
+            EvalSuiteDriftPolicy::Block => EvalSuiteDriftDecision::Block,
+            EvalSuiteDriftPolicy::NeedsHuman => EvalSuiteDriftDecision::NeedsHuman,
+        }
+    };
+
+    EvalSuiteDriftAssessment {
+        baseline_suite_digest,
+        candidate_suite_digest,
+        drift_digest,
+        policy,
+        decision,
+        approved_migration_id,
+        blockers,
+        drift,
+    }
+}
+
+pub fn eval_suite_digest(manifest: &EvalBenchmarkManifest) -> String {
+    let snapshot = EvalSuiteDigestInput {
+        schema_version: EVAL_SUITE_DIGEST_SCHEMA_VERSION,
+        suite: manifest.suite.as_str(),
+        cases: canonical_case_snapshots(manifest),
+    };
+    prefixed_sha256(&snapshot)
+}
+
+pub fn eval_suite_drift_digest(drift: &EvalSuiteDriftSummary) -> String {
+    prefixed_sha256(drift)
+}
+
+fn diff_eval_suites(
+    baseline: &EvalBenchmarkManifest,
+    candidate: &EvalBenchmarkManifest,
+) -> EvalSuiteDriftSummary {
+    let baseline_cases = case_index(&baseline.cases);
+    let candidate_cases = case_index(&candidate.cases);
+    let mut case_ids = BTreeSet::new();
+    case_ids.extend(baseline_cases.keys().copied());
+    case_ids.extend(candidate_cases.keys().copied());
+
+    let mut summary = EvalSuiteDriftSummary {
+        suite_name: (baseline.suite != candidate.suite).then(|| EvalSuiteStringChange {
+            baseline: baseline.suite.clone(),
+            candidate: candidate.suite.clone(),
+        }),
+        ..EvalSuiteDriftSummary::default()
+    };
+
+    for case_id in case_ids {
+        match (baseline_cases.get(case_id), candidate_cases.get(case_id)) {
+            (None, Some(candidate_case)) => {
+                summary.changed_cases.push(EvalSuiteCaseChange {
+                    case_id: case_id.to_string(),
+                    kind: EvalSuiteCaseChangeKind::Added,
+                    direction: EvalSuiteChangeDirection::Strengthened,
+                    baseline: None,
+                    candidate: Some(case_definition(candidate_case)),
+                });
+            }
+            (Some(baseline_case), None) => {
+                summary.changed_cases.push(EvalSuiteCaseChange {
+                    case_id: case_id.to_string(),
+                    kind: EvalSuiteCaseChangeKind::Removed,
+                    direction: EvalSuiteChangeDirection::Weakened,
+                    baseline: Some(case_definition(baseline_case)),
+                    candidate: None,
+                });
+            }
+            (Some(baseline_case), Some(candidate_case)) => {
+                let baseline_definition = case_definition(baseline_case);
+                let candidate_definition = case_definition(candidate_case);
+                if baseline_definition != candidate_definition {
+                    summary.changed_cases.push(EvalSuiteCaseChange {
+                        case_id: case_id.to_string(),
+                        kind: EvalSuiteCaseChangeKind::MetadataChanged,
+                        direction: EvalSuiteChangeDirection::Changed,
+                        baseline: Some(baseline_definition),
+                        candidate: Some(candidate_definition),
+                    });
+                }
+
+                if baseline_case.verify_commands != candidate_case.verify_commands {
+                    summary.changed_commands.push(EvalSuiteCommandsChange {
+                        case_id: case_id.to_string(),
+                        direction: sequence_change_direction(
+                            &baseline_case.verify_commands,
+                            &candidate_case.verify_commands,
+                        ),
+                        baseline: baseline_case.verify_commands.clone(),
+                        candidate: candidate_case.verify_commands.clone(),
+                    });
+                }
+
+                let baseline_expectations = case_expectations(baseline_case);
+                let candidate_expectations = case_expectations(candidate_case);
+                if baseline_expectations != candidate_expectations {
+                    summary
+                        .changed_expectations
+                        .push(EvalSuiteExpectationsChange {
+                            case_id: case_id.to_string(),
+                            direction: expectation_change_direction(
+                                &baseline_expectations,
+                                &candidate_expectations,
+                            ),
+                            baseline: baseline_expectations,
+                            candidate: candidate_expectations,
+                        });
+                }
+
+                let baseline_thresholds = case_thresholds(baseline_case);
+                let candidate_thresholds = case_thresholds(candidate_case);
+                if baseline_thresholds != candidate_thresholds {
+                    summary.changed_thresholds.push(EvalSuiteThresholdsChange {
+                        case_id: case_id.to_string(),
+                        direction: threshold_change_direction(
+                            &baseline_thresholds,
+                            &candidate_thresholds,
+                        ),
+                        baseline: baseline_thresholds,
+                        candidate: candidate_thresholds,
+                    });
+                }
+            }
+            (None, None) => {}
+        }
+    }
+
+    summary
+}
+
+fn validate_migration_record(
+    record: &EvalSuiteMigrationRecord,
+    baseline: &EvalBenchmarkManifest,
+    candidate: &EvalBenchmarkManifest,
+    baseline_suite_digest: &str,
+    candidate_suite_digest: &str,
+    drift_digest: &str,
+) -> Vec<String> {
+    let mut blockers = Vec::new();
+    if record.schema_version != EVAL_SUITE_MIGRATION_RECORD_SCHEMA_VERSION {
+        blockers.push(format!(
+            "migration record schema_version must be {EVAL_SUITE_MIGRATION_RECORD_SCHEMA_VERSION}"
+        ));
+    }
+    if record.migration_id.trim().is_empty() {
+        blockers.push("migration record migration_id must not be empty".to_string());
+    }
+    if record.baseline_suite != baseline.suite {
+        blockers.push(format!(
+            "migration record baseline_suite `{}` does not match baseline suite `{}`",
+            record.baseline_suite, baseline.suite
+        ));
+    }
+    if record.candidate_suite != candidate.suite {
+        blockers.push(format!(
+            "migration record candidate_suite `{}` does not match candidate suite `{}`",
+            record.candidate_suite, candidate.suite
+        ));
+    }
+    if record.baseline_suite_digest != baseline_suite_digest {
+        blockers.push(
+            "migration record baseline_suite_digest does not match baseline manifest".to_string(),
+        );
+    }
+    if record.candidate_suite_digest != candidate_suite_digest {
+        blockers.push(
+            "migration record candidate_suite_digest does not match candidate manifest".to_string(),
+        );
+    }
+    if record.drift_digest != drift_digest {
+        blockers.push("migration record drift_digest does not match manifest drift".to_string());
+    }
+    if record.approver_kind != EvalSuiteMigrationApproverKind::Human {
+        blockers.push("suite migration approval must come from a human approver".to_string());
+    }
+    for (field, value) in [
+        ("approved_by", record.approved_by.as_str()),
+        ("approval_url", record.approval_url.as_str()),
+        ("approved_at", record.approved_at.as_str()),
+        ("rationale", record.rationale.as_str()),
+    ] {
+        if value.trim().is_empty() {
+            blockers.push(format!("migration record {field} must not be empty"));
+        }
+    }
+    if !record.approved_at.trim().is_empty()
+        && chrono::DateTime::parse_from_rfc3339(&record.approved_at).is_err()
+    {
+        blockers.push("migration record approved_at must be an RFC3339 timestamp".to_string());
+    }
+    blockers
+}
+
+#[derive(Serialize)]
+struct EvalSuiteDigestInput<'a> {
+    schema_version: &'static str,
+    suite: &'a str,
+    cases: Vec<EvalSuiteCaseSnapshot>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct EvalSuiteCaseSnapshot {
+    definition: EvalSuiteCaseDefinition,
+    verify_commands: Vec<String>,
+    expectations: EvalSuiteCaseExpectations,
+    thresholds: EvalSuiteCaseThresholds,
+}
+
+fn canonical_case_snapshots(manifest: &EvalBenchmarkManifest) -> Vec<EvalSuiteCaseSnapshot> {
+    let mut snapshots = manifest
+        .cases
+        .iter()
+        .map(|case| EvalSuiteCaseSnapshot {
+            definition: case_definition(case),
+            verify_commands: case.verify_commands.clone(),
+            expectations: case_expectations(case),
+            thresholds: case_thresholds(case),
+        })
+        .collect::<Vec<_>>();
+    snapshots.sort_by(|left, right| left.definition.case_id.cmp(&right.definition.case_id));
+    snapshots
+}
+
+fn case_index(cases: &[EvalBenchmarkCase]) -> BTreeMap<&str, &EvalBenchmarkCase> {
+    cases
+        .iter()
+        .map(|case| (case.case_id.as_str(), case))
+        .collect()
+}
+
+fn case_definition(case: &EvalBenchmarkCase) -> EvalSuiteCaseDefinition {
+    EvalSuiteCaseDefinition {
+        case_id: case.case_id.clone(),
+        repo: case.repo.clone(),
+        issue: case.issue,
+        base_commit: case.base_commit.clone(),
+        paths: case.paths.clone(),
+        risk: case.risk,
+        evidence: case.evidence.clone(),
+        isolation: case.isolation.clone(),
+    }
+}
+
+fn case_expectations(case: &EvalBenchmarkCase) -> EvalSuiteCaseExpectations {
+    EvalSuiteCaseExpectations {
+        resolution_prs: case.resolution_prs.clone(),
+        resolution_commits: case.resolution_commits.clone(),
+        commit_resolution: case.commit_resolution,
+        verdict: case.verdict,
+    }
+}
+
+fn case_thresholds(case: &EvalBenchmarkCase) -> EvalSuiteCaseThresholds {
+    EvalSuiteCaseThresholds {
+        timeout_secs: case.timeout_secs,
+        resource_limits: case.resource_limits.clone(),
+    }
+}
+
+fn sequence_change_direction(
+    baseline: &[String],
+    candidate: &[String],
+) -> EvalSuiteChangeDirection {
+    let baseline_set = baseline.iter().collect::<BTreeSet<_>>();
+    let candidate_set = candidate.iter().collect::<BTreeSet<_>>();
+    if baseline_set.is_subset(&candidate_set) && baseline.len() < candidate.len() {
+        EvalSuiteChangeDirection::Strengthened
+    } else if candidate_set.is_subset(&baseline_set) && candidate.len() < baseline.len() {
+        EvalSuiteChangeDirection::Weakened
+    } else {
+        EvalSuiteChangeDirection::Changed
+    }
+}
+
+fn expectation_change_direction(
+    baseline: &EvalSuiteCaseExpectations,
+    candidate: &EvalSuiteCaseExpectations,
+) -> EvalSuiteChangeDirection {
+    let baseline_strength = expectation_strength(baseline);
+    let candidate_strength = expectation_strength(candidate);
+    if candidate_strength > baseline_strength {
+        EvalSuiteChangeDirection::Strengthened
+    } else if candidate_strength < baseline_strength {
+        EvalSuiteChangeDirection::Weakened
+    } else {
+        EvalSuiteChangeDirection::Changed
+    }
+}
+
+fn expectation_strength(expectations: &EvalSuiteCaseExpectations) -> u8 {
+    let mut strength = match expectations.commit_resolution {
+        Some(EvalCommitResolution::Resolved) => 2,
+        None => 1,
+        Some(EvalCommitResolution::Pending) => 0,
+    };
+    strength += match expectations.verdict {
+        Some(EvalCaseVerdict::Replayable) => 2,
+        None => 1,
+        Some(EvalCaseVerdict::Pending) => 0,
+    };
+    strength += u8::from(!expectations.resolution_prs.is_empty());
+    strength += u8::from(!expectations.resolution_commits.is_empty());
+    strength
+}
+
+fn threshold_change_direction(
+    baseline: &EvalSuiteCaseThresholds,
+    candidate: &EvalSuiteCaseThresholds,
+) -> EvalSuiteChangeDirection {
+    let mut strengthened = false;
+    let mut weakened = false;
+    record_limit_direction(
+        limit_direction(Some(baseline.timeout_secs), Some(candidate.timeout_secs)),
+        &mut strengthened,
+        &mut weakened,
+    );
+    for (baseline, candidate) in resource_limit_pairs(
+        baseline.resource_limits.effective,
+        candidate.resource_limits.effective,
+    ) {
+        record_limit_direction(
+            limit_direction(baseline, candidate),
+            &mut strengthened,
+            &mut weakened,
+        );
+    }
+    match (strengthened, weakened) {
+        (true, false) => EvalSuiteChangeDirection::Strengthened,
+        (false, true) => EvalSuiteChangeDirection::Weakened,
+        _ => EvalSuiteChangeDirection::Changed,
+    }
+}
+
+fn resource_limit_pairs(
+    baseline: ResourceLimits,
+    candidate: ResourceLimits,
+) -> [(Option<u64>, Option<u64>); 6] {
+    [
+        (baseline.cpu_time_secs, candidate.cpu_time_secs),
+        (baseline.memory_bytes, candidate.memory_bytes),
+        (baseline.pids, candidate.pids),
+        (baseline.disk_bytes, candidate.disk_bytes),
+        (baseline.output_bytes, candidate.output_bytes),
+        (baseline.wall_time_secs, candidate.wall_time_secs),
+    ]
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum LimitDirection {
+    Same,
+    Strengthened,
+    Weakened,
+}
+
+fn limit_direction(baseline: Option<u64>, candidate: Option<u64>) -> LimitDirection {
+    match (baseline, candidate) {
+        (left, right) if left == right => LimitDirection::Same,
+        (Some(left), Some(right)) if right < left => LimitDirection::Strengthened,
+        (Some(_), None) => LimitDirection::Weakened,
+        (None, Some(_)) => LimitDirection::Strengthened,
+        (Some(_), Some(_)) => LimitDirection::Weakened,
+        (None, None) => LimitDirection::Same,
+    }
+}
+
+fn record_limit_direction(direction: LimitDirection, strengthened: &mut bool, weakened: &mut bool) {
+    match direction {
+        LimitDirection::Same => {}
+        LimitDirection::Strengthened => *strengthened = true,
+        LimitDirection::Weakened => *weakened = true,
+    }
+}
+
+fn prefixed_sha256<T: Serialize>(value: &T) -> String {
+    let encoded = serde_json::to_vec(value).expect("eval suite digest serialization is infallible");
+    format!("sha256:{:x}", Sha256::digest(encoded))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suite_drift_detects_added_and_removed_cases() {
+        let baseline = manifest(
+            "harness-core",
+            vec![case("case-keep"), case("case-removed")],
+        );
+        let candidate = manifest("harness-core", vec![case("case-keep"), case("case-added")]);
+
+        let assessment =
+            assess_eval_suite_drift(&baseline, &candidate, None, EvalSuiteDriftPolicy::Block);
+
+        assert_eq!(assessment.decision, EvalSuiteDriftDecision::Block);
+        assert_eq!(assessment.drift.changed_cases.len(), 2);
+        assert!(assessment.drift.changed_cases.iter().any(|change| {
+            change.case_id == "case-added"
+                && change.kind == EvalSuiteCaseChangeKind::Added
+                && change.direction == EvalSuiteChangeDirection::Strengthened
+        }));
+        assert!(assessment.drift.changed_cases.iter().any(|change| {
+            change.case_id == "case-removed"
+                && change.kind == EvalSuiteCaseChangeKind::Removed
+                && change.direction == EvalSuiteChangeDirection::Weakened
+        }));
+        assert_eq!(
+            assessment.blockers,
+            vec!["suite drift requires a versioned human-approved migration record"]
+        );
+    }
+
+    #[test]
+    fn suite_drift_emits_weakened_commands_and_expectations() {
+        let mut baseline_case = resolved_case("case-drift");
+        baseline_case.verify_commands = vec!["cargo test".to_string(), "cargo clippy".to_string()];
+        let mut candidate_case = pending_case("case-drift");
+        candidate_case.verify_commands = vec!["cargo test".to_string()];
+        let baseline = manifest("harness-core", vec![baseline_case]);
+        let candidate = manifest("harness-core", vec![candidate_case]);
+
+        let assessment = assess_eval_suite_drift(
+            &baseline,
+            &candidate,
+            None,
+            EvalSuiteDriftPolicy::NeedsHuman,
+        );
+
+        assert_eq!(assessment.decision, EvalSuiteDriftDecision::NeedsHuman);
+        assert_eq!(assessment.drift.changed_commands.len(), 1);
+        assert_eq!(
+            assessment.drift.changed_commands[0].direction,
+            EvalSuiteChangeDirection::Weakened
+        );
+        assert_eq!(assessment.drift.changed_expectations.len(), 1);
+        assert_eq!(
+            assessment.drift.changed_expectations[0].direction,
+            EvalSuiteChangeDirection::Weakened
+        );
+    }
+
+    #[test]
+    fn suite_drift_emits_strengthened_commands_expectations_and_thresholds() {
+        let mut baseline_case = pending_case("case-drift");
+        baseline_case.verify_commands = vec!["cargo test".to_string()];
+        baseline_case.timeout_secs = 240;
+        baseline_case.resource_limits = limits(240);
+        let mut candidate_case = resolved_case("case-drift");
+        candidate_case.verify_commands = vec!["cargo test".to_string(), "cargo clippy".to_string()];
+        candidate_case.timeout_secs = 120;
+        candidate_case.resource_limits = limits(120);
+        let baseline = manifest("harness-core", vec![baseline_case]);
+        let candidate = manifest("harness-core", vec![candidate_case]);
+
+        let assessment =
+            assess_eval_suite_drift(&baseline, &candidate, None, EvalSuiteDriftPolicy::Block);
+
+        assert_eq!(
+            assessment.drift.changed_commands[0].direction,
+            EvalSuiteChangeDirection::Strengthened
+        );
+        assert_eq!(
+            assessment.drift.changed_expectations[0].direction,
+            EvalSuiteChangeDirection::Strengthened
+        );
+        assert_eq!(
+            assessment.drift.changed_thresholds[0].direction,
+            EvalSuiteChangeDirection::Strengthened
+        );
+    }
+
+    #[test]
+    fn suite_drift_approved_migration_record_allows_changed_suite() {
+        let baseline = manifest("harness-core", vec![case("case-removed")]);
+        let candidate = manifest("harness-core-v2", vec![case("case-added")]);
+        let pending =
+            assess_eval_suite_drift(&baseline, &candidate, None, EvalSuiteDriftPolicy::Block);
+        let migration = migration_record(&baseline, &candidate, &pending.drift_digest);
+
+        let assessment = assess_eval_suite_drift(
+            &baseline,
+            &candidate,
+            Some(&migration),
+            EvalSuiteDriftPolicy::Block,
+        );
+
+        assert_eq!(assessment.decision, EvalSuiteDriftDecision::Approved);
+        assert_eq!(
+            assessment.approved_migration_id.as_deref(),
+            Some("eval-suite-migration-1")
+        );
+        assert!(assessment.blockers.is_empty());
+        assert!(assessment.drift.suite_name.is_some());
+    }
+
+    #[test]
+    fn suite_drift_rejects_non_human_migration_approval() {
+        let baseline = manifest("harness-core", vec![case("case-removed")]);
+        let candidate = manifest("harness-core", vec![case("case-added")]);
+        let pending =
+            assess_eval_suite_drift(&baseline, &candidate, None, EvalSuiteDriftPolicy::Block);
+        let mut migration = migration_record(&baseline, &candidate, &pending.drift_digest);
+        migration.approver_kind = EvalSuiteMigrationApproverKind::Agent;
+
+        let assessment = assess_eval_suite_drift(
+            &baseline,
+            &candidate,
+            Some(&migration),
+            EvalSuiteDriftPolicy::Block,
+        );
+
+        assert_eq!(assessment.decision, EvalSuiteDriftDecision::Block);
+        assert!(assessment
+            .blockers
+            .contains(&"suite migration approval must come from a human approver".to_string()));
+    }
+
+    fn manifest(suite: &str, cases: Vec<EvalBenchmarkCase>) -> EvalBenchmarkManifest {
+        EvalBenchmarkManifest {
+            suite: suite.to_string(),
+            cases,
+        }
+    }
+
+    fn case(case_id: &str) -> EvalBenchmarkCase {
+        EvalBenchmarkCase {
+            case_id: case_id.to_string(),
+            repo: "majiayu000/harness".to_string(),
+            issue: 1745,
+            base_commit: "0123456789abcdef".to_string(),
+            verify_commands: vec!["cargo test".to_string()],
+            paths: vec!["crates/harness-workflow/src/runtime/eval/report.rs".to_string()],
+            risk: Some(EvalCaseRisk::Medium),
+            evidence: vec!["https://github.com/majiayu000/harness/issues/1745".to_string()],
+            resolution_prs: Vec::new(),
+            resolution_commits: Vec::new(),
+            commit_resolution: None,
+            verdict: None,
+            timeout_secs: 120,
+            resource_limits: limits(120),
+            isolation: EvalIsolationProfile::default(),
+        }
+    }
+
+    fn resolved_case(case_id: &str) -> EvalBenchmarkCase {
+        let mut case = case(case_id);
+        case.resolution_prs = vec![1900];
+        case.resolution_commits = vec!["fedcba9876543210".to_string()];
+        case.commit_resolution = Some(EvalCommitResolution::Resolved);
+        case.verdict = Some(EvalCaseVerdict::Replayable);
+        case
+    }
+
+    fn pending_case(case_id: &str) -> EvalBenchmarkCase {
+        let mut case = case(case_id);
+        case.commit_resolution = Some(EvalCommitResolution::Pending);
+        case.verdict = Some(EvalCaseVerdict::Pending);
+        case
+    }
+
+    fn limits(timeout_secs: u64) -> CappedResourceLimits {
+        ResourceLimits::evaluation_defaults(timeout_secs)
+            .cap_by(ResourceLimits::operator_default_maxima())
+            .expect("default resource limits should be valid")
+    }
+
+    fn migration_record(
+        baseline: &EvalBenchmarkManifest,
+        candidate: &EvalBenchmarkManifest,
+        drift_digest: &str,
+    ) -> EvalSuiteMigrationRecord {
+        EvalSuiteMigrationRecord {
+            schema_version: EVAL_SUITE_MIGRATION_RECORD_SCHEMA_VERSION.to_string(),
+            migration_id: "eval-suite-migration-1".to_string(),
+            baseline_suite: baseline.suite.clone(),
+            candidate_suite: candidate.suite.clone(),
+            baseline_suite_digest: eval_suite_digest(baseline),
+            candidate_suite_digest: eval_suite_digest(candidate),
+            drift_digest: drift_digest.to_string(),
+            approver_kind: EvalSuiteMigrationApproverKind::Human,
+            approved_by: "maintainer".to_string(),
+            approval_url: "https://github.com/majiayu000/harness/pull/1#issuecomment-1".to_string(),
+            approved_at: "2026-08-12T00:00:00Z".to_string(),
+            rationale: "Approved suite maintenance.".to_string(),
+        }
+    }
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -90,11 +90,11 @@ pub use dispatch_barrier::{
 pub use dispatcher::{CommandDispatchOutcome, RuntimeCommandDispatcher, RuntimeProfileSelector};
 pub use errors::RuntimeJobNotFoundError;
 pub use eval::{
-    classify_eval_run_attestation, collect_eval_case_evidence,
+    assess_eval_suite_drift, classify_eval_run_attestation, collect_eval_case_evidence,
     collect_eval_case_evidence_from_records, diff_eval_run_reports, dispatch_eval_case_workflow,
     enqueue_eval_case_workflow, eval_isolated_runtime_profile, eval_report_dry_run,
-    eval_report_from_evidence, eval_run_attestation_payload_digest,
-    historical_replay_command_digest, parse_benchmark_manifest_str,
+    eval_report_from_evidence, eval_run_attestation_payload_digest, eval_suite_digest,
+    eval_suite_drift_digest, historical_replay_command_digest, parse_benchmark_manifest_str,
     parse_historical_replay_cohort_str, score_pr_repair_eval, validate_historical_replay_cohort,
     verify_eval_run_attestation, EvalAttestationDecision, EvalAttestationSummary,
     EvalAttestationTrust, EvalAttestationVerificationError, EvalBenchmarkCase,
@@ -105,14 +105,20 @@ pub use eval::{
     EvalIsolationProfile, EvalQualityGateEvidence, EvalReportCase, EvalReportCaseStatus,
     EvalReportError, EvalReportFailedGate, EvalReportMetricDelta, EvalReportMetrics,
     EvalRunAttestation, EvalRunAttestationClaims, EvalRunAttestationExpected, EvalRunReport,
-    EvalRunReportDiff, EvalSubmissionEvidence, HistoricalReplayCase, HistoricalReplayCohort,
+    EvalRunReportDiff, EvalSubmissionEvidence, EvalSuiteCaseChange, EvalSuiteCaseChangeKind,
+    EvalSuiteCaseDefinition, EvalSuiteCaseExpectations, EvalSuiteCaseThresholds,
+    EvalSuiteChangeDirection, EvalSuiteCommandsChange, EvalSuiteDriftAssessment,
+    EvalSuiteDriftDecision, EvalSuiteDriftPolicy, EvalSuiteDriftSummary,
+    EvalSuiteExpectationsChange, EvalSuiteMigrationApproverKind, EvalSuiteMigrationRecord,
+    EvalSuiteStringChange, EvalSuiteThresholdsChange, HistoricalReplayCase, HistoricalReplayCohort,
     HistoricalReplayCohortVerdict, HistoricalReplayCommandEvidence, HistoricalReplayCommandRun,
     HistoricalReplayComparison, HistoricalReplayError, HistoricalReplayIssueSnapshot,
     HistoricalReplayPullRequestSnapshot, HistoricalReplayVerification, KeylessOidcProvider,
     KeylessOidcVerification, ManifestError, ScoringError, VerifiedEvalRunAttestation,
     DEFAULT_CASE_TIMEOUT_SECS, DEFAULT_EVAL_ISOLATION_BACKEND, DEFAULT_EVAL_ISOLATION_IMAGE,
     DEFAULT_EVAL_ISOLATION_RUNTIME_PROFILE, DEFAULT_EVAL_ISOLATION_SANDBOX, EVAL_BRANCH_PREFIX,
-    EVAL_PR_DRAFT_MODE, EVAL_RUN_ATTESTATION_SCHEMA_VERSION, HISTORICAL_REPLAY_COHORT_SCHEMA,
+    EVAL_PR_DRAFT_MODE, EVAL_RUN_ATTESTATION_SCHEMA_VERSION, EVAL_SUITE_DIGEST_SCHEMA_VERSION,
+    EVAL_SUITE_MIGRATION_RECORD_SCHEMA_VERSION, HISTORICAL_REPLAY_COHORT_SCHEMA,
 };
 pub use lease_state::{runtime_job_running_lease_state_at, RuntimeJobRunningLeaseState};
 pub use memory_retrieval::{


### PR DESCRIPTION
## Summary
- Add workflow-owned eval suite drift assessment with canonical suite/drift digests.
- Require versioned, human-approved migration records before changed suites are accepted.
- Add `harness eval suite-drift` to emit drift details for changed cases, commands, expectations, and thresholds.

## Validation
- `cargo test -p harness-workflow suite_drift`
- `cargo test -p harness-cli eval_suite_drift`
- `cargo test -p harness-cli eval_report_cli_parses_run_and_diff_commands`
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check -p harness-workflow -p harness-rules -p harness-cli --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Pre-commit hook: fmt + staged-scope clippy passed
- Pre-push hook with `RUST_TEST_THREADS=1`: clippy, DB-less workspace lib tests, and DB-less `harness-workflow` lib tests passed; PostgreSQL-backed suites deferred because `HARNESS_DATABASE_URL` is unset.

Scope guard: 4 files changed, 1,106 added lines against `origin/main` (limits: 30 files, 1,500 added lines).

Closes #1745