### PR TITLE
fix(runtime): persist prompt task PR links

### DIFF
--- a/crates/harness-server/src/http/tests/webhook_task_tests.rs
+++ b/crates/harness-server/src/http/tests/webhook_task_tests.rs
@@ -1,5 +1,34 @@
 use super::*;
 
+struct PromptPullRequestExecutor;
+
+#[async_trait]
+impl harness_workflow::runtime::RuntimeJobExecutor for PromptPullRequestExecutor {
+    async fn execute(
+        &self,
+        _job: harness_workflow::runtime::RuntimeJob,
+    ) -> harness_workflow::runtime::ActivityResult {
+        harness_workflow::runtime::ActivityResult::succeeded(
+            "implement_prompt",
+            "Implemented the requested change and opened a pull request.",
+        )
+        .with_artifact(harness_workflow::runtime::ActivityArtifact::new(
+            "validation_report",
+            serde_json::json!([{
+                "command": "cargo test -p harness-server completed_prompt_submission_reports_pr_url_after_store_reopen",
+                "exit_code": 0,
+            }]),
+        ))
+        .with_artifact(harness_workflow::runtime::ActivityArtifact::new(
+            "pull_request",
+            serde_json::json!({
+                "pr_number": 2044,
+                "pr_url": "https://github.com/owner/repo/pull/2044",
+            }),
+        ))
+    }
+}
+
 #[tokio::test]
 async fn webhook_issue_mention_schedules_runtime_issue() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
@@ -569,6 +598,120 @@ async fn create_task_with_prompt_returns_workflow_runtime_submission() -> anyhow
         canonical_project_root.to_string_lossy().as_ref()
     );
     assert!(detail["workflow"].get("data").is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn completed_prompt_submission_reports_pr_url_after_store_reopen() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("prompt-pr-project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let (task_id, workflow_id) = {
+        let state = make_test_state_with_workflow_runtime_and_registry(
+            dir.path(),
+            &project_root,
+            harness_agents::registry::AgentRegistry::new("test"),
+        )
+        .await?;
+        let response = runtime_submission_app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/workflows/runtime/submissions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "project": project_root.display().to_string(),
+                            "prompt": "Fix the reporting bug and open a pull request.",
+                            "external_id": "prompt-pr-reopen-regression",
+                        })
+                        .to_string(),
+                    ))?,
+            )
+            .await?;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let created = response_json(response).await?;
+        let task_id = created["task_id"].as_str().expect("task id").to_string();
+        let workflow_id = created["workflow_id"]
+            .as_str()
+            .expect("workflow id")
+            .to_string();
+        let store = state
+            .core
+            .workflow_runtime_store
+            .as_ref()
+            .expect("workflow runtime store");
+        let command = store
+            .commands_for(&workflow_id)
+            .await?
+            .into_iter()
+            .next()
+            .expect("implementation command");
+        store
+            .enqueue_runtime_job(
+                &command.id,
+                harness_workflow::runtime::RuntimeKind::CodexJsonrpc,
+                "codex-default",
+                serde_json::json!({ "activity": "implement_prompt" }),
+            )
+            .await?;
+        harness_workflow::runtime::RuntimeWorker::new(store, "prompt-pr-test-worker")
+            .run_once(&PromptPullRequestExecutor)
+            .await?
+            .expect("worker should complete the prompt job");
+
+        let detail = runtime_submission_app(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/workflows/runtime/submissions/{task_id}"))
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(detail.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(detail).await?["pr_url"],
+            "https://github.com/owner/repo/pull/2044"
+        );
+        (task_id, workflow_id)
+    };
+
+    let reopened = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test-reopened"),
+    )
+    .await?;
+    let persisted = reopened
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("reopened workflow runtime store")
+        .get_instance(&workflow_id)
+        .await?
+        .expect("completed prompt workflow should survive reopen");
+    assert_eq!(persisted.state, "done");
+    assert_eq!(
+        persisted.data["pr_url"],
+        "https://github.com/owner/repo/pull/2044"
+    );
+
+    let detail = runtime_submission_app(reopened)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/workflows/runtime/submissions/{task_id}"))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(detail.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(detail).await?["pr_url"],
+        "https://github.com/owner/repo/pull/2044"
+    );
     Ok(())
 }
 

