### PR TITLE
fix(runtime): enforce agent contract outcomes

### DIFF
--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -90,10 +90,8 @@ async fn runtime_task_response_by_handle(
     let error = match runtime_string_field(&workflow.data, "failure_reason") {
         Some(reason) => Some(reason),
         None => store
-            .rejected_decisions_for_workflows_limited(std::slice::from_ref(&workflow.id), 1)
+            .latest_unresolved_rejection_for_workflow(&workflow.id)
             .await?
-            .remove(&workflow.id)
-            .and_then(|records| records.into_iter().next())
             .and_then(|record| record.rejection_reason),
     };
     let terminal = TaskTerminalInfo::from_status_error(&task_status, error.as_deref());

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -87,7 +87,15 @@ async fn runtime_task_response_by_handle(
     let submission_id = submission_handle
         .map(|handle| handle.0)
         .unwrap_or_else(|| task_id.0.clone());
-    let error = runtime_string_field(&workflow.data, "failure_reason");
+    let error = match runtime_string_field(&workflow.data, "failure_reason") {
+        Some(reason) => Some(reason),
+        None => store
+            .rejected_decisions_for_workflows_limited(std::slice::from_ref(&workflow.id), 1)
+            .await?
+            .remove(&workflow.id)
+            .and_then(|records| records.into_iter().next())
+            .and_then(|record| record.rejection_reason),
+    };
     let terminal = TaskTerminalInfo::from_status_error(&task_status, error.as_deref());
     let runtime_usage = store.runtime_usage_for_workflow(&workflow.id).await?;
     let cost_usd_observed = runtime_usage.as_ref().map(|usage| usage.cost_usd_observed);

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use harness_workflow::runtime::{
     RuntimeKind, RuntimeUsageMetrics, RuntimeUsageUpsert, WorkflowCommand, WorkflowCommandStatus,
-    WorkflowCommandType, WorkflowInstance, WorkflowRunEvidenceInput, WorkflowRuntimeStore,
-    WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID,
+    WorkflowCommandType, WorkflowDecision, WorkflowDecisionRecord, WorkflowInstance,
+    WorkflowRunEvidenceInput, WorkflowRuntimeStore, WorkflowSubject, GITHUB_ISSUE_PR_DEFINITION_ID,
 };
 
 #[tokio::test]
@@ -841,6 +841,96 @@ async fn get_task_runtime_issue_surfaces_failure_reason() -> anyhow::Result<()> 
     assert_eq!(
         body["error"],
         "WorktreeCollision: workspace path is managed by another harness session"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_runtime_submission_surfaces_latest_transition_rejection() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "planning",
+        WorkflowSubject::new("issue", "issue:1300"),
+    )
+    .with_id("issue-1300")
+    .with_server_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 1300,
+        "task_id": "runtime-task-1300",
+        "task_ids": ["runtime-task-1300"],
+    }));
+    crate::test_helpers::force_upsert_runtime_lifecycle_state_for_test(store, &workflow).await?;
+    let rejected = WorkflowDecisionRecord::rejected(
+        WorkflowDecision::new(
+            &workflow.id,
+            "planning",
+            "apply_declarative_transition",
+            "blocked",
+            "route the workflow to the operator gate",
+        )
+        .with_command(WorkflowCommand::new(
+            WorkflowCommandType::RequestOperatorAttention,
+            "issue-1300:operator",
+            serde_json::json!({"reason": "operator input required"}),
+        )),
+        None,
+        "RequiredCommandMissing: transition 'planning' -> 'blocked' requires command MarkBlocked",
+    );
+    store.record_decision(&rejected).await?;
+    store
+        .record_decision(&WorkflowDecisionRecord::accepted(
+            WorkflowDecision::new(
+                &workflow.id,
+                "planning",
+                "record_runtime_heartbeat",
+                "planning",
+                "record a later accepted decision without resolving the rejection",
+            ),
+            None,
+        ))
+        .await?;
+    let app = Router::new()
+        .route(
+            "/api/workflows/runtime/submissions/{id}",
+            get(task_query_routes::get_runtime_submission),
+        )
+        .with_state(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/workflows/runtime/submissions/runtime-task-1300")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["status"], "planning");
+    assert_eq!(
+        body["error"],
+        "RequiredCommandMissing: transition 'planning' -> 'blocked' requires command MarkBlocked"
     );
     Ok(())
 }

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -881,6 +881,14 @@ async fn get_runtime_submission_surfaces_latest_transition_rejection() -> anyhow
         "task_ids": ["runtime-task-1300"],
     }));
     crate::test_helpers::force_upsert_runtime_lifecycle_state_for_test(store, &workflow).await?;
+    let rejected_event = store
+        .append_event(
+            &workflow.id,
+            "InvalidBlockedTransition",
+            "test",
+            serde_json::json!({}),
+        )
+        .await?;
     let rejected = WorkflowDecisionRecord::rejected(
         WorkflowDecision::new(
             &workflow.id,
@@ -894,10 +902,18 @@ async fn get_runtime_submission_surfaces_latest_transition_rejection() -> anyhow
             "issue-1300:operator",
             serde_json::json!({"reason": "operator input required"}),
         )),
-        None,
+        Some(rejected_event.id),
         "RequiredCommandMissing: transition 'planning' -> 'blocked' requires command MarkBlocked",
     );
     store.record_decision(&rejected).await?;
