### PR TITLE
fix(agents): stop waiting after codex exits

### DIFF
--- a/crates/harness-agents/src/codex_exec_parser.rs
+++ b/crates/harness-agents/src/codex_exec_parser.rs
@@ -238,10 +238,21 @@ pub(crate) async fn stream_codex_exec_output(
     let mut parsed = ParsedCodexExecOutput::default();
     let mut seen_message_deltas = HashSet::new();
     let mut container_egress_verified = !await_container_egress_canary;
+    enum StreamRead {
+        Line(std::io::Result<Option<String>>),
+        Exited(std::io::Result<std::process::ExitStatus>),
+    }
 
     loop {
-        let maybe_line = if let Some(duration) = idle_timeout {
-            tokio::time::timeout(duration, lines.next_line())
+        let read_or_exit = async {
+            tokio::select! {
+                biased;
+                line = lines.next_line() => StreamRead::Line(line),
+                status = child.wait() => StreamRead::Exited(status),
+            }
+        };
+        let read = if let Some(duration) = idle_timeout {
+            tokio::time::timeout(duration, read_or_exit)
                 .await
                 .map_err(|_| {
                     #[cfg(unix)]
@@ -251,17 +262,25 @@ pub(crate) async fn stream_codex_exec_output(
                         duration.as_secs()
                     ))
                 })?
-                .map_err(|error| {
-                    harness_core::error::HarnessError::AgentExecution(format!(
-                        "failed reading codex stdout: {error}"
-                    ))
-                })?
         } else {
-            lines.next_line().await.map_err(|error| {
+            read_or_exit.await
+        };
+        let maybe_line = match read {
+            StreamRead::Line(line) => line.map_err(|error| {
                 harness_core::error::HarnessError::AgentExecution(format!(
                     "failed reading codex stdout: {error}"
                 ))
-            })?
+            })?,
+            StreamRead::Exited(status) => {
+                status.map_err(|error| {
+                    harness_core::error::HarnessError::AgentExecution(format!(
+                        "failed waiting for codex process: {error}"
+                    ))
+                })?;
+                #[cfg(unix)]
+                crate::kill_process_group(child);
+                break;
+            }
         };
         let Some(line) = maybe_line else {
             break;

--- a/crates/harness-agents/src/codex_tests.rs
+++ b/crates/harness-agents/src/codex_tests.rs
@@ -339,6 +339,58 @@ printf '%s\n' '{{"type":"turn.completed","usage":{{"input_tokens":1,"output_toke
 }
 
 #[tokio::test]
+async fn execute_stream_does_not_wait_for_descendant_held_stdout_after_root_exit() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let descendant_marker = dir.path().join("stdout-descendant-started.txt");
+    let reached_marker = dir.path().join("stdout-descendant-reached.txt");
+    let (script_dir, script) = write_executable_script(&format!(
+        r#"
+( echo descendant > "{}"; sleep 1; echo reached > "{}"; sleep 30 ) &
+while [ ! -f "{}" ]; do sleep 0.01; done
+printf '%s\n' '{{"type":"item.completed","item":{{"id":"item_0","type":"agent_message","text":"root done"}}}}'
+printf '%s\n' '{{"type":"turn.completed","usage":{{"input_tokens":1,"output_tokens":1}}}}'
+"#,
+        descendant_marker.display(),
+        reached_marker.display(),
+        descendant_marker.display()
+    ));
+    let agent = CodexAgent::new(script, SandboxMode::DangerFullAccess);
+    let request = AgentRequest {
+        prompt: "ignored".to_string(),
+        project_root: dir.path().to_path_buf(),
+        ..AgentRequest::default()
+    };
+    let (tx, _rx) = tokio::sync::mpsc::channel(8);
+    let mut handle = tokio::spawn(async move { agent.execute_stream(request, tx).await });
+    assert_path_observed_before_task_exit(
+        &descendant_marker,
+        &mut handle,
+        Duration::from_secs(20),
+        "stdout descendant startup marker",
+    )
+    .await;
+
+    let result = match timeout(Duration::from_secs(5), &mut handle).await {
+        Ok(result) => result,
+        Err(_) => {
+            handle.abort();
+            let _ = timeout(Duration::from_secs(2), &mut handle).await;
+            panic!("execute_stream waited for descendant-held stdout after the root exited");
+        }
+    };
+    result
+        .expect("execute_stream task should join")
+        .expect("stream execution should succeed");
+
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    assert!(
+        !reached_marker.exists(),
+        "stream cleanup should kill the stdout-holding descendant"
+    );
+    drop(script_dir);
+}
+
+#[tokio::test]
 async fn execute_stream_cancel_path_converges_when_receiver_dropped_mid_stream() {
     let (dir, script) = write_executable_script(
         r#"


### PR DESCRIPTION
## What

- observe the root `codex exec` process while streaming JSONL stdout
- stop waiting for EOF when a descendant keeps the inherited stdout pipe open after the root exits
- terminate the remaining process group and preserve complete JSONL records already available
- add a focused regression test for descendant-held streaming stdout

The existing workflow turn lifecycle already covers an agent that never emits its first stream item with a bounded stall failure. This change fixes the production root cause that prevented the completed Codex output from reaching that lifecycle.

Fixes #2016

## Why

A real #2015 workflow run could remain in `planning / turn 0` with no persisted stream item. The root Codex process could finish while a descendant retained stdout, leaving the parser blocked on EOF. In a controlled before/after dogfood run, this patch allowed the same workflow to persist its plan, transcript, and seven artifacts after about 66 seconds. A later failure was the separate terminal-classification bug tracked by #2017.

## Test Plan

- [x] `cargo test --package harness-agents -- --test-threads=1`
- [x] `cargo check -p harness-agents --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`
- [x] pre-push `cargo clippy --workspace --all-targets -- -D warnings`
- [x] pre-push database-independent workspace and `harness-workflow` tests
- [x] fresh-context independent review: `APPROVED`
- [x] isolated #2015-style workflow dogfood advanced beyond planning and persisted artifacts

## AI Assistance

AI-assisted diagnosis, implementation, verification, and independent review were used for this pull request.