### PR TITLE
refactor(core): share stack wire enum macro

### DIFF
--- a/crates/harness-core/src/stack/capability_extraction/mod.rs
+++ b/crates/harness-core/src/stack/capability_extraction/mod.rs
@@ -63,18 +63,10 @@ pub enum AgentStackCapabilityExtractionError {
     Inventory(#[source] AgentStackInventoryError),
 }
 
-macro_rules! wire_enum {
-    ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-        #[serde(rename_all = "snake_case")]
-        pub enum $name { $($variant),+ }
-        impl $name { pub const fn as_str(self) -> &'static str { match self { $(Self::$variant => $wire),+ } } }
-    };
-}
 #[rustfmt::skip]
-wire_enum!(AgentStackCapabilityExtractionConfidence { Low => "low", Medium => "medium", High => "high" });
+stack_wire_enum!(AgentStackCapabilityExtractionConfidence { Low => "low", Medium => "medium", High => "high" });
 #[rustfmt::skip]
-wire_enum!(AgentStackCapabilityExtractionFailureKind { ReadFailed => "read_failed", LimitExceeded => "limit_exceeded", ParseFailed => "parse_failed", InvalidDeclaration => "invalid_declaration", EvidenceValidation => "evidence_validation" });
+stack_wire_enum!(AgentStackCapabilityExtractionFailureKind { ReadFailed => "read_failed", LimitExceeded => "limit_exceeded", ParseFailed => "parse_failed", InvalidDeclaration => "invalid_declaration", EvidenceValidation => "evidence_validation" });
 
 #[rustfmt::skip]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/crates/harness-core/src/stack/mod.rs
+++ b/crates/harness-core/src/stack/mod.rs
@@ -4,6 +4,32 @@ use sha2::{Digest, Sha256};
 use std::fmt;
 use std::path::Path;
 use thiserror::Error;
+
+macro_rules! stack_wire_enum {
+    (with_all $name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub enum $name { $($variant),+ }
+        impl $name {
+            pub const ALL: &'static [Self] = &[$(Self::$variant),+];
+
+            pub const fn as_str(&self) -> &'static str {
+                match self { $(Self::$variant => $wire),+ }
+            }
+        }
+    };
+    ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub enum $name { $($variant),+ }
+        impl $name {
+            pub const fn as_str(self) -> &'static str {
+                match self { $(Self::$variant => $wire),+ }
+            }
+        }
+    };
+}
+
 pub mod capability_evidence;
 pub mod capability_extraction;
 pub mod inventory;
@@ -42,35 +68,22 @@ use source_locator::{
 pub use source_locator::{resolve_xdg_config_harness_root, select_user_global_root};
 pub const AGENT_STACK_COMPONENT_SCHEMA_VERSION: &str = "agent-stack-component/v0.1";
 
-macro_rules! closed_enum {
-    ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-        #[serde(rename_all = "snake_case")]
-        pub enum $name { $($variant),+ }
-        impl $name {
-            pub const ALL: &'static [Self] = &[$(Self::$variant),+];
-            pub const fn as_str(&self) -> &'static str {
-                match self { $(Self::$variant => $wire),+ }
-            }
-        }
-    };
-}
 #[rustfmt::skip]
-closed_enum!(AgentStackComponentKind { Instructions => "instructions", Skill => "skill", McpServer => "mcp_server", McpTool => "mcp_tool", Hook => "hook", Memory => "memory", Policy => "policy", Workflow => "workflow", Validation => "validation", AgentRuntime => "agent_runtime" });
+stack_wire_enum!(with_all AgentStackComponentKind { Instructions => "instructions", Skill => "skill", McpServer => "mcp_server", McpTool => "mcp_tool", Hook => "hook", Memory => "memory", Policy => "policy", Workflow => "workflow", Validation => "validation", AgentRuntime => "agent_runtime" });
 #[rustfmt::skip]
-closed_enum!(AgentStackSourceScope { Repository => "repository", UserGlobal => "user_global", Admin => "admin", System => "system", Runtime => "runtime", Runner => "runner" });
+stack_wire_enum!(with_all AgentStackSourceScope { Repository => "repository", UserGlobal => "user_global", Admin => "admin", System => "system", Runtime => "runtime", Runner => "runner" });
 #[rustfmt::skip]
-closed_enum!(AgentStackUserGlobalRoot { HomeHarness => "home_harness", XdgConfigHarness => "xdg_config_harness", PlatformConfigHarness => "platform_config_harness", ConfiguredUser => "configured_user" });
+stack_wire_enum!(with_all AgentStackUserGlobalRoot { HomeHarness => "home_harness", XdgConfigHarness => "xdg_config_harness", PlatformConfigHarness => "platform_config_harness", ConfiguredUser => "configured_user" });
 #[rustfmt::skip]
-closed_enum!(AgentStackObservationClass { RepositoryObserved => "repository_observed", RuntimeObserved => "runtime_observed", RunnerObserved => "runner_observed" });
+stack_wire_enum!(with_all AgentStackObservationClass { RepositoryObserved => "repository_observed", RuntimeObserved => "runtime_observed", RunnerObserved => "runner_observed" });
 #[rustfmt::skip]
-closed_enum!(AgentStackSelectionState { Discovered => "discovered", Eligible => "eligible", Selected => "selected", Loaded => "loaded", Observed => "observed" });
+stack_wire_enum!(with_all AgentStackSelectionState { Discovered => "discovered", Eligible => "eligible", Selected => "selected", Loaded => "loaded", Observed => "observed" });
 #[rustfmt::skip]