+    let heartbeat_event = store
+        .append_event(
+            &workflow.id,
+            "RuntimeHeartbeat",
+            "test",
+            serde_json::json!({}),
+        )
+        .await?;
     store
         .record_decision(&WorkflowDecisionRecord::accepted(
             WorkflowDecision::new(
@@ -907,15 +923,23 @@ async fn get_runtime_submission_surfaces_latest_transition_rejection() -> anyhow
                 "planning",
                 "record a later accepted decision without resolving the rejection",
             ),
-            None,
+            Some(heartbeat_event.id),
         ))
         .await?;
+    sqlx::query(
+        "UPDATE workflow_decisions
+         SET created_at = TIMESTAMPTZ '2026-09-01 00:00:00+00'
+         WHERE workflow_id = $1",
+    )
+    .bind(&workflow.id)
+    .execute(store.pool())
+    .await?;
     let app = Router::new()
         .route(
             "/api/workflows/runtime/submissions/{id}",
             get(task_query_routes::get_runtime_submission),
         )
-        .with_state(state);
+        .with_state(state.clone());
 
     let response = app
         .oneshot(
@@ -932,6 +956,76 @@ async fn get_runtime_submission_surfaces_latest_transition_rejection() -> anyhow
         body["error"],
         "RequiredCommandMissing: transition 'planning' -> 'blocked' requires command MarkBlocked"
     );
+
+    let implementation_event = store
+        .append_event(
+            &workflow.id,
+            "ImplementationStarted",
+            "test",
+            serde_json::json!({}),
+        )
+        .await?;
+    store
+        .record_decision(&WorkflowDecisionRecord::accepted(
+            WorkflowDecision::new(
+                &workflow.id,
+                "planning",
+                "start_implementation",
+                "implementing",
+                "advance after retry",
+            ),
+            Some(implementation_event.id),
+        ))
+        .await?;
+    let replanning_event = store
+        .append_event(
+            &workflow.id,
+            "PlanningResumed",
+            "test",
+            serde_json::json!({}),
+        )
+        .await?;
+    store
+        .record_decision(&WorkflowDecisionRecord::accepted(
+            WorkflowDecision::new(
+                &workflow.id,
+                "implementing",
+                "return_to_planning",
+                "planning",
+                "re-enter the original state",
+            ),
+            Some(replanning_event.id),
+        ))
+        .await?;
+    sqlx::query(
+        "UPDATE workflow_decisions
+         SET created_at = TIMESTAMPTZ '2026-09-01 00:00:00+00'
+         WHERE workflow_id = $1",
+    )
+    .bind(&workflow.id)
+    .execute(store.pool())
+    .await?;
+    let mut recovered = workflow;
+    recovered.version = recovered.version.saturating_add(2);
+    crate::test_helpers::force_upsert_runtime_lifecycle_state_for_test(store, &recovered).await?;
+    let app = Router::new()
+        .route(
+            "/api/workflows/runtime/submissions/{id}",
+            get(task_query_routes::get_runtime_submission),
+        )
+        .with_state(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/workflows/runtime/submissions/runtime-task-1300")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["status"], "planning");
+    assert_eq!(body["error"], serde_json::Value::Null);
     Ok(())
 }
 

--- a/crates/harness-server/src/intake/declarative_routing.rs
+++ b/crates/harness-server/src/intake/declarative_routing.rs
@@ -204,6 +204,7 @@ async fn dispatch(
             subject_key: Some(subject_key),
             repo: issue.repo.as_deref(),
             author_trust_class: Some(issue.author_trust_class),
+            classification_input_provenance: harness_workflow::runtime::DataProvenance::External,
         },
     )
     .await?;

--- a/crates/harness-server/src/services/execution/runtime_submissions.rs
+++ b/crates/harness-server/src/services/execution/runtime_submissions.rs
@@ -204,6 +204,7 @@ impl DefaultExecutionService {
                 subject_key: None,
                 repo: prepared.req.repo.as_deref(),
                 author_trust_class: None,
+                classification_input_provenance: harness_workflow::runtime::DataProvenance::Server,
             },
         )
         .await

