### PR TITLE
docs(server): freeze partial *_svc service layer (#1976)

### DIFF
--- a/crates/harness-server/src/http/state.rs
+++ b/crates/harness-server/src/http/state.rs
@@ -280,10 +280,14 @@ pub struct AppState {
     /// Set once during `build_app_state`; read-only thereafter.
     pub degraded_subsystems: Vec<&'static str>,
 
-    // ── Service layer ────────────────────────────────────────────────────────
-    // Trait-based abstractions for independent testability. Each service owns
-    // its dependencies; the fields above are preserved for handlers that have
-    // not yet been migrated to the service interfaces.
+    // ── Service layer (frozen — GH-1976) ─────────────────────────────────────
+    // Existing ProjectService / TaskService / ExecutionService fields stay for
+    // the minority of call sites that already use them. This surface is frozen:
+    // do not add new *_svc traits/methods, and do not migrate handlers that
+    // reach state.core.* merely to improve the ratio. New handlers should use
+    // the dominant state.core.* pattern until a concrete execution, isolation,
+    // or testing need requires a service boundary (see crates/harness-server/
+    // src/services/mod.rs).
     /// Project registry operations and default-root lookup.
     pub project_svc: Arc<dyn crate::services::project::ProjectService>,
     /// Task lifecycle queries and stream subscriptions.

--- a/crates/harness-server/src/services/mod.rs
+++ b/crates/harness-server/src/services/mod.rs
@@ -4,6 +4,16 @@
 //! The traits enable independent testing via mock implementations without
 //! constructing the full [`crate::http::AppState`].
 //!
+//! # Freeze (GH-1976)
+//!
+//! This surface is **frozen**. Do not add new `*_svc` traits, methods, or
+//! default impls, and do not migrate the many handlers that already use
+//! `state.core.*` merely to improve the call-site ratio. Prefer the dominant
+//! `state.core.*` pattern for new handlers until a concrete execution,
+//! isolation, or testing need requires a service boundary. Coordinate any
+//! future unfreeze with dual-lifecycle work (#1958) and RuntimeContext
+//! extraction (#1798) instead of overlapping bulk migrations.
+//!
 //! # Services
 //! - [`ProjectService`] — project registry CRUD, path resolution, default root.
 //! - [`TaskService`] — task lifecycle, stream subscriptions.


### PR DESCRIPTION
## Summary
- Choose issue option 2 (freeze): document that `ProjectService` / `TaskService` / `ExecutionService` stay as-is and must not grow new traits/methods or bulk-migrate `state.core.*` bypasses.
- Direct new handlers to the dominant `state.core.*` pattern until a concrete execution, isolation, or testing need requires a service boundary; note coordination with #1958 / #1798.
- Comment-only change in `services/mod.rs` and `AppState` service-layer notes; no runtime behavior change.

Closes #1976

## Test plan
- [x] Review diff is comment-only (no new traits/methods, no call-site rewiring)
- [ ] CI green


Made with [Cursor](https://cursor.com)