### PR TITLE
perf(eval): batch runtime-job fetches in cleanup verification

### DIFF
--- a/crates/harness-workflow/src/runtime/eval/cleanup.rs
+++ b/crates/harness-workflow/src/runtime/eval/cleanup.rs
@@ -1,13 +1,25 @@
 use super::{data::eval_cleanup_data, transition_outcome::accepted_transition_record};
 use crate::runtime::{
-    DataProvenance, RuntimeJobStatus, ValidationContext, WorkflowCommand, WorkflowCommandStatus,
-    WorkflowCommandType, WorkflowDecision, WorkflowDecisionTransition, WorkflowEvidence,
-    WorkflowInstance, WorkflowRuntimeStore,
+    DataProvenance, RuntimeJobStatus, ValidationContext, WorkflowCommand, WorkflowCommandRecord,
+    WorkflowCommandStatus, WorkflowCommandType, WorkflowDecision, WorkflowDecisionTransition,
+    WorkflowEvidence, WorkflowInstance, WorkflowRuntimeStore,
 };
 use chrono::Utc;
 use serde_json::json;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::{Duration, Instant};
+
+/// Batch-fetch every runtime job belonging to `commands`, keyed by command id:
+/// one round trip instead of one per command (issue #1999). Callers iterate
+/// the returned map in their existing command order, so first-error bail
+/// semantics are unchanged.
+pub(super) async fn runtime_jobs_by_command_id(
+    store: &WorkflowRuntimeStore,
+    commands: &[WorkflowCommandRecord],
+) -> anyhow::Result<BTreeMap<String, Vec<crate::runtime::RuntimeJob>>> {
+    let command_ids: Vec<String> = commands.iter().map(|command| command.id.clone()).collect();
+    store.runtime_jobs_for_commands(&command_ids).await
+}
 
 const REMOTE_CLEANUP_ACK_TIMEOUT: Duration = Duration::from_secs(30);
 const REMOTE_CLEANUP_POLL_INTERVAL: Duration = Duration::from_millis(250);
@@ -242,8 +254,14 @@ async fn ensure_cancelled_workflow_family_clean(
         workflow_ids.push(workflow_id);
     }
 
-    let commands = store.commands_for_workflows(&workflow_ids).await?;
-    for command in commands.into_values().flatten() {
+    let commands: Vec<WorkflowCommandRecord> = store
+        .commands_for_workflows(&workflow_ids)
+        .await?
+        .into_values()
+        .flatten()
+        .collect();
+    let mut jobs_by_command = runtime_jobs_by_command_id(store, &commands).await?;
+    for command in commands {
         if matches!(
             command.status,
             WorkflowCommandStatus::Pending
@@ -257,7 +275,7 @@ async fn ensure_cancelled_workflow_family_clean(
                 command.status.as_str()
             );
         }
-        for job in store.runtime_jobs_for_command(&command.id).await? {
+        for job in jobs_by_command.remove(&command.id).unwrap_or_default() {
             if matches!(
                 job.status,
                 RuntimeJobStatus::Pending | RuntimeJobStatus::Running
@@ -291,10 +309,16 @@ async fn ensure_completed_workflow_family_clean(
         .collect::<Vec<_>>();
     ensure_no_active_work(store, &workflow_ids).await?;
 
-    let commands = store.commands_for_workflows(&workflow_ids).await?;
+    let commands: Vec<WorkflowCommandRecord> = store
+        .commands_for_workflows(&workflow_ids)
+        .await?
+        .into_values()
+        .flatten()
+        .collect();
+    let mut jobs_by_command = runtime_jobs_by_command_id(store, &commands).await?;
     let mut required_cleanup_proofs = 0_u64;
-    for command in commands.into_values().flatten() {
-        for job in store.runtime_jobs_for_command(&command.id).await? {
+    for command in commands {
+        for job in jobs_by_command.remove(&command.id).unwrap_or_default() {
             if eval_job_requires_cleanup_proof(&job) {
                 required_cleanup_proofs = required_cleanup_proofs.saturating_add(1);
                 if !runtime_job_has_cleanup_proof(&job) {
@@ -363,8 +387,14 @@ async fn ensure_no_active_work(
     store: &WorkflowRuntimeStore,
     workflow_ids: &[String],
 ) -> anyhow::Result<()> {
-    let commands = store.commands_for_workflows(workflow_ids).await?;
-    for command in commands.into_values().flatten() {
+    let commands: Vec<WorkflowCommandRecord> = store
+        .commands_for_workflows(workflow_ids)
+        .await?
+        .into_values()
+        .flatten()
+        .collect();
+    let mut jobs_by_command = runtime_jobs_by_command_id(store, &commands).await?;
+    for command in commands {
         if matches!(
             command.status,
             WorkflowCommandStatus::Pending
@@ -378,7 +408,7 @@ async fn ensure_no_active_work(
                 command.status.as_str()
             );
         }
-        for job in store.runtime_jobs_for_command(&command.id).await? {
+        for job in jobs_by_command.remove(&command.id).unwrap_or_default() {
             if matches!(
                 job.status,
                 RuntimeJobStatus::Pending | RuntimeJobStatus::Running

--- a/crates/harness-workflow/src/runtime/eval/run.rs
+++ b/crates/harness-workflow/src/runtime/eval/run.rs
@@ -437,11 +437,13 @@ async fn collect_remaining_eval_resources(
         summary.orphan_pull_requests += 1;
     }
 
-    for command in store.commands_for(workflow_id).await? {
+    let commands = store.commands_for(workflow_id).await?;
+    let mut jobs_by_command = super::cleanup::runtime_jobs_by_command_id(store, &commands).await?;
+    for command in commands {
         if active_command_status(command.status) {
             summary.active_commands += 1;
         }
-        for job in store.runtime_jobs_for_command(&command.id).await? {
+        for job in jobs_by_command.remove(&command.id).unwrap_or_default() {
             if active_runtime_job_status(job.status) {
                 summary.active_runtime_jobs += 1;
             }


### PR DESCRIPTION
Closes #1999

## Problem

Eval cleanup verification fetched a family's commands with the existing batch API (`commands_for_workflows`), then issued one `runtime_jobs_for_command` round trip **per command**:

- `ensure_cancelled_workflow_family_clean` (cleanup.rs)
- `ensure_completed_workflow_family_clean` (cleanup.rs)
- `ensure_no_active_work` (cleanup.rs, also driven by the cancellation wait loop)
- `collect_remaining_eval_resources` (run.rs, per workflow of every case)

A family with C commands paid C extra queries per pass. The cancellation wait (`wait_for_cancelled_workflow_family_clean`) re-runs the full check every 250 ms for up to 30 s, so a slow remote-host acknowledgement multiplied that cost ~120×.

## Change

- New shared helper `runtime_jobs_by_command_id` (cleanup.rs) wrapping the store's existing batch API `runtime_jobs_for_commands(&[String])`.
- All four sites pre-fetch once and iterate `jobs_by_command.remove(&command.id)` in their original command order — **first-error bail semantics are byte-for-byte unchanged**, only the query count collapses from 1 + C to 2 per pass.
- Poll cadence intentionally untouched: timing behavior stays identical; each attempt is now O(1) queries regardless of family size.

## Verification

- `cargo test -p harness-workflow --lib`: 747 passed / 0 failed / 9 ignored (incl. all 118 eval-module tests against PostgreSQL).
- `cargo fmt --all -- --check` and `cargo clippy -p harness-workflow --all-targets` clean.
- Full workspace pre-push suite green on push.