--- a/crates/harness-server/src/workflow_runtime_submission/declarative.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative.rs
@@ -1,7 +1,7 @@
 use super::{
-    classify_submission_data, insert_author_trust_class, merge_last_decision,
-    prompt_memory::prompt_ref_for_submission, submission_field_provenance, TaskId,
-    WorkflowSubmissionRuntimeRecord, EXECUTION_PATH_WORKFLOW_RUNTIME,
+    insert_author_trust_class, merge_last_decision, prompt_memory::prompt_ref_for_submission,
+    submission_field_provenance, TaskId, WorkflowSubmissionRuntimeRecord,
+    EXECUTION_PATH_WORKFLOW_RUNTIME,
 };
 use harness_core::config::isolation::IsolationTrustClass;
 use harness_workflow::runtime::{
@@ -161,7 +161,11 @@ async fn persist_new_submission(
     final_instance.state = decision.next_state.clone();
     final_instance.version = final_instance.version.saturating_add(1);
     let data = merge_last_decision(std::mem::take(&mut final_instance.data), &decision.decision);
-    classify_submission_data(&mut final_instance, data)?;
+    classify_declarative_submission_data(
+        &mut final_instance,
+        data,
+        ctx.classification_input_provenance,
+    )?;
     let event_id = uuid::Uuid::new_v4().to_string();
     let Some(outcome) = store
         .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
@@ -232,7 +236,6 @@ pub(super) fn submission_instance(
         "prompt_summary": "declarative workflow task",
         "prompt_chars": ctx.prompt.chars().count(),
         "prompt_ref": prompt_ref,
-        "classification_input": ctx.prompt,
         "source": ctx.source,
         "external_id": ctx.external_id,
         "repo": ctx.repo,
@@ -240,6 +243,9 @@ pub(super) fn submission_instance(
         "last_decision": DECLARATIVE_SUBMISSION_DECISION,
         "execution_path": EXECUTION_PATH_WORKFLOW_RUNTIME,
     });
+    if !definition.activity_contracts().is_empty() {
+        data["classification_input"] = json!(ctx.prompt);
+    }
     insert_author_trust_class(&mut data, ctx.author_trust_class);
     let data = crate::workflow_runtime_policy::merge_runtime_retry_policy(ctx.project_root, data);
     WorkflowInstance::new(
@@ -252,10 +258,29 @@ pub(super) fn submission_instance(
         ),
     )
     .with_id(workflow_id)
-    .with_data_field_provenance(data, |field| match field {
-        "classification_input" => ctx.classification_input_provenance,
-        _ => submission_field_provenance(field),
+    .with_data_field_provenance(data, |field| {
+        declarative_submission_field_provenance(field, ctx.classification_input_provenance)
     })
+}
+
+pub(super) fn classify_declarative_submission_data(
+    instance: &mut WorkflowInstance,
+    data: serde_json::Value,
+    classification_input_provenance: DataProvenance,
+) -> anyhow::Result<()> {
+    instance.replace_data_with_field_provenance(data, |field| {
+        declarative_submission_field_provenance(field, classification_input_provenance)
+    })
+}
+
+fn declarative_submission_field_provenance(
+    field: &str,
+    classification_input_provenance: DataProvenance,
+) -> DataProvenance {
+    match field {
+        "classification_input" => classification_input_provenance,
+        _ => submission_field_provenance(field),
+    }
 }
 
 async fn persist_definition_metadata(

--- a/crates/harness-server/src/workflow_runtime_submission/declarative.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use harness_core::config::isolation::IsolationTrustClass;
 use harness_workflow::runtime::{
-    build_declarative_submission_decision, persisted_declarative_definition,
+    build_declarative_submission_decision, persisted_declarative_definition, DataProvenance,
     DeclarativeWorkflowDefinition, ValidationContext, WorkflowCommandStatus, WorkflowInstance,
     WorkflowRuntimeStore, WorkflowSubject, WorkflowSubmissionDecisionTransition,
     WorkflowSubmissionPromptPayload, DECLARATIVE_SUBMISSION_DECISION,
@@ -26,6 +26,7 @@ pub(crate) struct DeclarativeSubmissionRuntimeContext<'a> {
     pub subject_key: Option<&'a str>,
     pub repo: Option<&'a str>,
     pub author_trust_class: Option<IsolationTrustClass>,
+    pub classification_input_provenance: DataProvenance,
 }
 
 pub(crate) async fn record_declarative_submission(
@@ -231,6 +232,7 @@ pub(super) fn submission_instance(
         "prompt_summary": "declarative workflow task",
         "prompt_chars": ctx.prompt.chars().count(),
         "prompt_ref": prompt_ref,
+        "classification_input": ctx.prompt,
         "source": ctx.source,
         "external_id": ctx.external_id,
         "repo": ctx.repo,
@@ -250,7 +252,10 @@ pub(super) fn submission_instance(
         ),
     )
     .with_id(workflow_id)
-    .with_data_field_provenance(data, submission_field_provenance)
+    .with_data_field_provenance(data, |field| match field {
+        "classification_input" => ctx.classification_input_provenance,
+        _ => submission_field_provenance(field),
+    })
 }
 
 async fn persist_definition_metadata(

--- a/crates/harness-server/src/workflow_runtime_submission/declarative_project_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative_project_tests.rs
@@ -110,6 +110,7 @@ fn declarative_submission_instance_persists_runtime_retry_policy() -> anyhow::Re
         subject_key: None,
         repo: None,
         author_trust_class: None,
+        classification_input_provenance: harness_workflow::runtime::DataProvenance::Server,
     };
 
     let instance = super::declarative::submission_instance(

--- a/crates/harness-server/src/workflow_runtime_submission/declarative_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative_tests.rs
@@ -257,10 +257,7 @@ fn agent_contract_submission_command_matches_the_committed_instance() -> anyhow:
 
 #[test]
 fn declarative_submission_preserves_intake_identity_and_trust() {
-    let registry = register_test_definition();
-    let Some(definition) = registry.current_declarative_definition(TEST_DEFINITION_ID) else {
-        panic!("definition should be registered");
-    };
+    let definition = agent_contract_definition();
     let task_id = TaskId::from_str("declarative-intake-identity");
     let ctx = DeclarativeSubmissionRuntimeContext {
         project_root: Path::new("/repo"),
@@ -296,6 +293,66 @@ fn declarative_submission_preserves_intake_identity_and_trust() {
             .and_then(|provenance| provenance.provenance_for("/classification_input")),
         Some(DataProvenance::External)
     );
+    let decision = build_declarative_submission_decision(&definition, &instance)
+        .expect("agent contract submission decision should build");
+    let mut committed = instance.clone();
+    committed.state = decision.next_state.clone();
+    committed.version = committed.version.saturating_add(1);
+    let data = merge_last_decision(std::mem::take(&mut committed.data), &decision.decision);
+    super::declarative::classify_declarative_submission_data(
+        &mut committed,
+        data,
+        DataProvenance::External,
+    )
+    .expect("committed intake facts should retain their trust classification");
+    assert_eq!(
+        committed
+            .data_provenance
+            .as_ref()
+            .and_then(|provenance| provenance.provenance_for("/classification_input")),
+        Some(DataProvenance::External)
+    );
+    assert!(validate_declarative_agent_contract_command(
+        &definition,
+        &committed,
+        &decision.commands[0],
+    )
+    .expect("committed intake command should retain its pinned provenance"));
+}
+
+#[test]
+fn declarative_submission_without_agent_contract_keeps_prompt_out_of_facts() {
+    let registry = register_test_definition();
+    let definition = registry
+        .current_declarative_definition(TEST_DEFINITION_ID)
+        .expect("definition should be registered");
+    let task_id = TaskId::from_str("declarative-no-agent-contract");
+    let instance = super::declarative::submission_instance(
+        &DeclarativeSubmissionRuntimeContext {
+            project_root: Path::new("/repo"),
+            definition_id: TEST_DEFINITION_ID,
+            task_id: &task_id,
+            prompt: "perform the declared work",
+            depends_on: &[],
+            serialization_depends_on: &[],
+            source: None,
+            external_id: None,
+            subject_key: None,
+            repo: None,
+            author_trust_class: None,
+            classification_input_provenance: DataProvenance::Server,
+        },
+        "/repo",
+        "declarative-no-agent-contract-workflow",
+        "prompt-ref",
+        &definition,
+    );
+
+    assert!(instance.data.get("classification_input").is_none());
+    assert!(instance
+        .data_provenance
+        .as_ref()
+        .is_some_and(|provenance| provenance.provenance_for("/classification_input").is_none()));
 }
 
 #[tokio::test]

--- a/crates/harness-server/src/workflow_runtime_submission/declarative_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_submission/declarative_tests.rs
@@ -10,7 +10,7 @@ use harness_core::{
 };
 use harness_workflow::runtime::{
     build_declarative_submission_decision, store::RuntimeJobEnqueueOutcome,
-    validate_declarative_agent_contract_command, ActivityResult, ActivitySignal,
+    validate_declarative_agent_contract_command, ActivityResult, ActivitySignal, DataProvenance,
     DeclarativeWorkflowDefinition, RuntimeKind, WorkflowCommandStatus, WorkflowCommandType,
     WorkflowDefinitionRegistry,
 };
@@ -209,6 +209,7 @@ fn agent_contract_submission_command_matches_the_committed_instance() -> anyhow:
             subject_key: None,
             repo: None,
             author_trust_class: None,
+            classification_input_provenance: DataProvenance::Server,
         },
         "/project",
         "agent-contract-workflow",
@@ -216,6 +217,30 @@ fn agent_contract_submission_command_matches_the_committed_instance() -> anyhow:
         &definition,
     );
     let decision = build_declarative_submission_decision(&definition, &instance)?;
+    assert_eq!(
+        instance.data["classification_input"],
+        "Assess this submission."
+    );
+    let provenance = instance
+        .data_provenance
+        .as_ref()
+        .expect("declarative submission facts must carry provenance");
+    assert_eq!(
+        provenance.provenance_for("/classification_input"),
+        Some(DataProvenance::Server)
+    );
+    assert!(provenance
+        .value_digests
+        .contains_key("/classification_input"));
+    assert_eq!(
+        decision.commands[0].command["agent_contract_input"]["facts"]["classification_input"],
+        "Assess this submission."
+    );
+    assert_eq!(
+        decision.commands[0].command["agent_contract_input"]["provenance"]["entries"]
+            ["/classification_input"],
+        "server"
+    );
     let mut committed = instance.clone();
     committed.state = decision.next_state.clone();
     committed.version = committed.version.saturating_add(1);
@@ -249,6 +274,7 @@ fn declarative_submission_preserves_intake_identity_and_trust() {
         subject_key: Some("github:owner/repo:issue:42"),
         repo: Some("owner/repo"),
         author_trust_class: Some(IsolationTrustClass::NonCollaborator),
+        classification_input_provenance: DataProvenance::External,
     };
 
     let instance = super::declarative::submission_instance(
@@ -263,6 +289,13 @@ fn declarative_submission_preserves_intake_identity_and_trust() {
     assert_eq!(instance.data["external_id"], "42");
     assert_eq!(instance.data["repo"], "owner/repo");
     assert_eq!(instance.data["author_trust_class"], "non_collaborator");
+    assert_eq!(
+        instance
+            .data_provenance
+            .as_ref()
+            .and_then(|provenance| provenance.provenance_for("/classification_input")),
+        Some(DataProvenance::External)
+    );
 }
 
 #[tokio::test]
@@ -289,6 +322,7 @@ async fn declarative_submission_pins_immutable_definition_metadata() -> anyhow::
             subject_key: None,
             repo: None,
             author_trust_class: None,
+            classification_input_provenance: DataProvenance::Server,
         },
     )
     .await?;
@@ -348,6 +382,7 @@ async fn declarative_submission_enqueues_initial_activity_atomically() -> anyhow
             subject_key: None,
             repo: None,
             author_trust_class: None,
+            classification_input_provenance: DataProvenance::Server,
         },
     )
     .await?;
@@ -389,6 +424,7 @@ async fn declarative_submission_mapped_signal_reaches_terminal_state() -> anyhow
             subject_key: None,
             repo: None,
             author_trust_class: None,
+            classification_input_provenance: DataProvenance::Server,
         },
     )
     .await?;
