### PR TITLE
fix(agents): stop waiting after Codex exits

### DIFF
--- a/crates/harness-agents/src/codex.rs
+++ b/crates/harness-agents/src/codex.rs
@@ -683,13 +683,25 @@ impl CodeAgent for CodexAgent {
             .filter(|&s| s > 0)
             .map(std::time::Duration::from_secs);
         let await_container_egress_canary = child.awaits_container_egress_canary();
-        let stream_result = stream_codex_exec_output(
-            child.inner_mut(),
-            &tx,
-            idle_timeout,
-            await_container_egress_canary,
-        )
-        .await;
+        let stdout = child.inner_mut().stdout.take().ok_or_else(|| {
+            harness_core::error::HarnessError::AgentExecution("codex stdout unavailable".into())
+        })?;
+        let stream_output =
+            stream_codex_exec_output(stdout, &tx, idle_timeout, await_container_egress_canary);
+        tokio::pin!(stream_output);
+        let mut root_status = None;
+        let stream_result = loop {
+            tokio::select! {
+                result = &mut stream_output => break result,
+                result = child.wait_and_cleanup_descendants(), if root_status.is_none() => {
+                    root_status = Some(result.map_err(|error| {
+                        harness_core::error::HarnessError::AgentExecution(format!(
+                            "failed waiting for codex process: {error}"
+                        ))
+                    })?);
+                }
+            }
+        };
         let stream_send_failed = matches!(
             &stream_result,
             Err(harness_core::error::HarnessError::AgentExecution(message))
@@ -700,17 +712,21 @@ impl CodeAgent for CodexAgent {
             Err(harness_core::error::HarnessError::AgentExecution(message))
                 if message.contains("codex exited with")
         );
-        if stream_result.is_err() && !stream_process_exited {
+        if stream_result.is_err() && !stream_process_exited && root_status.is_none() {
             child.terminate_now();
         }
-        let status = child
-            .wait_and_cleanup_descendants()
-            .await
-            .map_err(|error| {
-                harness_core::error::HarnessError::AgentExecution(format!(
-                    "failed waiting for codex process: {error}"
-                ))
-            })?;
+        let status = if let Some(status) = root_status {
+            status
+        } else {
+            child
+                .wait_and_cleanup_descendants()
+                .await
+                .map_err(|error| {
+                    harness_core::error::HarnessError::AgentExecution(format!(
+                        "failed waiting for codex process: {error}"
+                    ))
+                })?
+        };
         if stream_send_failed {
             return Err(stream_result.expect_err("stream send failures return an error"));
         }

--- a/crates/harness-agents/src/codex_exec_parser.rs
+++ b/crates/harness-agents/src/codex_exec_parser.rs
@@ -226,14 +226,11 @@ pub(crate) fn parse_codex_exec_output(
 }
 
 pub(crate) async fn stream_codex_exec_output(
-    child: &mut tokio::process::Child,
+    stdout: tokio::process::ChildStdout,
     tx: &tokio::sync::mpsc::Sender<StreamItem>,
     idle_timeout: Option<Duration>,
     await_container_egress_canary: bool,
 ) -> harness_core::error::Result<ParsedCodexExecOutput> {
-    let stdout = child.stdout.take().ok_or_else(|| {
-        harness_core::error::HarnessError::AgentExecution("codex stdout unavailable".into())
-    })?;
     let mut lines = BufReader::new(stdout).lines();
     let mut parsed = ParsedCodexExecOutput::default();
     let mut seen_message_deltas = HashSet::new();
@@ -244,8 +241,6 @@ pub(crate) async fn stream_codex_exec_output(
             tokio::time::timeout(duration, lines.next_line())
                 .await
                 .map_err(|_| {
-                    #[cfg(unix)]
-                    crate::kill_process_group(child);
                     harness_core::error::HarnessError::AgentExecution(format!(
                         "codex stream idle timeout after {}s: zombie connection terminated",
                         duration.as_secs()

--- a/crates/harness-agents/src/codex_tests.rs
+++ b/crates/harness-agents/src/codex_tests.rs
@@ -339,6 +339,56 @@ printf '%s\n' '{{"type":"turn.completed","usage":{{"input_tokens":1,"output_toke
 }
 
 #[tokio::test]
+async fn execute_stream_kills_descendant_that_keeps_stdout_pipe_open_after_root_exit() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let descendant_marker = dir.path().join("stream-stdout-descendant-started.txt");
+    let marker = dir.path().join("stream-stdout-descendant-reached.txt");
+    let (script_dir, script) = write_executable_script(&format!(
+        r#"
+printf '%s\n' '{{"type":"item.completed","item":{{"id":"item_0","type":"agent_message","text":"root done"}}}}'
+printf '%s\n' '{{"type":"turn.completed","usage":{{"input_tokens":1,"output_tokens":1}}}}'
+( echo descendant > "{}"; sleep 1; echo reached > "{}"; sleep 30 ) &
+while [ ! -f "{}" ]; do sleep 0.01; done
+"#,
+        descendant_marker.display(),
+        marker.display(),
+        descendant_marker.display()
+    ));
+    let agent = CodexAgent::new(script, SandboxMode::DangerFullAccess);
+    let request = AgentRequest {
+        prompt: "ignored".to_string(),
+        project_root: dir.path().to_path_buf(),
+        ..AgentRequest::default()
+    };
+
+    let (tx, _rx) = tokio::sync::mpsc::channel(8);
+    let mut handle = tokio::spawn(async move { agent.execute_stream(request, tx).await });
+    assert_path_observed_before_task_exit(
+        &descendant_marker,
+        &mut handle,
+        Duration::from_secs(20),
+        "stdout descendant startup marker",
+    )
+    .await;
+    timeout(Duration::from_secs(5), handle)
+        .await
+        .expect("execute_stream should not wait for descendant-held stdout")
+        .expect("execute_stream task should join")
+        .expect("stream execution should succeed");
+
+    assert!(
+        descendant_marker.exists(),
+        "descendant should start before process-group cleanup runs"
+    );
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    assert!(
+        !marker.exists(),
+        "stream cleanup should kill descendants before they can mutate the workspace"
+    );
+    drop(script_dir);
+}
+
+#[tokio::test]
 async fn execute_stream_cancel_path_converges_when_receiver_dropped_mid_stream() {
     let (dir, script) = write_executable_script(
         r#"

--- a/crates/harness-agents/src/egress_verification_tests.rs
+++ b/crates/harness-agents/src/egress_verification_tests.rs
@@ -21,10 +21,10 @@ async fn codex_waits_for_container_canary_marker() -> anyhow::Result<()> {
         .stdout(Stdio::piped())
         .spawn()?;
     let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    let stdout = child.stdout.take().expect("codex stdout should be piped");
 
     let parsed =
-        crate::codex::codex_exec_parser::stream_codex_exec_output(&mut child, &tx, None, true)
-            .await?;
+        crate::codex::codex_exec_parser::stream_codex_exec_output(stdout, &tx, None, true).await?;
 
     assert!(matches!(
         rx.recv().await,
@@ -43,11 +43,11 @@ async fn codex_rejects_missing_container_canary_marker() -> anyhow::Result<()> {
         .stdout(Stdio::piped())
         .spawn()?;
     let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    let stdout = child.stdout.take().expect("codex stdout should be piped");
 
-    let error =
-        crate::codex::codex_exec_parser::stream_codex_exec_output(&mut child, &tx, None, true)
-            .await
-            .expect_err("missing canary marker must fail");
+    let error = crate::codex::codex_exec_parser::stream_codex_exec_output(stdout, &tx, None, true)
+        .await
+        .expect_err("missing canary marker must fail");
 
     assert!(error
         .to_string()


### PR DESCRIPTION
## What

- supervise Codex JSONL reads alongside root-process completion
- clean up the remaining process group as soon as the root exits
- preserve buffered stream parsing after descendant-held pipes are closed
- add regression coverage for a descendant that inherits streaming stdout

## Why

A root `codex exec` process can exit while a descendant keeps the inherited stdout pipe open. Harness previously waited for EOF before observing root completion, so workflow planning could remain stuck at turn zero indefinitely.

Fixes #2016

## Test Plan

- [x] Tests pass
- [ ] Tested manually
- [x] RED: focused regression timed out before the production change
- [x] `cargo test -p harness-agents execute_stream_kills_descendant_that_keeps_stdout_pipe_open_after_root_exit -- --nocapture`
- [x] `cargo test --package harness-agents -- --test-threads=1` (354 passed, 7 ignored; doc test passed)
- [x] `cargo check -p harness-agents --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] DB-less pre-push gate (745 passed, 9 ignored, 15 filtered; PostgreSQL suites deferred by repository policy)

## AI Assistance

AI-assisted diagnosis, implementation, testing, and review preparation were used for this pull request.