### PR TITLE
build(deps): update h2 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

- update h2 from 0.4.13 to 0.4.16 in Cargo.lock
- remediate RUSTSEC-2026-0258
- preserve all manifests and unrelated dependency selections

## Validation

- cargo audit (no vulnerabilities; existing allowed warnings remain)
- cargo check --locked --workspace --all-targets
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --exclude harness-server --exclude harness-workflow --lib
- repository pre-commit and pre-push hooks
- fresh-context review: APPROVED

Fixes #1972

## AI disclosure

This pull request was implemented and reviewed with AI assistance. All changes and validation results were inspected before submission.