### PR TITLE
perf(server): index turn lookups and stop cloning transcripts for project roots

### DIFF
--- a/crates/harness-server/src/thread_manager.rs
+++ b/crates/harness-server/src/thread_manager.rs
@@ -24,6 +24,11 @@ use tracing;
 /// workflow-runtime store.
 pub struct ThreadManager {
     threads: DashMap<String, Thread>,
+    /// turn_id -> thread_id. Turn ids are unique across threads (fork rebinds
+    /// every inherited id, see `fork_thread`), so this is a 1:1 index that
+    /// keeps `find_thread_and_turn` / `find_thread_for_turn` off the
+    /// O(threads × turns) scan.
+    turn_index: DashMap<String, String>,
     running_turn_tasks: DashMap<String, JoinHandle<()>>,
     running_adapters: DashMap<String, Arc<dyn AgentAdapter>>,
     runtime_turn_aliases: DashMap<String, Vec<TurnId>>,
@@ -33,6 +38,7 @@ impl ThreadManager {
     pub fn new() -> Self {
         Self {
             threads: DashMap::new(),
+            turn_index: DashMap::new(),
             running_turn_tasks: DashMap::new(),
             running_adapters: DashMap::new(),
             runtime_turn_aliases: DashMap::new(),
@@ -57,6 +63,14 @@ impl ThreadManager {
         self.threads.get(id.as_str()).map(|t| t.clone())
     }
 
+    /// Read just the thread's project root without cloning the transcript.
+    pub fn thread_project_root(&self, id: &ThreadId) -> Option<std::path::PathBuf> {
+        record_usage(UsageProbeSurface::ThreadManager);
+        self.threads
+            .get(id.as_str())
+            .map(|t| t.value().project_root.clone())
+    }
+
     pub fn list_threads(&self) -> Vec<Thread> {
         record_usage(UsageProbeSurface::ThreadManager);
         self.threads.iter().map(|e| e.value().clone()).collect()
@@ -64,7 +78,15 @@ impl ThreadManager {
 
     pub fn delete_thread(&self, id: &ThreadId) -> bool {
         record_usage(UsageProbeSurface::ThreadManager);
-        self.threads.remove(id.as_str()).is_some()
+        match self.threads.remove(id.as_str()) {
+            Some((_, thread)) => {
+                for turn in &thread.turns {
+                    self.turn_index.remove(turn.id.as_str());
+                }
+                true
+            }
+            None => false,
+        }
     }
 
     pub fn register_turn_task(&self, turn_id: &TurnId, handle: JoinHandle<()>) {
@@ -109,6 +131,9 @@ impl ThreadManager {
         let turn_id = turn.id.clone();
         thread.turns.push(turn);
         thread.updated_at = chrono::Utc::now();
+        drop(thread);
+        self.turn_index
+            .insert(turn_id.as_str().to_string(), thread_id.as_str().to_string());
 
         Ok(turn_id)
     }
@@ -263,6 +288,26 @@ impl ThreadManager {
 
     pub fn find_thread_and_turn(&self, turn_id: &TurnId) -> Option<(ThreadId, Turn)> {
         record_usage(UsageProbeSurface::ThreadManager);
+        // Fast path: resolve via the turn index. The indexed result only wins
+        // when the thread and turn still exist, so a stale index entry falls
+        // through to the scan instead of hiding a live turn.
+        let indexed = self
+            .turn_index
+            .get(turn_id.as_str())
+            .map(|entry| entry.value().clone())
+            .and_then(|thread_id| {
+                self.threads.get(thread_id.as_str()).and_then(|thread| {
+                    thread
+                        .turns
+                        .iter()
+                        .find(|turn| turn.id == *turn_id)
+                        .cloned()
+                        .map(|turn| (ThreadId::from_str(&thread_id), turn))
+                })
+            });
+        if indexed.is_some() {
+            return indexed;
+        }
         for entry in self.threads.iter() {
             if let Some(turn) = entry.value().turns.iter().find(|turn| turn.id == *turn_id) {
                 return Some((entry.value().id.clone(), turn.clone()));
@@ -274,6 +319,15 @@ impl ThreadManager {
     /// Find which thread contains a given turn.
     pub fn find_thread_for_turn(&self, turn_id: &TurnId) -> Option<ThreadId> {
         record_usage(UsageProbeSurface::ThreadManager);
+        let indexed = self
+            .turn_index
+            .get(turn_id.as_str())
+            .map(|entry| entry.value().clone())
+            .filter(|thread_id| self.threads.contains_key(thread_id.as_str()))
+            .map(|thread_id| ThreadId::from_str(&thread_id));
+        if indexed.is_some() {
+            return indexed;
+        }
         for entry in self.threads.iter() {
             if entry.value().turns.iter().any(|t| t.id == *turn_id) {
                 return Some(entry.value().id.clone());
@@ -353,6 +407,10 @@ impl ThreadManager {
             turn.thread_id = fork_id.clone();
         }
 
+        for turn in &new_thread.turns {
+            self.turn_index
+                .insert(turn.id.as_str().to_string(), fork_id.as_str().to_string());
+        }
         self.threads
             .insert(fork_id.as_str().to_string(), new_thread);
         Ok(fork_id)

--- a/crates/harness-server/src/thread_manager_tests.rs
+++ b/crates/harness-server/src/thread_manager_tests.rs
@@ -708,3 +708,56 @@ async fn steer_active_turn_after_deregister_is_noop() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+// ── Turn index (issue #1992) ─────────────────────────────────────────────────
+
+#[test]
+fn find_after_delete_thread_does_not_leak_turn_lookup() -> anyhow::Result<()> {
+    let tm = ThreadManager::new();
+    let thread_id = tm.start_thread(PathBuf::from("/tmp"));
+    let turn_id = tm.start_turn(&thread_id, "task".to_string(), AgentId::new())?;
+
+    assert!(tm.delete_thread(&thread_id));
+
+    // The turn must not resolve through a stale index entry after deletion.
+    // The scan fallback would also return None here, but the assertion keeps
+    // the index-maintenance contract explicit.
+    assert!(tm.find_thread_and_turn(&turn_id).is_none());
+    assert!(tm.find_thread_for_turn(&turn_id).is_none());
+    Ok(())
+}
+
+#[test]
+fn fork_rebinds_turn_index_to_fork_for_inherited_turns() -> anyhow::Result<()> {
+    let tm = ThreadManager::new();
+    let thread_id = tm.start_thread(PathBuf::from("/tmp"));
+    tm.start_turn(&thread_id, "task".to_string(), AgentId::new())?;
+
+    let fork_id = tm.fork_thread(&thread_id, None)?;
+    let fork = tm
+        .get_thread(&fork_id)
+        .ok_or_else(|| anyhow::anyhow!("fork missing"))?;
+    assert!(!fork.turns.is_empty());
+    for turn in &fork.turns {
+        assert_eq!(
+            tm.find_thread_for_turn(&turn.id),
+            Some(fork_id.clone()),
+            "rebound fork turn must resolve to the fork via the index"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn thread_project_root_reads_root_without_cloning_transcript() -> anyhow::Result<()> {
+    let tm = ThreadManager::new();
+    let thread_id = tm.start_thread(PathBuf::from("/tmp/proj"));
+    let _turn_id = tm.start_turn(&thread_id, "task".to_string(), AgentId::new())?;
+
+    assert_eq!(
+        tm.thread_project_root(&thread_id),
+        Some(PathBuf::from("/tmp/proj"))
+    );
+    assert_eq!(tm.thread_project_root(&ThreadId::from_str("missing")), None);
+    Ok(())
+}

--- a/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/turn_engine/turn_lifecycle.rs
@@ -51,11 +51,7 @@ pub(crate) async fn run_turn_lifecycle_with_options(
     agent_name: String,
     mut options: TurnLifecycleOptions,
 ) {
-    let Some(project_root) = server
-        .thread_manager
-        .get_thread(&thread_id)
-        .map(|thread| thread.project_root)
-    else {
+    let Some(project_root) = server.thread_manager.thread_project_root(&thread_id) else {
         tracing::warn!(
             "run_turn_lifecycle skipped because thread {} no longer exists",
             thread_id


### PR DESCRIPTION
Closes #1992

## Problem

`ThreadManager` had no turn index, so `find_thread_and_turn` / `find_thread_for_turn` scanned **every turn of every thread** on each call. These run on hot paths:

- every runtime task-detail request resolves pending approvals through `pending_approval_items_for_runtime_handle` → one full scan per candidate turn id,
- each approval RPC pays the scan 3+ times (`find_thread_for_turn`, `has_pending_approval_request`, `set_approval_status`),
- `fork_thread` also scans.

With T live threads and M average turns a single poll costs O(T×M), repeated continuously by UI polling.

Additionally, `run_turn_lifecycle_with_options` read the thread's `project_root` through `get_thread()`, which deep-clones the entire `Thread` — all turns and transcript items — and discarded everything except the root path. Once per runtime turn start.

## Change

- New `turn_index: DashMap<turn_id, thread_id>`, maintained at exactly the three sites that create/remove turns:
  - `start_turn` (turn push),
  - `fork_thread` (inherited ids are rebound there — uniqueness invariant already documented),
  - `delete_thread` (drops the thread's turns).
  `threads_cache()` is not used to insert threads or add turns outside tests, so these cover all mutations.
- Both finders resolve via the index; if the indexed thread/turn no longer exists they fall back to today's scan, so a stale entry can never hide a live turn.
- `thread_project_root()` reads the root without cloning the transcript; used at turn-lifecycle start.

Semantics unchanged: fork rebinds every inherited `TurnId` precisely so an id lives in exactly one thread (`thread_manager.rs:345-349`), making the index equivalent to today's first-match scan.

## Tests

- `find_after_delete_thread_does_not_leak_turn_lookup` — deletion removes index entries.
- `fork_rebinds_turn_index_to_fork_for_inherited_turns` — inherited turns resolve to the fork after rebinding.
- `thread_project_root_reads_root_without_cloning_transcript`.
- Existing fork determinism tests still pass unchanged (`find_thread_for_turn_after_fork_returns_source_thread`, `find_thread_and_turn_fork_only_turn_routes_to_fork`).

## Verification

Fresh local runs against throwaway PostgreSQL 16:

- `cargo check -p harness-server` — clean
- `cargo test -p harness-server --lib` — **1629 passed / 0 failed** (1626 prior + 3 new)
- targeted: `thread_manager` filter 38 passed, `turn_lifecycle` filter 7 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean