### PR TITLE
refactor(workflow): inject immutable definition registry

### DIFF
--- a/crates/harness-server/src/handlers/dashboard_active_counts.rs
+++ b/crates/harness-server/src/handlers/dashboard_active_counts.rs
@@ -59,7 +59,9 @@ pub(super) async fn dashboard_active_counts(
     let allowed_project_roots = &state.core.server.config.server.allowed_project_roots;
 
     if let Some(store) = state.core.workflow_runtime_store.as_ref() {
-        match crate::handlers::definition_ids::active_count_definition_ids() {
+        match crate::handlers::definition_ids::active_count_definition_ids(
+            store.definition_registry(),
+        ) {
             Ok(definition_ids) => {
                 for definition_id in &definition_ids {
                     match store
@@ -69,7 +71,10 @@ pub(super) async fn dashboard_active_counts(
                         Ok(workflows) => {
                             for workflow in workflows {
                                 let projection =
-                                    RuntimeWorkflowProjection::from_workflow(&workflow);
+                                    RuntimeWorkflowProjection::from_workflow_with_registry(
+                                        store.definition_registry(),
+                                        &workflow,
+                                    );
                                 add_active_runtime_workflow(
                                     &mut counts,
                                     &projection,

--- a/crates/harness-server/src/handlers/definition_ids.rs
+++ b/crates/harness-server/src/handlers/definition_ids.rs
@@ -13,7 +13,7 @@
 //! mutating the process-global registry.
 
 use harness_workflow::runtime::{
-    known_workflow_definition_ids, PR_FEEDBACK_DEFINITION_ID, QUALITY_GATE_DEFINITION_ID,
+    WorkflowDefinitionRegistry, PR_FEEDBACK_DEFINITION_ID, QUALITY_GATE_DEFINITION_ID,
 };
 
 /// All definition ids for operator enumeration, from the frozen registry, in
@@ -21,8 +21,10 @@ use harness_workflow::runtime::{
 ///
 /// Errors when the registry reports no definitions (B-006) — impossible after a
 /// healthy startup, where the built-ins are always registered.
-pub fn operator_definition_ids() -> anyhow::Result<Vec<String>> {
-    sorted_non_empty(known_workflow_definition_ids())
+pub fn operator_definition_ids(
+    registry: &WorkflowDefinitionRegistry,
+) -> anyhow::Result<Vec<String>> {
+    sorted_non_empty(registry.known_definition_ids())
 }
 
 /// Definition ids for active-count surfaces (dashboard active counts, overview).
@@ -33,8 +35,10 @@ pub fn operator_definition_ids() -> anyhow::Result<Vec<String>> {
 /// runtime metrics" (commit 8d0fa39a), where active counts enumerated only the
 /// two top-level built-ins. Declarative definitions are always included: they
 /// are top-level and never shadow a built-in parent (B-002, B-003).
-pub fn active_count_definition_ids() -> anyhow::Result<Vec<String>> {
-    Ok(exclude_builtin_children(operator_definition_ids()?))
+pub fn active_count_definition_ids(
+    registry: &WorkflowDefinitionRegistry,
+) -> anyhow::Result<Vec<String>> {
+    Ok(exclude_builtin_children(operator_definition_ids(registry)?))
 }
 
 /// Sort ids and reject an empty set. Pure so it is testable without the global
@@ -110,7 +114,8 @@ mod tests {
     #[test]
     fn operator_ids_from_global_registry_include_all_builtins(/* B-001 */) {
         // The process-global registry is always seeded with the four built-ins.
-        let ids = operator_definition_ids().expect("built-ins registered");
+        let ids = operator_definition_ids(&WorkflowDefinitionRegistry::with_builtins())
+            .expect("built-ins registered");
         for expected in [
             GITHUB_ISSUE_PR_DEFINITION_ID,
             PR_FEEDBACK_DEFINITION_ID,

--- a/crates/harness-server/src/handlers/operator_monitor/activity.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/activity.rs
@@ -1,10 +1,7 @@
 use super::{workflow_legacy_task_ids, workflow_source, TaskSummary, WorkflowInstance};
 use crate::runtime_projection::{RuntimeActiveBucket, RuntimeWorkflowProjection};
 use crate::task_runner::{SchedulerAuthorityState, TaskPhase, TaskStatus};
-use harness_workflow::runtime::{
-    declarative_workflow_definition_for_instance, workflow_state_definition_for_instance,
-    WorkflowProgressMode,
-};
+use harness_workflow::runtime::{WorkflowDefinitionRegistry, WorkflowProgressMode};
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -45,10 +42,13 @@ enum WorkflowBucket {
     Other,
 }
 
-pub(super) fn runtime_workflow_counts(workflows: &[WorkflowInstance]) -> RuntimeWorkflowCounts {
+pub(super) fn runtime_workflow_counts(
+    registry: &WorkflowDefinitionRegistry,
+    workflows: &[WorkflowInstance],
+) -> RuntimeWorkflowCounts {
     let mut counts = RuntimeWorkflowCounts::default();
     for workflow in workflows {
-        match workflow_bucket(workflow) {
+        match workflow_bucket(registry, workflow) {
             WorkflowBucket::Pending => counts.pending += 1,
             WorkflowBucket::Running => counts.running += 1,
             WorkflowBucket::Review => counts.review += 1,
@@ -63,8 +63,11 @@ pub(super) fn runtime_workflow_counts(workflows: &[WorkflowInstance]) -> Runtime
     counts
 }
 
-fn workflow_bucket(workflow: &WorkflowInstance) -> WorkflowBucket {
-    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+fn workflow_bucket(
+    registry: &WorkflowDefinitionRegistry,
+    workflow: &WorkflowInstance,
+) -> WorkflowBucket {
+    let projection = RuntimeWorkflowProjection::from_workflow_with_registry(registry, workflow);
     match projection.task_status {
         TaskStatus::Pending => return WorkflowBucket::Pending,
         TaskStatus::Failed => return WorkflowBucket::Failed,
@@ -75,8 +78,11 @@ fn workflow_bucket(workflow: &WorkflowInstance) -> WorkflowBucket {
     if workflow.state == "ready_to_merge" {
         return WorkflowBucket::ReadyToMerge;
     }
-    if declarative_workflow_definition_for_instance(workflow).is_some()
-        && workflow_state_definition_for_instance(workflow, &workflow.state)
+    if registry
+        .declarative_definition_for_instance(workflow)
+        .is_some()
+        && registry
+            .state_definition_for_instance(workflow, &workflow.state)
             .is_some_and(|state| state.progress_mode == Some(WorkflowProgressMode::OperatorGate))
     {
         return WorkflowBucket::Blocked;
@@ -95,13 +101,14 @@ fn workflow_bucket(workflow: &WorkflowInstance) -> WorkflowBucket {
 }
 
 pub(super) fn source_activity(
+    registry: &WorkflowDefinitionRegistry,
     workflows: &[WorkflowInstance],
     active_tasks: &[TaskSummary],
 ) -> Vec<SourceActivity> {
     let mut by_source: HashMap<String, SourceActivity> = HashMap::new();
     let workflow_task_ids = workflow_legacy_task_ids(workflows);
     for workflow in workflows {
-        add_workflow_source_activity(&mut by_source, workflow);
+        add_workflow_source_activity(registry, &mut by_source, workflow);
     }
     for task in active_tasks {
         if task.workflow.is_some() || workflow_task_ids.contains(task.id.as_str()) {
@@ -119,10 +126,11 @@ pub(super) fn source_activity(
 }
 
 fn add_workflow_source_activity(
+    registry: &WorkflowDefinitionRegistry,
     by_source: &mut HashMap<String, SourceActivity>,
     workflow: &WorkflowInstance,
 ) {
-    let bucket = workflow_bucket(workflow);
+    let bucket = workflow_bucket(registry, workflow);
     if matches!(bucket, WorkflowBucket::Done | WorkflowBucket::Other) {
         return;
     }

--- a/crates/harness-server/src/handlers/operator_monitor/failure_classification.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/failure_classification.rs
@@ -1,0 +1,77 @@
+pub(super) fn classify_failure_family(message: &str) -> &'static str {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("ssl_error_syscall")
+        || lower.contains("failed to fetch")
+        || lower.contains("git fetch")
+        || lower.contains("github.com")
+    {
+        "github_fetch"
+    } else if lower.contains("timed out") || lower.contains("timeout") {
+        "timeout"
+    } else if lower.contains("rate limit") || lower.contains("secondary rate limit") {
+        "rate_limit"
+    } else if lower.contains("missing structured output")
+        || lower.contains("activity_result")
+        || lower.contains("structured activity")
+    {
+        "missing_structured_output"
+    } else if lower.contains("worktree") || lower.contains("workspace") {
+        "worktree_collision"
+    } else if lower.contains("agent turn") || lower.contains("agent failed") {
+        "agent_turn_failed"
+    } else {
+        "internal"
+    }
+}
+
+pub(super) fn failure_severity(family: &str) -> &'static str {
+    match family {
+        "github_fetch" | "timeout" | "rate_limit" => "warn",
+        "missing_structured_output" | "worktree_collision" | "agent_turn_failed" => "error",
+        _ => "error",
+    }
+}
+
+pub(super) fn failure_retryable(family: &str) -> bool {
+    matches!(family, "github_fetch" | "timeout" | "rate_limit")
+}
+
+pub(super) fn failure_next_action(family: &str) -> &'static str {
+    match family {
+        "github_fetch" => "Retry after GitHub connectivity recovers",
+        "timeout" => "Retry or inspect the long-running turn",
+        "rate_limit" => "Wait for the rate limit window",
+        "missing_structured_output" => "Inspect agent output and prompt contract",
+        "worktree_collision" => "Inspect workspace ownership",
+        "agent_turn_failed" => "Inspect agent logs",
+        _ => "Inspect task logs",
+    }
+}
+
+pub(super) fn normalize_failure_message(message: &str) -> String {
+    let first_line = message.lines().next().unwrap_or(message).trim();
+    let collapsed = first_line.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() > 180 {
+        collapsed.chars().take(177).collect::<String>() + "..."
+    } else if collapsed.is_empty() {
+        "unknown failure".to_string()
+    } else {
+        collapsed
+    }
+}
+
+pub(super) fn earlier_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<String> {
+    current
+        .into_iter()
+        .chain(candidate)
+        .min()
+        .map(str::to_string)
+}
+
+pub(super) fn later_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<String> {
+    current
+        .into_iter()
+        .chain(candidate)
+        .max()
+        .map(str::to_string)
+}

--- a/crates/harness-server/src/handlers/operator_monitor/mod.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/mod.rs
@@ -7,6 +7,7 @@
 
 mod activity;
 mod driverless_progress;
+mod failure_classification;
 mod response;
 mod sampling;
 
@@ -18,7 +19,9 @@ use crate::runtime_projection::{
 use crate::task_runner::{RecentFailureTask, SchedulerAuthorityState, TaskSummary};
 use activity::{runtime_workflow_counts, source_activity, RuntimeWorkflowCounts, SourceActivity};
 use chrono::{DateTime, Utc};
-use harness_workflow::runtime::{WorkflowInstance, WorkflowRuntimeStore, WorkflowTerminalState};
+use harness_workflow::runtime::{
+    WorkflowDefinitionRegistry, WorkflowInstance, WorkflowRuntimeStore, WorkflowTerminalState,
+};
 use sampling::{dedupe_workflows, list_operator_action_workflows, list_recent_failed_workflows};
 use serde::Serialize;
 use serde_json::Value;
@@ -27,6 +30,10 @@ use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use driverless_progress::{list_driverless_progress, DriverlessProgressEvidence};
+use failure_classification::{
+    classify_failure_family, earlier_timestamp, failure_next_action, failure_retryable,
+    failure_severity, later_timestamp, normalize_failure_message,
+};
 pub(crate) use response::{operator_monitor, OperatorMonitorResponse};
 
 /// A background loop whose last tick is older than this is reported stale and
@@ -192,7 +199,14 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
         "degraded"
     };
 
-    let runtime_workflows = runtime_workflow_counts(&workflows);
+    let fallback_registry = WorkflowDefinitionRegistry::with_builtins();
+    let registry = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .map(|store| store.definition_registry())
+        .unwrap_or(&fallback_registry);
+    let runtime_workflows = runtime_workflow_counts(registry, &workflows);
     let workflow_legacy_task_ids = workflow_legacy_task_ids(&workflows);
     let stopped_eligibility = stopped_action_eligibility_for_workflows(
         state.core.workflow_runtime_store.as_deref(),
@@ -210,11 +224,12 @@ async fn build_operator_monitor(state: &AppState) -> anyhow::Result<OperatorMoni
         dashboard_counts.global_failed,
         dashboard_counts.global_done,
     );
-    let by_source = source_activity(&workflows, &active_tasks);
-    let operator_actions = operator_actions(&workflows, generated_at, &stopped_eligibility);
+    let by_source = source_activity(registry, &workflows, &active_tasks);
+    let operator_actions =
+        operator_actions(registry, &workflows, generated_at, &stopped_eligibility);
     let stuck_workflows = list_stuck_workflows(state, generated_at).await?;
     let driverless_progress = list_driverless_progress(state).await?;
-    let failures = grouped_failures(&recent_failures, &workflows);
+    let failures = grouped_failures(registry, &recent_failures, &workflows);
     let capacity = state.concurrency.task_queue.global_limit() as u64;
     let local_live_worktrees = state
         .concurrency
@@ -314,6 +329,7 @@ async fn list_stuck_workflows(
     let stopped_eligibility =
         stopped_action_eligibility_for_workflows(Some(store), &workflows).await?;
     Ok(stuck_workflows_from_instances(
+        store.definition_registry(),
         &workflows,
         generated_at,
         &stopped_eligibility,
@@ -321,6 +337,7 @@ async fn list_stuck_workflows(
 }
 
 fn stuck_workflows_from_instances(
+    registry: &WorkflowDefinitionRegistry,
     workflows: &[WorkflowInstance],
     generated_at: DateTime<Utc>,
     stopped_eligibility: &HashMap<String, RuntimeStoppedActionEligibility>,
@@ -350,13 +367,15 @@ fn stuck_workflows_from_instances(
                 updated_at: workflow.updated_at.to_rfc3339(),
                 url: pr_url.or(issue_url),
                 source: workflow_source(workflow),
-                stopped_state: RuntimeStoppedStateProjection::from_workflow(workflow)
-                    .with_action_eligibility(
-                        stopped_eligibility
-                            .get(&workflow.id)
-                            .copied()
-                            .unwrap_or_default(),
-                    ),
+                stopped_state: RuntimeStoppedStateProjection::from_workflow_with_registry(
+                    registry, workflow,
+                )
+                .with_action_eligibility(
+                    stopped_eligibility
+                        .get(&workflow.id)
+                        .copied()
+                        .unwrap_or_default(),
+                ),
             }
         })
         .collect::<Vec<_>>();
@@ -375,7 +394,8 @@ async fn list_runtime_workflows_from_store(
     store: &WorkflowRuntimeStore,
 ) -> anyhow::Result<Vec<WorkflowInstance>> {
     let sample_limit = WORKFLOW_SAMPLE_LIMIT as usize;
-    let definition_ids = crate::handlers::definition_ids::operator_definition_ids()?;
+    let definition_ids =
+        crate::handlers::definition_ids::operator_definition_ids(store.definition_registry())?;
     let mut workflows = list_operator_action_workflows(store, &definition_ids).await?;
     workflows.extend(list_recent_failed_workflows(store, &definition_ids, sample_limit).await?);
     for definition_id in &definition_ids {
@@ -390,18 +410,22 @@ async fn list_runtime_workflows_from_store(
         );
     }
     dedupe_workflows(&mut workflows);
-    truncate_workflow_sample(&mut workflows, sample_limit);
+    truncate_workflow_sample(store.definition_registry(), &mut workflows, sample_limit);
     Ok(workflows)
 }
 
-fn truncate_workflow_sample(workflows: &mut Vec<WorkflowInstance>, limit: usize) {
+fn truncate_workflow_sample(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
+    workflows: &mut Vec<WorkflowInstance>,
+    limit: usize,
+) {
     let mut operator_actions = Vec::new();
     let mut failed = Vec::new();
     let mut other = Vec::new();
     for workflow in workflows.drain(..) {
-        if workflow.terminal_state() == Some(WorkflowTerminalState::Failed) {
+        if workflow.terminal_state_with_registry(registry) == Some(WorkflowTerminalState::Failed) {
             failed.push(workflow);
-        } else if workflow_action_kind(&workflow).is_some() {
+        } else if workflow_action_kind(registry, &workflow).is_some() {
             operator_actions.push(workflow);
         } else {
             other.push(workflow);
@@ -457,8 +481,7 @@ fn workflow_legacy_task_ids(workflows: &[WorkflowInstance]) -> HashSet<String> {
     workflows
         .iter()
         .filter_map(|workflow| {
-            RuntimeWorkflowProjection::from_workflow(workflow)
-                .legacy_dedupe_task_handle
+            crate::runtime_projection::legacy_dedupe_task_handle(&workflow.data)
                 .map(|task_id| task_id.0)
         })
         .collect()
@@ -475,22 +498,25 @@ fn filter_workflow_backed_tasks(
 }
 
 fn operator_actions(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
     workflows: &[WorkflowInstance],
     generated_at: DateTime<Utc>,
     stopped_eligibility: &HashMap<String, RuntimeStoppedActionEligibility>,
 ) -> Vec<OperatorAction> {
     let mut actions = Vec::new();
     for workflow in workflows {
-        let Some(kind) = workflow_action_kind(workflow) else {
+        let Some(kind) = workflow_action_kind(registry, workflow) else {
             continue;
         };
-        let projection = RuntimeWorkflowProjection::from_workflow_with_stopped_eligibility(
-            workflow,
-            stopped_eligibility
-                .get(&workflow.id)
-                .copied()
-                .unwrap_or_default(),
-        );
+        let projection =
+            RuntimeWorkflowProjection::from_workflow_with_registry_and_stopped_eligibility(
+                registry,
+                workflow,
+                stopped_eligibility
+                    .get(&workflow.id)
+                    .copied()
+                    .unwrap_or_default(),
+            );
         let next_action = workflow_next_action(kind, &projection.stopped_state);
         let task_id = projection
             .legacy_dedupe_task_handle
@@ -540,20 +566,24 @@ fn operator_actions(
     actions
 }
 
-fn workflow_action_kind(workflow: &WorkflowInstance) -> Option<&'static str> {
-    if workflow.terminal_state() == Some(WorkflowTerminalState::Failed) {
+fn workflow_action_kind(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
+    workflow: &WorkflowInstance,
+) -> Option<&'static str> {
+    if workflow.terminal_state_with_registry(registry) == Some(WorkflowTerminalState::Failed) {
         return Some("failed");
     }
-    if harness_workflow::runtime::declarative_workflow_definition_for_instance(workflow).is_some() {
-        return harness_workflow::runtime::workflow_state_definition_for_instance(
-            workflow,
-            &workflow.state,
-        )
-        .is_some_and(|state| {
-            state.progress_mode
-                == Some(harness_workflow::runtime::WorkflowProgressMode::OperatorGate)
-        })
-        .then_some("blocked");
+    if registry
+        .declarative_definition_for_instance(workflow)
+        .is_some()
+    {
+        return registry
+            .state_definition_for_instance(workflow, &workflow.state)
+            .is_some_and(|state| {
+                state.progress_mode
+                    == Some(harness_workflow::runtime::WorkflowProgressMode::OperatorGate)
+            })
+            .then_some("blocked");
     }
     match workflow.state.as_str() {
         "ready_to_merge" => Some("ready_to_merge"),
@@ -585,6 +615,7 @@ fn action_priority(kind: &str) -> u8 {
 }
 
 fn grouped_failures(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
     failures: &[RecentFailureTask],
     workflows: &[WorkflowInstance],
 ) -> Vec<FailureGroup> {
@@ -601,10 +632,9 @@ fn grouped_failures(
             Some(failure.id.as_str().to_string()),
         );
     }
-    for workflow in workflows
-        .iter()
-        .filter(|workflow| workflow.terminal_state() == Some(WorkflowTerminalState::Failed))
-    {
+    for workflow in workflows.iter().filter(|workflow| {
+        workflow.terminal_state_with_registry(registry) == Some(WorkflowTerminalState::Failed)
+    }) {
         let workflow_task_ids = workflow_failure_task_ids(workflow);
         if workflow_task_ids
             .iter()
@@ -675,106 +705,24 @@ fn workflow_failure_message(workflow: &WorkflowInstance) -> String {
 }
 
 fn workflow_failure_id(workflow: &WorkflowInstance) -> String {
-    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
-    projection
-        .submission_handle
+    crate::runtime_projection::runtime_submission_handle(&workflow.data)
         .map(|task_id| task_id.as_str().to_string())
         .or_else(|| {
-            projection
-                .legacy_dedupe_task_handle
+            crate::runtime_projection::legacy_dedupe_task_handle(&workflow.data)
                 .map(|task_id| task_id.0)
         })
         .unwrap_or_else(|| workflow.id.clone())
 }
 
 fn workflow_failure_task_ids(workflow: &WorkflowInstance) -> HashSet<String> {
-    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
     let mut ids = HashSet::new();
-    if let Some(task_id) = projection.submission_handle {
+    if let Some(task_id) = crate::runtime_projection::runtime_submission_handle(&workflow.data) {
         ids.insert(task_id.as_str().to_string());
     }
-    if let Some(task_id) = projection.legacy_dedupe_task_handle {
+    if let Some(task_id) = crate::runtime_projection::legacy_dedupe_task_handle(&workflow.data) {
         ids.insert(task_id.0);
     }
     ids
-}
-
-fn classify_failure_family(message: &str) -> &'static str {
-    let lower = message.to_ascii_lowercase();
-    if lower.contains("ssl_error_syscall")
-        || lower.contains("failed to fetch")
-        || lower.contains("git fetch")
-        || lower.contains("github.com")
-    {
-        "github_fetch"
-    } else if lower.contains("timed out") || lower.contains("timeout") {
-        "timeout"
-    } else if lower.contains("rate limit") || lower.contains("secondary rate limit") {
-        "rate_limit"
-    } else if lower.contains("missing structured output")
-        || lower.contains("activity_result")
-        || lower.contains("structured activity")
-    {
-        "missing_structured_output"
-    } else if lower.contains("worktree") || lower.contains("workspace") {
-        "worktree_collision"
-    } else if lower.contains("agent turn") || lower.contains("agent failed") {
-        "agent_turn_failed"
-    } else {
-        "internal"
-    }
-}
-
-fn failure_severity(family: &str) -> &'static str {
-    match family {
-        "github_fetch" | "timeout" | "rate_limit" => "warn",
-        "missing_structured_output" | "worktree_collision" | "agent_turn_failed" => "error",
-        _ => "error",
-    }
-}
-
-fn failure_retryable(family: &str) -> bool {
-    matches!(family, "github_fetch" | "timeout" | "rate_limit")
-}
-
-fn failure_next_action(family: &str) -> &'static str {
-    match family {
-        "github_fetch" => "Retry after GitHub connectivity recovers",
-        "timeout" => "Retry or inspect the long-running turn",
-        "rate_limit" => "Wait for the rate limit window",
-        "missing_structured_output" => "Inspect agent output and prompt contract",
-        "worktree_collision" => "Inspect workspace ownership",
-        "agent_turn_failed" => "Inspect agent logs",
-        _ => "Inspect task logs",
-    }
-}
-
-fn normalize_failure_message(message: &str) -> String {
-    let first_line = message.lines().next().unwrap_or(message).trim();
-    let collapsed = first_line.split_whitespace().collect::<Vec<_>>().join(" ");
-    if collapsed.chars().count() > 180 {
-        collapsed.chars().take(177).collect::<String>() + "..."
-    } else if collapsed.is_empty() {
-        "unknown failure".to_string()
-    } else {
-        collapsed
-    }
-}
-
-fn earlier_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<String> {
-    current
-        .into_iter()
-        .chain(candidate)
-        .min()
-        .map(str::to_string)
-}
-
-fn later_timestamp(current: Option<&str>, candidate: Option<&str>) -> Option<String> {
-    current
-        .into_iter()
-        .chain(candidate)
-        .max()
-        .map(str::to_string)
 }
 
 fn worktree_used_count(local_live_count: Option<u64>, card_count: usize) -> u64 {

--- a/crates/harness-server/src/handlers/operator_monitor/tests.rs
+++ b/crates/harness-server/src/handlers/operator_monitor/tests.rs
@@ -3,8 +3,8 @@ use crate::test_helpers;
 use axum::{body::to_bytes, routing::get, Router};
 use harness_core::types::TaskId;
 use harness_workflow::runtime::{
-    RuntimeKind, WorkflowCommand, WorkflowRuntimeStore, WorkflowSubject,
-    GITHUB_ISSUE_PR_DEFINITION_ID, QUALITY_GATE_DEFINITION_ID,
+    RuntimeKind, WorkflowCommand, WorkflowDefinitionRegistry, WorkflowRuntimeStore,
+    WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID, QUALITY_GATE_DEFINITION_ID,
 };
 
 fn workflow(state: &str, data: Value) -> WorkflowInstance {
@@ -54,7 +54,7 @@ fn runtime_workflow_counts_reconcile_execution_review_and_terminal_states() {
         workflow("done", json!({})),
     ];
 
-    let counts = runtime_workflow_counts(&workflows);
+    let counts = runtime_workflow_counts(&WorkflowDefinitionRegistry::with_builtins(), &workflows);
 
     assert_eq!(counts.running, 7);
     assert_eq!(counts.pending, 2);
@@ -93,7 +93,11 @@ fn workflow_sample_truncation_preserves_operator_action_and_failed_states() {
     failed.updated_at = base - chrono::Duration::hours(2);
     workflows.push(failed);
 
-    truncate_workflow_sample(&mut workflows, 500);
+    truncate_workflow_sample(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        &mut workflows,
+        500,
+    );
 
     assert!(workflows
         .iter()
@@ -134,7 +138,11 @@ fn workflow_sample_truncation_preserves_failed_reserve_before_operator_actions()
     failed.updated_at = base - chrono::Duration::hours(1);
     workflows.push(failed);
 
-    truncate_workflow_sample(&mut workflows, 500);
+    truncate_workflow_sample(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        &mut workflows,
+        500,
+    );
 
     assert_eq!(workflows.len(), 500);
     assert!(workflows
@@ -149,7 +157,7 @@ fn grouped_failures_classifies_and_counts_github_fetch_failures() {
         github_fetch_failure("task-2", 2, "2026-06-12T00:05:00Z"),
     ];
 
-    let groups = grouped_failures(&failures, &[]);
+    let groups = grouped_failures(&WorkflowDefinitionRegistry::with_builtins(), &failures, &[]);
 
     assert_eq!(groups.len(), 1);
     assert_eq!(groups[0].family, "github_fetch");
@@ -172,7 +180,11 @@ fn grouped_failures_includes_runtime_only_workflow_failures() {
     .with_id("quality-gate-workflow".to_string());
     failed_workflow.updated_at = Utc::now();
 
-    let groups = grouped_failures(&[], &[failed_workflow]);
+    let groups = grouped_failures(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        &[],
+        &[failed_workflow],
+    );
 
     assert_eq!(groups.len(), 1);
     assert_eq!(groups[0].message, "Quality gate execution failed.");
@@ -205,7 +217,11 @@ fn grouped_failures_deduplicates_workflow_failures_backed_by_task_rows() {
     .with_id("workflow-row".to_string());
     failed_workflow.updated_at = Utc::now();
 
-    let groups = grouped_failures(&failures, &[failed_workflow]);
+    let groups = grouped_failures(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        &failures,
+        &[failed_workflow],
+    );
 
     assert_eq!(groups.len(), 1);
     assert_eq!(groups[0].message, "Quality gate execution failed.");
@@ -340,7 +356,12 @@ fn operator_actions_link_evidence_to_current_legacy_task_id() {
     .with_id("ready-workflow".to_string());
     ready.updated_at = Utc::now();
 
-    let actions = operator_actions(&[ready], Utc::now(), &std::collections::HashMap::new());
+    let actions = operator_actions(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        &[ready],
+        Utc::now(),
+        &std::collections::HashMap::new(),
+    );
 
     assert_eq!(actions.len(), 1);
     assert_eq!(actions[0].task_id.as_deref(), Some("current-task"));
@@ -420,6 +441,7 @@ fn operator_monitor_actions_expose_structured_stop_metadata_and_eligibility() {
         },
     );
     let actions = operator_actions(
+        &WorkflowDefinitionRegistry::with_builtins(),
         &[blocked, retryable_failed, configuration_failed, cancelled],
         Utc::now(),
         &stopped_eligibility,
@@ -504,7 +526,12 @@ fn operator_monitor_stuck_workflows_expose_structured_stop_metadata() {
             can_retry: false,
         },
     );
-    let stuck = stuck_workflows_from_instances(&[blocked], Utc::now(), &stopped_eligibility);
+    let stuck = stuck_workflows_from_instances(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        &[blocked],
+        Utc::now(),
+        &stopped_eligibility,
+    );
     let row = serde_json::to_value(&stuck[0]).expect("stuck workflow should serialize");
 
     assert_eq!(row["workflow_id"], "stuck-blocked-workflow");
@@ -550,6 +577,7 @@ fn operator_monitor_stuck_workflows_expose_auto_recovery_fields() {
     .with_id("stuck-legacy-workflow".to_string());
 
     let stuck = stuck_workflows_from_instances(
+        &WorkflowDefinitionRegistry::with_builtins(),
         &[classified, legacy],
         Utc::now(),
         &std::collections::HashMap::new(),
@@ -891,8 +919,9 @@ async fn attach_recovery_source_job(
 fn idle_workflows_are_inactive_for_source_activity() {
     let workflows = vec![workflow("idle", json!({ "source": "github" }))];
 
-    let counts = runtime_workflow_counts(&workflows);
-    let by_source = source_activity(&workflows, &[]);
+    let registry = WorkflowDefinitionRegistry::with_builtins();
+    let counts = runtime_workflow_counts(&registry, &workflows);
+    let by_source = source_activity(&registry, &workflows, &[]);
 
     assert_eq!(counts.pending, 0);
     assert_eq!(counts.running, 0);
@@ -1019,23 +1048,20 @@ async fn endpoint_includes_config_enabled_stuck_workflows() -> anyhow::Result<()
 }
 
 const DECLARATIVE_VISIBILITY_DEFINITION_ID: &str = "operator_monitor_visibility_flow";
-static REGISTER_DECLARATIVE_VISIBILITY_DEFINITION: std::sync::Once = std::sync::Once::new();
 
 /// Register a uniquely-named declarative definition into the process-global
 /// registry (GH-1609 fixture pattern, `Once`-guarded so it is idempotent across
 /// tests in this binary). It carries no built-in instances, so counting tests in
 /// sibling suites are unaffected.
-fn register_declarative_visibility_definition() {
-    REGISTER_DECLARATIVE_VISIBILITY_DEFINITION.call_once(|| {
-        let historical = declarative_visibility_definition("done", "failed");
-        let current = declarative_visibility_definition("completed", "rejected");
-        harness_workflow::runtime::register_historical_declarative_workflow_definitions([
-            historical,
-        ])
+fn declarative_visibility_registry() -> WorkflowDefinitionRegistry {
+    let mut registry = WorkflowDefinitionRegistry::with_builtins();
+    registry
+        .register_declarative_historical(declarative_visibility_definition("done", "failed"))
         .expect("historical visibility fixture definition should register");
-        harness_workflow::runtime::register_declarative_workflow_definitions([current])
-            .expect("visibility fixture definition should register");
-    });
+    registry
+        .register_declarative_current(declarative_visibility_definition("completed", "rejected"))
+        .expect("visibility fixture definition should register");
+    registry
 }
 
 fn declarative_visibility_definition(
@@ -1105,23 +1131,21 @@ fn declarative_visibility_definition(
 /// exercised locally.
 #[test]
 fn declarative_visibility_fixture_definition_is_valid() {
-    register_declarative_visibility_definition();
+    let registry = declarative_visibility_registry();
     assert!(
-        harness_workflow::runtime::current_declarative_workflow_definition(
-            DECLARATIVE_VISIBILITY_DEFINITION_ID
-        )
-        .is_some(),
+        registry
+            .current_declarative_definition(DECLARATIVE_VISIBILITY_DEFINITION_ID)
+            .is_some(),
         "visibility fixture definition should register"
     );
 }
 
 #[test]
 fn declarative_command_driven_state_counts_as_running() {
-    register_declarative_visibility_definition();
-    let definition = harness_workflow::runtime::current_declarative_workflow_definition(
-        DECLARATIVE_VISIBILITY_DEFINITION_ID,
-    )
-    .expect("visibility fixture definition should be registered");
+    let registry = declarative_visibility_registry();
+    let definition = registry
+        .current_declarative_definition(DECLARATIVE_VISIBILITY_DEFINITION_ID)
+        .expect("visibility fixture definition should be registered");
     let workflow = WorkflowInstance::new(
         DECLARATIVE_VISIBILITY_DEFINITION_ID,
         definition.definition_version(),
@@ -1130,7 +1154,7 @@ fn declarative_command_driven_state_counts_as_running() {
     )
     .with_server_data(json!({ "definition_hash": definition.definition_hash() }));
 
-    let counts = runtime_workflow_counts(&[workflow]);
+    let counts = runtime_workflow_counts(&registry, &[workflow]);
 
     assert_eq!(counts.running, 1);
     assert_eq!(counts.pending, 0);
@@ -1138,11 +1162,10 @@ fn declarative_command_driven_state_counts_as_running() {
 
 #[test]
 fn workflow_sample_truncation_preserves_declarative_failed_terminal() {
-    register_declarative_visibility_definition();
-    let definition = harness_workflow::runtime::current_declarative_workflow_definition(
-        DECLARATIVE_VISIBILITY_DEFINITION_ID,
-    )
-    .expect("visibility fixture definition should be registered");
+    let registry = declarative_visibility_registry();
+    let definition = registry
+        .current_declarative_definition(DECLARATIVE_VISIBILITY_DEFINITION_ID)
+        .expect("visibility fixture definition should be registered");
     let failed = WorkflowInstance::new(
         DECLARATIVE_VISIBILITY_DEFINITION_ID,
         definition.definition_version(),
@@ -1162,7 +1185,7 @@ fn workflow_sample_truncation_preserves_declarative_failed_terminal() {
     active.updated_at = failed.updated_at + chrono::Duration::seconds(1);
     let mut workflows = vec![active, failed];
 
-    truncate_workflow_sample(&mut workflows, 1);
+    truncate_workflow_sample(&registry, &mut workflows, 1);
 
     assert_eq!(workflows.len(), 1);
     assert_eq!(workflows[0].id, "declarative-failed");
@@ -1170,11 +1193,10 @@ fn workflow_sample_truncation_preserves_declarative_failed_terminal() {
 
 #[test]
 fn declarative_failed_terminal_populates_failure_and_action_surfaces() {
-    register_declarative_visibility_definition();
-    let definition = harness_workflow::runtime::current_declarative_workflow_definition(
-        DECLARATIVE_VISIBILITY_DEFINITION_ID,
-    )
-    .expect("visibility fixture definition should be registered");
+    let registry = declarative_visibility_registry();
+    let definition = registry
+        .current_declarative_definition(DECLARATIVE_VISIBILITY_DEFINITION_ID)
+        .expect("visibility fixture definition should be registered");
     let failed = WorkflowInstance::new(
         DECLARATIVE_VISIBILITY_DEFINITION_ID,
         definition.definition_version(),
@@ -1187,22 +1209,26 @@ fn declarative_failed_terminal_populates_failure_and_action_surfaces() {
         "failure_reason": "declarative review rejected"
     }));
 
-    let failures = grouped_failures(&[], std::slice::from_ref(&failed));
+    let failures = grouped_failures(&registry, &[], std::slice::from_ref(&failed));
     assert_eq!(failures.len(), 1);
     assert_eq!(failures[0].message, "declarative review rejected");
 
-    let actions = operator_actions(&[failed], Utc::now(), &std::collections::HashMap::new());
+    let actions = operator_actions(
+        &registry,
+        &[failed],
+        Utc::now(),
+        &std::collections::HashMap::new(),
+    );
     assert_eq!(actions.len(), 1);
     assert_eq!(actions[0].kind, "failed");
 }
 
 #[test]
 fn declarative_operator_gate_uses_registry_progress_for_action_kind() {
-    register_declarative_visibility_definition();
-    let definition = harness_workflow::runtime::current_declarative_workflow_definition(
-        DECLARATIVE_VISIBILITY_DEFINITION_ID,
-    )
-    .expect("visibility fixture definition should be registered");
+    let registry = declarative_visibility_registry();
+    let definition = registry
+        .current_declarative_definition(DECLARATIVE_VISIBILITY_DEFINITION_ID)
+        .expect("visibility fixture definition should be registered");
     let gate = WorkflowInstance::new(
         DECLARATIVE_VISIBILITY_DEFINITION_ID,
         definition.definition_version(),
@@ -1212,18 +1238,22 @@ fn declarative_operator_gate_uses_registry_progress_for_action_kind() {
     .with_id("declarative-manual-review")
     .with_server_data(json!({ "definition_hash": definition.definition_hash() }));
 
-    let actions = operator_actions(&[gate], Utc::now(), &std::collections::HashMap::new());
+    let actions = operator_actions(
+        &registry,
+        &[gate],
+        Utc::now(),
+        &std::collections::HashMap::new(),
+    );
     assert_eq!(actions.len(), 1);
     assert_eq!(actions[0].kind, "blocked");
 }
 
 #[test]
 fn declarative_operator_gate_counts_as_blocked_activity() {
-    register_declarative_visibility_definition();
-    let definition = harness_workflow::runtime::current_declarative_workflow_definition(
-        DECLARATIVE_VISIBILITY_DEFINITION_ID,
-    )
-    .expect("visibility fixture definition should be registered");
+    let registry = declarative_visibility_registry();
+    let definition = registry
+        .current_declarative_definition(DECLARATIVE_VISIBILITY_DEFINITION_ID)
+        .expect("visibility fixture definition should be registered");
     let gate = WorkflowInstance::new(
         DECLARATIVE_VISIBILITY_DEFINITION_ID,
         definition.definition_version(),
@@ -1235,11 +1265,11 @@ fn declarative_operator_gate_counts_as_blocked_activity() {
         "source": "github"
     }));
 
-    let counts = runtime_workflow_counts(std::slice::from_ref(&gate));
+    let counts = runtime_workflow_counts(&registry, std::slice::from_ref(&gate));
     assert_eq!(counts.blocked, 1);
     assert_eq!(counts.pending, 0);
 
-    let by_source = source_activity(&[gate], &[]);
+    let by_source = source_activity(&registry, &[gate], &[]);
     assert_eq!(by_source.len(), 1);
     assert_eq!(by_source[0].source, "github");
     assert_eq!(by_source[0].blocked, 1);
@@ -1251,18 +1281,18 @@ async fn declarative_operator_gate_sampling_uses_registry_progress() -> anyhow::
     if !test_helpers::db_tests_enabled().await {
         return Ok(());
     }
-    register_declarative_visibility_definition();
-    let definition = harness_workflow::runtime::current_declarative_workflow_definition(
-        DECLARATIVE_VISIBILITY_DEFINITION_ID,
-    )
-    .expect("visibility fixture definition should be registered");
+    let registry = declarative_visibility_registry();
+    let definition = registry
+        .current_declarative_definition(DECLARATIVE_VISIBILITY_DEFINITION_ID)
+        .expect("visibility fixture definition should be registered");
     let _lock = test_helpers::HOME_LOCK.lock().await;
     let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-gate-progress-")?;
     let store = WorkflowRuntimeStore::open_with_database_url(
         &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
         Some(&test_helpers::test_database_url()?),
     )
-    .await?;
+    .await?
+    .with_definition_registry(registry.into_shared());
     crate::test_helpers::force_upsert_runtime_lifecycle_state_for_test(
         &store,
         &WorkflowInstance::new(
@@ -1292,7 +1322,7 @@ async fn declarative_definition_instances_are_visible_in_operator_monitor() -> a
     if !test_helpers::db_tests_enabled().await {
         return Ok(());
     }
-    register_declarative_visibility_definition();
+    let registry = declarative_visibility_registry();
 
     let _lock = test_helpers::HOME_LOCK.lock().await;
     let dir = test_helpers::tempdir_in_home("harness-test-operator-monitor-declarative-")?;
@@ -1300,7 +1330,8 @@ async fn declarative_definition_instances_are_visible_in_operator_monitor() -> a
         &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
         Some(&test_helpers::test_database_url()?),
     )
-    .await?;
+    .await?
+    .with_definition_registry(registry.into_shared());
 
     crate::test_helpers::force_upsert_runtime_lifecycle_state_for_test(
         &store,
@@ -1335,7 +1366,7 @@ async fn declarative_terminal_queries_use_pinned_versions_and_outcomes() -> anyh
     if !test_helpers::db_tests_enabled().await {
         return Ok(());
     }
-    register_declarative_visibility_definition();
+    let registry = declarative_visibility_registry();
     let historical = declarative_visibility_definition("done", "failed");
     let current = declarative_visibility_definition("completed", "rejected");
 
@@ -1345,7 +1376,8 @@ async fn declarative_terminal_queries_use_pinned_versions_and_outcomes() -> anyh
         &harness_core::config::dirs::default_db_path(dir.path(), "workflow_runtime"),
         Some(&test_helpers::test_database_url()?),
     )
-    .await?;
+    .await?
+    .with_definition_registry(registry.into_shared());
     for (id, definition, state) in [
         ("historical-success", &historical, "done"),
         ("current-success", &current, "completed"),
@@ -1437,7 +1469,9 @@ async fn recent_failed_workflow_sampling_prefers_newest_rows() -> anyhow::Result
         .execute(workflow_runtime_store.pool())
         .await?;
 
-    let definition_ids = crate::handlers::definition_ids::operator_definition_ids()?;
+    let definition_ids = crate::handlers::definition_ids::operator_definition_ids(
+        workflow_runtime_store.definition_registry(),
+    )?;
     let workflows =
         list_recent_failed_workflows(&workflow_runtime_store, &definition_ids, 1).await?;
 
@@ -1476,7 +1510,12 @@ async fn operator_action_age_uses_store_updated_at() -> anyhow::Result<()> {
         .await?;
 
     let workflows = list_runtime_workflows_from_store(&workflow_runtime_store).await?;
-    let actions = operator_actions(&workflows, Utc::now(), &std::collections::HashMap::new());
+    let actions = operator_actions(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        &workflows,
+        Utc::now(),
+        &std::collections::HashMap::new(),
+    );
 
     let action = actions
         .iter()
@@ -1573,6 +1612,7 @@ fn workflow_backed_and_queued_tasks_are_not_counted_by_source() {
     queued_row.status = crate::task_runner::TaskStatus::Pending;
 
     let mut by_source = source_activity(
+        &WorkflowDefinitionRegistry::with_builtins(),
         &[
             workflow(
                 "ready_to_merge",

--- a/crates/harness-server/src/handlers/overview.rs
+++ b/crates/harness-server/src/handlers/overview.rs
@@ -484,7 +484,9 @@ pub(crate) async fn active_task_overview_counts(state: &AppState) -> ActiveTaskO
     let runtime_counts_available = state.core.workflow_runtime_store.is_some();
 
     if let Some(store) = state.core.workflow_runtime_store.as_ref() {
-        match crate::handlers::definition_ids::active_count_definition_ids() {
+        match crate::handlers::definition_ids::active_count_definition_ids(
+            store.definition_registry(),
+        ) {
             Ok(definition_ids) => {
                 for definition_id in &definition_ids {
                     match store
@@ -493,7 +495,11 @@ pub(crate) async fn active_task_overview_counts(state: &AppState) -> ActiveTaskO
                     {
                         Ok(workflows) => {
                             for workflow in workflows {
-                                add_active_runtime_workflow(&mut counts, &workflow);
+                                add_active_runtime_workflow_with_registry(
+                                    store.definition_registry(),
+                                    &mut counts,
+                                    &workflow,
+                                );
                             }
                         }
                         Err(error) => {
@@ -523,11 +529,12 @@ pub(crate) async fn active_task_overview_counts(state: &AppState) -> ActiveTaskO
     counts
 }
 
-fn add_active_runtime_workflow(
+fn add_active_runtime_workflow_with_registry(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
     counts: &mut ActiveTaskOverviewCounts,
     workflow: &harness_workflow::runtime::WorkflowInstance,
 ) -> bool {
-    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+    let projection = RuntimeWorkflowProjection::from_workflow_with_registry(registry, workflow);
     let Some(bucket) = projection.active_bucket() else {
         return false;
     };
@@ -537,6 +544,18 @@ fn add_active_runtime_workflow(
     };
     counts.add(projection.project_id.as_deref(), bucket);
     true
+}
+
+#[cfg(test)]
+fn add_active_runtime_workflow(
+    counts: &mut ActiveTaskOverviewCounts,
+    workflow: &harness_workflow::runtime::WorkflowInstance,
+) -> bool {
+    add_active_runtime_workflow_with_registry(
+        &harness_workflow::runtime::WorkflowDefinitionRegistry::with_builtins(),
+        counts,
+        workflow,
+    )
 }
 
 /// Top of the current hour (i.e. `HH:00:00Z`). Falls back to `now` on the

--- a/crates/harness-server/src/handlers/worktrees.rs
+++ b/crates/harness-server/src/handlers/worktrees.rs
@@ -194,7 +194,12 @@ async fn runtime_projection_for_workflow_id(
     let Some(instance) = store.get_instance(workflow_id).await? else {
         return Ok(None);
     };
-    Ok(Some(RuntimeWorkflowProjection::from_workflow(&instance)))
+    Ok(Some(
+        RuntimeWorkflowProjection::from_workflow_with_registry(
+            store.definition_registry(),
+            &instance,
+        ),
+    ))
 }
 
 fn runtime_workflow_id_candidate(task: &TaskState) -> Option<String> {

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -52,6 +52,7 @@ pub(crate) async fn build_registry(
     // same policy at activity completion that the dispatcher enforces
     // pre-dispatch (GH-1770).
     let runtime_budget_policy = workflow_config.runtime_budget_policy.clone();
+    let mut workflow_definition_registry = server.configure_workflow_definition_registry()?;
     let workflow_ns = workflow_config.storage.schema_namespace;
     let mut startup_results = Vec::new();
     let plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>> = Arc::new(DashMap::new());
@@ -276,10 +277,11 @@ pub(crate) async fn build_registry(
                 .await?
                 .with_budget_policy(runtime_budget_policy.clone());
                 let historical_definitions = store.list_persisted_declarative_definitions().await?;
-                harness_workflow::runtime::register_historical_declarative_workflow_definitions(
-                    historical_definitions,
-                )?;
-                Ok::<_, anyhow::Error>(store)
+                workflow_definition_registry
+                    .register_declarative_historical_batch(historical_definitions)?;
+                Ok::<_, anyhow::Error>(
+                    store.with_definition_registry(workflow_definition_registry.into_shared()),
+                )
             }
             .await
             {

--- a/crates/harness-server/src/http/intake_status_routes.rs
+++ b/crates/harness-server/src/http/intake_status_routes.rs
@@ -205,7 +205,10 @@ fn legacy_task_recent_dispatch(task: &task_runner::TaskState) -> IntakeRecentDis
 }
 
 fn runtime_issue_recent_dispatch(workflow: &WorkflowInstance) -> Option<IntakeRecentDispatch> {
-    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+    let projection = RuntimeWorkflowProjection::from_workflow_with_registry(
+        &harness_workflow::runtime::WorkflowDefinitionRegistry::with_builtins(),
+        workflow,
+    );
     let task_id = projection.submission_handle?;
     let source = runtime_workflow_intake_source(workflow)?;
     Some(IntakeRecentDispatch {

--- a/crates/harness-server/src/http/misc_routes_runtime_tree.rs
+++ b/crates/harness-server/src/http/misc_routes_runtime_tree.rs
@@ -375,7 +375,10 @@ async fn workflow_runtime_tree_summary(
         .map(|state| state.count)
         .sum();
     let (workflow_statuses, workflow_scheduler_states, workflow_active_buckets) =
-        workflow_projection_summary_counts(&aggregate_summary.workflow_states);
+        workflow_projection_summary_counts(
+            store.definition_registry(),
+            &aggregate_summary.workflow_states,
+        );
     Ok((
         WorkflowRuntimeTreeSummary {
             workflow_statuses,
@@ -395,6 +398,7 @@ async fn workflow_runtime_tree_summary(
 }
 
 fn workflow_projection_summary_counts(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
     workflow_states: &[harness_workflow::runtime::store::WorkflowRuntimeStateCount],
 ) -> (
     BTreeMap<String, usize>,
@@ -408,14 +412,21 @@ fn workflow_projection_summary_counts(
     for state_count in workflow_states {
         let workflow = WorkflowInstance::new(
             &state_count.definition_id,
-            1,
+            state_count.definition_version,
             &state_count.state,
             WorkflowSubject::new(
                 "summary",
                 format!("{}:{}", state_count.definition_id, state_count.state),
             ),
         );
-        let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+        let workflow = match state_count.definition_hash.as_deref() {
+            Some(definition_hash) => {
+                workflow.with_server_data(json!({ "definition_hash": definition_hash }))
+            }
+            None => workflow,
+        };
+        let projection =
+            RuntimeWorkflowProjection::from_workflow_with_registry(registry, &workflow);
         add_summary_count(
             &mut workflow_statuses,
             projection.task_status.as_str(),
@@ -533,7 +544,8 @@ async fn build_full_workflow_runtime_nodes(
         by_id.insert(
             workflow_id,
             WorkflowRuntimeTreeNode {
-                projection: WorkflowRuntimeTreeProjection::from_workflow_with_stopped_eligibility(
+                projection: WorkflowRuntimeTreeProjection::from_workflow_with_registry_and_stopped_eligibility(
+                    store.definition_registry(),
                     &instance,
                     stopped_eligibility
                         .get(&instance.id)
@@ -639,7 +651,8 @@ async fn build_compact_workflow_runtime_nodes(
         by_id.insert(
             workflow_id,
             WorkflowRuntimeTreeNode {
-                projection: WorkflowRuntimeTreeProjection::from_workflow_with_stopped_eligibility(
+                projection: WorkflowRuntimeTreeProjection::from_workflow_with_registry_and_stopped_eligibility(
+                    store.definition_registry(),
                     &instance,
                     stopped_eligibility
                         .get(&instance.id)

--- a/crates/harness-server/src/http/misc_routes_runtime_tree_nodes.rs
+++ b/crates/harness-server/src/http/misc_routes_runtime_tree_nodes.rs
@@ -216,14 +216,29 @@ impl WorkflowRuntimeTreeProjection {
         )
     }
 
+    #[cfg(test)]
     pub(super) fn from_workflow_with_stopped_eligibility(
         workflow: &WorkflowInstance,
         stopped_eligibility: RuntimeStoppedActionEligibility,
     ) -> Self {
-        let projection = RuntimeWorkflowProjection::from_workflow_with_stopped_eligibility(
+        Self::from_workflow_with_registry_and_stopped_eligibility(
+            &harness_workflow::runtime::WorkflowDefinitionRegistry::with_builtins(),
             workflow,
             stopped_eligibility,
-        );
+        )
+    }
+
+    pub(super) fn from_workflow_with_registry_and_stopped_eligibility(
+        registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
+        workflow: &WorkflowInstance,
+        stopped_eligibility: RuntimeStoppedActionEligibility,
+    ) -> Self {
+        let projection =
+            RuntimeWorkflowProjection::from_workflow_with_registry_and_stopped_eligibility(
+                registry,
+                workflow,
+                stopped_eligibility,
+            );
         let active_bucket = projection.active_bucket().map(runtime_active_bucket_label);
         Self {
             status: projection.task_status,

--- a/crates/harness-server/src/http/misc_routes_runtime_tree_tests.rs
+++ b/crates/harness-server/src/http/misc_routes_runtime_tree_tests.rs
@@ -1,9 +1,14 @@
 use super::*;
+use harness_core::config::workflow::{
+    DeclaredProgressMode, DeclaredState, WorkflowActivityPolicy, WorkflowDefinitionPolicy,
+};
 use harness_workflow::runtime::{
-    ActivityArtifact, ActivityResult, RuntimeEvent, RuntimeJob, RuntimeKind, WorkflowInstance,
-    WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID,
+    build_declarative_definition, ActivityArtifact, ActivityResult, RuntimeEvent, RuntimeJob,
+    RuntimeKind, WorkflowDefinitionRegistry, WorkflowInstance, WorkflowSubject,
+    GITHUB_ISSUE_PR_DEFINITION_ID,
 };
 use serde_json::json;
+use std::collections::BTreeMap;
 
 fn runtime_job_with_artifacts(artifacts: Vec<ActivityArtifact>) -> RuntimeJob {
     let result = artifacts.into_iter().fold(
@@ -265,4 +270,101 @@ fn runtime_job_has_in_flight_model_turn_ends_after_result_for_latest_turn() {
     ];
 
     assert!(!runtime_job_has_in_flight_model_turn(&job, &events));
+}
+
+#[test]
+fn workflow_summary_projection_preserves_declarative_definition_pins() -> anyhow::Result<()> {
+    let definition_id = "runtime_tree_pinned_summary";
+    let activities = BTreeMap::from([("run".to_string(), WorkflowActivityPolicy::default())]);
+    let old = build_declarative_definition(
+        &WorkflowDefinitionPolicy {
+            id: definition_id.to_string(),
+            initial: "complete".to_string(),
+            states: BTreeMap::from([
+                (
+                    "complete".to_string(),
+                    DeclaredState {
+                        activity: Some("run".to_string()),
+                        on_success: Some("archived".to_string()),
+                        on_failure: Some("failed".to_string()),
+                        ..DeclaredState::default()
+                    },
+                ),
+                (
+                    "blocked".to_string(),
+                    DeclaredState {
+                        progress: Some(DeclaredProgressMode::OperatorGate),
+                        ..DeclaredState::default()
+                    },
+                ),
+            ]),
+            terminal: BTreeMap::from([
+                ("archived".to_string(), "succeeded".to_string()),
+                ("cancelled".to_string(), "cancelled".to_string()),
+                ("failed".to_string(), "failed".to_string()),
+            ]),
+            evidence_required: BTreeMap::new(),
+            recovery_targets: Vec::new(),
+            intake: None,
+        },
+        &activities,
+    )?;
+    let current = build_declarative_definition(
+        &WorkflowDefinitionPolicy {
+            id: definition_id.to_string(),
+            initial: "work".to_string(),
+            states: BTreeMap::from([
+                (
+                    "work".to_string(),
+                    DeclaredState {
+                        activity: Some("run".to_string()),
+                        on_success: Some("complete".to_string()),
+                        on_failure: Some("failed".to_string()),
+                        ..DeclaredState::default()
+                    },
+                ),
+                (
+                    "blocked".to_string(),
+                    DeclaredState {
+                        progress: Some(DeclaredProgressMode::OperatorGate),
+                        ..DeclaredState::default()
+                    },
+                ),
+            ]),
+            terminal: BTreeMap::from([
+                ("cancelled".to_string(), "cancelled".to_string()),
+                ("complete".to_string(), "succeeded".to_string()),
+                ("failed".to_string(), "failed".to_string()),
+            ]),
+            evidence_required: BTreeMap::new(),
+            recovery_targets: Vec::new(),
+            intake: None,
+        },
+        &activities,
+    )?;
+    let mut registry = WorkflowDefinitionRegistry::with_builtins();
+    registry.register_declarative_current(current.clone())?;
+    registry.register_declarative_historical(old.clone())?;
+    let counts = [
+        harness_workflow::runtime::store::WorkflowRuntimeStateCount {
+            definition_id: definition_id.to_string(),
+            definition_version: old.definition_version(),
+            definition_hash: Some(old.definition_hash().to_string()),
+            state: "complete".to_string(),
+            count: 1,
+        },
+        harness_workflow::runtime::store::WorkflowRuntimeStateCount {
+            definition_id: definition_id.to_string(),
+            definition_version: current.definition_version(),
+            definition_hash: Some(current.definition_hash().to_string()),
+            state: "complete".to_string(),
+            count: 1,
+        },
+    ];
+
+    let (statuses, _, _) = workflow_projection_summary_counts(&registry, &counts);
+
+    assert_eq!(statuses.get("done"), Some(&1));
+    assert_eq!(statuses.get("waiting"), Some(&1));
+    Ok(())
 }

--- a/crates/harness-server/src/http/mod.rs
+++ b/crates/harness-server/src/http/mod.rs
@@ -91,7 +91,6 @@ pub async fn serve(server: Arc<HarnessServer>, addr: SocketAddr) -> anyhow::Resu
     crate::handlers::dashboard::SERVER_START.get_or_init(std::time::Instant::now);
 
     let state = Arc::new(build_app_state(server.clone()).await?);
-    harness_workflow::runtime::freeze_workflow_definition_registry();
     let app = http_router::build_router(state.clone());
 
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/crates/harness-server/src/http/sse_routes.rs
+++ b/crates/harness-server/src/http/sse_routes.rs
@@ -168,7 +168,7 @@ impl RuntimeSubmissionSseCursor {
             }
         }
 
-        if workflow.is_terminal() {
+        if stream_should_finish(self.store.definition_registry(), &workflow) {
             self.push_item(StreamItem::Done);
             self.finished = true;
         }
@@ -186,5 +186,45 @@ impl RuntimeSubmissionSseCursor {
                 tracing::warn!("runtime_submission_sse_stream: failed to serialize event: {error}")
             }
         }
+    }
+}
+
+fn stream_should_finish(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
+    workflow: &harness_workflow::runtime::WorkflowInstance,
+) -> bool {
+    workflow.is_terminal_with_registry(registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_workflow::runtime::{
+        RegisteredWorkflowDefinition, TransitionAllowlist, WorkflowDefinitionRegistry,
+        WorkflowInstance, WorkflowStateDefinition, WorkflowSubject, WorkflowTerminalState,
+    };
+
+    #[test]
+    fn custom_terminal_definition_finishes_submission_stream() -> anyhow::Result<()> {
+        let definition_id = "sse_injected_terminal";
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+        registry.register(RegisteredWorkflowDefinition::new(
+            definition_id,
+            vec![WorkflowStateDefinition::terminal(
+                definition_id,
+                "complete",
+                WorkflowTerminalState::Succeeded,
+            )],
+            TransitionAllowlist::default(),
+        ))?;
+        let workflow = WorkflowInstance::new(
+            definition_id,
+            1,
+            "complete",
+            WorkflowSubject::new("test", "sse-terminal"),
+        )
+        .with_id("sse-injected-terminal-workflow");
+        assert!(stream_should_finish(&registry, &workflow));
+        Ok(())
     }
 }

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -117,7 +117,10 @@ async fn runtime_task_response_by_handle(
         project_id,
         submission_handle,
         ..
-    } = RuntimeWorkflowProjection::from_workflow(&workflow);
+    } = RuntimeWorkflowProjection::from_workflow_with_registry(
+        store.definition_registry(),
+        &workflow,
+    );
     let external_id = runtime_external_id(task_kind, &workflow.data, issue);
     let submission_id = submission_handle
         .map(|handle| handle.0)
@@ -176,12 +179,13 @@ async fn runtime_task_response_by_handle(
 }
 
 pub(crate) fn proof_from_runtime_workflow(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
     task_id: &harness_core::types::TaskId,
     workflow: &harness_workflow::runtime::WorkflowInstance,
     events: &[harness_workflow::runtime::WorkflowEvent],
     decisions: &[harness_workflow::runtime::WorkflowDecisionRecord],
 ) -> ProofOfWork {
-    let projection = RuntimeWorkflowProjection::from_workflow(workflow);
+    let projection = RuntimeWorkflowProjection::from_workflow_with_registry(registry, workflow);
     let status = projection.task_status;
     let pr_url = runtime_string_field(&workflow.data, "pr_url")
         .or_else(|| runtime_string_field(&workflow.data, "last_pr_url"));
@@ -290,7 +294,11 @@ async fn runtime_proof_by_handle(
     else {
         return Ok(RuntimeProofLookup::Missing);
     };
-    let status = RuntimeWorkflowProjection::from_workflow(&workflow).task_status;
+    let status = RuntimeWorkflowProjection::from_workflow_with_registry(
+        store.definition_registry(),
+        &workflow,
+    )
+    .task_status;
     if !status.is_terminal() {
         return Ok(RuntimeProofLookup::InFlight(status.as_ref().to_string()));
     }
@@ -299,6 +307,7 @@ async fn runtime_proof_by_handle(
     let proof_task_id = crate::workflow_runtime_submission::runtime_issue_task_handle(&workflow)
         .unwrap_or_else(|| task_id.clone());
     Ok(RuntimeProofLookup::Terminal(proof_from_runtime_workflow(
+        store.definition_registry(),
         &proof_task_id,
         &workflow,
         &events,

--- a/crates/harness-server/src/http/task_query_routes/runtime_submissions.rs
+++ b/crates/harness-server/src/http/task_query_routes/runtime_submissions.rs
@@ -89,13 +89,19 @@ async fn append_runtime_definition_summaries(
             .await?;
         let fetched = workflows.len();
         let next_cursor = workflows.last().and_then(|workflow| {
-            RuntimeWorkflowProjection::from_workflow(workflow)
-                .submission_handle
-                .map(|task_id| (workflow.created_at, task_id.as_str().to_string()))
+            RuntimeWorkflowProjection::from_workflow_with_registry(
+                store.definition_registry(),
+                workflow,
+            )
+            .submission_handle
+            .map(|task_id| (workflow.created_at, task_id.as_str().to_string()))
         });
 
         for workflow in workflows {
-            let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+            let projection = RuntimeWorkflowProjection::from_workflow_with_registry(
+                store.definition_registry(),
+                &workflow,
+            );
             let Some(task_id) = projection.submission_handle.clone() else {
                 continue;
             };
@@ -106,7 +112,12 @@ async fn append_runtime_definition_summaries(
             if !listed_ids.insert(task_id.as_str().to_string()) {
                 continue;
             }
-            let summary = runtime_workflow_task_summary(workflow, task_id, task_kind);
+            let summary = runtime_workflow_task_summary(
+                store.definition_registry(),
+                workflow,
+                task_id,
+                task_kind,
+            );
             if filter.matches_summary(&summary) {
                 summaries.push(summary);
             }
@@ -150,11 +161,12 @@ pub(crate) fn runtime_submission_task_kind(
 }
 
 fn runtime_workflow_task_summary(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
     workflow: harness_workflow::runtime::WorkflowInstance,
     task_id: harness_core::types::TaskId,
     task_kind: TaskKind,
 ) -> TaskSummary {
-    let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+    let projection = RuntimeWorkflowProjection::from_workflow_with_registry(registry, &workflow);
     let status = projection.task_status.clone();
     let issue = workflow
         .data

--- a/crates/harness-server/src/http/task_routes.rs
+++ b/crates/harness-server/src/http/task_routes.rs
@@ -62,7 +62,10 @@ pub(crate) async fn task_response_details(
     let submission_id = crate::workflow_runtime_submission::runtime_issue_task_handle(&workflow)
         .map(|task_id| task_id.0)
         .unwrap_or_else(|| task_id.as_str().to_string());
-    let projection = RuntimeWorkflowProjection::from_workflow(&workflow);
+    let projection = RuntimeWorkflowProjection::from_workflow_with_registry(
+        store.definition_registry(),
+        &workflow,
+    );
     Ok(TaskResponseDetails {
         status: projection.task_status.as_ref().to_string(),
         workflow_state: workflow.state,

--- a/crates/harness-server/src/periodic_reviewer/tick_helpers.rs
+++ b/crates/harness-server/src/periodic_reviewer/tick_helpers.rs
@@ -166,7 +166,7 @@ pub(super) async fn poll_task_output(
             .await
         {
             Ok(Some(event)) => event,
-            Ok(None) if workflow.is_terminal() => {
+            Ok(None) if workflow.is_terminal_with_registry(store.definition_registry()) => {
                 tracing::error!(
                     task_id = %task_id,
                     workflow_id = %workflow.id,

--- a/crates/harness-server/src/reconciliation_apply.rs
+++ b/crates/harness-server/src/reconciliation_apply.rs
@@ -12,7 +12,9 @@ pub(super) async fn apply_runtime_workflow_transition(
     let Some(instance) = runtime_store.get_instance(&candidate.workflow_id).await? else {
         return Ok(false);
     };
-    if instance.is_terminal() || instance.state != candidate.state {
+    if instance.is_terminal_with_registry(runtime_store.definition_registry())
+        || instance.state != candidate.state
+    {
         return Ok(false);
     }
     apply_loaded_runtime_workflow_transition(

--- a/crates/harness-server/src/reconciliation_runtime.rs
+++ b/crates/harness-server/src/reconciliation_runtime.rs
@@ -17,7 +17,7 @@ pub(super) async fn collect_runtime_candidates(
     let mut skipped_terminal = 0usize;
     for (data, row_updated_at) in rows {
         let instance: WorkflowInstance = serde_json::from_str(&data)?;
-        if instance.is_terminal() {
+        if instance.is_terminal_with_registry(store.definition_registry()) {
             skipped_terminal += 1;
             continue;
         }

--- a/crates/harness-server/src/runtime_projection/mod.rs
+++ b/crates/harness-server/src/runtime_projection/mod.rs
@@ -5,8 +5,8 @@ use crate::workflow_runtime_submission::{
     runtime_state::{SchedulerAuthorityState, TaskSchedulerState},
 };
 use harness_workflow::runtime::{
-    declarative_workflow_definition_for_instance, workflow_state_definition_for_instance,
-    WorkflowInstance, WorkflowProgressMode, WorkflowTerminalState, QUALITY_GATE_DEFINITION_ID,
+    WorkflowDefinitionRegistry, WorkflowInstance, WorkflowProgressMode, WorkflowTerminalState,
+    QUALITY_GATE_DEFINITION_ID,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -76,20 +76,30 @@ pub(crate) struct RuntimeStoppedActionEligibility {
 }
 
 impl RuntimeWorkflowProjection {
+    #[cfg(test)]
     pub(crate) fn from_workflow(workflow: &WorkflowInstance) -> Self {
-        Self::from_workflow_with_stopped_eligibility(
+        Self::from_workflow_with_registry(&WorkflowDefinitionRegistry::with_builtins(), workflow)
+    }
+
+    pub(crate) fn from_workflow_with_registry(
+        registry: &WorkflowDefinitionRegistry,
+        workflow: &WorkflowInstance,
+    ) -> Self {
+        Self::from_workflow_with_registry_and_stopped_eligibility(
+            registry,
             workflow,
             RuntimeStoppedActionEligibility::default(),
         )
     }
 
-    pub(crate) fn from_workflow_with_stopped_eligibility(
+    pub(crate) fn from_workflow_with_registry_and_stopped_eligibility(
+        registry: &WorkflowDefinitionRegistry,
         workflow: &WorkflowInstance,
         stopped_eligibility: RuntimeStoppedActionEligibility,
     ) -> Self {
-        let terminal_state = workflow.terminal_state();
+        let terminal_state = workflow.terminal_state_with_registry(registry);
         let task_status = workflow_state_to_task_status(workflow, terminal_state);
-        let scheduler = workflow_scheduler_state(workflow, &task_status, terminal_state);
+        let scheduler = workflow_scheduler_state(registry, workflow, &task_status, terminal_state);
         let active_bucket = workflow_active_bucket(
             &workflow.definition_id,
             &workflow.state,
@@ -105,8 +115,10 @@ impl RuntimeWorkflowProjection {
             project_id: runtime_string_field(&workflow.data, "project_id"),
             submission_handle: runtime_submission_handle(&workflow.data),
             legacy_dedupe_task_handle: legacy_dedupe_task_handle(&workflow.data),
-            stopped_state: RuntimeStoppedStateProjection::from_workflow(workflow)
-                .with_action_eligibility(stopped_eligibility),
+            stopped_state: RuntimeStoppedStateProjection::from_workflow_with_registry(
+                registry, workflow,
+            )
+            .with_action_eligibility(stopped_eligibility),
         }
     }
 
@@ -116,7 +128,10 @@ impl RuntimeWorkflowProjection {
 }
 
 impl RuntimeStoppedStateProjection {
-    pub(crate) fn from_workflow(workflow: &WorkflowInstance) -> Self {
+    pub(crate) fn from_workflow_with_registry(
+        registry: &WorkflowDefinitionRegistry,
+        workflow: &WorkflowInstance,
+    ) -> Self {
         let last_stop = structured_last_stop(&workflow.data);
         let error_kind = stopped_string_field(&workflow.data, "error_kind").or_else(|| {
             last_stop
@@ -162,7 +177,7 @@ impl RuntimeStoppedStateProjection {
                 .and_then(Value::as_bool),
             can_unblock: false,
             can_retry: false,
-            recovery_targets: stopped_actions::pinned_recovery_targets(workflow),
+            recovery_targets: stopped_actions::pinned_recovery_targets(registry, workflow),
             error_kind,
             last_stop,
         }
@@ -239,6 +254,7 @@ fn workflow_state_to_task_phase(
 }
 
 fn workflow_scheduler_state(
+    registry: &WorkflowDefinitionRegistry,
     workflow: &WorkflowInstance,
     status: &TaskStatus,
     terminal_state: Option<WorkflowTerminalState>,
@@ -251,10 +267,13 @@ fn workflow_scheduler_state(
     if workflow.definition_id == QUALITY_GATE_DEFINITION_ID && workflow.state == "pending" {
         return TaskSchedulerState::queued();
     }
-    if declarative_workflow_definition_for_instance(workflow).is_some() {
-        if let Some(progress_mode) =
-            workflow_state_definition_for_instance(workflow, &workflow.state)
-                .and_then(|state| state.progress_mode)
+    if registry
+        .declarative_definition_for_instance(workflow)
+        .is_some()
+    {
+        if let Some(progress_mode) = registry
+            .state_definition_for_instance(workflow, &workflow.state)
+            .and_then(|state| state.progress_mode)
         {
             return scheduler_state_for_progress_mode(progress_mode);
         }
@@ -284,7 +303,8 @@ fn workflow_scheduler_state(
         | "quality_gate_pending"
         | "ready_to_merge"
         | "blocked" => TaskSchedulerState::queued(),
-        _ => match workflow_state_definition_for_instance(workflow, &workflow.state)
+        _ => match registry
+            .state_definition_for_instance(workflow, &workflow.state)
             .and_then(|state| state.progress_mode)
         {
             Some(progress_mode) => scheduler_state_for_progress_mode(progress_mode),
@@ -341,7 +361,7 @@ fn workflow_active_bucket(
     }
 }
 
-fn runtime_submission_handle(data: &serde_json::Value) -> Option<TaskId> {
+pub(crate) fn runtime_submission_handle(data: &serde_json::Value) -> Option<TaskId> {
     trimmed_string_field(data, "submission_id")
         .or_else(|| first_string_array_field(data, "task_ids"))
         .or_else(|| trimmed_string_field(data, "task_id"))
@@ -364,7 +384,7 @@ fn structured_last_stop(data: &serde_json::Value) -> Option<Value> {
         .cloned()
 }
 
-fn legacy_dedupe_task_handle(data: &serde_json::Value) -> Option<TaskId> {
+pub(crate) fn legacy_dedupe_task_handle(data: &serde_json::Value) -> Option<TaskId> {
     trimmed_string_field(data, "task_id")
         .or_else(|| last_string_array_field(data, "task_ids"))
         .or_else(|| trimmed_string_field(data, "submission_id"))

--- a/crates/harness-server/src/runtime_projection/stopped_actions.rs
+++ b/crates/harness-server/src/runtime_projection/stopped_actions.rs
@@ -1,6 +1,6 @@
 use super::{RuntimeRecoveryTargetProjection, RuntimeStoppedActionEligibility};
 use harness_workflow::runtime::{
-    workflow_declarative_definition, ActivityErrorKind, WorkflowCommand, WorkflowCommandType,
+    ActivityErrorKind, WorkflowCommand, WorkflowCommandType, WorkflowDefinitionRegistry,
     WorkflowInstance, WorkflowRuntimeStore, GITHUB_ISSUE_PR_DEFINITION_ID, LOCAL_REVIEW_ACTIVITY,
     PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
 };
@@ -18,7 +18,7 @@ pub(crate) async fn stopped_action_eligibility_for_workflows(
     let mut plans = Vec::new();
     let mut runtime_job_ids = Vec::new();
     for workflow in workflows {
-        let Some(plan) = stopped_action_plan(workflow) else {
+        let Some(plan) = stopped_action_plan(store.definition_registry(), workflow) else {
             continue;
         };
         if let Some(runtime_job_id) = plan.runtime_job_id.as_ref() {
@@ -61,13 +61,14 @@ pub(crate) async fn stopped_action_eligibility_for_workflows(
 }
 
 pub(super) fn pinned_recovery_targets(
+    registry: &WorkflowDefinitionRegistry,
     workflow: &WorkflowInstance,
 ) -> Vec<RuntimeRecoveryTargetProjection> {
     if workflow.state != "blocked" {
         return Vec::new();
     }
     let Some(definition) =
-        workflow_declarative_definition(&workflow.definition_id, workflow.definition_version)
+        registry.declarative_definition(&workflow.definition_id, workflow.definition_version)
     else {
         return Vec::new();
     };
@@ -122,9 +123,12 @@ struct RecoveryDispatchTarget {
     activity: &'static str,
 }
 
-fn stopped_action_plan(workflow: &WorkflowInstance) -> Option<StoppedActionPlan> {
+fn stopped_action_plan(
+    registry: &WorkflowDefinitionRegistry,
+    workflow: &WorkflowInstance,
+) -> Option<StoppedActionPlan> {
     if workflow.definition_id != GITHUB_ISSUE_PR_DEFINITION_ID {
-        if workflow.state != "blocked" || pinned_recovery_targets(workflow).is_empty() {
+        if workflow.state != "blocked" || pinned_recovery_targets(registry, workflow).is_empty() {
             return None;
         }
         return Some(StoppedActionPlan {

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -107,38 +107,33 @@ impl HarnessServer {
 
     /// Start in stdio mode (JSON-RPC over stdin/stdout).
     pub async fn serve_stdio(self) -> anyhow::Result<()> {
-        self.apply_completion_evidence_policy()?;
-        self.register_declarative_workflow_definitions()?;
         let state = crate::http::build_app_state(Arc::new(self)).await?;
-        harness_workflow::runtime::freeze_workflow_definition_registry();
         crate::stdio::serve(state).await
     }
 
     /// Start in HTTP + WebSocket mode.
     pub async fn serve_http(self: Arc<Self>, addr: SocketAddr) -> anyhow::Result<()> {
-        self.apply_completion_evidence_policy()?;
-        self.register_declarative_workflow_definitions()?;
         crate::http::serve(self, addr).await
     }
 
-    fn apply_completion_evidence_policy(&self) -> anyhow::Result<()> {
+    pub(crate) fn configure_workflow_definition_registry(
+        &self,
+    ) -> anyhow::Result<harness_workflow::runtime::WorkflowDefinitionRegistry> {
+        let mut registry = harness_workflow::runtime::WorkflowDefinitionRegistry::with_builtins();
         let enforced = self.completion_evidence_enforced();
         if !enforced {
             tracing::warn!(
                 "deployment-wide workflow completion-evidence enforcement is disabled; terminal transitions accept agent-claimed results without server-verified evidence"
             );
         }
-        harness_workflow::runtime::apply_builtin_evidence_enforcement(enforced)
+        registry.apply_builtin_evidence_enforcement(enforced)?;
+        registry
+            .register_declarative_current_batch(self.load_declarative_workflow_definitions()?)?;
+        Ok(registry)
     }
 
     fn completion_evidence_enforced(&self) -> bool {
         self.config.workflow.completion_evidence_enforced
-    }
-
-    fn register_declarative_workflow_definitions(&self) -> anyhow::Result<()> {
-        harness_workflow::runtime::register_declarative_workflow_definitions(
-            self.load_declarative_workflow_definitions()?,
-        )
     }
 
     fn load_declarative_workflow_definitions(

--- a/crates/harness-server/src/services/execution/mod.rs
+++ b/crates/harness-server/src/services/execution/mod.rs
@@ -318,7 +318,7 @@ impl DefaultExecutionService {
         else {
             return Ok(None);
         };
-        if instance.is_terminal() {
+        if instance.is_terminal_with_registry(store.definition_registry()) {
             return Ok(None);
         }
         Ok(workflow_runtime_submission::runtime_issue_task_handle(
@@ -394,6 +394,10 @@ impl DefaultExecutionService {
 
         if let Some(definition_id) = req.definition_id.as_deref() {
             workflow_runtime_submission::resolve_declarative_definition_for_project(
+                self.workflow_runtime_store
+                    .as_ref()
+                    .expect("workflow runtime store checked above")
+                    .definition_registry(),
                 &canonical,
                 definition_id,
             )

--- a/crates/harness-server/src/workflow_runtime_submission/cancel.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/cancel.rs
@@ -16,6 +16,7 @@ use super::{
 
 struct DeclarativeCancellation {
     target_state: String,
+    current_terminal_state: Option<WorkflowTerminalState>,
     validator: DecisionValidator,
     missing_pin: bool,
 }
@@ -82,17 +83,12 @@ pub(crate) async fn cancel_submission_by_workflow_id(
 
 async fn cancel_submission_instance(
     store: &WorkflowRuntimeStore,
-    mut instance: WorkflowInstance,
+    instance: WorkflowInstance,
     correlation_id: &str,
 ) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
-    if instance.is_terminal_with_registry(store.definition_registry()) {
-        if instance.terminal_state_with_registry(store.definition_registry())
-            == Some(WorkflowTerminalState::Cancelled)
-        {
-            let (decision_name, remove_prompt) = cancellation_cleanup_policy(&instance);
-            finish_cancellation_cleanup(store, &mut instance, decision_name, remove_prompt).await?;
-        }
-        return Ok(RuntimeSubmissionCancelOutcome::AlreadyTerminal(instance));
+    if let Some(terminal_state) = instance.terminal_state_with_registry(store.definition_registry())
+    {
+        return finish_terminal_cancellation(store, instance, terminal_state).await;
     }
     let is_prompt = instance.definition_id == PROMPT_TASK_DEFINITION_ID;
     let is_issue = instance.definition_id == GITHUB_ISSUE_PR_DEFINITION_ID;
@@ -101,6 +97,12 @@ async fn cancel_submission_instance(
     } else {
         resolve_declarative_cancellation(store, &instance).await?
     };
+    if let Some(terminal_state) = declarative
+        .as_ref()
+        .and_then(|resolution| resolution.current_terminal_state)
+    {
+        return finish_terminal_cancellation(store, instance, terminal_state).await;
+    }
     let (event_type, decision_name, reason, command_prefix, target_state, remove_prompt) =
         if is_prompt {
             (
@@ -187,6 +189,18 @@ async fn cancel_submission_instance(
     Ok(RuntimeSubmissionCancelOutcome::Cancelled(cancelled))
 }
 
+async fn finish_terminal_cancellation(
+    store: &WorkflowRuntimeStore,
+    mut instance: WorkflowInstance,
+    terminal_state: WorkflowTerminalState,
+) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
+    if terminal_state == WorkflowTerminalState::Cancelled {
+        let (decision_name, remove_prompt) = cancellation_cleanup_policy(&instance);
+        finish_cancellation_cleanup(store, &mut instance, decision_name, remove_prompt).await?;
+    }
+    Ok(RuntimeSubmissionCancelOutcome::AlreadyTerminal(instance))
+}
+
 fn cancellation_cleanup_policy(instance: &WorkflowInstance) -> (&'static str, bool) {
     if instance.definition_id == PROMPT_TASK_DEFINITION_ID {
         ("cancel_prompt_submission", true)
@@ -240,6 +254,12 @@ async fn resolve_declarative_cancellation(
         let target_state = cancelled_state(definition.policy(), instance)?;
         return Ok(Some(DeclarativeCancellation {
             target_state,
+            current_terminal_state: definition
+                .registered()
+                .states
+                .iter()
+                .find(|state| state.key.state.as_ref() == instance.state)
+                .and_then(|state| state.terminal_state),
             // The pin resolved to this exact definition, so the validator
             // carries that identity and the store can re-verify at commit that
             // it still governs the row it locked (GH-1864).
@@ -316,6 +336,12 @@ async fn resolve_declarative_cancellation(
     }
     Ok(Some(DeclarativeCancellation {
         target_state: cancelled_state(&policy, instance)?,
+        current_terminal_state: definition
+            .registered()
+            .states
+            .iter()
+            .find(|state| state.key.state.as_ref() == instance.state)
+            .and_then(|state| state.terminal_state),
         // Rebuilt from the persisted snapshot, but only after its version and
         // content hash were checked against the instance pin above, so the
         // validator may claim that identity (GH-1864).

--- a/crates/harness-server/src/workflow_runtime_submission/cancel.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/cancel.rs
@@ -1,9 +1,8 @@
 use harness_core::config::workflow::{WorkflowActivityPolicy, WorkflowDefinitionPolicy};
 use harness_workflow::runtime::{
-    build_declarative_definition, resolve_declarative_definition, DecisionValidator,
-    DeclarativeDefinitionResolution, WorkflowCancellationCleanupOutcome, WorkflowCommand,
-    WorkflowCommandType, WorkflowDecision, WorkflowInstance, WorkflowRuntimeStore,
-    WorkflowTerminalState, PROMPT_TASK_DEFINITION_ID,
+    build_declarative_definition, DecisionValidator, DeclarativeDefinitionResolution,
+    WorkflowCancellationCleanupOutcome, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
+    WorkflowInstance, WorkflowRuntimeStore, WorkflowTerminalState, PROMPT_TASK_DEFINITION_ID,
 };
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -86,8 +85,10 @@ async fn cancel_submission_instance(
     mut instance: WorkflowInstance,
     correlation_id: &str,
 ) -> Result<RuntimeSubmissionCancelOutcome, RuntimeSubmissionCancelError> {
-    if instance.is_terminal() {
-        if instance.terminal_state() == Some(WorkflowTerminalState::Cancelled) {
+    if instance.is_terminal_with_registry(store.definition_registry()) {
+        if instance.terminal_state_with_registry(store.definition_registry())
+            == Some(WorkflowTerminalState::Cancelled)
+        {
             let (decision_name, remove_prompt) = cancellation_cleanup_policy(&instance);
             finish_cancellation_cleanup(store, &mut instance, decision_name, remove_prompt).await?;
         }
@@ -232,8 +233,9 @@ async fn resolve_declarative_cancellation(
     store: &WorkflowRuntimeStore,
     instance: &WorkflowInstance,
 ) -> Result<Option<DeclarativeCancellation>, RuntimeSubmissionCancelError> {
-    if let DeclarativeDefinitionResolution::Resolved(definition) =
-        resolve_declarative_definition(instance)
+    if let DeclarativeDefinitionResolution::Resolved(definition) = store
+        .definition_registry()
+        .resolve_declarative_definition(instance)
     {
         let target_state = cancelled_state(definition.policy(), instance)?;
         return Ok(Some(DeclarativeCancellation {
@@ -246,6 +248,7 @@ async fn resolve_declarative_cancellation(
                 definition.definition_version(),
                 definition.definition_hash(),
                 definition.registered().allowlist.clone(),
+                definition.registered().states.clone(),
             ),
             missing_pin: false,
         }));
@@ -255,7 +258,7 @@ async fn resolve_declarative_cancellation(
         .get_definition(&instance.definition_id, instance.definition_version)
         .await?
     else {
-        return match resolve_declarative_definition(instance) {
+        return match store.definition_registry().resolve_declarative_definition(instance) {
             DeclarativeDefinitionResolution::PinError(error) => {
                 Err(RuntimeSubmissionCancelError::Store(anyhow::anyhow!(
                     "declarative workflow '{}' has an invalid definition pin and no persisted definition during cancellation: {error:?}",
@@ -321,6 +324,7 @@ async fn resolve_declarative_cancellation(
             definition.definition_version(),
             definition.definition_hash(),
             definition.registered().allowlist.clone(),
+            definition.registered().states.clone(),
         ),
         missing_pin: true,
     }))

--- a/crates/harness-server/src/workflow_runtime_submission/commit.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/commit.rs
@@ -2,7 +2,7 @@ use super::{
     classify_submission_data, depends_on_strings, insert_author_trust_class, merge_last_decision,
     optional_string_field, string_field, IssueSubmissionRuntimeContext,
     PromptSubmissionRuntimeContext, WorkflowSubmissionRuntimeRecord,
-    EXECUTION_PATH_WORKFLOW_RUNTIME,
+    EXECUTION_PATH_WORKFLOW_RUNTIME, GITHUB_ISSUE_PR_DEFINITION_ID, PROMPT_TASK_DEFINITION_ID,
 };
 use super::{
     prompt_memory::{cache_prompt_submission_prompt, remove_prompt_submission_prompt},
@@ -18,6 +18,27 @@ use harness_workflow::runtime::{
 };
 use serde_json::json;
 
+pub(super) fn decision_validator_for_instance(
+    store: &WorkflowRuntimeStore,
+    instance: &WorkflowInstance,
+) -> anyhow::Result<DecisionValidator> {
+    match instance.definition_id.as_str() {
+        GITHUB_ISSUE_PR_DEFINITION_ID => Ok(DecisionValidator::github_issue_pr()),
+        PROMPT_TASK_DEFINITION_ID => Ok(DecisionValidator::prompt_task()),
+        other => store
+            .definition_registry()
+            .decision_validator_for_instance(instance)
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "workflow definition `{other}` has an invalid definition pin: {error:?}"
+                )
+            })?
+            .ok_or_else(|| {
+                anyhow::anyhow!("workflow definition `{other}` cannot be committed by submission")
+            }),
+    }
+}
+
 pub(super) async fn apply_decision(
     store: &WorkflowRuntimeStore,
     instance: WorkflowInstance,
@@ -26,7 +47,7 @@ pub(super) async fn apply_decision(
     ctx: &IssueSubmissionRuntimeContext<'_>,
     accepted_data: serde_json::Value,
 ) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
-    let validation_context = if instance.is_terminal() {
+    let validation_context = if instance.is_terminal_with_registry(store.definition_registry()) {
         ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
     } else {
         ValidationContext::new("workflow-policy", chrono::Utc::now())
@@ -154,7 +175,7 @@ pub(super) async fn apply_prompt_decision(
     execution_policy: &super::runtime_models::PromptExecutionPolicy,
     accepted_data: serde_json::Value,
 ) -> anyhow::Result<WorkflowSubmissionRuntimeRecord> {
-    let validation_context = if instance.is_terminal() {
+    let validation_context = if instance.is_terminal_with_registry(store.definition_registry()) {
         ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
     } else {
         ValidationContext::new("workflow-policy", chrono::Utc::now())

--- a/crates/harness-server/src/workflow_runtime_submission/declarative.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative.rs
@@ -5,8 +5,7 @@ use super::{
 };
 use harness_core::config::isolation::IsolationTrustClass;
 use harness_workflow::runtime::{
-    build_declarative_submission_decision, current_declarative_workflow_definition,
-    decision_validator_for_instance, persisted_declarative_definition,
+    build_declarative_submission_decision, persisted_declarative_definition,
     DeclarativeWorkflowDefinition, ValidationContext, WorkflowCommandStatus, WorkflowInstance,
     WorkflowRuntimeStore, WorkflowSubject, WorkflowSubmissionDecisionTransition,
     WorkflowSubmissionPromptPayload, DECLARATIVE_SUBMISSION_DECISION,
@@ -39,8 +38,11 @@ pub(crate) async fn record_declarative_submission(
             ctx.definition_id
         );
     }
-    let definition =
-        resolve_declarative_definition_for_project(ctx.project_root, ctx.definition_id)?;
+    let definition = resolve_declarative_definition_for_project(
+        store.definition_registry(),
+        ctx.project_root,
+        ctx.definition_id,
+    )?;
 
     let project_id = ctx.project_root.to_string_lossy().into_owned();
     let workflow_id = declarative_workflow_id(
@@ -58,15 +60,18 @@ pub(crate) async fn record_declarative_submission(
 }
 
 pub(crate) fn resolve_declarative_definition_for_project(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
     project_root: &Path,
     definition_id: &str,
 ) -> anyhow::Result<Arc<DeclarativeWorkflowDefinition>> {
-    let registered = current_declarative_workflow_definition(definition_id).ok_or_else(|| {
-        anyhow::anyhow!(
-            "workflow definition '{}' is not a registered declarative definition",
-            definition_id
-        )
-    })?;
+    let registered = registry
+        .current_declarative_definition(definition_id)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "workflow definition '{}' is not a registered declarative definition",
+                definition_id
+            )
+        })?;
     let document = harness_core::config::workflow::load_workflow_document(project_root)?;
     let policy = document.config.definition.as_ref().ok_or_else(|| {
         anyhow::anyhow!(
@@ -126,7 +131,9 @@ async fn persist_new_submission(
     );
     let instance = submission_instance(ctx, project_id, &workflow_id, &prompt_ref, definition);
     let decision = build_declarative_submission_decision(definition, &instance)?;
-    let validator = decision_validator_for_instance(&instance)
+    let validator = store
+        .definition_registry()
+        .decision_validator_for_instance(&instance)
         .map_err(|error| {
             anyhow::anyhow!(
                 "declarative workflow '{}@{}' has an invalid definition pin: {error:?}",

--- a/crates/harness-server/src/workflow_runtime_submission/declarative_cancel_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative_cancel_tests.rs
@@ -6,13 +6,11 @@ use harness_core::{
     db::resolve_database_url,
 };
 use harness_workflow::runtime::{
-    build_declarative_definition, persisted_declarative_definition,
-    register_declarative_workflow_definitions,
+    build_declarative_definition, persisted_declarative_definition, WorkflowDefinitionRegistry,
 };
-use std::{collections::BTreeMap, sync::Once};
+use std::collections::BTreeMap;
 
 const DEFINITION_ID: &str = "missing_pin_cancel_test_declarative";
-static REGISTER_CURRENT_DEFINITION: Once = Once::new();
 
 fn definition(with_stop_signal: bool) -> harness_workflow::runtime::DeclarativeWorkflowDefinition {
     let on_signal = if with_stop_signal {
@@ -67,14 +65,15 @@ async fn missing_registered_pin_can_use_persisted_definition_for_cancellation() 
         return Ok(());
     }
     let persisted_version = definition(false);
-    REGISTER_CURRENT_DEFINITION.call_once(|| {
-        register_declarative_workflow_definitions([definition(true)])
-            .expect("current cancellation fixture should register");
-    });
+    let mut registry = WorkflowDefinitionRegistry::with_builtins();
+    registry
+        .register_declarative_current(definition(true))
+        .expect("current cancellation fixture should register");
     let dir = tempfile::tempdir()?;
     let database_url = resolve_database_url(None)?;
-    let store =
-        WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url)).await?;
+    let store = WorkflowRuntimeStore::open_with_database_url(dir.path(), Some(&database_url))
+        .await?
+        .with_definition_registry(registry.into_shared());
     store
         .persist_definition_version(&persisted_declarative_definition(
             &persisted_version,
@@ -104,5 +103,13 @@ async fn missing_registered_pin_can_use_persisted_definition_for_cancellation() 
         cancelled.data["last_decision"],
         "cancel_declarative_submission"
     );
+
+    let repeated = cancel_submission_by_workflow_id(&store, &instance.id).await?;
+    let RuntimeSubmissionCancelOutcome::AlreadyTerminal(reloaded) = repeated else {
+        anyhow::bail!(
+            "repeated declarative cancellation did not report an already-terminal outcome"
+        );
+    };
+    assert_eq!(reloaded.state, "withdrawn");
     Ok(())
 }

--- a/crates/harness-server/src/workflow_runtime_submission/declarative_project_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative_project_tests.rs
@@ -2,11 +2,10 @@ use super::*;
 use harness_core::config::workflow::{
     DeclaredProgressMode, DeclaredState, WorkflowActivityPolicy, WorkflowDefinitionPolicy,
 };
+use harness_workflow::runtime::WorkflowDefinitionRegistry;
 use std::collections::BTreeMap;
-use std::sync::Once;
 
 const PROJECT_DEFINITION_ID: &str = "project_binding_test_declarative";
-static REGISTER_PROJECT_DEFINITION: Once = Once::new();
 
 fn project_binding_policy() -> WorkflowDefinitionPolicy {
     WorkflowDefinitionPolicy {
@@ -40,18 +39,18 @@ fn project_binding_policy() -> WorkflowDefinitionPolicy {
     }
 }
 
-fn register_project_definition() {
-    REGISTER_PROJECT_DEFINITION.call_once(|| {
-        let definition = harness_workflow::runtime::build_declarative_definition(
-            &project_binding_policy(),
-            &BTreeMap::from([(
-                "perform_work".to_string(),
-                WorkflowActivityPolicy::default(),
-            )]),
-        )
-        .unwrap();
-        harness_workflow::runtime::register_declarative_workflow_definitions([definition]).unwrap();
-    });
+fn project_registry() -> WorkflowDefinitionRegistry {
+    let definition = harness_workflow::runtime::build_declarative_definition(
+        &project_binding_policy(),
+        &BTreeMap::from([(
+            "perform_work".to_string(),
+            WorkflowActivityPolicy::default(),
+        )]),
+    )
+    .unwrap();
+    let mut registry = WorkflowDefinitionRegistry::with_builtins();
+    registry.register_declarative_current(definition).unwrap();
+    registry
 }
 
 fn write_workflow(project_root: &std::path::Path, extra_route: &str) -> anyhow::Result<()> {
@@ -90,11 +89,14 @@ Project workflow.
 
 #[test]
 fn declarative_submission_instance_persists_runtime_retry_policy() -> anyhow::Result<()> {
-    register_project_definition();
+    let registry = project_registry();
     let project = tempfile::tempdir()?;
     write_workflow(project.path(), "")?;
-    let definition =
-        resolve_declarative_definition_for_project(project.path(), PROJECT_DEFINITION_ID)?;
+    let definition = resolve_declarative_definition_for_project(
+        &registry,
+        project.path(),
+        PROJECT_DEFINITION_ID,
+    )?;
     let task_id = TaskId::from_str("project-retry-policy");
     let ctx = DeclarativeSubmissionRuntimeContext {
         project_root: project.path(),
@@ -128,24 +130,30 @@ fn declarative_submission_instance_persists_runtime_retry_policy() -> anyhow::Re
 
 #[test]
 fn project_definition_resolution_requires_matching_effective_workflow() -> anyhow::Result<()> {
-    register_project_definition();
+    let registry = project_registry();
 
     let valid = tempfile::tempdir()?;
     write_workflow(valid.path(), "")?;
-    let resolved = resolve_declarative_definition_for_project(valid.path(), PROJECT_DEFINITION_ID)?;
+    let resolved =
+        resolve_declarative_definition_for_project(&registry, valid.path(), PROJECT_DEFINITION_ID)?;
     assert_eq!(resolved.policy().id, PROJECT_DEFINITION_ID);
 
     let missing = tempfile::tempdir()?;
-    let error = resolve_declarative_definition_for_project(missing.path(), PROJECT_DEFINITION_ID)
-        .unwrap_err();
+    let error = resolve_declarative_definition_for_project(
+        &registry,
+        missing.path(),
+        PROJECT_DEFINITION_ID,
+    )
+    .unwrap_err();
     assert!(error
         .to_string()
         .contains("does not declare workflow definition"));
 
     let stale = tempfile::tempdir()?;
     write_workflow(stale.path(), "      on_failure: failed")?;
-    let error = resolve_declarative_definition_for_project(stale.path(), PROJECT_DEFINITION_ID)
-        .unwrap_err();
+    let error =
+        resolve_declarative_definition_for_project(&registry, stale.path(), PROJECT_DEFINITION_ID)
+            .unwrap_err();
     assert!(error
         .to_string()
         .contains("does not match the registered startup version"));

--- a/crates/harness-server/src/workflow_runtime_submission/declarative_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative_tests.rs
@@ -9,70 +9,69 @@ use harness_core::{
 };
 use harness_workflow::runtime::{
     store::RuntimeJobEnqueueOutcome, ActivityResult, ActivitySignal, RuntimeKind,
-    WorkflowCommandStatus, WorkflowCommandType,
+    WorkflowCommandStatus, WorkflowCommandType, WorkflowDefinitionRegistry,
 };
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
-    sync::Once,
 };
 
 const TEST_DEFINITION_ID: &str = "submission_test_declarative";
-static REGISTER_TEST_DEFINITION: Once = Once::new();
-
 async fn open_declarative_runtime_store(dir: &Path) -> anyhow::Result<WorkflowRuntimeStore> {
     let database_url = resolve_database_url(None)?;
-    WorkflowRuntimeStore::open_with_database_url(dir, Some(&database_url)).await
+    Ok(
+        WorkflowRuntimeStore::open_with_database_url(dir, Some(&database_url))
+            .await?
+            .with_definition_registry(register_test_definition().into_shared()),
+    )
 }
 
-fn register_test_definition() {
-    REGISTER_TEST_DEFINITION.call_once(|| {
-        let policy = WorkflowDefinitionPolicy {
-            id: TEST_DEFINITION_ID.to_string(),
-            initial: "working".to_string(),
-            states: BTreeMap::from([
-                (
-                    "working".to_string(),
-                    DeclaredState {
-                        activity: Some("perform_work".to_string()),
-                        on_success: Some("done".to_string()),
-                        on_failure: Some("failed".to_string()),
-                        on_blocked: Some("blocked".to_string()),
-                        on_signal: BTreeMap::from([(
-                            "cancel".to_string(),
-                            "cancelled".to_string(),
-                        )]),
-                        ..DeclaredState::default()
-                    },
-                ),
-                (
-                    "blocked".to_string(),
-                    DeclaredState {
-                        progress: Some(DeclaredProgressMode::OperatorGate),
-                        ..DeclaredState::default()
-                    },
-                ),
-            ]),
-            terminal: BTreeMap::from([
-                ("done".to_string(), "succeeded".to_string()),
-                ("failed".to_string(), "failed".to_string()),
-                ("cancelled".to_string(), "cancelled".to_string()),
-            ]),
-            evidence_required: BTreeMap::new(),
-            recovery_targets: vec!["working".to_string()],
-            intake: None,
-        };
-        let definition = harness_workflow::runtime::build_declarative_definition(
-            &policy,
-            &BTreeMap::from([(
-                "perform_work".to_string(),
-                WorkflowActivityPolicy::default(),
-            )]),
-        )
-        .expect("test declarative definition should be valid");
-        harness_workflow::runtime::register_declarative_workflow_definitions([definition])
-            .expect("test declarative definition should register");
-    });
+fn register_test_definition() -> WorkflowDefinitionRegistry {
+    let policy = WorkflowDefinitionPolicy {
+        id: TEST_DEFINITION_ID.to_string(),
+        initial: "working".to_string(),
+        states: BTreeMap::from([
+            (
+                "working".to_string(),
+                DeclaredState {
+                    activity: Some("perform_work".to_string()),
+                    on_success: Some("done".to_string()),
+                    on_failure: Some("failed".to_string()),
+                    on_blocked: Some("blocked".to_string()),
+                    on_signal: BTreeMap::from([("cancel".to_string(), "cancelled".to_string())]),
+                    ..DeclaredState::default()
+                },
+            ),
+            (
+                "blocked".to_string(),
+                DeclaredState {
+                    progress: Some(DeclaredProgressMode::OperatorGate),
+                    ..DeclaredState::default()
+                },
+            ),
+        ]),
+        terminal: BTreeMap::from([
+            ("done".to_string(), "succeeded".to_string()),
+            ("failed".to_string(), "failed".to_string()),
+            ("cancelled".to_string(), "cancelled".to_string()),
+        ]),
+        evidence_required: BTreeMap::new(),
+        recovery_targets: vec!["working".to_string()],
+        intake: None,
+    };
+    let definition = harness_workflow::runtime::build_declarative_definition(
+        &policy,
+        &BTreeMap::from([(
+            "perform_work".to_string(),
+            WorkflowActivityPolicy::default(),
+        )]),
+    )
+    .expect("test declarative definition should be valid");
+    let mut registry = WorkflowDefinitionRegistry::with_builtins();
+    registry
+        .register_declarative_current(definition)
+        .expect("test declarative definition should register");
+    registry
 }
 
 fn create_test_project(root: &Path) -> anyhow::Result<PathBuf> {
@@ -107,10 +106,10 @@ Submission fixture.
 
 #[test]
 fn declarative_submission_decision_validates_against_the_registered_submission_rule() {
-    register_test_definition();
-    let definition =
-        harness_workflow::runtime::current_declarative_workflow_definition(TEST_DEFINITION_ID)
-            .expect("definition should be registered");
+    let registry = register_test_definition();
+    let definition = registry
+        .current_declarative_definition(TEST_DEFINITION_ID)
+        .expect("definition should be registered");
     let instance = WorkflowInstance::new(
         TEST_DEFINITION_ID,
         definition.definition_version(),
@@ -121,7 +120,8 @@ fn declarative_submission_decision_validates_against_the_registered_submission_r
     let decision =
         harness_workflow::runtime::build_declarative_submission_decision(&definition, &instance)
             .expect("submission decision should build");
-    let validator = harness_workflow::runtime::decision_validator_for_instance(&instance)
+    let validator = registry
+        .decision_validator_for_instance(&instance)
         .expect("pinned definition should be valid")
         .expect("pinned definition should resolve a validator");
 
@@ -136,10 +136,8 @@ fn declarative_submission_decision_validates_against_the_registered_submission_r
 
 #[test]
 fn declarative_submission_preserves_intake_identity_and_trust() {
-    register_test_definition();
-    let Some(definition) =
-        harness_workflow::runtime::current_declarative_workflow_definition(TEST_DEFINITION_ID)
-    else {
+    let registry = register_test_definition();
+    let Some(definition) = registry.current_declarative_definition(TEST_DEFINITION_ID) else {
         panic!("definition should be registered");
     };
     let task_id = TaskId::from_str("declarative-intake-identity");
@@ -176,7 +174,6 @@ async fn declarative_submission_pins_immutable_definition_metadata() -> anyhow::
     if !crate::test_helpers::db_tests_enabled().await {
         return Ok(());
     }
-    register_test_definition();
     let dir = tempfile::tempdir()?;
     let store = open_declarative_runtime_store(dir.path()).await?;
     let project_root = create_test_project(dir.path())?;
@@ -199,9 +196,10 @@ async fn declarative_submission_pins_immutable_definition_metadata() -> anyhow::
         },
     )
     .await?;
-    let definition =
-        harness_workflow::runtime::current_declarative_workflow_definition(TEST_DEFINITION_ID)
-            .expect("definition should remain registered");
+    let definition = store
+        .definition_registry()
+        .current_declarative_definition(TEST_DEFINITION_ID)
+        .expect("definition should remain registered");
     let instance = store
         .get_instance(&record.workflow_id)
         .await?

--- a/crates/harness-server/src/workflow_runtime_submission/mod.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use cancel::cancel_issue_submission_by_task_id;
 pub(crate) use cancel::{
     cancel_submission_by_workflow_id, RuntimeSubmissionCancelError, RuntimeSubmissionCancelOutcome,
 };
-use commit::{apply_decision, apply_prompt_decision};
+use commit::{apply_decision, apply_prompt_decision, decision_validator_for_instance};
 pub(crate) use declarative::{
     record_declarative_submission, resolve_declarative_definition_for_project,
     DeclarativeSubmissionRuntimeContext,
@@ -140,7 +140,7 @@ pub(crate) async fn runtime_issue_by_submission_id(
 }
 
 pub(crate) fn runtime_issue_task_handle(instance: &WorkflowInstance) -> Option<TaskId> {
-    crate::runtime_projection::RuntimeWorkflowProjection::from_workflow(instance).submission_handle
+    crate::runtime_projection::runtime_submission_handle(&instance.data)
 }
 
 async fn persist_issue_submission(
@@ -275,7 +275,7 @@ async fn commit_runtime_decision(
     event_payload: serde_json::Value,
     accepted_data: Option<serde_json::Value>,
 ) -> anyhow::Result<WorkflowInstance> {
-    let validator = decision_validator_for_instance(&instance)?;
+    let validator = decision_validator_for_instance(store, &instance)?;
     commit_runtime_decision_with_validator(
         store,
         instance,
@@ -301,7 +301,8 @@ async fn commit_runtime_decision_with_validator(
     validator: DecisionValidator,
     allow_missing_pinned_cancel: bool,
 ) -> anyhow::Result<WorkflowInstance> {
-    let mut validation_context = if instance.is_terminal() {
+    let mut validation_context = if instance.is_terminal_with_registry(store.definition_registry())
+    {
         ValidationContext::new("workflow-policy", chrono::Utc::now()).allow_terminal_reopen()
     } else {
         ValidationContext::new("workflow-policy", chrono::Utc::now())
@@ -350,24 +351,6 @@ async fn commit_runtime_decision_with_validator(
         );
     }
     Ok(final_instance)
-}
-
-fn decision_validator_for_instance(
-    instance: &WorkflowInstance,
-) -> anyhow::Result<DecisionValidator> {
-    match instance.definition_id.as_str() {
-        GITHUB_ISSUE_PR_DEFINITION_ID => Ok(DecisionValidator::github_issue_pr()),
-        PROMPT_TASK_DEFINITION_ID => Ok(DecisionValidator::prompt_task()),
-        other => harness_workflow::runtime::decision_validator_for_instance(instance)
-            .map_err(|error| {
-                anyhow::anyhow!(
-                    "workflow definition `{other}` has an invalid definition pin: {error:?}"
-                )
-            })?
-            .ok_or_else(|| {
-                anyhow::anyhow!("workflow definition `{other}` cannot be committed by submission")
-            }),
-    }
 }
 
 async fn upsert_github_issue_pr_definition(store: &WorkflowRuntimeStore) -> anyhow::Result<()> {
@@ -779,30 +762,22 @@ fn string_array_field(data: &serde_json::Value, field: &str) -> anyhow::Result<V
 
 #[cfg(test)]
 mod atomicity_tests;
-
 #[cfg(test)]
-mod identity_tests;
-
-#[cfg(test)]
-mod dependency_tests;
-
+mod continuation_tests;
 #[cfg(test)]
 mod declarative_cancel_tests;
 #[cfg(test)]
-mod declarative_tests;
-
-#[cfg(test)]
 mod declarative_project_tests;
-
 #[cfg(test)]
-mod continuation_tests;
-
+mod declarative_tests;
+#[cfg(test)]
+mod dependency_tests;
+#[cfg(test)]
+mod identity_tests;
 #[cfg(test)]
 mod replay_tests;
-
-#[cfg(test)]
-mod trust_tests;
-
 #[cfg(test)]
 #[path = "../workflow_runtime_submission_tests.rs"]
 mod tests;
+#[cfg(test)]
+mod trust_tests;

--- a/crates/harness-server/src/workflow_runtime_worker/executor/mod.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor/mod.rs
@@ -73,7 +73,13 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
     pub(super) async fn execute_inner(&self, job: RuntimeJob) -> anyhow::Result<ActivityResult> {
         let workflow = super::job_context::workflow_for_job(self.state, &job).await?;
         if let Some(workflow) = workflow.as_ref() {
-            if workflow.is_terminal() {
+            let store = self
+                .state
+                .core
+                .workflow_runtime_store
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("workflow runtime store is unavailable"))?;
+            if workflow.is_terminal_with_registry(store.definition_registry()) {
                 return Ok(ActivityResult::cancelled(
                     activity_name(&job),
                     format!(
@@ -150,6 +156,12 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
             )
             .await;
             let prompt_packet = build_runtime_prompt_packet(
+                self.state
+                    .core
+                    .workflow_runtime_store
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("workflow runtime store unavailable"))?
+                    .definition_registry(),
                 &job,
                 workflow.as_ref(),
                 &project_root,

--- a/crates/harness-server/src/workflow_runtime_worker/executor/mod.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor/mod.rs
@@ -2,7 +2,9 @@ use crate::http::AppState;
 use harness_core::agent::AGENT_OUTPUT_SCHEMA_PATH_ENV;
 use harness_core::config::workflow::WorkflowConfig;
 use harness_core::types::AgentId;
-use harness_workflow::runtime::{ActivityArtifact, ActivityResult, RuntimeJob, WorkflowInstance};
+use harness_workflow::runtime::{
+    ActivityArtifact, ActivityResult, RuntimeJob, WorkflowInstance, WorkflowTerminalState,
+};
 use serde_json::{json, Value};
 use std::path::Path;
 use std::sync::{
@@ -79,14 +81,23 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                 .workflow_runtime_store
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("workflow runtime store is unavailable"))?;
-            if store.terminal_state_for_instance(workflow).await?.is_some() {
-                return Ok(ActivityResult::cancelled(
-                    activity_name(&job),
-                    format!(
-                        "Workflow {} was already terminal ({}) before runtime execution.",
-                        workflow.id, workflow.state
-                    ),
-                ));
+            if let Some(terminal_state) = store.terminal_state_for_instance(workflow).await? {
+                let activity = activity_name(&job);
+                let summary = format!(
+                    "Workflow {} was already terminal ({}) before runtime execution.",
+                    workflow.id, workflow.state
+                );
+                return Ok(match terminal_state {
+                    WorkflowTerminalState::Cancelled => {
+                        ActivityResult::cancelled(activity, summary)
+                    }
+                    WorkflowTerminalState::Failed => {
+                        ActivityResult::failed(activity, summary, "workflow already failed")
+                    }
+                    WorkflowTerminalState::Succeeded => {
+                        ActivityResult::succeeded(activity, summary)
+                    }
+                });
             }
         }
         let _queue_permit = super::runtime_execution_queue::acquire_runtime_execution_queue_permit(

--- a/crates/harness-server/src/workflow_runtime_worker/executor/mod.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/executor/mod.rs
@@ -79,7 +79,7 @@ impl<'a> ServerRuntimeJobExecutor<'a> {
                 .workflow_runtime_store
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("workflow runtime store is unavailable"))?;
-            if workflow.is_terminal_with_registry(store.definition_registry()) {
+            if store.terminal_state_for_instance(workflow).await?.is_some() {
                 return Ok(ActivityResult::cancelled(
                     activity_name(&job),
                     format!(

--- a/crates/harness-server/src/workflow_runtime_worker/mod.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/mod.rs
@@ -255,18 +255,24 @@ pub(crate) async fn notify_runtime_submission_terminal_workflow(
     let Some(callback) = state.intake.completion_callback.as_ref() else {
         return Ok(false);
     };
-    let Some(task) = runtime_submission_completion_task(&instance, result)? else {
+    let Some(task) = runtime_submission_completion_task_with_registry(
+        store.definition_registry(),
+        &instance,
+        result,
+    )?
+    else {
         return Ok(false);
     };
     callback(task).await;
     Ok(true)
 }
 
-fn runtime_submission_completion_task(
+fn runtime_submission_completion_task_with_registry(
+    registry: &harness_workflow::runtime::WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     result: Option<&ActivityResult>,
 ) -> anyhow::Result<Option<TaskState>> {
-    let projection = RuntimeWorkflowProjection::from_workflow(instance);
+    let projection = RuntimeWorkflowProjection::from_workflow_with_registry(registry, instance);
     let status = projection.task_status;
     if !status.is_terminal() {
         return Ok(None);
@@ -315,6 +321,18 @@ fn runtime_submission_completion_task(
     };
     task.error = runtime_completion_error(&status, result);
     Ok(Some(task))
+}
+
+#[cfg(test)]
+fn runtime_submission_completion_task(
+    instance: &WorkflowInstance,
+    result: Option<&ActivityResult>,
+) -> anyhow::Result<Option<TaskState>> {
+    runtime_submission_completion_task_with_registry(
+        &harness_workflow::runtime::WorkflowDefinitionRegistry::with_builtins(),
+        instance,
+        result,
+    )
 }
 
 fn runtime_job_activity_result(job: &RuntimeJob) -> Option<ActivityResult> {
@@ -403,7 +421,10 @@ fn runtime_completion_error(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harness_workflow::runtime::WorkflowSubject;
+    use harness_workflow::runtime::{
+        RegisteredWorkflowDefinition, TransitionAllowlist, WorkflowDefinitionRegistry,
+        WorkflowStateDefinition, WorkflowSubject, WorkflowTerminalState,
+    };
     use serde_json::json;
 
     fn issue_instance(state: &str) -> WorkflowInstance {
@@ -568,6 +589,41 @@ mod tests {
         assert_eq!(task.source.as_deref(), Some("github"));
         assert_eq!(task.external_id.as_deref(), Some("42"));
         assert_eq!(task.repo.as_deref(), Some("owner/repo"));
+    }
+
+    #[test]
+    fn runtime_submission_completion_task_uses_injected_custom_terminal() -> anyhow::Result<()> {
+        let definition_id = "completion_callback_injected_terminal";
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+        registry.register(RegisteredWorkflowDefinition::new(
+            definition_id,
+            vec![WorkflowStateDefinition::terminal(
+                definition_id,
+                "shipped",
+                WorkflowTerminalState::Succeeded,
+            )],
+            TransitionAllowlist::default(),
+        ))?;
+        let instance = WorkflowInstance::new(
+            definition_id,
+            1,
+            "shipped",
+            WorkflowSubject::new("declarative", "custom:42"),
+        )
+        .with_server_data(json!({
+            "task_id": "runtime-custom-42",
+            "project_id": "/tmp/project",
+            "prompt_summary": "custom workflow task",
+            "source": "dashboard",
+            "external_id": "custom:42",
+        }));
+
+        let task = runtime_submission_completion_task_with_registry(&registry, &instance, None)?
+            .ok_or_else(|| anyhow::anyhow!("custom terminal should produce a completion task"))?;
+
+        assert_eq!(task.id.as_str(), "runtime-custom-42");
+        assert_eq!(task.status, TaskStatus::Done);
+        Ok(())
     }
 
     #[test]

--- a/crates/harness-server/src/workflow_runtime_worker/otel_trajectory.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/otel_trajectory.rs
@@ -85,7 +85,7 @@ pub(super) async fn emit_runtime_job_trajectory_completion(
         }
     }
 
-    if workflow.is_terminal() {
+    if workflow.is_terminal_with_registry(store.definition_registry()) {
         state
             .observability
             .events

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/activity_policy.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/activity_policy.rs
@@ -1,20 +1,21 @@
 use super::pretty_json;
 use harness_core::config::workflow::WorkflowDocument;
 use harness_workflow::runtime::{
-    resolve_declarative_definition, DeclarativeDefinitionResolution, RuntimeJob, WorkflowInstance,
+    DeclarativeDefinitionResolution, RuntimeJob, WorkflowDefinitionRegistry, WorkflowInstance,
 };
 use serde_json::{json, Value};
 
 use crate::workflow_runtime_worker::data_helpers::activity_name;
 
 pub(super) fn apply_activity_policy(
+    registry: &WorkflowDefinitionRegistry,
     packet: &mut Value,
     job: &RuntimeJob,
     workflow: Option<&WorkflowInstance>,
     workflow_document: &WorkflowDocument,
 ) -> anyhow::Result<()> {
     apply_activity_policy_with_resolver(packet, job, workflow, workflow_document, |workflow| {
-        resolve_declarative_definition(workflow)
+        registry.resolve_declarative_definition(workflow)
     })
 }
 

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/context_provenance_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/context_provenance_tests.rs
@@ -48,6 +48,7 @@ fn build_packet(
     prompt_task_text: Option<&str>,
 ) -> Value {
     build_runtime_prompt_packet(
+        &harness_workflow::runtime::WorkflowDefinitionRegistry::with_builtins(),
         job,
         None,
         Path::new("/workspaces/job-1"),
@@ -524,6 +525,7 @@ fn prompt_task_text_is_digest_bound_without_becoming_context() {
     let mut missing_ref = runtime_job("implement_prompt");
     missing_ref.input = json!({ "activity": "implement_prompt" });
     let error = build_runtime_prompt_packet(
+        &harness_workflow::runtime::WorkflowDefinitionRegistry::with_builtins(),
         &missing_ref,
         None,
         Path::new("/workspaces/job-1"),
@@ -726,6 +728,7 @@ fn invalid_required_provenance_aborts_packet_construction() {
     };
     let profile = codex_profile();
     let error = build_runtime_prompt_packet(
+        &harness_workflow::runtime::WorkflowDefinitionRegistry::with_builtins(),
         &job,
         None,
         Path::new("/workspaces/job-1"),

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/mod.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/mod.rs
@@ -1,14 +1,13 @@
 use harness_core::config::workflow::WorkflowDocument;
 use harness_workflow::runtime::{
-    decision_validator_for_instance, ActivityArtifact, DecisionValidator,
-    RetrievedRepoMemoryRecord, RuntimeJob, RuntimeProfile, WorkflowInstance,
-    CANDIDATE_BRANCH_ARTIFACT, CANDIDATE_CLEANUP_ACTIVITY, CANDIDATE_PROMOTION_ACTIVITY,
-    ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL, ISSUE_PLAN_ACTIVITY, ISSUE_PLAN_ARTIFACT,
-    ISSUE_PLAN_READY_SIGNAL, ISSUE_STATE_ARTIFACT, PROMPT_TASK_DEFINITION_ID,
-    PROMPT_TASK_IMPLEMENT_ACTIVITY, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
-    PR_FEEDBACK_SNAPSHOT_ARTIFACT, QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL,
-    QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
-    SERVER_PR_SNAPSHOT_ARTIFACT,
+    ActivityArtifact, DecisionValidator, RetrievedRepoMemoryRecord, RuntimeJob, RuntimeProfile,
+    WorkflowDefinitionRegistry, WorkflowInstance, CANDIDATE_BRANCH_ARTIFACT,
+    CANDIDATE_CLEANUP_ACTIVITY, CANDIDATE_PROMOTION_ACTIVITY, ISSUE_ALREADY_RESOLVED_SIGNAL,
+    ISSUE_CLOSED_SIGNAL, ISSUE_PLAN_ACTIVITY, ISSUE_PLAN_ARTIFACT, ISSUE_PLAN_READY_SIGNAL,
+    ISSUE_STATE_ARTIFACT, PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY,
+    PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, PR_FEEDBACK_SNAPSHOT_ARTIFACT,
+    QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
+    QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL, SERVER_PR_SNAPSHOT_ARTIFACT,
 };
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -60,6 +59,7 @@ impl From<anyhow::Error> for PromptPacketConfigurationError {
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn build_runtime_prompt_packet(
+    registry: &WorkflowDefinitionRegistry,
     job: &RuntimeJob,
     workflow: Option<&WorkflowInstance>,
     project_root: &Path,
@@ -109,7 +109,7 @@ pub(super) fn build_runtime_prompt_packet(
             "agent_executes_repository_and_github_work": true,
             "follow_project_instructions": true,
         },
-        "activity_result_schema": activity_result_schema(job, workflow),
+        "activity_result_schema": activity_result_schema_with_registry(registry, job, workflow),
         "required_structured_output": {
             "summary": "Concise final activity summary.",
             "changed_files": "Files changed by this runtime activity, if any.",
@@ -131,7 +131,7 @@ pub(super) fn build_runtime_prompt_packet(
         repo_memory,
         prompt_task_text,
     )?;
-    apply_activity_policy(&mut packet, job, workflow, workflow_document)?;
+    apply_activity_policy(registry, &mut packet, job, workflow, workflow_document)?;
     apply_candidate_submission_contract(&mut packet, job);
     if let Some(context) = prompt_continuation_context(workflow) {
         packet["continuation_context"] = context;
@@ -274,7 +274,20 @@ pub(super) fn build_runtime_job_prompt(
     prompt
 }
 
+#[cfg(test)]
 pub(super) fn activity_result_schema(
+    job: &RuntimeJob,
+    workflow: Option<&WorkflowInstance>,
+) -> Value {
+    activity_result_schema_with_registry(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        job,
+        workflow,
+    )
+}
+
+fn activity_result_schema_with_registry(
+    registry: &WorkflowDefinitionRegistry,
     job: &RuntimeJob,
     workflow: Option<&WorkflowInstance>,
 ) -> Value {
@@ -285,7 +298,7 @@ pub(super) fn activity_result_schema(
     let activity_contract = activity_contract(workflow_definition, &activity);
     let transition_contract = activity_transition_contract(workflow_definition, &activity);
     let summary_contract = agent_summary_contract(workflow_definition, &activity);
-    let decision_contract = workflow_decision_contract(workflow);
+    let decision_contract = workflow_decision_contract(registry, workflow);
     let command_examples = workflow_decision_command_examples(workflow_definition, &activity);
     let mut schema = json!({
         "schema": "harness.runtime.activity_result.v1",
@@ -409,9 +422,15 @@ fn workflow_decision_command_examples(_workflow_definition: &str, _activity: &st
     json!([{"command_type":"enqueue_activity","dedupe_key":"<unique stable string for this command>","command":{"activity":"<next activity name>","note":"All activity-specific payload (repo, issue_number, signals, etc.) goes INSIDE this nested `command` Value. The outer object MUST have exactly the three fields: command_type, dedupe_key, command."}}])
 }
 
-fn workflow_decision_contract(workflow: Option<&WorkflowInstance>) -> Value {
+fn workflow_decision_contract(
+    registry: &WorkflowDefinitionRegistry,
+    workflow: Option<&WorkflowInstance>,
+) -> Value {
     workflow_decision_contract_with_resolver(workflow, |_| {
-        decision_validator_for_instance(workflow?).ok().flatten()
+        registry
+            .decision_validator_for_instance(workflow?)
+            .ok()
+            .flatten()
     })
 }
 
@@ -768,17 +787,14 @@ where
 }
 
 #[cfg(test)]
-#[path = "../prompt_packet_tests.rs"]
-mod tests;
-
-#[cfg(test)]
-#[path = "../prompt_packet_taint_tests.rs"]
-mod taint_tests;
-
+#[path = "../prompt_packet_activity_policy_tests.rs"]
+mod activity_policy_tests;
 #[cfg(test)]
 #[path = "../prompt_packet_pinning_tests.rs"]
 mod pinning_tests;
-
 #[cfg(test)]
-#[path = "../prompt_packet_activity_policy_tests.rs"]
-mod activity_policy_tests;
+#[path = "../prompt_packet_taint_tests.rs"]
+mod taint_tests;
+#[cfg(test)]
+#[path = "../prompt_packet_tests.rs"]
+mod tests;

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_activity_policy_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_activity_policy_tests.rs
@@ -205,6 +205,7 @@ fn runtime_prompt_packet_omits_duplicated_additional_prompt() {
         .unwrap_or_else(|error| panic!("test runtime settings should resolve: {error}"));
 
     let packet = build_runtime_prompt_packet(
+        &harness_workflow::runtime::WorkflowDefinitionRegistry::with_builtins(),
         &job,
         Some(&workflow),
         Path::new("/workspaces/job-1"),

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_pinning_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_pinning_tests.rs
@@ -13,7 +13,10 @@ fn prompt_contract_fails_closed_for_missing_pinned_definition_history() {
     .with_server_data(json!({
         "definition_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
     }));
-    let contract = workflow_decision_contract(Some(&workflow));
+    let contract = workflow_decision_contract(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        Some(&workflow),
+    );
     assert_eq!(contract["available"], false);
 }
 
@@ -28,7 +31,10 @@ fn forged_pin_marker_never_intercepts_builtin_prompt_contract() {
     .with_server_data(json!({
         "definition_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
     }));
-    let contract = workflow_decision_contract(Some(&workflow));
+    let contract = workflow_decision_contract(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        Some(&workflow),
+    );
     assert_eq!(contract["available"], true);
     assert_eq!(contract["observed_state"], "discovered");
 }

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_taint_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_taint_tests.rs
@@ -37,6 +37,7 @@ fn build_packet(workflow: &WorkflowInstance) -> anyhow::Result<Value> {
 fn build_packet_for_job(workflow: &WorkflowInstance, job: &RuntimeJob) -> anyhow::Result<Value> {
     let runtime_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
     build_runtime_prompt_packet(
+        &harness_workflow::runtime::WorkflowDefinitionRegistry::with_builtins(),
         job,
         Some(workflow),
         Path::new("/workspaces/issue-1771"),

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -461,6 +461,7 @@ fn runtime_prompt_packet_includes_workflow_file_contract() {
     let runtime_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
 
     let packet = build_runtime_prompt_packet(
+        &WorkflowDefinitionRegistry::with_builtins(),
         &job,
         None,
         Path::new("/workspaces/job-1"),
@@ -564,6 +565,7 @@ fn prompt_continuation_packet_includes_attempt_context_and_signal_contract() {
     );
     let runtime_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
     let packet = build_runtime_prompt_packet(
+        &WorkflowDefinitionRegistry::with_builtins(),
         &job,
         Some(&workflow),
         Path::new("/workspaces/job-continue"),
@@ -636,6 +638,7 @@ fn runtime_prompt_packet_describes_deferred_candidate_submission_contract() {
     let runtime_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
 
     let packet = build_runtime_prompt_packet(
+        &WorkflowDefinitionRegistry::with_builtins(),
         &job,
         None,
         Path::new("/workspaces/issue-1449-c1"),
@@ -690,6 +693,7 @@ fn memory_inject_prompt_packet_includes_fenced_repo_memory_section() {
     }];
 
     let packet = build_runtime_prompt_packet(
+        &WorkflowDefinitionRegistry::with_builtins(),
         &job,
         None,
         Path::new("/workspaces/job-1"),
@@ -752,6 +756,7 @@ fn model_facing_prompt_matches_frozen_v1_fixture_while_durable_packet_remains_v2
     };
     let runtime_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
     let packet = build_runtime_prompt_packet(
+        &WorkflowDefinitionRegistry::with_builtins(),
         &job,
         None,
         Path::new("/workspaces/job-1"),
@@ -813,6 +818,7 @@ fn memory_inject_fresh_repo_gets_no_repo_memory_section() {
     let runtime_profile = RuntimeProfile::new("codex-default", RuntimeKind::CodexJsonrpc);
 
     let packet = build_runtime_prompt_packet(
+        &WorkflowDefinitionRegistry::with_builtins(),
         &job,
         None,
         Path::new("/workspaces/job-1"),

--- a/crates/harness-server/src/workflow_runtime_worker/workspace.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/workspace.rs
@@ -192,7 +192,10 @@ pub(super) async fn cleanup_terminal_runtime_workspace(
     state: &AppState,
     workflow: &WorkflowInstance,
 ) -> anyhow::Result<()> {
-    if !workflow.is_terminal() {
+    let Some(store) = state.core.workflow_runtime_store.as_ref() else {
+        return Ok(());
+    };
+    if !workflow.is_terminal_with_registry(store.definition_registry()) {
         return Ok(());
     }
     let Some(workspace_mgr) = state.concurrency.workspace_mgr.as_ref() else {

--- a/crates/harness-workflow/src/runtime/candidate_promotion.rs
+++ b/crates/harness-workflow/src/runtime/candidate_promotion.rs
@@ -209,6 +209,7 @@ pub fn deferred_candidate_result_decision(
 }
 
 pub fn candidate_promotion_success_decision(
+    registry: &crate::runtime::WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
@@ -226,11 +227,12 @@ pub fn candidate_promotion_success_decision(
         return None;
     }
     Some(candidate_promotion_success_decision_inner(
-        instance, event, result, command,
+        registry, instance, event, result, command,
     ))
 }
 
 fn candidate_promotion_success_decision_inner(
+    registry: &crate::runtime::WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
@@ -238,7 +240,9 @@ fn candidate_promotion_success_decision_inner(
 ) -> anyhow::Result<WorkflowDecision> {
     let (pr_number, pr_url) = pull_request_artifact(result)
         .ok_or_else(|| anyhow::anyhow!("promote_candidate_pr succeeded without pull_request"))?;
-    let binding = match super::reducer::verified_pr_binding_evidence(result, pr_number, &pr_url) {
+    let binding = match super::reducer::verified_pr_binding_evidence_with_registry(
+        registry, result, pr_number, &pr_url,
+    ) {
         Ok(binding) => binding,
         Err(reason) => {
             return Ok(super::reducer::pr_binding_verification_blocked_decision(
@@ -718,6 +722,7 @@ mod tests {
             ));
 
         let decision = candidate_promotion_success_decision_inner(
+            &crate::runtime::WorkflowDefinitionRegistry::with_builtins(),
             &issue_instance(),
             &event(command.clone()),
             &result,

--- a/crates/harness-workflow/src/runtime/completion_evidence.rs
+++ b/crates/harness-workflow/src/runtime/completion_evidence.rs
@@ -88,12 +88,23 @@ pub fn transition_evidence_enforced(
     to_state: &str,
     evidence_kind: &str,
 ) -> bool {
-    crate::runtime::state_registry::transition_requires_evidence(
+    transition_evidence_enforced_with_registry(
+        &crate::runtime::WorkflowDefinitionRegistry::with_builtins(),
         definition_id,
         from_state,
         to_state,
         evidence_kind,
     )
+}
+
+pub fn transition_evidence_enforced_with_registry(
+    registry: &crate::runtime::WorkflowDefinitionRegistry,
+    definition_id: &str,
+    from_state: &str,
+    to_state: &str,
+    evidence_kind: &str,
+) -> bool {
+    registry.transition_requires_evidence(definition_id, from_state, to_state, evidence_kind)
 }
 
 /// The server-attached verified-PR-binding payload, if present.

--- a/crates/harness-workflow/src/runtime/dispatch_barrier.rs
+++ b/crates/harness-workflow/src/runtime/dispatch_barrier.rs
@@ -325,7 +325,10 @@ impl super::store::WorkflowRuntimeStore {
             return Ok(DeferClaimedCommandOutcome::StaleClaim);
         }
 
-        if let Some(workflow) = workflow.as_ref().filter(|workflow| workflow.is_terminal()) {
+        if let Some(workflow) = workflow
+            .as_ref()
+            .filter(|workflow| workflow.is_terminal_with_registry(&self.definition_registry))
+        {
             let terminal_status = if workflow.state == "cancelled" {
                 WorkflowCommandStatus::Cancelled
             } else {

--- a/crates/harness-workflow/src/runtime/dispatch_barrier.rs
+++ b/crates/harness-workflow/src/runtime/dispatch_barrier.rs
@@ -325,15 +325,18 @@ impl super::store::WorkflowRuntimeStore {
             return Ok(DeferClaimedCommandOutcome::StaleClaim);
         }
 
-        if let Some(workflow) = workflow
-            .as_ref()
-            .filter(|workflow| workflow.is_terminal_with_registry(&self.definition_registry))
-        {
-            let terminal_status = if workflow.state == "cancelled" {
-                WorkflowCommandStatus::Cancelled
-            } else {
-                WorkflowCommandStatus::Skipped
-            };
+        if let Some(terminal_state) = match workflow.as_ref() {
+            Some(workflow) => {
+                super::store::terminal_state_for_instance_tx(
+                    &mut tx,
+                    &self.definition_registry,
+                    workflow,
+                )
+                .await?
+            }
+            None => None,
+        } {
+            let terminal_status = super::store::terminal_command_status(terminal_state);
             sqlx::query(
                 "UPDATE workflow_commands
                  SET status = $2, dispatch_owner = NULL,

--- a/crates/harness-workflow/src/runtime/memory_extract.rs
+++ b/crates/harness-workflow/src/runtime/memory_extract.rs
@@ -41,7 +41,13 @@ impl WorkflowRuntimeStore {
         let Some(instance) = self.get_instance(&decision.workflow_id).await? else {
             return Ok(());
         };
-        let Some(record) = extract_terminal_repo_memory_record(&instance, event, decision)? else {
+        let Some(record) = extract_terminal_repo_memory_record_with_registry(
+            &self.definition_registry,
+            &instance,
+            event,
+            decision,
+        )?
+        else {
             return Ok(());
         };
         self.insert_repo_memory_record(&record).await?;
@@ -49,7 +55,8 @@ impl WorkflowRuntimeStore {
     }
 }
 
-fn extract_terminal_repo_memory_record(
+fn extract_terminal_repo_memory_record_with_registry(
+    registry: &super::state_registry::WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     decision: &WorkflowDecisionRecord,
@@ -57,7 +64,7 @@ fn extract_terminal_repo_memory_record(
     if !decision.accepted {
         return Ok(None);
     }
-    let Some(outcome) = repo_memory_outcome(instance) else {
+    let Some(outcome) = repo_memory_outcome(registry, instance) else {
         return Ok(None);
     };
     let result: ActivityResult =
@@ -97,6 +104,20 @@ fn extract_terminal_repo_memory_record(
     ))
 }
 
+#[cfg(test)]
+fn extract_terminal_repo_memory_record(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    decision: &WorkflowDecisionRecord,
+) -> anyhow::Result<Option<RepoMemoryRecord>> {
+    extract_terminal_repo_memory_record_with_registry(
+        &super::state_registry::WorkflowDefinitionRegistry::with_builtins(),
+        instance,
+        event,
+        decision,
+    )
+}
+
 fn repo_memory_enabled_for_result(result: &ActivityResult) -> bool {
     result
         .artifacts
@@ -108,11 +129,14 @@ fn repo_memory_enabled_for_result(result: &ActivityResult) -> bool {
         .unwrap_or(false)
 }
 
-fn repo_memory_outcome(instance: &WorkflowInstance) -> Option<RepoMemoryOutcome> {
-    match (instance.state.as_str(), instance.terminal_state()?) {
-        ("done", WorkflowTerminalState::Succeeded) => Some(RepoMemoryOutcome::Done),
-        ("failed", WorkflowTerminalState::Failed) => Some(RepoMemoryOutcome::Failed),
-        _ => None,
+fn repo_memory_outcome(
+    registry: &super::state_registry::WorkflowDefinitionRegistry,
+    instance: &WorkflowInstance,
+) -> Option<RepoMemoryOutcome> {
+    match instance.terminal_state_with_registry(registry)? {
+        WorkflowTerminalState::Succeeded => Some(RepoMemoryOutcome::Done),
+        WorkflowTerminalState::Failed => Some(RepoMemoryOutcome::Failed),
+        WorkflowTerminalState::Cancelled => None,
     }
 }
 
@@ -301,6 +325,10 @@ fn clean_string(value: &str) -> Option<String> {
     let trimmed = value.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
+
+#[cfg(test)]
+#[path = "memory_extract_registry_tests.rs"]
+mod registry_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/harness-workflow/src/runtime/memory_extract_registry_tests.rs
+++ b/crates/harness-workflow/src/runtime/memory_extract_registry_tests.rs
@@ -1,0 +1,39 @@
+use super::*;
+use crate::runtime::{
+    RegisteredWorkflowDefinition, TransitionAllowlist, WorkflowDefinitionRegistry,
+    WorkflowStateDefinition, WorkflowSubject,
+};
+
+#[test]
+fn repo_memory_outcome_uses_injected_custom_terminal_class() -> anyhow::Result<()> {
+    let definition_id = "repo_memory_injected_terminal";
+    let mut registry = WorkflowDefinitionRegistry::with_builtins();
+    registry.register(RegisteredWorkflowDefinition::new(
+        definition_id,
+        vec![
+            WorkflowStateDefinition::terminal(
+                definition_id,
+                "shipped",
+                WorkflowTerminalState::Succeeded,
+            ),
+            WorkflowStateDefinition::terminal(
+                definition_id,
+                "rejected",
+                WorkflowTerminalState::Failed,
+            ),
+        ],
+        TransitionAllowlist::default(),
+    ))?;
+    let instance =
+        |state| WorkflowInstance::new(definition_id, 1, state, WorkflowSubject::new("test", state));
+
+    assert_eq!(
+        repo_memory_outcome(&registry, &instance("shipped")),
+        Some(RepoMemoryOutcome::Done)
+    );
+    assert_eq!(
+        repo_memory_outcome(&registry, &instance("rejected")),
+        Some(RepoMemoryOutcome::Failed)
+    );
+    Ok(())
+}

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -48,6 +48,8 @@ pub mod validator;
 pub mod validator_binding;
 mod validator_progress;
 pub mod worker;
+#[path = "model_workflow_instance.rs"]
+mod workflow_instance_impl;
 
 #[cfg(test)]
 mod circuit_breaker_store_tests;
@@ -171,9 +173,9 @@ pub use reason_class::{
 };
 pub use reducer::{
     activity_result_has_closed_issue_evidence, activity_result_value_has_closed_issue_evidence,
-    reduce_runtime_job_completed, value_has_closed_issue_evidence, GITHUB_ISSUE_PR_DEFINITION_ID,
-    ISSUE_ALREADY_RESOLVED_SIGNAL, ISSUE_CLOSED_SIGNAL, ISSUE_STATE_ARTIFACT,
-    RUNTIME_JOB_COMPLETED_EVENT,
+    reduce_runtime_job_completed, reduce_runtime_job_completed_with_registry,
+    value_has_closed_issue_evidence, GITHUB_ISSUE_PR_DEFINITION_ID, ISSUE_ALREADY_RESOLVED_SIGNAL,
+    ISSUE_CLOSED_SIGNAL, ISSUE_STATE_ARTIFACT, RUNTIME_JOB_COMPLETED_EVENT,
 };
 pub use remote_facts::{
     remote_fact_command_dedupe_key, stable_pr_snapshot_fact_hash_input, stable_remote_fact_hash,
@@ -184,19 +186,8 @@ pub use repo_memory::{
     REPO_MEMORY_DEGRADATION_ARTIFACT,
 };
 pub use state_registry::{
-    apply_builtin_evidence_enforcement, current_declarative_workflow_definition,
-    decision_validator_for_definition, decision_validator_for_instance,
-    declarative_workflow_definition_for_instance, freeze_workflow_definition_registry,
-    known_workflow_definition_ids, register_declarative_workflow_definitions,
-    register_historical_declarative_workflow_definitions, register_workflow_definition,
-    resolve_declarative_definition, workflow_declarative_definition, workflow_definition,
-    workflow_definition_for_version, workflow_instance_is_declarative, workflow_state_definition,
-    workflow_state_definition_for_instance, workflow_state_definition_for_version,
-    workflow_state_exists, workflow_state_progress_mode, workflow_state_progress_mode_for_version,
-    workflow_state_terminal_state_for_version, workflow_states_for_definition,
-    workflow_terminal_state_names_for_definition, DeclarativeDefinitionPinError,
-    DeclarativeDefinitionResolution, RegisteredWorkflowDefinition, WorkflowDefinitionRegistry,
-    WorkflowProgressMode, WorkflowStateDefinition, WorkflowStateKey,
+    DeclarativeDefinitionPinError, DeclarativeDefinitionResolution, RegisteredWorkflowDefinition,
+    WorkflowDefinitionRegistry, WorkflowProgressMode, WorkflowStateDefinition, WorkflowStateKey,
 };
 pub use status::WorkflowCommandStatus;
 pub use store::PromptPayloadIntegrityError;
@@ -222,10 +213,7 @@ pub use submission::{
     build_issue_submission_decision, IssueSubmissionDecisionInput, IssueSubmissionDecisionOutput,
     IssueSubmissionWorkflowAction, SubmissionMode,
 };
-pub use terminal_state::{
-    workflow_terminal_state, workflow_terminal_state_for_instance,
-    workflow_terminal_state_for_version, WorkflowTerminalState,
-};
+pub use terminal_state::WorkflowTerminalState;
 pub use tier_resolution::{resolve_isolation_tier, IsolationTaskMetadata, IsolationTierResolution};
 pub use transcript::{
     prepare_runtime_transcript, runtime_transcript_artifact_ref, runtime_transcript_checksum,

--- a/crates/harness-workflow/src/runtime/model.rs
+++ b/crates/harness-workflow/src/runtime/model.rs
@@ -1,4 +1,3 @@
-use super::terminal_state::{workflow_terminal_state_for_instance, WorkflowTerminalState};
 use chrono::{DateTime, Utc};
 use harness_core::claim_trust::ClaimProvenance;
 use serde::{Deserialize, Serialize};
@@ -96,57 +95,6 @@ pub struct WorkflowInstance {
     pub lease: Option<WorkflowLease>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-}
-
-impl WorkflowInstance {
-    pub fn new(
-        definition_id: impl Into<String>,
-        definition_version: u32,
-        state: impl Into<String>,
-        subject: WorkflowSubject,
-    ) -> Self {
-        let now = Utc::now();
-        Self {
-            id: Uuid::new_v4().to_string(),
-            definition_id: definition_id.into(),
-            definition_version,
-            state: state.into(),
-            subject,
-            parent_workflow_id: None,
-            data: Value::Object(Default::default()),
-            data_provenance: Some(Default::default()),
-            version: 0,
-            lease: None,
-            created_at: now,
-            updated_at: now,
-        }
-    }
-
-    pub fn is_terminal(&self) -> bool {
-        self.terminal_state().is_some()
-    }
-
-    pub fn terminal_state(&self) -> Option<WorkflowTerminalState> {
-        workflow_terminal_state_for_instance(self)
-    }
-
-    pub fn with_id(mut self, id: impl Into<String>) -> Self {
-        self.id = id.into();
-        self
-    }
-
-    pub fn with_parent(mut self, parent_workflow_id: impl Into<String>) -> Self {
-        self.parent_workflow_id = Some(parent_workflow_id.into());
-        self
-    }
-
-    pub fn with_lease(mut self, owner: impl Into<String>, expires_at: DateTime<Utc>) -> Self {
-        self.lease = Some(WorkflowLease {
-            owner: owner.into(),
-            expires_at,
-        });
-        self
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/harness-workflow/src/runtime/model_workflow_instance.rs
+++ b/crates/harness-workflow/src/runtime/model_workflow_instance.rs
@@ -1,0 +1,67 @@
+use super::model::{WorkflowInstance, WorkflowLease, WorkflowSubject};
+use super::state_registry::{WorkflowDefinitionRegistry, WorkflowTerminalState};
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use uuid::Uuid;
+
+impl WorkflowInstance {
+    pub fn new(
+        definition_id: impl Into<String>,
+        definition_version: u32,
+        state: impl Into<String>,
+        subject: WorkflowSubject,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4().to_string(),
+            definition_id: definition_id.into(),
+            definition_version,
+            state: state.into(),
+            subject,
+            parent_workflow_id: None,
+            data: Value::Object(Default::default()),
+            data_provenance: Some(Default::default()),
+            version: 0,
+            lease: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        WorkflowDefinitionRegistry::with_builtins().instance_is_terminal(self)
+    }
+
+    pub fn is_terminal_with_registry(&self, registry: &WorkflowDefinitionRegistry) -> bool {
+        self.terminal_state_with_registry(registry).is_some()
+    }
+
+    pub fn terminal_state(&self) -> Option<WorkflowTerminalState> {
+        WorkflowDefinitionRegistry::with_builtins().terminal_state_for_instance(self)
+    }
+
+    pub fn terminal_state_with_registry(
+        &self,
+        registry: &WorkflowDefinitionRegistry,
+    ) -> Option<WorkflowTerminalState> {
+        registry.terminal_state_for_instance(self)
+    }
+
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    pub fn with_parent(mut self, parent_workflow_id: impl Into<String>) -> Self {
+        self.parent_workflow_id = Some(parent_workflow_id.into());
+        self
+    }
+
+    pub fn with_lease(mut self, owner: impl Into<String>, expires_at: DateTime<Utc>) -> Self {
+        self.lease = Some(WorkflowLease {
+            owner: owner.into(),
+            expires_at,
+        });
+        self
+    }
+}

--- a/crates/harness-workflow/src/runtime/reducer.rs
+++ b/crates/harness-workflow/src/runtime/reducer.rs
@@ -20,7 +20,7 @@ use self::builtin_github_issue::{
     closed_issue_evidence_from_value,
 };
 pub(crate) use self::builtin_github_issue::{
-    pr_binding_verification_blocked_decision, verified_pr_binding_evidence,
+    pr_binding_verification_blocked_decision, verified_pr_binding_evidence_with_registry,
 };
 use self::declarative_completion::{
     definition_pin_blocked_decision, reduce_declarative_completion,
@@ -30,7 +30,7 @@ pub(crate) use self::support::{
     budget_exhausted_blocked_decision, invalid_agent_output_blocked_decision,
 };
 use super::model::{ActivityResult, WorkflowDecision, WorkflowEvent, WorkflowInstance};
-use super::state_registry::{resolve_declarative_definition, DeclarativeDefinitionResolution};
+use super::state_registry::{DeclarativeDefinitionResolution, WorkflowDefinitionRegistry};
 use serde_json::Value;
 
 pub const RUNTIME_JOB_COMPLETED_EVENT: &str = "RuntimeJobCompleted";
@@ -60,6 +60,18 @@ pub fn reduce_runtime_job_completed(
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
 ) -> anyhow::Result<Option<WorkflowDecision>> {
+    reduce_runtime_job_completed_with_registry(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        instance,
+        event,
+    )
+}
+
+pub fn reduce_runtime_job_completed_with_registry(
+    registry: &WorkflowDefinitionRegistry,
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+) -> anyhow::Result<Option<WorkflowDecision>> {
     if event.event_type != RUNTIME_JOB_COMPLETED_EVENT {
         return Ok(None);
     }
@@ -69,9 +81,9 @@ pub fn reduce_runtime_job_completed(
             anyhow::anyhow!("RuntimeJobCompleted event missing activity_result")
         })?)?;
 
-    match resolve_declarative_definition(instance) {
+    match registry.resolve_declarative_definition(instance) {
         DeclarativeDefinitionResolution::Resolved(definition) => {
-            reduce_declarative_completion(&definition, instance, event, &result)
+            reduce_declarative_completion(registry, &definition, instance, event, &result)
         }
         DeclarativeDefinitionResolution::PinError(error) => Ok(Some(
             definition_pin_blocked_decision(instance, event, &result, error),

--- a/crates/harness-workflow/src/runtime/reducer/builtin_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/builtin_completion.rs
@@ -10,7 +10,7 @@ use super::builtin_pr_feedback::{
     pr_feedback_child_decision_from_activity_result, pr_feedback_success_contract_error,
     pr_feedback_sweep_decision_from_activity_result,
 };
-use super::builtin_prompt_task::prompt_task_success_decision;
+use super::builtin_prompt_task::prompt_task_success_decision_with_registry;
 use super::builtin_quality_gate::{
     parent_quality_gate_pass_decision, quality_gate_activity_matches,
     quality_gate_success_contract_error, quality_gate_success_decision,
@@ -39,11 +39,12 @@ use crate::runtime::pr_feedback::{
 };
 use crate::runtime::prompt_task::{PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY};
 use crate::runtime::quality_gate::{QUALITY_GATE_ACTIVITY, QUALITY_GATE_DEFINITION_ID};
-use crate::runtime::state_registry::decision_validator_for_definition;
+use crate::runtime::state_registry::WorkflowDefinitionRegistry;
 use crate::runtime::validator::ValidationContext;
 use serde_json::json;
 
 pub(super) fn reduce_builtin_completion(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
@@ -58,7 +59,7 @@ pub(super) fn reduce_builtin_completion(
         return None;
     }
     let decision = match result.status {
-        ActivityStatus::Succeeded => reduce_success(instance, event, result),
+        ActivityStatus::Succeeded => reduce_success(registry, instance, event, result),
         ActivityStatus::Blocked | ActivityStatus::SucceededWithBlockers => {
             github_issue_closed_decision(instance, event, result)
                 .or_else(|| Some(runtime_blocked_decision(instance, event, result)))
@@ -96,6 +97,7 @@ pub(super) fn reduce_builtin_completion(
 }
 
 fn reduce_success(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
@@ -125,7 +127,7 @@ fn reduce_success(
     }
     if let Some(command) = event_workflow_command(event) {
         if let Some(decision) =
-            candidate_promotion_success_decision(instance, event, result, &command)
+            candidate_promotion_success_decision(registry, instance, event, result, &command)
         {
             return Some(decision.unwrap_or_else(|error| {
                 invalid_agent_output_blocked_decision(
@@ -165,19 +167,22 @@ fn reduce_success(
     if let Some(decision) = structured_decision
         .as_ref()
         .filter(|_| !pr_feedback_blocker_overrides_structured_ready)
-        .filter(|decision| structured_decision_validates(instance, event, result, decision))
+        .filter(|decision| {
+            structured_decision_validates(registry, instance, event, result, decision)
+        })
         .cloned()
     {
         return Some(decision);
     }
 
-    if let Some(decision) = parent_quality_gate_pass_decision(instance, event, result) {
+    if let Some(decision) = parent_quality_gate_pass_decision(registry, instance, event, result) {
         return Some(decision);
     }
 
     if quality_gate_activity_matches(instance, result) {
         if let Some(decision) = structured_decision.as_ref() {
-            let reason = if let Some(contract_reason) = quality_gate_success_contract_error(result)
+            let reason = if let Some(contract_reason) =
+                quality_gate_success_contract_error(registry, result)
             {
                 format!(
                     "runtime activity `{}` emitted workflow_decision `{}` for workflow `{}` in state `{}`, but {contract_reason}",
@@ -197,14 +202,14 @@ fn reduce_success(
                 instance, event, result, &reason,
             ));
         }
-        return quality_gate_success_decision(instance, event, result);
+        return quality_gate_success_decision(registry, instance, event, result);
     }
 
     if prompt_task_activity_matches(instance, result) {
-        return prompt_task_success_decision(instance, event, result);
+        return prompt_task_success_decision_with_registry(registry, instance, event, result);
     }
 
-    if let Some(decision) = bind_pr_from_activity_result(instance, event, result) {
+    if let Some(decision) = bind_pr_from_activity_result(registry, instance, event, result) {
         return Some(decision);
     }
 
@@ -230,7 +235,8 @@ fn reduce_success(
         ));
     }
 
-    if let Some(decision) = pr_feedback_child_decision_from_activity_result(instance, event, result)
+    if let Some(decision) =
+        pr_feedback_child_decision_from_activity_result(registry, instance, event, result)
     {
         return Some(decision);
     }
@@ -536,6 +542,7 @@ fn canonicalize_verified_pr_binding_commands(
 }
 
 fn structured_decision_validates(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
@@ -556,11 +563,12 @@ fn structured_decision_validates(
     }
     if quality_gate_activity_matches(instance, result)
         && decision.next_state == "passed"
-        && quality_gate_success_contract_error(result).is_some()
+        && quality_gate_success_contract_error(registry, result).is_some()
     {
         return false;
     }
-    let Some(validator) = decision_validator_for_definition(&instance.definition_id) else {
+    let Some(validator) = registry.decision_validator_for_definition(&instance.definition_id)
+    else {
         return true;
     };
     validator

--- a/crates/harness-workflow/src/runtime/reducer/builtin_github_issue.rs
+++ b/crates/harness-workflow/src/runtime/reducer/builtin_github_issue.rs
@@ -6,16 +6,18 @@ use super::{
     ISSUE_STATE_ARTIFACT,
 };
 use crate::runtime::completion_evidence::{
-    github_pr_identity, pr_binding_verification_failure, transition_evidence_enforced,
-    verified_issue_state_artifact, verified_pr_binding_artifact,
-    ARTIFACT_MERGE_COMPLETION_VERIFICATION, EVIDENCE_GITHUB_TERMINAL, EVIDENCE_VERIFIED_PR_BINDING,
-    MERGE_COMPLETION_VERIFICATION_SCHEMA, REASON_PR_BINDING_VERIFICATION_FAILED,
+    github_pr_identity, pr_binding_verification_failure,
+    transition_evidence_enforced_with_registry, verified_issue_state_artifact,
+    verified_pr_binding_artifact, ARTIFACT_MERGE_COMPLETION_VERIFICATION, EVIDENCE_GITHUB_TERMINAL,
+    EVIDENCE_VERIFIED_PR_BINDING, MERGE_COMPLETION_VERIFICATION_SCHEMA,
+    REASON_PR_BINDING_VERIFICATION_FAILED,
 };
 use crate::runtime::model::{
     ActivityResult, WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowEvent,
     WorkflowEvidence, WorkflowInstance,
 };
 use crate::runtime::reason_class::STOP_REASON_INVALID_AGENT_OUTPUT;
+use crate::runtime::WorkflowDefinitionRegistry;
 use serde_json::{json, Value};
 
 pub(super) fn issue_implementation_missing_result_decision(
@@ -169,6 +171,7 @@ fn github_issue_state_can_finish_closed(state: &str) -> bool {
 }
 
 pub(super) fn bind_pr_from_activity_result(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
@@ -185,14 +188,15 @@ pub(super) fn bind_pr_from_activity_result(
         return None;
     }
     let (pr_number, pr_url) = pull_request_artifact(result)?;
-    let binding = match verified_pr_binding_evidence(result, pr_number, &pr_url) {
-        Ok(binding) => binding,
-        Err(reason) => {
-            return Some(pr_binding_verification_blocked_decision(
-                instance, event, result, &reason,
-            ));
-        }
-    };
+    let binding =
+        match verified_pr_binding_evidence_with_registry(registry, result, pr_number, &pr_url) {
+            Ok(binding) => binding,
+            Err(reason) => {
+                return Some(pr_binding_verification_blocked_decision(
+                    instance, event, result, &reason,
+                ));
+            }
+        };
     let pr_url = binding.canonical_pr_url;
     Some(
         WorkflowDecision::new(
@@ -224,7 +228,8 @@ pub(crate) struct VerifiedPrBindingEvidence {
     pub(crate) canonical_pr_url: String,
 }
 
-pub(crate) fn verified_pr_binding_evidence(
+pub(crate) fn verified_pr_binding_evidence_with_registry(
+    registry: &WorkflowDefinitionRegistry,
     result: &ActivityResult,
     claimed_pr_number: u64,
     claimed_pr_url: &str,
@@ -275,7 +280,8 @@ pub(crate) fn verified_pr_binding_evidence(
             ),
         });
     }
-    if !transition_evidence_enforced(
+    if !transition_evidence_enforced_with_registry(
+        registry,
         GITHUB_ISSUE_PR_DEFINITION_ID,
         "implementing",
         "pr_open",

--- a/crates/harness-workflow/src/runtime/reducer/builtin_pr_feedback.rs
+++ b/crates/harness-workflow/src/runtime/reducer/builtin_pr_feedback.rs
@@ -14,6 +14,7 @@ use crate::runtime::pr_feedback::{
     PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY, PR_REPAIR_SNAPSHOT_ARTIFACT,
     SERVER_PR_SNAPSHOT_ARTIFACT,
 };
+use crate::runtime::WorkflowDefinitionRegistry;
 use serde_json::Value;
 
 pub(super) fn pr_feedback_sweep_decision_from_activity_result(
@@ -159,6 +160,7 @@ pub(super) fn local_review_decision_from_activity_result(
 }
 
 pub(super) fn pr_feedback_child_decision_from_activity_result(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
@@ -208,7 +210,8 @@ pub(super) fn pr_feedback_child_decision_from_activity_result(
                 "server_pr_snapshot",
                 Some(event.id.clone()),
             ));
-        } else if !crate::runtime::completion_evidence::transition_evidence_enforced(
+        } else if !crate::runtime::completion_evidence::transition_evidence_enforced_with_registry(
+            registry,
             PR_FEEDBACK_DEFINITION_ID,
             "inspecting",
             "ready_to_merge",

--- a/crates/harness-workflow/src/runtime/reducer/builtin_prompt_task.rs
+++ b/crates/harness-workflow/src/runtime/reducer/builtin_prompt_task.rs
@@ -9,6 +9,7 @@ use crate::runtime::prompt_task::{
     PromptContinuationState, PROMPT_TASK_IMPLEMENT_ACTIVITY,
 };
 use crate::runtime::remote_facts::stable_remote_fact_hash;
+use crate::runtime::WorkflowDefinitionRegistry;
 use crate::runtime::RUNTIME_TRANSCRIPT_ARTIFACT;
 use chrono::Duration;
 use serde_json::{json, Value};
@@ -21,14 +22,29 @@ const SERVER_GENERATED_ARTIFACTS: [&str; 5] = [
     RUNTIME_TRANSCRIPT_ARTIFACT,
 ];
 
+#[cfg(test)]
 pub(super) fn prompt_task_success_decision(
+    instance: &WorkflowInstance,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Option<WorkflowDecision> {
+    prompt_task_success_decision_with_registry(
+        &WorkflowDefinitionRegistry::with_builtins(),
+        instance,
+        event,
+        result,
+    )
+}
+
+pub(super) fn prompt_task_success_decision_with_registry(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
 ) -> Option<WorkflowDecision> {
     let continuation = match prompt_continuation_state_from_data(&instance.data) {
         Ok(Some(continuation)) => continuation,
-        Ok(None) => return Some(single_shot_done_decision(instance, event, result)),
+        Ok(None) => return Some(single_shot_done_decision(registry, instance, event, result)),
         Err(reason) => {
             return Some(blocked_decision(
                 instance,
@@ -56,7 +72,7 @@ pub(super) fn prompt_task_success_decision(
     let observed = observed_state(&continuation, result, &signal);
     if !continuation.policy.active_states.contains(&signal.state) {
         return Some(settled_done_decision(
-            instance, event, result, &signal, &observed,
+            registry, instance, event, result, &signal, &observed,
         ));
     }
     if continuation.attempt >= continuation.policy.max_attempts {
@@ -143,11 +159,12 @@ fn missing_completion_evidence_decision(
 }
 
 fn single_shot_done_decision(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
 ) -> WorkflowDecision {
-    let completion = match prompt_completion_evidence(result) {
+    let completion = match prompt_completion_evidence(registry, result) {
         Ok(completion) => completion,
         Err(detail) => {
             return missing_completion_evidence_decision(instance, event, result, &detail, None)
@@ -166,13 +183,14 @@ fn single_shot_done_decision(
 }
 
 fn settled_done_decision(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
     signal: &ExternalStateSignal,
     continuation: &PromptContinuationState,
 ) -> WorkflowDecision {
-    let completion = match prompt_completion_evidence(result) {
+    let completion = match prompt_completion_evidence(registry, result) {
         Ok(completion) => completion,
         Err(detail) => {
             return missing_completion_evidence_decision(

--- a/crates/harness-workflow/src/runtime/reducer/builtin_quality_gate.rs
+++ b/crates/harness-workflow/src/runtime/reducer/builtin_quality_gate.rs
@@ -3,7 +3,7 @@ use super::support::{
 };
 use crate::runtime::completion_evidence::{
     server_validation_digest_artifact, server_validation_digest_passed,
-    transition_evidence_enforced, EVIDENCE_SERVER_VALIDATION_DIGEST,
+    transition_evidence_enforced_with_registry, EVIDENCE_SERVER_VALIDATION_DIGEST,
 };
 use crate::runtime::model::{
     ActivityResult, WorkflowDecision, WorkflowEvent, WorkflowEvidence, WorkflowInstance,
@@ -12,9 +12,11 @@ use crate::runtime::quality_gate::{
     QUALITY_BLOCKED_SIGNAL, QUALITY_FAILED_SIGNAL, QUALITY_GATE_ACTIVITY,
     QUALITY_GATE_DEFINITION_ID, QUALITY_PASSED_SIGNAL,
 };
+use crate::runtime::WorkflowDefinitionRegistry;
 use serde_json::Value;
 
 pub(super) fn quality_gate_success_decision(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
@@ -23,7 +25,7 @@ pub(super) fn quality_gate_success_decision(
         return None;
     }
 
-    if quality_gate_success_contract_error(result).is_none() {
+    if quality_gate_success_contract_error(registry, result).is_none() {
         return Some(
             WorkflowDecision::new(
                 &instance.id,
@@ -38,13 +40,14 @@ pub(super) fn quality_gate_success_decision(
         );
     }
 
-    let reason = quality_gate_success_contract_error(result)?;
+    let reason = quality_gate_success_contract_error(registry, result)?;
     Some(invalid_agent_output_blocked_decision(
         instance, event, result, reason,
     ))
 }
 
 pub(super) fn parent_quality_gate_pass_decision(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
@@ -61,7 +64,7 @@ pub(super) fn parent_quality_gate_pass_decision(
         return None;
     }
 
-    if let Some(reason) = quality_gate_success_contract_error(result) {
+    if let Some(reason) = quality_gate_success_contract_error(registry, result) {
         return Some(invalid_agent_output_blocked_decision(
             instance, event, result, reason,
         ));
@@ -95,7 +98,10 @@ pub(super) fn quality_gate_activity_matches(
     )
 }
 
-pub(super) fn quality_gate_success_contract_error(result: &ActivityResult) -> Option<&'static str> {
+pub(super) fn quality_gate_success_contract_error(
+    registry: &WorkflowDefinitionRegistry,
+    result: &ActivityResult,
+) -> Option<&'static str> {
     let passed = signal_count(result, QUALITY_PASSED_SIGNAL);
     let failed = signal_count(result, QUALITY_FAILED_SIGNAL);
     let blocked = signal_count(result, QUALITY_BLOCKED_SIGNAL);
@@ -108,12 +114,13 @@ pub(super) fn quality_gate_success_contract_error(result: &ActivityResult) -> Op
         Some("run_quality_gate succeeded with ambiguous quality status signals")
     } else if !quality_gate_has_validation_evidence(result) {
         Some("run_quality_gate succeeded without validation evidence")
-    } else if quality_gate_digest_enforced() && server_validation_digest_artifact(result).is_none()
+    } else if quality_gate_digest_enforced(registry)
+        && server_validation_digest_artifact(result).is_none()
     {
         // GH-1766 B-003: an agent QualityPassed claim without a server-side
         // validation re-run does not satisfy the gate.
         Some("run_quality_gate succeeded without a server validation digest; the server must re-execute the validation commands itself")
-    } else if quality_gate_digest_enforced() && !server_validation_digest_passed(result) {
+    } else if quality_gate_digest_enforced(registry) && !server_validation_digest_passed(result) {
         Some("run_quality_gate claimed QualityPassed but the server validation digest records failing or unstarted commands")
     } else {
         None
@@ -123,8 +130,9 @@ pub(super) fn quality_gate_success_contract_error(result: &ActivityResult) -> Op
 /// The transition table is the authority for whether `checking -> passed`
 /// still demands a server validation digest (GH-1815): the deployment-global
 /// kill switch strips the requirement, and this reducer gate lifts with it.
-fn quality_gate_digest_enforced() -> bool {
-    transition_evidence_enforced(
+fn quality_gate_digest_enforced(registry: &WorkflowDefinitionRegistry) -> bool {
+    transition_evidence_enforced_with_registry(
+        registry,
         QUALITY_GATE_DEFINITION_ID,
         "checking",
         "passed",

--- a/crates/harness-workflow/src/runtime/reducer/declarative_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/declarative_completion.rs
@@ -13,17 +13,20 @@ use crate::runtime::model::{
     ActivityResult, ActivityStatus, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
     WorkflowEvent, WorkflowEvidence, WorkflowInstance,
 };
-use crate::runtime::state_registry::{DeclarativeDefinitionPinError, WorkflowTerminalState};
+use crate::runtime::state_registry::{
+    DeclarativeDefinitionPinError, WorkflowDefinitionRegistry, WorkflowTerminalState,
+};
 use harness_core::config::workflow::DeclaredProgressMode;
 use serde_json::json;
 
 pub(crate) fn reduce_declarative_completion(
+    registry: &WorkflowDefinitionRegistry,
     definition: &DeclarativeWorkflowDefinition,
     instance: &WorkflowInstance,
     event: &WorkflowEvent,
     result: &ActivityResult,
 ) -> anyhow::Result<Option<WorkflowDecision>> {
-    if let Some(outcome) = reduce_builtin_completion(instance, event, result) {
+    if let Some(outcome) = reduce_builtin_completion(registry, instance, event, result) {
         return outcome;
     }
     Ok(Some(reduce_generic_declarative_completion(

--- a/crates/harness-workflow/src/runtime/reducer/declarative_tests.rs
+++ b/crates/harness-workflow/src/runtime/reducer/declarative_tests.rs
@@ -51,10 +51,11 @@ fn declarative_failure_without_route_uses_configured_generic_retry() -> anyhow::
         )]),
     )?;
     let version = definition.definition_version();
-    super::super::state_registry::register_declarative_workflow_definitions([definition])?;
-    let definition =
-        super::super::state_registry::workflow_declarative_definition(DEFINITION_ID, version)
-            .ok_or_else(|| anyhow::anyhow!("generic-retry definition should resolve"))?;
+    let mut registry = super::super::state_registry::WorkflowDefinitionRegistry::with_builtins();
+    registry.register_declarative_current(definition)?;
+    let definition = registry
+        .declarative_definition(DEFINITION_ID, version)
+        .ok_or_else(|| anyhow::anyhow!("generic-retry definition should resolve"))?;
     let instance = WorkflowInstance::new(
         DEFINITION_ID,
         definition.definition_version(),
@@ -75,7 +76,7 @@ fn declarative_failure_without_route_uses_configured_generic_retry() -> anyhow::
             "activity_result": result,
         }));
 
-    let decision = reduce_runtime_job_completed(&instance, &event)?
+    let decision = reduce_runtime_job_completed_with_registry(&registry, &instance, &event)?
         .ok_or_else(|| anyhow::anyhow!("generic retry should produce a decision"))?;
     assert_eq!(decision.decision, "retry_failed_runtime_activity");
     assert_eq!(decision.next_state, "working");
@@ -84,7 +85,8 @@ fn declarative_failure_without_route_uses_configured_generic_retry() -> anyhow::
         WorkflowCommandType::EnqueueActivity
     );
     assert_eq!(decision.commands[0].command["retry_attempt"], 1);
-    super::super::state_registry::decision_validator_for_instance(&instance)
+    registry
+        .decision_validator_for_instance(&instance)
         .map_err(|error| anyhow::anyhow!("declarative definition pin failed: {error:?}"))?
         .ok_or_else(|| anyhow::anyhow!("generic retry validator should resolve"))?
         .validate(

--- a/crates/harness-workflow/src/runtime/reducer/prompt_completion_evidence.rs
+++ b/crates/harness-workflow/src/runtime/reducer/prompt_completion_evidence.rs
@@ -4,9 +4,10 @@
 //! information. These artifacts remain agent-authored claims: parsing them in
 //! the reducer does not upgrade their trust provenance.
 
+use crate::runtime::completion_evidence::transition_evidence_enforced_with_registry;
 use crate::runtime::model::{ActivityResult, WorkflowEvidence, EVIDENCE_PROMPT_COMPLETION};
 use crate::runtime::prompt_task::PROMPT_TASK_DEFINITION_ID;
-use crate::runtime::state_registry::transition_requires_evidence;
+use crate::runtime::WorkflowDefinitionRegistry;
 use serde_json::Value;
 
 use super::PromptValidationReportEntry;
@@ -54,9 +55,10 @@ impl PromptCompletionEvidence {
 /// transition tables have had their requirements stripped too, so minting Done
 /// without evidence is consistent rather than a hole.
 pub(super) fn prompt_completion_evidence(
+    registry: &WorkflowDefinitionRegistry,
     result: &ActivityResult,
 ) -> Result<Option<PromptCompletionEvidence>, String> {
-    if !enforced() {
+    if !enforced(registry) {
         return Ok(None);
     }
     resolve_completion_evidence(result).map(Some)
@@ -64,8 +66,9 @@ pub(super) fn prompt_completion_evidence(
 
 /// The transition table is the authority: if it no longer demands the kind,
 /// the operator lifted the contract and the reducer must not block on it.
-fn enforced() -> bool {
-    transition_requires_evidence(
+fn enforced(registry: &WorkflowDefinitionRegistry) -> bool {
+    transition_evidence_enforced_with_registry(
+        registry,
         PROMPT_TASK_DEFINITION_ID,
         "implementing",
         "done",

--- a/crates/harness-workflow/src/runtime/state_registry.rs
+++ b/crates/harness-workflow/src/runtime/state_registry.rs
@@ -9,15 +9,13 @@ use super::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::Arc;
 
 mod builtins;
 mod evidence_policy;
 mod versioning;
 
 use self::builtins::{builtin_definitions, builtin_registered_definitions};
-
-pub use evidence_policy::{apply_builtin_evidence_enforcement, transition_requires_evidence};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeclarativeDefinitionPinError {
@@ -156,7 +154,7 @@ impl WorkflowDefinitionRegistry {
         }
     }
 
-    fn with_builtins() -> Self {
+    pub fn with_builtins() -> Self {
         let mut registry = Self::new();
         if let Err(error) = registry.register_declarative_current_batch(builtin_definitions()) {
             panic!("built-in workflow definitions must be unique and valid: {error}");
@@ -241,6 +239,13 @@ impl WorkflowDefinitionRegistry {
         self.frozen
     }
 
+    /// Freeze this registry and return the immutable handle shared by a
+    /// workflow runtime. Runtime lookups never acquire a blocking lock.
+    pub fn into_shared(mut self) -> Arc<Self> {
+        self.freeze();
+        Arc::new(self)
+    }
+
     pub fn definition(&self, definition_id: &str) -> Option<Arc<RegisteredWorkflowDefinition>> {
         self.definitions.get(definition_id).cloned()
     }
@@ -250,7 +255,11 @@ impl WorkflowDefinitionRegistry {
         definition_id: &str,
     ) -> Option<DecisionValidator> {
         self.definition(definition_id).map(|definition| {
-            DecisionValidator::for_definition(definition_id, definition.allowlist.clone())
+            DecisionValidator::for_definition(
+                definition_id,
+                definition.allowlist.clone(),
+                definition.states.clone(),
+            )
         })
     }
 
@@ -271,6 +280,7 @@ impl WorkflowDefinitionRegistry {
                     definition.definition_version(),
                     definition.definition_hash(),
                     definition.registered().allowlist.clone(),
+                    definition.registered().states.clone(),
                 )))
             }
             DeclarativeDefinitionResolution::PinError(error) => Err(error),
@@ -284,7 +294,113 @@ impl WorkflowDefinitionRegistry {
         self.definition_ids.clone()
     }
 
-    fn terminal_state_selectors(&self, definition_id: &str) -> Vec<WorkflowTerminalStateSelector> {
+    pub fn declarative_definition_for_instance(
+        &self,
+        instance: &WorkflowInstance,
+    ) -> Option<Arc<DeclarativeWorkflowDefinition>> {
+        match self.resolve_declarative_definition(instance) {
+            DeclarativeDefinitionResolution::Resolved(definition) => Some(definition),
+            DeclarativeDefinitionResolution::NotDeclarative
+            | DeclarativeDefinitionResolution::PinError(_) => None,
+        }
+    }
+
+    pub fn instance_is_declarative(&self, instance: &WorkflowInstance) -> bool {
+        !matches!(
+            self.resolve_declarative_definition(instance),
+            DeclarativeDefinitionResolution::NotDeclarative
+        )
+    }
+
+    pub fn states_for_definition(&self, definition_id: &str) -> Vec<WorkflowStateDefinition> {
+        self.definition(definition_id)
+            .map(|definition| definition.states.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn terminal_state_names_for_definition(&self, definition_id: &str) -> Vec<String> {
+        self.definition(definition_id)
+            .map(|definition| {
+                definition
+                    .states
+                    .iter()
+                    .filter(|state| state.terminal_state.is_some())
+                    .map(|state| state.key.state.to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn state_definition(
+        &self,
+        definition_id: &str,
+        state: &str,
+    ) -> Option<WorkflowStateDefinition> {
+        self.definition(definition_id).and_then(|definition| {
+            definition
+                .states
+                .iter()
+                .find(|definition| definition.key.state.as_ref() == state)
+                .cloned()
+        })
+    }
+
+    pub fn state_exists(&self, definition_id: &str, state: &str) -> bool {
+        self.state_definition(definition_id, state).is_some()
+    }
+
+    pub fn state_terminal_state(
+        &self,
+        definition_id: &str,
+        state: &str,
+    ) -> Option<WorkflowTerminalState> {
+        self.state_definition(definition_id, state)?.terminal_state
+    }
+
+    pub fn state_progress_mode(
+        &self,
+        definition_id: &str,
+        state: &str,
+    ) -> Option<WorkflowProgressMode> {
+        self.state_definition(definition_id, state)?.progress_mode
+    }
+
+    pub fn state_progress_mode_for_version(
+        &self,
+        definition_id: &str,
+        definition_version: u32,
+        state: &str,
+    ) -> Option<WorkflowProgressMode> {
+        self.state_definition_for_version(definition_id, definition_version, state)?
+            .progress_mode
+    }
+
+    pub fn state_terminal_state_for_version(
+        &self,
+        definition_id: &str,
+        definition_version: u32,
+        state: &str,
+    ) -> Option<WorkflowTerminalState> {
+        self.state_definition_for_version(definition_id, definition_version, state)?
+            .terminal_state
+    }
+
+    pub fn terminal_state_for_instance(
+        &self,
+        instance: &WorkflowInstance,
+    ) -> Option<WorkflowTerminalState> {
+        self.state_definition_for_instance(instance, &instance.state)?
+            .terminal_state
+    }
+
+    pub fn instance_is_terminal(&self, instance: &WorkflowInstance) -> bool {
+        self.terminal_state_for_instance(instance).is_some()
+    }
+
+    pub(super) fn terminal_state_selectors(
+        &self,
+        definition_id: &str,
+    ) -> Vec<WorkflowTerminalStateSelector> {
         if is_builtin_definition_id(definition_id) {
             if let Some(definition) = self.definition(definition_id) {
                 return definition
@@ -336,7 +452,7 @@ impl WorkflowDefinitionRegistry {
         selectors
     }
 
-    fn progress_state_selectors(
+    pub(super) fn progress_state_selectors(
         &self,
         definition_id: &str,
         progress_mode: WorkflowProgressMode,
@@ -400,237 +516,6 @@ impl Default for WorkflowDefinitionRegistry {
     fn default() -> Self {
         Self::new()
     }
-}
-
-static REGISTRY: OnceLock<RwLock<WorkflowDefinitionRegistry>> = OnceLock::new();
-
-fn registry() -> &'static RwLock<WorkflowDefinitionRegistry> {
-    REGISTRY.get_or_init(|| RwLock::new(WorkflowDefinitionRegistry::with_builtins()))
-}
-
-pub fn register_workflow_definition(
-    definition: RegisteredWorkflowDefinition,
-) -> anyhow::Result<()> {
-    registry()
-        .write()
-        .expect("workflow definition registry lock poisoned")
-        .register(definition)
-}
-
-pub fn register_declarative_workflow_definitions(
-    definitions: impl IntoIterator<Item = DeclarativeWorkflowDefinition>,
-) -> anyhow::Result<()> {
-    registry()
-        .write()
-        .expect("workflow definition registry lock poisoned")
-        .register_declarative_current_batch(definitions)
-}
-
-pub fn register_historical_declarative_workflow_definitions(
-    definitions: impl IntoIterator<Item = DeclarativeWorkflowDefinition>,
-) -> anyhow::Result<()> {
-    registry()
-        .write()
-        .expect("workflow definition registry lock poisoned")
-        .register_declarative_historical_batch(definitions)
-}
-
-pub fn freeze_workflow_definition_registry() {
-    registry()
-        .write()
-        .expect("workflow definition registry lock poisoned")
-        .freeze();
-}
-
-pub fn workflow_definition(definition_id: &str) -> Option<Arc<RegisteredWorkflowDefinition>> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .definition(definition_id)
-}
-
-pub fn workflow_declarative_definition(
-    definition_id: &str,
-    definition_version: u32,
-) -> Option<Arc<DeclarativeWorkflowDefinition>> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .declarative_definition(definition_id, definition_version)
-}
-
-pub fn current_declarative_workflow_definition(
-    definition_id: &str,
-) -> Option<Arc<DeclarativeWorkflowDefinition>> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .current_declarative_definition(definition_id)
-}
-
-pub fn declarative_workflow_definition_for_instance(
-    instance: &WorkflowInstance,
-) -> Option<Arc<DeclarativeWorkflowDefinition>> {
-    match resolve_declarative_definition(instance) {
-        DeclarativeDefinitionResolution::Resolved(definition) => Some(definition),
-        DeclarativeDefinitionResolution::NotDeclarative
-        | DeclarativeDefinitionResolution::PinError(_) => None,
-    }
-}
-
-pub fn workflow_instance_is_declarative(instance: &WorkflowInstance) -> bool {
-    !matches!(
-        resolve_declarative_definition(instance),
-        DeclarativeDefinitionResolution::NotDeclarative
-    )
-}
-
-pub fn workflow_definition_for_version(
-    definition_id: &str,
-    definition_version: u32,
-) -> Option<Arc<RegisteredWorkflowDefinition>> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .definition_for_version(definition_id, definition_version)
-}
-
-pub fn decision_validator_for_definition(definition_id: &str) -> Option<DecisionValidator> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .decision_validator_for_definition(definition_id)
-}
-
-pub fn resolve_declarative_definition(
-    instance: &WorkflowInstance,
-) -> DeclarativeDefinitionResolution {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .resolve_declarative_definition(instance)
-}
-
-pub fn decision_validator_for_instance(
-    instance: &WorkflowInstance,
-) -> Result<Option<DecisionValidator>, DeclarativeDefinitionPinError> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .decision_validator_for_instance(instance)
-}
-
-pub fn known_workflow_definition_ids() -> Vec<String> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .known_definition_ids()
-}
-
-pub fn workflow_states_for_definition(definition_id: &str) -> Vec<WorkflowStateDefinition> {
-    workflow_definition(definition_id)
-        .map(|definition| definition.states.clone())
-        .unwrap_or_default()
-}
-
-pub fn workflow_terminal_state_names_for_definition(definition_id: &str) -> Vec<String> {
-    workflow_definition(definition_id)
-        .map(|definition| {
-            definition
-                .states
-                .iter()
-                .filter(|state| state.terminal_state.is_some())
-                .map(|state| state.key.state.to_string())
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-pub(super) fn workflow_terminal_state_selectors_for_definition(
-    definition_id: &str,
-) -> Vec<WorkflowTerminalStateSelector> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .terminal_state_selectors(definition_id)
-}
-
-pub(super) fn workflow_progress_state_selectors_for_definition(
-    definition_id: &str,
-    progress_mode: WorkflowProgressMode,
-) -> Vec<WorkflowProgressStateSelector> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .progress_state_selectors(definition_id, progress_mode)
-}
-
-pub fn workflow_state_definition(
-    definition_id: &str,
-    state: &str,
-) -> Option<WorkflowStateDefinition> {
-    workflow_definition(definition_id).and_then(|definition| {
-        definition
-            .states
-            .iter()
-            .find(|definition| definition.key.state.as_ref() == state)
-            .cloned()
-    })
-}
-
-pub fn workflow_state_definition_for_version(
-    definition_id: &str,
-    definition_version: u32,
-    state: &str,
-) -> Option<WorkflowStateDefinition> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .state_definition_for_version(definition_id, definition_version, state)
-}
-
-pub fn workflow_state_definition_for_instance(
-    instance: &WorkflowInstance,
-    state: &str,
-) -> Option<WorkflowStateDefinition> {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .state_definition_for_instance(instance, state)
-}
-
-pub fn workflow_state_exists(definition_id: &str, state: &str) -> bool {
-    workflow_state_definition(definition_id, state).is_some()
-}
-
-pub fn workflow_state_terminal_state(
-    definition_id: &str,
-    state: &str,
-) -> Option<WorkflowTerminalState> {
-    workflow_state_definition(definition_id, state)?.terminal_state
-}
-
-pub fn workflow_state_progress_mode(
-    definition_id: &str,
-    state: &str,
-) -> Option<WorkflowProgressMode> {
-    workflow_state_definition(definition_id, state)?.progress_mode
-}
-
-pub fn workflow_state_progress_mode_for_version(
-    definition_id: &str,
-    definition_version: u32,
-    state: &str,
-) -> Option<WorkflowProgressMode> {
-    workflow_state_definition_for_version(definition_id, definition_version, state)?.progress_mode
-}
-
-pub fn workflow_state_terminal_state_for_version(
-    definition_id: &str,
-    definition_version: u32,
-    state: &str,
-) -> Option<WorkflowTerminalState> {
-    workflow_state_definition_for_version(definition_id, definition_version, state)?.terminal_state
 }
 
 fn is_builtin_definition_id(definition_id: &str) -> bool {

--- a/crates/harness-workflow/src/runtime/state_registry/builtins.rs
+++ b/crates/harness-workflow/src/runtime/state_registry/builtins.rs
@@ -370,7 +370,7 @@ fn activity_policies(
 
 #[cfg(test)]
 mod tests {
-    use super::super::registry;
+    use super::super::WorkflowDefinitionRegistry;
     use crate::runtime::WorkflowCommandType;
     use std::collections::BTreeSet;
 
@@ -492,9 +492,7 @@ mod tests {
 
     #[test]
     fn github_issue_pr_builtin_preserves_the_transition_contract() {
-        let definition = registry()
-            .read()
-            .expect("workflow definition registry lock poisoned")
+        let definition = WorkflowDefinitionRegistry::with_builtins()
             .definition(crate::runtime::GITHUB_ISSUE_PR_DEFINITION_ID)
             .expect("github_issue_pr built-in must be registered");
         let derived: Vec<(Option<String>, String, BTreeSet<WorkflowCommandType>)> = definition

--- a/crates/harness-workflow/src/runtime/state_registry/evidence_policy.rs
+++ b/crates/harness-workflow/src/runtime/state_registry/evidence_policy.rs
@@ -8,38 +8,8 @@
 //! rollback if agents have not yet caught up with the contract.
 
 use super::{
-    builtin_registered_definitions, registry, RegisteredWorkflowDefinition,
-    WorkflowDefinitionRegistry,
+    builtin_registered_definitions, RegisteredWorkflowDefinition, WorkflowDefinitionRegistry,
 };
-
-/// Apply the completion-evidence enforcement policy to the process-wide
-/// registry's built-in definitions. Must run before the registry is frozen.
-pub fn apply_builtin_evidence_enforcement(enforced: bool) -> anyhow::Result<()> {
-    registry()
-        .write()
-        .expect("workflow definition registry lock poisoned")
-        .apply_builtin_evidence_enforcement(enforced)
-}
-
-/// Whether the registered definition still demands `evidence_kind` for this
-/// transition.
-///
-/// Reducers refuse to build a claim-only terminal decision in the first place,
-/// so that the agent gets a precise reason instead of a bare rejection. They
-/// ask this rather than tracking enforcement separately: the transition table
-/// is the single authority, so the kill switch that strips a requirement lifts
-/// the reducer gate with it, and the two layers cannot drift apart.
-pub fn transition_requires_evidence(
-    definition_id: &str,
-    from_state: &str,
-    to_state: &str,
-    evidence_kind: &str,
-) -> bool {
-    registry()
-        .read()
-        .expect("workflow definition registry lock poisoned")
-        .transition_requires_evidence(definition_id, from_state, to_state, evidence_kind)
-}
 
 impl WorkflowDefinitionRegistry {
     /// Whether `definition_id`'s rule for this transition declares
@@ -104,8 +74,9 @@ impl WorkflowDefinitionRegistry {
 mod tests {
     use super::super::{builtin_registered_definitions, WorkflowDefinitionRegistry};
     use crate::runtime::{
-        ValidationContext, WorkflowCommand, WorkflowCommandType, WorkflowDecision,
-        WorkflowDecisionRejectionKind, WorkflowInstance, WorkflowSubject,
+        reduce_runtime_job_completed_with_registry, ActivityResult, ValidationContext,
+        WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowDecisionRejectionKind,
+        WorkflowEvent, WorkflowInstance, WorkflowSubject, RUNTIME_JOB_COMPLETED_EVENT,
     };
     use chrono::Utc;
     use serde_json::json;
@@ -179,6 +150,42 @@ mod tests {
             "done",
             crate::runtime::model::EVIDENCE_PROMPT_COMPLETION,
         ));
+    }
+
+    #[test]
+    fn injected_policy_lifts_prompt_reducer_and_validator_together() {
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+        registry
+            .apply_builtin_evidence_enforcement(false)
+            .expect("test policy should apply");
+        let instance = WorkflowInstance::new(
+            "prompt_task",
+            1,
+            "implementing",
+            WorkflowSubject::new("prompt", "task-no-evidence"),
+        );
+        let event = WorkflowEvent::new(&instance.id, 1, RUNTIME_JOB_COMPLETED_EVENT, "runtime")
+            .with_payload(json!({
+                "activity_result": ActivityResult::succeeded(
+                    "implement_prompt",
+                    "completed without a validation artifact",
+                )
+            }));
+
+        let decision = reduce_runtime_job_completed_with_registry(&registry, &instance, &event)
+            .expect("completion should reduce")
+            .expect("completion should produce a decision");
+        assert_eq!(decision.next_state, "done");
+        registry
+            .decision_validator_for_instance(&instance)
+            .expect("built-in pin should resolve")
+            .expect("prompt validator should exist")
+            .validate(
+                &instance,
+                &decision,
+                &ValidationContext::new("runtime", Utc::now()),
+            )
+            .expect("disabled policy should accept the reducer decision");
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -93,12 +93,14 @@ mod transaction_helpers;
 mod transition_validation;
 pub use child_instance_start::{WorkflowChildStart, WorkflowChildStartOutcome};
 pub use command_facade::DispatchPoolSnapshot;
+pub(in crate::runtime) use command_store::terminal_command_status;
 pub use coverage_recovery::{
     WorkflowCoverageRecoveryExpected, WorkflowCoverageRecoveryOutcome,
     WorkflowCoverageRecoveryTransition,
 };
 pub(in crate::runtime) use decision_provenance::insert_decision_record_once_tx;
 pub use decision_provenance::DecisionProvenanceConflict;
+pub(in crate::runtime) use definitions::terminal_state_for_instance_tx;
 pub use driverless_progress::{DriverlessProgressInstance, DriverlessProgressProvenanceStatus};
 pub use evidence::{
     WorkflowRunEvidence, WorkflowRunEvidenceExport, WorkflowRunEvidenceInput,

--- a/crates/harness-workflow/src/runtime/store.rs
+++ b/crates/harness-workflow/src/runtime/store.rs
@@ -10,6 +10,7 @@ use super::model::{
 use super::status::WorkflowCommandStatus;
 use super::store_migrations::WORKFLOW_RUNTIME_MIGRATIONS;
 use super::transcript::PendingRuntimeTranscript;
+use super::WorkflowDefinitionRegistry;
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 use harness_core::config::workflow::{RuntimeBudgetEnforcement, RuntimeBudgetPolicy};
@@ -19,6 +20,7 @@ use serde_json::{json, Value};
 use sqlx::postgres::PgPool;
 use std::collections::BTreeMap;
 use std::path::Path;
+use std::sync::Arc;
 
 #[path = "store/activity_completion.rs"]
 mod activity_completion;
@@ -52,6 +54,8 @@ mod evidence;
 mod instance_helpers;
 #[path = "store/instances.rs"]
 mod instances;
+#[path = "store/instances_retention.rs"]
+mod instances_retention;
 #[path = "store/lock_order.rs"]
 mod lock_order;
 #[path = "store/lock_order_tests.rs"]
@@ -132,6 +136,7 @@ pub(super) use transaction_helpers::{enum_str, insert_event_tx, to_jsonb_string}
 #[derive(Clone)]
 pub struct WorkflowRuntimeStore {
     pub(super) pool: PgPool,
+    pub(super) definition_registry: Arc<WorkflowDefinitionRegistry>,
     /// Hard workflow budget ceiling policy (GH-1770 spec §4.4), applied when a
     /// completed activity commits its decision. Defaults to shadow enforcement
     /// so a store opened without explicit wiring only records decisions.
@@ -189,6 +194,8 @@ pub struct WorkflowSubmissionHourlyDone {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkflowRuntimeStateCount {
     pub definition_id: String,
+    pub definition_version: u32,
+    pub definition_hash: Option<String>,
     pub state: String,
     pub count: usize,
 }
@@ -330,6 +337,7 @@ impl WorkflowRuntimeStore {
             .await?;
         Ok(Self {
             pool,
+            definition_registry: WorkflowDefinitionRegistry::with_builtins().into_shared(),
             budget_policy: RuntimeBudgetPolicy::default(),
         })
     }
@@ -343,6 +351,7 @@ impl WorkflowRuntimeStore {
             .await?;
         Ok(Self {
             pool,
+            definition_registry: WorkflowDefinitionRegistry::with_builtins().into_shared(),
             budget_policy: RuntimeBudgetPolicy::default(),
         })
     }
@@ -355,6 +364,7 @@ impl WorkflowRuntimeStore {
             .await?;
         Ok(Self {
             pool,
+            definition_registry: WorkflowDefinitionRegistry::with_builtins().into_shared(),
             budget_policy: RuntimeBudgetPolicy::default(),
         })
     }
@@ -368,6 +378,7 @@ impl WorkflowRuntimeStore {
         .await?;
         Ok(Self {
             pool,
+            definition_registry: WorkflowDefinitionRegistry::with_builtins().into_shared(),
             budget_policy: RuntimeBudgetPolicy::default(),
         })
     }
@@ -376,6 +387,19 @@ impl WorkflowRuntimeStore {
     pub fn with_budget_policy(mut self, budget_policy: RuntimeBudgetPolicy) -> Self {
         self.budget_policy = budget_policy;
         self
+    }
+    /// Inject the immutable definition universe used by this runtime store.
+    /// The handle is built and frozen during startup, before the store is
+    /// shared with workers.
+    pub fn with_definition_registry(
+        mut self,
+        definition_registry: Arc<WorkflowDefinitionRegistry>,
+    ) -> Self {
+        self.definition_registry = definition_registry;
+        self
+    }
+    pub fn definition_registry(&self) -> &WorkflowDefinitionRegistry {
+        &self.definition_registry
     }
     /// The wired budget policy, so mid-turn enforcement (the GH-1770 §4.3
     /// turn-stream watchdog) applies the same ceiling as the dispatch gate and

--- a/crates/harness-workflow/src/runtime/store/activity_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/activity_completion.rs
@@ -346,6 +346,7 @@ impl WorkflowRuntimeStore {
 
         let decision_record = runtime_completion::apply_runtime_completion_decision_tx(
             &mut tx,
+            &self.definition_registry,
             &command.workflow_id,
             owner,
             &event,

--- a/crates/harness-workflow/src/runtime/store/commands.rs
+++ b/crates/harness-workflow/src/runtime/store/commands.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::runtime::{
     DispatchClaim, RuntimeJob, RuntimeKind, WorkflowCommand, WorkflowCommandStatus,
-    WorkflowInstance,
+    WorkflowDefinitionRegistry,
 };
 use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
@@ -79,7 +79,9 @@ impl WorkflowRuntimeStore {
             tx.rollback().await?;
             return Ok(ClaimedCommandTerminalOutcome::StaleClaim);
         }
-        let Some(workflow) = workflow.filter(WorkflowInstance::is_terminal) else {
+        let Some(workflow) = workflow
+            .filter(|workflow| workflow.is_terminal_with_registry(&self.definition_registry))
+        else {
             tx.rollback().await?;
             return Ok(ClaimedCommandTerminalOutcome::NotTerminal);
         };
@@ -170,6 +172,7 @@ pub(super) async fn insert_or_reactivate_cancelled_tx(
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn enqueue_runtime_job_for_command(
     pool: &PgPool,
+    definition_registry: &WorkflowDefinitionRegistry,
     command_id: &str,
     dispatch_claim: Option<DispatchClaim<'_>>,
     runtime_kind: RuntimeKind,
@@ -233,7 +236,10 @@ pub(super) async fn enqueue_runtime_job_for_command(
             tx.rollback().await?;
             return Ok(RuntimeJobEnqueueOutcome::StaleClaim);
         }
-        if let Some(workflow) = workflow.as_ref().filter(|workflow| workflow.is_terminal()) {
+        if let Some(workflow) = workflow
+            .as_ref()
+            .filter(|workflow| workflow.is_terminal_with_registry(definition_registry))
+        {
             let terminal_status = if workflow.state == "cancelled" {
                 WorkflowCommandStatus::Cancelled
             } else {

--- a/crates/harness-workflow/src/runtime/store/commands.rs
+++ b/crates/harness-workflow/src/runtime/store/commands.rs
@@ -1,11 +1,12 @@
 use super::{
     command_attempts::{insert_command_attempt_tx, AttemptReplacement},
+    definitions::terminal_state_for_instance_tx,
     enum_str, runtime_job_for_command_tx, to_jsonb_string, workflow_instance_from_persisted_json,
     ClaimedCommandTerminalOutcome, RuntimeJobEnqueueOutcome, WorkflowRuntimeStore,
 };
 use crate::runtime::{
     DispatchClaim, RuntimeJob, RuntimeKind, WorkflowCommand, WorkflowCommandStatus,
-    WorkflowDefinitionRegistry,
+    WorkflowDefinitionRegistry, WorkflowTerminalState,
 };
 use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
@@ -79,17 +80,17 @@ impl WorkflowRuntimeStore {
             tx.rollback().await?;
             return Ok(ClaimedCommandTerminalOutcome::StaleClaim);
         }
-        let Some(workflow) = workflow
-            .filter(|workflow| workflow.is_terminal_with_registry(&self.definition_registry))
+        let Some(workflow) = workflow else {
+            tx.rollback().await?;
+            return Ok(ClaimedCommandTerminalOutcome::NotTerminal);
+        };
+        let Some(terminal_state) =
+            terminal_state_for_instance_tx(&mut tx, &self.definition_registry, &workflow).await?
         else {
             tx.rollback().await?;
             return Ok(ClaimedCommandTerminalOutcome::NotTerminal);
         };
-        let terminal_status = if workflow.state == "cancelled" {
-            WorkflowCommandStatus::Cancelled
-        } else {
-            WorkflowCommandStatus::Skipped
-        };
+        let terminal_status = terminal_command_status(terminal_state);
         let result = sqlx::query(
             "UPDATE workflow_commands
              SET status = $2, dispatch_owner = NULL,
@@ -236,15 +237,13 @@ pub(super) async fn enqueue_runtime_job_for_command(
             tx.rollback().await?;
             return Ok(RuntimeJobEnqueueOutcome::StaleClaim);
         }
-        if let Some(workflow) = workflow
-            .as_ref()
-            .filter(|workflow| workflow.is_terminal_with_registry(definition_registry))
-        {
-            let terminal_status = if workflow.state == "cancelled" {
-                WorkflowCommandStatus::Cancelled
-            } else {
-                WorkflowCommandStatus::Skipped
-            };
+        if let Some(terminal_state) = match workflow.as_ref() {
+            Some(workflow) => {
+                terminal_state_for_instance_tx(&mut tx, definition_registry, workflow).await?
+            }
+            None => None,
+        } {
+            let terminal_status = terminal_command_status(terminal_state);
             sqlx::query(
                 "UPDATE workflow_commands SET status = $2, dispatch_owner = NULL,
                     dispatch_lease_expires_at = NULL, dispatch_not_before = NULL,
@@ -352,6 +351,17 @@ pub(super) async fn enqueue_runtime_job_for_command(
     }
     tx.commit().await?;
     Ok(RuntimeJobEnqueueOutcome::Enqueued(job))
+}
+
+pub(in crate::runtime) fn terminal_command_status(
+    terminal_state: WorkflowTerminalState,
+) -> WorkflowCommandStatus {
+    match terminal_state {
+        WorkflowTerminalState::Cancelled => WorkflowCommandStatus::Cancelled,
+        WorkflowTerminalState::Succeeded | WorkflowTerminalState::Failed => {
+            WorkflowCommandStatus::Skipped
+        }
+    }
 }
 
 fn exact_dispatch_claim(job: &RuntimeJob, owner: &str, generation: u64) -> bool {

--- a/crates/harness-workflow/src/runtime/store/coverage_recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/coverage_recovery.rs
@@ -147,6 +147,7 @@ impl WorkflowRuntimeStore {
         let validation_context =
             ValidationContext::new("reconciliation", chrono::Utc::now()).allow_terminal_reopen();
         match validate_transition_with_context(
+            &self.definition_registry,
             &validation_current,
             transition.decision,
             &validation_context,
@@ -158,7 +159,12 @@ impl WorkflowRuntimeStore {
             }
         }
         if current.is_none()
-            && !insert_validated_observed_instance_tx(&mut tx, &validation_current).await?
+            && !insert_validated_observed_instance_tx(
+                &mut tx,
+                &self.definition_registry,
+                &validation_current,
+            )
+            .await?
         {
             anyhow::bail!("coverage recovery lost its advisory-locked absent insert");
         }

--- a/crates/harness-workflow/src/runtime/store/decision_transitions.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions.rs
@@ -79,7 +79,13 @@ impl WorkflowRuntimeStore {
         validation_actor: &str,
     ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
         self.apply_decision_transition_inner(transition, |current, decision, event| {
-            validate_transition(current, decision, validation_actor, event.created_at)
+            validate_transition(
+                &self.definition_registry,
+                current,
+                decision,
+                validation_actor,
+                event.created_at,
+            )
         })
         .await
     }
@@ -144,6 +150,7 @@ impl WorkflowRuntimeStore {
         let mut tx = self.pool.begin().await?;
         let Some(current) = load_or_insert_initial_instance_tx(
             &mut tx,
+            &self.definition_registry,
             &final_instance.id,
             transition.expected_state,
             transition.create_if_missing,
@@ -152,7 +159,9 @@ impl WorkflowRuntimeStore {
         else {
             return Ok(None);
         };
-        if current.is_terminal() || current.state != transition.expected_state {
+        if current.is_terminal_with_registry(&self.definition_registry)
+            || current.state != transition.expected_state
+        {
             return Ok(None);
         }
         if current.version.checked_add(1) != Some(final_instance.version) {
@@ -219,6 +228,7 @@ impl WorkflowRuntimeStore {
         let mut tx = self.pool.begin().await?;
         let Some(current) = load_or_insert_initial_instance_tx(
             &mut tx,
+            &self.definition_registry,
             &decision.workflow_id,
             transition.expected_state,
             transition.create_if_missing,
@@ -227,7 +237,9 @@ impl WorkflowRuntimeStore {
         else {
             return Ok(None);
         };
-        if current.is_terminal() || current.state != transition.expected_state {
+        if current.is_terminal_with_registry(&self.definition_registry)
+            || current.state != transition.expected_state
+        {
             return Ok(None);
         }
 
@@ -255,7 +267,11 @@ mod tests;
 #[cfg(test)]
 mod submission_guard_tests {
     use super::*;
-    use crate::runtime::{WorkflowCommand, WorkflowSubject, WorkflowSubmissionDecisionTransition};
+    use crate::runtime::{
+        RegisteredWorkflowDefinition, TransitionAllowlist, WorkflowCommand,
+        WorkflowDefinitionRegistry, WorkflowProgressMode, WorkflowStateDefinition, WorkflowSubject,
+        WorkflowSubmissionDecisionTransition, WorkflowTerminalState,
+    };
     use harness_core::db::resolve_database_url;
     use serde_json::json;
 
@@ -480,6 +496,79 @@ mod submission_guard_tests {
             assert!(store.decisions_for(&initial.id).await?.is_empty());
             assert!(store.commands_for(&initial.id).await?.is_empty());
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejected_new_submission_uses_injected_failed_terminal_state() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+        let definition_id = "submission_rejection_injected_registry";
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+        registry.register(RegisteredWorkflowDefinition::new(
+            definition_id,
+            vec![
+                WorkflowStateDefinition::active(
+                    definition_id,
+                    "queued",
+                    WorkflowProgressMode::ExternalWait,
+                ),
+                WorkflowStateDefinition::terminal(
+                    definition_id,
+                    "denied",
+                    WorkflowTerminalState::Failed,
+                ),
+            ],
+            TransitionAllowlist::default(),
+        ))?;
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&dir.path().join("runtime"))
+            .await?
+            .with_definition_registry(registry.into_shared());
+        let initial = WorkflowInstance::new(
+            definition_id,
+            1,
+            "queued",
+            WorkflowSubject::new("test", "injected-rejection"),
+        )
+        .with_id("injected-rejected-submission");
+        let decision = WorkflowDecision::new(
+            &initial.id,
+            "queued",
+            "reject_submission",
+            "denied",
+            "submission policy rejected the request",
+        );
+        let mut final_instance = initial.clone();
+        final_instance.state = "denied".to_string();
+        final_instance.version = 1;
+
+        let outcome = store
+            .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
+                workflow_id: &initial.id,
+                expected_state: &initial.state,
+                expected_version: initial.version,
+                create_if_missing: Some(&initial),
+                event_id: None,
+                new_event_id: Some("injected-rejected-submission-event"),
+                event_type: "SubmissionRejected",
+                source: "workflow-runtime-test",
+                payload: json!({}),
+                decision: &decision,
+                existing_record: None,
+                rejection_reason: Some("rejected by policy"),
+                final_instance: Some(&final_instance),
+                command_status: WorkflowCommandStatus::Pending,
+                prompt_payload: None,
+            })
+            .await?
+            .expect("rejected submission should be committed atomically");
+
+        assert!(!outcome.record.accepted);
+        assert_eq!(store.get_instance(&initial.id).await?, Some(final_instance));
+        assert_eq!(store.events_for(&initial.id).await?.len(), 1);
+        assert_eq!(store.decisions_for(&initial.id).await?.len(), 1);
         Ok(())
     }
 }

--- a/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
@@ -458,7 +458,7 @@ async fn apply_decision_transition_with_validator_rejects_a_foreign_validator() 
     let cases = [
         (
             "another definition",
-            DecisionValidator::for_definition("prompt_task", permissive.clone()),
+            DecisionValidator::for_definition("prompt_task", permissive.clone(), Vec::new()),
         ),
         (
             "another version",
@@ -467,6 +467,7 @@ async fn apply_decision_transition_with_validator_rejects_a_foreign_validator() 
                 initial.definition_version.saturating_add(1),
                 &"a".repeat(64),
                 permissive.clone(),
+                Vec::new(),
             ),
         ),
         (
@@ -476,6 +477,7 @@ async fn apply_decision_transition_with_validator_rejects_a_foreign_validator() 
                 initial.definition_version,
                 &"a".repeat(64),
                 permissive.clone(),
+                Vec::new(),
             ),
         ),
         ("no definition", DecisionValidator::new(permissive.clone())),

--- a/crates/harness-workflow/src/runtime/store/definitions.rs
+++ b/crates/harness-workflow/src/runtime/store/definitions.rs
@@ -1,8 +1,11 @@
 use super::{to_jsonb_string, WorkflowRuntimeStore};
 use crate::runtime::declarative_pinning::hydrate_persisted_declarative_definition;
 use crate::runtime::declarative_pinning::DECLARATIVE_DEFINITION_METADATA_KIND;
-use crate::runtime::model::WorkflowDefinition;
-use crate::runtime::DeclarativeWorkflowDefinition;
+use crate::runtime::model::{WorkflowDefinition, WorkflowInstance};
+use crate::runtime::{
+    DeclarativeWorkflowDefinition, WorkflowDefinitionRegistry, WorkflowTerminalState,
+};
+use sqlx::{Postgres, Transaction};
 
 impl WorkflowRuntimeStore {
     pub async fn upsert_definition(&self, definition: &WorkflowDefinition) -> anyhow::Result<()> {
@@ -52,6 +55,22 @@ impl WorkflowRuntimeStore {
         row.map(|(data,)| serde_json::from_str(&data))
             .transpose()
             .map_err(Into::into)
+    }
+
+    pub async fn terminal_state_for_instance(
+        &self,
+        instance: &WorkflowInstance,
+    ) -> anyhow::Result<Option<WorkflowTerminalState>> {
+        if let Some(terminal_state) = self
+            .definition_registry
+            .terminal_state_for_instance(instance)
+        {
+            return Ok(Some(terminal_state));
+        }
+        let definition = self
+            .get_definition(&instance.definition_id, instance.definition_version)
+            .await?;
+        persisted_terminal_state(instance, definition.as_ref())
     }
 
     pub async fn persist_definition_version(
@@ -124,6 +143,66 @@ impl WorkflowRuntimeStore {
             .map(|definition| hydrate_persisted_declarative_definition(&definition))
             .collect()
     }
+}
+
+pub(in crate::runtime) async fn terminal_state_for_instance_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    registry: &WorkflowDefinitionRegistry,
+    instance: &WorkflowInstance,
+) -> anyhow::Result<Option<WorkflowTerminalState>> {
+    if let Some(terminal_state) = registry.terminal_state_for_instance(instance) {
+        return Ok(Some(terminal_state));
+    }
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT data::text FROM workflow_definitions
+         WHERE id = $1 AND version = $2",
+    )
+    .bind(&instance.definition_id)
+    .bind(i64::from(instance.definition_version))
+    .fetch_optional(&mut **tx)
+    .await?;
+    let definition = row
+        .map(|(data,)| serde_json::from_str::<WorkflowDefinition>(&data))
+        .transpose()?;
+    persisted_terminal_state(instance, definition.as_ref())
+}
+
+fn persisted_terminal_state(
+    instance: &WorkflowInstance,
+    definition: Option<&WorkflowDefinition>,
+) -> anyhow::Result<Option<WorkflowTerminalState>> {
+    let Some(definition) = definition.filter(|definition| is_declarative_definition(definition))
+    else {
+        return Ok(None);
+    };
+    let expected_hash = instance
+        .data
+        .get("definition_hash")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "declarative workflow '{}' is missing its pinned definition hash",
+                instance.id
+            )
+        })?;
+    if definition.id != instance.definition_id
+        || definition.version != instance.definition_version
+        || definition.definition_hash != expected_hash
+    {
+        anyhow::bail!(
+            "persisted declarative workflow definition '{}@{}' does not match workflow '{}' pin",
+            definition.id,
+            definition.version,
+            instance.id
+        );
+    }
+    let definition = hydrate_persisted_declarative_definition(definition)?;
+    Ok(definition
+        .registered()
+        .states
+        .iter()
+        .find(|state| state.key.state.as_ref() == instance.state)
+        .and_then(|state| state.terminal_state))
 }
 
 fn is_declarative_definition(definition: &WorkflowDefinition) -> bool {

--- a/crates/harness-workflow/src/runtime/store/driverless_progress.rs
+++ b/crates/harness-workflow/src/runtime/store/driverless_progress.rs
@@ -45,10 +45,24 @@ impl WorkflowRuntimeStore {
         &self,
         limit: i64,
     ) -> anyhow::Result<Vec<DriverlessProgressInstance>> {
-        let selectors = progress_state_selector_rows(
+        let mut selectors = progress_state_selector_rows(
             &self.definition_registry,
             WorkflowProgressMode::CommandDriven,
         );
+        for definition in self.list_persisted_declarative_definitions().await? {
+            for state in
+                definition.registered().states.iter().filter(|state| {
+                    state.progress_mode == Some(WorkflowProgressMode::CommandDriven)
+                })
+            {
+                selectors.insert(
+                    definition.registered().id.clone(),
+                    Some(i64::from(definition.definition_version())),
+                    Some(definition.definition_hash().to_string()),
+                    state.key.state.to_string(),
+                );
+            }
+        }
         if selectors.definition_ids.is_empty() {
             return Ok(Vec::new());
         }

--- a/crates/harness-workflow/src/runtime/store/driverless_progress.rs
+++ b/crates/harness-workflow/src/runtime/store/driverless_progress.rs
@@ -1,7 +1,5 @@
 use super::WorkflowRuntimeStore;
-use crate::runtime::state_registry::{
-    known_workflow_definition_ids, workflow_states_for_definition, WorkflowProgressMode,
-};
+use crate::runtime::{WorkflowDefinitionRegistry, WorkflowProgressMode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DriverlessProgressProvenanceStatus {
@@ -47,7 +45,7 @@ impl WorkflowRuntimeStore {
         &self,
         limit: i64,
     ) -> anyhow::Result<Vec<DriverlessProgressInstance>> {
-        let (definition_ids, states) = command_driven_state_pairs();
+        let (definition_ids, states) = command_driven_state_pairs(&self.definition_registry);
         if definition_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -179,11 +177,13 @@ impl WorkflowRuntimeStore {
     }
 }
 
-fn command_driven_state_pairs() -> (Vec<String>, Vec<String>) {
-    let pairs: Vec<(String, String)> = known_workflow_definition_ids()
+fn command_driven_state_pairs(registry: &WorkflowDefinitionRegistry) -> (Vec<String>, Vec<String>) {
+    let pairs: Vec<(String, String)> = registry
+        .known_definition_ids()
         .into_iter()
         .flat_map(|definition_id| {
-            workflow_states_for_definition(&definition_id)
+            registry
+                .states_for_definition(&definition_id)
                 .into_iter()
                 .filter(|state| state.progress_mode == Some(WorkflowProgressMode::CommandDriven))
                 .map(move |state| (definition_id.clone(), state.key.state.to_string()))

--- a/crates/harness-workflow/src/runtime/store/driverless_progress.rs
+++ b/crates/harness-workflow/src/runtime/store/driverless_progress.rs
@@ -1,5 +1,5 @@
-use super::WorkflowRuntimeStore;
-use crate::runtime::{WorkflowDefinitionRegistry, WorkflowProgressMode};
+use super::{instance_helpers::progress_state_selector_rows, WorkflowRuntimeStore};
+use crate::runtime::WorkflowProgressMode;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DriverlessProgressProvenanceStatus {
@@ -45,15 +45,20 @@ impl WorkflowRuntimeStore {
         &self,
         limit: i64,
     ) -> anyhow::Result<Vec<DriverlessProgressInstance>> {
-        let (definition_ids, states) = command_driven_state_pairs(&self.definition_registry);
-        if definition_ids.is_empty() {
+        let selectors = progress_state_selector_rows(
+            &self.definition_registry,
+            WorkflowProgressMode::CommandDriven,
+        );
+        if selectors.definition_ids.is_empty() {
             return Ok(Vec::new());
         }
 
         let limit = limit.clamp(1, 500);
         let rows: Vec<(String, String, String, i64, String)> = sqlx::query_as(
-            "WITH command_driven_states(definition_id, state) AS (
-                 SELECT * FROM unnest($1::text[], $2::text[])
+            "WITH command_driven_states(
+                     definition_id, definition_version, definition_hash, state
+                 ) AS (
+                 SELECT * FROM unnest($1::text[], $2::bigint[], $3::text[], $4::text[])
              ),
              candidates AS (
                  SELECT instance.id,
@@ -64,6 +69,16 @@ impl WorkflowRuntimeStore {
                  JOIN command_driven_states AS registered
                    ON registered.definition_id = instance.definition_id
                   AND registered.state = instance.state
+                  AND (
+                      (registered.definition_version IS NULL
+                       AND registered.definition_hash IS NULL)
+                      OR (
+                          registered.definition_version =
+                              (instance.data->>'definition_version')::bigint
+                          AND registered.definition_hash =
+                              instance.data->'data'->>'definition_hash'
+                      )
+                  )
              ),
              accepted_with_sequence AS (
                  SELECT decision.id AS decision_id,
@@ -151,10 +166,12 @@ impl WorkflowRuntimeStore {
                       )
                 )
              ORDER BY classified.updated_at ASC, classified.id ASC
-             LIMIT $3",
+             LIMIT $5",
         )
-        .bind(&definition_ids)
-        .bind(&states)
+        .bind(&selectors.definition_ids)
+        .bind(&selectors.definition_versions)
+        .bind(&selectors.definition_hashes)
+        .bind(&selectors.states)
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
@@ -175,19 +192,4 @@ impl WorkflowRuntimeStore {
             )
             .collect()
     }
-}
-
-fn command_driven_state_pairs(registry: &WorkflowDefinitionRegistry) -> (Vec<String>, Vec<String>) {
-    let pairs: Vec<(String, String)> = registry
-        .known_definition_ids()
-        .into_iter()
-        .flat_map(|definition_id| {
-            registry
-                .states_for_definition(&definition_id)
-                .into_iter()
-                .filter(|state| state.progress_mode == Some(WorkflowProgressMode::CommandDriven))
-                .map(move |state| (definition_id.clone(), state.key.state.to_string()))
-        })
-        .collect();
-    pairs.into_iter().unzip()
 }

--- a/crates/harness-workflow/src/runtime/store/instance_helpers.rs
+++ b/crates/harness-workflow/src/runtime/store/instance_helpers.rs
@@ -1,8 +1,4 @@
-use crate::runtime::state_registry::{
-    known_workflow_definition_ids, workflow_state_terminal_state,
-    workflow_terminal_state_names_for_definition,
-};
-use crate::runtime::{WorkflowOtelTraceContext, WorkflowTerminalState};
+use crate::runtime::{WorkflowDefinitionRegistry, WorkflowOtelTraceContext, WorkflowTerminalState};
 
 pub(super) fn otel_trace_context_from_data(
     data: &serde_json::Value,
@@ -13,31 +9,55 @@ pub(super) fn otel_trace_context_from_data(
     context.has_valid_trace_ids().then_some(context)
 }
 
-pub(super) fn terminal_state_pairs() -> (Vec<String>, Vec<String>) {
-    let mut definition_ids = Vec::new();
-    let mut states = Vec::new();
-    for definition_id in known_workflow_definition_ids() {
-        for state in workflow_terminal_state_names_for_definition(&definition_id) {
-            definition_ids.push(definition_id.clone());
-            states.push(state);
-        }
-    }
-    (definition_ids, states)
+pub(super) struct TerminalStateSelectorRows {
+    pub(super) definition_ids: Vec<String>,
+    pub(super) definition_versions: Vec<Option<i64>>,
+    pub(super) definition_hashes: Vec<Option<String>>,
+    pub(super) states: Vec<String>,
 }
 
-pub(super) fn terminal_task_status_rows() -> (Vec<String>, Vec<String>, Vec<String>) {
+pub(super) fn terminal_state_selector_rows(
+    registry: &WorkflowDefinitionRegistry,
+) -> TerminalStateSelectorRows {
+    let mut definition_ids = Vec::new();
+    let mut definition_versions = Vec::new();
+    let mut definition_hashes = Vec::new();
+    let mut states = Vec::new();
+    for definition_id in registry.known_definition_ids() {
+        for selector in registry.terminal_state_selectors(&definition_id) {
+            definition_ids.push(definition_id.clone());
+            definition_versions.push(selector.definition_version.map(i64::from));
+            definition_hashes.push(selector.definition_hash);
+            states.push(selector.state);
+        }
+    }
+    TerminalStateSelectorRows {
+        definition_ids,
+        definition_versions,
+        definition_hashes,
+        states,
+    }
+}
+
+pub(super) fn terminal_task_status_rows(
+    registry: &WorkflowDefinitionRegistry,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut definition_ids = Vec::new();
     let mut states = Vec::new();
     let mut task_statuses = Vec::new();
-    for definition_id in known_workflow_definition_ids() {
-        for state in workflow_terminal_state_names_for_definition(&definition_id) {
-            let Some(terminal_state) = workflow_state_terminal_state(&definition_id, &state) else {
+    for definition_id in registry.known_definition_ids() {
+        for selector in registry.terminal_state_selectors(&definition_id) {
+            // Declarative versions are joined through persisted definition
+            // metadata by the submission queries. Keeping them out of this
+            // unversioned CTE prevents current policy from overriding a
+            // historical pin that reused the same state name.
+            if selector.definition_version.is_some() || selector.definition_hash.is_some() {
                 continue;
-            };
+            }
             definition_ids.push(definition_id.clone());
-            states.push(state);
+            states.push(selector.state);
             task_statuses.push(
-                match terminal_state {
+                match selector.terminal_state {
                     WorkflowTerminalState::Succeeded => "done",
                     WorkflowTerminalState::Failed => "failed",
                     WorkflowTerminalState::Cancelled => "cancelled",
@@ -47,4 +67,76 @@ pub(super) fn terminal_task_status_rows() -> (Vec<String>, Vec<String>, Vec<Stri
         }
     }
     (definition_ids, states, task_statuses)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::build_declarative_definition;
+    use harness_core::config::workflow::{
+        DeclaredProgressMode, DeclaredState, WorkflowActivityPolicy, WorkflowDefinitionPolicy,
+    };
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn declarative_terminal_rows_preserve_version_and_hash() -> anyhow::Result<()> {
+        let definition_id = "terminal_selector_pin_fixture";
+        let definition = build_declarative_definition(
+            &WorkflowDefinitionPolicy {
+                id: definition_id.to_string(),
+                initial: "work".to_string(),
+                states: BTreeMap::from([
+                    (
+                        "work".to_string(),
+                        DeclaredState {
+                            activity: Some("run".to_string()),
+                            on_success: Some("done".to_string()),
+                            on_failure: Some("failed".to_string()),
+                            ..DeclaredState::default()
+                        },
+                    ),
+                    (
+                        "blocked".to_string(),
+                        DeclaredState {
+                            progress: Some(DeclaredProgressMode::OperatorGate),
+                            ..DeclaredState::default()
+                        },
+                    ),
+                ]),
+                terminal: BTreeMap::from([
+                    ("cancelled".to_string(), "cancelled".to_string()),
+                    ("done".to_string(), "succeeded".to_string()),
+                    ("failed".to_string(), "failed".to_string()),
+                ]),
+                evidence_required: BTreeMap::new(),
+                recovery_targets: Vec::new(),
+                intake: None,
+            },
+            &BTreeMap::from([("run".to_string(), WorkflowActivityPolicy::default())]),
+        )?;
+        let expected_version = i64::from(definition.definition_version());
+        let expected_hash = definition.definition_hash().to_string();
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+        registry.register_declarative_current(definition)?;
+
+        let rows = terminal_state_selector_rows(&registry);
+        let pinned_rows = rows
+            .definition_ids
+            .iter()
+            .zip(&rows.definition_versions)
+            .zip(&rows.definition_hashes)
+            .zip(&rows.states)
+            .filter(|(((id, _), _), _)| id.as_str() == definition_id)
+            .collect::<Vec<_>>();
+        assert_eq!(pinned_rows.len(), 3);
+        assert!(pinned_rows.iter().all(|(((id, version), hash), _)| {
+            id.as_str() == definition_id
+                && **version == Some(expected_version)
+                && hash.as_deref() == Some(expected_hash.as_str())
+        }));
+
+        let (unversioned_ids, _, _) = terminal_task_status_rows(&registry);
+        assert!(!unversioned_ids.iter().any(|id| id == definition_id));
+        Ok(())
+    }
 }

--- a/crates/harness-workflow/src/runtime/store/instance_helpers.rs
+++ b/crates/harness-workflow/src/runtime/store/instance_helpers.rs
@@ -23,28 +23,59 @@ pub(super) struct ProgressStateSelectorRows {
     pub(super) states: Vec<String>,
 }
 
+impl ProgressStateSelectorRows {
+    pub(super) fn insert(
+        &mut self,
+        definition_id: String,
+        definition_version: Option<i64>,
+        definition_hash: Option<String>,
+        state: String,
+    ) {
+        let duplicate = self
+            .definition_ids
+            .iter()
+            .zip(&self.definition_versions)
+            .zip(&self.definition_hashes)
+            .zip(&self.states)
+            .any(
+                |(((registered_id, registered_version), registered_hash), registered_state)| {
+                    registered_id == &definition_id
+                        && registered_version == &definition_version
+                        && registered_hash == &definition_hash
+                        && registered_state == &state
+                },
+            );
+        if duplicate {
+            return;
+        }
+        self.definition_ids.push(definition_id);
+        self.definition_versions.push(definition_version);
+        self.definition_hashes.push(definition_hash);
+        self.states.push(state);
+    }
+}
+
 pub(super) fn progress_state_selector_rows(
     registry: &WorkflowDefinitionRegistry,
     progress_mode: crate::runtime::WorkflowProgressMode,
 ) -> ProgressStateSelectorRows {
-    let mut definition_ids = Vec::new();
-    let mut definition_versions = Vec::new();
-    let mut definition_hashes = Vec::new();
-    let mut states = Vec::new();
+    let mut rows = ProgressStateSelectorRows {
+        definition_ids: Vec::new(),
+        definition_versions: Vec::new(),
+        definition_hashes: Vec::new(),
+        states: Vec::new(),
+    };
     for definition_id in registry.known_definition_ids() {
         for selector in registry.progress_state_selectors(&definition_id, progress_mode) {
-            definition_ids.push(definition_id.clone());
-            definition_versions.push(selector.definition_version.map(i64::from));
-            definition_hashes.push(selector.definition_hash);
-            states.push(selector.state);
+            rows.insert(
+                definition_id.clone(),
+                selector.definition_version.map(i64::from),
+                selector.definition_hash,
+                selector.state,
+            );
         }
     }
-    ProgressStateSelectorRows {
-        definition_ids,
-        definition_versions,
-        definition_hashes,
-        states,
-    }
+    rows
 }
 
 pub(super) fn terminal_state_selector_rows(

--- a/crates/harness-workflow/src/runtime/store/instance_helpers.rs
+++ b/crates/harness-workflow/src/runtime/store/instance_helpers.rs
@@ -16,6 +16,37 @@ pub(super) struct TerminalStateSelectorRows {
     pub(super) states: Vec<String>,
 }
 
+pub(super) struct ProgressStateSelectorRows {
+    pub(super) definition_ids: Vec<String>,
+    pub(super) definition_versions: Vec<Option<i64>>,
+    pub(super) definition_hashes: Vec<Option<String>>,
+    pub(super) states: Vec<String>,
+}
+
+pub(super) fn progress_state_selector_rows(
+    registry: &WorkflowDefinitionRegistry,
+    progress_mode: crate::runtime::WorkflowProgressMode,
+) -> ProgressStateSelectorRows {
+    let mut definition_ids = Vec::new();
+    let mut definition_versions = Vec::new();
+    let mut definition_hashes = Vec::new();
+    let mut states = Vec::new();
+    for definition_id in registry.known_definition_ids() {
+        for selector in registry.progress_state_selectors(&definition_id, progress_mode) {
+            definition_ids.push(definition_id.clone());
+            definition_versions.push(selector.definition_version.map(i64::from));
+            definition_hashes.push(selector.definition_hash);
+            states.push(selector.state);
+        }
+    }
+    ProgressStateSelectorRows {
+        definition_ids,
+        definition_versions,
+        definition_hashes,
+        states,
+    }
+}
+
 pub(super) fn terminal_state_selector_rows(
     registry: &WorkflowDefinitionRegistry,
 ) -> TerminalStateSelectorRows {

--- a/crates/harness-workflow/src/runtime/store/instances.rs
+++ b/crates/harness-workflow/src/runtime/store/instances.rs
@@ -1,10 +1,9 @@
 use super::{
     commit_parent_attachment_instance_tx, commit_same_state_instance_tx, insert_event_tx,
-    insert_validated_canonical_initial_instance_tx,
-    instance_helpers::{otel_trace_context_from_data, terminal_state_pairs},
+    insert_validated_canonical_initial_instance_tx, instance_helpers::otel_trace_context_from_data,
     select_instance_for_update_tx, validate_instance_for_persistence,
-    workflow_instance_from_persisted_json, workflow_instance_from_row, RuntimeHistoryPruneSummary,
-    WorkflowInstancePage, WorkflowRuntimeStore,
+    workflow_instance_from_persisted_json, workflow_instance_from_row, WorkflowInstancePage,
+    WorkflowRuntimeStore,
 };
 use crate::runtime::model::WorkflowInstance;
 use crate::runtime::WorkflowOtelTraceContext;
@@ -14,86 +13,6 @@ use serde_json::json;
 /// Event recorded when a workflow row is created outside a decision
 /// transition, so no creation is eventless (GH-1864).
 pub const WORKFLOW_INSTANCE_CREATED_EVENT: &str = "WorkflowInstanceCreated";
-
-/// Shared candidate-selection CTE for retention: terminal workflow root
-/// families older than the cutoff that are not depended on by any live
-/// workflow. Both the dry-run count and the destructive prune use it so they
-/// can never diverge.
-const PRUNE_ELIGIBLE_ROOTS_CTE: &str = r#"WITH RECURSIVE terminal_states(definition_id, state) AS (
-                 SELECT * FROM unnest($1::text[], $2::text[])
-             ),
-             candidate_roots AS (
-                 SELECT root.id
-                 FROM workflow_instances AS root
-                 WHERE root.parent_workflow_id IS NULL
-                   AND root.updated_at < $3
-                   AND EXISTS (
-                       SELECT 1
-                       FROM terminal_states AS terminal
-                       WHERE terminal.definition_id = root.definition_id
-                         AND terminal.state = root.state
-                   )
-                 ORDER BY root.updated_at ASC, root.id ASC
-                 LIMIT $4
-             ),
-             family AS (
-                 SELECT root.id AS root_id,
-                        root.id,
-                        root.definition_id,
-                        root.state,
-                        root.updated_at
-                 FROM workflow_instances AS root
-                 JOIN candidate_roots ON candidate_roots.id = root.id
-                 UNION ALL
-                 SELECT family.root_id,
-                        child.id,
-                        child.definition_id,
-                        child.state,
-                        child.updated_at
-                 FROM workflow_instances AS child
-                 JOIN family ON child.parent_workflow_id = family.id
-             ),
-             eligible_roots AS (
-                 SELECT family.root_id
-                 FROM family
-                 GROUP BY family.root_id
-                 HAVING bool_and(family.updated_at < $3)
-                    AND bool_and(EXISTS (
-                        SELECT 1
-                        FROM terminal_states AS terminal
-                        WHERE terminal.definition_id = family.definition_id
-                          AND terminal.state = family.state
-                    ))
-                    AND bool_and(NOT EXISTS (
-                        SELECT 1
-                        FROM workflow_artifact_dependencies AS dependency
-                        JOIN workflow_instances AS dependent
-                          ON dependent.id = dependency.workflow_id
-                        LEFT JOIN workflow_artifacts AS artifact
-                          ON artifact.id = dependency.artifact_ref
-                        LEFT JOIN runtime_jobs AS producer_job
-                          ON producer_job.id = CASE
-                              WHEN dependency.artifact_ref LIKE 'runtime-transcript:%'
-                              THEN substr(dependency.artifact_ref, length('runtime-transcript:') + 1)
-                              ELSE NULL
-                          END
-                        LEFT JOIN workflow_commands AS producer_command
-                          ON producer_command.id = producer_job.command_id
-                        WHERE (
-                            artifact.workflow_id = family.id
-                            OR producer_job.id = family.id
-                            OR producer_command.workflow_id = family.id
-                            OR dependency.workflow_id = family.id
-                        )
-                          AND (NOT EXISTS (
-                              SELECT 1 FROM terminal_states AS dependent_terminal
-                              WHERE dependent_terminal.definition_id = dependent.definition_id
-                                AND dependent_terminal.state = dependent.state
-                          ) OR COALESCE(dependent.data->'data'->>'stop_reason_code',
-                              dependent.data->'data'->'last_stop'->>'stop_reason_code')
-                              = 'runtime_transcript_lost')
-                    ))
-             )"#;
 
 impl WorkflowRuntimeStore {
     /// Create a workflow at its canonical initial state if it does not exist.
@@ -467,139 +386,13 @@ impl WorkflowRuntimeStore {
         rows.into_iter()
             .map(|(data, updated_at)| workflow_instance_from_row(data, updated_at))
             .filter_map(|result| match result {
-                Ok(instance) if !instance.is_terminal() => Some(Ok(instance)),
+                Ok(instance) if !instance.is_terminal_with_registry(&self.definition_registry) => {
+                    Some(Ok(instance))
+                }
                 Ok(_) => None,
                 Err(error) => Some(Err(error)),
             })
             .collect()
-    }
-
-    /// Count terminal workflow families eligible for retention pruning,
-    /// without deleting anything. Bounded by the same batch limit as
-    /// `prune_terminal_runtime_history` so dry-run reports match what the
-    /// next real pass would delete.
-    pub async fn count_terminal_history_candidates(
-        &self,
-        terminal_before: DateTime<Utc>,
-        batch_limit: i64,
-    ) -> anyhow::Result<u64> {
-        let batch_limit = batch_limit.clamp(1, 10_000);
-        let (terminal_definition_ids, terminal_states) = terminal_state_pairs();
-        if terminal_definition_ids.is_empty() {
-            return Ok(0);
-        }
-        let sql = format!("{PRUNE_ELIGIBLE_ROOTS_CTE} SELECT COUNT(*) FROM eligible_roots");
-        let (count,): (i64,) = sqlx::query_as(&sql)
-            .bind(&terminal_definition_ids)
-            .bind(&terminal_states)
-            .bind(terminal_before)
-            .bind(batch_limit)
-            .fetch_one(&self.pool)
-            .await?;
-        Ok(count.max(0) as u64)
-    }
-
-    pub async fn prune_terminal_runtime_history(
-        &self,
-        terminal_before: DateTime<Utc>,
-        batch_limit: i64,
-    ) -> anyhow::Result<RuntimeHistoryPruneSummary> {
-        let batch_limit = batch_limit.clamp(1, 10_000);
-        let (terminal_definition_ids, terminal_states) = terminal_state_pairs();
-        if terminal_definition_ids.is_empty() {
-            return Ok(RuntimeHistoryPruneSummary::default());
-        }
-
-        let rows: Vec<(String,)> = sqlx::query_as(&format!(
-            "{PRUNE_ELIGIBLE_ROOTS_CTE} SELECT family.id
-             FROM family
-             JOIN eligible_roots ON eligible_roots.root_id = family.root_id
-             ORDER BY family.root_id ASC, family.id ASC"
-        ))
-        .bind(&terminal_definition_ids)
-        .bind(&terminal_states)
-        .bind(terminal_before)
-        .bind(batch_limit)
-        .fetch_all(&self.pool)
-        .await?;
-        let workflow_ids: Vec<String> = rows.into_iter().map(|(id,)| id).collect();
-        if workflow_ids.is_empty() {
-            return Ok(RuntimeHistoryPruneSummary::default());
-        }
-
-        let mut summary = self
-            .runtime_history_counts_for_workflows(&workflow_ids)
-            .await?;
-        let result = sqlx::query("DELETE FROM workflow_instances WHERE id = ANY($1::text[])")
-            .bind(&workflow_ids)
-            .execute(&self.pool)
-            .await?;
-        summary.workflow_instances_deleted = result.rows_affected() as usize;
-        Ok(summary)
-    }
-
-    async fn runtime_history_counts_for_workflows(
-        &self,
-        workflow_ids: &[String],
-    ) -> anyhow::Result<RuntimeHistoryPruneSummary> {
-        let (workflow_instances,): (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM workflow_instances WHERE id = ANY($1::text[])")
-                .bind(workflow_ids)
-                .fetch_one(&self.pool)
-                .await?;
-        let (workflow_events,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM workflow_events WHERE workflow_id = ANY($1::text[])",
-        )
-        .bind(workflow_ids)
-        .fetch_one(&self.pool)
-        .await?;
-        let (workflow_decisions,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM workflow_decisions WHERE workflow_id = ANY($1::text[])",
-        )
-        .bind(workflow_ids)
-        .fetch_one(&self.pool)
-        .await?;
-        let (workflow_commands,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM workflow_commands WHERE workflow_id = ANY($1::text[])",
-        )
-        .bind(workflow_ids)
-        .fetch_one(&self.pool)
-        .await?;
-        let (runtime_jobs,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*)
-             FROM runtime_jobs AS job
-             JOIN workflow_commands AS command ON command.id = job.command_id
-             WHERE command.workflow_id = ANY($1::text[])",
-        )
-        .bind(workflow_ids)
-        .fetch_one(&self.pool)
-        .await?;
-        let (runtime_events,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*)
-             FROM runtime_events AS event
-             JOIN runtime_jobs AS job ON job.id = event.runtime_job_id
-             JOIN workflow_commands AS command ON command.id = job.command_id
-             WHERE command.workflow_id = ANY($1::text[])",
-        )
-        .bind(workflow_ids)
-        .fetch_one(&self.pool)
-        .await?;
-        let (workflow_artifacts,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM workflow_artifacts WHERE workflow_id = ANY($1::text[])",
-        )
-        .bind(workflow_ids)
-        .fetch_one(&self.pool)
-        .await?;
-
-        Ok(RuntimeHistoryPruneSummary {
-            workflow_instances_deleted: workflow_instances.max(0) as usize,
-            workflow_events_deleted: workflow_events.max(0) as usize,
-            workflow_decisions_deleted: workflow_decisions.max(0) as usize,
-            workflow_commands_deleted: workflow_commands.max(0) as usize,
-            runtime_jobs_deleted: runtime_jobs.max(0) as usize,
-            runtime_events_deleted: runtime_events.max(0) as usize,
-            workflow_artifacts_deleted: workflow_artifacts.max(0) as usize,
-        })
     }
 
     pub async fn touch_instance(&self, workflow_id: &str) -> anyhow::Result<()> {

--- a/crates/harness-workflow/src/runtime/store/instances_retention.rs
+++ b/crates/harness-workflow/src/runtime/store/instances_retention.rs
@@ -1,0 +1,236 @@
+use super::{
+    instance_helpers::terminal_state_selector_rows, RuntimeHistoryPruneSummary,
+    WorkflowRuntimeStore,
+};
+use chrono::{DateTime, Utc};
+
+/// Shared candidate-selection CTE for retention: terminal workflow root
+/// families older than the cutoff that are not depended on by any live
+/// workflow. Declarative terminal selectors include the exact version and
+/// content hash so a current definition cannot reclassify historical rows.
+const PRUNE_ELIGIBLE_ROOTS_CTE: &str = r#"WITH RECURSIVE terminal_states(
+                 definition_id, definition_version, definition_hash, state
+             ) AS (
+                 SELECT * FROM unnest($1::text[], $2::bigint[], $3::text[], $4::text[])
+             ),
+             candidate_roots AS (
+                 SELECT root.id
+                 FROM workflow_instances AS root
+                 WHERE root.parent_workflow_id IS NULL
+                   AND root.updated_at < $5
+                   AND EXISTS (
+                       SELECT 1
+                       FROM terminal_states AS terminal
+                       WHERE terminal.definition_id = root.definition_id
+                         AND terminal.state = root.state
+                         AND (
+                             terminal.definition_version IS NULL
+                             OR (
+                                 terminal.definition_version =
+                                     (root.data->>'definition_version')::bigint
+                                 AND terminal.definition_hash =
+                                     root.data->'data'->>'definition_hash'
+                             )
+                         )
+                   )
+                 ORDER BY root.updated_at ASC, root.id ASC
+                 LIMIT $6
+             ),
+             family AS (
+                 SELECT root.id AS root_id,
+                        root.id,
+                        root.definition_id,
+                        root.state,
+                        root.data,
+                        root.updated_at
+                 FROM workflow_instances AS root
+                 JOIN candidate_roots ON candidate_roots.id = root.id
+                 UNION ALL
+                 SELECT family.root_id,
+                        child.id,
+                        child.definition_id,
+                        child.state,
+                        child.data,
+                        child.updated_at
+                 FROM workflow_instances AS child
+                 JOIN family ON child.parent_workflow_id = family.id
+             ),
+             eligible_roots AS (
+                 SELECT family.root_id
+                 FROM family
+                 GROUP BY family.root_id
+                 HAVING bool_and(family.updated_at < $5)
+                    AND bool_and(EXISTS (
+                        SELECT 1
+                        FROM terminal_states AS terminal
+                        WHERE terminal.definition_id = family.definition_id
+                          AND terminal.state = family.state
+                          AND (
+                              terminal.definition_version IS NULL
+                              OR (
+                                  terminal.definition_version =
+                                      (family.data->>'definition_version')::bigint
+                                  AND terminal.definition_hash =
+                                      family.data->'data'->>'definition_hash'
+                              )
+                          )
+                    ))
+                    AND bool_and(NOT EXISTS (
+                        SELECT 1
+                        FROM workflow_artifact_dependencies AS dependency
+                        JOIN workflow_instances AS dependent
+                          ON dependent.id = dependency.workflow_id
+                        LEFT JOIN workflow_artifacts AS artifact
+                          ON artifact.id = dependency.artifact_ref
+                        LEFT JOIN runtime_jobs AS producer_job
+                          ON producer_job.id = CASE
+                              WHEN dependency.artifact_ref LIKE 'runtime-transcript:%'
+                              THEN substr(dependency.artifact_ref, length('runtime-transcript:') + 1)
+                              ELSE NULL
+                          END
+                        LEFT JOIN workflow_commands AS producer_command
+                          ON producer_command.id = producer_job.command_id
+                        WHERE (
+                            artifact.workflow_id = family.id
+                            OR producer_job.id = family.id
+                            OR producer_command.workflow_id = family.id
+                            OR dependency.workflow_id = family.id
+                        )
+                          AND (NOT EXISTS (
+                              SELECT 1 FROM terminal_states AS dependent_terminal
+                              WHERE dependent_terminal.definition_id = dependent.definition_id
+                                AND dependent_terminal.state = dependent.state
+                                AND (
+                                    dependent_terminal.definition_version IS NULL
+                                    OR (
+                                        dependent_terminal.definition_version =
+                                            (dependent.data->>'definition_version')::bigint
+                                        AND dependent_terminal.definition_hash =
+                                            dependent.data->'data'->>'definition_hash'
+                                    )
+                                )
+                          ) OR COALESCE(dependent.data->'data'->>'stop_reason_code',
+                              dependent.data->'data'->'last_stop'->>'stop_reason_code')
+                              = 'runtime_transcript_lost')
+                    ))
+             )"#;
+
+impl WorkflowRuntimeStore {
+    pub async fn count_terminal_history_candidates(
+        &self,
+        terminal_before: DateTime<Utc>,
+        batch_limit: i64,
+    ) -> anyhow::Result<u64> {
+        let batch_limit = batch_limit.clamp(1, 10_000);
+        let selectors = terminal_state_selector_rows(&self.definition_registry);
+        if selectors.definition_ids.is_empty() {
+            return Ok(0);
+        }
+        let sql = format!("{PRUNE_ELIGIBLE_ROOTS_CTE} SELECT COUNT(*) FROM eligible_roots");
+        let (count,): (i64,) = sqlx::query_as(&sql)
+            .bind(&selectors.definition_ids)
+            .bind(&selectors.definition_versions)
+            .bind(&selectors.definition_hashes)
+            .bind(&selectors.states)
+            .bind(terminal_before)
+            .bind(batch_limit)
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(count.max(0) as u64)
+    }
+
+    pub async fn prune_terminal_runtime_history(
+        &self,
+        terminal_before: DateTime<Utc>,
+        batch_limit: i64,
+    ) -> anyhow::Result<RuntimeHistoryPruneSummary> {
+        let batch_limit = batch_limit.clamp(1, 10_000);
+        let selectors = terminal_state_selector_rows(&self.definition_registry);
+        if selectors.definition_ids.is_empty() {
+            return Ok(RuntimeHistoryPruneSummary::default());
+        }
+        let rows: Vec<(String,)> = sqlx::query_as(&format!(
+            "{PRUNE_ELIGIBLE_ROOTS_CTE} SELECT family.id
+             FROM family
+             JOIN eligible_roots ON eligible_roots.root_id = family.root_id
+             ORDER BY family.root_id ASC, family.id ASC"
+        ))
+        .bind(&selectors.definition_ids)
+        .bind(&selectors.definition_versions)
+        .bind(&selectors.definition_hashes)
+        .bind(&selectors.states)
+        .bind(terminal_before)
+        .bind(batch_limit)
+        .fetch_all(&self.pool)
+        .await?;
+        let workflow_ids: Vec<String> = rows.into_iter().map(|(id,)| id).collect();
+        if workflow_ids.is_empty() {
+            return Ok(RuntimeHistoryPruneSummary::default());
+        }
+        let mut summary = self
+            .runtime_history_counts_for_workflows(&workflow_ids)
+            .await?;
+        let result = sqlx::query("DELETE FROM workflow_instances WHERE id = ANY($1::text[])")
+            .bind(&workflow_ids)
+            .execute(&self.pool)
+            .await?;
+        summary.workflow_instances_deleted = result.rows_affected() as usize;
+        Ok(summary)
+    }
+
+    async fn runtime_history_counts_for_workflows(
+        &self,
+        workflow_ids: &[String],
+    ) -> anyhow::Result<RuntimeHistoryPruneSummary> {
+        let count = |table: &str| {
+            format!("SELECT COUNT(*) FROM {table} WHERE workflow_id = ANY($1::text[])")
+        };
+        let (workflow_instances,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM workflow_instances WHERE id = ANY($1::text[])")
+                .bind(workflow_ids)
+                .fetch_one(&self.pool)
+                .await?;
+        let (workflow_events,): (i64,) = sqlx::query_as(&count("workflow_events"))
+            .bind(workflow_ids)
+            .fetch_one(&self.pool)
+            .await?;
+        let (workflow_decisions,): (i64,) = sqlx::query_as(&count("workflow_decisions"))
+            .bind(workflow_ids)
+            .fetch_one(&self.pool)
+            .await?;
+        let (workflow_commands,): (i64,) = sqlx::query_as(&count("workflow_commands"))
+            .bind(workflow_ids)
+            .fetch_one(&self.pool)
+            .await?;
+        let (runtime_jobs,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM runtime_jobs AS job
+             JOIN workflow_commands AS command ON command.id = job.command_id
+             WHERE command.workflow_id = ANY($1::text[])",
+        )
+        .bind(workflow_ids)
+        .fetch_one(&self.pool)
+        .await?;
+        let (runtime_events,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM runtime_events AS event
+             JOIN runtime_jobs AS job ON job.id = event.runtime_job_id
+             JOIN workflow_commands AS command ON command.id = job.command_id
+             WHERE command.workflow_id = ANY($1::text[])",
+        )
+        .bind(workflow_ids)
+        .fetch_one(&self.pool)
+        .await?;
+        let (workflow_artifacts,): (i64,) = sqlx::query_as(&count("workflow_artifacts"))
+            .bind(workflow_ids)
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(RuntimeHistoryPruneSummary {
+            workflow_instances_deleted: workflow_instances.max(0) as usize,
+            workflow_events_deleted: workflow_events.max(0) as usize,
+            workflow_decisions_deleted: workflow_decisions.max(0) as usize,
+            workflow_commands_deleted: workflow_commands.max(0) as usize,
+            runtime_jobs_deleted: runtime_jobs.max(0) as usize,
+            runtime_events_deleted: runtime_events.max(0) as usize,
+            workflow_artifacts_deleted: workflow_artifacts.max(0) as usize,
+        })
+    }
+}

--- a/crates/harness-workflow/src/runtime/store/recovery.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery.rs
@@ -14,19 +14,23 @@ use crate::runtime::model::{
 use crate::runtime::pr_feedback::{
     LOCAL_REVIEW_ACTIVITY, PR_FEEDBACK_DEFINITION_ID, PR_FEEDBACK_INSPECT_ACTIVITY,
 };
-use crate::runtime::prompt_task::PROMPT_TASK_DEFINITION_ID;
-use crate::runtime::quality_gate::QUALITY_GATE_DEFINITION_ID;
 use crate::runtime::reducer::GITHUB_ISSUE_PR_DEFINITION_ID;
 use crate::runtime::state_registry::{
-    DeclarativeDefinitionPinError, DeclarativeDefinitionResolution, WorkflowProgressMode,
+    DeclarativeDefinitionPinError, DeclarativeDefinitionResolution, WorkflowDefinitionRegistry,
+    WorkflowProgressMode,
 };
 use crate::runtime::status::WorkflowCommandStatus;
 use crate::runtime::validator::ValidationContext;
 use anyhow::{bail, Context};
 use serde_json::{json, Value};
 
+#[path = "recovery_definition.rs"]
+mod recovery_definition;
 #[path = "recovery_validation.rs"]
 mod recovery_validation;
+use recovery_definition::{
+    custom_declarative_definition, declarative_recovery_rejection, is_builtin_definition_id,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorkflowRuntimeRecoveryAction {
@@ -103,8 +107,9 @@ impl WorkflowRuntimeStore {
             tx.commit().await?;
             return Ok(WorkflowRuntimeRecoveryOutcome::NotFound);
         };
-        let declarative = custom_declarative_definition(&snapshot).is_some();
-        if let Some(outcome) = recovery_rejection(&snapshot, &request)? {
+        let declarative =
+            custom_declarative_definition(&self.definition_registry, &snapshot).is_some();
+        if let Some(outcome) = recovery_rejection(&self.definition_registry, &snapshot, &request)? {
             if declarative {
                 audit_recovery_rejection_tx(&mut tx, &snapshot, &request, "eligibility_rejected")
                     .await?;
@@ -112,7 +117,14 @@ impl WorkflowRuntimeStore {
             tx.commit().await?;
             return Ok(outcome);
         }
-        let plan = match recovery_dispatch_plan_tx(&mut tx, &snapshot, &request).await? {
+        let plan = match recovery_dispatch_plan_tx(
+            &mut tx,
+            &self.definition_registry,
+            &snapshot,
+            &request,
+        )
+        .await?
+        {
             Ok(plan) => plan,
             Err(activity) => {
                 if declarative {
@@ -129,9 +141,14 @@ impl WorkflowRuntimeStore {
             }
         };
         if declarative {
-            if let Some(outcome) =
-                recovery_validation::validate_request_tx(&mut tx, &snapshot, &request, &plan)
-                    .await?
+            if let Some(outcome) = recovery_validation::validate_request_tx(
+                &mut tx,
+                &self.definition_registry,
+                &snapshot,
+                &request,
+                &plan,
+            )
+            .await?
             {
                 tx.commit().await?;
                 return Ok(outcome);
@@ -144,11 +161,14 @@ impl WorkflowRuntimeStore {
             return Ok(WorkflowRuntimeRecoveryOutcome::NotFound);
         };
 
-        if let Some(outcome) = recovery_rejection(&instance, &request)? {
+        if let Some(outcome) = recovery_rejection(&self.definition_registry, &instance, &request)? {
             tx.rollback().await?;
             return Ok(outcome);
         }
-        if recovery_dispatch_plan_tx(&mut tx, &instance, &request).await? != Ok(plan.clone()) {
+        if recovery_dispatch_plan_tx(&mut tx, &self.definition_registry, &instance, &request)
+            .await?
+            != Ok(plan.clone())
+        {
             tx.rollback().await?;
             return Ok(unsupported_stopped_activity(&instance, None));
         }
@@ -183,13 +203,13 @@ impl WorkflowRuntimeStore {
             &event.id,
             request.evidence,
         );
-        let Some(validator) = validator_for_instance(&instance)? else {
+        let Some(validator) = validator_for_instance(&self.definition_registry, &instance)? else {
             anyhow::bail!(
                 "workflow runtime recovery cannot validate definition {}",
                 instance.definition_id
             );
         };
-        let validation_context = if instance.is_terminal() {
+        let validation_context = if instance.is_terminal_with_registry(&self.definition_registry) {
             ValidationContext::new("workflow_runtime_operator_action", event.created_at)
                 .allow_terminal_reopen()
         } else {
@@ -257,10 +277,11 @@ async fn audit_recovery_rejection_tx(tx: &mut sqlx::Transaction<'_, sqlx::Postgr
 }
 
 fn recovery_rejection(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     request: &WorkflowRuntimeRecoveryRequest<'_>,
 ) -> anyhow::Result<Option<WorkflowRuntimeRecoveryOutcome>> {
-    match custom_declarative_definition(instance) {
+    match custom_declarative_definition(registry, instance) {
         Some(Ok(definition)) => {
             return Ok(declarative_recovery_rejection(
                 instance,
@@ -277,7 +298,7 @@ fn recovery_rejection(
         None => {}
     }
     if let DeclarativeDefinitionResolution::PinError(error) =
-        crate::runtime::state_registry::resolve_declarative_definition(instance)
+        registry.resolve_declarative_definition(instance)
     {
         if !is_builtin_definition_id(&instance.definition_id) {
             return Ok(Some(WorkflowRuntimeRecoveryOutcome::InvalidDefinitionPin {
@@ -317,48 +338,13 @@ fn recovery_rejection(
     Ok(None)
 }
 
-fn custom_declarative_definition(
-    instance: &WorkflowInstance,
-) -> Option<
-    Result<
-        std::sync::Arc<crate::runtime::declarative::DeclarativeWorkflowDefinition>,
-        DeclarativeDefinitionPinError,
-    >,
-> {
-    if is_builtin_definition_id(&instance.definition_id) {
-        return None;
-    }
-    match crate::runtime::state_registry::resolve_declarative_definition(instance) {
-        DeclarativeDefinitionResolution::PinError(error) => Some(Err(error)),
-        DeclarativeDefinitionResolution::Resolved(definition) => Some(Ok(definition)),
-        DeclarativeDefinitionResolution::NotDeclarative => None,
-    }
-}
-
-fn is_builtin_definition_id(definition_id: &str) -> bool {
-    matches!(
-        definition_id,
-        GITHUB_ISSUE_PR_DEFINITION_ID
-            | PROMPT_TASK_DEFINITION_ID
-            | QUALITY_GATE_DEFINITION_ID
-            | PR_FEEDBACK_DEFINITION_ID
-    )
-}
-
-#[rustfmt::skip]
-fn declarative_recovery_rejection(instance: &WorkflowInstance, request: &WorkflowRuntimeRecoveryRequest<'_>, definition: &crate::runtime::declarative::DeclarativeWorkflowDefinition) -> Option<WorkflowRuntimeRecoveryOutcome> {
-    if request.actor != "operator" { return Some(WorkflowRuntimeRecoveryOutcome::OperatorRequired { workflow: instance.clone() }); }
-    if request.action != WorkflowRuntimeRecoveryAction::Unblock || instance.state != "blocked" { return Some(WorkflowRuntimeRecoveryOutcome::WrongState { workflow: instance.clone() }); }
-    if request.target_state.is_none() && definition.policy().recovery_targets.len() != 1 { return Some(WorkflowRuntimeRecoveryOutcome::TargetRequired { workflow: instance.clone() }); }
-    request.target_state.filter(|target| !definition.policy().recovery_targets.iter().any(|allowed| allowed == target)).map(|target_state| WorkflowRuntimeRecoveryOutcome::TargetNotAllowed { workflow: instance.clone(), target_state: target_state.to_string() })
-}
-
 async fn recovery_dispatch_plan_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     request: &WorkflowRuntimeRecoveryRequest<'_>,
 ) -> anyhow::Result<Result<RecoveryDispatchPlan, Option<String>>> {
-    if let Some(Ok(definition)) = custom_declarative_definition(instance) {
+    if let Some(Ok(definition)) = custom_declarative_definition(registry, instance) {
         return declarative_recovery_dispatch_plan(request, &definition);
     }
     validate_stopped_metadata(&instance.data)?;

--- a/crates/harness-workflow/src/runtime/store/recovery_definition.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery_definition.rs
@@ -1,0 +1,48 @@
+use super::{
+    WorkflowInstance, WorkflowRuntimeRecoveryAction, WorkflowRuntimeRecoveryOutcome,
+    WorkflowRuntimeRecoveryRequest,
+};
+use crate::runtime::pr_feedback::PR_FEEDBACK_DEFINITION_ID;
+use crate::runtime::prompt_task::PROMPT_TASK_DEFINITION_ID;
+use crate::runtime::quality_gate::QUALITY_GATE_DEFINITION_ID;
+use crate::runtime::reducer::GITHUB_ISSUE_PR_DEFINITION_ID;
+use crate::runtime::state_registry::{
+    DeclarativeDefinitionPinError, DeclarativeDefinitionResolution, WorkflowDefinitionRegistry,
+};
+
+pub(super) fn custom_declarative_definition(
+    registry: &WorkflowDefinitionRegistry,
+    instance: &WorkflowInstance,
+) -> Option<
+    Result<
+        std::sync::Arc<crate::runtime::declarative::DeclarativeWorkflowDefinition>,
+        DeclarativeDefinitionPinError,
+    >,
+> {
+    if is_builtin_definition_id(&instance.definition_id) {
+        return None;
+    }
+    match registry.resolve_declarative_definition(instance) {
+        DeclarativeDefinitionResolution::PinError(error) => Some(Err(error)),
+        DeclarativeDefinitionResolution::Resolved(definition) => Some(Ok(definition)),
+        DeclarativeDefinitionResolution::NotDeclarative => None,
+    }
+}
+
+pub(super) fn is_builtin_definition_id(definition_id: &str) -> bool {
+    matches!(
+        definition_id,
+        GITHUB_ISSUE_PR_DEFINITION_ID
+            | PROMPT_TASK_DEFINITION_ID
+            | QUALITY_GATE_DEFINITION_ID
+            | PR_FEEDBACK_DEFINITION_ID
+    )
+}
+
+#[rustfmt::skip]
+pub(super) fn declarative_recovery_rejection(instance: &WorkflowInstance, request: &WorkflowRuntimeRecoveryRequest<'_>, definition: &crate::runtime::declarative::DeclarativeWorkflowDefinition) -> Option<WorkflowRuntimeRecoveryOutcome> {
+    if request.actor != "operator" { return Some(WorkflowRuntimeRecoveryOutcome::OperatorRequired { workflow: instance.clone() }); }
+    if request.action != WorkflowRuntimeRecoveryAction::Unblock || instance.state != "blocked" { return Some(WorkflowRuntimeRecoveryOutcome::WrongState { workflow: instance.clone() }); }
+    if request.target_state.is_none() && definition.policy().recovery_targets.len() != 1 { return Some(WorkflowRuntimeRecoveryOutcome::TargetRequired { workflow: instance.clone() }); }
+    request.target_state.filter(|target| !definition.policy().recovery_targets.iter().any(|allowed| allowed == target)).map(|target_state| WorkflowRuntimeRecoveryOutcome::TargetNotAllowed { workflow: instance.clone(), target_state: target_state.to_string() })
+}

--- a/crates/harness-workflow/src/runtime/store/recovery_validation.rs
+++ b/crates/harness-workflow/src/runtime/store/recovery_validation.rs
@@ -4,11 +4,13 @@ use super::{
 };
 use crate::runtime::model::WorkflowInstance;
 use crate::runtime::validator::{ValidationContext, WorkflowDecisionRejectionKind};
+use crate::runtime::WorkflowDefinitionRegistry;
 use chrono::Utc;
 use serde_json::json;
 
 pub(super) async fn validate_request_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     request: &WorkflowRuntimeRecoveryRequest<'_>,
     plan: &RecoveryDispatchPlan,
@@ -22,7 +24,7 @@ pub(super) async fn validate_request_tx(
         "recovery-validation-preview",
         request.evidence,
     );
-    let Some(validator) = validator_for_instance(instance)? else {
+    let Some(validator) = validator_for_instance(registry, instance)? else {
         anyhow::bail!(
             "workflow runtime recovery cannot validate definition {}",
             instance.definition_id

--- a/crates/harness-workflow/src/runtime/store/runtime_completion.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion.rs
@@ -12,11 +12,9 @@ use crate::runtime::prompt_task::{
     prompt_continuation_state_from_data, PromptContinuationState, PROMPT_TASK_DEFINITION_ID,
 };
 use crate::runtime::reducer::{
-    invalid_agent_output_blocked_decision, reduce_runtime_job_completed,
+    invalid_agent_output_blocked_decision, reduce_runtime_job_completed_with_registry,
 };
-use crate::runtime::state_registry::{
-    resolve_declarative_definition, DeclarativeDefinitionResolution,
-};
+use crate::runtime::state_registry::{DeclarativeDefinitionResolution, WorkflowDefinitionRegistry};
 use crate::runtime::status::WorkflowCommandStatus;
 use crate::runtime::validator::{
     ValidationContext, WorkflowDecisionRejection, WorkflowDecisionRejectionKind,
@@ -25,15 +23,18 @@ use crate::runtime::{DataProvenance, WorkflowDataWrite};
 use serde_json::{json, Value};
 
 pub(super) fn validator_for_instance(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
 ) -> anyhow::Result<Option<crate::runtime::validator::DecisionValidator>> {
-    crate::runtime::state_registry::decision_validator_for_instance(instance).map_err(|error| {
-        anyhow::anyhow!(
-            "invalid declarative definition pin for workflow '{}': {:?}",
-            instance.id,
-            error
-        )
-    })
+    registry
+        .decision_validator_for_instance(instance)
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "invalid declarative definition pin for workflow '{}': {:?}",
+                instance.id,
+                error
+            )
+        })
 }
 
 impl WorkflowRuntimeStore {
@@ -61,6 +62,7 @@ impl WorkflowRuntimeStore {
         .await?;
         let decision = apply_runtime_completion_decision_for_instance_tx(
             &mut tx,
+            &self.definition_registry,
             instance,
             source,
             &event,
@@ -92,6 +94,7 @@ impl WorkflowRuntimeStore {
             insert_event_tx(&mut tx, workflow_id, "RuntimeJobCompleted", source, payload).await?;
         let record = persist_runtime_completion_decision_tx(
             &mut tx,
+            &self.definition_registry,
             instance,
             source,
             &event,
@@ -105,6 +108,7 @@ impl WorkflowRuntimeStore {
 
 pub(super) async fn apply_runtime_completion_decision_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    registry: &WorkflowDefinitionRegistry,
     workflow_id: &str,
     source: &str,
     event: &WorkflowEvent,
@@ -113,30 +117,48 @@ pub(super) async fn apply_runtime_completion_decision_tx(
     let Some(instance) = select_instance_for_update_tx(tx, workflow_id).await? else {
         return Ok(None);
     };
-    apply_runtime_completion_decision_for_instance_tx(tx, instance, source, event, budget_policy)
-        .await
+    apply_runtime_completion_decision_for_instance_tx(
+        tx,
+        registry,
+        instance,
+        source,
+        event,
+        budget_policy,
+    )
+    .await
 }
 
 async fn apply_runtime_completion_decision_for_instance_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    registry: &WorkflowDefinitionRegistry,
     instance: WorkflowInstance,
     source: &str,
     event: &WorkflowEvent,
     budget_policy: &RuntimeBudgetPolicy,
 ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
-    let driverless_decision = driverless_structured_completion_decision(&instance, source, event)?;
-    let Some(decision) = reduce_runtime_job_completed(&instance, event)? else {
+    let driverless_decision =
+        driverless_structured_completion_decision(registry, &instance, source, event)?;
+    let Some(decision) = reduce_runtime_job_completed_with_registry(registry, &instance, event)?
+    else {
         return Ok(None);
     };
     // Hard workflow budget ceiling (GH-1770 §4.4). Checked before the policy
     // fallbacks below: those already stop the workflow, so a budget block on
     // top of them would only mask the real reason.
-    if let Some(budget_decision) =
-        budget_ceiling_blocked_decision(tx, budget_policy, &instance, source, event, &decision)
-            .await?
+    if let Some(budget_decision) = budget_ceiling_blocked_decision(
+        tx,
+        budget_policy,
+        registry,
+        &instance,
+        source,
+        event,
+        &decision,
+    )
+    .await?
     {
         return persist_runtime_completion_decision_tx(
             tx,
+            registry,
             instance,
             source,
             event,
@@ -153,6 +175,7 @@ async fn apply_runtime_completion_decision_for_instance_tx(
         if let Some(driverless_decision) = driverless_decision {
             let rejected = persist_runtime_completion_decision_tx(
                 tx,
+                registry,
                 instance.clone(),
                 source,
                 event,
@@ -177,6 +200,7 @@ async fn apply_runtime_completion_decision_for_instance_tx(
             ));
             let policy = persist_runtime_completion_decision_tx(
                 tx,
+                registry,
                 instance,
                 source,
                 event,
@@ -196,10 +220,17 @@ async fn apply_runtime_completion_decision_for_instance_tx(
         }
     }
 
-    if declarative_decision_requires_blocked_fallback(&instance, source, event, &decision) {
-        let rejected =
-            persist_runtime_completion_decision_tx(tx, instance.clone(), source, event, decision)
-                .await?;
+    if declarative_decision_requires_blocked_fallback(registry, &instance, source, event, &decision)
+    {
+        let rejected = persist_runtime_completion_decision_tx(
+            tx,
+            registry,
+            instance.clone(),
+            source,
+            event,
+            decision,
+        )
+        .await?;
         if rejected.accepted {
             anyhow::bail!("insufficient-evidence decision unexpectedly passed validation");
         }
@@ -226,9 +257,15 @@ async fn apply_runtime_completion_decision_for_instance_tx(
                 rejected.id
             ),
         ));
-        let policy =
-            persist_runtime_completion_decision_tx(tx, instance, source, event, policy_decision)
-                .await?;
+        let policy = persist_runtime_completion_decision_tx(
+            tx,
+            registry,
+            instance,
+            source,
+            event,
+            policy_decision,
+        )
+        .await?;
         if !policy.accepted {
             anyhow::bail!(
                 "blocked policy decision was rejected after insufficient trusted evidence: {}",
@@ -241,24 +278,25 @@ async fn apply_runtime_completion_decision_for_instance_tx(
         return Ok(Some(policy));
     }
 
-    persist_runtime_completion_decision_tx(tx, instance, source, event, decision)
+    persist_runtime_completion_decision_tx(tx, registry, instance, source, event, decision)
         .await
         .map(Some)
 }
 
 fn declarative_decision_requires_blocked_fallback(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     source: &str,
     event: &WorkflowEvent,
     decision: &WorkflowDecision,
 ) -> bool {
     if !matches!(
-        resolve_declarative_definition(instance),
+        registry.resolve_declarative_definition(instance),
         DeclarativeDefinitionResolution::Resolved(_)
     ) {
         return false;
     }
-    let Ok(Some(validator)) = validator_for_instance(instance) else {
+    let Ok(Some(validator)) = validator_for_instance(registry, instance) else {
         return false;
     };
     matches!(
@@ -284,6 +322,7 @@ fn is_generic_invalid_structured_fallback(decision: &WorkflowDecision) -> bool {
 }
 
 fn driverless_structured_completion_decision(
+    registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     source: &str,
     event: &WorkflowEvent,
@@ -306,7 +345,7 @@ fn driverless_structured_completion_decision(
     else {
         return Ok(None);
     };
-    let Ok(Some(validator)) = validator_for_instance(instance) else {
+    let Ok(Some(validator)) = validator_for_instance(registry, instance) else {
         return Ok(None);
     };
     let rejection = validator.validate(
@@ -324,6 +363,7 @@ fn driverless_structured_completion_decision(
 
 async fn persist_runtime_completion_decision_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    registry: &WorkflowDefinitionRegistry,
     instance: WorkflowInstance,
     source: &str,
     event: &WorkflowEvent,
@@ -332,6 +372,7 @@ async fn persist_runtime_completion_decision_tx(
     let validation_context = runtime_completion_validation_context(source, event);
     persist_runtime_completion_decision_with_context_tx(
         tx,
+        registry,
         instance,
         event,
         decision,
@@ -342,13 +383,14 @@ async fn persist_runtime_completion_decision_tx(
 
 async fn persist_runtime_completion_decision_with_context_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    registry: &WorkflowDefinitionRegistry,
     mut instance: WorkflowInstance,
     event: &WorkflowEvent,
     decision: WorkflowDecision,
     validation_context: ValidationContext,
 ) -> anyhow::Result<WorkflowDecisionRecord> {
     let current = instance.clone();
-    let record = match validator_for_instance(&instance) {
+    let record = match validator_for_instance(registry, &instance) {
         Ok(Some(validator)) => {
             match validator.validate(&instance, &decision, &validation_context) {
                 Ok(()) => {

--- a/crates/harness-workflow/src/runtime/store/runtime_completion_budget.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion_budget.rs
@@ -17,7 +17,7 @@ use super::runtime_usage::{
 use super::{insert_event_tx, RuntimeBudgetEnforcement, RuntimeBudgetPolicy};
 use crate::runtime::model::{ActivityResult, WorkflowDecision, WorkflowEvent, WorkflowInstance};
 use crate::runtime::reducer::budget_exhausted_blocked_decision;
-use crate::runtime::terminal_state::workflow_terminal_state_for_version;
+use crate::runtime::WorkflowDefinitionRegistry;
 use serde_json::json;
 
 /// Returns the replacement decision when the completed activity pushed the
@@ -26,12 +26,15 @@ use serde_json::json;
 pub(super) async fn budget_ceiling_blocked_decision(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     budget_policy: &RuntimeBudgetPolicy,
+    definition_registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
     source: &str,
     event: &WorkflowEvent,
     decision: &WorkflowDecision,
 ) -> anyhow::Result<Option<WorkflowDecision>> {
-    if budget_policy.unlimited || !decision_schedules_more_work(instance, decision) {
+    if budget_policy.unlimited
+        || !decision_schedules_more_work(definition_registry, instance, decision)
+    {
         return Ok(None);
     }
     // Compare in integer micro-dollars, matching the dispatch gate: spend is
@@ -90,14 +93,19 @@ pub(super) async fn budget_ceiling_blocked_decision(
 /// The ceiling only preempts decisions that would keep the workflow running.
 /// A decision that already lands in a terminal state or in `blocked` needs no
 /// budget intervention — the workflow is stopping either way.
-fn decision_schedules_more_work(instance: &WorkflowInstance, decision: &WorkflowDecision) -> bool {
+fn decision_schedules_more_work(
+    definition_registry: &WorkflowDefinitionRegistry,
+    instance: &WorkflowInstance,
+    decision: &WorkflowDecision,
+) -> bool {
     if decision.next_state == "blocked" {
         return false;
     }
-    workflow_terminal_state_for_version(
-        &instance.definition_id,
-        instance.definition_version,
-        &decision.next_state,
-    )
-    .is_none()
+    definition_registry
+        .state_terminal_state_for_version(
+            &instance.definition_id,
+            instance.definition_version,
+            &decision.next_state,
+        )
+        .is_none()
 }

--- a/crates/harness-workflow/src/runtime/store/runtime_completion_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_completion_tests.rs
@@ -135,7 +135,9 @@ async fn pin_error_safety_decision_persists_blocked_without_current_definition(
     let store = WorkflowRuntimeStore::open(&dir.path().join("pin-safety.db")).await?;
     let instance = pin_error_instance("pin-safety-accepted");
     assert!(matches!(
-        crate::runtime::state_registry::resolve_declarative_definition(&instance),
+        store
+            .definition_registry()
+            .resolve_declarative_definition(&instance),
         crate::runtime::state_registry::DeclarativeDefinitionResolution::PinError(
             crate::runtime::state_registry::DeclarativeDefinitionPinError::MissingVersion
         )
@@ -186,6 +188,7 @@ async fn pin_error_safety_decision_requires_explicit_context_override() -> anyho
     .await?;
     let record = persist_runtime_completion_decision_with_context_tx(
         &mut tx,
+        store.definition_registry(),
         instance.clone(),
         &event,
         pin_safety_decision(&instance),

--- a/crates/harness-workflow/src/runtime/store/runtime_jobs.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_jobs.rs
@@ -288,6 +288,7 @@ impl WorkflowRuntimeStore {
     ) -> anyhow::Result<RuntimeJobEnqueueOutcome> {
         command_store::enqueue_runtime_job_for_command(
             &self.pool,
+            &self.definition_registry,
             command_id,
             None,
             runtime_kind,
@@ -309,6 +310,7 @@ impl WorkflowRuntimeStore {
     ) -> anyhow::Result<RuntimeJobEnqueueOutcome> {
         command_store::enqueue_runtime_job_for_command(
             &self.pool,
+            &self.definition_registry,
             command_id,
             Some(dispatch_claim),
             runtime_kind,

--- a/crates/harness-workflow/src/runtime/store/runtime_usage.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_usage.rs
@@ -337,7 +337,7 @@ impl WorkflowRuntimeStore {
             .await?;
         let policy_events = policy_events_for_usage_records(event_store, &usage_records).await?;
         let usage = aggregate_usage_records(&usage_records)?;
-        let terminal = workflow.is_terminal();
+        let terminal = workflow.is_terminal_with_registry(&self.definition_registry);
         Ok(Some(RuntimeAgentTelemetry {
             workflow_id: workflow.id,
             workflow_state: workflow.state.clone(),

--- a/crates/harness-workflow/src/runtime/store/submission_commit.rs
+++ b/crates/harness-workflow/src/runtime/store/submission_commit.rs
@@ -91,7 +91,7 @@ impl WorkflowRuntimeStore {
         let mut tx = self.pool.begin().await?;
         lock_submission_tx(&mut tx, transition.workflow_id).await?;
         let Some((current, created_for_submission)) =
-            load_submission_instance_tx(&mut tx, &transition).await?
+            load_submission_instance_tx(&mut tx, &self.definition_registry, &transition).await?
         else {
             return Ok(None);
         };
@@ -132,7 +132,9 @@ impl WorkflowRuntimeStore {
                         "rejected workflow submission final instance is only allowed for a newly created submission"
                     );
                 }
-                if final_instance.terminal_state() != Some(WorkflowTerminalState::Failed) {
+                if final_instance.terminal_state_with_registry(&self.definition_registry)
+                    != Some(WorkflowTerminalState::Failed)
+                {
                     anyhow::bail!(
                         "rejected workflow submission final instance must use the definition-specific failed terminal state"
                     );
@@ -198,13 +200,18 @@ impl WorkflowRuntimeStore {
                 .existing_record
                 .is_none_or(|_| current.state == record.decision.observed_state);
         if validate_as_new_transition {
-            let validation_context = if current.is_terminal() {
+            let validation_context = if current.is_terminal_with_registry(&self.definition_registry)
+            {
                 ValidationContext::new("workflow-policy", Utc::now()).allow_terminal_reopen()
             } else {
                 ValidationContext::new("workflow-policy", Utc::now())
             };
-            match validate_transition_with_context(&current, &record.decision, &validation_context)
-            {
+            match validate_transition_with_context(
+                &self.definition_registry,
+                &current,
+                &record.decision,
+                &validation_context,
+            ) {
                 TransitionValidation::Accepted => {}
                 TransitionValidation::Rejected(reason) if transition.existing_record.is_none() => {
                     let rejected = WorkflowDecisionRecord::rejected(
@@ -275,6 +282,7 @@ impl WorkflowRuntimeStore {
             } else {
                 commit_rejected_initial_failure_instance_tx(
                     &mut tx,
+                    &self.definition_registry,
                     &current,
                     final_instance,
                     &record,
@@ -306,6 +314,7 @@ async fn lock_submission_tx(
 
 async fn load_submission_instance_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    definition_registry: &crate::runtime::WorkflowDefinitionRegistry,
     transition: &WorkflowSubmissionDecisionTransition<'_>,
 ) -> anyhow::Result<Option<(WorkflowInstance, bool)>> {
     if let Some(current) = select_instance_for_update_tx(tx, transition.workflow_id).await? {
@@ -326,7 +335,7 @@ async fn load_submission_instance_tx(
     {
         return Ok(None);
     }
-    if insert_validated_observed_instance_tx(tx, initial).await? {
+    if insert_validated_observed_instance_tx(tx, definition_registry, initial).await? {
         return Ok(Some((initial.clone(), true)));
     }
     Ok(select_instance_for_update_tx(tx, transition.workflow_id)

--- a/crates/harness-workflow/src/runtime/store/submission_instances.rs
+++ b/crates/harness-workflow/src/runtime/store/submission_instances.rs
@@ -42,7 +42,7 @@ impl WorkflowRuntimeStore {
     ) -> anyhow::Result<Vec<WorkflowInstance>> {
         let limit = limit.max(1);
         let (terminal_definition_ids, terminal_states, terminal_task_statuses) =
-            terminal_task_status_rows();
+            terminal_task_status_rows(&self.definition_registry);
         let rows: Vec<(String,)> = sqlx::query_as(
             "WITH terminal_states(definition_id, state, task_status) AS (
                  SELECT * FROM unnest($1::text[], $2::text[], $3::text[])
@@ -175,7 +175,7 @@ impl WorkflowRuntimeStore {
         since: DateTime<Utc>,
     ) -> anyhow::Result<WorkflowSubmissionMetrics> {
         let (terminal_definition_ids, terminal_states, terminal_task_statuses) =
-            terminal_task_status_rows();
+            terminal_task_status_rows(&self.definition_registry);
         let stalled_reason = "round_budget_exhausted";
         let stalled_pattern = format!("%\"reason\":\"{stalled_reason}\"%");
         let rows = sqlx::query_as::<_, SubmissionMetricRow>(

--- a/crates/harness-workflow/src/runtime/store/terminal_instance_queries.rs
+++ b/crates/harness-workflow/src/runtime/store/terminal_instance_queries.rs
@@ -1,8 +1,6 @@
 use super::{workflow_instance_from_row, WorkflowInstance, WorkflowRuntimeStore};
 use crate::runtime::state_registry::{
-    workflow_progress_state_selectors_for_definition,
-    workflow_terminal_state_selectors_for_definition, WorkflowProgressStateSelector,
-    WorkflowTerminalStateSelector,
+    WorkflowProgressStateSelector, WorkflowTerminalStateSelector,
 };
 use crate::runtime::{WorkflowProgressMode, WorkflowTerminalState};
 use chrono::{DateTime, Utc};
@@ -21,8 +19,9 @@ impl WorkflowRuntimeStore {
         progress_mode: WorkflowProgressMode,
         limit: i64,
     ) -> anyhow::Result<Vec<WorkflowInstance>> {
-        let selectors =
-            workflow_progress_state_selectors_for_definition(definition_id, progress_mode);
+        let selectors = self
+            .definition_registry
+            .progress_state_selectors(definition_id, progress_mode);
         let query = progress_selector_query_parts(&selectors)?;
         if query.unversioned_states.is_empty() && query.versioned_states.is_empty() {
             return Ok(Vec::new());
@@ -64,7 +63,9 @@ impl WorkflowRuntimeStore {
         limit: i64,
     ) -> anyhow::Result<Vec<WorkflowInstance>> {
         let limit = limit.clamp(1, 500);
-        let selectors = workflow_terminal_state_selectors_for_definition(definition_id)
+        let selectors = self
+            .definition_registry
+            .terminal_state_selectors(definition_id)
             .into_iter()
             .filter(|selector| selector.terminal_state == terminal_state)
             .collect::<Vec<_>>();
@@ -109,7 +110,9 @@ impl WorkflowRuntimeStore {
         limit: Option<i64>,
     ) -> anyhow::Result<Vec<WorkflowInstance>> {
         let limit = limit.map(|value| value.clamp(1, 500));
-        let selectors = workflow_terminal_state_selectors_for_definition(definition_id);
+        let selectors = self
+            .definition_registry
+            .terminal_state_selectors(definition_id);
         let query = terminal_selector_query_parts(&selectors)?;
         let rows: Vec<(String, DateTime<Utc>)> = sqlx::query_as(
             "SELECT data::text, updated_at FROM workflow_instances

--- a/crates/harness-workflow/src/runtime/store/transaction_helpers.rs
+++ b/crates/harness-workflow/src/runtime/store/transaction_helpers.rs
@@ -31,6 +31,7 @@ pub(super) async fn runtime_job_for_command_tx(
 
 pub(super) async fn load_or_insert_initial_instance_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    definition_registry: &WorkflowDefinitionRegistry,
     workflow_id: &str,
     expected_state: &str,
     create_if_missing: Option<&WorkflowInstance>,
@@ -53,7 +54,7 @@ pub(super) async fn load_or_insert_initial_instance_tx(
         return Ok(None);
     }
 
-    if insert_validated_observed_instance_tx(tx, initial_instance).await? {
+    if insert_validated_observed_instance_tx(tx, definition_registry, initial_instance).await? {
         return Ok(Some(initial_instance.clone()));
     }
 
@@ -142,6 +143,7 @@ pub(super) async fn insert_event_tx_with_id(
 
 pub(super) async fn insert_validated_observed_instance_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    definition_registry: &WorkflowDefinitionRegistry,
     instance: &WorkflowInstance,
 ) -> anyhow::Result<bool> {
     if instance.version != 0 {
@@ -151,7 +153,9 @@ pub(super) async fn insert_validated_observed_instance_tx(
             instance.version
         );
     }
-    if crate::runtime::workflow_state_definition_for_instance(instance, &instance.state).is_none()
+    if definition_registry
+        .state_definition_for_instance(instance, &instance.state)
+        .is_none()
         && !persisted_declarative_state_exists_tx(tx, instance).await?
     {
         anyhow::bail!(
@@ -386,6 +390,7 @@ pub(super) async fn commit_decision_instance_tx(
 
 pub(super) async fn commit_rejected_initial_failure_instance_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    registry: &crate::runtime::WorkflowDefinitionRegistry,
     current: &WorkflowInstance,
     target: &WorkflowInstance,
     record: &WorkflowDecisionRecord,
@@ -405,7 +410,8 @@ pub(super) async fn commit_rejected_initial_failure_instance_tx(
         );
     }
     if current.version != 0
-        || target.terminal_state() != Some(crate::runtime::WorkflowTerminalState::Failed)
+        || target.terminal_state_with_registry(registry)
+            != Some(crate::runtime::WorkflowTerminalState::Failed)
     {
         anyhow::bail!(
             "rejected initial failure write requires a version-0 instance and failed target"

--- a/crates/harness-workflow/src/runtime/store/transition_validation.rs
+++ b/crates/harness-workflow/src/runtime/store/transition_validation.rs
@@ -12,6 +12,7 @@ use chrono::{DateTime, Utc};
 use super::runtime_completion::validator_for_instance;
 use crate::runtime::model::{WorkflowDecision, WorkflowInstance};
 use crate::runtime::validator::ValidationContext;
+use crate::runtime::WorkflowDefinitionRegistry;
 
 /// Result of validating a decision against the definition it targets.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,20 +29,27 @@ pub(super) enum TransitionValidation {
 /// is a rejection, not a pass. `current` must be the instance as loaded under
 /// the row lock, before the transition is applied.
 pub(super) fn validate_transition(
+    registry: &WorkflowDefinitionRegistry,
     current: &WorkflowInstance,
     decision: &WorkflowDecision,
     actor: &str,
     now: DateTime<Utc>,
 ) -> TransitionValidation {
-    validate_transition_with_context(current, decision, &ValidationContext::new(actor, now))
+    validate_transition_with_context(
+        registry,
+        current,
+        decision,
+        &ValidationContext::new(actor, now),
+    )
 }
 
 pub(super) fn validate_transition_with_context(
+    registry: &WorkflowDefinitionRegistry,
     current: &WorkflowInstance,
     decision: &WorkflowDecision,
     context: &ValidationContext,
 ) -> TransitionValidation {
-    match validator_for_instance(current) {
+    match validator_for_instance(registry, current) {
         Ok(Some(validator)) => match validator.validate(current, decision, context) {
             Ok(()) => TransitionValidation::Accepted,
             Err(error) => TransitionValidation::Rejected(error.to_string()),

--- a/crates/harness-workflow/src/runtime/store_summary.rs
+++ b/crates/harness-workflow/src/runtime/store_summary.rs
@@ -41,24 +41,37 @@ async fn workflow_states_for_instances(
     store: &WorkflowRuntimeStore,
     project_id: Option<&str>,
 ) -> anyhow::Result<Vec<WorkflowRuntimeStateCount>> {
-    let rows: Vec<(String, String, i64)> = sqlx::query_as(
-        "SELECT definition_id, state, COUNT(*)
+    let rows: Vec<(String, i64, Option<String>, String, i64)> = sqlx::query_as(
+        "SELECT definition_id,
+                (data->>'definition_version')::bigint,
+                NULLIF(BTRIM(data->'data'->>'definition_hash'), ''),
+                state,
+                COUNT(*)
          FROM workflow_instances
          WHERE ($1::text IS NULL OR data->'data'->>'project_id' = $1)
-         GROUP BY definition_id, state
-         ORDER BY definition_id ASC, state ASC",
+         GROUP BY 1, 2, 3, 4
+         ORDER BY 1 ASC, 2 ASC, 3 ASC NULLS FIRST, 4 ASC",
     )
     .bind(project_id)
     .fetch_all(store.pool())
     .await?;
-    Ok(rows
-        .into_iter()
-        .map(|(definition_id, state, count)| WorkflowRuntimeStateCount {
-            definition_id,
-            state,
-            count: count.max(0) as usize,
-        })
-        .collect())
+    rows.into_iter()
+        .map(
+            |(definition_id, definition_version, definition_hash, state, count)| {
+                Ok(WorkflowRuntimeStateCount {
+                    definition_id,
+                    definition_version: u32::try_from(definition_version).map_err(|_| {
+                        anyhow::anyhow!(
+                        "workflow summary contains invalid definition version {definition_version}"
+                    )
+                    })?,
+                    definition_hash,
+                    state,
+                    count: count.max(0) as usize,
+                })
+            },
+        )
+        .collect()
 }
 
 async fn command_statuses_for_instances(
@@ -251,6 +264,8 @@ mod tests {
             summary.workflow_states,
             vec![WorkflowRuntimeStateCount {
                 definition_id: "github_issue_pr".to_string(),
+                definition_version: 1,
+                definition_hash: None,
                 state: "implementing".to_string(),
                 count: 1,
             }]

--- a/crates/harness-workflow/src/runtime/terminal_state.rs
+++ b/crates/harness-workflow/src/runtime/terminal_state.rs
@@ -1,62 +1,48 @@
 pub use super::state_registry::WorkflowTerminalState;
 
-pub fn workflow_terminal_state(definition_id: &str, state: &str) -> Option<WorkflowTerminalState> {
-    super::state_registry::workflow_state_terminal_state(definition_id, state)
-}
-
-pub fn workflow_terminal_state_for_version(
-    definition_id: &str,
-    definition_version: u32,
-    state: &str,
-) -> Option<WorkflowTerminalState> {
-    super::state_registry::workflow_state_terminal_state_for_version(
-        definition_id,
-        definition_version,
-        state,
-    )
-}
-
-pub fn workflow_terminal_state_for_instance(
-    instance: &super::model::WorkflowInstance,
-) -> Option<WorkflowTerminalState> {
-    super::state_registry::workflow_state_definition_for_instance(instance, &instance.state)?
-        .terminal_state
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn terminal_state_treats_done_failed_and_cancelled_as_shared_terminal_states() {
+        let registry = super::super::state_registry::WorkflowDefinitionRegistry::with_builtins();
         assert_eq!(
-            workflow_terminal_state("github_issue_pr", "done"),
+            registry.state_terminal_state("github_issue_pr", "done"),
             Some(WorkflowTerminalState::Succeeded)
         );
         assert_eq!(
-            workflow_terminal_state("prompt_task", "failed"),
+            registry.state_terminal_state("prompt_task", "failed"),
             Some(WorkflowTerminalState::Failed)
         );
         assert_eq!(
-            workflow_terminal_state("pr_feedback", "cancelled"),
+            registry.state_terminal_state("pr_feedback", "cancelled"),
             Some(WorkflowTerminalState::Cancelled)
         );
     }
 
     #[test]
     fn terminal_state_scopes_success_states_to_workflow_definitions() {
+        let registry = super::super::state_registry::WorkflowDefinitionRegistry::with_builtins();
         assert_eq!(
-            workflow_terminal_state("quality_gate", "passed"),
+            registry.state_terminal_state("quality_gate", "passed"),
             Some(WorkflowTerminalState::Succeeded)
         );
-        assert_eq!(workflow_terminal_state("github_issue_pr", "passed"), None);
-        assert_eq!(workflow_terminal_state("quality_gate", "done"), None);
+        assert_eq!(
+            registry.state_terminal_state("github_issue_pr", "passed"),
+            None
+        );
+        assert_eq!(registry.state_terminal_state("quality_gate", "done"), None);
     }
 
     #[test]
     fn terminal_state_rejects_terminal_looking_states_for_unknown_definitions() {
+        let registry = super::super::state_registry::WorkflowDefinitionRegistry::with_builtins();
         for state in ["done", "passed", "failed", "cancelled"] {
-            assert_eq!(workflow_terminal_state("unknown_workflow", state), None);
+            assert_eq!(
+                registry.state_terminal_state("unknown_workflow", state),
+                None
+            );
         }
     }
 }

--- a/crates/harness-workflow/src/runtime/tests/decision_validator.rs
+++ b/crates/harness-workflow/src/runtime/tests/decision_validator.rs
@@ -523,7 +523,8 @@ fn empty_and_omitted_commands_share_progress_rejection() {
 
 #[test]
 fn wait_and_inline_commands_do_not_drive_progress() {
-    let validator = DecisionValidator::new(
+    let validator = DecisionValidator::for_definition(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
         super::validator::TransitionAllowlist::default().allow(
             "implementing",
             "implementing",
@@ -534,6 +535,8 @@ fn wait_and_inline_commands_do_not_drive_progress() {
                 WorkflowCommandType::RequestOperatorAttention,
             ],
         ),
+        crate::runtime::WorkflowDefinitionRegistry::with_builtins()
+            .states_for_definition(GITHUB_ISSUE_PR_DEFINITION_ID),
     );
     let cases = [
         WorkflowCommand::wait("still waiting", "non-driver:wait"),

--- a/crates/harness-workflow/src/runtime/tests/declarative_interpreter.rs
+++ b/crates/harness-workflow/src/runtime/tests/declarative_interpreter.rs
@@ -133,7 +133,11 @@ mod declarative_interpreter {
         event: &WorkflowEvent,
         result: &ActivityResult,
     ) -> WorkflowDecision {
-        reduce_declarative_completion(definition, instance, event, result)
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+        registry
+            .register_declarative_current(definition.clone())
+            .expect("fixture definition should register");
+        reduce_declarative_completion(&registry, definition, instance, event, result)
             .expect("declarative reduction should not error")
             .expect("generic declarative reduction should produce a decision")
     }
@@ -354,13 +358,15 @@ mod declarative_interpreter {
     #[test]
     fn reducer_entry_uses_strict_custom_pinning_and_declarative_builtins() {
         let definition = definition_for(&policy());
-        register_declarative_workflow_definitions([definition.clone()])
-            .expect("fixture definition should register once");
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+        registry
+            .register_declarative_current(definition.clone())
+            .expect("fixture definition should register");
         let instance = instance_for(&definition, "reviewing");
         let result = ActivityResult::succeeded("review", "reviewed")
             .with_artifact(ActivityArtifact::new("review_report", json!({})));
         let event = completion_event(&instance, "review", &result);
-        let decision = reduce_runtime_job_completed(&instance, &event)
+        let decision = reduce_runtime_job_completed_with_registry(&registry, &instance, &event)
             .expect("completion should reduce")
             .expect("declarative completion should produce a decision");
         assert_eq!(decision.next_state, "publishing");
@@ -372,7 +378,7 @@ mod declarative_interpreter {
             WorkflowSubject::new("document", "missing-hash"),
         );
         let missing_hash_event = completion_event(&missing_hash, "review", &result);
-        let pin_error = reduce_runtime_job_completed(&missing_hash, &missing_hash_event)
+        let pin_error = reduce_runtime_job_completed_with_registry(&registry, &missing_hash, &missing_hash_event)
             .expect("pin error should reduce")
             .expect("pin error should block");
         assert_eq!(pin_error.decision, "definition_version_missing");
@@ -382,7 +388,7 @@ mod declarative_interpreter {
             "definition_hash": "not-a-canonical-hash"
         }));
         let invalid_hash_event = completion_event(&invalid_hash, "review", &result);
-        let invalid_hash_decision = reduce_runtime_job_completed(&invalid_hash, &invalid_hash_event)
+        let invalid_hash_decision = reduce_runtime_job_completed_with_registry(&registry, &invalid_hash, &invalid_hash_event)
             .expect("invalid hash should reduce")
             .expect("invalid hash should block");
         assert_eq!(invalid_hash_decision.decision, "definition_version_missing");
@@ -401,7 +407,7 @@ mod declarative_interpreter {
             .with_server_data(json!({ "definition_hash": mismatched_hash }));
         let hash_mismatch_event = completion_event(&hash_mismatch, "review", &result);
         let hash_mismatch_decision =
-            reduce_runtime_job_completed(&hash_mismatch, &hash_mismatch_event)
+            reduce_runtime_job_completed_with_registry(&registry, &hash_mismatch, &hash_mismatch_event)
                 .expect("hash mismatch should reduce")
                 .expect("hash mismatch should block");
         assert_eq!(
@@ -419,7 +425,7 @@ mod declarative_interpreter {
         .with_server_data(json!({ "definition_hash": definition.definition_hash() }));
         let missing_version_event = completion_event(&missing_version, "review", &result);
         let missing_version_decision =
-            reduce_runtime_job_completed(&missing_version, &missing_version_event)
+            reduce_runtime_job_completed_with_registry(&registry, &missing_version, &missing_version_event)
                 .expect("missing version should reduce")
                 .expect("missing version should block");
         assert_eq!(
@@ -429,7 +435,7 @@ mod declarative_interpreter {
         assert!(missing_version_decision.reason.contains("missing_version"));
 
         let builtin = issue_instance("replanning");
-        assert!(workflow_instance_is_declarative(&builtin));
+        assert!(registry.instance_is_declarative(&builtin));
         let builtin_result = ActivityResult::succeeded("replan_issue", "replanned");
         let builtin_event = WorkflowEvent::new(
             &builtin.id,
@@ -441,7 +447,7 @@ mod declarative_interpreter {
             "command_id": "builtin-command",
             "activity_result": builtin_result,
         }));
-        let builtin_decision = reduce_runtime_job_completed(&builtin, &builtin_event)
+        let builtin_decision = reduce_runtime_job_completed_with_registry(&registry, &builtin, &builtin_event)
             .expect("builtin completion should reduce")
             .expect("builtin declarative completion should produce a decision");
         assert_eq!(

--- a/crates/harness-workflow/src/runtime/tests/declarative_pinning.rs
+++ b/crates/harness-workflow/src/runtime/tests/declarative_pinning.rs
@@ -4,6 +4,8 @@ mod declarative_pinning {
         DeclaredProgressMode, DeclaredState, WorkflowActivityPolicy, WorkflowDefinitionPolicy,
     };
     use harness_core::db::resolve_database_url;
+    use chrono::Utc;
+    use crate::runtime::store::RuntimeJobEnqueueOutcome;
     use serde_json::json;
     use std::collections::BTreeMap;
 
@@ -259,6 +261,112 @@ mod declarative_pinning {
         assert!(raw_registry
             .state_definition_for_instance(&raw_with_unrelated_hash, "done")
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn driverless_progress_uses_exact_declarative_progress_pin() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+        let v1 = compiled(&policy_v1());
+        let v2 = compiled(&policy_v2());
+        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+        registry.register_declarative_historical(v1.clone())?;
+        registry.register_declarative_current(v2.clone())?;
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db"))
+            .await?
+            .with_definition_registry(registry.into_shared());
+        let historical = WorkflowInstance::new(
+            "docs_review",
+            v1.definition_version(),
+            "reviewing",
+            WorkflowSubject::new("document", "historical-driverless"),
+        )
+        .with_id("historical-driverless")
+        .with_server_data(json!({ "definition_hash": v1.definition_hash() }));
+        let current = WorkflowInstance::new(
+            "docs_review",
+            v2.definition_version(),
+            "reviewing",
+            WorkflowSubject::new("document", "current-external-wait"),
+        )
+        .with_id("current-external-wait")
+        .with_server_data(json!({ "definition_hash": v2.definition_hash() }));
+        store.force_upsert_lifecycle_state_for_test(&historical).await?;
+        store.force_upsert_lifecycle_state_for_test(&current).await?;
+
+        let rows = store.list_driverless_progress_instances(500).await?;
+        assert!(rows.iter().any(|row| row.workflow_id == historical.id));
+        assert!(!rows.iter().any(|row| row.workflow_id == current.id));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn claimed_enqueue_recognizes_persisted_only_cancelled_pin() -> anyhow::Result<()> {
+        if resolve_database_url(None).is_err() {
+            return Ok(());
+        }
+        let mut historical_policy = policy_v1();
+        historical_policy.terminal.remove("cancelled");
+        historical_policy
+            .terminal
+            .insert("withdrawn".to_string(), "cancelled".to_string());
+        historical_policy
+            .states
+            .get_mut("reviewing")
+            .expect("fixture reviewing state should exist")
+            .on_signal
+            .insert("cancel".to_string(), "withdrawn".to_string());
+        let historical = compiled(&historical_policy);
+        let current = compiled(&policy_v2());
+        let mut registry = WorkflowDefinitionRegistry::new_for_tests();
+        registry.register_declarative_current(current)?;
+        let dir = tempfile::tempdir()?;
+        let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db"))
+            .await?
+            .with_definition_registry(registry.into_shared());
+        store
+            .persist_definition_version(&persisted_declarative_definition(&historical, None))
+            .await?;
+        let workflow = WorkflowInstance::new(
+            "docs_review",
+            historical.definition_version(),
+            "withdrawn",
+            WorkflowSubject::new("document", "persisted-terminal-dispatch"),
+        )
+        .with_id("persisted-terminal-dispatch")
+        .with_server_data(json!({ "definition_hash": historical.definition_hash() }));
+        store.force_upsert_lifecycle_state_for_test(&workflow).await?;
+        let command = WorkflowCommand::enqueue_activity("review", "persisted-terminal-command");
+        let command_id = store.enqueue_command(&workflow.id, None, &command).await?;
+        let claim = store
+            .claim_pending_commands("persisted-terminal-owner", Utc::now(), 10)
+            .await?
+            .into_iter()
+            .find(|record| record.id == command_id)
+            .expect("persisted-only terminal command should reach the transactional guard");
+
+        assert_eq!(
+            store
+                .enqueue_runtime_job_for_claimed_command(
+                    &command_id,
+                    DispatchClaim {
+                        owner: "persisted-terminal-owner",
+                        generation: claim.dispatch_claim_generation,
+                    },
+                    RuntimeKind::CodexJsonrpc,
+                    "codex-default",
+                    json!({ "activity": "review" }),
+                    None,
+                )
+                .await?,
+            RuntimeJobEnqueueOutcome::WorkflowTerminal {
+                status: WorkflowCommandStatus::Cancelled,
+            }
+        );
+        assert!(store.runtime_jobs_for_command(&command_id).await?.is_empty());
+        Ok(())
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/tests/declarative_pinning.rs
+++ b/crates/harness-workflow/src/runtime/tests/declarative_pinning.rs
@@ -215,7 +215,9 @@ mod declarative_pinning {
         assert!(registry
             .state_definition_for_instance(&missing_unmarked_version, "completed")
             .is_none());
-        assert!(workflow_definition_for_version(GITHUB_ISSUE_PR_DEFINITION_ID, u32::MAX).is_some());
+        assert!(WorkflowDefinitionRegistry::with_builtins()
+            .definition_for_version(GITHUB_ISSUE_PR_DEFINITION_ID, u32::MAX)
+            .is_some());
         let builtin_with_unrelated_hash = WorkflowInstance::new(
             GITHUB_ISSUE_PR_DEFINITION_ID,
             u32::MAX,
@@ -224,7 +226,8 @@ mod declarative_pinning {
         )
         .with_server_data(json!({ "definition_hash": "unrelated-business-metadata" }));
         assert_eq!(
-            workflow_state_definition_for_instance(&builtin_with_unrelated_hash, "done")
+            WorkflowDefinitionRegistry::with_builtins()
+                .state_definition_for_instance(&builtin_with_unrelated_hash, "done")
                 .and_then(|state| state.terminal_state),
             Some(WorkflowTerminalState::Succeeded),
         );

--- a/crates/harness-workflow/src/runtime/tests/declarative_pinning.rs
+++ b/crates/harness-workflow/src/runtime/tests/declarative_pinning.rs
@@ -271,12 +271,14 @@ mod declarative_pinning {
         let v1 = compiled(&policy_v1());
         let v2 = compiled(&policy_v2());
         let mut registry = WorkflowDefinitionRegistry::new_for_tests();
-        registry.register_declarative_historical(v1.clone())?;
         registry.register_declarative_current(v2.clone())?;
         let dir = tempfile::tempdir()?;
         let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db"))
             .await?
             .with_definition_registry(registry.into_shared());
+        store
+            .persist_definition_version(&persisted_declarative_definition(&v1, None))
+            .await?;
         let historical = WorkflowInstance::new(
             "docs_review",
             v1.definition_version(),

--- a/crates/harness-workflow/src/runtime/tests/declarative_recovery_integration.rs
+++ b/crates/harness-workflow/src/runtime/tests/declarative_recovery_integration.rs
@@ -59,9 +59,12 @@ async fn declarative_recovery_is_atomic_and_persists_exact_driver_status() -> an
     }
 
     let definition = declarative_recovery_definition()?;
-    super::register_declarative_workflow_definitions([definition.clone()])?;
+    let mut registry = crate::runtime::WorkflowDefinitionRegistry::with_builtins();
+    registry.register_declarative_current(definition.clone())?;
     let dir = tempfile::tempdir()?;
-    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
+    let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db"))
+        .await?
+        .with_definition_registry(registry.into_shared());
     let blocked = |id: &str| {
         WorkflowInstance::new(
             definition.policy().id.clone(),

--- a/crates/harness-workflow/src/runtime/tests/declarative_validation.rs
+++ b/crates/harness-workflow/src/runtime/tests/declarative_validation.rs
@@ -84,7 +84,9 @@ mod declarative_validation {
                 WorkflowCommandType::RequestOperatorAttention,
             ])
         );
-        assert!(workflow_definition("docs_review").is_none());
+        assert!(WorkflowDefinitionRegistry::with_builtins()
+            .definition("docs_review")
+            .is_none());
     }
 
     #[test]

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -1,11 +1,15 @@
 use super::model::{WorkflowCommand, WorkflowCommandType, WorkflowDecision, WorkflowInstance};
+use super::state_registry::{WorkflowDefinitionRegistry, WorkflowStateDefinition};
 use super::validator_binding::DecisionValidatorBinding;
 use super::validator_progress;
-use chrono::{DateTime, Utc};
+#[cfg(test)]
+use chrono::Utc;
 use harness_core::claim_trust::ClaimTrustLevel;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+#[path = "validator_command_rules.rs"]
+mod command_rules;
 #[path = "validator_evidence.rs"]
 mod evidence_contract;
 #[path = "validator_github_issue_pr.rs"]
@@ -16,6 +20,9 @@ mod hidden_transitions;
 mod prompt_task_validation;
 #[path = "validator_context.rs"]
 mod validation_context;
+
+use command_rules::{is_replan_command, required_command_for_transition};
+pub use validation_context::ValidationContext;
 
 #[cfg(test)]
 #[path = "validator_tests.rs"]
@@ -366,19 +373,6 @@ impl TransitionAllowlist {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct ValidationContext {
-    pub actor: String,
-    pub now: DateTime<Utc>,
-    pub resource_budget_available: bool,
-    pub replan_available: bool,
-    pub wait_available: bool,
-    pub allow_terminal_reopen: bool,
-    pub allow_missing_pinned_cancel: bool,
-    pub allow_definition_pin_safety_decision: bool,
-    pub active_dedupe_keys: BTreeSet<String>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorkflowDecisionRejectionKind {
     WorkflowIdMismatch,
@@ -430,6 +424,7 @@ impl std::error::Error for WorkflowDecisionRejection {}
 #[derive(Debug, Clone)]
 pub struct DecisionValidator {
     allowlist: TransitionAllowlist,
+    states: Vec<WorkflowStateDefinition>,
     kind: DecisionValidatorKind,
     binding: DecisionValidatorBinding,
 }
@@ -448,6 +443,7 @@ impl DecisionValidator {
     pub fn new(allowlist: TransitionAllowlist) -> Self {
         Self {
             allowlist,
+            states: Vec::new(),
             kind: DecisionValidatorKind::Generic,
             binding: DecisionValidatorBinding::unbound(),
         }
@@ -459,8 +455,9 @@ impl DecisionValidator {
         definition_version: u32,
         definition_hash: &str,
         allowlist: TransitionAllowlist,
+        states: Vec<WorkflowStateDefinition>,
     ) -> Self {
-        let mut validator = Self::for_definition(definition_id, allowlist);
+        let mut validator = Self::for_definition(definition_id, allowlist, states);
         validator.binding = DecisionValidatorBinding::for_declarative(
             definition_id,
             definition_version,
@@ -475,34 +472,34 @@ impl DecisionValidator {
     }
 
     pub fn github_issue_pr() -> Self {
-        super::state_registry::decision_validator_for_definition(
-            super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID,
-        )
-        .expect("built-in github_issue_pr workflow definition must be registered")
+        WorkflowDefinitionRegistry::with_builtins()
+            .decision_validator_for_definition(super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID)
+            .expect("built-in github_issue_pr workflow definition must be registered")
     }
 
     pub fn quality_gate() -> Self {
-        super::state_registry::decision_validator_for_definition(
-            super::quality_gate::QUALITY_GATE_DEFINITION_ID,
-        )
-        .expect("built-in quality_gate workflow definition must be registered")
+        WorkflowDefinitionRegistry::with_builtins()
+            .decision_validator_for_definition(super::quality_gate::QUALITY_GATE_DEFINITION_ID)
+            .expect("built-in quality_gate workflow definition must be registered")
     }
 
     pub fn pr_feedback() -> Self {
-        super::state_registry::decision_validator_for_definition(
-            super::pr_feedback::PR_FEEDBACK_DEFINITION_ID,
-        )
-        .expect("built-in pr_feedback workflow definition must be registered")
+        WorkflowDefinitionRegistry::with_builtins()
+            .decision_validator_for_definition(super::pr_feedback::PR_FEEDBACK_DEFINITION_ID)
+            .expect("built-in pr_feedback workflow definition must be registered")
     }
 
     pub fn prompt_task() -> Self {
-        super::state_registry::decision_validator_for_definition(
-            super::prompt_task::PROMPT_TASK_DEFINITION_ID,
-        )
-        .expect("built-in prompt_task workflow definition must be registered")
+        WorkflowDefinitionRegistry::with_builtins()
+            .decision_validator_for_definition(super::prompt_task::PROMPT_TASK_DEFINITION_ID)
+            .expect("built-in prompt_task workflow definition must be registered")
     }
 
-    pub(crate) fn for_definition(definition_id: &str, allowlist: TransitionAllowlist) -> Self {
+    pub(crate) fn for_definition(
+        definition_id: &str,
+        allowlist: TransitionAllowlist,
+        states: Vec<WorkflowStateDefinition>,
+    ) -> Self {
         let kind = match definition_id {
             super::reducer::GITHUB_ISSUE_PR_DEFINITION_ID => DecisionValidatorKind::GithubIssuePr,
             super::prompt_task::PROMPT_TASK_DEFINITION_ID => DecisionValidatorKind::PromptTask,
@@ -510,6 +507,7 @@ impl DecisionValidator {
         };
         Self {
             allowlist,
+            states,
             kind,
             binding: DecisionValidatorBinding::for_definition(definition_id),
         }
@@ -541,7 +539,9 @@ impl DecisionValidator {
             ));
         }
 
-        if instance.is_terminal()
+        if self
+            .state_definition(&instance.state)
+            .is_some_and(|state| state.terminal_state.is_some())
             && decision.next_state != instance.state
             && !context.allow_terminal_reopen
         {
@@ -603,6 +603,7 @@ impl DecisionValidator {
         self.validate_commands(rule, decision, context)?;
         validator_progress::validate_required_evidence(rule, decision)?;
         validator_progress::validate_target_progress_contract_with_override(
+            self.state_definition(&decision.next_state),
             instance,
             decision,
             context.allow_missing_pinned_cancel,
@@ -615,6 +616,12 @@ impl DecisionValidator {
         from_state: &'a str,
     ) -> impl Iterator<Item = &'a TransitionRule> + 'a {
         self.allowlist.rules_from(from_state)
+    }
+
+    pub(super) fn state_definition(&self, state: &str) -> Option<&WorkflowStateDefinition> {
+        self.states
+            .iter()
+            .find(|definition| definition.key.state.as_ref() == state)
     }
 
     fn validate_commands(
@@ -780,26 +787,5 @@ impl DecisionValidator {
         }
 
         Ok(())
-    }
-}
-
-fn is_replan_command(command: &WorkflowCommand) -> bool {
-    command.activity_name() == Some("replan_issue")
-}
-
-fn required_command_for_transition(
-    from_state: &str,
-    to_state: &str,
-) -> Option<WorkflowCommandType> {
-    match (from_state, to_state) {
-        (from_state, "pr_open") if from_state != "pr_open" => Some(WorkflowCommandType::BindPr),
-        ("idle", "scanning") => Some(WorkflowCommandType::EnqueueActivity),
-        ("scanning", "planning_batch") => Some(WorkflowCommandType::EnqueueActivity),
-        ("planning_batch", "dispatching") => Some(WorkflowCommandType::StartChildWorkflow),
-        (_, "done") => Some(WorkflowCommandType::MarkDone),
-        (_, "blocked") => Some(WorkflowCommandType::MarkBlocked),
-        (_, "failed") => Some(WorkflowCommandType::MarkFailed),
-        (_, "cancelled") => Some(WorkflowCommandType::MarkCancelled),
-        _ => None,
     }
 }

--- a/crates/harness-workflow/src/runtime/validator_command_rules.rs
+++ b/crates/harness-workflow/src/runtime/validator_command_rules.rs
@@ -1,0 +1,22 @@
+use super::{WorkflowCommand, WorkflowCommandType};
+
+pub(super) fn is_replan_command(command: &WorkflowCommand) -> bool {
+    command.activity_name() == Some("replan_issue")
+}
+
+pub(super) fn required_command_for_transition(
+    from_state: &str,
+    to_state: &str,
+) -> Option<WorkflowCommandType> {
+    match (from_state, to_state) {
+        (from_state, "pr_open") if from_state != "pr_open" => Some(WorkflowCommandType::BindPr),
+        ("idle", "scanning") => Some(WorkflowCommandType::EnqueueActivity),
+        ("scanning", "planning_batch") => Some(WorkflowCommandType::EnqueueActivity),
+        ("planning_batch", "dispatching") => Some(WorkflowCommandType::StartChildWorkflow),
+        (_, "done") => Some(WorkflowCommandType::MarkDone),
+        (_, "blocked") => Some(WorkflowCommandType::MarkBlocked),
+        (_, "failed") => Some(WorkflowCommandType::MarkFailed),
+        (_, "cancelled") => Some(WorkflowCommandType::MarkCancelled),
+        _ => None,
+    }
+}

--- a/crates/harness-workflow/src/runtime/validator_context.rs
+++ b/crates/harness-workflow/src/runtime/validator_context.rs
@@ -1,6 +1,18 @@
-use super::ValidationContext;
 use chrono::{DateTime, Utc};
 use std::collections::BTreeSet;
+
+#[derive(Debug, Clone)]
+pub struct ValidationContext {
+    pub actor: String,
+    pub now: DateTime<Utc>,
+    pub resource_budget_available: bool,
+    pub replan_available: bool,
+    pub wait_available: bool,
+    pub allow_terminal_reopen: bool,
+    pub allow_missing_pinned_cancel: bool,
+    pub allow_definition_pin_safety_decision: bool,
+    pub active_dedupe_keys: BTreeSet<String>,
+}
 
 impl ValidationContext {
     pub fn new(actor: impl Into<String>, now: DateTime<Utc>) -> Self {

--- a/crates/harness-workflow/src/runtime/validator_hidden_transitions.rs
+++ b/crates/harness-workflow/src/runtime/validator_hidden_transitions.rs
@@ -31,7 +31,11 @@ impl DecisionValidator {
             [WorkflowCommandType::MarkDone],
         );
         self.validate_commands(&rule, decision, context)?;
-        validator_progress::validate_target_progress_contract(instance, decision)?;
+        validator_progress::validate_target_progress_contract(
+            self.state_definition(&decision.next_state),
+            instance,
+            decision,
+        )?;
         github_issue_pr_validation::validate_reconciliation_only_done(decision, context)?;
         Ok(true)
     }
@@ -83,7 +87,11 @@ impl DecisionValidator {
             coverage_recovery_allowed_commands(decision.next_state.as_str()),
         );
         self.validate_commands(&rule, decision, context)?;
-        validator_progress::validate_target_progress_contract(instance, decision)
+        validator_progress::validate_target_progress_contract(
+            self.state_definition(&decision.next_state),
+            instance,
+            decision,
+        )
     }
 }
 

--- a/crates/harness-workflow/src/runtime/validator_progress.rs
+++ b/crates/harness-workflow/src/runtime/validator_progress.rs
@@ -1,5 +1,5 @@
 use super::model::{WorkflowDecision, WorkflowInstance};
-use super::state_registry::{self, WorkflowProgressMode};
+use super::state_registry::{WorkflowProgressMode, WorkflowStateDefinition};
 use super::validator::{
     TransitionRule, ValidationContext, WorkflowDecisionRejection, WorkflowDecisionRejectionKind,
 };
@@ -148,19 +148,19 @@ fn validated_evidence_trust(
 }
 
 pub(super) fn validate_target_progress_contract(
+    state: Option<&WorkflowStateDefinition>,
     instance: &WorkflowInstance,
     decision: &WorkflowDecision,
 ) -> Result<(), WorkflowDecisionRejection> {
-    validate_target_progress_contract_with_override(instance, decision, false)
+    validate_target_progress_contract_with_override(state, instance, decision, false)
 }
 
 pub(super) fn validate_target_progress_contract_with_override(
+    state: Option<&WorkflowStateDefinition>,
     instance: &WorkflowInstance,
     decision: &WorkflowDecision,
     allow_missing_pinned_cancel: bool,
 ) -> Result<(), WorkflowDecisionRejection> {
-    let state =
-        state_registry::workflow_state_definition_for_instance(instance, &decision.next_state);
     if state.is_none()
         && allow_missing_pinned_cancel
         && decision.decision == "cancel_declarative_submission"

--- a/crates/harness-workflow/src/runtime/validator_tests.rs
+++ b/crates/harness-workflow/src/runtime/validator_tests.rs
@@ -346,10 +346,12 @@ fn declared_evidence_gates_a_decision_and_enforcement_can_be_lifted() {
         json!({ "reason": "done" }),
     ));
 
-    let enforcing = DecisionValidator::new(
+    let enforcing = DecisionValidator::for_definition(
+        "prompt_task",
         TransitionAllowlist::default()
             .allow("implementing", "done", [WorkflowCommandType::MarkDone])
             .require_evidence("implementing", "done", ["prompt_completion_evidence"]),
+        WorkflowDefinitionRegistry::with_builtins().states_for_definition("prompt_task"),
     );
     let err = enforcing
         .validate(
@@ -375,11 +377,13 @@ fn declared_evidence_gates_a_decision_and_enforcement_can_be_lifted() {
         )
         .expect("decision carrying the declared evidence must be accepted");
 
-    let lifted = DecisionValidator::new(
+    let lifted = DecisionValidator::for_definition(
+        "prompt_task",
         TransitionAllowlist::default()
             .allow("implementing", "done", [WorkflowCommandType::MarkDone])
             .require_evidence("implementing", "done", ["prompt_completion_evidence"])
             .without_required_evidence(),
+        WorkflowDefinitionRegistry::with_builtins().states_for_definition("prompt_task"),
     );
     lifted
         .validate(

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -3,6 +3,7 @@ use super::model::{
     WorkflowCommandRecord, WorkflowInstance,
 };
 use super::store::{RuntimeJobClaimDeferOutcome, WorkflowRuntimeStore};
+use super::WorkflowTerminalState;
 use anyhow::Context;
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -229,18 +230,20 @@ impl<'a> RuntimeWorker<'a> {
         let Some(instance) = self.store.get_instance(workflow_id).await? else {
             return Ok(None);
         };
-        if !instance.is_terminal_with_registry(self.store.definition_registry()) {
+        let Some(terminal_state) = self.store.terminal_state_for_instance(&instance).await? else {
             return Ok(None);
-        }
+        };
         let activity = runtime_job_activity_name(job);
         let summary = format!(
             "Workflow {} was already terminal ({}) before runtime execution.",
             instance.id, instance.state
         );
-        let result = match instance.state.as_str() {
-            "cancelled" => ActivityResult::cancelled(activity, summary),
-            "failed" => ActivityResult::failed(activity, summary, "workflow already failed"),
-            _ => ActivityResult::succeeded(activity, summary),
+        let result = match terminal_state {
+            WorkflowTerminalState::Cancelled => ActivityResult::cancelled(activity, summary),
+            WorkflowTerminalState::Failed => {
+                ActivityResult::failed(activity, summary, "workflow already failed")
+            }
+            WorkflowTerminalState::Succeeded => ActivityResult::succeeded(activity, summary),
         };
         Ok(Some(result))
     }

--- a/crates/harness-workflow/src/runtime/worker.rs
+++ b/crates/harness-workflow/src/runtime/worker.rs
@@ -229,7 +229,7 @@ impl<'a> RuntimeWorker<'a> {
         let Some(instance) = self.store.get_instance(workflow_id).await? else {
             return Ok(None);
         };
-        if !instance.is_terminal() {
+        if !instance.is_terminal_with_registry(self.store.definition_registry()) {
             return Ok(None);
         }
         let activity = runtime_job_activity_name(job);

--- a/crates/harness-workflow/tests/state_registry_public_api.rs
+++ b/crates/harness-workflow/tests/state_registry_public_api.rs
@@ -1,7 +1,7 @@
 use harness_workflow::runtime::{
-    register_workflow_definition, workflow_definition, RegisteredWorkflowDefinition,
-    TransitionAllowlist, TransitionRule, WorkflowDefinition as PersistedWorkflowDefinition,
-    WorkflowProgressMode, WorkflowStateDefinition,
+    RegisteredWorkflowDefinition, TransitionAllowlist, TransitionRule,
+    WorkflowDefinition as PersistedWorkflowDefinition, WorkflowDefinitionRegistry,
+    WorkflowProgressMode, WorkflowStateDefinition, WorkflowTerminalState,
 };
 
 #[test]
@@ -24,10 +24,13 @@ fn downstream_crate_can_construct_and_register_a_runtime_definition() {
         TransitionAllowlist::new(vec![TransitionRule::new("pending", "running", [])]),
     );
 
-    register_workflow_definition(definition)
+    let mut registry = WorkflowDefinitionRegistry::new();
+    registry
+        .register(definition)
         .expect("downstream runtime definition should register through the public API");
 
-    let registered = workflow_definition(definition_id)
+    let registered = registry
+        .definition(definition_id)
         .expect("downstream runtime definition should be available after registration");
     assert_eq!(registered.id, definition_id);
     assert_eq!(registered.states.len(), 2);
@@ -38,4 +41,45 @@ fn downstream_crate_can_construct_and_register_a_runtime_definition() {
 
     let persisted = PersistedWorkflowDefinition::new(definition_id, 1, "Downstream fixture");
     assert_eq!(persisted.id, registered.id);
+}
+
+#[test]
+fn independent_registries_can_resolve_concurrently_without_cross_contamination() {
+    fn registry_with_terminal(
+        state: &str,
+        terminal: WorkflowTerminalState,
+    ) -> std::sync::Arc<WorkflowDefinitionRegistry> {
+        let mut registry = WorkflowDefinitionRegistry::new();
+        registry
+            .register(RegisteredWorkflowDefinition::new(
+                "isolated_definition",
+                vec![WorkflowStateDefinition::terminal(
+                    "isolated_definition",
+                    state,
+                    terminal,
+                )],
+                TransitionAllowlist::default(),
+            ))
+            .expect("isolated definition should register");
+        registry.into_shared()
+    }
+
+    let succeeded = registry_with_terminal("complete", WorkflowTerminalState::Succeeded);
+    let failed = registry_with_terminal("rejected", WorkflowTerminalState::Failed);
+    let succeeded_thread = std::thread::spawn(move || {
+        succeeded.state_terminal_state("isolated_definition", "complete")
+    });
+    let failed_thread =
+        std::thread::spawn(move || failed.state_terminal_state("isolated_definition", "rejected"));
+
+    assert_eq!(
+        succeeded_thread
+            .join()
+            .expect("success lookup should finish"),
+        Some(WorkflowTerminalState::Succeeded)
+    );
+    assert_eq!(
+        failed_thread.join().expect("failure lookup should finish"),
+        Some(WorkflowTerminalState::Failed)
+    );
 }


### PR DESCRIPTION
## Summary

- replace the process-global workflow definition registry with an immutable registry owned by `WorkflowRuntimeStore`
- route terminal, progress, validator, evidence, projection, retention, and repo-memory lookups through the injected handle
- preserve declarative definition version/hash semantics across historical retention and runtime summaries
- add concurrent isolation and production-path regressions

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- DB-less `cargo test -p harness-workflow --lib -- --skip runtime::tests::remote_host_lease`
- targeted `harness-server` declarative, projection, SSE, and completion tests

Closes #1794