--- a/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/activity_contract.rs
@@ -137,7 +137,11 @@ pub(super) fn activity_contract(workflow_definition: &str, activity: &str) -> Ac
         .requires("pr_repair_snapshot_with_action_and_passing_validation_or_closed_issue_evidence"),
         (PROMPT_TASK_DEFINITION_ID, PROMPT_TASK_IMPLEMENT_ACTIVITY) => {
             ActivityContract::new(workflow_definition, activity)
-                .with_accepted_artifacts(vec!["validation_report", "no_change_rationale"])
+                .with_accepted_artifacts(vec![
+                    "validation_report",
+                    "no_change_rationale",
+                    "pull_request",
+                ])
                 .requires("validation_report artifact ([{command, exit_code}]) or no_change_rationale string artifact; completion is rejected without one of them")
         }
         (QUALITY_GATE_DEFINITION_ID, QUALITY_GATE_ACTIVITY) => {

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet/mod.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet/mod.rs
@@ -582,12 +582,10 @@ fn activity_transition_contract(workflow_definition: &str, activity: &str) -> Va
             "on_succeeded": {
                 "reducer_next_state": "done",
                 "success_requires": "A succeeded implement_prompt result MUST carry either a validation_report artifact — a non-empty array of {command, exit_code} entries — or a no_change_rationale string artifact explaining why no change was made. Free-text validation records do not satisfy this; completion is rejected without one of the two artifacts. Reporting a non-zero exit_code is allowed: report truthfully rather than omitting a failing command.",
+                "optional_pr_binding": "When the activity created or reused a pull request, include one pull_request artifact with pr_number and pr_url. Harness records that structured binding before marking the prompt task done; prompt tasks that do not produce a PR remain valid.",
                 "required_summary": "Include changed files, validation commands, and remaining blockers."
             },
-            "on_failed": {
-                "reducer_next_state": "failed_or_retry",
-                "retry_policy": "runtime_retry_policy may retry this activity before failure."
-            }
+            "on_failed": {"reducer_next_state": "failed_or_retry", "retry_policy": "runtime_retry_policy may retry this activity before failure."}
         }),
         (QUALITY_GATE_DEFINITION_ID, QUALITY_GATE_ACTIVITY) => json!({
             "on_succeeded": {
@@ -666,7 +664,8 @@ fn agent_summary_contract(workflow_definition: &str, activity: &str) -> Value {
                     "required_when": "The prompt task is ready to complete and no repository change was needed; use this or validation_report.",
                     "type": "string",
                     "non_blank": true
-                }
+                },
+                "pull_request": {"required_when": "A PR was created or reused by the activity.", "fields": ["pr_number", "pr_url"]}
             }
         }),
         ("github_issue_pr", "replan_issue") => json!({

--- a/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
+++ b/crates/harness-server/src/workflow_runtime_worker/prompt_packet_tests.rs
@@ -535,6 +535,13 @@ fn prompt_task_packet_describes_disjunctive_completion_evidence_contract() {
     );
     assert_eq!(artifacts["no_change_rationale"]["type"], "string");
     assert_eq!(artifacts["no_change_rationale"]["non_blank"], true);
+    assert_eq!(
+        artifacts["pull_request"]["fields"],
+        json!(["pr_number", "pr_url"])
+    );
+    assert!(schema["activity_contract"]["accepted_artifacts"]
+        .as_array()
+        .is_some_and(|items| items.contains(&json!("pull_request"))));
     assert!(
         schema["transition_contract"]["on_succeeded"]["success_requires"]
             .as_str()

--- a/crates/harness-workflow/src/runtime/reducer/builtin_prompt_task.rs
+++ b/crates/harness-workflow/src/runtime/reducer/builtin_prompt_task.rs
@@ -177,8 +177,21 @@ fn single_shot_done_decision(
         "done",
         "prompt implementation activity completed successfully",
     )
-    .with_command(mark_done_command(instance, result, None))
     .with_evidence(runtime_completion_evidence(event, result));
+    let decision = match with_prompt_pr_binding(decision, event, result) {
+        Ok(decision) => decision,
+        Err(detail) => {
+            return blocked_decision(
+                instance,
+                event,
+                result,
+                "prompt_pr_binding_invalid",
+                &detail,
+                None,
+            )
+        }
+    }
+    .with_command(mark_done_command(instance, result, None));
     with_completion_evidence(decision, completion).high_confidence()
 }
 
@@ -212,10 +225,58 @@ fn settled_done_decision(
             signal.state
         ),
     )
-    .with_command(mark_done_command(instance, result, Some(continuation)))
     .with_evidence(runtime_completion_evidence(event, result))
     .with_evidence(signal.evidence());
+    let decision = match with_prompt_pr_binding(decision, event, result) {
+        Ok(decision) => decision,
+        Err(detail) => {
+            return blocked_decision(
+                instance,
+                event,
+                result,
+                "prompt_pr_binding_invalid",
+                &detail,
+                Some((signal, continuation)),
+            )
+        }
+    }
+    .with_command(mark_done_command(instance, result, Some(continuation)));
     with_completion_evidence(decision, completion).high_confidence()
+}
+
+fn with_prompt_pr_binding(
+    decision: WorkflowDecision,
+    event: &WorkflowEvent,
+    result: &ActivityResult,
+) -> Result<WorkflowDecision, String> {
+    let mut artifacts = result
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact.artifact_type == "pull_request");
+    let Some(artifact) = artifacts.next() else {
+        return Ok(decision);
+    };
+    if artifacts.next().is_some() {
+        return Err("implement_prompt result contains multiple pull_request artifacts".to_string());
+    }
+    let pr_number = artifact
+        .artifact
+        .get("pr_number")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| "pull_request artifact must contain numeric pr_number".to_string())?;
+    let pr_url = artifact
+        .artifact
+        .get("pr_url")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "pull_request artifact must contain non-empty pr_url".to_string())?;
+    Ok(decision
+        .with_command(WorkflowCommand::bind_pr(
+            pr_number,
+            pr_url,
+            format!("runtime-completion:{}:bind-pr:{pr_number}", event.id),
+        ))
+        .with_evidence(WorkflowEvidence::new("pull_request", pr_url)))
 }
 
 fn continue_decision(

--- a/crates/harness-workflow/src/runtime/validator.rs
+++ b/crates/harness-workflow/src/runtime/validator.rs
@@ -338,7 +338,7 @@ impl TransitionAllowlist {
 
     pub fn prompt_task_defaults() -> Self {
         use WorkflowCommandType::{
-            EnqueueActivity, MarkBlocked, MarkCancelled, MarkDone, MarkFailed,
+            BindPr, EnqueueActivity, MarkBlocked, MarkCancelled, MarkDone, MarkFailed,
             RequestOperatorAttention, Wait,
         };
 
@@ -358,7 +358,7 @@ impl TransitionAllowlist {
             .allow("implementing", "implementing", [EnqueueActivity])
             .allow("blocked", "awaiting_dependencies", [Wait])
             .allow("blocked", "implementing", [EnqueueActivity, Wait])
-            .allow("implementing", "done", [MarkDone])
+            .allow("implementing", "done", [BindPr, MarkDone])
             // A prompt task may mint Done only with structured self-declared
             // evidence; the reducer resolves validation-report-or-no-change and
             // mints this kind (GH-1817).


### PR DESCRIPTION
## Summary

- advertise `pull_request` as an optional `implement_prompt` artifact without requiring every prompt task to create a PR
- validate one structured PR binding and emit `BindPr` before `MarkDone`
- preserve the existing validation-report/no-change completion alternatives
- cover submission detail before and after reopening the workflow store

## Root cause

The previous prompt activity contract advertised only `validation_report` and `no_change_rationale`. Even when an agent created a PR and mentioned its URL in the summary, the prompt-task reducer emitted only `MarkDone`. The existing `BindPr` side effect therefore never wrote `pr_number` or `pr_url` into durable workflow data, while the submission detail projection correctly read only `workflow.data.pr_url`.

This change reuses the existing structured `pull_request` artifact and `BindPr` command. It does not parse summary prose, add backfill or fallback behavior, or require PR output for ordinary prompt tasks. A malformed or duplicate PR artifact blocks explicitly instead of silently producing a missing URL.

## Reproduction evidence

The retained native submission `3f4dfc45-c6ec-4f34-8d79-5cee6b20e44d` completed successfully and created PR #2043, but its retained detail has `pr_url: null`. Its accepted activity result contains the PR URL only in `summary`, with no structured `pull_request` artifact.

## Validation

- `cargo test -p harness-workflow prompt_task`
- `cargo test -p harness-server prompt_task_packet_describes_disjunctive_completion_evidence_contract`
- `HARNESS_DATABASE_URL=postgresql://harness@127.0.0.1:19845/harness_pr_link_tests_20260905 HARNESS_ALLOW_NON_TEST_DATABASE_FOR_TESTS=1 RUST_TEST_THREADS=1 cargo test -p harness-server completed_prompt_submission_reports_pr_url_after_store_reopen`
- `cargo check -p harness-workflow --all-targets`
- `cargo check -p harness-server --all-targets`
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- normal DB-less pre-commit and pre-push hooks
- `cargo build -p harness-cli --bin harness`

The native candidate is `/tmp/harness-backlog-20260905/target/debug/harness` with SHA-256 `49e05bddd08b211651446a6882a7f797a19cd3a2ffb42b650e883b887d6cf9e3`.

## Operator restart acceptance

After starting the candidate with the existing native configuration, submit a read-only prompt that reuses this PR and emits both `no_change_rationale` and `pull_request`. Confirm the completed submission detail reports this PR URL, restart the same candidate without changing the database or configuration, then repeat the same GET and assertion. No workflow table edits are needed.

Related to #1958
