### PR TITLE
fix(workflow): persist instance update time

### DIFF
--- a/crates/harness-workflow/src/runtime/store/decision_transitions.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions.rs
@@ -419,6 +419,15 @@ mod submission_guard_tests {
             anyhow::bail!("initial same-state transition should commit");
         };
 
+        let first_persisted = store
+            .get_instance(&initial.id)
+            .await?
+            .expect("the first submission must persist its instance");
+        assert!(first_persisted.updated_at > initial.updated_at);
+        let mut expected = final_instance.clone();
+        expected.updated_at = first_persisted.updated_at;
+        assert_eq!(first_persisted, expected);
+
         let Some(replay) = store
             .commit_submission_decision_transition(WorkflowSubmissionDecisionTransition {
                 workflow_id: &initial.id,
@@ -444,7 +453,10 @@ mod submission_guard_tests {
 
         assert_eq!(replay.record.id, first.record.id);
         assert_eq!(replay.command_ids, first.command_ids);
-        assert_eq!(store.get_instance(&initial.id).await?, Some(final_instance));
+        assert_eq!(
+            store.get_instance(&initial.id).await?,
+            Some(first_persisted)
+        );
         assert_eq!(store.events_for(&initial.id).await?.len(), 1);
         assert_eq!(store.decisions_for(&initial.id).await?.len(), 1);
         assert_eq!(store.commands_for(&initial.id).await?.len(), 1);
@@ -568,7 +580,13 @@ mod submission_guard_tests {
             .expect("rejected submission should be committed atomically");
 
         assert!(!outcome.record.accepted);
-        assert_eq!(store.get_instance(&initial.id).await?, Some(final_instance));
+        let stored = store
+            .get_instance(&initial.id)
+            .await?
+            .expect("the rejected submission must persist its failed instance");
+        assert!(stored.updated_at > initial.updated_at);
+        final_instance.updated_at = stored.updated_at;
+        assert_eq!(stored, final_instance);
         assert_eq!(store.events_for(&initial.id).await?.len(), 1);
         assert_eq!(store.decisions_for(&initial.id).await?.len(), 1);
         Ok(())

--- a/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
+++ b/crates/harness-workflow/src/runtime/store/decision_transitions_tests.rs
@@ -97,7 +97,9 @@ async fn apply_decision_transition_accepts_an_allowlisted_transition() -> anyhow
     let dir = tempfile::tempdir()?;
     let store = WorkflowRuntimeStore::open(&dir.path().join("workflow_runtime.db")).await?;
 
-    let initial = instance("gh1784-apply-decision-accepts", "addressing_feedback");
+    let mut initial = instance("gh1784-apply-decision-accepts", "addressing_feedback");
+    initial.created_at = Utc::now() - Duration::hours(1);
+    initial.updated_at = initial.created_at;
     let decision = WorkflowDecision::new(
         &initial.id,
         "addressing_feedback",
@@ -136,6 +138,14 @@ async fn apply_decision_transition_accepts_an_allowlisted_transition() -> anyhow
         .await?
         .expect("instance should exist");
     assert_eq!(stored.state, "local_review_gate");
+    assert_eq!(stored.created_at, initial.created_at);
+    assert!(stored.updated_at > initial.updated_at);
+    let row_updated_at: chrono::DateTime<Utc> =
+        sqlx::query_scalar("SELECT updated_at FROM workflow_instances WHERE id = $1")
+            .bind(&initial.id)
+            .fetch_one(&store.pool)
+            .await?;
+    assert_eq!(stored.updated_at, row_updated_at);
     assert_eq!(store.commands_for(&initial.id).await?.len(), 1);
     Ok(())
 }

--- a/crates/harness-workflow/src/runtime/store/submission_commit.rs
+++ b/crates/harness-workflow/src/runtime/store/submission_commit.rs
@@ -553,6 +553,7 @@ mod tests {
             })
             .await?
             .expect("initial transition should commit");
+        let first_persisted = store.get_instance(&initial.id).await?;
 
         let mut substituted = final_instance.clone();
         substituted.parent_workflow_id = Some("substituted-parent".to_string());
@@ -581,7 +582,7 @@ mod tests {
         )
         .await;
         assert!(error.to_string().contains("expected `1`"));
-        assert_eq!(store.get_instance(&initial.id).await?, Some(final_instance));
+        assert_eq!(store.get_instance(&initial.id).await?, first_persisted);
         Ok(())
     }
 

--- a/crates/harness-workflow/src/runtime/store/transaction_helpers.rs
+++ b/crates/harness-workflow/src/runtime/store/transaction_helpers.rs
@@ -352,7 +352,10 @@ pub(super) async fn commit_decision_instance_tx(
     {
         anyhow::bail!("workflow decision instance write identifiers do not match");
     }
-    if target == current {
+    // Persistence owns updated_at; callers replay the original accepted instance.
+    let mut comparable_target = target.clone();
+    comparable_target.updated_at = current.updated_at;
+    if comparable_target == *current {
         if allow_idempotent_replay && current.state == record.decision.next_state {
             return Ok(());
         }
@@ -570,7 +573,7 @@ async fn upsert_instance_row_tx(
             subject_type = EXCLUDED.subject_type,
             subject_key = EXCLUDED.subject_key,
             parent_workflow_id = EXCLUDED.parent_workflow_id,
-            data = EXCLUDED.data,
+            data = jsonb_set(EXCLUDED.data, '{updated_at}', to_jsonb(CURRENT_TIMESTAMP)),
             version = EXCLUDED.version,
             updated_at = CURRENT_TIMESTAMP",
     )


### PR DESCRIPTION
Workflow submissions kept reporting their creation time as `updated_at` after state transitions because instance JSON retained the caller timestamp while the database column advanced. Persist the transaction timestamp in both places. Idempotent replay ignores only this storage-owned timestamp when comparing the accepted instance and preserves the existing stored snapshot.

Validation: the timestamp regression failed before the fix; 13 decision-transition and 5 submission tests passed against isolated disposable PostgreSQL. Package all-target check, formatting, workspace Clippy, and normal DB-less pre-push checks passed. Independent review approved the final diff.
