### PR TITLE
fix(agents): preserve Codex cached token usage

### DIFF
--- a/crates/harness-agents/src/codex_adapter_tests.rs
+++ b/crates/harness-agents/src/codex_adapter_tests.rs
@@ -189,15 +189,21 @@ fn parse_turn_completed_without_status_fails_closed() {
 
 #[test]
 fn otel_turn_spans_parse_token_usage_notification() {
-    let line = r#"{"method":"thread/tokenUsage/updated","params":{"threadId":"thread-1","turnId":"turn-1","tokenUsage":{"last":{"inputTokens":10,"cachedInputTokens":4,"outputTokens":3,"reasoningOutputTokens":2,"totalTokens":15},"total":{"inputTokens":25,"cachedInputTokens":9,"outputTokens":8,"reasoningOutputTokens":5,"totalTokens":38}}}}"#;
+    let line = r#"{"method":"thread/tokenUsage/updated","params":{"threadId":"thread-1","turnId":"turn-1","tokenUsage":{"last":{"inputTokens":10,"cachedInputTokens":4,"outputTokens":3,"reasoningOutputTokens":2,"totalTokens":13},"total":{"inputTokens":25,"cachedInputTokens":9,"outputTokens":8,"reasoningOutputTokens":5,"totalTokens":33}}}}"#;
     let message = parse_codex_message(line).unwrap();
+    let ParsedCodexMessage::Event(AgentEvent::TokenUsage { ref usage, .. }) = message else {
+        panic!("expected usage notification");
+    };
+    let metrics = harness_observe::usage::UsageMetrics::from_token_usage(usage);
+    assert_eq!(metrics.cache_read_input_tokens, 9);
+    assert_eq!(metrics.total_tokens(), 33);
     assert_eq!(
         message,
         ParsedCodexMessage::Event(AgentEvent::TokenUsage {
             usage: harness_core::types::TokenUsage {
-                input_tokens: 25,
+                input_tokens: 16,
                 output_tokens: 8,
-                total_tokens: 38,
+                total_tokens: 33,
                 cost_usd: 0.0,
             },
             cost_usd_observed: false,

--- a/crates/harness-agents/src/codex_exec_parser.rs
+++ b/crates/harness-agents/src/codex_exec_parser.rs
@@ -135,9 +135,16 @@ pub(crate) fn parse_codex_token_usage(usage: &Value) -> Option<TokenUsage> {
         .or_else(|| usage.get("totalTokens"))
         .and_then(|field| field.as_u64())
         .unwrap_or(input_tokens.saturating_add(output_tokens));
+    let cached_input_tokens = usage
+        .get("cached_input_tokens")
+        .or_else(|| usage.get("cachedInputTokens"))
+        .and_then(|field| field.as_u64())
+        .unwrap_or(0);
 
     Some(TokenUsage {
-        input_tokens,
+        // Codex includes cache hits in input; Harness stores uncached input and
+        // derives the cached component from the unchanged provider total.
+        input_tokens: input_tokens.saturating_sub(cached_input_tokens),
         output_tokens,
         total_tokens,
         cost_usd: 0.0,

--- a/crates/harness-agents/src/codex_exec_parser_tests.rs
+++ b/crates/harness-agents/src/codex_exec_parser_tests.rs
@@ -2,6 +2,37 @@ use super::*;
 use harness_core::types::{Item, TokenUsage};
 
 #[test]
+fn codex_cached_usage_preserves_total_and_cache_metrics() {
+    for value in [
+        serde_json::json!({
+            "input_tokens": 100, "cached_input_tokens": 80, "output_tokens": 10
+        }),
+        serde_json::json!({
+            "inputTokens": 100, "cachedInputTokens": 80,
+            "outputTokens": 10, "totalTokens": 110
+        }),
+        serde_json::json!({
+            "inputTokens": 100, "cachedInputTokens": 100,
+            "outputTokens": 10, "totalTokens": 110
+        }),
+    ] {
+        let usage = parse_codex_token_usage(&value).expect("valid Codex usage");
+        let cached = value
+            .get("cached_input_tokens")
+            .or_else(|| value.get("cachedInputTokens"))
+            .and_then(serde_json::Value::as_u64)
+            .expect("fixture includes cached input");
+        let metrics = harness_observe::usage::UsageMetrics::from_token_usage(&usage);
+        assert_eq!(metrics.input_tokens, 100 - cached);
+        assert_eq!(metrics.cache_read_input_tokens, cached);
+        assert_eq!(metrics.output_tokens, 10);
+        assert_eq!(metrics.total_tokens(), 110);
+        assert_eq!(metrics.component_total_tokens(), 110);
+        assert_eq!(usage.cost_usd, 0.0);
+    }
+}
+
+#[test]
 fn parse_exec_agent_message_completion() {
     let line =
         r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hi"}}"#;
@@ -226,7 +257,7 @@ fn parse_exec_turn_completed_usage() {
             assert_eq!(
                 usage,
                 TokenUsage {
-                    input_tokens: 10,
+                    input_tokens: 6,
                     output_tokens: 3,
                     total_tokens: 13,
                     cost_usd: 0.0,


### PR DESCRIPTION
Codex includes cache hits in input token counts, while Harness usage metrics treat input as uncached and derive the cache component from the remaining total. Normalize the shared Codex parser for both exec JSON and app-server notifications by subtracting cached input once while preserving the inclusive provider total. This restores cache-read attribution without schema changes, historical backfill, or a USD estimate.

Related to #1770. Billing/account reconciliation remains deferred.

Validation: the cache-attribution regression failed before the fix. All 113 Codex-filtered tests passed serially; the app-server fixture now uses upstream total semantics and asserts cache attribution. Package all-target check, formatting, workspace Clippy, and the complete normal DB-less pre-push passed. A parallel process-initialization test timed out and passed unchanged in the serial rerun.