@@ -478,6 +514,7 @@ async fn declarative_submission_can_be_cancelled_by_an_operator() -> anyhow::Res
             subject_key: None,
             repo: None,
             author_trust_class: None,
+            classification_input_provenance: DataProvenance::Server,
         },
     )
     .await?;
@@ -520,6 +557,7 @@ async fn declarative_submission_rejects_dependencies() -> anyhow::Result<()> {
             subject_key: None,
             repo: None,
             author_trust_class: None,
+            classification_input_provenance: DataProvenance::Server,
         },
     )
     .await
@@ -564,6 +602,7 @@ async fn declarative_submission_rejects_unknown_and_builtin_ids() -> anyhow::Res
                 subject_key: None,
                 repo: None,
                 author_trust_class: None,
+                classification_input_provenance: DataProvenance::Server,
             },
         )
         .await
@@ -609,6 +648,7 @@ async fn declarative_dedupe_and_cap_query_key_off_subject_external_id() -> anyho
                     subject_key: None,
                     repo: None,
                     author_trust_class: None,
+                    classification_input_provenance: DataProvenance::Server,
                 },
             )
             .await

--- a/crates/harness-server/src/workflow_runtime_worker/agent_contract_attempt.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/agent_contract_attempt.rs
@@ -77,7 +77,7 @@ pub(super) fn contract_attempt_activity_result(
         .with_error_kind(ActivityErrorKind::Fatal)
         .with_artifact(observation_artifact);
     }
