### PR TITLE
refactor(core): derive capability summaries

### DIFF
--- a/crates/harness-core/src/stack/capability_evidence/mod.rs
+++ b/crates/harness-core/src/stack/capability_evidence/mod.rs
@@ -25,15 +25,22 @@ pub struct AgentStackCapabilityDefinition {
     pub summary: &'static str,
 }
 
+const fn capability_definition(capability: AgentStackCapability) -> AgentStackCapabilityDefinition {
+    AgentStackCapabilityDefinition {
+        capability,
+        summary: capability.definition(),
+    }
+}
+
 #[rustfmt::skip]
 pub const AGENT_STACK_CAPABILITY_DEFINITIONS: &[AgentStackCapabilityDefinition] = &[
-    AgentStackCapabilityDefinition { capability: AgentStackCapability::Destructive, summary: "May delete, overwrite, or irreversibly mutate local or remote state." },
-    AgentStackCapabilityDefinition { capability: AgentStackCapability::SecretRead, summary: "May read credentials, tokens, private configuration, or sensitive material." },
-    AgentStackCapabilityDefinition { capability: AgentStackCapability::Network, summary: "May initiate outbound network calls or access remote resources." },
-    AgentStackCapabilityDefinition { capability: AgentStackCapability::Privileged, summary: "May bypass normal sandbox, permission, or isolation boundaries." },
-    AgentStackCapabilityDefinition { capability: AgentStackCapability::ProductionWrite, summary: "May write to production infrastructure, deployments, or customer-affecting systems." },
-    AgentStackCapabilityDefinition { capability: AgentStackCapability::Shell, summary: "May execute shell commands or arbitrary local programs." },
-    AgentStackCapabilityDefinition { capability: AgentStackCapability::FileWrite, summary: "May create, modify, or delete filesystem content." },
+    capability_definition(AgentStackCapability::Destructive),
+    capability_definition(AgentStackCapability::SecretRead),
+    capability_definition(AgentStackCapability::Network),
+    capability_definition(AgentStackCapability::Privileged),
+    capability_definition(AgentStackCapability::ProductionWrite),
+    capability_definition(AgentStackCapability::Shell),
+    capability_definition(AgentStackCapability::FileWrite),
 ];
 
 impl AgentStackCapability {

--- a/crates/harness-core/src/stack/capability_evidence/tests.rs
+++ b/crates/harness-core/src/stack/capability_evidence/tests.rs
@@ -92,13 +92,17 @@ fn assert_grants(
 
 #[test]
 fn capability_evidence_defines_complete_initial_vocabulary() {
-    let defined = AGENT_STACK_CAPABILITY_DEFINITIONS
+    assert_eq!(
+        AGENT_STACK_CAPABILITY_DEFINITIONS.len(),
+        AgentStackCapability::ALL.len()
+    );
+    for (definition, capability) in AGENT_STACK_CAPABILITY_DEFINITIONS
         .iter()
-        .map(|definition| definition.capability)
-        .collect::<Vec<_>>();
-    assert_eq!(defined, AgentStackCapability::ALL);
-    for capability in AgentStackCapability::ALL {
-        assert!(!capability.definition().is_empty());
+        .zip(AgentStackCapability::ALL)
+    {
+        assert_eq!(definition.capability, *capability);
+        assert_eq!(definition.summary, capability.definition());
+        assert!(!definition.summary.is_empty());
     }
 }
 


### PR DESCRIPTION
## What

Derive `AGENT_STACK_CAPABILITY_DEFINITIONS` entries from `AgentStackCapability::definition()` so the summary strings live in one production location.

Fixes #2015

## Why

The capability definition table and method previously duplicated the seven user-visible summaries, allowing them to drift without a failing regression test.

## Test Plan

- [x] `cargo fmt --all`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p harness-core capability_evidence`
- [x] `cargo check -p harness-core --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
