### PR TITLE
fix(sandbox): deny inbound macOS networking

### DIFF
--- a/crates/harness-sandbox/src/network_policy.rs
+++ b/crates/harness-sandbox/src/network_policy.rs
@@ -40,7 +40,10 @@ impl NetworkPolicy {
     pub(crate) fn seatbelt_rules(self, mode: SandboxMode) -> Vec<String> {
         match (self, mode) {
             (Self::Deny, SandboxMode::DangerFullAccess) => {
-                vec!["(deny network-outbound)".to_string()]
+                vec![
+                    "(deny network-outbound)".to_string(),
+                    "(deny network-inbound)".to_string(),
+                ]
             }
             (Self::Deny, _) | (Self::InheritSandboxMode, SandboxMode::ReadOnly) => Vec::new(),
             (Self::LocalProxy { port }, SandboxMode::DangerFullAccess) => vec![format!(

--- a/crates/harness-sandbox/src/network_policy_tests.rs
+++ b/crates/harness-sandbox/src/network_policy_tests.rs
@@ -9,6 +9,7 @@ fn danger_mode_with_denied_network_is_not_a_passthrough() {
 
     assert!(policy.contains("(allow default)"));
     assert!(policy.contains("(deny network-outbound)"));
+    assert!(policy.contains("(deny network-inbound)"));
 }
 
 #[test]


### PR DESCRIPTION
When `NetworkPolicy::Deny` is combined with `DangerFullAccess` on macOS, the generated Seatbelt policy allows everything by default and only denies outbound networking. A process can therefore still bind and listen on a TCP port. Add an explicit inbound denial and strengthen the existing policy regression test.

Validation: reproduced the old policy accepting a localhost TCP listener and the fixed policy rejecting it with `PermissionError`; the strengthened test failed before the fix, then all 6 network-policy tests passed. `cargo check -p harness-sandbox --all-targets`, formatting checks, and workspace Clippy passed.

Related to #1751. This fixes the local macOS policy only; remote-host evaluation network enforcement and the live evaluator remain outstanding.