-closed_enum!(AgentStackCapability { Destructive => "destructive", SecretRead => "secret_read", Network => "network", Privileged => "privileged", ProductionWrite => "production_write", Shell => "shell", FileWrite => "file_write" });
+stack_wire_enum!(with_all AgentStackCapability { Destructive => "destructive", SecretRead => "secret_read", Network => "network", Privileged => "privileged", ProductionWrite => "production_write", Shell => "shell", FileWrite => "file_write" });
 #[rustfmt::skip]
-closed_enum!(AgentStackTrustLevel { SelfDeclared => "self_declared", RepositoryObserved => "repository_observed", RuntimeObserved => "runtime_observed", RunnerObserved => "runner_observed" });
+stack_wire_enum!(with_all AgentStackTrustLevel { SelfDeclared => "self_declared", RepositoryObserved => "repository_observed", RuntimeObserved => "runtime_observed", RunnerObserved => "runner_observed" });
 #[rustfmt::skip]
-closed_enum!(AgentStackFreshness { Unknown => "unknown", Fresh => "fresh", Stale => "stale", Expired => "expired" });
+stack_wire_enum!(with_all AgentStackFreshness { Unknown => "unknown", Fresh => "fresh", Stale => "stale", Expired => "expired" });
 macro_rules! string_newtype {
     ($name:ident) => {
         #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]

--- a/crates/harness-core/src/stack/mod.rs
+++ b/crates/harness-core/src/stack/mod.rs
@@ -7,24 +7,21 @@ use thiserror::Error;
 
 macro_rules! stack_wire_enum {
     (with_all $name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-        #[serde(rename_all = "snake_case")]
-        pub enum $name { $($variant),+ }
+        stack_wire_enum!(@define (&self) self $name { $($variant => $wire),+ });
         impl $name {
             pub const ALL: &'static [Self] = &[$(Self::$variant),+];
-
-            pub const fn as_str(&self) -> &'static str {
-                match self { $(Self::$variant => $wire),+ }
-            }
         }
     };
     ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
+        stack_wire_enum!(@define (self) self $name { $($variant => $wire),+ });
+    };
+    (@define ($($receiver:tt)+) $value:ident $name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[serde(rename_all = "snake_case")]
         pub enum $name { $($variant),+ }
         impl $name {
-            pub const fn as_str(self) -> &'static str {
-                match self { $(Self::$variant => $wire),+ }
+            pub const fn as_str($($receiver)+) -> &'static str {
+                match $value { $(Self::$variant => $wire),+ }
             }
         }
     };

--- a/crates/harness-core/src/stack/protective_control_diff.rs
+++ b/crates/harness-core/src/stack/protective_control_diff.rs
@@ -12,21 +12,8 @@ use replacements::{
     replacement_assignments, replacement_candidates, CandidateMode, ReplacementAssignmentIndex,
     ReplacementCandidateConflicts, ReplacementStateConflicts, RoleReplacementCoverage,
 };
-macro_rules! closed_enum {
-    ($name:ident { $($variant:ident => $wire:literal),+ $(,)? }) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-        #[serde(rename_all = "snake_case")]
-        pub enum $name { $($variant),+ }
-        impl $name {
-            pub const ALL: &'static [Self] = &[$(Self::$variant),+];
-            pub const fn as_str(&self) -> &'static str {
-                match self { $(Self::$variant => $wire),+ }
-            }
-        }
-    };
-}
 #[rustfmt::skip]
-closed_enum!(AgentStackProtectionRole {
+stack_wire_enum!(with_all AgentStackProtectionRole {
     Policy => "policy",
     Hook => "hook",
     Validation => "validation",
@@ -34,7 +21,7 @@ closed_enum!(AgentStackProtectionRole {
     Check => "check",
 });
 #[rustfmt::skip]
-closed_enum!(AgentStackProtectionDiffKind {
+stack_wire_enum!(with_all AgentStackProtectionDiffKind {
     Removed => "removed",
     Disabled => "disabled",
     ScopeReduced => "scope_reduced",
@@ -42,25 +29,25 @@ closed_enum!(AgentStackProtectionDiffKind {
     AmbiguousReviewEvidence => "ambiguous_review_evidence",
 });
 #[rustfmt::skip]
-closed_enum!(AgentStackProtectionConfidence {
+stack_wire_enum!(with_all AgentStackProtectionConfidence {
     Low => "low",
     Medium => "medium",
     High => "high",
 });
 #[rustfmt::skip]
-closed_enum!(AgentStackProtectionFailureMode {
+stack_wire_enum!(with_all AgentStackProtectionFailureMode {
     FailOpen => "fail_open",
     FailClosed => "fail_closed",
 });
 #[rustfmt::skip]
-closed_enum!(AgentStackProtectionScope {
+stack_wire_enum!(with_all AgentStackProtectionScope {
     Advisory => "advisory",
     Partial => "partial",
     Required => "required",
     Comprehensive => "comprehensive",
 });
 #[rustfmt::skip]
-closed_enum!(AgentStackProtectionControlReason {
+stack_wire_enum!(with_all AgentStackProtectionControlReason {
     RemovedWithoutEquivalent => "removed_without_equivalent",
     ExplicitlyDisabled => "explicitly_disabled",
     RoleSetReduced => "role_set_reduced",


### PR DESCRIPTION
## Summary
- define one stack-local wire enum macro with ALL and conversion-only forms
- replace duplicate stack enum macro definitions in core stack modules
- route both macro forms through an internal definition rule while preserving existing as_str receiver signatures

## Validation
- cargo test -p harness-core stack
- cargo fmt --all
- cargo check -p harness-core --all-targets
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- git commit pre-commit hook: fmt + staged-scope clippy

Closes #2014