### PR TITLE
fix(server): keep root-heavy recent_failures roots-only (GH-2053)

### DIFF
--- a/crates/harness-server/src/handlers/operator_snapshot/mod.rs
+++ b/crates/harness-server/src/handlers/operator_snapshot/mod.rs
@@ -16,7 +16,7 @@ use harness_core::types::EventFilters;
 use harness_protocol::rest::OperatorSnapshotResponse;
 use harness_workflow::runtime::{
     WorkflowDefinitionRegistry, WorkflowInstance, WorkflowRuntimeStore, WorkflowTerminalState,
-    QUALITY_GATE_DEFINITION_ID,
+    PROMPT_TASK_DEFINITION_ID, PR_FEEDBACK_DEFINITION_ID,
 };
 use serde_json::{json, Value};
 use std::cmp::Reverse;
@@ -283,13 +283,14 @@ async fn list_recent_failed_runtime_workflows(
     let definition_ids =
         crate::handlers::definition_ids::operator_definition_ids(store.definition_registry())?;
     let futures = definition_ids.iter().map(|id| async move {
-        // Quality-gate child failures propagate to the parent, so roots-only
-        // avoids duplicate rows and child crowding. Other child definitions
-        // (prompt_task, nested github_issue_pr, pr_feedback) do not propagate
-        // terminal failure — keep those child rows visible.
-        if id == QUALITY_GATE_DEFINITION_ID {
+        // Non-propagating child definitions must stay visible while the parent
+        // remains non-failed. Every other definition (github_issue_pr,
+        // quality_gate, declarative roots) filters roots in SQL before LIMIT so
+        // same-definition children cannot crowd older root failures out of the
+        // window.
+        if id == PROMPT_TASK_DEFINITION_ID || id == PR_FEEDBACK_DEFINITION_ID {
             store
-                .list_recent_root_terminal_instances_by_definition(
+                .list_recent_terminal_instances_by_definition(
                     id,
                     WorkflowTerminalState::Failed,
                     MAX_TASKS as i64,
@@ -297,7 +298,7 @@ async fn list_recent_failed_runtime_workflows(
                 .await
         } else {
             store
-                .list_recent_terminal_instances_by_definition(
+                .list_recent_root_terminal_instances_by_definition(
                     id,
                     WorkflowTerminalState::Failed,
                     MAX_TASKS as i64,

--- a/crates/harness-server/src/handlers/operator_snapshot/snapshot_runtime_cases.rs
+++ b/crates/harness-server/src/handlers/operator_snapshot/snapshot_runtime_cases.rs
@@ -364,6 +364,66 @@ async fn recent_failures_keep_older_root_when_newer_quality_gate_children_fill_l
 }
 
 #[tokio::test]
+async fn recent_failures_keep_older_root_when_newer_github_issue_pr_children_fill_limit(
+) -> anyhow::Result<()> {
+    let _lock = test_helpers::HOME_LOCK.lock().await;
+    let dir = test_helpers::tempdir_in_home("harness-test-op-snap-runtime-issue-root-limit-")?;
+    let state = Arc::new(test_helpers::make_test_state(dir.path()).await?);
+    let store = state
+        .core
+        .workflow_runtime_store
+        .as_ref()
+        .expect("workflow runtime store");
+
+    let root = runtime_workflow(
+        "failed",
+        "issue:runtime-issue-root-limit",
+        serde_json::json!({
+            "project_id": "/tmp/harness-runtime-issue-root-limit",
+            "submission_id": "runtime-issue-root-limit",
+            "failure_reason": "older github_issue_pr root failure",
+        }),
+    )
+    .with_id("runtime-issue-root-limit-workflow".to_string());
+    test_helpers::force_upsert_runtime_lifecycle_state_for_test(store, &root).await?;
+    age_workflow(store, "runtime-issue-root-limit-workflow").await?;
+
+    for index in 0..MAX_TASKS {
+        let child = runtime_workflow(
+            "failed",
+            &format!("issue:runtime-issue-child-limit-{index}"),
+            serde_json::json!({
+                "failure_reason": "newer github_issue_pr child failure",
+            }),
+        )
+        .with_id(format!("runtime-issue-child-limit-{index}"))
+        .with_parent("runtime-issue-root-limit-workflow");
+        test_helpers::force_upsert_runtime_lifecycle_state_for_test(store, &child).await?;
+    }
+
+    let app = Router::new()
+        .route("/api/operator-snapshot", get(operator_snapshot))
+        .with_state(state);
+    let req = axum::http::Request::builder()
+        .uri("/api/operator-snapshot")
+        .body(axum::body::Body::empty())?;
+    let resp = tower::ServiceExt::oneshot(app, req).await?;
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+    let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+    let failures = body["recent_failures"]
+        .as_array()
+        .expect("recent_failures array");
+    assert!(
+        failures
+            .iter()
+            .any(|row| row["task_id"] == "runtime-issue-root-limit"),
+        "older github_issue_pr root failure must survive the per-definition limit: {failures:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn recent_failures_include_non_propagating_pr_feedback_child() -> anyhow::Result<()> {
     let _lock = test_helpers::HOME_LOCK.lock().await;
     let dir = test_helpers::tempdir_in_home("harness-test-op-snap-runtime-pr-feedback-")?;


### PR DESCRIPTION
## Summary
- Invert `list_recent_failed_runtime_workflows` so only non-propagating child definitions (`prompt_task`, `pr_feedback`) use full terminal listing.
- Default all other definitions (`github_issue_pr`, `quality_gate`, declarative roots) to roots-only before LIMIT so same-definition children cannot crowd older root failures out of the window.
- Restore a `github_issue_pr` root-limit regression test mirroring the quality_gate case.

Closes #2053

## Test plan
- [x] `cargo test -p harness-server recent_failures_ -- --test-threads=1` (6 passed on isolated `harness_issue_2053_test`)
- [ ] CI `CI Result` check


Made with [Cursor](https://cursor.com)