-    match parse_contract_verdict(&attempt.output, &pinned.contract) {
+    match parse_contract_verdict(&attempt.output, &pinned.contract, &pinned.input) {
         Ok(verdict) => ActivityResult::succeeded(
             activity,
             format!("Agent contract verdict: {}.", verdict.outcome),
@@ -151,10 +151,13 @@ pub(super) fn contract_violations(attempt: &ContractAttempt) -> Vec<String> {
 pub(super) fn parse_contract_verdict(
     output: &str,
     contract: &WorkflowAgentContract,
+    input: &Value,
 ) -> Result<ContractVerdict, String> {
     let raw: Value = serde_json::from_str(output.trim())
         .map_err(|error| format!("reply is not valid JSON: {error}"))?;
     validate_agent_contract_output(&contract.output_schema, &raw)?;
+    harness_workflow::runtime::validate_agent_contract_evidence_refs(input, &raw)
+        .map_err(|error| error.to_string())?;
     let outcome = raw
         .get("outcome")
         .and_then(Value::as_str)
@@ -197,14 +200,20 @@ mod tests {
         let contract_hash = harness_workflow::runtime::stable_remote_fact_hash(
             &serde_json::to_value(&contract).expect("serialize contract"),
         );
+        let facts = json!({"changed_files": ["src/lib.rs"]});
+        let facts_digest = harness_workflow::runtime::stable_remote_fact_hash(&facts);
         PinnedJobAgentContract {
             contract,
             prompt: "Classify only the supplied facts.".to_string(),
             input: json!({
                 "schema": "harness.semantic_activity_input.v1",
                 "subject": {"kind": "issue", "identity": "owner/repo#126"},
-                "facts": {"changed_files": ["src/lib.rs"]},
-                "provenance": {"/changed_files": "server"},
+                "facts": facts,
+                "provenance": {
+                    "schema": "harness.workflow.data_provenance.v1",
+                    "entries": {"": "server"},
+                    "value_digests": {"": facts_digest}
+                },
                 "contract_hash": contract_hash,
             }),
             definition_hash: "sha256:pinned".to_string(),
@@ -629,6 +638,16 @@ mod tests {
                 })
                 .to_string(),
                 "does not match schema",
+            ),
+            (
+                json!({
+                    "schema": "harness.semantic_verdict.v1",
+                    "outcome": "small",
+                    "rationale": "x",
+                    "evidence_refs": ["/facts/missing"],
+                })
+                .to_string(),
+                "does not resolve",
             ),
         ] {
             let attempt = ContractAttempt {

--- a/crates/harness-server/src/workflow_runtime_worker/agent_contract_execution.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/agent_contract_execution.rs
@@ -186,7 +186,7 @@ pub(super) async fn execute_contract_attempts(
                 result.artifacts = observations;
                 return Ok(result);
             }
-            match parse_contract_verdict(&attempt.output, &pinned.contract) {
+            match parse_contract_verdict(&attempt.output, &pinned.contract, &pinned.input) {
                 Ok(verdict) => {
                     record_attempt_completed(
                         store,

--- a/crates/harness-server/src/workflow_runtime_worker/agent_contract_job.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/agent_contract_job.rs
@@ -689,6 +689,8 @@ mod dogfood_tests {
         let contract_hash = harness_workflow::runtime::stable_remote_fact_hash(
             &serde_json::to_value(&contract).expect("serialize dogfood contract"),
         );
+        let facts = json!({"changed_files": ["docs/agent-contract.md"]});
+        let facts_digest = harness_workflow::runtime::stable_remote_fact_hash(&facts);
         PinnedJobAgentContract {
             contract,
             prompt: concat!(
@@ -700,8 +702,12 @@ mod dogfood_tests {
             input: json!({
                 "schema": "harness.semantic_activity_input.v1",
                 "subject": {"kind": "pull_request", "identity": "owner/repo#2020"},
-                "facts": {"changed_files": ["docs/agent-contract.md"]},
-                "provenance": {"/changed_files": "server"},
+                "facts": facts,
+                "provenance": {
+                    "schema": "harness.workflow.data_provenance.v1",
+                    "entries": {"": "server"},
+                    "value_digests": {"": facts_digest}
+                },
                 "contract_hash": contract_hash,
             }),
             definition_hash: "sha256:dogfood-definition".to_string(),
@@ -733,7 +739,7 @@ mod dogfood_tests {
             violations.is_empty(),
             "live attempt violations: {violations:?}"
         );
-        let verdict = parse_contract_verdict(&attempt.output, &pinned.contract)
+        let verdict = parse_contract_verdict(&attempt.output, &pinned.contract, &pinned.input)
             .map_err(anyhow::Error::msg)?;
         assert_eq!(verdict.outcome, "small");
         assert!(

--- a/crates/harness-workflow/src/runtime/declarative_agent_contract.rs
+++ b/crates/harness-workflow/src/runtime/declarative_agent_contract.rs
@@ -6,6 +6,7 @@
 //! the `EnqueueActivity` command payload so the runtime job snapshot always
 //! carries the exact contract the instance was pinned to.
 
+use super::data_provenance::WorkflowDataProvenance;
 use super::declarative::DeclarativeWorkflowDefinition;
 use super::model::{
     ActivityResult, RuntimeKind, WorkflowCommand, WorkflowCommandType, WorkflowInstance,
@@ -176,6 +177,7 @@ pub(crate) fn validated_agent_contract_assessment_outcome(
         .ok_or_else(|| anyhow::anyhow!("agent contract verdict artifact is missing verdict"))?;
     validate_agent_contract_output(&pinned.contract.output_schema, &assessment.verdict)
         .map_err(anyhow::Error::msg)?;
+    validate_agent_contract_evidence_refs(input, &assessment.verdict)?;
     let expected_contract_hash = super::remote_facts::stable_remote_fact_hash(contract_value);
     let expected_input_hash = super::remote_facts::stable_remote_fact_hash(input);
     let mut expected_primary = 1;
@@ -232,6 +234,57 @@ pub(crate) fn validated_agent_contract_assessment_outcome(
         anyhow::bail!("agent contract assessment failed pinned-event validation");
     }
     Ok(Some(assessment.outcome))
+}
+
+/// Validates that every model-supplied evidence reference names an immutable,
+/// provenance-covered value in the pinned facts envelope.
+pub fn validate_agent_contract_evidence_refs(input: &Value, verdict: &Value) -> anyhow::Result<()> {
+    let evidence_refs = verdict
+        .get("evidence_refs")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("agent contract verdict is missing evidence_refs"))?;
+    if evidence_refs.is_empty() {
+        return Ok(());
+    }
+    let facts = input
+        .get("facts")
+        .ok_or_else(|| anyhow::anyhow!("agent contract input is missing facts"))?;
+    let provenance: WorkflowDataProvenance = serde_json::from_value(
+        input
+            .get("provenance")
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("agent contract input is missing provenance"))?,
+    )?;
+    provenance
+        .validate_persisted_data(facts)
+        .map_err(|error| anyhow::anyhow!("agent contract input provenance is invalid: {error}"))?;
+    for evidence_ref in evidence_refs {
+        let evidence_ref = evidence_ref
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("agent contract evidence reference is not a string"))?;
+        let Some(facts_pointer) = evidence_ref.strip_prefix("/facts") else {
+            anyhow::bail!(
+                "agent contract evidence reference '{evidence_ref}' must start with '/facts/'"
+            );
+        };
+        if !facts_pointer.starts_with('/') {
+            anyhow::bail!(
+                "agent contract evidence reference '{evidence_ref}' must start with '/facts/'"
+            );
+        }
+        if input.pointer(evidence_ref).is_none() {
+            anyhow::bail!(
+                "agent contract evidence reference '{evidence_ref}' does not resolve in the pinned input"
+            );
+        }
+        if provenance.is_legacy(facts_pointer) || provenance.provenance_for(facts_pointer).is_none()
+        {
+            anyhow::bail!(
+                "agent contract evidence reference '{evidence_ref}' has no provenance coverage"
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Validates and pins the agent contracts of every activity the definition

--- a/crates/harness-workflow/src/runtime/mod.rs
+++ b/crates/harness-workflow/src/runtime/mod.rs
@@ -80,9 +80,9 @@ pub use data_provenance::{
 pub use data_write::WorkflowDataWrite;
 pub use declarative::{build_declarative_definition, DeclarativeWorkflowDefinition};
 pub use declarative_agent_contract::{
-    validate_declarative_agent_contract_command, PinnedAgentContractActivity,
-    AGENT_CONTRACT_ASSESSMENT_ARTIFACT, AGENT_CONTRACT_ASSESSMENT_SCHEMA,
-    AGENT_CONTRACT_VERDICT_ARTIFACT,
+    validate_agent_contract_evidence_refs, validate_declarative_agent_contract_command,
+    PinnedAgentContractActivity, AGENT_CONTRACT_ASSESSMENT_ARTIFACT,
+    AGENT_CONTRACT_ASSESSMENT_SCHEMA, AGENT_CONTRACT_VERDICT_ARTIFACT,
 };
 pub use declarative_interpreter::{
     build_declarative_submission_decision, DECLARATIVE_SUBMISSION_DECISION,

--- a/crates/harness-workflow/src/runtime/reducer/declarative_completion.rs
+++ b/crates/harness-workflow/src/runtime/reducer/declarative_completion.rs
@@ -289,15 +289,23 @@ fn transition_decision(
         }
     };
 
-    Ok(WorkflowDecision::new(
+    let mut decision = WorkflowDecision::new(
         &instance.id,
         &instance.state,
         "apply_declarative_transition",
         target,
-        reason,
-    )
-    .with_command(command)
-    .high_confidence())
+        &reason,
+    );
+    if target == "blocked" {
+        decision = decision.with_command(runtime_blocked_command(
+            &reason,
+            None,
+            format!("{}:mark-blocked", event_dedupe_key(instance, target, event)),
+            event,
+            result,
+        ));
+    }
+    Ok(decision.with_command(command).high_confidence())
 }
 
 fn terminal_class(

--- a/crates/harness-workflow/src/runtime/store/decisions.rs
+++ b/crates/harness-workflow/src/runtime/store/decisions.rs
@@ -56,6 +56,40 @@ impl WorkflowRuntimeStore {
         Ok(by_workflow)
     }
 
+    pub async fn latest_unresolved_rejection_for_workflow(
+        &self,
+        workflow_id: &str,
+    ) -> anyhow::Result<Option<WorkflowDecisionRecord>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT rejected.data::text
+             FROM workflow_decisions AS rejected
+             JOIN workflow_events AS rejected_event
+               ON rejected_event.id = rejected.event_id
+              AND rejected_event.workflow_id = rejected.workflow_id
+             WHERE rejected.workflow_id = $1
+               AND rejected.accepted = false
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM workflow_decisions AS progress
+                   JOIN workflow_events AS progress_event
+                     ON progress_event.id = progress.event_id
+                    AND progress_event.workflow_id = progress.workflow_id
+                   WHERE progress.workflow_id = rejected.workflow_id
+                     AND progress.accepted = true
+                     AND progress_event.sequence >= rejected_event.sequence
+                     AND progress.data->'decision'->>'observed_state'
+                         <> progress.data->'decision'->>'next_state'
+               )
+             ORDER BY rejected_event.sequence DESC
+             LIMIT 1",
+        )
+        .bind(workflow_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|(data,)| serde_json::from_str(&data).map_err(Into::into))
+            .transpose()
+    }
+
     pub async fn detail_counts_for_workflows(
         &self,
         workflow_ids: &[String],

--- a/crates/harness-workflow/src/runtime/tests/declarative_agent_contract.rs
+++ b/crates/harness-workflow/src/runtime/tests/declarative_agent_contract.rs
@@ -440,7 +440,7 @@ mod declarative_agent_contract_tests {
             "activity_result": result,
         }));
         let mut registry = WorkflowDefinitionRegistry::with_builtins();
-        registry.register_declarative_current(definition)?;
+        registry.register_declarative_current(definition.clone())?;
 
         let decision = crate::runtime::reducer::reduce_runtime_job_completed_with_registry(
             &registry,
@@ -459,6 +459,82 @@ mod declarative_agent_contract_tests {
         .expect("persisted assessment must replay without a model call");
         assert_eq!(replay.next_state, decision.next_state);
         assert_eq!(replay.reason, decision.reason);
+
+        let blocked_verdict = json!({
+            "schema": "harness.semantic_verdict.v1",
+            "outcome": "large",
+            "rationale": "The supplied facts require operator review.",
+            "evidence_refs": []
+        });
+        let blocked_result = ActivityResult::succeeded("classify_scope", "Assessment completed.")
+            .with_artifact(ActivityArtifact::new(
+                "agent_contract_verdict",
+                json!({"verdict": blocked_verdict}),
+            ))
+            .with_artifact(ActivityArtifact::new(
+                "agent_contract_assessment",
+                json!({
+                    "schema": "harness.agent_contract_assessment.v1",
+                    "assessment_id": "job-blocked:agent-contract-assessment",
+                    "activity": "classify_scope",
+                    "definition_hash": definition.definition_hash(),
+                    "contract_hash": stable_remote_fact_hash(&command.command["agent_contract"]),
+                    "input_hash": stable_remote_fact_hash(&command.command["agent_contract_input"]),
+                    "runtime_job_id": "job-blocked",
+                    "command_id": "command-blocked",
+                    "runtime_profile": "codex-contract",
+                    "runtime_kind": "codex_exec",
+                    "outcome": "large",
+                    "verdict": blocked_verdict,
+                    "budget": {
+                        "max_primary_attempts": 1,
+                        "max_corrections": 1,
+                        "primary_attempts_used": 1,
+                        "corrections_used": 0
+                    }
+                }),
+            ));
+        let blocked_event = WorkflowEvent::new(
+            &instance.id,
+            2,
+            crate::runtime::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+            "runtime-test",
+        )
+        .with_payload(json!({
+            "command_id": "command-blocked",
+            "runtime_job_id": "job-blocked",
+            "runtime_job_profile": "codex-contract",
+            "runtime_job_kind": "codex_exec",
+            "agent_contract_attempts": [
+                {"primary_attempt": 1, "correction_attempt": 0}
+            ],
+            "command": command,
+            "activity_result": blocked_result,
+        }));
+        let blocked_decision =
+            crate::runtime::reducer::reduce_runtime_job_completed_with_registry(
+                &registry,
+                &instance,
+                &blocked_event,
+            )?
+            .expect("blocked assessment must route to the operator gate");
+
+        assert_eq!(blocked_decision.next_state, "blocked");
+        assert!(blocked_decision.commands.iter().any(|command| {
+            command.command_type == WorkflowCommandType::MarkBlocked
+        }));
+        assert!(blocked_decision.commands.iter().any(|command| {
+            command.command_type == WorkflowCommandType::RequestOperatorAttention
+        }));
+        registry
+            .decision_validator_for_instance(&instance)
+            .expect("definition pin must resolve")
+            .expect("declarative definition must resolve a validator")
+            .validate(
+                &instance,
+                &blocked_decision,
+                &ValidationContext::new("workflow-policy", chrono::Utc::now()),
+            )?;
 
         let forged_result = ActivityResult::succeeded("classify_scope", "forged signal")
             .with_signal(ActivitySignal::new("small", json!({"source": "model"})));
@@ -490,6 +566,130 @@ mod declarative_agent_contract_tests {
         assert!(forged_decision
             .reason
             .contains("exactly one server assessment"));
+        Ok(())
+    }
+
+    #[test]
+    fn server_assessment_rejects_unverifiable_evidence_refs() -> anyhow::Result<()> {
+        let definition = build_declarative_definition(
+            &classifier_policy(),
+            &activity_policies(Some(contract())),
+        )?;
+        let instance = WorkflowInstance::new(
+            definition.policy().id.clone(),
+            definition.definition_version(),
+            "classifying",
+            WorkflowSubject::new("test", "assessment-evidence"),
+        )
+        .with_id("assessment-evidence")
+        .with_server_data(json!({
+            "definition_hash": definition.definition_hash(),
+            "classification_input": "Assess this submission."
+        }));
+        let base_command =
+            crate::runtime::declarative_agent_contract::declarative_enqueue_activity_command(
+                &definition,
+                &instance,
+                "classify_scope",
+                "assessment-evidence-1".to_string(),
+            )?;
+        let mut missing_provenance_command = base_command.clone();
+        missing_provenance_command.command["agent_contract_input"]["provenance"]["entries"] =
+            json!({});
+        missing_provenance_command.command["agent_contract_input"]["provenance"]
+            ["value_digests"] = json!({});
+        let cases = [
+            (
+                "missing-path",
+                base_command.clone(),
+                "/facts/does_not_exist",
+                "does not resolve",
+            ),
+            (
+                "outside-facts",
+                base_command,
+                "/subject/identity",
+                "must start with '/facts/'",
+            ),
+            (
+                "missing-provenance",
+                missing_provenance_command,
+                "/facts/classification_input",
+                "provenance",
+            ),
+        ];
+        let mut registry = WorkflowDefinitionRegistry::with_builtins();
+        registry.register_declarative_current(definition.clone())?;
+
+        for (case, command, evidence_ref, expected_error) in cases {
+            let runtime_job_id = format!("job-{case}");
+            let command_id = format!("command-{case}");
+            let verdict = json!({
+                "schema": "harness.semantic_verdict.v1",
+                "outcome": "small",
+                "rationale": "The supplied facts describe a bounded change.",
+                "evidence_refs": [evidence_ref]
+            });
+            let result = ActivityResult::succeeded("classify_scope", "Assessment completed.")
+                .with_artifact(ActivityArtifact::new(
+                    "agent_contract_verdict",
+                    json!({"verdict": verdict}),
+                ))
+                .with_artifact(ActivityArtifact::new(
+                    "agent_contract_assessment",
+                    json!({
+                        "schema": "harness.agent_contract_assessment.v1",
+                        "assessment_id": format!("{runtime_job_id}:agent-contract-assessment"),
+                        "activity": "classify_scope",
+                        "definition_hash": definition.definition_hash(),
+                        "contract_hash": stable_remote_fact_hash(&command.command["agent_contract"]),
+                        "input_hash": stable_remote_fact_hash(&command.command["agent_contract_input"]),
+                        "runtime_job_id": runtime_job_id,
+                        "command_id": command_id,
+                        "runtime_profile": "codex-contract",
+                        "runtime_kind": "codex_exec",
+                        "outcome": "small",
+                        "verdict": verdict,
+                        "budget": {
+                            "max_primary_attempts": 1,
+                            "max_corrections": 1,
+                            "primary_attempts_used": 1,
+                            "corrections_used": 0
+                        }
+                    }),
+                ));
+            let event = WorkflowEvent::new(
+                &instance.id,
+                1,
+                crate::runtime::reducer::RUNTIME_JOB_COMPLETED_EVENT,
+                "runtime-test",
+            )
+            .with_payload(json!({
+                "command_id": command_id,
+                "runtime_job_id": runtime_job_id,
+                "runtime_job_profile": "codex-contract",
+                "runtime_job_kind": "codex_exec",
+                "agent_contract_attempts": [
+                    {"primary_attempt": 1, "correction_attempt": 0}
+                ],
+                "command": command,
+                "activity_result": result,
+            }));
+
+            let decision = crate::runtime::reducer::reduce_runtime_job_completed_with_registry(
+                &registry,
+                &instance,
+                &event,
+            )?
+            .expect("unverifiable evidence must fail closed");
+
+            assert_eq!(decision.next_state, "blocked", "{case}");
+            assert!(
+                decision.reason.contains(expected_error),
+                "{case}: {}",
+                decision.reason
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- emit both MarkBlocked and RequestOperatorAttention for blocked declarative outcomes without relaxing transition validation
- surface the newest rejected workflow decision through the submission API, including an independent RequiredCommandMissing regression test
- pin classification input in immutable submission facts with explicit provenance and digest coverage
- require evidence_refs to resolve below /facts and be covered by provenance

## Validation

- cargo fmt --all -- --check
- env -u DATABASE_URL -u HARNESS_DATABASE_URL cargo check --workspace --all-targets
- env -u DATABASE_URL -u HARNESS_DATABASE_URL cargo clippy --workspace --all-targets -- -D warnings
- focused harness-workflow and harness-server tests, including an isolated PostgreSQL API rejection test
- fresh-context review: APPROVED

## Product evaluation

Replayed the original 8 classification cases through the public submission API using the real workflow runtime:

- semantic accuracy: 8/8
- route accuracy: 8/8
- restart redispatch: 0
- evidence refs: all cite /facts/classification_input
- observed model tokens: 173,610 total
- observed model latency: 10.260s to 20.583s, 13.782s mean
- observed USD cost: unavailable

This clears the current-runtime correctness gate. It does not establish broad classifier reliability or make the token, latency, and cost profile acceptable for high-frequency use. The vNext umbrella and Cutover remain outside this PR.