### PR TITLE
fix(workflow): use structured PR repair blockers

### DIFF
--- a/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_result_tests.rs
@@ -351,6 +351,51 @@ fn activity_result_from_turn_downgrades_succeeded_with_textual_blockers() {
 }
 
 #[test]
+fn pr_feedback_repair_uses_structured_facts_independently_of_prose() {
+    for summary in [
+        "The failed checks were repaired; changes requested was the previous review state.",
+        "Changes requested: addressed. Unresolved review threads: resolved.",
+        "No new failed checks were introduced; two failed checks remain.",
+        "The PR is not merge-ready; requested changes remain.",
+    ] {
+        let mut claimed = ActivityResult::succeeded("address_pr_feedback", summary).with_artifact(
+            ActivityArtifact::new(
+                "pr_repair_snapshot",
+                json!({
+                    "fresh_pr_state": {
+                        "merge_state_status": "CLEAN",
+                        "failed_checks": 0,
+                        "open_review_threads": 0,
+                        "review_decision": "APPROVED"
+                    }
+                }),
+            ),
+        );
+        claimed.error = Some(summary.to_string());
+        let (changed, result) =
+            enforce_activity_status_contract(Some(GITHUB_ISSUE_PR_DEFINITION_ID), claimed);
+        assert!(
+            !changed,
+            "prose must not override structured facts: {summary}"
+        );
+        assert_eq!(result.status, ActivityStatus::Succeeded);
+    }
+}
+
+#[test]
+fn pr_feedback_repair_preserves_structured_signals_despite_positive_prose() {
+    for signal in ["ChangesRequested", "ChecksFailed"] {
+        let claimed = ActivityResult::succeeded("address_pr_feedback", "Everything is resolved.")
+            .with_signal(ActivitySignal::new(signal, json!({})));
+        let (changed, result) =
+            enforce_activity_status_contract(Some(GITHUB_ISSUE_PR_DEFINITION_ID), claimed);
+        assert!(changed);
+        assert_eq!(result.status, ActivityStatus::SucceededWithBlockers);
+        assert!(status_contract_blockers_from_result(&result).contains(&format!("signal:{signal}")));
+    }
+}
+
+#[test]
 fn pr_feedback_repair_can_return_while_new_checks_are_pending() {
     let claimed = ActivityResult::succeeded(
         "address_pr_feedback",
@@ -381,7 +426,7 @@ fn pr_feedback_repair_keeps_actual_check_and_merge_blockers() {
         json!({ "failed_checks": 1 }),
         json!({ "merge_state_status": "DIRTY" }),
     ] {
-        let claimed = ActivityResult::succeeded("address_pr_feedback", "Repair result recorded.")
+        let claimed = ActivityResult::succeeded("address_pr_feedback", "Everything is resolved.")
             .with_artifact(ActivityArtifact::new("pr_repair_snapshot", artifact));
 
         let (changed, result) =
@@ -436,9 +481,9 @@ fn pr_feedback_repair_allows_blocked_merge_state_only_for_proven_pending_checks(
 }
 
 #[test]
-fn pr_feedback_repair_keeps_failed_checks_reported_only_in_summary() {
+fn issue_implementation_keeps_failed_checks_reported_only_in_summary() {
     let claimed = ActivityResult::succeeded(
-        "address_pr_feedback",
+        "implement_issue",
         "The repair was pushed, but hosted CI still has failed checks.",
     )
     .with_artifact(ActivityArtifact::new(
@@ -463,14 +508,14 @@ fn pr_feedback_repair_keeps_failed_checks_reported_only_in_summary() {
 }
 
 #[test]
-fn pr_feedback_repair_keeps_non_ci_blockers_reported_in_summary() {
+fn issue_implementation_keeps_non_ci_blockers_reported_in_summary() {
     for blocker_summary in [
         "The repair was pushed, but the review state remains changes requested.",
         "The repair was pushed, but an unresolved review thread remains.",
         "The repair was pushed, but the PR is not merge-ready.",
         "The repair was pushed, but a quota notice blocks review.",
     ] {
-        let claimed = ActivityResult::succeeded("address_pr_feedback", blocker_summary);
+        let claimed = ActivityResult::succeeded("implement_issue", blocker_summary);
 
         let (changed, result) =
             enforce_activity_status_contract(Some(GITHUB_ISSUE_PR_DEFINITION_ID), claimed);
@@ -512,9 +557,9 @@ fn pr_feedback_repair_does_not_treat_resolved_review_threads_as_a_blocker() {
 }
 
 #[test]
-fn pr_feedback_repair_keeps_requested_changes_remain_blocking() {
+fn issue_implementation_keeps_requested_changes_remain_blocking() {
     let claimed = ActivityResult::succeeded(
-        "address_pr_feedback",
+        "implement_issue",
         "The repair was pushed, but requested changes remain.",
     );
 
@@ -531,7 +576,7 @@ fn pr_feedback_repair_keeps_requested_changes_remain_blocking() {
 #[test]
 fn negated_check_delta_does_not_hide_a_remaining_failed_check_clause() {
     let claimed = ActivityResult::succeeded(
-        "address_pr_feedback",
+        "implement_issue",
         "No new failed checks were introduced; two failed checks remain.",
     );
 
@@ -548,7 +593,7 @@ fn negated_check_delta_does_not_hide_a_remaining_failed_check_clause() {
 #[test]
 fn comma_joined_negated_check_delta_does_not_hide_a_remaining_failed_check_clause() {
     let claimed = ActivityResult::succeeded(
-        "address_pr_feedback",
+        "implement_issue",
         "No new failed checks were introduced, two failed checks remain.",
     );
 

--- a/crates/harness-server/src/workflow_runtime_worker/activity_status_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_status_contract.rs
@@ -144,12 +144,16 @@ fn activity_status_contract_blockers(
         }
     }
 
+    // Repair prose describes what happened; structured signals and artifacts
+    // determine blockers. The reducer still requires repair action evidence,
+    // then local review and a server-owned PR snapshot before merge readiness.
+    if pr_feedback_repair {
+        return blockers;
+    }
+
     let mut summary_blockers = Vec::new();
     if !local_review_outcome_accepts_blockers {
         collect_textual_blockers(&result.summary, &mut summary_blockers);
-    }
-    if pr_feedback_repair {
-        summary_blockers.retain(|blocker| blocker != "text:pending_ci");
     }
     if workflow_definition == Some(PROMPT_TASK_DEFINITION_ID)
         && result.activity == PROMPT_TASK_IMPLEMENT_ACTIVITY

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/mod.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/mod.rs
@@ -510,6 +510,7 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
             "on_succeeded": {
                 "reducer_next_state": "local_review_gate",
                 "success_requires": "A succeeded address_pr_feedback result MUST include pr_repair_snapshot with final head, observed_at, action proof, and passing validation evidence, unless IssueClosed/IssueAlreadyResolved or issue_state proves the issue or PR is already closed/resolved.",
+                "blocker_evidence": "Report remaining blockers through structured status, signals, and pr_repair_snapshot fields. Summary and error prose are descriptive and do not determine PR repair blockers. A succeeded repair still requires action evidence and proceeds through local review and server-owned remote PR inspection before readiness.",
                 "required_summary": "Describe addressed review feedback, pushed/no-code action, validation evidence, or closed issue evidence. If the fresh PR merge_state_status is DIRTY or BEHIND, update or rebase the PR branch and push it before returning; a no-code result is invalid while mergeability remains blocked. For command_input.source=pr_hygiene, also describe the configured rebase-needed label action on update/rebase failure and the stale comment/escalation threshold decision. Harness will run local review before remote feedback unless terminal closed evidence finishes the workflow."
             },
             "on_failed": {


### PR DESCRIPTION
## Problem and change

A PR repair could report clean structured facts and still be blocked because its summary mentioned previous failed checks or requested changes. For `github_issue_pr/address_pr_feedback`, blocker reconciliation now uses structured signals and artifacts without scanning summary/error prose. The prompt explains that contract.

Repair action evidence, local review, server-owned remote readiness snapshots, and structured failures remain enforced. Generic prose-contract tests remain on an unaffected activity.

## Validation

- Reproduced the new prose/structured-fact contradiction test failing before the fix.
- 34 result parsing/status tests and 35 PR repair evidence tests passed after the fix.
- Formatting, full workspace Clippy, and the complete DB-less pre-push checks passed (`RUST_TEST_THREADS=1`).
- Fresh-context independent review: `APPROVED`.

Related operating work: two real read-only issue audits ran through the latest-main Harness server and supported closing #1953 and #1979. They completed without retry jobs or in-task intervention and survived restart without replay. Those audits are not end-to-end PR repair verification or an evaluation baseline; provider USD cost remained unknown.

Follow-up to #2033. Evaluation rollout remains in #1768; USD observation remains in #1770.
