### PR TITLE
[ASC-022] feat(runtime-host): deny evaluation network access by default

### DIFF
--- a/crates/harness-sandbox/src/lib.rs
+++ b/crates/harness-sandbox/src/lib.rs
@@ -13,7 +13,12 @@ use linux::linux_network_only_bwrap_args;
 #[cfg(any(target_os = "linux", test))]
 use linux::{linux_bwrap_args, linux_landlock_args};
 mod network_policy;
-pub use network_policy::NetworkPolicy;
+pub use network_policy::{
+    validate_network_policy_backend, EvalNetworkAccess, EvalNetworkPolicy,
+    EvalNetworkPolicyBackend, EvalNetworkPolicyReport, NetworkConnectionMetadata, NetworkDecision,
+    NetworkDirection, NetworkPolicy, NetworkPolicyGrant, NetworkPolicyReportError, NetworkProtocol,
+    EVAL_NETWORK_POLICY_CAPABILITY,
+};
 mod resource_limits;
 pub use resource_limits::{
     classify_resource_termination, validate_resource_limit_backend,

--- a/crates/harness-sandbox/src/network_policy.rs
+++ b/crates/harness-sandbox/src/network_policy.rs
@@ -2,6 +2,11 @@
 use harness_core::config::agents::SandboxMode;
 #[cfg(any(target_os = "linux", test))]
 use harness_core::error::SandboxError;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use thiserror::Error;
+
+pub const EVAL_NETWORK_POLICY_CAPABILITY: &str = "eval_network_policy";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum NetworkPolicy {
@@ -56,4 +61,288 @@ impl NetworkPolicy {
             (Self::InheritSandboxMode, _) => vec!["(allow network-outbound)".to_string()],
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvalNetworkPolicy {
+    pub inbound: EvalNetworkAccess,
+    pub outbound: EvalNetworkAccess,
+    #[serde(default)]
+    pub network_allowlist: Vec<String>,
+}
+
+impl EvalNetworkPolicy {
+    pub fn for_allowlist(allowlist: &[String]) -> Result<Self, NetworkPolicyReportError> {
+        let network_allowlist = normalize_dns_allowlist(allowlist)?;
+        let outbound = if network_allowlist.is_empty() {
+            EvalNetworkAccess::Deny
+        } else {
+            EvalNetworkAccess::Allowlist
+        };
+        Ok(Self {
+            inbound: EvalNetworkAccess::Deny,
+            outbound,
+            network_allowlist,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalNetworkAccess {
+    Deny,
+    Allowlist,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalNetworkPolicyBackend {
+    ContainerRuntimeHost,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvalNetworkPolicyReport {
+    pub runtime_job_id: String,
+    pub enforced: bool,
+    pub policy: EvalNetworkPolicy,
+    #[serde(default)]
+    pub grants: Vec<NetworkPolicyGrant>,
+    #[serde(default)]
+    pub connections: Vec<NetworkConnectionMetadata>,
+    pub payloads_recorded: bool,
+    pub reason: String,
+}
+
+impl EvalNetworkPolicyReport {
+    pub fn validate_against(
+        &self,
+        expected: &EvalNetworkPolicy,
+        runtime_job_id: &str,
+    ) -> Result<(), NetworkPolicyReportError> {
+        if self.runtime_job_id.trim() != runtime_job_id {
+            return Err(NetworkPolicyReportError::RuntimeJobMismatch);
+        }
+        if !self.enforced {
+            return Err(NetworkPolicyReportError::EnforcementMissing);
+        }
+        if self.payloads_recorded {
+            return Err(NetworkPolicyReportError::PayloadRecordingForbidden);
+        }
+        if self.reason.trim().is_empty() {
+            return Err(NetworkPolicyReportError::MissingReason);
+        }
+        if self.policy != *expected {
+            return Err(NetworkPolicyReportError::PolicyMismatch);
+        }
+        validate_grants(&self.grants, expected)?;
+        for connection in &self.connections {
+            validate_connection(connection, expected)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkPolicyGrant {
+    pub direction: NetworkDirection,
+    pub host: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<NetworkProtocol>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkConnectionMetadata {
+    pub direction: NetworkDirection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<NetworkProtocol>,
+    pub decision: NetworkDecision,
+    pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bytes_sent: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bytes_received: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkDirection {
+    Inbound,
+    Outbound,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkProtocol {
+    Tcp,
+    Udp,
+    Dns,
+    Http,
+    Https,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkDecision {
+    Allowed,
+    Denied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NetworkPolicyReportError {
+    #[error("eval network policy report enforcement must be true")]
+    EnforcementMissing,
+    #[error("eval network policy report must not record payloads")]
+    PayloadRecordingForbidden,
+    #[error("eval network policy report reason must not be empty")]
+    MissingReason,
+    #[error("eval network policy report policy does not match the required policy")]
+    PolicyMismatch,
+    #[error("eval network policy report grants do not match the required allowlist")]
+    GrantMismatch,
+    #[error("invalid eval network allowlist hostname `{host}`")]
+    InvalidAllowlistHost { host: String },
+    #[error("eval network connection metadata reason must not be empty")]
+    MissingConnectionReason,
+    #[error("eval network policy report allowed a connection outside the required policy")]
+    UnexpectedAllowedConnection,
+    #[error("eval network policy report runtime_job_id does not match the claimed job")]
+    RuntimeJobMismatch,
+    #[error("eval network policy backend `{backend}` cannot enforce policy")]
+    UnsupportedBackend { backend: &'static str },
+}
+
+pub fn validate_network_policy_backend(
+    policy: &EvalNetworkPolicy,
+    backend: EvalNetworkPolicyBackend,
+) -> Result<(), NetworkPolicyReportError> {
+    match backend {
+        EvalNetworkPolicyBackend::ContainerRuntimeHost => Ok(()),
+        EvalNetworkPolicyBackend::Unsupported => {
+            let _ = policy;
+            Err(NetworkPolicyReportError::UnsupportedBackend {
+                backend: "unsupported",
+            })
+        }
+    }
+}
+
+fn validate_grants(
+    grants: &[NetworkPolicyGrant],
+    expected: &EvalNetworkPolicy,
+) -> Result<(), NetworkPolicyReportError> {
+    let expected_hosts = expected
+        .network_allowlist
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut actual_hosts = BTreeSet::new();
+    for grant in grants {
+        if grant.direction != NetworkDirection::Outbound {
+            return Err(NetworkPolicyReportError::GrantMismatch);
+        }
+        actual_hosts.insert(normalize_dns_name(&grant.host)?);
+    }
+    if actual_hosts == expected_hosts {
+        Ok(())
+    } else {
+        Err(NetworkPolicyReportError::GrantMismatch)
+    }
+}
+
+fn validate_connection(
+    connection: &NetworkConnectionMetadata,
+    expected: &EvalNetworkPolicy,
+) -> Result<(), NetworkPolicyReportError> {
+    if connection.reason.trim().is_empty() {
+        return Err(NetworkPolicyReportError::MissingConnectionReason);
+    }
+    if connection.decision == NetworkDecision::Denied {
+        return Ok(());
+    }
+    let access = match connection.direction {
+        NetworkDirection::Inbound => expected.inbound,
+        NetworkDirection::Outbound => expected.outbound,
+    };
+    match access {
+        EvalNetworkAccess::Deny => Err(NetworkPolicyReportError::UnexpectedAllowedConnection),
+        EvalNetworkAccess::Allowlist => {
+            let Some(host) = connection.host.as_deref() else {
+                return Err(NetworkPolicyReportError::UnexpectedAllowedConnection);
+            };
+            let normalized = normalize_dns_name(host)?;
+            if expected.network_allowlist.contains(&normalized) {
+                Ok(())
+            } else {
+                Err(NetworkPolicyReportError::UnexpectedAllowedConnection)
+            }
+        }
+    }
+}
+
+fn normalize_dns_allowlist(allowlist: &[String]) -> Result<Vec<String>, NetworkPolicyReportError> {
+    let mut seen = BTreeSet::new();
+    let mut normalized = Vec::new();
+    for host in allowlist {
+        let host = normalize_dns_name(host)?;
+        if seen.insert(host.clone()) {
+            normalized.push(host);
+        }
+    }
+    Ok(normalized)
+}
+
+fn normalize_dns_name(value: &str) -> Result<String, NetworkPolicyReportError> {
+    let candidate = value.trim().trim_end_matches('.').to_ascii_lowercase();
+    if candidate.is_empty()
+        || candidate.len() > 253
+        || candidate.contains(['/', ':', '@', '*', '?', '#'])
+        || looks_like_numeric_address(&candidate)
+        || candidate == "localhost"
+        || candidate.ends_with(".localhost")
+    {
+        return Err(NetworkPolicyReportError::InvalidAllowlistHost {
+            host: value.to_string(),
+        });
+    }
+    let labels = candidate.split('.').collect::<Vec<_>>();
+    if labels.len() < 2
+        || labels.iter().any(|label| {
+            label.is_empty()
+                || label.len() > 63
+                || label.starts_with('-')
+                || label.ends_with('-')
+                || !label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+    {
+        return Err(NetworkPolicyReportError::InvalidAllowlistHost {
+            host: value.to_string(),
+        });
+    }
+    Ok(candidate)
+}
+
+fn looks_like_numeric_address(candidate: &str) -> bool {
+    if candidate.parse::<std::net::IpAddr>().is_ok() {
+        return true;
+    }
+    // Reject non-canonical numeric aliases such as `127.1`, `127.0.0.01`, and
+    // `0177.0.0.1` that can resolve to loopback on Linux.
+    let labels = candidate.split('.').collect::<Vec<_>>();
+    !labels.is_empty()
+        && labels
+            .iter()
+            .all(|label| !label.is_empty() && label.bytes().all(|byte| byte.is_ascii_digit()))
 }

--- a/crates/harness-sandbox/src/network_policy.rs
+++ b/crates/harness-sandbox/src/network_policy.rs
@@ -86,6 +86,13 @@ impl EvalNetworkPolicy {
             network_allowlist,
         })
     }
+
+    /// Re-normalize a deserialized claim/report policy through the same allowlist
+    /// gate used by manifest and dispatcher paths. Rejects IP/alias injection that
+    /// raw serde acceptance would otherwise preserve.
+    pub fn revalidated(self) -> Result<Self, NetworkPolicyReportError> {
+        Self::for_allowlist(&self.network_allowlist)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -338,11 +345,27 @@ fn looks_like_numeric_address(candidate: &str) -> bool {
     if candidate.parse::<std::net::IpAddr>().is_ok() {
         return true;
     }
-    // Reject non-canonical numeric aliases such as `127.1`, `127.0.0.01`, and
-    // `0177.0.0.1` that can resolve to loopback on Linux.
-    let labels = candidate.split('.').collect::<Vec<_>>();
-    !labels.is_empty()
-        && labels
-            .iter()
-            .all(|label| !label.is_empty() && label.bytes().all(|byte| byte.is_ascii_digit()))
+    // Reject non-canonical numeric aliases such as `127.1`, `127.0.0.01`,
+    // `0177.0.0.1`, and hex forms like `0x7f.0.0.1` / `0x7f.1` that can resolve
+    // to loopback on Linux via inet_aton-style parsing.
+    let mut labels = candidate.split('.');
+    let Some(first) = labels.next() else {
+        return false;
+    };
+    std::iter::once(first)
+        .chain(labels)
+        .all(is_numeric_or_hex_label)
+}
+
+fn is_numeric_or_hex_label(label: &str) -> bool {
+    if label.is_empty() {
+        return false;
+    }
+    if let Some(hex) = label
+        .strip_prefix("0x")
+        .or_else(|| label.strip_prefix("0X"))
+    {
+        return !hex.is_empty() && hex.bytes().all(|byte| byte.is_ascii_hexdigit());
+    }
+    label.bytes().all(|byte| byte.is_ascii_digit())
 }

--- a/crates/harness-sandbox/src/network_policy.rs
+++ b/crates/harness-sandbox/src/network_policy.rs
@@ -322,18 +322,23 @@ fn normalize_dns_name(value: &str) -> Result<String, NetworkPolicyReportError> {
             host: value.to_string(),
         });
     }
-    let labels = candidate.split('.').collect::<Vec<_>>();
-    if labels.len() < 2
-        || labels.iter().any(|label| {
-            label.is_empty()
-                || label.len() > 63
-                || label.starts_with('-')
-                || label.ends_with('-')
-                || !label
-                    .bytes()
-                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
-        })
-    {
+    let mut label_count = 0;
+    for label in candidate.split('.') {
+        label_count += 1;
+        if label.is_empty()
+            || label.len() > 63
+            || label.starts_with('-')
+            || label.ends_with('-')
+            || !label
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        {
+            return Err(NetworkPolicyReportError::InvalidAllowlistHost {
+                host: value.to_string(),
+            });
+        }
+    }
+    if label_count < 2 {
         return Err(NetworkPolicyReportError::InvalidAllowlistHost {
             host: value.to_string(),
         });

--- a/crates/harness-sandbox/src/network_policy_tests.rs
+++ b/crates/harness-sandbox/src/network_policy_tests.rs
@@ -105,3 +105,224 @@ fn linux_network_only_bwrap_isolates_the_process_tree() {
     assert!(args.contains(&OsString::from("--unshare-pid")));
     assert!(args.contains(&OsString::from("--die-with-parent")));
 }
+
+#[test]
+fn eval_network_policy_defaults_to_deny_inbound_and_outbound() {
+    let policy = EvalNetworkPolicy::for_allowlist(&[]).unwrap();
+
+    assert_eq!(policy.inbound, EvalNetworkAccess::Deny);
+    assert_eq!(policy.outbound, EvalNetworkAccess::Deny);
+    assert!(policy.network_allowlist.is_empty());
+
+    let report = EvalNetworkPolicyReport {
+        runtime_job_id: "job-1".to_string(),
+        enforced: true,
+        policy: policy.clone(),
+        grants: Vec::new(),
+        connections: vec![NetworkConnectionMetadata {
+            direction: NetworkDirection::Outbound,
+            host: Some("denied.invalid".to_string()),
+            port: Some(443),
+            protocol: Some(NetworkProtocol::Tcp),
+            decision: NetworkDecision::Denied,
+            reason: "empty eval allowlist denies outbound connections".to_string(),
+            bytes_sent: None,
+            bytes_received: None,
+        }],
+        payloads_recorded: false,
+        reason: "container network policy denied all eval networking".to_string(),
+    };
+
+    report.validate_against(&policy, "job-1").unwrap();
+}
+
+#[test]
+fn eval_network_policy_allows_trusted_dns_allowlist_grants_without_payloads() {
+    let policy = EvalNetworkPolicy::for_allowlist(&[
+        " GitHub.COM. ".to_string(),
+        "api.github.com".to_string(),
+    ])
+    .unwrap();
+
+    assert_eq!(
+        policy.network_allowlist,
+        vec!["github.com".to_string(), "api.github.com".to_string()]
+    );
+    assert_eq!(policy.inbound, EvalNetworkAccess::Deny);
+    assert_eq!(policy.outbound, EvalNetworkAccess::Allowlist);
+
+    let report = EvalNetworkPolicyReport {
+        runtime_job_id: "job-2".to_string(),
+        enforced: true,
+        policy: policy.clone(),
+        grants: vec![
+            NetworkPolicyGrant {
+                direction: NetworkDirection::Outbound,
+                host: "github.com".to_string(),
+                port: Some(443),
+                protocol: Some(NetworkProtocol::Https),
+            },
+            NetworkPolicyGrant {
+                direction: NetworkDirection::Outbound,
+                host: "api.github.com".to_string(),
+                port: Some(443),
+                protocol: Some(NetworkProtocol::Https),
+            },
+        ],
+        connections: vec![NetworkConnectionMetadata {
+            direction: NetworkDirection::Outbound,
+            host: Some("github.com".to_string()),
+            port: Some(443),
+            protocol: Some(NetworkProtocol::Https),
+            decision: NetworkDecision::Allowed,
+            reason: "host matched trusted eval network allowlist".to_string(),
+            bytes_sent: Some(128),
+            bytes_received: Some(256),
+        }],
+        payloads_recorded: false,
+        reason: "recorded grants and connection metadata only".to_string(),
+    };
+
+    report.validate_against(&policy, "job-2").unwrap();
+}
+
+#[test]
+fn eval_network_policy_rejects_ambiguous_dns_allowlist_entries() {
+    for host in [
+        "https://github.com",
+        "*.github.com",
+        "127.0.0.1",
+        "127.1",
+        "127.0.0.01",
+        "0177.0.0.1",
+        "localhost",
+        "github.com:443",
+        "github.com/path",
+    ] {
+        let error = EvalNetworkPolicy::for_allowlist(&[host.to_string()])
+            .expect_err("ambiguous eval allowlist host should fail closed");
+
+        assert!(matches!(
+            error,
+            NetworkPolicyReportError::InvalidAllowlistHost { .. }
+        ));
+    }
+}
+
+#[test]
+fn eval_network_policy_report_rejects_unsupported_allowed_connections() {
+    let policy = EvalNetworkPolicy::for_allowlist(&[]).unwrap();
+    let report = EvalNetworkPolicyReport {
+        runtime_job_id: "job-3".to_string(),
+        enforced: true,
+        policy: policy.clone(),
+        grants: Vec::new(),
+        connections: vec![NetworkConnectionMetadata {
+            direction: NetworkDirection::Outbound,
+            host: Some("github.com".to_string()),
+            port: Some(443),
+            protocol: Some(NetworkProtocol::Https),
+            decision: NetworkDecision::Allowed,
+            reason: "backend reported an outbound connection despite deny-all policy".to_string(),
+            bytes_sent: None,
+            bytes_received: None,
+        }],
+        payloads_recorded: false,
+        reason: "backend reported enforcement".to_string(),
+    };
+
+    assert_eq!(
+        report.validate_against(&policy, "job-3"),
+        Err(NetworkPolicyReportError::UnexpectedAllowedConnection)
+    );
+}
+
+#[test]
+fn eval_network_policy_inbound_allowlist_validates_host_fail_closed() {
+    let policy = EvalNetworkPolicy {
+        inbound: EvalNetworkAccess::Allowlist,
+        outbound: EvalNetworkAccess::Deny,
+        network_allowlist: vec!["api.github.com".to_string()],
+    };
+    let allowed = EvalNetworkPolicyReport {
+        runtime_job_id: "job-in".to_string(),
+        enforced: true,
+        policy: policy.clone(),
+        grants: vec![NetworkPolicyGrant {
+            direction: NetworkDirection::Outbound,
+            host: "api.github.com".to_string(),
+            port: Some(443),
+            protocol: Some(NetworkProtocol::Https),
+        }],
+        connections: vec![NetworkConnectionMetadata {
+            direction: NetworkDirection::Inbound,
+            host: Some("api.github.com".to_string()),
+            port: Some(443),
+            protocol: Some(NetworkProtocol::Https),
+            decision: NetworkDecision::Allowed,
+            reason: "inbound host matched allowlist".to_string(),
+            bytes_sent: None,
+            bytes_received: None,
+        }],
+        payloads_recorded: false,
+        reason: "inbound allowlist validated".to_string(),
+    };
+    let rejected = EvalNetworkPolicyReport {
+        runtime_job_id: "job-in".to_string(),
+        enforced: true,
+        policy: policy.clone(),
+        grants: vec![NetworkPolicyGrant {
+            direction: NetworkDirection::Outbound,
+            host: "api.github.com".to_string(),
+            port: Some(443),
+            protocol: Some(NetworkProtocol::Https),
+        }],
+        connections: vec![NetworkConnectionMetadata {
+            direction: NetworkDirection::Inbound,
+            host: Some("evil.example".to_string()),
+            port: Some(443),
+            protocol: Some(NetworkProtocol::Https),
+            decision: NetworkDecision::Allowed,
+            reason: "inbound host outside allowlist".to_string(),
+            bytes_sent: None,
+            bytes_received: None,
+        }],
+        payloads_recorded: false,
+        reason: "inbound allowlist validated".to_string(),
+    };
+
+    allowed.validate_against(&policy, "job-in").unwrap();
+    assert_eq!(
+        rejected.validate_against(&policy, "job-in"),
+        Err(NetworkPolicyReportError::UnexpectedAllowedConnection)
+    );
+}
+
+#[test]
+fn eval_network_policy_rejects_unsupported_backend() {
+    let policy = EvalNetworkPolicy::for_allowlist(&[]).unwrap();
+    let err = validate_network_policy_backend(&policy, EvalNetworkPolicyBackend::Unsupported)
+        .expect_err("unsupported backend must fail closed");
+    assert!(matches!(
+        err,
+        NetworkPolicyReportError::UnsupportedBackend { .. }
+    ));
+}
+
+#[test]
+fn eval_network_policy_report_binds_runtime_job_id() {
+    let policy = EvalNetworkPolicy::for_allowlist(&[]).unwrap();
+    let report = EvalNetworkPolicyReport {
+        runtime_job_id: "other-job".to_string(),
+        enforced: true,
+        policy: policy.clone(),
+        grants: Vec::new(),
+        connections: Vec::new(),
+        payloads_recorded: false,
+        reason: "enforced".to_string(),
+    };
+    assert_eq!(
+        report.validate_against(&policy, "job-1"),
+        Err(NetworkPolicyReportError::RuntimeJobMismatch)
+    );
+}

--- a/crates/harness-sandbox/src/network_policy_tests.rs
+++ b/crates/harness-sandbox/src/network_policy_tests.rs
@@ -195,6 +195,9 @@ fn eval_network_policy_rejects_ambiguous_dns_allowlist_entries() {
         "127.1",
         "127.0.0.01",
         "0177.0.0.1",
+        "0x7f.0.0.1",
+        "0x7f.1",
+        "0X7F.0.0.1",
         "localhost",
         "github.com:443",
         "github.com/path",
@@ -207,6 +210,35 @@ fn eval_network_policy_rejects_ambiguous_dns_allowlist_entries() {
             NetworkPolicyReportError::InvalidAllowlistHost { .. }
         ));
     }
+}
+
+#[test]
+fn eval_network_policy_revalidated_rejects_injected_numeric_aliases() {
+    let injected = EvalNetworkPolicy {
+        inbound: EvalNetworkAccess::Allowlist,
+        outbound: EvalNetworkAccess::Allowlist,
+        network_allowlist: vec!["0x7f.0.0.1".to_string()],
+    };
+    let error = injected
+        .revalidated()
+        .expect_err("claim-time alias injection must fail closed");
+    assert!(matches!(
+        error,
+        NetworkPolicyReportError::InvalidAllowlistHost { .. }
+    ));
+}
+
+#[test]
+fn eval_network_policy_revalidated_rebuilds_secure_shape() {
+    let injected = EvalNetworkPolicy {
+        inbound: EvalNetworkAccess::Allowlist,
+        outbound: EvalNetworkAccess::Deny,
+        network_allowlist: vec![" API.GitHub.COM. ".to_string()],
+    };
+    let policy = injected.revalidated().unwrap();
+    assert_eq!(policy.inbound, EvalNetworkAccess::Deny);
+    assert_eq!(policy.outbound, EvalNetworkAccess::Allowlist);
+    assert_eq!(policy.network_allowlist, vec!["api.github.com".to_string()]);
 }
 
 #[test]

--- a/crates/harness-server/src/handlers/runtime_hosts/claim.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/claim.rs
@@ -1,16 +1,16 @@
 use super::*;
 
-const RESOURCE_LIMIT_CAPABILITY_RETRY_DELAY_SECS: i64 = 30;
+const CAPABILITY_RETRY_DELAY_SECS: i64 = 30;
 
-pub(super) async fn defer_runtime_host_resource_limit_claim(
+pub(super) async fn defer_runtime_host_capability_claim(
     store: &WorkflowRuntimeStore,
     host_id: &str,
     lease_expires_at: DateTime<Utc>,
     job: &RuntimeJob,
     reason: &str,
+    required_capability: &str,
 ) -> (StatusCode, serde_json::Value) {
-    let not_before =
-        Utc::now() + chrono::TimeDelta::seconds(RESOURCE_LIMIT_CAPABILITY_RETRY_DELAY_SECS);
+    let not_before = Utc::now() + chrono::TimeDelta::seconds(CAPABILITY_RETRY_DELAY_SECS);
     match store
         .defer_runtime_job_claim_if_owned(&job.id, host_id, lease_expires_at, not_before)
         .await
@@ -25,7 +25,7 @@ pub(super) async fn defer_runtime_host_resource_limit_claim(
                         "not_before": not_before,
                         "reason": reason,
                         "claim_api": "runtime_host",
-                        "required_capability": EVAL_RESOURCE_LIMITS_CAPABILITY,
+                        "required_capability": required_capability,
                     }),
                 )
                 .await
@@ -34,7 +34,7 @@ pub(super) async fn defer_runtime_host_resource_limit_claim(
                     runtime_job_id = %job.id,
                     host_id = %host_id,
                     %error,
-                    "runtime host resource-limit claim defer succeeded but event recording failed"
+                    "runtime host capability claim defer succeeded but event recording failed"
                 );
             }
             (
@@ -46,7 +46,7 @@ pub(super) async fn defer_runtime_host_resource_limit_claim(
                     "runtime_job": deferred,
                     "not_before": not_before,
                     "reason": reason,
-                    "required_capability": EVAL_RESOURCE_LIMITS_CAPABILITY,
+                    "required_capability": required_capability,
                 }),
             )
         }
@@ -85,7 +85,7 @@ pub(super) async fn defer_runtime_host_resource_limit_claim(
             tracing::warn!(
                 runtime_job_id = %job.id,
                 host_id = %host_id,
-                "runtime host resource-limit claim defer ignored because the host no longer owns the lease"
+                "runtime host capability claim defer ignored because the host no longer owns the lease"
             );
             (StatusCode::OK, json!({ "claimed": false }))
         }
@@ -94,7 +94,7 @@ pub(super) async fn defer_runtime_host_resource_limit_claim(
                 runtime_job_id = %job.id,
                 host_id = %host_id,
                 %error,
-                "runtime host failed to defer resource-limit-incompatible runtime job"
+                "runtime host failed to defer capability-incompatible runtime job"
             );
             (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/harness-server/src/handlers/runtime_hosts/completion.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/completion.rs
@@ -125,6 +125,9 @@ pub async fn complete_runtime_job_for_runtime_host(
         Err(response) => return (StatusCode::BAD_REQUEST, completion_json(response)),
     };
     if !cancellation_ack {
+        if let Err((status, response)) = validate_eval_network_policy_report(&job, &result) {
+            return (status, completion_json(response));
+        }
         if let Err((status, response)) = validate_eval_resource_limit_report(&job, &result) {
             return (status, completion_json(response));
         }
@@ -346,6 +349,7 @@ pub async fn complete_runtime_job_for_runtime_host(
 
 mod capabilities;
 mod evidence;
+mod network_policy;
 mod reservation;
 use capabilities::validate_eval_host_capabilities;
 use evidence::{
@@ -354,6 +358,9 @@ use evidence::{
 };
 pub(super) use evidence::{
     eval_resource_limit_preflight_failure, validate_eval_resource_limit_report,
+};
+pub(super) use network_policy::{
+    eval_network_policy_preflight_failure, validate_eval_network_policy_report,
 };
 pub(crate) use reservation::replay_completion_reservation;
 use reservation::reserve_completion_lease;

--- a/crates/harness-server/src/handlers/runtime_hosts/completion/capabilities.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/completion/capabilities.rs
@@ -44,12 +44,16 @@ mod tests {
                 "eval": {
                     "required_runtime_host_capabilities": [
                         "eval_resource_limits",
+                        "eval_network_policy",
                         "trusted_eval_verifier_v1"
                     ]
                 }
             }
         });
-        let supported = vec!["eval_resource_limits".to_string()];
+        let supported = vec![
+            "eval_resource_limits".to_string(),
+            "eval_network_policy".to_string(),
+        ];
 
         assert_eq!(
             missing_required_eval_capabilities(&input, &supported),

--- a/crates/harness-server/src/handlers/runtime_hosts/completion/evidence.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/completion/evidence.rs
@@ -49,7 +49,7 @@ pub(in crate::handlers::runtime_hosts) fn eval_resource_limit_preflight_failure(
     ))
 }
 
-fn runtime_job_activity(job: &RuntimeJob) -> String {
+pub(super) fn runtime_job_activity(job: &RuntimeJob) -> String {
     job.input
         .get("activity")
         .and_then(Value::as_str)

--- a/crates/harness-server/src/handlers/runtime_hosts/completion/network_policy.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/completion/network_policy.rs
@@ -1,0 +1,246 @@
+use super::*;
+use crate::handlers::runtime_hosts::applied_eval_network_policy;
+use harness_sandbox::EvalNetworkPolicy;
+
+pub(in crate::handlers::runtime_hosts) fn eval_network_policy_preflight_failure(
+    job: &RuntimeJob,
+    error: &str,
+    network_policy: Option<EvalNetworkPolicy>,
+) -> ActivityResult {
+    let mut artifact = json!({
+        "enforced": false,
+        "reason": error,
+    });
+    if let Some(network_policy) = network_policy {
+        artifact["network_policy"] = json!(network_policy);
+    }
+    ActivityResult::failed(
+        super::evidence::runtime_job_activity(job),
+        "Evaluation network policy could not be enforced.",
+        error,
+    )
+    .with_error_kind(ActivityErrorKind::Configuration)
+    .with_artifact(ActivityArtifact::new(
+        "network_policy_enforcement",
+        artifact,
+    ))
+}
+
+pub(in crate::handlers::runtime_hosts) fn validate_eval_network_policy_report(
+    job: &RuntimeJob,
+    result: &ActivityResult,
+) -> Result<(), (StatusCode, serde_json::Value)> {
+    // Only require a report for leases that received the policy contract at claim time.
+    let Some(expected_policy) = applied_eval_network_policy(job).map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            json!({ "error": format!("invalid eval network policy: {error}") }),
+        )
+    })?
+    else {
+        return Ok(());
+    };
+
+    let report_artifacts = result
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact.artifact_type == "network_policy_report")
+        .collect::<Vec<_>>();
+    if report_artifacts.len() > 1 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            json!({
+                "error": "eval runtime job completion must include exactly one network_policy_report artifact"
+            }),
+        ));
+    }
+    let Some(report_value) = report_artifacts
+        .first()
+        .map(|artifact| artifact.artifact.clone())
+    else {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            json!({
+                "error": "eval runtime job completion requires network_policy_report artifact"
+            }),
+        ));
+    };
+    let report: harness_sandbox::EvalNetworkPolicyReport = serde_json::from_value(report_value)
+        .map_err(|error| {
+            (
+                StatusCode::BAD_REQUEST,
+                json!({ "error": format!("invalid network_policy_report artifact: {error}") }),
+            )
+        })?;
+    report
+        .validate_against(&expected_policy, &job.id)
+        .map_err(|error| {
+            (
+                StatusCode::BAD_REQUEST,
+                json!({ "error": format!("network_policy_report is not valid: {error}") }),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_workflow::runtime::RuntimeKind;
+
+    fn eval_job_with_applied_policy(job_id_seed: &str) -> RuntimeJob {
+        let mut job = RuntimeJob::pending(
+            job_id_seed,
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({
+                "activity": "implement_issue",
+                "command": {
+                    "eval": {
+                        "eval_run_id": "run-1",
+                        "case_id": "case-1",
+                        "timeout_secs": 45,
+                        "network_policy": {
+                            "inbound": "deny",
+                            "outbound": "deny",
+                            "network_allowlist": [],
+                        }
+                    }
+                }
+            }),
+        );
+        job.id = format!("job-{job_id_seed}");
+        job
+    }
+
+    #[test]
+    fn eval_network_policy_report_skipped_without_claim_contract() {
+        let job = RuntimeJob::pending(
+            "cmd-1",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({
+                "activity": "implement_issue",
+                "command": {
+                    "eval": {
+                        "eval_run_id": "run-1",
+                        "case_id": "case-1",
+                        "timeout_secs": 45
+                    }
+                }
+            }),
+        );
+        let result = ActivityResult::succeeded("implement_issue", "done");
+        validate_eval_network_policy_report(&job, &result)
+            .expect("legacy leases without applied policy must not require a report");
+    }
+
+    #[test]
+    fn eval_network_policy_report_is_required_when_policy_was_applied() {
+        let job = eval_job_with_applied_policy("required");
+        let result = ActivityResult::succeeded("implement_issue", "done");
+        let err = validate_eval_network_policy_report(&job, &result)
+            .expect_err("missing network report should fail closed");
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            err.1["error"],
+            "eval runtime job completion requires network_policy_report artifact"
+        );
+    }
+
+    #[test]
+    fn eval_network_policy_report_accepts_matching_metadata() {
+        let job = eval_job_with_applied_policy("accept");
+        let result = ActivityResult::succeeded("implement_issue", "done").with_artifact(
+            ActivityArtifact::new(
+                "network_policy_report",
+                json!({
+                    "runtime_job_id": job.id,
+                    "enforced": true,
+                    "policy": {
+                        "inbound": "deny",
+                        "outbound": "deny",
+                        "network_allowlist": [],
+                    },
+                    "grants": [],
+                    "connections": [],
+                    "payloads_recorded": false,
+                    "reason": "runtime host enforced eval network policy",
+                }),
+            ),
+        );
+        validate_eval_network_policy_report(&job, &result)
+            .expect("matching network policy report should be accepted");
+    }
+
+    #[test]
+    fn eval_network_policy_report_rejects_payload_recording() {
+        let job = eval_job_with_applied_policy("payload");
+        let result = ActivityResult::succeeded("implement_issue", "done").with_artifact(
+            ActivityArtifact::new(
+                "network_policy_report",
+                json!({
+                    "runtime_job_id": job.id,
+                    "enforced": true,
+                    "policy": {
+                        "inbound": "deny",
+                        "outbound": "deny",
+                        "network_allowlist": [],
+                    },
+                    "grants": [],
+                    "connections": [],
+                    "payloads_recorded": true,
+                    "reason": "runtime host recorded network details",
+                }),
+            ),
+        );
+        let err = validate_eval_network_policy_report(&job, &result)
+            .expect_err("payload recording must fail closed");
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(err.1["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("must not record payloads")));
+    }
+
+    #[test]
+    fn eval_network_policy_report_rejects_duplicates() {
+        let job = eval_job_with_applied_policy("dup");
+        let result = ActivityResult::succeeded("implement_issue", "done")
+            .with_artifact(ActivityArtifact::new(
+                "network_policy_report",
+                json!({
+                    "runtime_job_id": job.id,
+                    "enforced": true,
+                    "policy": {
+                        "inbound": "deny",
+                        "outbound": "deny",
+                        "network_allowlist": [],
+                    },
+                    "grants": [],
+                    "connections": [],
+                    "payloads_recorded": false,
+                    "reason": "runtime host enforced eval network policy",
+                }),
+            ))
+            .with_artifact(ActivityArtifact::new(
+                "network_policy_report",
+                json!({
+                    "runtime_job_id": job.id,
+                    "enforced": true,
+                    "policy": {
+                        "inbound": "deny",
+                        "outbound": "deny",
+                        "network_allowlist": [],
+                    },
+                    "grants": [],
+                    "connections": [],
+                    "payloads_recorded": true,
+                    "reason": "contradictory report",
+                }),
+            ));
+        let err = validate_eval_network_policy_report(&job, &result)
+            .expect_err("duplicate reports must fail closed");
+        assert!(err.1["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("exactly one")));
+    }
+}

--- a/crates/harness-server/src/handlers/runtime_hosts/completion/network_policy.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/completion/network_policy.rs
@@ -41,23 +41,11 @@ pub(in crate::handlers::runtime_hosts) fn validate_eval_network_policy_report(
         return Ok(());
     };
 
-    let report_artifacts = result
+    let mut report_artifacts = result
         .artifacts
         .iter()
-        .filter(|artifact| artifact.artifact_type == "network_policy_report")
-        .collect::<Vec<_>>();
-    if report_artifacts.len() > 1 {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            json!({
-                "error": "eval runtime job completion must include exactly one network_policy_report artifact"
-            }),
-        ));
-    }
-    let Some(report_value) = report_artifacts
-        .first()
-        .map(|artifact| artifact.artifact.clone())
-    else {
+        .filter(|artifact| artifact.artifact_type == "network_policy_report");
+    let Some(first_artifact) = report_artifacts.next() else {
         return Err((
             StatusCode::BAD_REQUEST,
             json!({
@@ -65,6 +53,15 @@ pub(in crate::handlers::runtime_hosts) fn validate_eval_network_policy_report(
             }),
         ));
     };
+    if report_artifacts.next().is_some() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            json!({
+                "error": "eval runtime job completion must include exactly one network_policy_report artifact"
+            }),
+        ));
+    }
+    let report_value = first_artifact.artifact.clone();
     let report: harness_sandbox::EvalNetworkPolicyReport = serde_json::from_value(report_value)
         .map_err(|error| {
             (

--- a/crates/harness-server/src/handlers/runtime_hosts/eval_enforcement.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/eval_enforcement.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+pub(crate) fn eval_resource_limit_enforcement_for_job(
+    job: &RuntimeJob,
+) -> Result<Option<CappedResourceLimits>, String> {
+    let Some(eval) = eval_metadata(&job.input) else {
+        return Ok(None);
+    };
+    if let Some(value) = eval.get("resource_limits") {
+        if value.get("requested").is_some() && value.get("effective").is_some() {
+            return serde_json::from_value(value.clone())
+                .map(Some)
+                .map_err(|error| format!("invalid eval resource_limits: {error}"));
+        }
+        let requested: ResourceLimits = serde_json::from_value(value.clone())
+            .map_err(|error| format!("invalid eval resource_limits: {error}"))?;
+        return requested
+            .cap_by(ResourceLimits::operator_default_maxima())
+            .map(Some)
+            .map_err(|error| format!("invalid eval resource_limits: {error}"));
+    }
+    let timeout_secs = eval
+        .get("timeout_secs")
+        .and_then(Value::as_u64)
+        .filter(|value| *value > 0)
+        .ok_or_else(|| {
+            "eval runtime job must include timeout_secs or resource_limits".to_string()
+        })?;
+    ResourceLimits::evaluation_defaults(timeout_secs)
+        .cap_by(ResourceLimits::operator_default_maxima())
+        .map(Some)
+        .map_err(|error| format!("invalid eval resource_limits: {error}"))
+}
+
+pub(super) fn eval_network_policy_enforcement_for_job(
+    job: &RuntimeJob,
+) -> Result<Option<EvalNetworkPolicy>, String> {
+    let Some(eval) = eval_metadata(&job.input) else {
+        return Ok(None);
+    };
+    if let Some(value) = eval.get("network_policy") {
+        return serde_json::from_value(value.clone())
+            .map(Some)
+            .map_err(|error| format!("invalid eval network_policy: {error}"));
+    }
+    let network_allowlist = job
+        .input
+        .pointer("/isolation/network_allowlist")
+        .or_else(|| eval.pointer("/isolation/network_allowlist"))
+        .map(|value| {
+            serde_json::from_value::<Vec<String>>(value.clone())
+                .map_err(|error| format!("invalid eval network_allowlist: {error}"))
+        })
+        .transpose()?
+        .unwrap_or_default();
+    EvalNetworkPolicy::for_allowlist(&network_allowlist)
+        .map(Some)
+        .map_err(|error| format!("invalid eval network policy: {error}"))
+}
+
+pub(crate) fn applied_eval_network_policy(
+    job: &RuntimeJob,
+) -> Result<Option<EvalNetworkPolicy>, String> {
+    let Some(eval) = eval_metadata(&job.input) else {
+        return Ok(None);
+    };
+    let Some(value) = eval.get("network_policy") else {
+        return Ok(None);
+    };
+    serde_json::from_value(value.clone())
+        .map(Some)
+        .map_err(|error| format!("invalid eval network_policy: {error}"))
+}
+
+pub(crate) fn eval_metadata(input: &Value) -> Option<&Value> {
+    input
+        .pointer("/command/eval")
+        .or_else(|| input.get("eval"))
+        .filter(|value| value.is_object())
+}
+
+pub(super) fn set_eval_resource_limit_enforcement(
+    job: &mut RuntimeJob,
+    resource_limits: &CappedResourceLimits,
+) {
+    let value = json!(resource_limits);
+    if let Some(eval) = job
+        .input
+        .pointer_mut("/command/eval")
+        .and_then(Value::as_object_mut)
+    {
+        eval.insert("resource_limits".to_string(), value.clone());
+    }
+    if let Some(eval) = job.input.get_mut("eval").and_then(Value::as_object_mut) {
+        eval.insert("resource_limits".to_string(), value);
+    }
+}
+
+pub(super) fn set_eval_network_policy_enforcement(
+    job: &mut RuntimeJob,
+    network_policy: &EvalNetworkPolicy,
+) {
+    let value = json!(network_policy);
+    if let Some(eval) = job
+        .input
+        .pointer_mut("/command/eval")
+        .and_then(Value::as_object_mut)
+    {
+        eval.insert("network_policy".to_string(), value.clone());
+    }
+    if let Some(eval) = job.input.get_mut("eval").and_then(Value::as_object_mut) {
+        eval.insert("network_policy".to_string(), value);
+    }
+}

--- a/crates/harness-server/src/handlers/runtime_hosts/eval_enforcement.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/eval_enforcement.rs
@@ -39,9 +39,7 @@ pub(super) fn eval_network_policy_enforcement_for_job(
         return Ok(None);
     };
     if let Some(value) = eval.get("network_policy") {
-        return serde_json::from_value(value.clone())
-            .map(Some)
-            .map_err(|error| format!("invalid eval network_policy: {error}"));
+        return parse_eval_network_policy(value).map(Some);
     }
     let network_allowlist = job
         .input
@@ -67,8 +65,14 @@ pub(crate) fn applied_eval_network_policy(
     let Some(value) = eval.get("network_policy") else {
         return Ok(None);
     };
-    serde_json::from_value(value.clone())
-        .map(Some)
+    parse_eval_network_policy(value).map(Some)
+}
+
+fn parse_eval_network_policy(value: &Value) -> Result<EvalNetworkPolicy, String> {
+    let policy: EvalNetworkPolicy = serde_json::from_value(value.clone())
+        .map_err(|error| format!("invalid eval network_policy: {error}"))?;
+    policy
+        .revalidated()
         .map_err(|error| format!("invalid eval network_policy: {error}"))
 }
 
@@ -110,5 +114,67 @@ pub(super) fn set_eval_network_policy_enforcement(
     }
     if let Some(eval) = job.input.get_mut("eval").and_then(Value::as_object_mut) {
         eval.insert("network_policy".to_string(), value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness_sandbox::EvalNetworkAccess;
+    use harness_workflow::runtime::RuntimeKind;
+
+    fn eval_job_with_network_policy(policy: Value) -> RuntimeJob {
+        RuntimeJob::pending(
+            "cmd-claim-network-policy",
+            RuntimeKind::RemoteHost,
+            "remote-host-default",
+            json!({
+                "activity": "implement_issue",
+                "command": {
+                    "eval": {
+                        "eval_run_id": "run-1",
+                        "case_id": "case-1",
+                        "timeout_secs": 45,
+                        "network_policy": policy,
+                    }
+                }
+            }),
+        )
+    }
+
+    #[test]
+    fn claim_path_rejects_injected_hex_numeric_allowlist_aliases() {
+        let job = eval_job_with_network_policy(json!({
+            "inbound": "allowlist",
+            "outbound": "allowlist",
+            "network_allowlist": ["0x7f.0.0.1"],
+        }));
+        let err = eval_network_policy_enforcement_for_job(&job)
+            .expect_err("hex numeric alias injection must fail closed at claim");
+        assert!(
+            err.contains("invalid eval network_policy"),
+            "unexpected error: {err}"
+        );
+        let applied_err = applied_eval_network_policy(&job)
+            .expect_err("completion path must also reject injected aliases");
+        assert!(
+            applied_err.contains("invalid eval network_policy"),
+            "unexpected error: {applied_err}"
+        );
+    }
+
+    #[test]
+    fn claim_path_renormalizes_deserialized_network_policy() {
+        let job = eval_job_with_network_policy(json!({
+            "inbound": "allowlist",
+            "outbound": "deny",
+            "network_allowlist": [" API.GitHub.COM. "],
+        }));
+        let policy = eval_network_policy_enforcement_for_job(&job)
+            .expect("valid DNS hosts should renormalize")
+            .expect("eval jobs must produce a policy");
+        assert_eq!(policy.inbound, EvalNetworkAccess::Deny);
+        assert_eq!(policy.outbound, EvalNetworkAccess::Allowlist);
+        assert_eq!(policy.network_allowlist, vec!["api.github.com".to_string()]);
     }
 }

--- a/crates/harness-server/src/handlers/runtime_hosts/mod.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts/mod.rs
@@ -5,7 +5,15 @@ pub(crate) use completion::{
     install_completion_reservation_test_gate, replay_completion_reservation,
 };
 mod claim;
-use claim::defer_runtime_host_resource_limit_claim;
+use claim::defer_runtime_host_capability_claim;
+mod eval_enforcement;
+pub(crate) use eval_enforcement::{
+    applied_eval_network_policy, eval_metadata, eval_resource_limit_enforcement_for_job,
+};
+use eval_enforcement::{
+    eval_network_policy_enforcement_for_job, set_eval_network_policy_enforcement,
+    set_eval_resource_limit_enforcement,
+};
 
 use crate::http::rest_contract::{ContractJson, LegacyJson as Json, PrimitivePath as Path};
 use crate::http::AppState;
@@ -18,7 +26,8 @@ use harness_protocol::rest::{
     ClaimRuntimeJobRequest, RuntimeHostClaimResponse, RUNTIME_JOB_LEASE_PROOF_V1_CAPABILITY,
 };
 use harness_sandbox::{
-    CappedResourceLimits, ResourceLimitReport, ResourceLimits, EVAL_RESOURCE_LIMITS_CAPABILITY,
+    CappedResourceLimits, EvalNetworkPolicy, ResourceLimitReport, ResourceLimits,
+    EVAL_NETWORK_POLICY_CAPABILITY, EVAL_RESOURCE_LIMITS_CAPABILITY,
 };
 use harness_workflow::runtime::{
     prepare_runtime_transcript, ActivityArtifact, ActivityErrorKind, ActivityResult, RuntimeJob,
@@ -277,7 +286,9 @@ pub async fn claim_runtime_job_for_runtime_host(
         );
     }
     let host_supports_eval_resource_limits =
-        runtime_host_supports_eval_resource_limits(&state, &host_id);
+        runtime_host_supports_capability(&state, &host_id, EVAL_RESOURCE_LIMITS_CAPABILITY);
+    let host_supports_eval_network_policy =
+        runtime_host_supports_capability(&state, &host_id, EVAL_NETWORK_POLICY_CAPABILITY);
     let host_supports_trusted_eval_verifier =
         runtime_host_supports_capability(&state, &host_id, TRUSTED_EVAL_VERIFIER_V1_CAPABILITY);
     let store = match workflow_runtime_store(&state) {
@@ -403,12 +414,13 @@ pub async fn claim_runtime_job_for_runtime_host(
     let resource_limits = match eval_resource_limit_enforcement_for_job(&job) {
         Ok(Some(resource_limits)) => {
             if !host_supports_eval_resource_limits {
-                let (status, response) = defer_runtime_host_resource_limit_claim(
+                let (status, response) = defer_runtime_host_capability_claim(
                     store.as_ref(),
                     &host_id,
                     lease_expires_at,
                     &job,
                     "runtime host lacks eval_resource_limits capability",
+                    EVAL_RESOURCE_LIMITS_CAPABILITY,
                 )
                 .await;
                 return (status, claim_json(response));
@@ -449,6 +461,72 @@ pub async fn claim_runtime_job_for_runtime_host(
                 host_id = %host_id,
                 %error,
                 "runtime host claim succeeded but eval resource-limit event recording failed"
+            );
+        }
+    }
+
+    let network_policy = match eval_network_policy_enforcement_for_job(&job) {
+        Ok(Some(network_policy)) => {
+            if !host_supports_eval_network_policy {
+                let (status, response) = defer_runtime_host_capability_claim(
+                    store.as_ref(),
+                    &host_id,
+                    lease_expires_at,
+                    &job,
+                    "runtime host lacks eval_network_policy capability",
+                    EVAL_NETWORK_POLICY_CAPABILITY,
+                )
+                .await;
+                return (status, claim_json(response));
+            }
+            Some(network_policy)
+        }
+        Ok(None) => None,
+        Err(error) => {
+            let result = completion::eval_network_policy_preflight_failure(&job, &error, None);
+            return complete_runtime_host_preflight_failure(
+                &state,
+                store.as_ref(),
+                &host_id,
+                lease_expires_at,
+                &job,
+                result,
+            )
+            .await;
+        }
+    };
+
+    if let Some(network_policy) = &network_policy {
+        set_eval_network_policy_enforcement(&mut job, network_policy);
+        if let Err(error) = store.persist_runtime_job_data(&job).await {
+            tracing::error!(
+                runtime_job_id = %job.id,
+                host_id = %host_id,
+                %error,
+                "failed to persist eval network policy on claimed runtime job"
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                claim_json(json!({ "error": "failed to persist eval network policy" })),
+            );
+        }
+        if let Err(error) = store
+            .record_runtime_event(
+                &job.id,
+                "EvalNetworkPolicyApplied",
+                json!({
+                    "host_id": host_id.as_str(),
+                    "network_policy": network_policy,
+                    "reason": "runtime host claim",
+                }),
+            )
+            .await
+        {
+            tracing::warn!(
+                runtime_job_id = %job.id,
+                host_id = %host_id,
+                %error,
+                "runtime host claim succeeded but eval network-policy event recording failed"
             );
         }
     }
@@ -532,6 +610,9 @@ pub async fn claim_runtime_job_for_runtime_host(
     }
     if let Some(resource_limits) = resource_limits {
         response["resource_limits"] = json!(resource_limits);
+    }
+    if let Some(network_policy) = network_policy {
+        response["network_policy"] = json!(network_policy);
     }
     (StatusCode::OK, claim_json(response))
 }
@@ -638,72 +719,12 @@ async fn complete_runtime_host_preflight_failure(
     )
 }
 
-fn runtime_host_supports_eval_resource_limits(state: &Arc<AppState>, host_id: &str) -> bool {
-    runtime_host_supports_capability(state, host_id, EVAL_RESOURCE_LIMITS_CAPABILITY)
-}
-
 fn runtime_host_supports_capability(state: &Arc<AppState>, host_id: &str, required: &str) -> bool {
     state.runtime_hosts.hosts.get(host_id).is_some_and(|host| {
         host.capabilities
             .iter()
             .any(|capability| capability == required)
     })
-}
-
-fn eval_resource_limit_enforcement_for_job(
-    job: &RuntimeJob,
-) -> Result<Option<CappedResourceLimits>, String> {
-    let Some(eval) = eval_metadata(&job.input) else {
-        return Ok(None);
-    };
-    if let Some(value) = eval.get("resource_limits") {
-        if value.get("requested").is_some() && value.get("effective").is_some() {
-            return serde_json::from_value(value.clone())
-                .map(Some)
-                .map_err(|error| format!("invalid eval resource_limits: {error}"));
-        }
-        let requested: ResourceLimits = serde_json::from_value(value.clone())
-            .map_err(|error| format!("invalid eval resource_limits: {error}"))?;
-        return requested
-            .cap_by(ResourceLimits::operator_default_maxima())
-            .map(Some)
-            .map_err(|error| format!("invalid eval resource_limits: {error}"));
-    }
-    let timeout_secs = eval
-        .get("timeout_secs")
-        .and_then(Value::as_u64)
-        .filter(|value| *value > 0)
-        .ok_or_else(|| {
-            "eval runtime job must include timeout_secs or resource_limits".to_string()
-        })?;
-    ResourceLimits::evaluation_defaults(timeout_secs)
-        .cap_by(ResourceLimits::operator_default_maxima())
-        .map(Some)
-        .map_err(|error| format!("invalid eval resource_limits: {error}"))
-}
-
-fn eval_metadata(input: &Value) -> Option<&Value> {
-    input
-        .pointer("/command/eval")
-        .or_else(|| input.get("eval"))
-        .filter(|value| value.is_object())
-}
-
-fn set_eval_resource_limit_enforcement(
-    job: &mut RuntimeJob,
-    resource_limits: &CappedResourceLimits,
-) {
-    let value = json!(resource_limits);
-    if let Some(eval) = job
-        .input
-        .pointer_mut("/command/eval")
-        .and_then(Value::as_object_mut)
-    {
-        eval.insert("resource_limits".to_string(), value.clone());
-    }
-    if let Some(eval) = job.input.get_mut("eval").and_then(Value::as_object_mut) {
-        eval.insert("resource_limits".to_string(), value);
-    }
 }
 
 fn ensure_runtime_state_persistence_available(

--- a/crates/harness-server/src/handlers/runtime_hosts_terminal_fence_cases.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_terminal_fence_cases.rs
@@ -26,11 +26,32 @@ fn ordinary_eval_input() -> serde_json::Value {
 }
 
 fn ordinary_eval_completion_request(claimed: &serde_json::Value) -> serde_json::Value {
+    let network_policy = claimed.get("network_policy").cloned().unwrap_or_else(|| {
+        json!({
+            "inbound": "deny",
+            "outbound": "deny",
+            "network_allowlist": [],
+        })
+    });
+    let result = ActivityResult::succeeded("implement_issue", "ordinary completion").with_artifact(
+        ActivityArtifact::new(
+            "network_policy_report",
+            json!({
+                "runtime_job_id": claimed["runtime_job_id"],
+                "enforced": true,
+                "policy": network_policy,
+                "grants": [],
+                "connections": [],
+                "payloads_recorded": false,
+                "reason": "runtime host enforced eval network policy",
+            }),
+        ),
+    );
     json!({
         "lease_generation": claimed["lease_generation"],
         "lease_expires_at": claimed["lease_expires_at"],
         "lease_proof": claimed["lease_proof"],
-        "result": ActivityResult::succeeded("implement_issue", "ordinary completion"),
+        "result": result,
         "execution_evidence": {
             "checked_out_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "resource_limit_report": {

--- a/crates/harness-server/src/handlers/runtime_hosts_terminal_fence_cases.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_terminal_fence_cases.rs
@@ -162,7 +162,12 @@ async fn runtime_job_completion_preserves_cancelled_eval_feedback_cleanup_proof(
         return Ok(());
     };
     let app = support::runtime_hosts_workflow_app(state);
-    support::register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits"]).await?;
+    support::register_host_with_capabilities(
+        &app,
+        "host-a",
+        vec!["eval_resource_limits", "eval_network_policy"],
+    )
+    .await?;
     let job = support::enqueue_runtime_host_test_job(
         &store,
         "cancelled-eval-feedback",
@@ -246,7 +251,12 @@ async fn completion_reservation_reports_cleanup_ack_when_terminal_fence_wins_rac
         return Ok(());
     };
     let app = support::runtime_hosts_workflow_app(state);
-    support::register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits"]).await?;
+    support::register_host_with_capabilities(
+        &app,
+        "host-a",
+        vec!["eval_resource_limits", "eval_network_policy"],
+    )
+    .await?;
     let job = support::enqueue_runtime_host_test_job(
         &store,
         "completion-terminal-fence-race",
@@ -320,7 +330,12 @@ async fn completion_commit_reports_cleanup_ack_when_post_reservation_fence_wins_
         return Ok(());
     };
     let app = support::runtime_hosts_workflow_app(state);
-    support::register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits"]).await?;
+    support::register_host_with_capabilities(
+        &app,
+        "host-a",
+        vec!["eval_resource_limits", "eval_network_policy"],
+    )
+    .await?;
     let key = "post-reservation-terminal-fence-race";
     let workflow_id = format!("runtime-host-test-{key}");
     let job = support::enqueue_runtime_host_test_job(
@@ -415,7 +430,12 @@ async fn stale_dead_letter_reports_cleanup_ack_when_terminal_fence_wins_race() -
         return Ok(());
     };
     let app = support::runtime_hosts_workflow_app(state);
-    support::register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits"]).await?;
+    support::register_host_with_capabilities(
+        &app,
+        "host-a",
+        vec!["eval_resource_limits", "eval_network_policy"],
+    )
+    .await?;
     let key = "stale-dead-letter-terminal-fence-race";
     let workflow_id = format!("runtime-host-test-{key}");
     let job = support::enqueue_runtime_host_test_job(

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_claim_cases.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_claim_cases.rs
@@ -123,7 +123,7 @@ async fn runtime_job_claim_endpoint_includes_eval_credential_environment_policy(
         return Ok(());
     };
     let app = runtime_hosts_workflow_app(state);
-    register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits"]).await?;
+    register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits", "eval_network_policy"]).await?;
 
     let job = enqueue_runtime_host_test_job(
         &store,
@@ -204,11 +204,11 @@ async fn trusted_eval_job_is_claimed_only_by_a_capable_runtime_host() -> anyhow:
         return Ok(());
     };
     let app = runtime_hosts_workflow_app(state);
-    register_host_with_capabilities(&app, "host-limited", vec!["eval_resource_limits"]).await?;
+    register_host_with_capabilities(&app, "host-limited", vec!["eval_resource_limits", "eval_network_policy"]).await?;
     register_host_with_capabilities(
         &app,
         "host-trusted",
-        vec!["eval_resource_limits", "trusted_eval_verifier_v1"],
+        vec!["eval_resource_limits", "eval_network_policy", "trusted_eval_verifier_v1"],
     )
     .await?;
     let job = enqueue_runtime_host_test_job(
@@ -225,6 +225,7 @@ async fn trusted_eval_job_is_claimed_only_by_a_capable_runtime_host() -> anyhow:
                     "timeout_secs": 45,
                     "required_runtime_host_capabilities": [
                         "eval_resource_limits",
+                        "eval_network_policy",
                         "trusted_eval_verifier_v1"
                     ]
                 }
@@ -249,6 +250,78 @@ async fn trusted_eval_job_is_claimed_only_by_a_capable_runtime_host() -> anyhow:
     .await?;
     assert_eq!(trusted["claimed"], true);
     assert_eq!(trusted["runtime_job_id"], job.id);
+    Ok(())
+}
+
+#[tokio::test]
+async fn runtime_job_claim_endpoint_injects_eval_network_policy() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let Some((state, store)) = make_test_state_with_runtime_store(dir.path()).await? else {
+        return Ok(());
+    };
+    let app = runtime_hosts_workflow_app(state);
+    register_host_with_capabilities(
+        &app,
+        "host-a",
+        vec!["eval_resource_limits", "eval_network_policy"],
+    )
+    .await?;
+
+    let job = enqueue_runtime_host_test_job(
+        &store,
+        "command-eval-network-policy",
+        RuntimeKind::RemoteHost,
+        "remote-host-default",
+        json!({
+            "activity": "implement_issue",
+            "isolation": {
+                "network_allowlist": ["api.github.com"]
+            },
+            "command": {
+                "eval": {
+                    "eval_run_id": "run-1",
+                    "case_id": "case-1",
+                    "timeout_secs": 45
+                }
+            }
+        }),
+    )
+    .await?;
+
+    let json = post_json(
+        &app,
+        "/api/runtime-hosts/host-a/runtime-jobs/claim".to_string(),
+        json!({ "lease_secs": 60 }),
+    )
+    .await?;
+
+    assert_eq!(json["claimed"], true);
+    assert_eq!(json["runtime_job_id"], job.id);
+    assert_eq!(
+        json["network_policy"],
+        json!({
+            "inbound": "deny",
+            "outbound": "allowlist",
+            "network_allowlist": ["api.github.com"],
+        })
+    );
+    assert_eq!(
+        json["runtime_job"]["input"]["command"]["eval"]["network_policy"],
+        json["network_policy"]
+    );
+    let events = store.runtime_events_for(&job.id).await?;
+    assert!(events.iter().any(|event| {
+        event.event_type == "EvalNetworkPolicyApplied"
+            && event.event["network_policy"] == json["network_policy"]
+    }));
+    let persisted = store
+        .get_runtime_job(&job.id)
+        .await?
+        .expect("claimed job should remain readable");
+    assert_eq!(
+        persisted.input["command"]["eval"]["network_policy"],
+        json["network_policy"]
+    );
     Ok(())
 }
 

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_completion_fencing_cases.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_completion_fencing_cases.rs
@@ -186,7 +186,7 @@ async fn draining_host_completion_revalidates_required_eval_capabilities() -> an
     register_host_with_capabilities(
         &app,
         "host-a",
-        vec!["eval_resource_limits", "trusted_eval_verifier_v1"],
+        vec!["eval_resource_limits", "eval_network_policy", "trusted_eval_verifier_v1"],
     )
     .await?;
     let job = enqueue_runtime_host_test_job(
@@ -201,6 +201,7 @@ async fn draining_host_completion_revalidates_required_eval_capabilities() -> an
                     "timeout_secs": 45,
                     "required_runtime_host_capabilities": [
                         "eval_resource_limits",
+                        "eval_network_policy",
                         "trusted_eval_verifier_v1"
                     ]
                 }
@@ -242,7 +243,7 @@ async fn draining_host_completion_revalidates_required_eval_capabilities() -> an
     );
     assert_eq!(
         body["missing_capabilities"],
-        json!(["eval_resource_limits", "trusted_eval_verifier_v1"])
+        json!(["eval_resource_limits", "eval_network_policy", "trusted_eval_verifier_v1"])
     );
     Ok(())
 }
@@ -626,7 +627,7 @@ async fn runtime_job_completion_preflight_error_preserves_the_client_lease_fence
         return Ok(());
     };
     let app = runtime_hosts_workflow_app(state);
-    register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits"]).await?;
+    register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits", "eval_network_policy"]).await?;
     let job = enqueue_runtime_host_test_job(
         &store,
         "completion-preflight-fence",

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_completion_fencing_cases.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_completion_fencing_cases.rs
@@ -666,7 +666,7 @@ async fn runtime_job_completion_preflight_error_preserves_the_client_lease_fence
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(
         body["error"],
-        "eval runtime job completion requires resource_limit_report artifact"
+        "eval runtime job completion requires network_policy_report artifact"
     );
     assert!(body.get("lease_reserved").is_none());
 

--- a/crates/harness-server/src/handlers/runtime_hosts_workflow_review_tests.rs
+++ b/crates/harness-server/src/handlers/runtime_hosts_workflow_review_tests.rs
@@ -266,7 +266,12 @@ async fn draining_host_can_acknowledge_eval_cancellation_then_finish_deregister(
     let dir = tempfile::tempdir()?;
     let (state, store) = required_runtime_store_state(dir.path()).await?;
     let app = support::runtime_hosts_workflow_app(state.clone());
-    support::register_host_with_capabilities(&app, "host-a", vec!["eval_resource_limits"]).await?;
+    support::register_host_with_capabilities(
+        &app,
+        "host-a",
+        vec!["eval_resource_limits", "eval_network_policy"],
+    )
+    .await?;
     let job = support::enqueue_runtime_host_test_job(
         &store,
         "draining-cancellation-ack",

--- a/crates/harness-workflow/src/runtime/dispatcher.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher.rs
@@ -648,11 +648,31 @@ fn eval_required_isolation_resolution(
         );
     }
 
+    let network_allowlist = isolation
+        .get("network_allowlist")
+        .map(|value| {
+            serde_json::from_value::<Vec<String>>(value.clone()).with_context(|| {
+                format!(
+                    "eval command {} has invalid eval.isolation.network_allowlist: {value}",
+                    command.id
+                )
+            })
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let network_policy = harness_sandbox::EvalNetworkPolicy::for_allowlist(&network_allowlist)
+        .with_context(|| {
+            format!(
+                "eval command {} has invalid eval.isolation.network_allowlist",
+                command.id
+            )
+        })?;
+
     Ok(Some(IsolationTierResolution {
         tier,
         reason: "eval command required container isolation tier from policy".to_string(),
         trust_class: IsolationTrustClass::NonCollaborator,
-        network_allowlist: Vec::new(),
+        network_allowlist: network_policy.network_allowlist,
     }))
 }
 

--- a/crates/harness-workflow/src/runtime/dispatcher_tests.rs
+++ b/crates/harness-workflow/src/runtime/dispatcher_tests.rs
@@ -107,6 +107,40 @@ mod tests {
     }
 
     #[test]
+    fn eval_isolation_command_policy_normalizes_network_allowlist() -> anyhow::Result<()> {
+        let command = command_record(WorkflowCommand::new(
+            WorkflowCommandType::EnqueueActivity,
+            "eval-implement",
+            json!({
+                "activity": "implement_issue",
+                "eval": {
+                    "timeout_secs": 1800,
+                    "isolation": {
+                        "tier": "container",
+                        "runtime_kind": "remote_host",
+                        "runtime_profile": "eval-isolated-runtime-host",
+                        "sandbox": "workspace-write",
+                        "backend": "container_runtime_host",
+                        "image": "harness-eval-runner:local",
+                        "lifecycle": "ephemeral",
+                        "cleanup_required": true,
+                        "network_allowlist": [" GitHub.COM. ", "api.github.com"]
+                    }
+                }
+            }),
+        ));
+
+        let resolution =
+            isolation_resolution_for_command(None, &command, &IsolationConfig::default())?;
+
+        assert_eq!(
+            resolution.network_allowlist,
+            vec!["github.com".to_string(), "api.github.com".to_string()]
+        );
+        Ok(())
+    }
+
+    #[test]
     fn eval_isolation_command_policy_selects_remote_host_profile() -> anyhow::Result<()> {
         let command = command_record(WorkflowCommand::new(
             WorkflowCommandType::EnqueueActivity,

--- a/crates/harness-workflow/src/runtime/eval/manifest.rs
+++ b/crates/harness-workflow/src/runtime/eval/manifest.rs
@@ -65,6 +65,8 @@ pub struct EvalIsolationProfile {
     #[serde(default = "default_eval_isolation_image")]
     pub image: String,
     #[serde(default)]
+    pub network_allowlist: Vec<String>,
+    #[serde(default)]
     pub lifecycle: EvalIsolationLifecycle,
     #[serde(default = "default_cleanup_required")]
     pub cleanup_required: bool,
@@ -79,6 +81,7 @@ impl Default for EvalIsolationProfile {
             sandbox: default_eval_isolation_sandbox(),
             backend: default_eval_isolation_backend(),
             image: default_eval_isolation_image(),
+            network_allowlist: Vec::new(),
             lifecycle: EvalIsolationLifecycle::default(),
             cleanup_required: true,
         }
@@ -335,6 +338,10 @@ fn normalize_manifest(raw: RawManifest) -> Result<EvalBenchmarkManifest, Manifes
 mod command_tests;
 
 #[cfg(test)]
+#[path = "manifest_network_allowlist_tests.rs"]
+mod network_allowlist_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -468,6 +475,7 @@ resource_limits = { memory_bytes = 0 }
         assert_eq!(case.isolation.lifecycle, EvalIsolationLifecycle::Ephemeral);
         assert_eq!(case.isolation.backend, "container_runtime_host");
         assert_eq!(case.isolation.image, "harness-eval-runner:local");
+        assert!(case.isolation.network_allowlist.is_empty());
         assert!(case.isolation.cleanup_required);
     }
 

--- a/crates/harness-workflow/src/runtime/eval/manifest_network_allowlist_tests.rs
+++ b/crates/harness-workflow/src/runtime/eval/manifest_network_allowlist_tests.rs
@@ -1,0 +1,45 @@
+use super::*;
+
+#[test]
+fn eval_manifest_normalizes_trusted_network_allowlist() {
+    let input = r#"
+suite = "harness-core"
+
+[isolation]
+network_allowlist = [" GitHub.COM. ", "api.github.com"]
+
+[[cases]]
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = ["cargo test"]
+"#;
+
+    let manifest = parse_benchmark_manifest_str(input).expect("allowlisted case should parse");
+
+    assert_eq!(
+        manifest.cases[0].isolation.network_allowlist,
+        vec!["github.com".to_string(), "api.github.com".to_string()]
+    );
+}
+
+#[test]
+fn eval_manifest_rejects_ambiguous_network_allowlist_entries() {
+    let input = r#"
+suite = "harness-core"
+
+[isolation]
+network_allowlist = ["*.github.com"]
+
+[[cases]]
+repo = "majiayu000/harness"
+issue = 1437
+base_commit = "b308b380"
+verify_commands = ["cargo test"]
+"#;
+
+    let err = parse_benchmark_manifest_str(input)
+        .expect_err("ambiguous eval network allowlist should fail");
+
+    assert!(err.to_string().contains("network_allowlist"));
+}

--- a/crates/harness-workflow/src/runtime/eval/manifest_validation.rs
+++ b/crates/harness-workflow/src/runtime/eval/manifest_validation.rs
@@ -236,6 +236,10 @@ pub(super) fn normalize_isolation_profile(
     profile.sandbox = non_empty(profile.sandbox, "eval isolation sandbox")?;
     profile.backend = non_empty(profile.backend, "eval isolation backend")?;
     profile.image = non_empty(profile.image, "eval isolation image")?;
+    profile.network_allowlist =
+        harness_sandbox::EvalNetworkPolicy::for_allowlist(&profile.network_allowlist)
+            .map_err(|error| ManifestError::new(format!("{context} network_allowlist: {error}")))?
+            .network_allowlist;
 
     match profile.tier {
         IsolationTier::Host => {

--- a/crates/harness-workflow/src/runtime/eval/run.rs
+++ b/crates/harness-workflow/src/runtime/eval/run.rs
@@ -554,13 +554,17 @@ fn eval_isolation_metadata(isolation: &EvalIsolationProfile) -> Value {
         "sandbox": isolation.sandbox,
         "backend": isolation.backend,
         "image": isolation.image,
+        "network_allowlist": isolation.network_allowlist,
         "lifecycle": isolation.lifecycle,
         "cleanup_required": isolation.cleanup_required,
     })
 }
 
 fn eval_required_runtime_host_capabilities(verification_argv: &[Vec<String>]) -> Vec<&'static str> {
-    let mut capabilities = vec![harness_sandbox::EVAL_RESOURCE_LIMITS_CAPABILITY];
+    let mut capabilities = vec![
+        harness_sandbox::EVAL_RESOURCE_LIMITS_CAPABILITY,
+        harness_sandbox::EVAL_NETWORK_POLICY_CAPABILITY,
+    ];
     if verification_argv
         .iter()
         .any(|argv| is_trusted_eval_verifier_argv(argv))

--- a/crates/harness-workflow/src/runtime/eval/run_tests.rs
+++ b/crates/harness-workflow/src/runtime/eval/run_tests.rs
@@ -53,6 +53,14 @@ fn eval_run_plan_marks_issue_submission_for_draft_prs() -> anyhow::Result<()> {
         initial.data["eval"]["isolation"]["runtime_profile"],
         "eval-isolated-runtime-host"
     );
+    assert_eq!(
+        initial.data["eval"]["isolation"]["network_allowlist"],
+        json!([])
+    );
+    assert_eq!(
+        initial.data["eval"]["required_runtime_host_capabilities"],
+        json!(["eval_resource_limits", "eval_network_policy"])
+    );
     assert_eq!(initial.data["eval"]["isolation"]["lifecycle"], "ephemeral");
     assert_eq!(initial.data["eval"]["isolation"]["cleanup_required"], true);
 

--- a/crates/harness-workflow/src/runtime/store/runtime_job_state.rs
+++ b/crates/harness-workflow/src/runtime/store/runtime_job_state.rs
@@ -238,6 +238,18 @@ impl WorkflowRuntimeStore {
             .map_err(Into::into)
     }
 
+    pub async fn persist_runtime_job_data(&self, job: &RuntimeJob) -> anyhow::Result<()> {
+        let data = to_jsonb_string(job)?;
+        sqlx::query(
+            "UPDATE runtime_jobs SET data = $1::jsonb, updated_at = CURRENT_TIMESTAMP WHERE id = $2",
+        )
+        .bind(&data)
+        .bind(&job.id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     pub async fn runtime_job_matches_running_lease(
         &self,
         expected: &RuntimeJob,


### PR DESCRIPTION
## Summary
- Add eval network policy/report model that defaults inbound and outbound to deny, accepts only exact trusted DNS allowlists (rejecting IP literals and numeric aliases), and validates connection metadata without payloads.
- Require remote hosts to advertise `eval_network_policy` before claiming eval jobs, inject the expected policy into claim responses, and persist the applied contract so completion requires `network_policy_report` only for leases that received it.
- Propagate optional `network_allowlist` through eval isolation manifests, run metadata, and dispatcher isolation policy; fail closed for unsupported backends and duplicate/mismatched reports.

## Test plan
- [x] `cargo check -p harness-sandbox -p harness-server -p harness-workflow --all-targets`
- [x] `cargo test -p harness-sandbox network_policy`
- [x] `cargo test -p harness-server eval_network_policy`
- [x] `cargo test -p harness-workflow eval_manifest`
- [x] `cargo test -p harness-workflow eval_run`
- [x] `cargo test -p harness-workflow eval_isolation_command_policy`
- [x] `cargo fmt --all -- --check`
- [ ] CI full suite

Closes #1751


Made with [Cursor](https://cursor.com)