### PR TITLE
fix(api): expose cached input tokens in runtime detail

### DIFF
--- a/crates/harness-protocol/src/rest.rs
+++ b/crates/harness-protocol/src/rest.rs
@@ -163,7 +163,7 @@ pub struct RuntimeTaskDetailResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub token_usage: Option<harness_core::types::TokenUsage>,
+    pub token_usage: Option<RuntimeTaskTokenUsageResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost_usd_observed: Option<bool>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -176,6 +176,17 @@ pub struct RuntimeTaskDetailResponse {
     pub subtask_ids: Vec<harness_core::types::TaskId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workflow: Option<RuntimeTaskWorkflowResponse>,
+}
+
+/// Persisted token usage returned by the workflow submission detail API.
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeTaskTokenUsageResponse {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_input_tokens: u64,
+    pub cache_creation_input_tokens: u64,
+    pub total_tokens: u64,
+    pub cost_usd: f64,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/harness-server/src/http/task_query_routes/detail.rs
+++ b/crates/harness-server/src/http/task_query_routes/detail.rs
@@ -7,7 +7,8 @@ use crate::workflow_runtime_submission::{
 };
 use harness_protocol::rest::{
     RuntimeTaskDetailErrorResponse, RuntimeTaskDetailResponse, RuntimeTaskSchedulerOwnerResponse,
-    RuntimeTaskSchedulerResponse, RuntimeTaskTerminalResponse, RuntimeTaskWorkflowResponse,
+    RuntimeTaskSchedulerResponse, RuntimeTaskTerminalResponse, RuntimeTaskTokenUsageResponse,
+    RuntimeTaskWorkflowResponse,
 };
 
 enum RuntimeProofLookup {
@@ -97,9 +98,11 @@ async fn runtime_task_response_by_handle(
     let terminal = TaskTerminalInfo::from_status_error(&task_status, error.as_deref());
     let runtime_usage = store.runtime_usage_for_workflow(&workflow.id).await?;
     let cost_usd_observed = runtime_usage.as_ref().map(|usage| usage.cost_usd_observed);
-    let token_usage = runtime_usage.map(|usage| harness_core::types::TokenUsage {
+    let token_usage = runtime_usage.map(|usage| RuntimeTaskTokenUsageResponse {
         input_tokens: usage.metrics.input_tokens,
         output_tokens: usage.metrics.output_tokens,
+        cache_read_input_tokens: usage.metrics.cache_read_input_tokens,
+        cache_creation_input_tokens: usage.metrics.cache_creation_input_tokens,
         total_tokens: usage.metrics.total_tokens(),
         cost_usd: harness_workflow::runtime::cost_usd_from_micros(usage.cost_usd_micros),
     });

--- a/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
+++ b/crates/harness-server/src/http/tests/runtime_task_route_tests.rs
@@ -246,6 +246,153 @@ async fn get_task_runtime_issue_exposes_tracker_identity_and_cost_observation() 
 }
 
 #[tokio::test]
+async fn get_task_runtime_detail_reports_persisted_cache_usage_after_store_reopen(
+) -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let task_id = "runtime-cache-usage-detail";
+    let workflow_id = "runtime-cache-usage-detail-workflow";
+    {
+        let state = make_test_state_with_workflow_runtime_and_registry(
+            dir.path(),
+            &project_root,
+            harness_agents::registry::AgentRegistry::new("test"),
+        )
+        .await?;
+        let store = state
+            .core
+            .workflow_runtime_store
+            .as_ref()
+            .expect("workflow runtime store should be configured");
+        let workflow = WorkflowInstance::new(
+            GITHUB_ISSUE_PR_DEFINITION_ID,
+            1,
+            "implementing",
+            WorkflowSubject::new("issue", "issue:65"),
+        )
+        .with_id(workflow_id)
+        .with_server_data(serde_json::json!({
+            "project_id": project_root,
+            "repo": "owner/repo",
+            "issue_number": 65,
+            "submission_id": task_id,
+        }));
+        crate::test_helpers::force_upsert_runtime_lifecycle_state_for_test(store, &workflow)
+            .await?;
+        store
+            .upsert_runtime_usage(&RuntimeUsageUpsert {
+                runtime_job_id: "cache-usage-job".to_string(),
+                command_id: "cache-usage-command".to_string(),
+                workflow_id: workflow_id.to_string(),
+                turn_id: Some("cache-usage-turn".to_string()),
+                agent_run_id: None,
+                runtime_kind: RuntimeKind::CodexJsonrpc,
+                runtime_profile: "codex-default".to_string(),
+                agent: "codex".to_string(),
+                model: "gpt-5.6-sol".to_string(),
+                project: project_root.display().to_string(),
+                task_id: Some(task_id.to_string()),
+                candidate_group_id: None,
+                candidate_id: None,
+                candidate_index: None,
+                candidate_count: None,
+                metrics: RuntimeUsageMetrics {
+                    input_tokens: 204_546,
+                    output_tokens: 35_969,
+                    cache_read_input_tokens: 8_332_288,
+                    cache_creation_input_tokens: 4_096,
+                    reported_total_tokens: Some(9_000_000),
+                },
+                cost_usd_micros: 0,
+                cost_usd_observed: false,
+                reported_at: Utc::now(),
+            })
+            .await?;
+    }
+
+    let reopened = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test-reopened"),
+    )
+    .await?;
+    let response = runtime_submission_app(reopened)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/workflows/runtime/submissions/{task_id}"))
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["token_usage"]["input_tokens"], 204_546);
+    assert_eq!(body["token_usage"]["output_tokens"], 35_969);
+    assert_eq!(body["token_usage"]["cache_read_input_tokens"], 8_332_288);
+    assert_eq!(body["token_usage"]["cache_creation_input_tokens"], 4_096);
+    assert_eq!(body["token_usage"]["total_tokens"], 9_000_000);
+    assert_eq!(body["token_usage"]["cost_usd"], 0.0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_task_runtime_detail_omits_token_usage_when_usage_is_absent() -> anyhow::Result<()> {
+    if !crate::test_helpers::db_tests_enabled().await {
+        return Ok(());
+    }
+
+    let dir = tempfile::tempdir()?;
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root)?;
+    init_fake_git_repo(&project_root)?;
+    let state = make_test_state_with_workflow_runtime_and_registry(
+        dir.path(),
+        &project_root,
+        harness_agents::registry::AgentRegistry::new("test"),
+    )
+    .await?;
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store should be configured");
+    let workflow = WorkflowInstance::new(
+        GITHUB_ISSUE_PR_DEFINITION_ID,
+        1,
+        "implementing",
+        WorkflowSubject::new("issue", "issue:66"),
+    )
+    .with_id("runtime-absent-usage-detail-workflow")
+    .with_server_data(serde_json::json!({
+        "project_id": project_root,
+        "repo": "owner/repo",
+        "issue_number": 66,
+        "submission_id": "runtime-absent-usage-detail",
+    }));
+    crate::test_helpers::force_upsert_runtime_lifecycle_state_for_test(store, &workflow).await?;
+
+    let response = runtime_submission_app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/workflows/runtime/submissions/runtime-absent-usage-detail")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert!(body.get("token_usage").is_none());
+    assert!(body.get("cost_usd_observed").is_none());
+    Ok(())
+}
+
+#[tokio::test]
 async fn get_task_runtime_issue_projects_detail_status_from_shared_projection() -> anyhow::Result<()>
 {
     if !crate::test_helpers::db_tests_enabled().await {


### PR DESCRIPTION
## Summary

- expose persisted cache-read and cache-creation input tokens in runtime submission detail
- preserve uncached input, output, reported total, cost, and absent-usage semantics
- add focused HTTP coverage for store reopen durability and missing usage

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p harness-server --all-targets`
- `cargo test -p harness-server get_task_runtime_detail_ -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build -p harness-cli --bin harness`

Related to #1958