### PR TITLE
perf(server): share cached ExecPlans instead of deep-cloning per request

### DIFF
--- a/crates/harness-context/src/providers.rs
+++ b/crates/harness-context/src/providers.rs
@@ -173,12 +173,14 @@ impl ContextProvider for ContractProvider {
     }
 }
 
+/// Holds shared handles to cached plans so that proposing never deep-clones
+/// plan contents (the server's plan cache stores `Arc<ExecPlan>`).
 pub struct ExecPlanProvider {
-    plans: Vec<harness_exec::plan::ExecPlan>,
+    plans: Vec<std::sync::Arc<harness_exec::plan::ExecPlan>>,
 }
 
 impl ExecPlanProvider {
-    pub fn new(plans: Vec<harness_exec::plan::ExecPlan>) -> Self {
+    pub fn new(plans: Vec<std::sync::Arc<harness_exec::plan::ExecPlan>>) -> Self {
         Self { plans }
     }
 }
@@ -194,7 +196,6 @@ impl ContextProvider for ExecPlanProvider {
             .iter()
             .filter(|plan| ProjectId::from_path(&plan.project_root) == req.project)
             .filter(|plan| matches!(plan.status, ExecPlanStatus::Draft | ExecPlanStatus::Active))
-            .cloned()
             .collect::<Vec<_>>();
         plans.sort_by(|left, right| left.id.as_str().cmp(right.id.as_str()));
 

--- a/crates/harness-context/src/tests.rs
+++ b/crates/harness-context/src/tests.rs
@@ -334,7 +334,7 @@ fn providers_include_active_exec_plans_for_matching_project() {
     let mut plan = harness_exec::plan::ExecPlan::from_spec("# Ship context composer", dir.path())
         .expect("plan");
     plan.activate();
-    let provider = ExecPlanProvider::new(vec![plan.clone()]);
+    let provider = ExecPlanProvider::new(vec![std::sync::Arc::new(plan.clone())]);
     let mut request = req();
     request.project = ProjectId::from_path(dir.path());
 

--- a/crates/harness-server/src/handlers/exec.rs
+++ b/crates/harness-server/src/handlers/exec.rs
@@ -27,7 +27,7 @@ pub async fn exec_plan_init(
             state
                 .core
                 .plan_cache
-                .insert(plan_id.as_str().to_string(), plan);
+                .insert(plan_id.as_str().to_string(), std::sync::Arc::new(plan));
             RpcResponse::success(id, serde_json::json!({ "plan_id": plan_id }))
         }
         Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
@@ -47,10 +47,10 @@ pub async fn exec_plan_status(
         match db.get(&plan_id).await {
             Ok(Some(plan)) => {
                 // Keep cache warm for the write path.
-                state
-                    .core
-                    .plan_cache
-                    .insert(plan_id.as_str().to_string(), plan.clone());
+                state.core.plan_cache.insert(
+                    plan_id.as_str().to_string(),
+                    std::sync::Arc::new(plan.clone()),
+                );
                 match serde_json::to_value(&plan) {
                     Ok(v) => RpcResponse::success(id, v),
                     Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
@@ -123,10 +123,10 @@ pub async fn exec_plan_update(
     match result {
         Ok(Some(plan)) => {
             // Keep in-memory cache in sync with the persisted state.
-            state
-                .core
-                .plan_cache
-                .insert(plan_id.as_str().to_string(), plan.clone());
+            state.core.plan_cache.insert(
+                plan_id.as_str().to_string(),
+                std::sync::Arc::new(plan.clone()),
+            );
             match serde_json::to_value(&plan) {
                 Ok(v) => RpcResponse::success(id, v),
                 Err(e) => RpcResponse::error(id, INTERNAL_ERROR, e.to_string()),

--- a/crates/harness-server/src/http/builders/registry.rs
+++ b/crates/harness-server/src/http/builders/registry.rs
@@ -15,7 +15,7 @@ use crate::server::HarnessServer;
 /// Outputs of the registry initialization phase.
 pub(crate) struct RegistryBundle {
     pub plan_db: Option<PlanDb>,
-    pub plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>>,
+    pub plan_cache: Arc<DashMap<String, std::sync::Arc<harness_exec::plan::ExecPlan>>>,
     pub issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     pub project_workflow_store:
         Option<Arc<harness_workflow::project_lifecycle::ProjectWorkflowStore>>,
@@ -55,7 +55,8 @@ pub(crate) async fn build_registry(
     let mut workflow_definition_registry = server.configure_workflow_definition_registry()?;
     let workflow_ns = workflow_config.storage.schema_namespace;
     let mut startup_results = Vec::new();
-    let plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>> = Arc::new(DashMap::new());
+    let plan_cache: Arc<DashMap<String, std::sync::Arc<harness_exec::plan::ExecPlan>>> =
+        Arc::new(DashMap::new());
 
     let database_url = match harness_core::db::resolve_database_url(configured_database_url) {
         Ok(database_url) => database_url,
@@ -123,7 +124,7 @@ pub(crate) async fn build_registry(
             Ok(plans) => {
                 let count = plans.len();
                 for plan in plans {
-                    plan_cache.insert(plan.id.as_str().to_string(), plan);
+                    plan_cache.insert(plan.id.as_str().to_string(), std::sync::Arc::new(plan));
                 }
                 if count > 0 {
                     tracing::debug!(count, "plan cache: loaded {} plan(s) from db", count);

--- a/crates/harness-server/src/http/builders/registry_failures.rs
+++ b/crates/harness-server/src/http/builders/registry_failures.rs
@@ -18,7 +18,7 @@ pub(crate) fn failed_registry_startup_results(error: &str) -> Vec<StoreStartupRe
 }
 
 pub(crate) fn failed_registry_bundle(
-    plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>>,
+    plan_cache: Arc<DashMap<String, std::sync::Arc<harness_exec::plan::ExecPlan>>>,
     error: &str,
 ) -> RegistryBundle {
     RegistryBundle {

--- a/crates/harness-server/src/http/state.rs
+++ b/crates/harness-server/src/http/state.rs
@@ -64,7 +64,8 @@ pub struct CoreServices {
     pub plan_db: Option<crate::plan_db::PlanDb>,
     /// In-memory plan cache hydrated from `plan_db` on startup.
     /// Write-through: every mutation must also persist via `plan_db`.
-    pub plan_cache: Arc<DashMap<String, harness_exec::plan::ExecPlan>>,
+    /// Values are shared handles so read paths never deep-clone plan contents.
+    pub plan_cache: Arc<DashMap<String, std::sync::Arc<harness_exec::plan::ExecPlan>>>,
     pub issue_workflow_store: Option<Arc<harness_workflow::issue_lifecycle::IssueWorkflowStore>>,
     pub project_workflow_store:
         Option<Arc<harness_workflow::project_lifecycle::ProjectWorkflowStore>>,


### PR DESCRIPTION
Closes #1990

## Problem

Every `context/preview` request paid two full deep clones of plan contents:

1. `handlers/context.rs` cloned **every** entry of `plan_cache` into a fresh `Vec<ExecPlan>` (`entry.value().clone()`).
2. `ExecPlanProvider::propose` then cloned the project/status-matching subset a second time before rendering.

An `ExecPlan` carries its milestones, concrete steps, decision log, surprises, and validation criteria — so both clones are O(plan size) on every compose call, even though neither copy is ever mutated.

Secondary observation from #1990 (cache is startup-hydrated and never evicted) is intentionally **not** addressed here; size caps/TTL are a separate product decision tracked in the issue.

## Change

- `plan_cache` now stores `Arc<ExecPlan>` (`DashMap<String, Arc<ExecPlan>>`); all insert sites wrap in `Arc::new`.
- `ExecPlanProvider` holds `Vec<Arc<ExecPlan>>` and renders `ContextItem`s by borrowing (`&Arc<ExecPlan>` auto-derefs), dropping both `.clone()` calls.
- The handler-side snapshot loop is unchanged textually — it now clones cheap reference handles instead of plan contents.

Zero behavior change: same plans proposed, same ordering, same rendered markdown.

## Verification

Fresh local runs against a throwaway PostgreSQL 16 (`HARNESS_DATABASE_URL=postgres://postgres@localhost:5433/harness_test`, `max_connections=500`):

- `cargo check -p harness-context -p harness-server` — clean
- `cargo test -p harness-context` — 14 passed
- `cargo test -p harness-server` — lib suite 1626 passed / 0 failed
- `cargo test -p harness-server --test gc_adopt_pipeline` — 8 passed (initially failed with pool timeouts caused by the throwaway PG's default `max_connections=100` under 8 concurrent full-stack tests; passes after raising the cap — environmental, not related to this change)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean