### PR TITLE
fix(sandbox): block inbound proxy-mode traffic

### DIFF
--- a/crates/harness-sandbox/src/network_policy.rs
+++ b/crates/harness-sandbox/src/network_policy.rs
@@ -46,9 +46,10 @@ impl NetworkPolicy {
                 ]
             }
             (Self::Deny, _) | (Self::InheritSandboxMode, SandboxMode::ReadOnly) => Vec::new(),
-            (Self::LocalProxy { port }, SandboxMode::DangerFullAccess) => vec![format!(
-                "(deny network-outbound (require-not (remote tcp \"localhost:{port}\")))"
-            )],
+            (Self::LocalProxy { port }, SandboxMode::DangerFullAccess) => vec![
+                format!("(deny network-outbound (require-not (remote tcp \"localhost:{port}\")))"),
+                "(deny network-inbound)".to_string(),
+            ],
             (Self::LocalProxy { port }, _) => vec![format!(
                 "(allow network-outbound (remote tcp \"localhost:{port}\"))"
             )],

--- a/crates/harness-sandbox/src/network_policy_tests.rs
+++ b/crates/harness-sandbox/src/network_policy_tests.rs
@@ -33,6 +33,7 @@ fn danger_seatbelt_policy_allows_only_the_local_proxy() {
     assert!(
         policy.contains("(deny network-outbound (require-not (remote tcp \"localhost:18080\")))")
     );
+    assert!(policy.contains("(deny network-inbound)"));
     assert!(!policy.contains("(allow network-outbound)"));
 }
 


### PR DESCRIPTION
The macOS `LocalProxy` policy under `DangerFullAccess` restricts outbound traffic but inherits inbound permissions from `allow default`. Add explicit inbound denial while retaining the selected localhost proxy exception. This addresses the corresponding review finding on #2038.

Validation: the strengthened regression failed before the change, then all 6 network-policy tests passed. Native `sandbox-exec` probes confirmed old-policy TCP listening, fixed-policy inbound rejection, continued access to the selected proxy, and denial of a different outbound port. Package check, formatting, workspace Clippy, repository pre-push checks, and fresh-context independent review passed.

Related to #1751; remote-host evaluation isolation remains outside this local policy fix.
