### PR TITLE
fix(agents): update Codex container to 0.153.4

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -2,7 +2,7 @@
 ARG NODE_BASE_IMAGE=docker.io/library/node:22-bookworm-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4
 FROM ${NODE_BASE_IMAGE}
 
-ARG CODEX_CLI_PACKAGE=@openai/codex@0.142.5
+ARG CODEX_CLI_PACKAGE=@openai/codex@0.153.4
 ARG CLAUDE_CODE_PACKAGE=@anthropic-ai/claude-code@2.1.201
 
 RUN apt-get update \

--- a/docker/agent/README.md
+++ b/docker/agent/README.md
@@ -6,7 +6,7 @@ the Codex and Claude CLIs plus basic repository tools.
 Current pinned inputs:
 
 - Base image: `docker.io/library/node:22-bookworm-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4`
-- Codex CLI package: `@openai/codex@0.142.5`
+- Codex CLI package: `@openai/codex@0.153.4`
 - Claude Code package: `@anthropic-ai/claude-code@2.1.201`
 
 Build and verify locally:


### PR DESCRIPTION
The reference agent image pins Codex 0.142.5, which rejects the configured gpt-6-astra model with a provider error requiring a newer Codex version. Update the pin and its documentation to 0.153.4, matching the installed CLI and npm release verified on 2026-09-06.

Validation: scripts/verify-agent-container-image.sh rebuilt the image and passed. An identical ChatGPT-authenticated request through an internal Docker network and the existing allowlist proxy failed on the old image and returned EVAL_CODEX_READY on the new image (12.97 seconds). Temporary containers, network, proxy, and login copy were removed. cargo fmt --all -- --check, workspace Clippy, and the DB-less pre-push checks passed.

Independent fresh-context review examined both changed files against f78021c5ce88081d63fd8b7eaa56004c83e9bdb3 and returned APPROVED. The reviewer independently checked the diff and verification script; the authenticated probe results were author-supplied.

Related to #1768. This fixes the container model-access prerequisite only; it does not supply the missing evaluation runtime-host client or establish a benchmark baseline.
